### PR TITLE
Alert silencing v0

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -168,6 +168,7 @@ services:
       CLICKHOUSE_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
       CLICKHOUSE_PASSWORD: worker
       CLICKHOUSE_USER: worker
+      EXPRESS_SESSION_SECRET: 'hyperdx is cool 👋'
       FRONTEND_URL: 'http://localhost:8080' # need to be localhost (CORS)
       HDX_NODE_ADVANCED_NETWORK_CAPTURE: 1
       HDX_NODE_BETA_MODE: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       CLICKHOUSE_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
       CLICKHOUSE_PASSWORD: worker
       CLICKHOUSE_USER: worker
+      EXPRESS_SESSION_SECRET: 'hyperdx is cool 👋'
       FRONTEND_URL: ${HYPERDX_APP_URL}:${HYPERDX_APP_PORT} # need to be localhost (CORS)
       HDX_NODE_ADVANCED_NETWORK_CAPTURE: 1
       HDX_NODE_BETA_MODE: 0

--- a/packages/api/src/models/alert.ts
+++ b/packages/api/src/models/alert.ts
@@ -34,6 +34,7 @@ export interface IAlert {
   channel: AlertChannel;
   cron: string;
   interval: AlertInterval;
+  silencedUntil?: Date;
   source?: AlertSource;
   state: AlertState;
   team: ObjectId;
@@ -80,6 +81,10 @@ const AlertSchema = new Schema<IAlert>(
       required: true,
     },
     channel: Schema.Types.Mixed, // slack, email, etc
+    silencedUntil: {
+      type: Date,
+      required: false,
+    },
     state: {
       type: String,
       enum: AlertState,

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -7,6 +7,7 @@ import {
   createAlert,
   deleteAlert,
   getAlertsWithLogViewAndDashboard,
+  silenceAlertFromTokenAndTeam,
   updateAlert,
   validateGroupByProperty,
 } from '@/controllers/alerts';
@@ -106,6 +107,7 @@ router.get('/', async (req, res, next) => {
             'chartId',
             'createdAt',
             'updatedAt',
+            'silencedUntil',
           ]),
         };
       }),
@@ -184,6 +186,28 @@ router.delete(
 
       await deleteAlert(alertId, teamId);
       res.sendStatus(200);
+    } catch (e) {
+      next(e);
+    }
+  },
+);
+
+router.post(
+  '/silence',
+  validateRequest({
+    body: z.object({
+      token: z.string().max(512).min(1),
+    }),
+  }),
+  async (req, res, next) => {
+    try {
+      const teamId = req.user?.team;
+      if (teamId == null) {
+        return res.sendStatus(403);
+      }
+
+      await silenceAlertFromTokenAndTeam(req.body.token, teamId);
+      res.json({});
     } catch (e) {
       next(e);
     }

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -132,8 +132,13 @@ function AlertDetails({ alert }: { alert: AlertData }) {
     return '';
   }, [alert]);
 
-  const silencedUntilDate = new Date(alert.silencedUntil);
-  const isSilenced = silencedUntilDate.getTime() > Date.now();
+  const silencedUntilDate = alert.silencedUntil
+    ? new Date(alert.silencedUntil)
+    : undefined;
+  const isSilenced =
+    silencedUntilDate != null
+      ? silencedUntilDate.getTime() > Date.now()
+      : undefined;
 
   return (
     <div className={styles.alertRow}>
@@ -148,10 +153,11 @@ function AlertDetails({ alert }: { alert: AlertData }) {
           <Badge
             color="gray"
             size="sm"
-            title={`Acknowledged, silenced until ${formatRelative(
-              silencedUntilDate,
-              new Date(),
-            )}`}
+            title={`Acknowledged, silenced until ${
+              silencedUntilDate
+                ? formatRelative(silencedUntilDate, new Date())
+                : ''
+            }`}
           >
             Ack
           </Badge>

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -577,6 +577,14 @@ const api = {
       }),
     );
   },
+  useSilenceAlert() {
+    return useMutation<any, Error, { token: string }>(`alerts`, async token =>
+      server(`alerts/silence`, {
+        method: 'POST',
+        json: token,
+      }).json(),
+    );
+  },
   useLogHistogram(
     q: string,
     startDate: Date,

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -96,6 +96,7 @@ export type Alert = {
   timezone?: string;
   type: AlertType;
   source: AlertSource;
+  silencedUntil?: string;
 
   // Log alerts
   logView?: string;


### PR DESCRIPTION
- Allows creation of an alert token, a 1 hour valid JWT tied to a specific alert (ensures you can't accidentally silence an alert from an old token). To be inserted into the alert message itself (once that stabilizes a bit more)
- Allows user to visit a URL with the alert token in the URL param that silences the alert, currently also verifies user auth as well, but that's not necessary.
- Silenced alerts will default silence for 30m.
- Skips sending alerts when the alert is silenced.