### PR TITLE
Remove validation for slack-specific URL in webhook configuration

### DIFF
--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -114,7 +114,7 @@ export default function TeamPage() {
       toast.error('Please enter a name for the Slack webhook');
       return;
     }
-    if (!url || !isValidUrl(url) || !url.includes('hooks.slack.com')) {
+    if (!url || !isValidUrl(url)) {
       toast.error('Please enter a valid Slack webhook URL');
       return;
     }


### PR DESCRIPTION
Some people offer a slack-compatible webhook that is not hosted on the Slack domain, this removes the domain check to allow people to enter any URL they like