### PR TITLE
alert api

### DIFF
--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -1,5 +1,6 @@
 import { getHours, getMinutes } from 'date-fns';
 import ms from 'ms';
+import { z } from 'zod';
 
 import * as clickhouse from '@/clickhouse';
 import { SQLSerializer } from '@/clickhouse/searchQueryParser';
@@ -11,6 +12,9 @@ import Alert, {
   AlertType,
   IAlert,
 } from '@/models/alert';
+import Dashboard, { IDashboard } from '@/models/dashboard';
+import LogView, { ILogView } from '@/models/logView';
+import { alertSchema } from '@/utils/zod';
 
 export type AlertInput = {
   source: AlertSource;
@@ -93,11 +97,38 @@ const makeAlert = (alert: AlertInput) => {
   };
 };
 
-export const createAlert = async (teamId: ObjectId, alertInput: AlertInput) => {
+export const createAlert = async (
+  teamId: ObjectId,
+  alertInput: z.infer<typeof alertSchema>,
+) => {
+  if (alertInput.source === 'CHART') {
+    if ((await Dashboard.findById(alertInput.dashboardId)) == null) {
+      throw new Error('Dashboard ID not found');
+    }
+  }
+
+  if (alertInput.source === 'LOG') {
+    if ((await LogView.findById(alertInput.logViewId)) == null) {
+      throw new Error('Saved Search ID not found');
+    }
+  }
+
   return new Alert({
     ...makeAlert(alertInput),
     team: teamId,
   }).save();
+};
+
+const dashboardLogViewIds = async (teamId: ObjectId) => {
+  const [dashboards, logViews] = await Promise.all([
+    Dashboard.find({ team: teamId }, { _id: 1 }),
+    LogView.find({ team: teamId }, { _id: 1 }),
+  ]);
+
+  return [
+    logViews.map(logView => logView._id),
+    dashboards.map(dashboard => dashboard._id),
+  ];
 };
 
 // create an update alert function based off of the above create alert function
@@ -106,9 +137,89 @@ export const updateAlert = async (
   teamId: ObjectId,
   alertInput: AlertInput,
 ) => {
-  // TODO: find by id and teamId
   // should consider clearing AlertHistory when updating an alert?
-  return Alert.findByIdAndUpdate(id, makeAlert(alertInput), {
-    returnDocument: 'after',
+  const [logViewIds, dashboardIds] = await dashboardLogViewIds(teamId);
+
+  return Alert.findOneAndUpdate(
+    {
+      _id: id,
+      $or: [
+        {
+          logView: {
+            $in: logViewIds,
+          },
+        },
+        {
+          dashboardId: {
+            $in: dashboardIds,
+          },
+        },
+      ],
+    },
+    makeAlert(alertInput),
+    {
+      returnDocument: 'after',
+    },
+  );
+};
+
+export const getAlerts = async (teamId: ObjectId) => {
+  const [logViewIds, dashboardIds] = await dashboardLogViewIds(teamId);
+
+  return Alert.find({
+    $or: [
+      {
+        logView: {
+          $in: logViewIds,
+        },
+      },
+      {
+        dashboardId: {
+          $in: dashboardIds,
+        },
+      },
+    ],
+  });
+};
+
+export const getAlertsWithLogViewAndDashboard = async (teamId: ObjectId) => {
+  const [logViewIds, dashboardIds] = await dashboardLogViewIds(teamId);
+
+  return Alert.find({
+    $or: [
+      {
+        logView: {
+          $in: logViewIds,
+        },
+      },
+      {
+        dashboardId: {
+          $in: dashboardIds,
+        },
+      },
+    ],
+  }).populate<{
+    logView: ILogView;
+    dashboardId: IDashboard;
+  }>(['logView', 'dashboardId']);
+};
+
+export const deleteAlert = async (id: string, teamId: ObjectId) => {
+  const [logViewIds, dashboardIds] = await dashboardLogViewIds(teamId);
+
+  return Alert.deleteOne({
+    _id: id,
+    $or: [
+      {
+        logView: {
+          $in: logViewIds,
+        },
+      },
+      {
+        dashboardId: {
+          $in: dashboardIds,
+        },
+      },
+    ],
   });
 };

--- a/packages/api/src/controllers/dashboard.ts
+++ b/packages/api/src/controllers/dashboard.ts
@@ -1,0 +1,16 @@
+import type { ObjectId } from '@/models';
+import Alert from '@/models/alert';
+import Dashboard from '@/models/dashboard';
+
+export default async function deleteDashboardAndAlerts(
+  dashboardId: string,
+  teamId: ObjectId,
+) {
+  const dashboard = await Dashboard.findOneAndDelete({
+    _id: dashboardId,
+    team: teamId,
+  });
+  if (dashboard) {
+    await Alert.deleteMany({ dashboardId: dashboard._id });
+  }
+}

--- a/packages/api/src/routers/api/__tests__/alerts.test.ts
+++ b/packages/api/src/routers/api/__tests__/alerts.test.ts
@@ -3,43 +3,9 @@ import {
   closeDB,
   getLoggedInAgent,
   getServer,
+  makeAlert,
+  makeChart,
 } from '@/fixtures';
-
-const randomId = () => Math.random().toString(36).substring(7);
-
-const makeChart = () => ({
-  id: randomId(),
-  name: 'Test Chart',
-  x: 1,
-  y: 1,
-  w: 1,
-  h: 1,
-  series: [
-    {
-      type: 'time',
-      table: 'metrics',
-    },
-  ],
-});
-
-const makeAlert = ({
-  dashboardId,
-  chartId,
-}: {
-  dashboardId: string;
-  chartId: string;
-}) => ({
-  channel: {
-    type: 'webhook',
-    webhookId: 'test-webhook-id',
-  },
-  interval: '15m',
-  threshold: 8,
-  type: 'presence',
-  source: 'CHART',
-  dashboardId,
-  chartId,
-});
 
 const MOCK_DASHBOARD = {
   name: 'Test Dashboard',
@@ -63,7 +29,7 @@ describe('alerts router', () => {
     await closeDB();
   });
 
-  it('index has alerts attached to dashboards', async () => {
+  it('has alerts attached to dashboards', async () => {
     const { agent } = await getLoggedInAgent(server);
 
     await agent.post('/dashboards').send(MOCK_DASHBOARD).expect(200);

--- a/packages/api/src/routers/external-api/__tests__/alerts.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.test.ts
@@ -1,0 +1,205 @@
+import _ from 'lodash';
+
+import {
+  clearDBCollections,
+  closeDB,
+  getLoggedInAgent,
+  getServer,
+  makeChart,
+  makeExternalAlert,
+} from '@/fixtures';
+
+const MOCK_DASHBOARD = {
+  name: 'Test Dashboard',
+  charts: [
+    makeChart({ id: 'aaaaaaa' }),
+    makeChart({ id: 'bbbbbbb' }),
+    makeChart({ id: 'ccccccc' }),
+    makeChart({ id: 'ddddddd' }),
+    makeChart({ id: 'eeeeeee' }),
+  ],
+  query: 'test query',
+};
+
+describe('/api/v1/alerts', () => {
+  const server = getServer();
+
+  beforeAll(async () => {
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await clearDBCollections();
+  });
+
+  afterAll(async () => {
+    await server.closeHttpServer();
+    await closeDB();
+  });
+
+  it('CRUD Dashboard Alerts', async () => {
+    const { agent, user } = await getLoggedInAgent(server);
+
+    await agent.post('/dashboards').send(MOCK_DASHBOARD).expect(200);
+    const initialDashboards = await agent.get('/dashboards').expect(200);
+
+    // Create alerts for all charts
+    const dashboard = initialDashboards.body.data[0];
+    await Promise.all(
+      dashboard.charts.map(chart =>
+        agent
+          .post('/api/v1/alerts')
+          .set('Authorization', `Bearer ${user?.accessKey}`)
+          .send(
+            makeExternalAlert({
+              dashboardId: dashboard._id,
+              chartId: chart.id,
+            }),
+          )
+          .expect(200),
+      ),
+    );
+
+    const alerts = await agent
+      .get(`/api/v1/alerts`)
+      .set('Authorization', `Bearer ${user?.accessKey}`)
+      .expect(200);
+    // sort alerts.body.data by chartId
+    const sortedAlerts = alerts.body.data
+      .sort((a, b) => {
+        if (a.chartId < b.chartId) {
+          return -1;
+        }
+        if (a.chartId > b.chartId) {
+          return 1;
+        }
+        return 0;
+      })
+      .map(alert => {
+        return {
+          ..._.omit(alert, ['id', 'dashboardId']),
+        };
+      });
+
+    for (let i = 0; i < 5; i++) {
+      expect(alerts.body.data[i].dashboardId.length).toBeGreaterThan(0);
+      expect(alerts.body.data[i].id.length).toBeGreaterThan(0);
+    }
+
+    expect(sortedAlerts).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "channel": Object {
+      "type": "slack_webhook",
+      "webhookId": "65ad876b6b08426ab4ba7830",
+    },
+    "chartId": "aaaaaaa",
+    "interval": "15m",
+    "source": "chart",
+    "threshold": 8,
+    "threshold_type": "above",
+  },
+  Object {
+    "channel": Object {
+      "type": "slack_webhook",
+      "webhookId": "65ad876b6b08426ab4ba7830",
+    },
+    "chartId": "bbbbbbb",
+    "interval": "15m",
+    "source": "chart",
+    "threshold": 8,
+    "threshold_type": "above",
+  },
+  Object {
+    "channel": Object {
+      "type": "slack_webhook",
+      "webhookId": "65ad876b6b08426ab4ba7830",
+    },
+    "chartId": "ccccccc",
+    "interval": "15m",
+    "source": "chart",
+    "threshold": 8,
+    "threshold_type": "above",
+  },
+  Object {
+    "channel": Object {
+      "type": "slack_webhook",
+      "webhookId": "65ad876b6b08426ab4ba7830",
+    },
+    "chartId": "ddddddd",
+    "interval": "15m",
+    "source": "chart",
+    "threshold": 8,
+    "threshold_type": "above",
+  },
+  Object {
+    "channel": Object {
+      "type": "slack_webhook",
+      "webhookId": "65ad876b6b08426ab4ba7830",
+    },
+    "chartId": "eeeeeee",
+    "interval": "15m",
+    "source": "chart",
+    "threshold": 8,
+    "threshold_type": "above",
+  },
+]
+`);
+
+    for (let i = 0; i < 4; i++) {
+      await agent
+        .delete(`/api/v1/alerts/${alerts.body.data[i].id}`)
+        .set('Authorization', `Bearer ${user?.accessKey}`)
+        .expect(200);
+    }
+
+    const remainingAlert = alerts.body.data[4];
+    const updateAlert = await agent
+      .put(`/api/v1/alerts/${remainingAlert.id}`)
+      .send(
+        makeExternalAlert({
+          dashboardId: remainingAlert.dashboardId,
+          chartId: remainingAlert.chartId,
+          threshold: 1000,
+          interval: '1h',
+        }),
+      )
+      .set('Authorization', `Bearer ${user?.accessKey}`)
+      .expect(200);
+
+    expect(_.omit(updateAlert.body.data, ['id', 'chartId', 'dashboardId']))
+      .toMatchInlineSnapshot(`
+Object {
+  "channel": Object {
+    "type": "slack_webhook",
+    "webhookId": "65ad876b6b08426ab4ba7830",
+  },
+  "interval": "1h",
+  "source": "chart",
+  "threshold": 1000,
+  "threshold_type": "above",
+}
+`);
+
+    const singleAlert = await agent
+      .get(`/api/v1/alerts`)
+      .set('Authorization', `Bearer ${user?.accessKey}`)
+      .expect(200);
+
+    expect(singleAlert.body.data.length).toBe(1);
+    expect(singleAlert.body.data[0].id).toEqual(remainingAlert.id);
+    expect(_.omit(singleAlert.body.data[0], ['id', 'chartId', 'dashboardId']))
+      .toMatchInlineSnapshot(`
+Object {
+  "channel": Object {
+    "type": "slack_webhook",
+    "webhookId": "65ad876b6b08426ab4ba7830",
+  },
+  "interval": "1h",
+  "source": "chart",
+  "threshold": 1000,
+  "threshold_type": "above",
+}
+`);
+  });
+});

--- a/packages/api/src/routers/external-api/v1/index.ts
+++ b/packages/api/src/routers/external-api/v1/index.ts
@@ -13,6 +13,8 @@ import logger from '@/utils/logger';
 import rateLimiter from '@/utils/rateLimiter';
 import { SimpleCache } from '@/utils/redis';
 
+import alertsRouter from './alerts';
+
 const router = express.Router();
 
 const rateLimiterKeyGenerator = (req: express.Request) => {
@@ -34,6 +36,13 @@ router.get('/', validateUserAccessKey, (req, res, next) => {
     user: req.user?.toJSON(),
   });
 });
+
+router.use(
+  '/alerts',
+  getDefaultRateLimiter(),
+  validateUserAccessKey,
+  alertsRouter,
+);
 
 router.get(
   '/logs/properties',

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -1,6 +1,25 @@
+import { Types } from 'mongoose';
 import { z } from 'zod';
 
 import { AggFn, MetricsDataType } from '@/clickhouse';
+
+export const objectIdSchema = z.string().refine(val => {
+  return Types.ObjectId.isValid(val);
+});
+
+export const sourceTableSchema = z.union([
+  z.literal('logs'),
+  z.literal('rrweb'),
+  z.literal('metrics'),
+]);
+
+export type SourceTable = z.infer<typeof sourceTableSchema>;
+
+// ==============================
+// Charts
+// ==============================
+
+export const aggFnSchema = z.nativeEnum(AggFn);
 
 export const numberFormatSchema = z.object({
   output: z
@@ -20,16 +39,6 @@ export const numberFormatSchema = z.object({
   currencySymbol: z.string().optional(),
   unit: z.string().optional(),
 });
-
-export const aggFnSchema = z.nativeEnum(AggFn);
-
-export const sourceTableSchema = z.union([
-  z.literal('logs'),
-  z.literal('rrweb'),
-  z.literal('metrics'),
-]);
-
-export type SourceTable = z.infer<typeof sourceTableSchema>;
 
 export const timeChartSeriesSchema = z.object({
   table: z.optional(sourceTableSchema),
@@ -81,3 +90,125 @@ export const chartSeriesSchema = z.union([
     content: z.string(),
   }),
 ]);
+
+export const chartSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  x: z.number(),
+  y: z.number(),
+  w: z.number(),
+  h: z.number(),
+  series: z.array(
+    // We can't do a strict validation here since mongo and the frontend
+    // have a bug where chart types will not delete extraneous properties
+    // when attempting to save.
+    z.object({
+      type: z.enum([
+        'time',
+        'histogram',
+        'search',
+        'number',
+        'table',
+        'markdown',
+      ]),
+      table: z.string().optional(),
+      aggFn: z.string().optional(), // TODO: Replace with the actual AggFn schema
+      field: z.union([z.string(), z.undefined()]).optional(),
+      where: z.string().optional(),
+      groupBy: z.array(z.string()).optional(),
+      sortOrder: z.union([z.literal('desc'), z.literal('asc')]).optional(),
+      content: z.string().optional(),
+      numberFormat: z
+        .object({
+          output: z
+            .union([
+              z.literal('currency'),
+              z.literal('percent'),
+              z.literal('byte'),
+              z.literal('time'),
+              z.literal('number'),
+            ])
+            .optional(),
+          mantissa: z.number().optional(),
+          thousandSeparated: z.boolean().optional(),
+          average: z.boolean().optional(),
+          decimalBytes: z.boolean().optional(),
+          factor: z.number().optional(),
+          currencySymbol: z.string().optional(),
+          unit: z.string().optional(),
+        })
+        .optional(),
+    }),
+  ),
+});
+
+export const tagsSchema = z.array(z.string().max(32)).max(50).optional();
+
+// ==============================
+// Alerts
+// ==============================
+export const zChannel = z.object({
+  type: z.literal('webhook'),
+  webhookId: z.string().min(1),
+});
+
+export const zLogAlert = z.object({
+  source: z.literal('LOG'),
+  groupBy: z.string().optional(),
+  logViewId: z.string().min(1),
+  message: z.string().optional(),
+});
+
+export const zChartAlert = z.object({
+  source: z.literal('CHART'),
+  chartId: z.string().min(1),
+  dashboardId: z.string().min(1),
+});
+
+export const alertSchema = z
+  .object({
+    channel: zChannel,
+    interval: z.enum(['1m', '5m', '15m', '30m', '1h', '6h', '12h', '1d']),
+    threshold: z.number().min(0),
+    type: z.enum(['presence', 'absence']),
+    source: z.enum(['LOG', 'CHART']).default('LOG'),
+  })
+  .and(zLogAlert.or(zChartAlert));
+
+// ==============================
+// External API Alerts
+// ==============================
+
+export const externalSlackWebhookAlertChannel = z.object({
+  type: z.literal('slack_webhook'),
+  webhookId: objectIdSchema,
+});
+
+export const externalSearchAlertSchema = z.object({
+  source: z.literal('search'),
+  groupBy: z.string().optional(),
+  savedSearchId: objectIdSchema,
+  message: z.string().optional(),
+});
+
+export const externalChartAlertSchema = z.object({
+  source: z.literal('chart'),
+  chartId: z.string().min(1),
+  dashboardId: objectIdSchema,
+});
+
+export const externalAlertSchema = z
+  .object({
+    channel: externalSlackWebhookAlertChannel,
+    interval: z.enum(['1m', '5m', '15m', '30m', '1h', '6h', '12h', '1d']),
+    threshold: z.number().min(0),
+    threshold_type: z.enum(['above', 'below']),
+    source: z.enum(['search', 'chart']).default('search'),
+  })
+  .and(externalSearchAlertSchema.or(externalChartAlertSchema));
+
+export const externalAlertSchemaWithId = externalAlertSchema.and(
+  z.object({
+    id: objectIdSchema,
+  }),
+);

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -168,7 +168,7 @@ function AlertDetails({ alert }: { alert: AlertData }) {
             <span className="fw-bold">{alert.threshold}</span>
             <span className="text-slate-400">&middot;</span>
             {alert.channel.type === 'webhook' && (
-              <span>Notify via Webhook</span>
+              <span>Notify via Slack Webhook</span>
             )}
           </div>
         </Stack>


### PR DESCRIPTION
Introduces external alert api to OSS, adds translation layer between internal naming and product-aligned external naming.

Example:

```
PUT /api/v1/alerts/<ALERT_ID>
Authorization: Bearer <PERSONAL_API>

{
  "interval": "30m",
  "threshold": 10,
  "threshold_type": "below",
  "channel": {
    "type": "slack_webhook",
    "webhookId": "<WEBHOOK_ID>"
  },
  "source": "search",
  "savedSearchId": "<SAVED_SEARCH_ID>"
}
```