### PR TITLE
refactor: set output datetime format on the client side

### DIFF
--- a/.changeset/thick-rings-peel.md
+++ b/.changeset/thick-rings-peel.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+refactor: set output datetime format on the client side

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,1 @@
+version = 1

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ HYPERDX_API_KEY=<YOUR_INGESTION_KEY> docker compose up -d
 > variable with the `-E` flag:
 > `HYPERDX_API_KEY=<YOUR_KEY> sudo -E docker compose up -d`
 
+**Changing Hostname and Port**
+
+By default, HyperDX app/api will run on localhost with port `8080`/`8000`. You
+can change this by updating `HYPERDX_APP_**` and `HYPERDX_API_**` variables in
+the `.env` file. After making your changes, rebuild images with
+`make build-local`.
+
 ### Hosted Cloud
 
 HyperDX is also available as a hosted cloud service at
@@ -140,7 +147,8 @@ including but not limited to:
 - Opening a PR ([Contribution Guide](./CONTRIBUTING.md))
 - [Submitting feature requests or bugs](https://github.com/hyperdxio/hyperdx/issues/new)
 - Improving our product or contribution documentation
-- Voting on [open issues](https://github.com/hyperdxio/hyperdx/issues) or contributing use cases to a feature request
+- Voting on [open issues](https://github.com/hyperdxio/hyperdx/issues) or
+  contributing use cases to a feature request
 
 ## Motivation
 
@@ -167,7 +175,8 @@ we're doing!
 
 HyperDX is open core, with most of our features available here under an MIT
 license. We have a cloud-hosted version available at
-[hyperdx.io](https://hyperdx.io) with a few [additional features](https://www.hyperdx.io/docs/oss-vs-cloud) beyond what's
+[hyperdx.io](https://hyperdx.io) with a few
+[additional features](https://www.hyperdx.io/docs/oss-vs-cloud) beyond what's
 offered in the open source version.
 
 Our cloud hosted version exists so that we can build a sustainable business and

--- a/docker/clickhouse/local/users.xml
+++ b/docker/clickhouse/local/users.xml
@@ -6,7 +6,6 @@
             <use_uncompressed_cache>0</use_uncompressed_cache>
             <load_balancing>in_order</load_balancing>
             <log_queries>1</log_queries>
-            <date_time_output_format>iso</date_time_output_format>
         </default>
     </profiles>
 

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -147,8 +147,9 @@ export const client = createClient({
   },
   clickhouse_settings: {
     connect_timeout: ms('1m') / 1000,
-    max_download_threads: 32,
+    date_time_output_format: 'iso',
     max_download_buffer_size: (10 * 1024 * 1024).toString(), // default
+    max_download_threads: 32,
     max_execution_time: ms('2m') / 1000,
   },
   log: {


### PR DESCRIPTION
The ultimate goal is to remove the clickhouse config mounting at `docker-compose.yml` so people can spin up the project w/o copying `docker/clickhouse` dir