### PR TITLE
fix: boolean env var type issue (older compose version)

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3'
 services:
   ch_keeper:
     container_name: hdx-ci-ch-keeper

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,7 +47,7 @@ services:
     environment:
       RUST_BACKTRACE: full
       VECTOR_LOG: ${HYPERDX_LOG_LEVEL}
-      VECTOR_OPENSSL_LEGACY_PROVIDER: false
+      VECTOR_OPENSSL_LEGACY_PROVIDER: 'false'
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       RUST_BACKTRACE: full
       VECTOR_LOG: ${HYPERDX_LOG_LEVEL}
-      VECTOR_OPENSSL_LEGACY_PROVIDER: false
+      VECTOR_OPENSSL_LEGACY_PROVIDER: 'false'
     restart: always
     networks:
       - internal


### PR DESCRIPTION
for docker-vompose v1x, it throws error like:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.ingestor.environment.VECTOR_OPENSSL_LEGACY_PROVIDER contains false, which is an invalid type, it should be a string, number, or a null
```