### PR TITLE
Fix time chart group count regression

### DIFF
--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -256,7 +256,7 @@ const HDXMultiSeriesLineChart = memo(
     // and a data value per series, we just need to turn them all into keys
     if (data != null) {
       for (const row of data.data) {
-        groupSet.add(row.group);
+        groupSet.add(`${row.group}`);
 
         const tsBucket = tsBucketMap.get(row.ts_bucket) ?? {};
         tsBucketMap.set(row.ts_bucket, {
@@ -394,7 +394,7 @@ const HDXMultiSeriesLineChart = memo(
               </Link>
             </div>
           ) : null}
-          {totalGroups > groupKeys.length ? (
+          {/* {totalGroups > groupKeys.length ? (
             <div
               className="bg-grey px-3 py-2 rounded fs-8"
               style={{
@@ -413,7 +413,7 @@ const HDXMultiSeriesLineChart = memo(
                 {groupKeys.length} groups shown
               </span>
             </div>
-          ) : null}
+          ) : null} */}
           <div
             className="bg-grey px-3 py-2 rounded fs-8"
             style={{


### PR DESCRIPTION
We were showing the "Only showing top N groups" indicator in line charts extraneously from #184. I've removed the UI since it's been somewhat broken for some while, and patched the group counter logic so it's not completely broken at least.