### PR TITLE
feat: support sum + count aggregation for histogram metrics + merge histogram metric name

### DIFF
--- a/.changeset/chatty-maps-march.md
+++ b/.changeset/chatty-maps-march.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/api': major
+'@hyperdx/app': major
+---
+
+feat: support sum + count aggregation for histogram metrics + merge histogram
+metric names

--- a/.changeset/chatty-maps-march.md
+++ b/.changeset/chatty-maps-march.md
@@ -1,6 +1,6 @@
 ---
-'@hyperdx/api': major
-'@hyperdx/app': major
+'@hyperdx/api': minor
+'@hyperdx/app': minor
 ---
 
 feat: support sum + count aggregation for histogram metrics + merge histogram

--- a/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
+++ b/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
@@ -117,7 +117,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_lower_bound',
+          name: 'test.two_timestamps_lower_bound_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -137,7 +137,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_lower_bound_inf',
+          name: 'test.two_timestamps_lower_bound_inf_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -157,7 +157,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_higher_bound',
+          name: 'test.two_timestamps_higher_bound_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -177,7 +177,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_higher_bound_inf',
+          name: 'test.two_timestamps_higher_bound_inf_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -197,7 +197,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_zero_offset',
+          name: 'test.two_timestamps_zero_offset_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -217,7 +217,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.two_timestamps_non_zero_offset',
+          name: 'test.two_timestamps_non_zero_offset_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -237,7 +237,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.three_timestamps',
+          name: 'test.three_timestamps_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -261,7 +261,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.three_timestamps_group_by',
+          name: 'test.three_timestamps_group_by_bucket',
           tags: { host: 'host-a', region: 'region-a' },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -285,7 +285,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.three_timestamps_group_by',
+          name: 'test.three_timestamps_group_by_bucket',
           tags: { host: 'host-b', region: 'region-a' },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -309,7 +309,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.four_timestamps',
