### PR TITLE
disable ASO to properly use publicRuntimeConfig

### DIFF
--- a/packages/app/pages/benchmark.tsx
+++ b/packages/app/pages/benchmark.tsx
@@ -1,3 +1,5 @@
 import BenchmarkPage from '@/BenchmarkPage';
 
 export default BenchmarkPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/chart.tsx
+++ b/packages/app/pages/chart.tsx
@@ -1,3 +1,5 @@
 import ChartPage from '@/DBChartPage';
 
 export default ChartPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/dashboards/[dashboardId].tsx
+++ b/packages/app/pages/dashboards/[dashboardId].tsx
@@ -1,3 +1,5 @@
 import DashboardPage from '@/DBDashboardPage';
 
+export { getServerSideProps } from '@/emptyGetServerSideProps';
+
 export default DashboardPage;

--- a/packages/app/pages/dashboards/index.tsx
+++ b/packages/app/pages/dashboards/index.tsx
@@ -1,2 +1,4 @@
 import DBDashboardPage from '@/DBDashboardPage';
 export default DBDashboardPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -1,2 +1,4 @@
 import LandingPage from '@/LandingPage';
 export default LandingPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/join-team.tsx
+++ b/packages/app/pages/join-team.tsx
@@ -1,3 +1,5 @@
 import JoinTeamPage from '@/JoinTeamPage';
 
 export default JoinTeamPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/login/index.tsx
+++ b/packages/app/pages/login/index.tsx
@@ -1,5 +1,7 @@
 import AuthPage from '@/AuthPage';
 
+export { getServerSideProps } from '@/emptyGetServerSideProps';
+
 export default function Login() {
   return (
     <div>

--- a/packages/app/pages/register.tsx
+++ b/packages/app/pages/register.tsx
@@ -6,3 +6,5 @@ export default function Register() {
     </div>
   );
 }
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/search/[savedSearchId].tsx
+++ b/packages/app/pages/search/[savedSearchId].tsx
@@ -1,3 +1,5 @@
 import SearchPage from '@/DBSearchPage';
 
 export default SearchPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/search/index.tsx
+++ b/packages/app/pages/search/index.tsx
@@ -1,3 +1,5 @@
 import SearchPage from '@/DBSearchPage';
 
 export default SearchPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/services.tsx
+++ b/packages/app/pages/services.tsx
@@ -1,2 +1,4 @@
 import ServicesDashboardPage from '@/ServicesDashboardPage';
 export default ServicesDashboardPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/pages/team/index.tsx
+++ b/packages/app/pages/team/index.tsx
@@ -1,2 +1,4 @@
 import TeamPage from '@/TeamPage';
 export default TeamPage;
+
+export { getServerSideProps } from '@/emptyGetServerSideProps';

--- a/packages/app/src/emptyGetServerSideProps.tsx
+++ b/packages/app/src/emptyGetServerSideProps.tsx
@@ -1,0 +1,7 @@
+// Force ASO to be disabled so that we can use dynamic values for
+// publicRuntimeConfig for self-hosted configs
+export const getServerSideProps = async () => {
+  return {
+    props: {},
+  };
+};


### PR DESCRIPTION
Tested via:

1. Build
```sh
NODE_ENV=production NEXT_PUBLIC_IS_LOCAL_MODE=true npm run build
```

2. Run and observe configs are set correctly
```sh
HDX_LOCAL_DEFAULT_CONNECTIONS='[{"id":"local","name":"Demo","host":"https://demo-ch.hyperdx.io","username":"demo","password":"demo"}]' HDX_LOCAL_DEFAULT_SOURCES='[{"id":"l701179602","kind":"trace","name":"Demo Traces","connection":"local","from":{"databaseName":"default","tableName":"otel_traces"},"timestampValueExpression":"Timestamp","defaultTableSelectExpression":"Timestamp, ServiceName, StatusCode, round(Duration / 1e6), SpanName","serviceNameExpression":"ServiceName","eventAttributesExpression":"SpanAttributes","resourceAttributesExpression":"ResourceAttributes","traceIdExpression":"TraceId","spanIdExpression":"SpanId","implicitColumnExpression":"SpanName","durationExpression":"Duration","durationPrecision":9,"parentSpanIdExpression":"ParentSpanId","spanKindExpression":"SpanKind","spanNameExpression":"SpanName","logSourceId":"l-758211293","statusCodeExpression":"StatusCode","statusMessageExpression":"StatusMessage"},{"id":"l-758211293","kind":"log","name":"Demo Logs","connection":"local","from":{"databaseName":"default","tableName":"otel_logs"},"timestampValueExpression":"TimestampTime","defaultTableSelectExpression":"Timestamp, ServiceName, SeverityText, Body","serviceNameExpression":"ServiceName","severityTextExpression":"SeverityText","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","traceIdExpression":"TraceId","spanIdExpression":"SpanId","implicitColumnExpression":"Body","traceSourceId":"l701179602"}]' y start
```