### PR TITLE
fix: services endpoint bug

### DIFF
--- a/.changeset/violet-singers-melt.md
+++ b/.changeset/violet-singers-melt.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+fix: services endpoint bug (missing log lines results in no matches)


### PR DESCRIPTION
The bug happened when:
1. Property map has custom attributes
2. Found log lines don't have custom properties

And because the query has 'group-by' column checks in where clause, it ends up no matches
even 'service' should exist.
