### PR TITLE
perf: remove redundant otel-logs fields (`timestamp` + `spanID` + `traceID`)

### DIFF
--- a/.changeset/sweet-icons-boil.md
+++ b/.changeset/sweet-icons-boil.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+perf: remove redundant otel-logs fields (timestamp + spanID + traceID)

--- a/docker/ingestor/core.toml
+++ b/docker/ingestor/core.toml
@@ -462,12 +462,9 @@ if .hdx_platform == "vector-internal" {
         }
       } 
 
-      .r.timestamp = tmp_timestamp
-      .b.timestamp = tmp_timestamp
-
       .h = .b.host
       .sv = .b."service.name"
-      .ts = to_unix_timestamp(from_unix_timestamp(.b.timestamp, unit: "milliseconds") ?? now(), unit: "nanoseconds")
+      .ts = to_unix_timestamp(from_unix_timestamp(tmp_timestamp, unit: "milliseconds") ?? now(), unit: "nanoseconds")
       .b._hdx_body = .b.message
       structured = parse_json(.b.message) ?? null
       if is_object(structured) {
@@ -574,8 +571,14 @@ reroute_dropped = true
 source = '''
 # extract shared fields
 if is_object(.b) {
-  .s_id = string(del(.b.span_id)) ?? string(del(.b.spanID)) ?? null
-  .t_id = string(del(.b.trace_id)) ?? string(del(.b.traceID)) ?? null
+  # extract span/trace id
+  .s_id = string(.b.span_id) ?? string(.b.spanID) ?? null
+  .t_id = string(.b.trace_id) ?? string(.b.traceID) ?? null
+  del(.b.spanID)
+  del(.b.span_id)
+  del(.b.traceID)
+  del(.b.trace_id)
+
   .tso = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if is_nullish(.st) {


### PR DESCRIPTION
Before:
<img width="500" alt="Screenshot 2024-04-26 at 4 42 29 PM" src="https://github.com/hyperdxio/hyperdx/assets/5959690/74654fcd-faac-4837-8866-25f6e3e3e69e">

After:
<img width="498" alt="Screenshot 2024-04-26 at 4 41 37 PM" src="https://github.com/hyperdxio/hyperdx/assets/5959690/9c34893f-d9f6-442d-a877-e04ea319471c">
