### PR TITLE
User can remove users/Invites from team settings

### DIFF
--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -20,6 +20,15 @@ export async function findUserByEmailInTeam(
   return User.findOne({ email, team });
 }
 
+export const deleteUserByIdAndTeam = async (
+  id: string,
+  team: string | ObjectId,
+) => {
+  const user = await User.findOneAndDelete({ _id: id, team }).lean();
+
+  return user;
+};
+
 export function findUsersByTeam(team: string | ObjectId) {
   return User.find({ team }).sort({ createdAt: 1 });
 }

--- a/packages/api/src/routers/api/__tests__/team.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.test.ts
@@ -29,6 +29,16 @@ Object {
   "allowedAuthMethods": Array [],
   "name": "fake@deploysentinel.com's Team",
   "sentryDSN": "",
+  "teamInvites": Array [],
+  "users": Array [
+    Object {
+      "_id": "${resp.body.users[0]._id}",
+      "email": "fake@deploysentinel.com",
+      "hasPasswordAuth": true,
+      "isCurrentUser": true,
+      "name": "fake@deploysentinel.com",
+    },
+  ],
 }
 `);
   });

--- a/packages/api/src/routers/api/__tests__/team.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.test.ts
@@ -1,8 +1,12 @@
 import _ from 'lodash';
 
-import { getLoggedInAgent, getServer } from '@/fixtures';
 import TeamInvite from '@/models/teamInvite';
 import User from '@/models/user';
+import {
+  getLoggedInAgent,
+  getLoggedInAgentWithInvite,
+  getServer,
+} from '@/fixtures';
 
 describe('team router', () => {
   const server = getServer();
@@ -162,5 +166,36 @@ Array [
   },
 ]
 `);
+  });
+
+  it('DELETE /team/user/:userId', async () => {
+    const { agent, team } = await getLoggedInAgent(server);
+
+    const user1 = await User.create({
+      email: 'user1@example.com',
+      team: team._id,
+    });
+
+    await agent.delete(`/team/user/${user1.id}`).expect(200);
+
+    const resp2 = await agent.get('/team').expect(200);
+
+    expect(resp2.body.users).toHaveLength(0);
+  });
+
+  it('DELETE /teamInvites/:teamInviteId', async () => {
+    const { agent, team } = await getLoggedInAgent(server);
+
+    const invite = await TeamInvite.create({
+      email: 'fake_invite@example.com',
+      name: 'Fake Invite',
+      teamId: team._id,
+    });
+
+    await agent.delete(`/team/teamInvites/${invite.id}`).expect(200);
+
+    const resp2 = await agent.get('/team/invitations').expect(200);
+
+    expect(resp2.body.data).toHaveLength(0);
   });
 });

--- a/packages/api/src/routers/api/__tests__/team.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.test.ts
@@ -29,15 +29,6 @@ Object {
   "allowedAuthMethods": Array [],
   "name": "fake@deploysentinel.com's Team",
   "sentryDSN": "",
-  "teamInvites": Array [],
-  "users": Array [
-    Object {
-      "email": "fake@deploysentinel.com",
-      "hasPasswordAuth": true,
-      "isCurrentUser": true,
-      "name": "fake@deploysentinel.com",
-    },
-  ],
 }
 `);
   });
@@ -88,17 +79,23 @@ Object {
     expect(resp.body.data).toMatchInlineSnapshot(`
 Array [
   Object {
+    "_id": "${resp.body.data[0]._id}",
     "email": "fake@deploysentinel.com",
     "hasPasswordAuth": true,
+    "isCurrentUser": true,
     "name": "fake@deploysentinel.com",
   },
   Object {
+    "_id": "${user1._id}",
     "email": "user1@example.com",
     "hasPasswordAuth": true,
+    "isCurrentUser": false,
   },
   Object {
+    "_id": "${user2._id}",
     "email": "user2@example.com",
     "hasPasswordAuth": true,
+    "isCurrentUser": false,
   },
 ]
 `);
@@ -173,7 +170,7 @@ Array [
 
     await agent.delete(`/team/member/${user1._id}`).expect(200);
 
-    const resp2 = await agent.get('/members').expect(200);
+    const resp2 = await agent.get('/team/members').expect(200);
 
     expect(resp2.body.data).toHaveLength(1);
   });

--- a/packages/api/src/routers/api/__tests__/team.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.test.ts
@@ -32,7 +32,6 @@ Object {
   "teamInvites": Array [],
   "users": Array [
     Object {
-      "_id": "${resp.body.users[0]._id}",
       "email": "fake@deploysentinel.com",
       "hasPasswordAuth": true,
       "isCurrentUser": true,
@@ -164,7 +163,7 @@ Array [
 `);
   });
 
