### PR TITLE
Join on all keys in multi series chart

### DIFF
--- a/packages/api/src/clickhouse/__tests__/clickhouse.test.ts
+++ b/packages/api/src/clickhouse/__tests__/clickhouse.test.ts
@@ -851,9 +851,37 @@ Array [
     "ts_bucket": 1641341100,
   },
   Object {
+    "group": Array [
+      "test1",
+    ],
+    "series_0.data": 0,
+    "ts_bucket": 1641341400,
+  },
+  Object {
+    "group": Array [
+      "test2",
+    ],
+    "series_0.data": 0,
+    "ts_bucket": 1641341400,
+  },
+  Object {
     "group": Array [],
     "series_0.data": null,
     "ts_bucket": 1641341400,
+  },
+  Object {
+    "group": Array [
+      "test1",
+    ],
+    "series_0.data": 0,
+    "ts_bucket": 1641341700,
+  },
+  Object {
+    "group": Array [
+      "test2",
+    ],
+    "series_0.data": 0,
+    "ts_bucket": 1641341700,
   },
   Object {
     "group": Array [],


### PR DESCRIPTION
Previously, we'd only join on the first series groupby values, which can lead to groups being dropped if it didn't exist in series_0. This will allow groups from all series to be included in the final result.

We still need to make some improvements to the 0 fill and `join_use_nulls` (and let the user opt in to whether they want to get null values back or 0 values back when values are missing)