### PR TITLE
feat: Keep tile data if dashboard save failed

### DIFF
--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -46,7 +46,6 @@ import {
   Transition,
 } from '@mantine/core';
 import { useHover, usePrevious } from '@mantine/hooks';
-import { notifications } from '@mantine/notifications';
 import { useQueryClient } from '@tanstack/react-query';
 
 import EditTimeChartForm from '@/components/DBEditTimeChartForm';
@@ -680,7 +679,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           if (dashboard == null) {
             return;
           }
-
           setDashboard(
             produce(dashboard, draft => {
               const chartIndex = draft.tiles.findIndex(
@@ -693,9 +691,10 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
                 draft.tiles[chartIndex] = newChart;
               }
             }),
+            () => {
+              setEditedTile(undefined);
+            },
           );
-
-          setEditedTile(undefined);
         }}
       />
       {IS_LOCAL_MODE === false && isLocalDashboard && isLocalDashboardEmpty && (

--- a/packages/app/src/dashboard.ts
+++ b/packages/app/src/dashboard.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { parseAsJson, useQueryState } from 'nuqs';
 import { SavedChartConfig } from '@hyperdx/common-utils/dist/types';
+import { notifications } from '@mantine/notifications';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { hashCode } from '@/utils';
@@ -125,6 +126,14 @@ export function useDashboard({
         return updateDashboard.mutate(newDashboard, {
           onSuccess: () => {
             onSuccess?.();
+          },
+          onError: e => {
+            notifications.show({
+              color: 'red',
+              title: 'Unable to save dashboard',
+              message: e.message.slice(0, 100),
+              autoClose: 5000,
+            });
           },
         });
       }


### PR DESCRIPTION
To prevent user data loss in case of a transient error in network/dashboard APIs, do not close the edit tile modal in case of error.