-  it('DELETE /team/user/:userId', async () => {
+  it('DELETE /team/member/:userId', async () => {
     const { agent, team } = await getLoggedInAgent(server);
 
     const user1 = await User.create({
@@ -172,14 +171,14 @@ Array [
       team: team._id,
     });
 
-    await agent.delete(`/team/user/${user1._id}`).expect(200);
+    await agent.delete(`/team/member/${user1._id}`).expect(200);
 
-    const resp2 = await agent.get('/team').expect(200);
+    const resp2 = await agent.get('/members').expect(200);
 
-    expect(resp2.body.users).toHaveLength(0);
+    expect(resp2.body.data).toHaveLength(1);
   });
 
-  it('DELETE /invitations/:teamInviteId', async () => {
+  it('DELETE /team/invitation/:teamInviteId', async () => {
     const { agent, team } = await getLoggedInAgent(server);
 
     const invite = await TeamInvite.create({
@@ -189,7 +188,7 @@ Array [
       token: 'fake_token',
     });
 
-    await agent.delete(`/team/invitations/${invite._id}`).expect(200);
+    await agent.delete(`/team/invitation/${invite._id}`).expect(200);
 
     const resp2 = await agent.get('/team/invitations').expect(200);
 

--- a/packages/api/src/routers/api/__tests__/team.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.test.ts
@@ -1,12 +1,8 @@
 import _ from 'lodash';
 
+import { getLoggedInAgent, getServer } from '@/fixtures';
 import TeamInvite from '@/models/teamInvite';
 import User from '@/models/user';
-import {
-  getLoggedInAgent,
-  getLoggedInAgentWithInvite,
-  getServer,
-} from '@/fixtures';
 
 describe('team router', () => {
   const server = getServer();
@@ -176,23 +172,24 @@ Array [
       team: team._id,
     });
 
-    await agent.delete(`/team/user/${user1.id}`).expect(200);
+    await agent.delete(`/team/user/${user1._id}`).expect(200);
 
     const resp2 = await agent.get('/team').expect(200);
 
     expect(resp2.body.users).toHaveLength(0);
   });
 
-  it('DELETE /teamInvites/:teamInviteId', async () => {
+  it('DELETE /invitations/:teamInviteId', async () => {
     const { agent, team } = await getLoggedInAgent(server);
 
     const invite = await TeamInvite.create({
       email: 'fake_invite@example.com',
       name: 'Fake Invite',
       teamId: team._id,
+      token: 'fake_token',
     });
 
-    await agent.delete(`/team/teamInvites/${invite.id}`).expect(200);
+    await agent.delete(`/team/invitations/${invite._id}`).expect(200);
 
     const resp2 = await agent.get('/team/invitations').expect(200);
 

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import express from 'express';
 import pick from 'lodash/pick';
+import mongoose from 'mongoose';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
@@ -196,7 +197,9 @@ router.delete(
   '/users/:id',
   validateRequest({
     params: z.object({
-      id: z.string(),
+      id: z.string().refine(val => {
+        return mongoose.Types.ObjectId.isValid(val);
+      }),
     }),
   }),
   async (req, res, next) => {
@@ -224,7 +227,9 @@ router.delete(
   '/teamInvites/:id',
   validateRequest({
     params: z.object({
-      id: z.string(),
+      id: z.string().refine(val => {
+        return mongoose.Types.ObjectId.isValid(val);
+      }),
     }),
   }),
   async (req, res, next) => {

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -8,8 +8,8 @@ import { validateRequest } from 'zod-express-middleware';
 import * as config from '@/config';
 import { getTags, getTeam, rotateTeamApiKey } from '@/controllers/team';
 import {
+  deleteUserByIdAndTeam,
   findUserByEmail,
-  findUserByEmailInTeam,
   findUsersByTeam,
 } from '@/controllers/user';
 import TeamInvite from '@/models/teamInvite';
@@ -204,14 +204,10 @@ router.delete(
     try {
       const teamId = req.user?.team || '';
       const id = req.params.id;
-      const user = await findUserByEmailInTeam(id, teamId);
+      const user = await deleteUserByIdAndTeam(id, teamId);
 
       if (user == null) {
         throw new Error(`User ${id} not found`);
-      }
-
-      if (user) {
-        await user.deleteOne();
       }
 
       res.json({ message: 'User deleted' });

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -13,9 +13,9 @@ import {
   findUsersByTeam,
 } from '@/controllers/user';
 import TeamInvite from '@/models/teamInvite';
+import { Api404Error } from '@/utils/errors';
 import logger from '@/utils/logger';
 import { objectIdSchema } from '@/utils/zod';
-import { Api404Error } from '@/utils/errors';
 
 const router = express.Router();
 
@@ -238,7 +238,9 @@ router.delete(
       const deletedTeamInvite = await TeamInvite.findByIdAndDelete(id);
 
       if (deletedTeamInvite == null) {
-        throw new Api404Error('Team invite with the specified ID does not exist.');
+        throw new Api404Error(
+          'Team invite with the specified ID ' + 'does not exist.',
+        );
       }
     } catch (e) {
       next(e);

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -198,7 +198,7 @@ router.get('/tags', async (req, res, next) => {
 });
 
 router.delete(
-  '/users/:id',
+  '/member/:id',
   validateRequest({
     params: z.object({
       id: objectIdSchema,
@@ -222,7 +222,7 @@ router.delete(
 );
 
 router.delete(
-  '/invitations/:id',
+  '/invitation/:id',
   validateRequest({
     params: z.object({
       id: objectIdSchema,

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import express from 'express';
 import pick from 'lodash/pick';
-import mongoose from 'mongoose';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
@@ -15,6 +14,7 @@ import {
 } from '@/controllers/user';
 import TeamInvite from '@/models/teamInvite';
 import logger from '@/utils/logger';
+import { objectIdSchema } from '@/utils/zod';
 
 const router = express.Router();
 
@@ -197,9 +197,7 @@ router.delete(
   '/users/:id',
   validateRequest({
     params: z.object({
-      id: z.string().refine(val => {
-        return mongoose.Types.ObjectId.isValid(val);
-      }),
+      id: objectIdSchema,
     }),
   }),
   async (req, res, next) => {
@@ -227,9 +225,7 @@ router.delete(
   '/teamInvites/:id',
   validateRequest({
     params: z.object({
-      id: z.string().refine(val => {
-        return mongoose.Types.ObjectId.isValid(val);
-      }),
+      id: objectIdSchema,
     }),
   }),
   async (req, res, next) => {

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -167,6 +167,9 @@ router.get('/members', async (req, res, next) => {
     if (teamId == null) {
       throw new Error(`User ${req.user?._id} not associated with a team`);
     }
+    if (userId == null) {
+      throw new Error(`User has no id`);
+    }
     const teamUsers = await findUsersByTeam(teamId);
     res.json({
       data: teamUsers.map(user => ({
@@ -176,7 +179,7 @@ router.get('/members', async (req, res, next) => {
           'name',
           'hasPasswordAuth',
         ]),
-        isCurrentUser: userId ? user._id.equals(userId) : false,
+        isCurrentUser: user._id.equals(userId),
       })),
     });
   } catch (e) {

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -15,6 +15,7 @@ import {
 import TeamInvite from '@/models/teamInvite';
 import logger from '@/utils/logger';
 import { objectIdSchema } from '@/utils/zod';
+import { Api404Error } from '@/utils/errors';
 
 const router = express.Router();
 
@@ -168,7 +169,7 @@ router.get('/members', async (req, res, next) => {
       throw new Error(`User ${req.user?._id} not associated with a team`);
     }
     if (userId == null) {
-      throw new Error(`User has no id`);
+      throw new Api404Error('Request without user found');
     }
     const teamUsers = await findUsersByTeam(teamId);
     res.json({
@@ -237,7 +238,7 @@ router.delete(
       const deletedTeamInvite = await TeamInvite.findByIdAndDelete(id);
 
       if (deletedTeamInvite == null) {
-        throw new Error(`TeamInvite ${id} not found`);
+        throw new Api404Error('Team invite with the specified ID does not exist.');
       }
     } catch (e) {
       next(e);

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -203,11 +203,8 @@ router.delete(
     try {
       const id = req.params.id;
       const user = await findUserById(id);
-      const teamInvite = await TeamInvite.findOne({
-        _id: id,
-      });
 
-      if (user == null && teamInvite == null) {
+      if (user == null) {
         throw new Error(`User ${id} not found`);
       }
 
@@ -215,14 +212,37 @@ router.delete(
         await user.deleteOne();
       }
 
-      if (teamInvite) {
-        await teamInvite.deleteOne();
-      }
-
       res.json({ message: 'User deleted' });
     } catch (e) {
       next(e);
     }
+  },
+);
+
+router.delete(
+  '/teamInvites/:id',
+  validateRequest({
+    params: z.object({
+      id: z.string(),
+    }),
+  }),
+  async (req, res, next) => {
+    try {
+      const id = req.params.id;
+      const teamInvite = await TeamInvite.findOne({
+        _id: id,
+      });
+
+      if (teamInvite == null) {
+        throw new Error(`TeamInvite ${id} not found`);
+      }
+
+      await teamInvite.deleteOne();
+    } catch (e) {
+      next(e);
+    }
+
+    return res.json({ message: 'TeamInvite deleted' });
   },
 );
 

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -148,6 +148,7 @@ router.get('/invitations', async (req, res, next) => {
     );
     res.json({
       data: teamInvites.map(ti => ({
+        _id: ti._id,
         createdAt: ti.createdAt,
         email: ti.email,
         name: ti.name,
@@ -162,6 +163,7 @@ router.get('/invitations', async (req, res, next) => {
 router.get('/members', async (req, res, next) => {
   try {
     const teamId = req.user?.team;
+    const userId = req.user?._id;
     if (teamId == null) {
       throw new Error(`User ${req.user?._id} not associated with a team`);
     }
@@ -169,10 +171,12 @@ router.get('/members', async (req, res, next) => {
     res.json({
       data: teamUsers.map(user => ({
         ...pick(user.toJSON({ virtuals: true }), [
+          '_id',
           'email',
           'name',
           'hasPasswordAuth',
         ]),
+        isCurrentUser: userId ? user._id.equals(userId) : false,
       })),
     });
   } catch (e) {
@@ -218,7 +222,7 @@ router.delete(
 );
 
 router.delete(
-  '/teamInvites/:id',
+  '/invitations/:id',
   validateRequest({
     params: z.object({
       id: objectIdSchema,

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -9,7 +9,7 @@ import * as config from '@/config';
 import { getTags, getTeam, rotateTeamApiKey } from '@/controllers/team';
 import {
   findUserByEmail,
-  findUserById,
+  findUserByEmailInTeam,
   findUsersByTeam,
 } from '@/controllers/user';
 import TeamInvite from '@/models/teamInvite';
@@ -201,8 +201,9 @@ router.delete(
   }),
   async (req, res, next) => {
     try {
+      const teamId = req.user?.team || '';
       const id = req.params.id;
-      const user = await findUserById(id);
+      const user = await findUserByEmailInTeam(id, teamId);
 
       if (user == null) {
         throw new Error(`User ${id} not found`);

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -227,15 +227,11 @@ router.delete(
   async (req, res, next) => {
     try {
       const id = req.params.id;
-      const teamInvite = await TeamInvite.findOne({
-        _id: id,
-      });
+      const deletedTeamInvite = await TeamInvite.findByIdAndDelete(id);
 
-      if (teamInvite == null) {
+      if (deletedTeamInvite == null) {
         throw new Error(`TeamInvite ${id} not found`);
       }
-
-      await teamInvite.deleteOne();
     } catch (e) {
       next(e);
     }

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -15,7 +15,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { toast } from 'react-toastify';
 import { json } from '@codemirror/lang-json';
 import { tags as lt } from '@lezer/highlight';
-import { Alert } from '@mantine/core';
+import { Alert, Button as MButton } from '@mantine/core';
 import { createTheme } from '@uiw/codemirror-themes';
 import CodeMirror, { placeholder } from '@uiw/react-codemirror';
 
@@ -788,9 +788,10 @@ export default function TeamPage() {
                 {member.name} - {member.email} -
                 {member.hasPasswordAuth && ' Password Auth'}
                 {!member.isCurrentUser && (
-                  <Button
-                    variant="link"
-                    className="px-0 fs-7 ms-3"
+                  <MButton
+                    size="xs"
+                    variant="transparent"
+                    type="button"
                     onClick={() =>
                       setDeleteTeamMemberConfirmationModalData({
                         id: member._id,
@@ -799,7 +800,7 @@ export default function TeamPage() {
                     }
                   >
                     <i className="bi bi-x-square text-danger" />
-                  </Button>
+                  </MButton>
                 )}
               </div>
             ))}
@@ -816,18 +817,19 @@ export default function TeamPage() {
                     📋 Copy URL
                   </Button>
                 </CopyToClipboard>
-                <Button
-                  variant="link"
-                  className="px-0 fs-7 ms-3"
-                  onClick={() => {
+                <MButton
+                  size="xs"
+                  variant="transparent"
+                  type="button"
+                  onClick={() =>
                     setDeleteTeamMemberConfirmationModalData({
                       id: invitation._id,
                       email: invitation.email,
-                    });
-                  }}
+                    })
+                  }
                 >
                   <i className="bi bi-x-square text-danger" />
-                </Button>
+                </MButton>
               </div>
             ))}
           <div className="mt-3 mb-5">

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -124,7 +124,7 @@ export default function TeamPage() {
         {
           onSuccess: resp => {
             toast.success('Deleted team member');
-            refetchTeam();
+            refetchMembers();
           },
           onError: e => {
             e.response
@@ -155,7 +155,7 @@ export default function TeamPage() {
         {
           onSuccess: resp => {
             toast.success('Deleted team invite');
-            refetchTeam();
+            refetchInvitations();
           },
           onError: e => {
             e.response

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -35,8 +35,8 @@ export default function TeamPage() {
     deleteTeamMemberConfirmationModalData,
     setDeleteTeamMemberConfirmationModalData,
   ] = useState({
-    show: false,
-    email: '',
+    id: null,
+    email: null,
   });
   const [teamInviteModalShow, setTeamInviteModalShow] = useState(false);
   const [teamInviteUrl, setTeamInviteUrl] = useState('');
@@ -111,10 +111,10 @@ export default function TeamPage() {
     });
   };
 
-  const deleteTeamMemberAction = (userEmail: string) => {
-    if (userEmail) {
+  const deleteTeamMemberAction = (id: string) => {
+    if (id) {
       deleteTeamMember.mutate(
-        { userEmail: encodeURIComponent(userEmail) },
+        { userEmail: encodeURIComponent(id) },
         {
           onSuccess: resp => {
             toast.success('Deleted team member');
@@ -147,11 +147,11 @@ export default function TeamPage() {
     setRotateApiKeyConfirmationModalShow(false);
   };
 
-  const onConfirmDeleteTeamMember = (email: string) => {
-    deleteTeamMemberAction(email);
+  const onConfirmDeleteTeamMember = (id: string) => {
+    deleteTeamMemberAction(id);
     setDeleteTeamMemberConfirmationModalData({
-      show: false,
-      email: '',
+      id: null,
+      email: null,
     });
   };
 
@@ -734,11 +734,11 @@ export default function TeamPage() {
             centered
             onHide={() =>
               setDeleteTeamMemberConfirmationModalData({
-                show: false,
-                email: '',
+                id: null,
+                email: null,
               })
             }
-            show={deleteTeamMemberConfirmationModalData.show}
+            show={deleteTeamMemberConfirmationModalData.id != null}
             size="lg"
           >
             <Modal.Body className="bg-grey rounded">
@@ -755,8 +755,8 @@ export default function TeamPage() {
                 size="sm"
                 onClick={() =>
                   setDeleteTeamMemberConfirmationModalData({
-                    show: false,
-                    email: '',
+                    id: null,
+                    email: null,
                   })
                 }
               >
@@ -767,8 +767,9 @@ export default function TeamPage() {
                 className="mt-2 px-4 float-end"
                 size="sm"
                 onClick={() =>
+                  deleteTeamMemberConfirmationModalData.id &&
                   onConfirmDeleteTeamMember(
-                    deleteTeamMemberConfirmationModalData.email,
+                    deleteTeamMemberConfirmationModalData.id,
                   )
                 }
               >
@@ -792,7 +793,7 @@ export default function TeamPage() {
                     className="px-0 fs-7 ms-3"
                     onClick={() =>
                       setDeleteTeamMemberConfirmationModalData({
-                        show: true,
+                        id: member._id,
                         email: member.email,
                       })
                     }
@@ -820,7 +821,7 @@ export default function TeamPage() {
                   className="px-0 fs-7 ms-3"
                   onClick={() => {
                     setDeleteTeamMemberConfirmationModalData({
-                      show: true,
+                      id: invitation._id,
                       email: invitation.email,
                     });
                   }}

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -714,7 +714,7 @@ const api = {
   },
   useDeleteTeamInvite() {
     return useMutation<any, HTTPError, { id: string }>(async ({ id }) =>
-      server(`team/teamInvites/${id}`, {
+      server(`team/invitations/${id}`, {
         method: 'DELETE',
       }).json(),
     );

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -705,6 +705,14 @@ const api = {
       }).json(),
     );
   },
+  useDeleteTeamMember() {
+    return useMutation<any, HTTPError, { userEmail: string }>(
+      async ({ userEmail }) =>
+        server(`team/users/${userEmail}`, {
+          method: 'DELETE',
+        }).json(),
+    );
+  },
   useSaveTeamInvitation() {
     return useMutation<any, HTTPError, { name?: string; email: string }>(
       async ({ name, email }) =>

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -706,11 +706,17 @@ const api = {
     );
   },
   useDeleteTeamMember() {
-    return useMutation<any, HTTPError, { userEmail: string }>(
-      async ({ userEmail }) =>
-        server(`team/users/${userEmail}`, {
-          method: 'DELETE',
-        }).json(),
+    return useMutation<any, HTTPError, { userId: string }>(async ({ userId }) =>
+      server(`team/users/${userId}`, {
+        method: 'DELETE',
+      }).json(),
+    );
+  },
+  useDeleteTeamInvite() {
+    return useMutation<any, HTTPError, { id: string }>(async ({ id }) =>
+      server(`team/teamInvites/${id}`, {
+        method: 'DELETE',
+      }).json(),
     );
   },
   useSaveTeamInvitation() {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -707,7 +707,7 @@ const api = {
   },
   useDeleteTeamMember() {
     return useMutation<any, HTTPError, { userId: string }>(async ({ userId }) =>
-      server(`team/users/${userId}`, {
+      server(`team/member/${userId}`, {
         method: 'DELETE',
       }).json(),
     );


### PR DESCRIPTION
Currently, we are unable to delete a team member (whether they are authorized or pending an invitation). This PR primarily resolves this issue by adding a remove icon next to each member. Upon clicking it, a confirmation modal will pop up. After pressing confirm, the team member can be deleted.