### PR TITLE
fix: Customize 24h vs 12h time formatting globally

### DIFF
--- a/packages/app/src/HDXLineChart.tsx
+++ b/packages/app/src/HDXLineChart.tsx
@@ -16,6 +16,7 @@ import pick from 'lodash/pick';
 
 import api from './api';
 import { AggFn, Granularity, convertGranularityToSeconds } from './ChartUtils';
+import useUserPreferences, { TimeFormat, TIME_TOKENS } from './useUserPreferences';
 
 import { semanticKeyedColor, truncateMiddle } from './utils';
 import Link from 'next/link';
@@ -72,6 +73,8 @@ const MemoChart = memo(function MemoChart({
   }, [groupKeys]);
 
   const sizeRef = useRef<[number, number]>([0, 0]);
+  const timeFormat: TimeFormat = useUserPreferences().timeFormat
+  const tsFormat = TIME_TOKENS[timeFormat]
 
   return (
     <ResponsiveContainer
@@ -120,7 +123,7 @@ const MemoChart = memo(function MemoChart({
           interval="preserveStartEnd"
           scale="time"
           type="number"
-          tickFormatter={tick => format(new Date(tick * 1000), 'MMM d HH:mm')}
+          tickFormatter={tick => format(new Date(tick * 1000), tsFormat)}
           minTickGap={50}
           tick={{ fontSize: 12, fontFamily: 'IBM Plex Mono, monospace' }}
         />
@@ -177,7 +180,8 @@ const MemoChart = memo(function MemoChart({
 });
 
 const HDXLineChartTooltip = (props: any) => {
-  const tsFormat = 'MMM d HH:mm:ss.SSS';
+  const timeFormat: TimeFormat = useUserPreferences().timeFormat
+  const tsFormat = TIME_TOKENS[timeFormat]
   const { active, payload, label } = props;
   if (active && payload && payload.length) {
     return (

--- a/packages/app/src/HDXLineChart.tsx
+++ b/packages/app/src/HDXLineChart.tsx
@@ -16,10 +16,12 @@ import pick from 'lodash/pick';
 
 import api from './api';
 import { AggFn, Granularity, convertGranularityToSeconds } from './ChartUtils';
-import useUserPreferences, { TimeFormat, TIME_TOKENS } from './useUserPreferences';
+import useUserPreferences, { TimeFormat } from './useUserPreferences';
+import { TIME_TOKENS } from './utils';
 
 import { semanticKeyedColor, truncateMiddle } from './utils';
 import Link from 'next/link';
+
 
 function ExpandableLegendItem({ value, entry }: any) {
   const [expanded, setExpanded] = useState(false);
@@ -75,6 +77,7 @@ const MemoChart = memo(function MemoChart({
   const sizeRef = useRef<[number, number]>([0, 0]);
   const timeFormat: TimeFormat = useUserPreferences().timeFormat
   const tsFormat = TIME_TOKENS[timeFormat]
+  // Gets the preffered time format from User Preferences, then converts it to a formattable token
 
   return (
     <ResponsiveContainer

--- a/packages/app/src/LogTable.tsx
+++ b/packages/app/src/LogTable.tsx
@@ -23,6 +23,9 @@ import api from './api';
 import { usePrevious, useWindowSize } from './utils';
 import { useSearchEventStream } from './search';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { TIME_TOKENS } from './utils';
+import useUserPreferences from './useUserPreferences';
+import type { TimeFormat } from './useUserPreferences';
 
 type Row = Record<string, any> & { duration: number };
 type AccessorFn = (row: Row, column: string) => any;
@@ -262,8 +265,8 @@ export const RawLogTable = memo(
 
     const { width } = useWindowSize();
     const isSmallScreen = (width ?? 1000) < 900;
-
-    const tsFormat = 'MMM d HH:mm:ss.SSS';
+    const timeFormat: TimeFormat = useUserPreferences().timeFormat
+    const tsFormat = TIME_TOKENS[timeFormat]
     const tsShortFormat = 'HH:mm:ss';
     // https://github.com/TanStack/table/discussions/3192#discussioncomment-3873093
     const UNDEFINED_WIDTH = 99999;

--- a/packages/app/src/SearchTimeRangePicker.tsx
+++ b/packages/app/src/SearchTimeRangePicker.tsx
@@ -37,7 +37,7 @@ export default function SearchTimeRangePicker({
   setInputValue,
   onSearch,
   showLive = false,
-  timeFormat = '24h',
+  timeFormat = '12h',
 }: {
   inputValue: string;
   setInputValue: (str: string) => any;

--- a/packages/app/src/useUserPreferences.tsx
+++ b/packages/app/src/useUserPreferences.tsx
@@ -1,10 +1,14 @@
 import React, { useContext, useState } from 'react';
 
 export type TimeFormat = '12h' | '24h';
+export const TIME_TOKENS = {
+  '12h' : 'MMM d h:mm:ss a',
+  '24h' : 'MMM d HH:mm:ss.SSS',
+}
 
 export const UserPreferences = React.createContext({
   isUTC: false,
-  timeFormat: '24h' as TimeFormat,
+  timeFormat: '12h' as TimeFormat,
   setTimeFormat: (timeFormat: TimeFormat) => {},
   setIsUTC: (isUTC: boolean) => {},
 });

--- a/packages/app/src/useUserPreferences.tsx
+++ b/packages/app/src/useUserPreferences.tsx
@@ -1,10 +1,6 @@
 import React, { useContext, useState } from 'react';
 
 export type TimeFormat = '12h' | '24h';
-export const TIME_TOKENS = {
-  '12h' : 'MMM d h:mm:ss a',
-  '24h' : 'MMM d HH:mm:ss.SSS',
-}
 
 export const UserPreferences = React.createContext({
   isUTC: false,
@@ -20,7 +16,7 @@ export const UserPreferencesProvider = ({
 }) => {
   const initState = {
     isUTC: false,
-    timeFormat: '24h' as TimeFormat,
+    timeFormat: '12h' as TimeFormat,
     setTimeFormat: (timeFormat: TimeFormat) =>
       setState(state => ({ ...state, timeFormat })),
     setIsUTC: (isUTC: boolean) => setState(state => ({ ...state, isUTC })),

--- a/packages/app/src/utils.tsx
+++ b/packages/app/src/utils.tsx
@@ -152,6 +152,11 @@ export const useDebounce = <T,>(
   return debouncedValue;
 };
 
+export const TIME_TOKENS = {
+  '12h' : 'MMM d h:mm:ss a',
+  '24h' : 'MMM d HH:mm:ss.SSS',
+}
+
 export function useLocalStorage<T>(key: string, initialValue: T) {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once


### PR DESCRIPTION
## What does this Pull Request Do?

Opening up this PR in order to discuss implementation of 12h and 24h time formats. I added the tokens used for formatting (ex: `MMM d h:mm:ss a`) as [constant](https://github.com/treypisano/hyperdx/blob/4b001cf1ddfa9047e5818023e77ca0eef280255b/packages/app/src/utils.tsx#L155-L158) in `utils.ts`, in order to avoid copy and pasting these in all the places its needed. 

Then, I used the `userUserPreferences` hook to read what the preference is in the Context, get the required token, and then format the graph accordingly.

At the moment, all the line charts and the logger are changing when the [`initialState`](https://github.com/treypisano/hyperdx/blob/main/packages/app/src/useUserPreferences.tsx#L19) is changed. Of course in the future this will be changed with a UI component, but I wanted to make sure the base implementation is solid first.

## How did I test this?

1. Launch the dev build using docker compose
2. Open up either the logger or dashboard
3. Change initial state from `24hr` to `12hr` , refresh, and observe how it changes