### PR TITLE
fix(dev): otel collector should wait for clickhouse

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,7 +67,8 @@ services:
     networks:
       - internal
     depends_on:
-      - ch-server
+      ch-server:
+        condition: service_healthy
   # task-check-alerts:
   #   build:
   #     context: .
@@ -115,5 +116,11 @@ services:
     restart: on-failure
     networks:
       - internal
+    healthcheck:
+      # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
+      test: wget --no-verbose --tries=1 http://127.0.0.1:8123/ping || exit 1
+      interval: 3s
+      timeout: 3s
+      retries: 3
 networks:
   internal:


### PR DESCRIPTION
The OTEL collector can start execution before the Clickhouse DB is ready. This can cause the OTEL collector to crash, which aborts the container and caused the compose command to fail. This commit adds a health check to the Clickhouse container and then orders the OTEL collector container to wait until the database is healthy.