### PR TITLE
Allow to set custom healthcheck endpoint path + app healthcheck

### DIFF
--- a/.changeset/mean-plums-jam.md
+++ b/.changeset/mean-plums-jam.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+Allow to set custom healthcheck endpoint path + app healthcheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       REDIS_URL: redis://redis:6379
       SERVER_URL: ${HYPERDX_API_URL}:${HYPERDX_API_PORT}
       USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
-      HEALTHCHECK_PATH: '/healthcheck'
+      HEALTHCHECK_PATH: '/health'
     networks:
       - internal
     depends_on:
@@ -195,7 +195,7 @@ services:
       HYPERDX_API_KEY: ${HYPERDX_API_KEY}
       NODE_ENV: development
       PORT: ${HYPERDX_APP_PORT}
-      HEALTHCHECK_PATH: '/healthcheck'
+      HEALTHCHECK_PATH: '/health'
     networks:
       - internal
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,7 @@ services:
       REDIS_URL: redis://redis:6379
       SERVER_URL: ${HYPERDX_API_URL}:${HYPERDX_API_PORT}
       USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
+      HEALTHCHECK_PATH: '/healthcheck'
     networks:
       - internal
     depends_on:
@@ -194,6 +195,7 @@ services:
       HYPERDX_API_KEY: ${HYPERDX_API_KEY}
       NODE_ENV: development
       PORT: ${HYPERDX_APP_PORT}
+      HEALTHCHECK_PATH: '/healthcheck'
     networks:
       - internal
     depends_on:

--- a/packages/api/src/routers/api/root.ts
+++ b/packages/api/src/routers/api/root.ts
@@ -43,7 +43,7 @@ const registrationSchema = z
 
 const router = express.Router();
 
-router.get('/health', async (req, res) => {
+router.get(process.env.HEALTHCHECK_PATH || '/healthcheck', async (req, res) => {
   res.send({ data: 'OK', version: config.CODE_VERSION, ip: req.ip });
 });
 

--- a/packages/api/src/routers/api/root.ts
+++ b/packages/api/src/routers/api/root.ts
@@ -43,7 +43,7 @@ const registrationSchema = z
 
 const router = express.Router();
 
-router.get(process.env.HEALTHCHECK_PATH || '/healthcheck', async (req, res) => {
+router.get(process.env.HEALTHCHECK_PATH || '/health', async (req, res) => {
   res.send({ data: 'OK', version: config.CODE_VERSION, ip: req.ip });
 });
 

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -32,9 +32,10 @@ ENV NEXT_PUBLIC_OTEL_SERVICE_NAME $OTEL_SERVICE_NAME
 ENV NEXT_PUBLIC_SERVER_URL $SERVER_URL
 
 COPY ./packages/app/tsconfig.json ./packages/app/next.config.js ./packages/app/mdx.d.ts ./packages/app/.eslintrc.js ./
-COPY ./packages/app/src ./src 
-COPY ./packages/app/pages ./pages 
-COPY ./packages/app/public ./public 
+COPY ./packages/app/middleware.ts ./
+COPY ./packages/app/src ./src
+COPY ./packages/app/pages ./pages
+COPY ./packages/app/public ./public
 COPY ./packages/app/styles ./styles
 COPY --from=base /app/node_modules ./node_modules
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline

--- a/packages/app/middleware.ts
+++ b/packages/app/middleware.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-const healthCheckUrl = process.env.HEALTHCHECK_PATH || '/healthcheck';
+const healthCheckUrl = process.env.HEALTHCHECK_PATH || '/health';
 
 export function middleware(request: NextRequest) {
   if (healthCheckUrl === request.nextUrl.pathname) {

--- a/packages/app/middleware.ts
+++ b/packages/app/middleware.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const healthCheckUrl = process.env.HEALTHCHECK_PATH || '/healthcheck';
+
+export function middleware(request: NextRequest) {
+  if (healthCheckUrl === request.nextUrl.pathname) {
+    return NextResponse.json({ data: 'ok' }, { status: 200 });
+  }
+
+  return NextResponse.next();
+}

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -23,6 +23,6 @@
       "@styles/*": ["styles/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "middleware.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Allow to set custom healthcheck endpoint path, add healthcheck to app

app endpoint is a bit tricky via middleware.
Not sure is there is an another way to use env variable without rebuilding image, so made it like this to make it work 100% via docker-compose env variables.