### PR TITLE
feat: alert template message pt6

### DIFF
--- a/packages/api/src/tasks/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/__tests__/checkAlerts.test.ts
@@ -146,6 +146,7 @@ describe('checkAlerts', () => {
   });
 
   it('expandToNestedObject', () => {
+    expect(expandToNestedObject({}).__proto__).toBeUndefined();
     expect(expandToNestedObject({})).toEqual({});
     expect(expandToNestedObject({ foo: 'bar' })).toEqual({ foo: 'bar' });
     expect(expandToNestedObject({ 'foo.bar': 'baz' })).toEqual({

--- a/packages/api/src/tasks/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/__tests__/checkAlerts.test.ts
@@ -24,6 +24,7 @@ import {
   buildLogSearchLink,
   doesExceedThreshold,
   escapeJsonValues,
+  expandToNestedObject,
   getDefaultExternalAction,
   injectIntoPlaceholders,
   processAlert,
@@ -142,6 +143,46 @@ describe('checkAlerts', () => {
     expect(doesExceedThreshold(true, 10, 10)).toBe(true);
     expect(doesExceedThreshold(false, 10, 9)).toBe(true);
     expect(doesExceedThreshold(false, 10, 10)).toBe(false);
+  });
+
+  it('expandToNestedObject', () => {
+    expect(expandToNestedObject({})).toEqual({});
+    expect(expandToNestedObject({ foo: 'bar' })).toEqual({ foo: 'bar' });
+    expect(expandToNestedObject({ 'foo.bar': 'baz' })).toEqual({
+      foo: { bar: 'baz' },
+    });
+    expect(expandToNestedObject({ 'foo.bar.baz': 'qux' })).toEqual({
+      foo: { bar: { baz: 'qux' } },
+    });
+    // mix
+    expect(
+      expandToNestedObject({
+        'foo.bar.baz': 'qux',
+        'foo.bar.quux': 'quuz',
+        'foo1.bar1.baz1': 'qux1',
+      }),
+    ).toEqual({
+      foo: { bar: { baz: 'qux', quux: 'quuz' } },
+      foo1: { bar1: { baz1: 'qux1' } },
+    });
+    // overwriting
+    expect(
+      expandToNestedObject({ 'foo.bar.baz': 'qux', 'foo.bar': 'quuz' }),
+    ).toEqual({
+      foo: { bar: 'quuz' },
+    });
+    // max depth
+    expect(
+      expandToNestedObject(
+        {
+          'foo.bar.baz.qux.quuz.quux': 'qux',
+        },
+        '.',
+        3,
+      ),
+    ).toEqual({
+      foo: { bar: { baz: {} } },
+    });
   });
 
   describe('Alert Templates', () => {
@@ -532,8 +573,8 @@ describe('checkAlerts', () => {
 
       await renderAlertTemplate({
         template: `
-{{#is_match "k8s.pod.name" "otel-collector-123"}}
-  Runbook URL: {{attributes.runbookUrl}}
+{{#is_match "attributes.k8s.pod.name" "otel-collector-123"}}
+  Runbook URL: {{attributes.runbook.url}}
   hi i matched
   @slack_webhook-My_Web
 {{/is_match}}
@@ -549,8 +590,14 @@ describe('checkAlerts', () => {
             },
           },
           attributes: {
-            runbookUrl: 'https://example.com',
-            'k8s.pod.name': 'otel-collector-123',
+            runbook: {
+              url: 'https://example.com',
+            },
+            k8s: {
+              pod: {
+                name: 'otel-collector-123',
+              },
+            },
           },
         },
         title: 'Alert for "My Search" - 10 lines found',
@@ -563,7 +610,7 @@ describe('checkAlerts', () => {
       // @slack_webhook should not be called
       await renderAlertTemplate({
         template:
-          '{{#is_match "host" "web"}} @slack_webhook-My_Web {{/is_match}}', // partial name should work
+          '{{#is_match "attributes.host" "web"}} @slack_webhook-My_Web {{/is_match}}', // partial name should work
         view: {
           ...defaultSearchView,
           alert: {

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -115,7 +115,7 @@ export const expandToNestedObject = (
   separator = '.',
   maxDepth = 10,
 ) => {
-  const result: Record<string, any> = Object.create(null); // An object NOT inheriting from `Object.prototype
+  const result: Record<string, any> = Object.create(null); // An object NOT inheriting from `Object.prototype`
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const keys = key.split(separator);
@@ -459,7 +459,7 @@ export const renderAlertTemplate = async ({
       targetValue: string,
       options: HelperOptions,
     ) {
-      if (_.get(view, targetKey) === targetValue) {
+      if (_.has(view, targetKey) && _.get(view, targetKey) === targetValue) {
         if (shouldRender) {
           return options.fn(this);
         } else {

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -115,7 +115,7 @@ export const expandToNestedObject = (
   separator = '.',
   maxDepth = 10,
 ) => {
-  const result: Record<string, any> = {};
+  const result: Record<string, any> = Object.create(null); // An object NOT inheriting from `Object.prototype
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const keys = key.split(separator);

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -4,13 +4,13 @@
 import * as fns from 'date-fns';
 import * as fnsTz from 'date-fns-tz';
 import Handlebars, { HelperOptions } from 'handlebars';
-import PromisedHandlebars from 'promised-handlebars';
 import _ from 'lodash';
+import { escapeRegExp, isString } from 'lodash';
 import mongoose from 'mongoose';
 import ms from 'ms';
-import { URLSearchParams } from 'url';
-import { escapeRegExp, isString } from 'lodash';
+import PromisedHandlebars from 'promised-handlebars';
 import { serializeError } from 'serialize-error';
+import { URLSearchParams } from 'url';
 import { z } from 'zod';
 
 import * as clickhouse from '@/clickhouse';

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -115,7 +115,7 @@ export const expandToNestedObject = (
   separator = '.',
   maxDepth = 10,
 ) => {
-  const result = {};
+  const result: Record<string, any> = {};
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const keys = key.split(separator);
@@ -145,7 +145,7 @@ export const expandToNestedObject = (
 type AlertMessageTemplateDefaultView = {
   // FIXME: do we want to include groupBy in the external alert schema?
   alert: z.infer<typeof externalAlertSchema> & { groupBy?: string };
-  attributes: Record<string, string>;
+  attributes: ReturnType<typeof expandToNestedObject>;
   dashboard: ReturnType<
     typeof translateDashboardDocumentToExternalDashboard
   > | null;


### PR DESCRIPTION
users should be able to use the same path expression (with `.`) for all template helpers or within handlebar