### PR TITLE
fix: Sentry exception in the side panel should not assume all events in trace are exceptions, add Sentry SDK to API server

### DIFF
--- a/.changeset/fifty-papayas-look.md
+++ b/.changeset/fifty-papayas-look.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+Fix Sentry exception rendering error in side panel, add Sentry SDK to API
+server.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -176,6 +176,7 @@ services:
       HDX_NODE_CONSOLE_CAPTURE: 1
       HYPERDX_API_KEY: ${HYPERDX_API_KEY}
       HYPERDX_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
+      SENTRY_DSN: ${SENTRY_DSN}
       INGESTOR_API_URL: 'http://ingestor:8002'
       MINER_API_URL: 'http://miner:5123'
       MONGO_URI: 'mongodb://db:27017/hyperdx'

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,6 +11,7 @@
     "@hyperdx/lucene": "^3.1.1",
     "@hyperdx/node-logger": "^0.2.8",
     "@hyperdx/node-opentelemetry": "^0.3.0",
+    "@sentry/node": "^7.85.0",
     "@slack/webhook": "^6.1.0",
     "compression": "^1.7.4",
     "connect-mongo": "^4.6.0",

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -13,6 +13,7 @@ export const FRONTEND_URL = env.FRONTEND_URL as string;
 export const HYPERDX_API_KEY = env.HYPERDX_API_KEY as string;
 export const HYPERDX_LOG_LEVEL = env.HYPERDX_LOG_LEVEL as string;
 export const INGESTOR_API_URL = env.INGESTOR_API_URL as string;
+export const SENTRY_DSN = env.SENTRY_DSN as string;
 export const IS_CI = NODE_ENV === 'ci';
 export const IS_DEV = NODE_ENV === 'development';
 export const IS_PROD = NODE_ENV === 'production';

