### PR TITLE
chore: bump vector to v0.40.1

### DIFF
--- a/.changeset/loud-bottles-switch.md
+++ b/.changeset/loud-bottles-switch.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+chore: bump vector to v0.40.1

--- a/docker/ingestor/Dockerfile
+++ b/docker/ingestor/Dockerfile
@@ -1,5 +1,5 @@
 ## base #############################################################################################
-FROM timberio/vector:0.39.0-alpine AS base
+FROM timberio/vector:0.40.1-alpine AS base
 
 RUN mkdir -p /var/lib/vector
 VOLUME ["/var/lib/vector"]


### PR DESCRIPTION
https://vector.dev/releases/0.40.0/

https://vector.dev/releases/0.40.1/