### PR TITLE
perf: decouple team member + invitation services

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,7 +27,6 @@
     "extract-domain": "^2.4.1",
     "handlebars": "^4.7.8",
     "http-graceful-shutdown": "^3.1.13",
-    "isemail": "^3.2.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.7",

--- a/packages/api/src/controllers/team.ts
+++ b/packages/api/src/controllers/team.ts
@@ -41,12 +41,12 @@ export async function createTeam({ name }: { name: string }) {
   return team;
 }
 
-export function getTeam(id: string | ObjectId) {
+export function getTeam(id: string | ObjectId, fields?: string[]) {
   if (config.IS_LOCAL_APP_MODE) {
     return LOCAL_APP_TEAM;
   }
 
-  return Team.findById(id);
+  return Team.findById(id, fields);
 }
 
 export function getTeamByApiKey(apiKey: string) {

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import express from 'express';
-import isemail from 'isemail';
 import pick from 'lodash/pick';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';

--- a/packages/app/src/CreateLogAlertModal.tsx
+++ b/packages/app/src/CreateLogAlertModal.tsx
@@ -52,8 +52,6 @@ function AlertForm({
   onDeleteClick: () => void;
   query: string;
 }) {
-  const { data: team } = api.useTeam();
-
   const {
     register,
     handleSubmit,

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -53,7 +53,7 @@ export default function TeamPage() {
     api.useWebhooks(['slack']);
   const { data: genericWebhooks, refetch: refetchGenericWebhooks } =
     api.useWebhooks(['generic']);
-  const sendTeamInvite = api.useSendTeamInvite();
+  const saveTeamInvitation = api.useSaveTeamInvitation();
   const rotateTeamApiKey = api.useRotateTeamApiKey();
   const saveWebhook = api.useSaveWebhook();
   const deleteWebhook = api.useDeleteWebhook();
@@ -110,7 +110,7 @@ export default function TeamPage() {
 
   const sendTeamInviteAction = (email: string) => {
     if (email) {
-      sendTeamInvite.mutate(
+      saveTeamInvitation.mutate(
         { email },
         {
           onSuccess: resp => {

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -39,6 +39,16 @@ export default function TeamPage() {
     useState(false);
   const { data: me, isLoading: isLoadingMe } = api.useMe();
   const { data: team, isLoading, refetch: refetchTeam } = api.useTeam();
+  const {
+    data: members,
+    isLoading: isLoadingMembers,
+    refetch: refetchMembers,
+  } = api.useTeamMembers();
+  const {
+    data: invitations,
+    isLoading: isLoadingInvitations,
+    refetch: refetchInvitations,
+  } = api.useTeamInvitations();
   const { data: slackWebhooks, refetch: refetchSlackWebhooks } =
     api.useWebhooks(['slack']);
   const { data: genericWebhooks, refetch: refetchGenericWebhooks } =
@@ -107,7 +117,7 @@ export default function TeamPage() {
             toast.success(
               'Click "Copy URL" and share the URL with your team member',
             );
-            refetchTeam();
+            refetchInvitations();
           },
           onError: e => {
             e.response
@@ -673,28 +683,32 @@ export default function TeamPage() {
             </>
           )}
           <h2 className="mt-5">Team Members</h2>
-          {team.users.map((user: any) => (
-            <div key={user.email} className="mt-2">
-              {user.isCurrentUser && (
-                <span className="fw-bold text-primary">(You) </span>
-              )}
-              {user.name} - {user.email} -
-              {user.hasPasswordAuth && ' Password Auth'}
-            </div>
-          ))}
-          {team.teamInvites.map((teamInvite: any) => (
-            <div key={teamInvite.email} className="mt-2">
-              {teamInvite.email} - Pending Invite -
-              <CopyToClipboard text={teamInvite.url}>
-                <Button
-                  variant="link"
-                  className="px-0 text-muted-hover text-decoration-none fs-7 ms-3"
-                >
-                  📋 Copy URL
-                </Button>
-              </CopyToClipboard>
-            </div>
-          ))}
+          {!isLoadingMembers &&
+            Array.isArray(members.data) &&
+            members.data.map((member: any) => (
+              <div key={member.email} className="mt-2">
+                {member.isCurrentUser && (
+                  <span className="fw-bold text-primary">(You) </span>
+                )}
+                {member.name} - {member.email} -
+                {member.hasPasswordAuth && ' Password Auth'}
+              </div>
+            ))}
+          {!isLoadingInvitations &&
+            Array.isArray(invitations.data) &&
+            invitations.data.map((invitation: any) => (
+              <div key={invitation.email} className="mt-2">
+                {invitation.email} - Pending Invite -
+                <CopyToClipboard text={invitation.url}>
+                  <Button
+                    variant="link"
+                    className="px-0 text-muted-hover text-decoration-none fs-7 ms-3"
+                  >
+                    📋 Copy URL
+                  </Button>
+                </CopyToClipboard>
+              </div>
+            ))}
           <div className="mt-3 mb-5">
             <Button
               variant="secondary text-white"

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -730,6 +730,16 @@ const api = {
       retry: 1,
     });
   },
+  useTeamInvitations() {
+    return useQuery<any, HTTPError>(`team/invitations`, () =>
+      hdxServer(`team/invitations`).json(),
+    );
+  },
+  useTeamMembers() {
+    return useQuery<any, HTTPError>(`team/members`, () =>
+      hdxServer(`team/members`).json(),
+    );
+  },
   useTags() {
     return useQuery<{ data: string[] }, HTTPError>(`team/tags`, () =>
       hdxServer(`team/tags`).json<{ data: string[] }>(),

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -705,10 +705,10 @@ const api = {
       }).json(),
     );
   },
-  useSendTeamInvite() {
+  useSaveTeamInvitation() {
     return useMutation<any, HTTPError, { name?: string; email: string }>(
       async ({ name, email }) =>
-        hdxServer(`team`, {
+        hdxServer(`team/invitation`, {
           method: 'POST',
           json: {
             name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8865,13 +8865,6 @@ isarray@^2.0.5:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
-isemail@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
-  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
-  dependencies:
-    punycode "2.x.x"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -11847,7 +11840,7 @@ pstree.remy@^1.1.8:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==


### PR DESCRIPTION
The `/team` endpoint should only fetch team metadata instead of pulling both members and invites