### PR TITLE
Add multi-group-by support for event charts

### DIFF
--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -12,6 +12,7 @@ import {
 import { NumberFormatInput } from './components/NumberFormat';
 import api from './api';
 import Checkbox from './Checkbox';
+import FieldMultiSelect from './FieldMultiSelect';
 import MetricTagFilterInput from './MetricTagFilterInput';
 import SearchInput from './SearchInput';
 import { AggFn, ChartSeries, MetricsDataType, SourceTable } from './types';
@@ -930,12 +931,12 @@ export function ChartSeriesFormCompact({
 }: {
   aggFn: AggFn;
   field: string | undefined;
-  groupBy?: string | undefined;
+  groupBy?: string[] | undefined;
   setAggFn: (fn: AggFn) => void;
   setField: (field: string | undefined) => void;
   setFieldAndAggFn: (field: string | undefined, fn: AggFn) => void;
   setTableAndAggFn?: (table: SourceTable, fn: AggFn) => void;
-  setGroupBy?: (groupBy: string | undefined) => void;
+  setGroupBy?: (groupBy: string[] | undefined) => void;
   setSortOrder?: (sortOrder: SortOrder) => void;
   setWhere: (where: string) => void;
   sortOrder?: string;
@@ -1049,10 +1050,12 @@ export function ChartSeriesFormCompact({
           <div className="d-flex align-items-center">
             <div className="text-muted">Group By</div>
             <div className="ms-3 flex-grow-1" style={{ minWidth: 300 }}>
-              <GroupBySelect
-                groupBy={groupBy}
-                table={table}
-                setGroupBy={setGroupBy}
+              <FieldMultiSelect
+                types={['number', 'bool', 'string']}
+                values={groupBy ?? []}
+                setValues={(values: string[]) => {
+                  setGroupBy(values);
+                }}
               />
             </div>
           </div>
@@ -1093,10 +1096,10 @@ export function ChartSeriesFormCompact({
                 <div className="text-muted fw-500">Group By</div>
                 <div className="ms-3 flex-grow-1" style={{ minWidth: 300 }}>
                   <GroupBySelect
-                    groupBy={groupBy}
+                    groupBy={groupBy?.[0]}
                     fields={field != null ? [field] : []}
                     table={table}
-                    setGroupBy={setGroupBy}
+                    setGroupBy={g => setGroupBy(g != null ? [g] : undefined)}
                   />
                   {/* <MetricTagSelect
                     value={groupBy}

--- a/packages/app/src/EditChartForm.tsx
+++ b/packages/app/src/EditChartForm.tsx
@@ -29,6 +29,7 @@ import {
 import Checkbox from './Checkbox';
 import * as config from './config';
 import EditChartFormAlerts from './EditChartFormAlerts';
+import FieldMultiSelect from './FieldMultiSelect';
 import GranularityPicker from './GranularityPicker';
 import HDXHistogramChart from './HDXHistogramChart';
 import HDXMarkdownChart from './HDXMarkdownChart';
@@ -1002,7 +1003,7 @@ export const EditMultiSeriesChartForm = ({
               table={series.table ?? 'logs'}
               aggFn={series.aggFn}
               where={series.where}
-              groupBy={series.type !== 'number' ? series.groupBy[0] : undefined}
+              groupBy={series.type !== 'number' ? series.groupBy : undefined}
               field={series.field ?? ''}
               numberFormat={series.numberFormat}
               setAggFn={aggFn =>
@@ -1036,7 +1037,7 @@ export const EditMultiSeriesChartForm = ({
                             draftSeries.type !== 'number'
                           ) {
                             if (groupBy != undefined) {
-                              draftSeries.groupBy[0] = groupBy;
+                              draftSeries.groupBy = groupBy;
                             } else {
                               draftSeries.groupBy = [];
                             }
@@ -1091,33 +1092,58 @@ export const EditMultiSeriesChartForm = ({
           <Flex align="center" gap="md" mb="sm">
             <div className="text-muted">Group By</div>
             <div className="flex-grow-1">
-              <GroupBySelect
-                table={editedChart.series[0].table ?? 'logs'}
-                groupBy={editedChart.series[0].groupBy[0]}
-                fields={
-                  editedChart.series
-                    .map(s => (s as TimeChartSeries).field)
-                    .filter(f => f != null) as string[]
-                }
-                setGroupBy={groupBy => {
-                  setEditedChart(
-                    produce(editedChart, draft => {
-                      draft.series.forEach((series, i) => {
-                        if (
-                          series.type === chartType &&
-                          series.type !== 'number'
-                        ) {
-                          if (groupBy != undefined) {
-                            series.groupBy[0] = groupBy;
-                          } else {
-                            series.groupBy = [];
+              {editedChart.series[0].table === 'logs' ? (
+                <FieldMultiSelect
+                  types={['number', 'bool', 'string']}
+                  values={editedChart.series[0].groupBy}
+                  setValues={(values: string[]) => {
+                    setEditedChart(
+                      produce(editedChart, draft => {
+                        draft.series.forEach((series, i) => {
+                          if (
+                            series.type === chartType &&
+                            series.type !== 'number'
+                          ) {
+                            if (values != undefined) {
+                              series.groupBy = values;
+                            } else {
+                              series.groupBy = [];
+                            }
                           }
-                        }
-                      });
-                    }),
-                  );
-                }}
-              />
+                        });
+                      }),
+                    );
+                  }}
+                />
+              ) : (
+                <GroupBySelect
+                  table={editedChart.series[0].table ?? 'logs'}
+                  groupBy={editedChart.series[0].groupBy[0]}
+                  fields={
+                    editedChart.series
+                      .map(s => (s as TimeChartSeries).field)
+                      .filter(f => f != null) as string[]
+                  }
+                  setGroupBy={groupBy => {
+                    setEditedChart(
+                      produce(editedChart, draft => {
+                        draft.series.forEach((series, i) => {
+                          if (
+                            series.type === chartType &&
+                            series.type !== 'number'
+                          ) {
+                            if (groupBy != undefined) {
+                              series.groupBy[0] = groupBy;
+                            } else {
+                              series.groupBy = [];
+                            }
+                          }
+                        });
+                      }),
+                    );
+                  }}
+                />
+              )}
             </div>
           </Flex>
         )}
@@ -1267,10 +1293,10 @@ export const EditLineChartForm = ({
         : null,
     [_editedChart, alertEnabled, editedAlert?.interval, dateRange, granularity],
   );
-  const previewConfig = useDebounce(
-    withDashboardFilter(chartConfig, dashboardQuery),
-    500,
-  );
+  const chartConfigWithDashboardFilter = useMemo(() => {
+    return withDashboardFilter(chartConfig, dashboardQuery);
+  }, [chartConfig, dashboardQuery]);
+  const previewConfig = useDebounce(chartConfigWithDashboardFilter, 500);
 
   if (
     chartConfig == null ||

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -883,7 +883,10 @@ export const useMultiSeriesChartV2 = (
       },
     })
       .json()
-      .then((data: any) => setData(data as MultiSeriesChartResponse))
+      .then((data: any) => {
+        setData(data as MultiSeriesChartResponse);
+        setIsError(false);
+      })
       .catch(() => setIsError(true))
       .finally(() => {
         setIsLoading(false);


### PR DESCRIPTION
- use multi field selector for group by in event charts (we need to follow up w/ metrics, but that requires a new selector component)
- fixed a bug where multi-group-by requires same data type properties for events.
- fixed a bug where chart edit form will do excess re-rendering due to non-memo value passed into useDebounce
- fixed a regression where if a chart is in the error state, it'll be stuck with an error message even if the chart config changes to a valid one