--- a/packages/app/src/LogSidePanel.tsx
+++ b/packages/app/src/LogSidePanel.tsx
@@ -493,7 +493,6 @@ function isExceptionSpan({ logData }: { logData: any }) {
 
 function TraceSubpanel({
   logData,
-  isException,
   onClose,
   onPropertyAddClick,
   generateChartUrl,
@@ -502,7 +501,6 @@ function TraceSubpanel({
   toggleColumn,
 }: {
   logData: any;
-  isException: boolean;
   onClose: () => void;
   generateSearchUrl: (query?: string, timeRange?: [Date, Date]) => string;
   generateChartUrl: (config: {
@@ -585,6 +583,11 @@ function TraceSubpanel({
       return [];
     }
   }, [selectedLogData]);
+
+  const isSelectedLogDataException = useMemo(
+    () => isExceptionSpan({ logData: selectedLogData }),
+    [selectedLogData],
+  );
 
   // Clear search query when we close the panel
   // TODO: This doesn't work because it breaks navigation to things like the sessions page,
@@ -682,7 +685,7 @@ function TraceSubpanel({
                 />
               </ErrorBoundary>
             )}
-            {isException && (
+            {isSelectedLogDataException && (
               <ErrorBoundary
                 onError={err => {
                   console.error(err);
@@ -700,7 +703,7 @@ function TraceSubpanel({
                 />
               </ErrorBoundary>
             )}
-            {!isException && (
+            {!isSelectedLogDataException && (
               <ErrorBoundary
                 onError={err => {
                   console.error(err);
@@ -2261,7 +2264,6 @@ export default function LogSidePanel({
                   >
                     <TraceSubpanel
                       logData={logData}
-                      isException={isException}
                       onPropertyAddClick={onPropertyAddClick}
                       generateSearchUrl={generateSearchUrl}
                       generateChartUrl={generateChartUrl}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,6 +3635,15 @@
     "@sentry/utils" "7.64.0"
     tslib "^2.4.1 || ^1.9.3"
 
+"@sentry-internal/tracing@7.85.0":
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.85.0.tgz#1b4781a61e1e43badeff826cf40abe33dd760f1d"
+  integrity sha512-p3YMUwkPCy2su9cm/3+7QYR4RiMI0+07DU1BZtht9NLTzY2O87/yvUbn1v2yHR3vJQTy/+7N0ud9/mPBFznRQQ==
+  dependencies:
+    "@sentry/core" "7.85.0"
+    "@sentry/types" "7.85.0"
+    "@sentry/utils" "7.85.0"
+
 "@sentry/browser@^7.64.0":
   version "7.64.0"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.64.0.tgz#76db08a5d32ffe7c5aa907f258e6c845ce7f10d7"
@@ -3656,6 +3665,25 @@
     "@sentry/utils" "7.64.0"
     tslib "^2.4.1 || ^1.9.3"
 
+"@sentry/core@7.85.0":
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.85.0.tgz#dd90d772a5f75ff674f931f59b22a3fc286d0983"
+  integrity sha512-DFDAc4tWmHN5IWhr7XbHCiyF1Xgb95jz8Uj/JTX9atlgodId1UIbER77qpEmH3eQGid/QBdqrlR98zCixgSbwg==
+  dependencies:
+    "@sentry/types" "7.85.0"
+    "@sentry/utils" "7.85.0"
+
+"@sentry/node@^7.85.0":
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.85.0.tgz#cf4e6022b5cd1f3fb007186c5e04427b108ebe1d"
+  integrity sha512-uiBtRW9G017NHoCXBlK3ttkTwHXLFyI8ndHpaObtyajKTv3ptGIThVEn7DuK7Pwor//RjwjSEEOa7WDK+FdMVQ==
+  dependencies:
+    "@sentry-internal/tracing" "7.85.0"
+    "@sentry/core" "7.85.0"
+    "@sentry/types" "7.85.0"
+    "@sentry/utils" "7.85.0"
+    https-proxy-agent "^5.0.0"
+
 "@sentry/replay@7.64.0":
   version "7.64.0"
   resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.64.0.tgz#bdf09b0c4712f9dc6b24b3ebefa55a4ac76708e6"
@@ -3670,6 +3698,11 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.64.0.tgz#21fc545ea05c3c8c4c3e518583eca1a8c5429506"
   integrity sha512-LqjQprWXjUFRmzIlUjyA+KL+38elgIYmAeoDrdyNVh8MK5IC1W2Lh1Q87b4yOiZeMiIhIVNBd7Ecoh2rodGrGA==
 
+"@sentry/types@7.85.0":
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.85.0.tgz#648488b90f958ca6a86922cc5d26004853410ba6"
+  integrity sha512-R5jR4XkK5tBU2jDiPdSVqzkmjYRr666bcGaFGUHB/xDQCjPsjk+pEmCCL+vpuWoaZmQJUE1hVU7rgnVX81w8zg==
+
 "@sentry/utils@7.64.0":
   version "7.64.0"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.64.0.tgz#6fe3ce9a56d3433ed32119f914907361a54cc184"
@@ -3677,6 +3710,13 @@
   dependencies:
     "@sentry/types" "7.64.0"
     tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/utils@7.85.0":
+  version "7.85.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.85.0.tgz#b84467fd07bc2ef09fdf382ddcdcdc3f5b0d78b0"
+  integrity sha512-JZ7seNOLvhjAQ8GeB3GYknPQJkuhF88xAYOaESZP3xPOWBMFUN+IO4RqjMqMLFDniOwsVQS7GB/MfP+hxufieg==
+  dependencies:
+    "@sentry/types" "7.85.0"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
Sentry DSN config is mainly for us to test against our own ingestor. In case anyone runs across this you need to set SENTRY_DSN to `http://YOUR_KEY_WITHOUT_DASHES@ingestor:8002/0` (you need to use `ingestor`, not `localhost` as the api server won't resolve that to the ingestor)