### PR TITLE
fix: Disallow usage of translation in app

### DIFF
--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -187,6 +187,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
           content="width=device-width, initial-scale=0.75"
         />
         <meta name="theme-color" content="#25292e"></meta>
+        <meta name="google" content="notranslate" />
         <ColorSchemeScript forceColorScheme="dark" />
       </Head>
 

--- a/packages/app/src/Spotlights.tsx
+++ b/packages/app/src/Spotlights.tsx
@@ -160,7 +160,7 @@ export const HDXSpotlightProvider = ({
   const { actions } = useSpotlightActions();
 
   return (
-    <>
+    <div className="notranslate" translate="no">
       {children}
       <Spotlight
         shortcut="mod + K"
@@ -176,6 +176,6 @@ export const HDXSpotlightProvider = ({
         limit={7}
         scrollable
       />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Translating app with Chrome Translate breaks react renders and causes the page to crash:

https://github.com/facebook/react/issues/11538