### PR TITLE
Use partition key in selecting search results

### DIFF
--- a/packages/app/src/clickhouse.ts
+++ b/packages/app/src/clickhouse.ts
@@ -216,6 +216,23 @@ export class ClickHouseQueryError extends Error {
   }
 }
 
+export function extractColumnReference(
+  sql: string,
+  maxIterations = 10,
+): string | null {
+  let iterations = 0;
+
+  // Loop until we remove all function calls and get just the column, with a maximum limit
+  while (/\w+\([^()]*\)/.test(sql) && iterations < maxIterations) {
+    // Replace the outermost function with its content
+    sql = sql.replace(/\w+\(([^()]*)\)/, '$1');
+    iterations++;
+  }
+
+  // If we reached the max iterations without resolving, return null to indicate an issue
+  return iterations < maxIterations ? sql.trim() : null;
+}
+
 const client = {
   async query<T extends DataFormat>({
     query,

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -20,9 +20,10 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   ClickHouseQueryError,
   convertCHDataTypeToJSType,
+  extractColumnReference,
   JSDataType,
 } from '@/clickhouse';
-import { useTablePrimaryKey } from '@/hooks/useMetadata';
+import { useTableMetadata } from '@/hooks/useMetadata';
 import useOffsetPaginatedQuery from '@/hooks/useOffsetPaginatedQuery';
 import useRowWhere from '@/hooks/useRowWhere';
 import { ChartConfigWithDateRange } from '@/renderChartConfig';
@@ -681,24 +682,30 @@ export const RawLogTable = memo(
   },
 );
 
-function mergeSelectWithPrimaryKey(
+function mergeSelectWithPrimaryAndPartitionKey(
   select: SelectList,
   primaryKeys: string,
+  partitionKey: string,
 ): { select: SelectList; additionalKeysLength: number } {
-  const keys = primaryKeys.split(',').map(k => k.trim());
+  const partitionKeyArr = partitionKey
+    .split(',')
+    .map(k => extractColumnReference(k.trim()))
+    .filter(k => k != null && k.length > 0);
+  const primaryKeyArr = primaryKeys.split(',').map(k => k.trim());
+  const allKeys = [...partitionKeyArr, ...primaryKeyArr];
   if (typeof select === 'string') {
     const selectSplit = select
       .split(',')
       .map(s => s.trim())
       .filter(s => s.length > 0);
     const selectColumns = new Set(selectSplit);
-    const additionalKeys = keys.filter(k => !selectColumns.has(k));
+    const additionalKeys = allKeys.filter(k => !selectColumns.has(k));
     return {
       select: [...selectColumns, ...additionalKeys].join(','),
       additionalKeysLength: additionalKeys.length,
     };
   } else {
-    const additionalKeys = keys.map(k => ({ valueExpression: k }));
+    const additionalKeys = allKeys.map(k => ({ valueExpression: k }));
     return {
       select: [...select, ...additionalKeys],
       additionalKeysLength: additionalKeys.length,
@@ -731,23 +738,28 @@ export function DBSqlRowTable({
   isLive?: boolean;
   onScroll: (scrollTop: number) => void;
 }) {
-  const { data: primaryKey } = useTablePrimaryKey({
+  const { data: tableMetadata } = useTableMetadata({
     databaseName: config.from.databaseName,
     tableName: config.from.tableName,
     connectionId: config.connection,
   });
 
+  const primaryKey = tableMetadata?.primary_key;
+  const partitionKey = tableMetadata?.partition_key;
+
   const mergedConfig = useMemo(() => {
-    if (primaryKey == null) {
+    if (primaryKey == null || partitionKey == null) {
       return undefined;
     }
 
-    const { select, additionalKeysLength } = mergeSelectWithPrimaryKey(
-      config.select,
-      primaryKey,
-    );
+    const { select, additionalKeysLength } =
+      mergeSelectWithPrimaryAndPartitionKey(
+        config.select,
+        primaryKey,
+        partitionKey,
+      );
     return { ...config, select, additionalKeysLength };
-  }, [primaryKey, config]);
+  }, [primaryKey, partitionKey, config]);
 
   const { data, fetchNextPage, hasNextPage, isFetching, isError, error } =
     useOffsetPaginatedQuery(mergedConfig ?? config, {

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -690,7 +690,7 @@ function mergeSelectWithPrimaryAndPartitionKey(
   const partitionKeyArr = partitionKey
     .split(',')
     .map(k => extractColumnReference(k.trim()))
-    .filter(k => k != null && k.length > 0);
+    .filter((k): k is string => k != null && k.length > 0);
   const primaryKeyArr = primaryKeys.split(',').map(k => k.trim());
   const allKeys = [...partitionKeyArr, ...primaryKeyArr];
   if (typeof select === 'string') {

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -10,7 +10,7 @@ import {
   filterColumnMetaByType,
   JSDataType,
 } from '@/clickhouse';
-import { Field, metadata } from '@/metadata';
+import { Field, metadata, TableMetadata } from '@/metadata';
 import { ChartConfigWithDateRange } from '@/renderChartConfig';
 
 export function useColumns(
@@ -63,7 +63,7 @@ export function useAllFields(
   });
 }
 
-export function useTablePrimaryKey(
+export function useTableMetadata(
   {
     databaseName,
     tableName,
@@ -75,10 +75,10 @@ export function useTablePrimaryKey(
   },
   options?: Omit<UseQueryOptions<any, Error>, 'queryKey'>,
 ) {
-  return useQuery<string>({
-    queryKey: ['useMetadata.useTablePrimaryKeys', { databaseName, tableName }],
+  return useQuery<TableMetadata>({
+    queryKey: ['useMetadata.useTableMetadata', { databaseName, tableName }],
     queryFn: async () => {
-      return await metadata.getTablePrimaryKey({
+      return await metadata.getTableMetadata({
         databaseName,
         tableName,
         connectionId,

--- a/packages/app/src/metadata.ts
+++ b/packages/app/src/metadata.ts
@@ -49,6 +49,33 @@ class MetadataCache {
   // TODO: Shard cache by time
 }
 
+export type TableMetadata = {
+  database: string;
+  name: string;
+  uuid: string;
+  engine: string;
+  is_temporary: number;
+  data_paths: string[];
+  metadata_path: string;
+  metadata_modification_time: string;
+  metadata_version: number;
+  create_table_query: string;
+  engine_full: string;
+  as_select: string;
+  partition_key: string;
+  sorting_key: string;
+  primary_key: string;
+  sampling_key: string;
+  storage_policy: string;
+  total_rows: string;
+  total_bytes: string;
+  total_bytes_uncompressed: string;
+  parts: string;
+  active_parts: string;
+  total_marks: string;
+  comment: string;
+};
+
 export class Metadata {
   private cache = new MetadataCache();
 
@@ -69,34 +96,7 @@ export class Metadata {
         query: sql.sql,
         query_params: sql.params,
         connectionId,
-      }).then(res =>
-        res.json<{
-          database: string;
-          name: string;
-          uuid: string;
-          engine: string;
-          is_temporary: number;
-          data_paths: string[];
-          metadata_path: string;
-          metadata_modification_time: string;
-          metadata_version: number;
-          create_table_query: string;
-          engine_full: string;
-          as_select: string;
-          partition_key: string;
-          sorting_key: string;
-          primary_key: string;
-          sampling_key: string;
-          storage_policy: string;
-          total_rows: string;
-          total_bytes: string;
-          total_bytes_uncompressed: string;
-          parts: string;
-          active_parts: string;
-          total_marks: string;
-          comment: string;
-        }>(),
-      );
+      }).then(res => res.json<TableMetadata>());
       return json.data[0];
     });
   }
@@ -379,7 +379,7 @@ export class Metadata {
     return fields;
   }
 
-  async getTablePrimaryKey({
+  async getTableMetadata({
     databaseName,
     tableName,
     connectionId,
@@ -395,7 +395,7 @@ export class Metadata {
       connectionId,
     });
 
-    return tableMetadata.primary_key;
+    return tableMetadata;
   }
 
   async getKeyValues({


### PR DESCRIPTION
We now use the `partition_key` in helping narrow down a given row that's selected in the UI, which is necessary for large datasets where the `partition_key` is not already part of the `primary_key`

Fixes HDX-1281