### PR TITLE
fix: Fix empty state for HDXSpanPerformanceBarChart

### DIFF
--- a/packages/app/src/HDXListBarChart.tsx
+++ b/packages/app/src/HDXListBarChart.tsx
@@ -256,16 +256,16 @@ export const HDXSpanPerformanceBarChart = memo(
     };
 
     return isLoading ? (
-      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
+      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-slate-400">
         Loading Chart Data...
       </div>
     ) : isError ? (
-      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
+      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-slate-400">
         Error loading chart, please try again or contact support.
       </div>
-    ) : data?.data?.length === 0 ? (
-      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
-        No data found within time range.
+    ) : rows?.length === 0 ? (
+      <div className="d-flex h-100 w-100 align-items-center justify-content-center text-slate-400">
+        No children spans recorded for this route
       </div>
     ) : (
       <Box className="overflow-auto" h="100%">


### PR DESCRIPTION
![Screenshot 2024-03-03 at 10 41 37 PM](https://github.com/hyperdxio/hyperdx/assets/149748269/039fed8a-8af9-45ad-bc59-f5ed14afaa35)
