### PR TITLE
fix: When the data source is changed, ensure select/orderby fields are reset properly

### DIFF
--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -742,6 +742,20 @@ function DBSearchPage() {
     setIsLive(false);
   }, [setIsLive]);
 
+  // When source changes, make sure select and orderby fields are set to default
+  const defaultOrderBy = useMemo(
+    () =>
+      `${getFirstTimestampValueExpression(
+        inputSourceObj?.timestampValueExpression ?? '',
+      )} DESC`,
+    [inputSourceObj?.timestampValueExpression],
+  );
+
+  useEffect(() => {
+    setValue('select', inputSourceObj?.defaultTableSelectExpression ?? '');
+    setValue('orderBy', defaultOrderBy);
+  }, [inputSource, inputSourceObj, defaultOrderBy]);
+
   return (
     <Flex direction="column" h="100vh" style={{ overflow: 'hidden' }}>
       <OnboardingModal />
@@ -797,9 +811,7 @@ function DBSearchPage() {
               table={tableName}
               control={control}
               name="orderBy"
-              defaultValue={`${getFirstTimestampValueExpression(
-                inputSourceObj?.timestampValueExpression ?? '',
-              )} DESC`}
+              defaultValue={defaultOrderBy}
               onSubmit={onSubmit}
               label="ORDER BY"
               size="xs"


### PR DESCRIPTION
Adds effects to reset select and orderby field when connection sources are changed.

Ref: HDX-1176

[screen-capture.webm](https://github.com/user-attachments/assets/2c3a5316-0419-47bc-b6c9-395a0f72e1ca)
