### PR TITLE
fix: limit inferred dates to the past

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
     "@uiw/codemirror-themes": "^4.23.3",
     "@uiw/react-codemirror": "^4.23.3",
     "bootstrap": "^5.1.3",
-    "chrono-node": "^2.5.0",
+    "chrono-node": "^2.7.8",
     "classnames": "^2.3.1",
     "crypto-js": "^4.2.0",
     "date-fns": "^2.28.0",

--- a/packages/app/src/components/TimePicker/__tests__/utils.test.ts
+++ b/packages/app/src/components/TimePicker/__tests__/utils.test.ts
@@ -1,0 +1,101 @@
+import { dateParser, parseTimeRangeInput } from '../utils';
+
+describe('dateParser', () => {
+  beforeEach(() => {
+    // Mock current date to ensure consistent test results
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-15T22:00'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(dateParser(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(dateParser('')).toBeNull();
+  });
+
+  it('parses absolute date', () => {
+    expect(dateParser('2024-01-15')).toEqual(new Date('2024-01-15T12:00:00'));
+  });
+
+  it('parses month/date at specific time correctly', () => {
+    expect(dateParser('Jan 15 13:12:00')).toEqual(
+      new Date('2025-01-15T13:12:00'),
+    );
+  });
+
+  it('parses future numeric month/date with prior year', () => {
+    expect(dateParser('01/31')).toEqual(new Date('2024-01-31T12:00:00'));
+  });
+
+  it('parses non-future numeric month/date with current year', () => {
+    expect(dateParser('01/15')).toEqual(new Date('2025-01-15T12:00:00'));
+  });
+
+  it('parses future month name/date with prior year', () => {
+    expect(dateParser('Jan 31')).toEqual(new Date('2024-01-31T12:00:00'));
+  });
+
+  it('parses non-future month name/date with current year', () => {
+    expect(dateParser('Jan 15')).toEqual(new Date('2025-01-15T12:00:00'));
+  });
+});
+
+describe('parseTimeRangeInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-15T22:00'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns [null, null] for empty string', () => {
+    expect(parseTimeRangeInput('')).toEqual([null, null]);
+  });
+
+  it('returns [null, null] for invalid input', () => {
+    expect(parseTimeRangeInput('invalid input')).toEqual([null, null]);
+  });
+
+  it('parses a range fully before the current time correctly', () => {
+    expect(parseTimeRangeInput('Jan 2 - Jan 10')).toEqual([
+      new Date('2025-01-02T12:00:00'),
+      new Date('2025-01-10T12:00:00'),
+    ]);
+  });
+
+  it('parses a range with an implied start date in the previous year', () => {
+    expect(parseTimeRangeInput('Jan 31 - Jan 15')).toEqual([
+      new Date('2024-01-31T12:00:00'),
+      new Date('2025-01-15T12:00:00'),
+    ]);
+  });
+});
+
+it('parses a range with specific times correctly', () => {
+  expect(parseTimeRangeInput('Jan 31 12:00:00 - Jan 14 13:05:29')).toEqual([
+    new Date('2024-01-31T12:00:00'),
+    new Date('2025-01-14T13:05:29'),
+  ]);
+});
+
+it('parses single date correctly', () => {
+  expect(parseTimeRangeInput('2024-01-13')).toEqual([
+    new Date('2024-01-13T12:00:00'),
+    new Date(),
+  ]);
+});
+
+it('parses explicit date range correctly', () => {
+  expect(parseTimeRangeInput('2024-01-15 to 2024-01-16')).toEqual([
+    new Date('2024-01-15T12:00:00'),
+    new Date('2024-01-16T12:00:00'),
+  ]);
+});

--- a/packages/app/src/timeQuery.ts
+++ b/packages/app/src/timeQuery.ts
@@ -8,7 +8,6 @@ import {
   useState,
 } from 'react';
 import { useRouter } from 'next/router';
-import * as chrono from 'chrono-node';
 import {
   format,
   formatDuration,
@@ -27,6 +26,7 @@ import {
   withDefault,
 } from 'use-query-params';
 
+import { parseTimeRangeInput } from './components/TimePicker/utils';
 import { useUserPreferences } from './useUserPreferences';
 import { usePrevious } from './utils';
 
@@ -62,31 +62,7 @@ export function parseTimeQuery(
     const end = startOfSecond(new Date());
     return [sub(end, { minutes: 15 }), end];
   }
-
-  const parsedTimeResult = chrono.parse(
-    timeQuery,
-    isUTC
-      ? {
-          timezone: 0, // 0 minute offset, UTC
-        }
-      : {},
-  );
-  const start =
-    parsedTimeResult.length === 1
-      ? parsedTimeResult[0].start?.date()
-      : parsedTimeResult.length > 1
-        ? parsedTimeResult[1].start?.date()
-        : null;
-  const end =
-    parsedTimeResult.length === 1 && parsedTimeResult[0].end != null
-      ? parsedTimeResult[0].end.date()
-      : parsedTimeResult.length > 1 && parsedTimeResult[1].end != null
-        ? parsedTimeResult[1].end.date()
-        : start != null && start instanceof Date
-          ? new Date()
-          : null;
-
-  return [start, end];
+  return parseTimeRangeInput(timeQuery, isUTC);
 }
 
 export function parseValidTimeRange(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4348,7 +4348,7 @@ __metadata:
     "@uiw/codemirror-themes": "npm:^4.23.3"
     "@uiw/react-codemirror": "npm:^4.23.3"
     bootstrap: "npm:^5.1.3"
-    chrono-node: "npm:^2.5.0"
+    chrono-node: "npm:^2.7.8"
     classnames: "npm:^2.3.1"
     crypto-js: "npm:^4.2.0"
     date-fns: "npm:^2.28.0"
@@ -12642,12 +12642,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrono-node@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "chrono-node@npm:2.5.0"
+"chrono-node@npm:^2.7.8":
+  version: 2.7.8
+  resolution: "chrono-node@npm:2.7.8"
   dependencies:
     dayjs: "npm:^1.10.0"
-  checksum: 10c0/1569fa2353b12f38aa81b8cea3498dac7cb19ecde075221c60aaa1743a4133cd0fd2b874033d0da44308e4e8fe07d5e6daf1fb338cf531dad3e3c20355db8e53
+  checksum: 10c0/734af27b9cfa6aff34e41c2ec3f532a015ecb078241ab9c6a25e7503a3297109cd3503d1b74813ce453c850bdb45bf525c5b5961f35f307da2952d1ff49109ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When parsing a date with inferred parts, this commit changes the parser to assume that the intended date was in the past. This impacts individual date fields and date range fields.