### PR TITLE
refactor: metrics tags endpoints

### DIFF
--- a/.changeset/warm-berries-wash.md
+++ b/.changeset/warm-berries-wash.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+refactor + perf: decouple and performance opt metrics tags endpoints

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -615,7 +615,7 @@ export const getMetricsNames = async ({
         format('{} - {}', name, data_type) as name
       FROM ??
       WHERE (_timestamp_sort_key >= ? AND _timestamp_sort_key < ?)
-      AND (_created_at >= toDateTime(?) AND _created_at < toDateTime(?))
+      AND (_created_at >= fromUnixTimestamp64Milli(?) AND _created_at < fromUnixTimestamp64Milli(?))
       GROUP BY name, data_type
       ORDER BY name
     `,
@@ -623,8 +623,8 @@ export const getMetricsNames = async ({
       tableName,
       msToBigIntNs(startTime),
       msToBigIntNs(endTime),
-      startTime / 1000,
-      endTime / 1000,
+      startTime,
+      endTime,
     ],
   );
   const ts = Date.now();
@@ -678,7 +678,7 @@ export const getMetricsTags = async ({
       WHERE name = ?
       AND data_type = ?
       AND (_timestamp_sort_key >= ? AND _timestamp_sort_key < ?)
-      AND (_created_at >= toDateTime(?) AND _created_at < toDateTime(?))
+      AND (_created_at >= fromUnixTimestamp64Milli(?) AND _created_at < fromUnixTimestamp64Milli(?))
     `,
     [
       tableName,
@@ -686,8 +686,8 @@ export const getMetricsTags = async ({
       dataType,
       msToBigIntNs(startTime),
       msToBigIntNs(endTime),
-      startTime / 1000,
-      endTime / 1000,
+      startTime,
+      endTime,
     ],
   );
   const ts = Date.now();

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -766,6 +766,7 @@ export const getMetricsTags = async ({
         data_type,
         tags
       FROM (?)
+      ORDER BY name
     `,
     [SqlString.raw(unions)],
   );

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -679,6 +679,7 @@ export const getMetricsTags = async ({
       AND data_type = ?
       AND (_timestamp_sort_key >= ? AND _timestamp_sort_key < ?)
       AND (_created_at >= fromUnixTimestamp64Milli(?) AND _created_at < fromUnixTimestamp64Milli(?))
+      ORDER BY tag
     `,
     [
       tableName,

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -711,7 +711,10 @@ export const getMetricsTags = async ({
     query,
     took: Date.now() - ts,
   });
-  return result;
+  return {
+    ...result,
+    data: result.data.map(row => row.tag),
+  };
 };
 
 export const isRateAggFn = (aggFn: AggFn) => {

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -644,7 +644,6 @@ export const getMetricsNames = async ({
       is_delta: boolean;
       is_monotonic: boolean;
       name: string;
-      tags: Record<string, string>[];
       unit: string;
     }>
   >();

--- a/packages/api/src/routers/api/__tests__/metrics.test.ts
+++ b/packages/api/src/routers/api/__tests__/metrics.test.ts
@@ -47,27 +47,32 @@ describe('metrics router', () => {
       }),
     );
 
-    const resp = await clickhouse.client.query({
-      query: 'select _timestamp_sort_key from metric_stream',
-      format: 'JSONEachRow',
-    });
-
     const names = await agent.get('/metrics/names').expect(200);
-    expect(names.body.data).toEqual([
-      {
-        is_delta: false,
-        is_monotonic: false,
-        unit: 'Percent',
-        data_type: 'Gauge',
-        name: 'test.cpu - Gauge',
-      },
-    ]);
+    expect(names.body.data).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "data_type": "Gauge",
+    "is_delta": false,
+    "is_monotonic": false,
+    "name": "test.cpu - Gauge",
+    "unit": "Percent",
+  },
+]
+`);
     const tags = await agent
       .get('/metrics/tags?name=test.cpu&dataType=Gauge')
       .expect(200);
-    expect(tags.body.data).toEqual([
-      { tag: { host: 'host2', foo2: 'bar2' } },
-      { tag: { host: 'host1', foo: 'bar' } },
-    ]);
+    expect(tags.body.data).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "foo": "bar",
+    "host": "host1",
+  },
+  Object {
+    "foo2": "bar2",
+    "host": "host2",
+  },
+]
+`);
   });
 });

