### PR TITLE
fix: aggregator should return 413 (Content Too Large) to make ingestor ARC work properly

### DIFF
--- a/.changeset/honest-ears-allow.md
+++ b/.changeset/honest-ears-allow.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+fix: aggregator should return 413 (Content Too Large) to make ingestor ARC work
+properly

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -81,6 +81,7 @@ services:
     # ports:
     #   - 9000:9000
     environment:
+      AGGREGATOR_PAYLOAD_SIZE_LIMIT: '64mb'
       APP_TYPE: 'api'
       CLICKHOUSE_HOST: http://ch_server:8123
       CLICKHOUSE_PASSWORD: api

--- a/packages/api/src/utils/errors.ts
+++ b/packages/api/src/utils/errors.ts
@@ -1,6 +1,7 @@
 export enum StatusCode {
   BAD_REQUEST = 400,
   CONFLICT = 409,
+  CONTENT_TOO_LARGE = 413,
   FORBIDDEN = 403,
   INTERNAL_SERVER = 500,
   NOT_FOUND = 404,


### PR DESCRIPTION
500 errors will cause ingestors to slow down due to ARC (https://vector.dev/docs/reference/configuration/sinks/http/#request.adaptive_concurrency), which is good.
However, for case like 413 (due to aggregator payload size limit), ingestors shouldn't slow down and be blocked.
The fix here is to return the original status code so ARC will tune up the concurrency properly

Before:
Events buffer will be queued up and ingestors will be blocked (concurrency stays)

<img width="1170" alt="Screenshot 2024-07-08 at 4 46 10 PM" src="https://github.com/hyperdxio/hyperdx/assets/5959690/a149092a-b062-4508-b62b-a85116ac74b2">


Now:
Events buffer will be cleared out properly (concurrency increases) 

<img width="1237" alt="Screenshot 2024-07-08 at 4 43 22 PM" src="https://github.com/hyperdxio/hyperdx/assets/5959690/7871593b-0e2f-4a1e-960c-c27d90869514">

TODO: we want to revisit the error global handler to make sure the proper status code is returned