+          name: 'test.four_timestamps_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -336,7 +336,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream(
         buildMetricSeries({
-          name: 'test.counter_reset_with_inconsistent_bucket_resolution',
+          name: 'test.counter_reset_with_inconsistent_bucket_resolution_bucket',
           tags: { host: 'test2', runId },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -367,7 +367,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
       ),
       clickhouse.bulkInsertTeamMetricStream([
         ...buildMetricSeries({
-          name: 'test.counter_might_reset',
+          name: 'test.counter_might_reset_bucket',
           tags: { host: 'host-a', region: 'region-a' },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,
@@ -397,7 +397,7 @@ describe('clickhouse - getMultiSeriesChart', () => {
           team_id: teamId,
         }),
         ...buildMetricSeries({
-          name: 'test.counter_might_reset',
+          name: 'test.counter_might_reset_bucket',
           tags: { host: 'host-b', region: 'region-a' },
           data_type: clickhouse.MetricsDataType.Histogram,
           is_monotonic: false,

--- a/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
+++ b/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
@@ -890,7 +890,7 @@ Array [
         tableVersion: undefined,
         teamId,
         startTime: now,
-        endTime: now + ms('2m'),
+        endTime: now + ms('3m'),
         granularity: '1 minute',
         maxNumGroups: 20,
         seriesReturnType: clickhouse.SeriesReturnType.Column,
@@ -915,7 +915,7 @@ Array [
         tableVersion: undefined,
         teamId,
         startTime: now,
-        endTime: now + ms('2m'),
+        endTime: now + ms('3m'),
         granularity: '1 minute',
         maxNumGroups: 20,
         seriesReturnType: clickhouse.SeriesReturnType.Column,
@@ -936,6 +936,11 @@ Array [
     "series_0.data": 2,
     "ts_bucket": 1641340860,
   },
+  Object {
+    "group": Array [],
+    "series_0.data": 3,
+    "ts_bucket": 1641340920,
+  },
 ]
 `);
 
@@ -950,6 +955,11 @@ Array [
     "group": Array [],
     "series_0.data": 2,
     "ts_bucket": 1641340860,
+  },
+  Object {
+    "group": Array [],
+    "series_0.data": 3,
+    "ts_bucket": 1641340920,
   },
 ]
 `);

--- a/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
+++ b/packages/api/src/clickhouse/__tests__/clickhouseGetMultiSeriesChart.test.ts
@@ -874,55 +874,104 @@ Array [
   });
 
   it('three_timestamps histogram (sum + count)', async () => {
-    const sumData = (
-      await clickhouse.getMultiSeriesChart({
-        series: [
-          {
-            type: 'time',
-            table: 'metrics',
-            aggFn: clickhouse.AggFn.Sum,
-            field: 'test.three_timestamps',
-            where: `runId:${runId}`,
-            groupBy: [],
-            metricDataType: clickhouse.MetricsDataType.Histogram,
-          },
-        ],
-        tableVersion: undefined,
-        teamId,
-        startTime: now,
-        endTime: now + ms('3m'),
-        granularity: '1 minute',
-        maxNumGroups: 20,
-        seriesReturnType: clickhouse.SeriesReturnType.Column,
-      })
-    ).data.map(d => {
-      return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
-    });
-
-    const countData = (
-      await clickhouse.getMultiSeriesChart({
-        series: [
-          {
-            type: 'time',
-            table: 'metrics',
-            aggFn: clickhouse.AggFn.Count,
-            field: 'test.three_timestamps',
-            where: `runId:${runId}`,
-            groupBy: [],
-            metricDataType: clickhouse.MetricsDataType.Histogram,
-          },
-        ],
-        tableVersion: undefined,
-        teamId,
-        startTime: now,
-        endTime: now + ms('3m'),
-        granularity: '1 minute',
-        maxNumGroups: 20,
-        seriesReturnType: clickhouse.SeriesReturnType.Column,
-      })
-    ).data.map(d => {
-      return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
-    });
+    const [sumData, sumRateData, countData, countRateData] = await Promise.all([
+      (
+        await clickhouse.getMultiSeriesChart({
+          series: [
+            {
+              type: 'time',
+              table: 'metrics',
+              aggFn: clickhouse.AggFn.Sum,
+              field: 'test.three_timestamps',
+              where: `runId:${runId}`,
+              groupBy: [],
+              metricDataType: clickhouse.MetricsDataType.Histogram,
+            },
+          ],
+          tableVersion: undefined,
+          teamId,
+          startTime: now,
+          endTime: now + ms('3m'),
+          granularity: '1 minute',
+          maxNumGroups: 20,
+          seriesReturnType: clickhouse.SeriesReturnType.Column,
+        })
+      ).data.map(d => {
+        return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
+      }),
+      (
+        await clickhouse.getMultiSeriesChart({
+          series: [
+            {
+              type: 'time',
+              table: 'metrics',
+              aggFn: clickhouse.AggFn.SumRate,
+              field: 'test.three_timestamps',
+              where: `runId:${runId}`,
+              groupBy: [],
+              metricDataType: clickhouse.MetricsDataType.Histogram,
+            },
+          ],
+          tableVersion: undefined,
+          teamId,
+          startTime: now,
+          endTime: now + ms('3m'),
+          granularity: '1 minute',
+          maxNumGroups: 20,
+          seriesReturnType: clickhouse.SeriesReturnType.Column,
+        })
+      ).data.map(d => {
+        return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
+      }),
+      (
+        await clickhouse.getMultiSeriesChart({
+          series: [
+            {
+              type: 'time',
+              table: 'metrics',
+              aggFn: clickhouse.AggFn.Count,
+              field: 'test.three_timestamps',
+              where: `runId:${runId}`,
+              groupBy: [],
+              metricDataType: clickhouse.MetricsDataType.Histogram,
+            },
+          ],
+          tableVersion: undefined,
+          teamId,
+          startTime: now,
+          endTime: now + ms('3m'),
+          granularity: '1 minute',
+          maxNumGroups: 20,
+          seriesReturnType: clickhouse.SeriesReturnType.Column,
+        })
+      ).data.map(d => {
+        return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
+      }),
+      (
+        await clickhouse.getMultiSeriesChart({
+          series: [
+            {
+              type: 'time',
+              table: 'metrics',
+              aggFn: clickhouse.AggFn.CountRate,
+              field: 'test.three_timestamps',
+              where: `runId:${runId}`,
+              groupBy: [],
+              metricDataType: clickhouse.MetricsDataType.Histogram,
+            },
+          ],
+          tableVersion: undefined,
+          teamId,
+          startTime: now,
+          endTime: now + ms('3m'),
+          granularity: '1 minute',
+          maxNumGroups: 20,
+          seriesReturnType: clickhouse.SeriesReturnType.Column,
+        })
+      ).data.map(d => {
+        return _.pick(d, ['group', 'series_0.data', 'ts_bucket']);
+      }),
+    ]);
 
     expect(sumData).toMatchInlineSnapshot(`
 Array [
@@ -943,6 +992,25 @@ Array [
   },
 ]
 `);
+    expect(sumRateData).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "group": Array [],
+    "series_0.data": 0,
+    "ts_bucket": 1641340800,
+  },
+  Object {
+    "group": Array [],
+    "series_0.data": 2,
+    "ts_bucket": 1641340860,
+  },
+  Object {
+    "group": Array [],
+    "series_0.data": 1,
+    "ts_bucket": 1641340920,
+  },
+]
+`);
 
     expect(countData).toMatchInlineSnapshot(`
 Array [
@@ -959,6 +1027,25 @@ Array [
   Object {
     "group": Array [],
     "series_0.data": 3,
+    "ts_bucket": 1641340920,
+  },
+]
+`);
+    expect(countRateData).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "group": Array [],
+    "series_0.data": 0,
+    "ts_bucket": 1641340800,
+  },
+  Object {
+    "group": Array [],
+    "series_0.data": 2,
+    "ts_bucket": 1641340860,
+  },
+  Object {
+    "group": Array [],
+    "series_0.data": 1,
     "ts_bucket": 1641340920,
   },
 ]

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -675,7 +675,7 @@ export const getMetricsNames = async ({
         any(unit) AS unit,
         data_type,
         if(
-          data_type = ?,
+          data_type IN (?),
           format(
               '{} - {}',
               replaceRegexpOne(name, '_[^_]+$', ''),
@@ -691,7 +691,7 @@ export const getMetricsNames = async ({
       ORDER BY name
     `,
     [
-      MetricsDataType.Summary,
+      [MetricsDataType.Summary, MetricsDataType.Histogram],
       tableName,
       Object.values(MetricsDataType),
       msToBigIntNs(startTime),
@@ -753,7 +753,7 @@ export const getMetricsTags = async ({
         groupUniqArray(_string_attributes) AS tags,
         data_type,
         if(
-          data_type = ?,
+          data_type IN (?),
           format(
               '{} - {}',
               replaceRegexpOne(name, '_[^_]+$', ''),
@@ -769,10 +769,12 @@ export const getMetricsTags = async ({
       GROUP BY name, data_type
     `,
         [
-          MetricsDataType.Summary,
+          [MetricsDataType.Summary, MetricsDataType.Histogram],
           tableName,
           SqlString.raw(
-            m.dataType === MetricsDataType.Summary
+            [MetricsDataType.Summary, MetricsDataType.Histogram].includes(
+              m.dataType,
+            )
               ? // FIXME: since the summary data type doesn't include the postfix
                 SqlString.format('name LIKE ?', [`${m.name}_%`])
               : SqlString.format('name = ?', [m.name]),

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -1146,12 +1146,12 @@ export const buildMetricSeriesQuery = async ({
     switch (aggFn) {
       case AggFn.Sum:
         name = `${name}_sum`;
-        gaugeMetricSelectClause.push('SUM(value) as value');
+        gaugeMetricSelectClause.push('LAST_VALUE(value) as value');
         selectClause.push('SUM(value) as data');
         break;
       case AggFn.Count:
         name = `${name}_count`;
-        gaugeMetricSelectClause.push('SUM(value) as value');
+        gaugeMetricSelectClause.push('LAST_VALUE(value) as value');
         selectClause.push('SUM(value) as data');
         break;
       case AggFn.P50:

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -1143,6 +1143,9 @@ export const buildMetricSeriesQuery = async ({
           })(${isRate ? 'rate' : 'value'}) as data`,
     );
   } else if (dataType === MetricsDataType.Histogram) {
+    // TODO: remove this (backward compatibility)
+    const isOlderVersion = name.endsWith('_bucket');
+
     switch (aggFn) {
       case AggFn.Sum:
         name = `${name}_sum`;
@@ -1156,19 +1159,19 @@ export const buildMetricSeriesQuery = async ({
         break;
       case AggFn.P50:
         isHistogram = true;
-        name = `${name}_bucket`;
+        name = isOlderVersion ? name : `${name}_bucket`;
         break;
       case AggFn.P90:
         isHistogram = true;
-        name = `${name}_bucket`;
+        name = isOlderVersion ? name : `${name}_bucket`;
         break;
       case AggFn.P95:
         isHistogram = true;
-        name = `${name}_bucket`;
+        name = isOlderVersion ? name : `${name}_bucket`;
         break;
       case AggFn.P99:
         isHistogram = true;
-        name = `${name}_bucket`;
+        name = isOlderVersion ? name : `${name}_bucket`;
         break;
       default:
         throw new Error(`Unsupported aggFn for Histogram: ${aggFn}`);

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -471,6 +471,8 @@ export function MetricRateSelect({
       ?.data_type;
   }, [metricNamesData, metricName]);
 
+  const isDisabled = metricType === MetricsDataType.Histogram;
+
   return (
     <>
       {metricType === MetricsDataType.Sum ||
@@ -482,6 +484,7 @@ export function MetricRateSelect({
           labelClassName="fs-7"
           checked={isRate}
           onChange={() => setIsRate(!isRate)}
+          disabled={isDisabled}
           label="Use Increase"
         />
       ) : null}

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -398,6 +398,12 @@ export function MetricSelect({
   // TODO: Dedup with metric rate checkbox
   const { data: metricNamesData, isLoading, isError } = api.useMetricsNames();
 
+  // TODO: depcrcate this (backward compatibility)
+  if (metricName?.endsWith('- Histogram')) {
+    // patch for old histogram metric names
+    metricName = metricName.replace('_bucket', '');
+  }
+
   const aggFnWithMaybeRate = (aggFn: AggFn, isRate: boolean) => {
     if (isRate) {
       if (aggFn.includes('_rate')) {

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -49,10 +49,12 @@ export const getMetricAggFns = (
 ): { value: AggFn; label: string }[] => {
   if (dataType === MetricsDataType.Histogram) {
     return [
+      { value: 'sum', label: 'Sum' },
       { value: 'p99', label: '99th Percentile' },
       { value: 'p95', label: '95th Percentile' },
       { value: 'p90', label: '90th Percentile' },
       { value: 'p50', label: 'Median' },
+      { value: 'count', label: 'Sample Count' },
     ];
   } else if (dataType === MetricsDataType.Summary) {
     return [

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -432,7 +432,11 @@ export function MetricSelect({
               metric => metric.name === name,
             )?.data_type;
 
-            const newAggFn = aggFnWithMaybeRate(aggFn, metricType === 'Sum');
+            const newAggFn = aggFnWithMaybeRate(
+              aggFn,
+              metricType === MetricsDataType.Sum ||
+                metricType === MetricsDataType.Histogram,
+            );
 
             setFieldAndAggFn(name, newAggFn);
           }}
@@ -469,7 +473,8 @@ export function MetricRateSelect({
 
   return (
     <>
-      {metricType === 'Sum' ? (
+      {metricType === MetricsDataType.Sum ||
+      metricType === MetricsDataType.Histogram ? (
         <Checkbox
           title="When checked, this calculates the increase of the Sum metric over each time bucket, accounting for counter resets. Recommended for Sum metrics as opposed to the raw value."
           id="metric-use-rate"

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -181,6 +181,7 @@ export type AggFn =
   | 'avg'
   | 'count_distinct'
   | 'count'
+  | 'count_rate'
   | 'count_per_sec'
   | 'count_per_min'
   | 'count_per_hour'


### PR DESCRIPTION
1. Support `sum` and `count` aggregation functions for querying Histogram metrics
2. Merge three types of old Histogram names (xxx_bucket, xxx_count, xxx_sum) into single one xxx

<img width="1156" alt="Screenshot 2024-08-07 at 3 50 34 PM" src="https://github.com/user-attachments/assets/fc26898f-baff-44c8-bd24-3a23a8bb43ad">