--- a/packages/api/src/routers/api/__tests__/metrics.test.ts
+++ b/packages/api/src/routers/api/__tests__/metrics.test.ts
@@ -1,3 +1,5 @@
+import ms from 'ms';
+
 import * as clickhouse from '@/clickhouse';
 import { buildMetricSeries, getLoggedInAgent, getServer } from '@/fixtures';
 
@@ -16,7 +18,7 @@ describe('metrics router', () => {
     await server.stop();
   });
 
-  it('GET /metrics/tags', async () => {
+  it('GET /metrics/names + /metrics/tags', async () => {
     const { agent, team } = await getLoggedInAgent(server);
 
     const now = Date.now();
@@ -28,7 +30,7 @@ describe('metrics router', () => {
         is_monotonic: false,
         is_delta: false,
         unit: 'Percent',
-        points: [{ value: 1, timestamp: now }],
+        points: [{ value: 1, timestamp: now - ms('1d') }],
         team_id: team.id,
       }),
     );
@@ -40,30 +42,32 @@ describe('metrics router', () => {
         is_monotonic: false,
         is_delta: false,
         unit: 'Percent',
-        points: [{ value: 1, timestamp: now }],
+        points: [{ value: 1, timestamp: now - ms('1d') }],
         team_id: team.id,
       }),
     );
 
-    const results = await agent.get('/metrics/tags').expect(200);
-    expect(results.body.data).toEqual([
+    const resp = await clickhouse.client.query({
+      query: 'select _timestamp_sort_key from metric_stream',
+      format: 'JSONEachRow',
+    });
+
+    const names = await agent.get('/metrics/names').expect(200);
+    expect(names.body.data).toEqual([
       {
         is_delta: false,
         is_monotonic: false,
         unit: 'Percent',
         data_type: 'Gauge',
         name: 'test.cpu - Gauge',
-        tags: [
-          {
-            foo2: 'bar2',
-            host: 'host2',
-          },
-          {
-            foo: 'bar',
-            host: 'host1',
-          },
-        ],
       },
+    ]);
+    const tags = await agent
+      .get('/metrics/tags?name=test.cpu&dataType=Gauge')
+      .expect(200);
+    expect(tags.body.data).toEqual([
+      { tag: { host: 'host2', foo2: 'bar2' } },
+      { tag: { host: 'host1', foo: 'bar' } },
     ]);
   });
 });

--- a/packages/api/src/routers/api/__tests__/metrics.test.ts
+++ b/packages/api/src/routers/api/__tests__/metrics.test.ts
@@ -101,12 +101,18 @@ Array [
     expect(tags.body.data).toMatchInlineSnapshot(`
 Array [
   Object {
-    "foo": "bar",
-    "host": "host1",
-  },
-  Object {
-    "foo2": "bar2",
-    "host": "host2",
+    "data_type": "Gauge",
+    "name": "test.cpu - Gauge",
+    "tags": Array [
+      Object {
+        "foo2": "bar2",
+        "host": "host2",
+      },
+      Object {
+        "foo": "bar",
+        "host": "host1",
+      },
+    ],
   },
 ]
 `);
@@ -131,8 +137,28 @@ Array [
     expect(tags.body.data).toMatchInlineSnapshot(`
 Array [
   Object {
-    "foo2": "bar2",
-    "host": "host2",
+    "data_type": "Gauge",
+    "name": "test.cpu - Gauge",
+    "tags": Array [
+      Object {
+        "foo2": "bar2",
+        "host": "host2",
+      },
+      Object {
+        "foo": "bar",
+        "host": "host1",
+      },
+    ],
+  },
+  Object {
+    "data_type": "Gauge",
+    "name": "test.cpu2 - Gauge",
+    "tags": Array [
+      Object {
+        "foo2": "bar2",
+        "host": "host2",
+      },
+    ],
   },
 ]
 `);

--- a/packages/api/src/routers/api/metrics.ts
+++ b/packages/api/src/routers/api/metrics.ts
@@ -30,9 +30,9 @@ router.get('/names', async (req, res, next) => {
           teamId: teamId.toString(),
         }),
       result => {
-        // if (result.rows != null) {
-        //   return result.rows > 0;
-        // }
+        if (result.rows != null) {
+          return result.rows > 0;
+        }
         return false;
       },
     );
@@ -76,9 +76,9 @@ router.get(
             teamId: teamId.toString(),
           }),
         result => {
-          // if (result.rows != null) {
-          //   return result.rows > 0;
-          // }
+          if (result.rows != null) {
+            return result.rows > 0;
+          }
           return false;
         },
       );

