### PR TITLE
Move SERVER_URL to a nextjs runtime config.

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -23,6 +23,7 @@ module.exports = withNextra({
   swcMinify: false,
   publicRuntimeConfig: {
     version,
+    serverUrl: process.env.NEXT_PUBLIC_SERVER_URL
   },
   productionBrowserSourceMaps: false,
   ...(process.env.NEXT_OUTPUT_STANDALONE === 'true'

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -1,5 +1,10 @@
+import getConfig from 'next/config';
+
+const runtimeConfig = getConfig().publicRuntimeConfig;
 export const SERVER_URL =
-  process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:8000'; // NEXT_PUBLIC_SERVER_URL can be empty string
+  runtimeConfig.serverUrl ||
+  process.env.NEXT_PUBLIC_SERVER_URL ||
+  'http://localhost:8000'; // NEXT_PUBLIC_SERVER_URL can be empty string
 
 export const HDX_API_KEY = process.env.HYPERDX_API_KEY as string; // for nextjs server
 export const HDX_SERVICE_NAME =


### PR DESCRIPTION
### Problem
Currently, Changing the SERVER_URL requires to rebuild the frontend app image, and push it to a container registry. 

This isn't usually a problem for a client application, but for one that some folks are self hosting it can cause problems and confusion at the moment of setup 

### Solution
Move the config value to a runtime config value. This feature is technically deprecated by nextjs in favor of using their "new" App Router system, but hyperdx isn't using it and it will require a good amount of work to migrate it. 

The main issue for this feature seems to be that [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization), [Output File Tracing](https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files), or [React Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components) don't work with this, which may be a problem. Although I don't see hyperdx needing those features. This is an app that is behind a login, where the bottleneck isn't "rendering" but the query speed to clickhouse.