### PR TITLE
Fix UI rough edges on charts

### DIFF
--- a/packages/app/src/AutocompleteInput.tsx
+++ b/packages/app/src/AutocompleteInput.tsx
@@ -16,6 +16,7 @@ export default function AutocompleteInput({
   belowSuggestions,
   showSuggestionsOnEmpty,
   suggestionsHeader = 'Properties',
+  zIndex = 999,
 }: {
   inputRef: React.RefObject<HTMLInputElement>;
   value: string;
@@ -28,6 +29,7 @@ export default function AutocompleteInput({
   belowSuggestions?: React.ReactNode;
   showSuggestionsOnEmpty?: boolean;
   suggestionsHeader?: string;
+  zIndex?: number;
 }) {
   const suggestionsLimit = 10;
   const inputGroupRef = useRef<HTMLDivElement>(null);
@@ -96,7 +98,7 @@ export default function AutocompleteInput({
             ...style,
             maxWidth: inputGroupRef.current?.clientWidth ?? 720,
             width: '100%',
-            zIndex: 200000,
+            zIndex,
           }}
           {...props}
         >

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { add } from 'date-fns';
 import Select from 'react-select';
 import AsyncSelect from 'react-select/async';
-import { Divider, Group, Paper } from '@mantine/core';
+import { Divider, Group, Paper, SegmentedControl } from '@mantine/core';
 
 import { NumberFormatInput } from './components/NumberFormat';
 import api from './api';
@@ -793,6 +793,34 @@ export function TableSelect({
   );
 }
 
+export function TableToggle({
+  table,
+  setTableAndAggFn,
+}: {
+  setTableAndAggFn: (table: SourceTable, fn: AggFn) => void;
+  table: string;
+}) {
+  return (
+    <SegmentedControl
+      value={table}
+      onChange={(value: string) => {
+        const val = value ?? 'logs';
+        if (val === 'logs') {
+          setTableAndAggFn('logs', 'count');
+        } else if (val === 'metrics') {
+          // TODO: This should set rate if metric field is a sum
+          // or we should just reset the field if changing tables
+          setTableAndAggFn('metrics', 'max');
+        }
+      }}
+      data={[
+        { label: 'Logs/Spans', value: 'logs' },
+        { label: 'Metrics', value: 'metrics' },
+      ]}
+    />
+  );
+}
+
 export function GroupBySelect(
   props:
     | {
@@ -891,7 +919,7 @@ export function ChartSeriesFormCompact({
         style={{ rowGap: '1rem', columnGap: '1rem' }}
       >
         {setTableAndAggFn && (
-          <TableSelect
+          <TableToggle
             table={table ?? 'logs'}
             setTableAndAggFn={setTableAndAggFn}
           />
@@ -953,6 +981,7 @@ export function ChartSeriesFormCompact({
                 onChange={v => setWhere(v)}
                 onSearch={() => {}}
                 showHotkey={false}
+                zIndex={99999}
               />
             </div>
           </div>

--- a/packages/app/src/SearchInput.tsx
+++ b/packages/app/src/SearchInput.tsx
@@ -12,6 +12,7 @@ export default function SearchInput({
   placeholder = 'Search your events for anything...',
   showHotkey = true,
   size = 'lg',
+  zIndex,
 }: {
   inputRef: React.RefObject<HTMLInputElement>;
   value: string;
@@ -20,6 +21,7 @@ export default function SearchInput({
   placeholder?: string;
   showHotkey?: boolean;
   size?: 'sm' | 'lg';
+  zIndex: number;
 }) {
   const { data: propertyTypeMappingsResult } = api.usePropertyTypeMappings();
   const propertyTypeMappings = useMemo(() => {
@@ -58,6 +60,7 @@ export default function SearchInput({
       autocompleteOptions={propertyTypeMappings}
       showHotkey={showHotkey}
       size={size}
+      zIndex={zIndex}
       aboveSuggestions={
         <>
           <div className="text-muted fs-8 fw-bold me-1">Searching for:</div>

--- a/packages/app/src/SearchInput.tsx
+++ b/packages/app/src/SearchInput.tsx
@@ -21,7 +21,7 @@ export default function SearchInput({
   placeholder?: string;
   showHotkey?: boolean;
   size?: 'sm' | 'lg';
-  zIndex: number;
+  zIndex?: number;
 }) {
   const { data: propertyTypeMappingsResult } = api.usePropertyTypeMappings();
   const propertyTypeMappings = useMemo(() => {


### PR DESCRIPTION
- Disable metric line chart if series is missing metric name
- Allow where field autocomplete to show up properly with zindex
- One click toggle between metrics and logs/spans data source
<img width="682" alt="image" src="https://github.com/hyperdxio/hyperdx/assets/2781687/fa4aeb41-47ba-4121-81ad-3791acafed09">


- Draw dots for line charts if the series is non-continuous (UX duct tape for discontinuous series for now)

<img width="1421" alt="image" src="https://github.com/hyperdxio/hyperdx/assets/2781687/49290506-5416-4014-bebd-82023c26e9a4">
