### PR TITLE
fix: query to extract metrics names + Summary count UI label

### DIFF
--- a/.changeset/afraid-days-deny.md
+++ b/.changeset/afraid-days-deny.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+fix: query to extract metrics names

--- a/.changeset/funny-singers-give.md
+++ b/.changeset/funny-singers-give.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+style: Summary count UI label

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -676,7 +676,11 @@ export const getMetricsNames = async ({
         data_type,
         if(
           data_type = ?,
-          format('{} - {}', splitByChar('_', name)[1], data_type),
+          format(
+              '{} - {}',
+              replaceRegexpOne(name, '_[^_]+$', ''),
+              data_type
+          ),
           format('{} - {}', name, data_type)
         ) AS name
       FROM ??
@@ -750,7 +754,11 @@ export const getMetricsTags = async ({
         data_type,
         if(
           data_type = ?,
-          format('{} - {}', splitByChar('_', name)[1], data_type),
+          format(
+              '{} - {}',
+              replaceRegexpOne(name, '_[^_]+$', ''),
+              data_type
+          ),
           format('{} - {}', name, data_type)
         ) AS combined_name
       FROM ??

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -59,7 +59,7 @@ export const getMetricAggFns = (
       { value: 'sum', label: 'Sum' },
       { value: 'max', label: 'Maximum' },
       { value: 'min', label: 'Minimum' },
-      { value: 'count', label: 'Count' },
+      { value: 'count', label: 'Sample Count' },
     ];
   }
 


### PR DESCRIPTION
Fix the case when metric name is like 'ProcessedBytes_TCP_sum'