### PR TITLE
fix(results): Prevent live reloading if there's an error in results

### DIFF
--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -738,6 +738,10 @@ function DBSearchPage() {
     ],
   );
 
+  const handleTableError = useCallback(() => {
+    setIsLive(false);
+  }, [setIsLive]);
+
   return (
     <Flex direction="column" h="100vh" style={{ overflow: 'hidden' }}>
       <OnboardingModal />
@@ -1125,6 +1129,7 @@ function DBSearchPage() {
                       isLive={isLive ?? true}
                       queryKeyPrefix={QUERY_KEY_PREFIX}
                       onScroll={onTableScroll}
+                      onError={handleTableError}
                     />
                   )}
               </div>

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -723,6 +723,7 @@ function getSelectLength(select: SelectList): number {
 
 export function DBSqlRowTable({
   config,
+  onError,
   onRowExpandClick,
   highlightedLineId,
   enabled = true,
@@ -737,6 +738,7 @@ export function DBSqlRowTable({
   enabled?: boolean;
   isLive?: boolean;
   onScroll?: (scrollTop: number) => void;
+  onError?: () => void;
 }) {
   const { data: tableMetadata } = useTableMetadata({
     databaseName: config.from.databaseName,
@@ -829,6 +831,12 @@ export function DBSqlRowTable({
     },
     [onRowExpandClick, getRowWhere],
   );
+
+  useEffect(() => {
+    if (isError && onError) {
+      onError();
+    }
+  }, [isError, onError]);
 
   return (
     <RawLogTable


### PR DESCRIPTION
Adds an onError callback so that isLive is set to false when there is an error with the query.

Ref: HDX-1265