### PR TITLE
chore: bump vector base image to v0.33.0

### DIFF
--- a/docker/ingestor/Dockerfile
+++ b/docker/ingestor/Dockerfile
@@ -1,5 +1,5 @@
 ## base #############################################################################################
-FROM timberio/vector:0.32.1-alpine AS base
+FROM timberio/vector:0.33.0-alpine AS base
 
 RUN mkdir -p /var/lib/vector
 VOLUME ["/var/lib/vector"]


### PR DESCRIPTION
Not in this PR. We might need to migrate vector config files from TOML -> YAML (https://vector.dev/highlights/2023-08-30-yaml-default-format/)