--- a/packages/api/src/routers/api/metrics.ts
+++ b/packages/api/src/routers/api/metrics.ts
@@ -9,7 +9,7 @@ import { SimpleCache } from '@/utils/redis';
 
 const router = express.Router();
 
-router.get('/tags', async (req, res, next) => {
+router.get('/names', async (req, res, next) => {
   try {
     const teamId = req.user?.team;
     if (teamId == null) {
@@ -18,21 +18,21 @@ router.get('/tags', async (req, res, next) => {
 
     const nowInMs = Date.now();
     const simpleCache = new SimpleCache<
-      Awaited<ReturnType<typeof clickhouse.getMetricsTags>>
+      Awaited<ReturnType<typeof clickhouse.getMetricsNames>>
     >(
-      `metrics-tags-${teamId}`,
+      `metrics-names-${teamId}`,
       ms('10m'),
       () =>
-        clickhouse.getMetricsTags({
+        clickhouse.getMetricsNames({
           // FIXME: fix it 5 days ago for now
           startTime: nowInMs - ms('5d'),
           endTime: nowInMs,
           teamId: teamId.toString(),
         }),
       result => {
-        if (result.rows != null) {
-          return result.rows > 0;
-        }
+        // if (result.rows != null) {
+        //   return result.rows > 0;
+        // }
         return false;
       },
     );
@@ -44,6 +44,53 @@ router.get('/tags', async (req, res, next) => {
     next(e);
   }
 });
+
+router.get(
+  '/tags',
+  validateRequest({
+    query: z.object({
+      name: z.string().min(1).max(1024),
+      dataType: z.nativeEnum(clickhouse.MetricsDataType),
+    }),
+  }),
+  async (req, res, next) => {
+    try {
+      const teamId = req.user?.team;
+      if (teamId == null) {
+        return res.sendStatus(403);
+      }
+      const { name, dataType } = req.query;
+      const nowInMs = Date.now();
+      const simpleCache = new SimpleCache<
+        Awaited<ReturnType<typeof clickhouse.getMetricsTags>>
+      >(
+        `metrics-tags-${teamId}`,
+        ms('10m'),
+        () =>
+          clickhouse.getMetricsTags({
+            dataType,
+            name,
+            // FIXME: fix it 5 days ago for now
+            startTime: nowInMs - ms('5d'),
+            endTime: nowInMs,
+            teamId: teamId.toString(),
+          }),
+        result => {
+          // if (result.rows != null) {
+          //   return result.rows > 0;
+          // }
+          return false;
+        },
+      );
+      res.json(await simpleCache.get());
+    } catch (e) {
+      const span = opentelemetry.trace.getActiveSpan();
+      span?.recordException(e as Error);
+      span?.setStatus({ code: SpanStatusCode.ERROR });
+      next(e);
+    }
+  },
+);
 
 router.post(
   '/chart',

--- a/packages/api/src/routers/external-api/__tests__/v1.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/v1.test.ts
@@ -27,21 +27,11 @@ describe('external api v1', () => {
     expect(resp.body.user._id).toEqual(user?._id.toString());
   });
 
-  it('GET /api/v1/metrics/tags', async () => {
-    jest.spyOn(clickhouse, 'getMetricsTags').mockResolvedValueOnce({
+  it('GET /api/v1/metrics/names', async () => {
+    jest.spyOn(clickhouse, 'getMetricsNames').mockResolvedValueOnce({
       data: [
         {
           name: 'system.filesystem.usage - Sum',
-          tags: [
-            {
-              device: '/dev/vda1',
-              host: 'unknown',
-              mode: 'rw',
-              mountpoint: '/etc/resolv.conf',
-              state: 'reserved',
-              type: 'ext4',
-            },
-          ],
           data_type: 'Sum',
         },
       ],
@@ -63,7 +53,7 @@ describe('external api v1', () => {
     } as any);
     const { agent, user } = await getLoggedInAgent(server);
     const resp = await agent
-      .get(`/api/v1/metrics/tags`)
+      .get(`/api/v1/metrics/names`)
       .set('Authorization', `Bearer ${user?.accessKey}`)
       .expect(200);
 
@@ -72,16 +62,6 @@ describe('external api v1', () => {
       data: [
         {
           name: 'system.filesystem.usage',
-          tags: [
-            {
-              device: '/dev/vda1',
-              host: 'unknown',
-              mode: 'rw',
-              mountpoint: '/etc/resolv.conf',
-              state: 'reserved',
-              type: 'ext4',
-            },
-          ],
           type: 'Sum',
         },
       ],

--- a/packages/api/src/routers/external-api/__tests__/v1.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/v1.test.ts
@@ -67,7 +67,7 @@ describe('external api v1', () => {
       .set('Authorization', `Bearer ${user?.accessKey}`)
       .expect(200);
 
-    expect(clickhouse.getMetricsTags).toBeCalledTimes(1);
+    expect(clickhouse.getMetricsNames).toBeCalledTimes(1);
     expect(resp.body).toEqual({
       data: [
         {

--- a/packages/api/src/routers/external-api/__tests__/v1.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/v1.test.ts
@@ -27,11 +27,21 @@ describe('external api v1', () => {
     expect(resp.body.user._id).toEqual(user?._id.toString());
   });
 
-  it('GET /api/v1/metrics/names', async () => {
-    jest.spyOn(clickhouse, 'getMetricsNames').mockResolvedValueOnce({
+  it('GET /api/v1/metrics/tags', async () => {
+    jest.spyOn(clickhouse, 'getMetricsTagsDEPRECATED').mockResolvedValueOnce({
       data: [
         {
           name: 'system.filesystem.usage - Sum',
+          tags: [
+            {
+              device: '/dev/vda1',
+              host: 'unknown',
+              mode: 'rw',
+              mountpoint: '/etc/resolv.conf',
+              state: 'reserved',
+              type: 'ext4',
+            },
+          ],
           data_type: 'Sum',
         },
       ],
@@ -53,15 +63,25 @@ describe('external api v1', () => {
     } as any);
     const { agent, user } = await getLoggedInAgent(server);
     const resp = await agent
-      .get(`/api/v1/metrics/names`)
+      .get(`/api/v1/metrics/tags`)
       .set('Authorization', `Bearer ${user?.accessKey}`)
       .expect(200);
 
-    expect(clickhouse.getMetricsNames).toBeCalledTimes(1);
+    expect(clickhouse.getMetricsTagsDEPRECATED).toBeCalledTimes(1);
     expect(resp.body).toEqual({
       data: [
         {
           name: 'system.filesystem.usage',
+          tags: [
+            {
+              device: '/dev/vda1',
+              host: 'unknown',
+              mode: 'rw',
+              mountpoint: '/etc/resolv.conf',
+              state: 'reserved',
+              type: 'ext4',
+            },
+          ],
           type: 'Sum',
         },
       ],

--- a/packages/api/src/routers/external-api/v1/index.ts
+++ b/packages/api/src/routers/external-api/v1/index.ts
@@ -212,16 +212,15 @@ router.get(
           return false;
         },
       );
-      const tags = await simpleCache.get();
+      const names = await simpleCache.get();
       res.json({
-        data: tags.data.map(tag => ({
+        data: names.data.map(name => ({
           // FIXME: unify the return type of both internal and external APIs
-          name: tag.name.split(' - ')[0], // FIXME: we want to separate name and data type into two columns
-          type: tag.data_type,
-          tags: tag.tags,
+          name: name.name.split(' - ')[0], // FIXME: we want to separate name and data type into two columns
+          type: name.data_type,
         })),
-        meta: tags.meta,
-        rows: tags.rows,
+        meta: names.meta,
+        rows: names.rows,
       });
     } catch (e) {
       const span = opentelemetry.trace.getActiveSpan();

--- a/packages/api/src/routers/external-api/v1/index.ts
+++ b/packages/api/src/routers/external-api/v1/index.ts
@@ -182,7 +182,7 @@ router.get(
 );
 
 router.get(
-  '/metrics/tags',
+  '/metrics/names',
   getDefaultRateLimiter(),
   validateUserAccessKey,
   async (req, res, next) => {
@@ -194,12 +194,12 @@ router.get(
 
       const nowInMs = Date.now();
       const simpleCache = new SimpleCache<
-        Awaited<ReturnType<typeof clickhouse.getMetricsTags>>
+        Awaited<ReturnType<typeof clickhouse.getMetricsNames>>
       >(
-        `metrics-tags-${teamId}`,
+        `metrics-names-${teamId}`,
         ms('10m'),
         () =>
-          clickhouse.getMetricsTags({
+          clickhouse.getMetricsNames({
             // FIXME: fix it 5 days ago for now
             startTime: nowInMs - ms('5d'),
             endTime: nowInMs,

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -251,20 +251,18 @@ function useMetricTagOptions({ metricNames }: { metricNames?: string[] }) {
 
   const options = useMemo(() => {
     const tags = metricTagsData?.data ?? [];
-    const tagNameValueSet = new Set<string>();
+    const tagNameSet = new Set<string>();
     tags.forEach(tag => {
-      Object.entries(tag).forEach(([name, value]) =>
-        tagNameValueSet.add(`${name}:"${value}"`),
-      );
+      Object.entries(tag).forEach(([name]) => tagNameSet.add(name));
     });
     return [
       { value: undefined, label: 'None' },
-      ...Array.from(tagNameValueSet).map(tagName => ({
+      ...Array.from(tagNameSet).map(tagName => ({
         value: tagName,
         label: tagName,
       })),
     ];
-  }, [metricTagsData, metricNames]);
+  }, [metricTagsData]);
 
   return options;
 }

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -243,7 +243,7 @@ export function usePropertyOptions(types: ('number' | 'string' | 'bool')[]) {
 }
 
 function useMetricTagOptions({ metricNames }: { metricNames?: string[] }) {
-  const { data: metricTagsData } = api.useMetricsTags();
+  const { data: metricTagsData } = api.useMetricsNames();
 
   const options = useMemo(() => {
     let tagNameSet = new Set<string>();
@@ -338,7 +338,7 @@ export function MetricSelect({
   setMetricName: (value: string | undefined) => void;
 }) {
   // TODO: Dedup with metric rate checkbox
-  const { data: metricTagsData, isLoading, isError } = api.useMetricsTags();
+  const { data: metricTagsData, isLoading, isError } = api.useMetricsNames();
 
   const aggFnWithMaybeRate = (aggFn: AggFn, isRate: boolean) => {
     if (isRate) {
@@ -396,7 +396,7 @@ export function MetricRateSelect({
   setIsRate: (isRate: boolean) => void;
   metricName: string | undefined | null;
 }) {
-  const { data: metricTagsData } = api.useMetricsTags();
+  const { data: metricTagsData } = api.useMetricsNames();
 
   const metricType = useMemo(() => {
     return metricTagsData?.data?.find(metric => metric.name === metricName)
@@ -431,7 +431,7 @@ export function MetricNameSelect({
   isLoading?: boolean;
   isError?: boolean;
 }) {
-  const { data: metricTagsData } = api.useMetricsTags();
+  const { data: metricTagsData } = api.useMetricsNames();
 
   const options = useMemo(() => {
     return (

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -338,7 +338,7 @@ export function MetricSelect({
   setMetricName: (value: string | undefined) => void;
 }) {
   // TODO: Dedup with metric rate checkbox
-  const { data: metricTagsData, isLoading, isError } = api.useMetricsNames();
+  const { data: metricNamesData, isLoading, isError } = api.useMetricsNames();
 
   const aggFnWithMaybeRate = (aggFn: AggFn, isRate: boolean) => {
     if (isRate) {
@@ -364,7 +364,7 @@ export function MetricSelect({
           isError={isError}
           value={metricName}
           setValue={name => {
-            const metricType = metricTagsData?.data?.find(
+            const metricType = metricNamesData?.data?.find(
               metric => metric.name === name,
             )?.data_type;
 
@@ -396,12 +396,12 @@ export function MetricRateSelect({
   setIsRate: (isRate: boolean) => void;
   metricName: string | undefined | null;
 }) {
-  const { data: metricTagsData } = api.useMetricsNames();
+  const { data: metricNamesData } = api.useMetricsNames();
 
   const metricType = useMemo(() => {
-    return metricTagsData?.data?.find(metric => metric.name === metricName)
+    return metricNamesData?.data?.find(metric => metric.name === metricName)
       ?.data_type;
-  }, [metricTagsData, metricName]);
+  }, [metricNamesData, metricName]);
 
   return (
     <>
@@ -431,16 +431,16 @@ export function MetricNameSelect({
   isLoading?: boolean;
   isError?: boolean;
 }) {
-  const { data: metricTagsData } = api.useMetricsNames();
+  const { data: metricNamesData } = api.useMetricsNames();
 
   const options = useMemo(() => {
     return (
-      metricTagsData?.data?.map(entry => ({
+      metricNamesData?.data?.map(entry => ({
         value: entry.name,
         label: entry.name,
       })) ?? []
     );
-  }, [metricTagsData]);
+  }, [metricNamesData]);
 
   return (
     <AsyncSelect

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -262,8 +262,6 @@ function useMetricTagOptions({ metricNames }: { metricNames?: string[] }) {
         Object.keys(tag).forEach(tagName => tagNameSet.add(tagName));
       });
 
-      console.log(tags);
-
       for (let i = 1; i < metricNames.length; i++) {
         const tags =
           metricTagsData?.data?.filter(

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -250,11 +250,37 @@ function useMetricTagOptions({ metricNames }: { metricNames?: string[] }) {
   const { data: metricTagsData } = api.useMetricsTags(metrics);
 
   const options = useMemo(() => {
-    const tags = metricTagsData?.data ?? [];
-    const tagNameSet = new Set<string>();
-    tags.forEach(tag => {
-      Object.entries(tag).forEach(([name]) => tagNameSet.add(name));
-    });
+    let tagNameSet = new Set<string>();
+    if (metricNames != null && metricNames.length > 0) {
+      const firstMetricName = metricNames[0]; // Start the set
+
+      const tags =
+        metricTagsData?.data?.filter(
+          metric => metric.name === firstMetricName,
+        )?.[0]?.tags ?? [];
+      tags.forEach(tag => {
+        Object.keys(tag).forEach(tagName => tagNameSet.add(tagName));
+      });
+
+      console.log(tags);
+
+      for (let i = 1; i < metricNames.length; i++) {
+        const tags =
+          metricTagsData?.data?.filter(
+            metric => metric.name === metricNames[i],
+          )?.[0]?.tags ?? [];
+        const intersection = new Set<string>();
+        tags.forEach(tag => {
+          Object.keys(tag).forEach(tagName => {
+            if (tagNameSet.has(tagName)) {
+              intersection.add(tagName);
+            }
+          });
+        });
+        tagNameSet = intersection;
+      }
+    }
+
     return [
       { value: undefined, label: 'None' },
       ...Array.from(tagNameSet).map(tagName => ({

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -31,7 +31,9 @@ export default function MetricTagFilterInput({
   ]);
 
   const options = useMemo(() => {
-    const tags = metricTagsData?.data ?? [];
+    const tags =
+      metricTagsData?.data?.filter(metric => metric.name === metricName)?.[0]
+        ?.tags ?? [];
     const tagNameValueSet = new Set<string>();
     tags.forEach(tag => {
       Object.entries(tag).forEach(([name, value]) =>

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
 import api from './api';
 import AutocompleteInput from './AutocompleteInput';
+import { legacyMetricNameToNameAndDataType } from './utils';
 
 export default function MetricTagFilterInput({
   inputRef,
@@ -20,21 +21,21 @@ export default function MetricTagFilterInput({
   size?: 'sm' | 'lg';
   metricName?: string;
 }) {
-  const { data: metricTagsData } = api.useMetricsNames();
+  const { name: mName, dataType: mDataType } =
+    legacyMetricNameToNameAndDataType(metricName);
+  const { data: metricTagsData } = api.useMetricsTags({
+    name: mName,
+    dataType: mDataType,
+  });
 
   const options = useMemo(() => {
-    const tags =
-      metricTagsData?.data?.filter(metric => metric.name === metricName)?.[0]
-        ?.tags ?? [];
-
+    const tags = (metricTagsData?.data ?? []).map(row => row.tag);
     const tagNameValueSet = new Set<string>();
-
     tags.forEach(tag => {
       Object.entries(tag).forEach(([name, value]) =>
         tagNameValueSet.add(`${name}:"${value}"`),
       );
     });
-
     return Array.from(tagNameValueSet).map(tagName => ({
       value: tagName,
       label: tagName,

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -29,7 +29,7 @@ export default function MetricTagFilterInput({
   });
 
   const options = useMemo(() => {
-    const tags = (metricTagsData?.data ?? []).map(row => row.tag);
+    const tags = metricTagsData?.data ?? [];
     const tagNameValueSet = new Set<string>();
     tags.forEach(tag => {
       Object.entries(tag).forEach(([name, value]) =>

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -23,10 +23,12 @@ export default function MetricTagFilterInput({
 }) {
   const { name: mName, dataType: mDataType } =
     legacyMetricNameToNameAndDataType(metricName);
-  const { data: metricTagsData } = api.useMetricsTags({
-    name: mName,
-    dataType: mDataType,
-  });
+  const { data: metricTagsData } = api.useMetricsTags([
+    {
+      name: mName,
+      dataType: mDataType,
+    },
+  ]);
 
   const options = useMemo(() => {
     const tags = metricTagsData?.data ?? [];

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -42,7 +42,7 @@ export default function MetricTagFilterInput({
       value: tagName,
       label: tagName,
     }));
-  }, [metricTagsData, metricName]);
+  }, [metricTagsData]);
 
   return (
     <AutocompleteInput
@@ -55,6 +55,7 @@ export default function MetricTagFilterInput({
       size={size}
       showSuggestionsOnEmpty
       suggestionsHeader="Tags"
+      zIndex={9999}
     />
   );
 }

--- a/packages/app/src/MetricTagFilterInput.tsx
+++ b/packages/app/src/MetricTagFilterInput.tsx
@@ -20,7 +20,7 @@ export default function MetricTagFilterInput({
   size?: 'sm' | 'lg';
   metricName?: string;
 }) {
-  const { data: metricTagsData } = api.useMetricsTags();
+  const { data: metricTagsData } = api.useMetricsNames();
 
   const options = useMemo(() => {
     const tags =

--- a/packages/app/src/MetricTagValueSelect.tsx
+++ b/packages/app/src/MetricTagValueSelect.tsx
@@ -23,10 +23,12 @@ export default function MetricTagValueSelect({
   const { name: mName, dataType: mDataType } =
     legacyMetricNameToNameAndDataType(metricName);
   const { data: metricTagsData, isLoading: isMetricTagsLoading } =
-    api.useMetricsTags({
-      name: mName,
-      dataType: mDataType,
-    });
+    api.useMetricsTags([
+      {
+        name: mName,
+        dataType: mDataType,
+      },
+    ]);
 
   const options = useMemo(() => {
     const tags = metricTagsData?.data ?? [];

--- a/packages/app/src/MetricTagValueSelect.tsx
+++ b/packages/app/src/MetricTagValueSelect.tsx
@@ -31,7 +31,9 @@ export default function MetricTagValueSelect({
     ]);
 
   const options = useMemo(() => {
-    const tags = metricTagsData?.data ?? [];
+    const tags =
+      metricTagsData?.data?.filter(metric => metric.name === metricName)?.[0]
+        ?.tags ?? [];
     const tagNameValueSet = new Set<string>();
     tags.forEach(tag => {
       Object.entries(tag).forEach(([name, value]) =>

--- a/packages/app/src/MetricTagValueSelect.tsx
+++ b/packages/app/src/MetricTagValueSelect.tsx
@@ -20,7 +20,7 @@ export default function MetricTagValueSelect({
   onChange: (value: string) => void;
 } & Partial<React.ComponentProps<typeof Select>>) {
   const { data: metricTagsData, isLoading: isMetricTagsLoading } =
-    api.useMetricsTags();
+    api.useMetricsNames();
 
   const options = useMemo(() => {
     const tags =

--- a/packages/app/src/MetricTagValueSelect.tsx
+++ b/packages/app/src/MetricTagValueSelect.tsx
@@ -29,7 +29,7 @@ export default function MetricTagValueSelect({
     });
 
   const options = useMemo(() => {
-    const tags = (metricTagsData?.data ?? []).map(row => row.tag);
+    const tags = metricTagsData?.data ?? [];
     const tagNameValueSet = new Set<string>();
     tags.forEach(tag => {
       Object.entries(tag).forEach(([name, value]) =>

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -111,13 +111,12 @@ const api = {
         }).json(),
     });
   },
-  useMetricsTags({
-    name,
-    dataType,
-  }: {
-    name: string;
-    dataType: MetricsDataType;
-  }) {
+  useMetricsTags(
+    metrics: {
+      name: string;
+      dataType: MetricsDataType;
+    }[],
+  ) {
     return useQuery<
       {
         data: Record<string, string>[];
@@ -125,14 +124,13 @@ const api = {
       Error
     >({
       refetchOnWindowFocus: false,
-      queryKey: ['metrics/tags', name, dataType],
+      queryKey: ['metrics/tags', metrics],
       queryFn: () =>
         server('metrics/tags', {
-          method: 'GET',
-          searchParams: [
-            ['name', name],
-            ['dataType', dataType],
-          ],
+          method: 'POST',
+          json: {
+            metrics,
+          },
         }).json(),
     });
   },

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -18,6 +18,7 @@ import type {
   ChartSeries,
   Dashboard,
   LogView,
+  MetricsDataType,
   Session,
 } from './types';
 
@@ -107,6 +108,33 @@ const api = {
       queryFn: () =>
         server('metrics/names', {
           method: 'GET',
+        }).json(),
+    });
+  },
+  useMetricsTags({
+    name,
+    dataType,
+  }: {
+    name: string;
+    dataType: MetricsDataType;
+  }) {
+    return useQuery<
+      {
+        data: {
+          tag: Record<string, string>;
+        }[];
+      },
+      Error
+    >({
+      refetchOnWindowFocus: false,
+      queryKey: ['metrics/tags', name, dataType],
+      queryFn: () =>
+        server('metrics/tags', {
+          method: 'GET',
+          searchParams: [
+            ['name', name],
+            ['dataType', dataType],
+          ],
         }).json(),
     });
   },

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -119,7 +119,11 @@ const api = {
   ) {
     return useQuery<
       {
-        data: Record<string, string>[];
+        data: {
+          name: string;
+          data_type: string;
+          tags: Record<string, string>[];
+        }[];
       },
       Error
     >({

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -89,21 +89,23 @@ const api = {
       },
     );
   },
-  useMetricsTags() {
+  useMetricsNames() {
     return useQuery<
       {
         data: {
-          name: string;
           data_type: string;
-          tags: Record<string, string>[];
+          is_delta: boolean;
+          is_monotonic: boolean;
+          name: string;
+          unit: string;
         }[];
       },
       Error
     >({
       refetchOnWindowFocus: false,
-      queryKey: ['metrics/tags'],
+      queryKey: ['metrics/names'],
       queryFn: () =>
-        server('metrics/tags', {
+        server('metrics/names', {
           method: 'GET',
         }).json(),
     });

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -120,9 +120,7 @@ const api = {
   }) {
     return useQuery<
       {
-        data: {
-          tag: Record<string, string>;
-        }[];
+        data: Record<string, string>[];
       },
       Error
     >({

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -198,6 +198,12 @@ export type AggFn =
 
 export type SourceTable = 'logs' | 'rrweb' | 'metrics';
 
+export enum MetricsDataType {
+  Gauge = 'Gauge',
+  Histogram = 'Histogram',
+  Sum = 'Sum',
+}
+
 export type TimeChartSeries = {
   displayName?: string;
   table: SourceTable;

--- a/packages/app/src/utils.tsx
+++ b/packages/app/src/utils.tsx
@@ -5,7 +5,7 @@ import numbro from 'numbro';
 import type { MutableRefObject } from 'react';
 
 import { dateRangeToString } from './timeQuery';
-import { NumberFormat, MetricsDataType } from './types';
+import { MetricsDataType, NumberFormat } from './types';
 
 export function generateSearchUrl({
   query,

--- a/packages/app/src/utils.tsx
+++ b/packages/app/src/utils.tsx
@@ -5,7 +5,7 @@ import numbro from 'numbro';
 import type { MutableRefObject } from 'react';
 
 import { dateRangeToString } from './timeQuery';
-import { NumberFormat } from './types';
+import { NumberFormat, MetricsDataType } from './types';
 
 export function generateSearchUrl({
   query,
@@ -443,4 +443,14 @@ export const formatUptime = (seconds: number) => {
   } else {
     return `${Math.floor(seconds / 60 / 60 / 24)}d`;
   }
+};
+
+// FIXME: eventually we want to separate metric name into two fields
+export const legacyMetricNameToNameAndDataType = (metricName?: string) => {
+  const [mName, mDataType] = (metricName ?? '').split(' - ');
+
+  return {
+    name: mName,
+    dataType: mDataType as MetricsDataType,
+  };
 };


### PR DESCRIPTION
1. endpoints to fetch metrics names and tags separately
2. performance improvement (use _created_at partition filtering)