### PR TITLE
feat: add correlate span logs in traces waterfall chart

### DIFF
--- a/.changeset/lemon-walls-collect.md
+++ b/.changeset/lemon-walls-collect.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+add correlate log in trace waterfall chart

--- a/packages/app/src/TimelineChart.tsx
+++ b/packages/app/src/TimelineChart.tsx
@@ -334,6 +334,7 @@ type Row = {
   label: React.ReactNode;
   events: TimelineEventT[];
   style?: any;
+  type?: string;
   className?: string;
 };
 

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -13,7 +13,7 @@ import { parseAsStringEnum, useQueryState } from 'nuqs';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useHotkeys } from 'react-hotkeys-hook';
 import Drawer from 'react-modern-drawer';
-import { TSource } from '@hyperdx/common-utils/dist/types';
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
 import { Box } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 
@@ -177,8 +177,12 @@ export default function DBRowSidePanel({
   const focusDate = timestampDate;
   const traceId = normalizedRow?.['__hdx_trace_id'];
 
-  const traceSourceId =
-    source.kind === 'log' ? source.traceSourceId : source.id;
+  const childSourceId =
+    source.kind === SourceKind.Log
+      ? source.traceSourceId
+      : source.kind === SourceKind.Trace
+        ? source.logSourceId
+        : undefined;
 
   return (
     <Drawer
@@ -267,7 +271,7 @@ export default function DBRowSidePanel({
                   <Box style={{ overflowY: 'auto' }} p="sm" h="100%">
                     <DBTracePanel
                       parentSourceId={source.id}
-                      sourceId={traceSourceId}
+                      childSourceId={childSourceId}
                       traceId={traceId}
                       dateRange={rng}
                       focusDate={focusDate}

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -13,7 +13,7 @@ import { parseAsStringEnum, useQueryState } from 'nuqs';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useHotkeys } from 'react-hotkeys-hook';
 import Drawer from 'react-modern-drawer';
-import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import { TSource } from '@hyperdx/common-utils/dist/types';
 import { Box } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 
@@ -178,9 +178,9 @@ export default function DBRowSidePanel({
   const traceId = normalizedRow?.['__hdx_trace_id'];
 
   const childSourceId =
-    source.kind === SourceKind.Log
+    source.kind === 'log'
       ? source.traceSourceId
-      : source.kind === SourceKind.Trace
+      : source.kind === 'trace'
         ? source.logSourceId
         : undefined;
 

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -24,21 +24,21 @@ import { SourceSelectControlled } from './SourceSelect';
 import { SQLInlineEditorControlled } from './SQLInlineEditor';
 
 export default function DBTracePanel({
-  sourceId,
+  childSourceId,
   traceId,
   dateRange,
   focusDate,
   parentSourceId,
 }: {
   parentSourceId?: string;
-  sourceId?: string;
+  childSourceId?: string;
   traceId: string;
   dateRange: [Date, Date];
   focusDate: Date;
 }) {
   const { control, watch, setValue } = useForm({
     defaultValues: {
-      source: sourceId,
+      source: childSourceId,
     },
   });
 

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -74,8 +74,8 @@ export default function DBTracePanel({
 
   const { mutate: updateTableSource } = useUpdateSource();
 
-  const [spanRowWhere, setSpanRowWhere] = useQueryState(
-    'spanRowWhere',
+  const [eventRowWhere, setEventRowWhere] = useQueryState(
+    'eventRowWhere',
     parseAsJson<{ id: string; type: string }>(),
   );
 
@@ -116,9 +116,9 @@ export default function DBTracePanel({
   // otherwise we'll show stale span details
   useEffect(() => {
     return () => {
-      setSpanRowWhere(null);
+      setEventRowWhere(null);
     };
-  }, [traceId, setSpanRowWhere]);
+  }, [traceId, setEventRowWhere]);
 
   return (
     <>
@@ -143,7 +143,7 @@ export default function DBTracePanel({
           <Text size="sm" c="gray.4">
             {parentSourceData?.kind === SourceKind.Log
               ? 'Trace Source'
-              : 'Correlate Log Source'}
+              : 'Correlated Log Source'}
           </Text>
           <SourceSelectControlled control={control} name="source" size="xs" />
           <ActionIcon
@@ -215,27 +215,27 @@ export default function DBTracePanel({
           traceId={traceId}
           dateRange={dateRange}
           focusDate={focusDate}
-          highlightedRowWhere={spanRowWhere?.id}
-          onClick={setSpanRowWhere}
+          highlightedRowWhere={eventRowWhere?.id}
+          onClick={setEventRowWhere}
         />
       )}
-      {traceSourceData != null && spanRowWhere != null && (
+      {traceSourceData != null && eventRowWhere != null && (
         <>
           <Divider my="md" />
           <Text size="sm" c="dark.2" my="sm">
-            Span Details
+            Event Details
           </Text>
           <RowDataPanel
             source={
-              spanRowWhere?.type === SourceKind.Log && logSourceData
+              eventRowWhere?.type === SourceKind.Log && logSourceData
                 ? logSourceData
                 : traceSourceData
             }
-            rowId={spanRowWhere?.id}
+            rowId={eventRowWhere?.id}
           />
         </>
       )}
-      {traceSourceData != null && !spanRowWhere && (
+      {traceSourceData != null && !eventRowWhere && (
         <Paper shadow="xs" p="xl" mt="md">
           <Center mih={100}>
             <Text size="sm" c="gray.4">

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { parseAsJson, parseAsString, useQueryState } from 'nuqs';
 import { useForm } from 'react-hook-form';
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
 import {
   ActionIcon,
   Box,
@@ -56,7 +57,7 @@ export default function DBTracePanel({
 
   const [traceRowWhere, setTraceRowWhere] = useQueryState(
     'traceRowWhere',
-    parseAsString,
+    parseAsJson<{ id: string; type: string }>(),
   );
 
   const {
@@ -186,13 +187,14 @@ export default function DBTracePanel({
       )}
       <Divider my="sm" />
       {sourceFormModalOpened && <TableSourceForm sourceId={watch('source')} />}
-      {traceSourceData?.kind === 'trace' && (
+      {traceSourceData?.kind === SourceKind.Trace && (
         <DBTraceWaterfallChartContainer
           traceTableModel={traceSourceData}
+          logTableModel={parentSourceData}
           traceId={traceId}
           dateRange={dateRange}
           focusDate={focusDate}
-          highlightedRowWhere={traceRowWhere}
+          highlightedRowWhere={traceRowWhere?.id}
           onClick={setTraceRowWhere}
         />
       )}
@@ -202,7 +204,14 @@ export default function DBTracePanel({
           <Text size="sm" c="dark.2" my="sm">
             Span Details
           </Text>
-          <RowDataPanel source={traceSourceData} rowId={traceRowWhere} />
+          <RowDataPanel
+            source={
+              traceRowWhere?.type === SourceKind.Log && parentSourceData
+                ? parentSourceData
+                : traceSourceData
+            }
+            rowId={traceRowWhere?.id}
+          />
         </>
       )}
       {traceSourceData != null && !traceRowWhere && (

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -53,16 +53,16 @@ export default function DBTracePanel({
     });
 
   const logSourceData =
-    childSourceData?.kind === SourceKind.Log
-      ? childSourceData
-      : parentSourceData?.kind === SourceKind.Log
-        ? parentSourceData
+    parentSourceData?.kind === SourceKind.Log
+      ? parentSourceData
+      : childSourceData?.kind === SourceKind.Log
+        ? childSourceData
         : null;
   const traceSourceData =
-    childSourceData?.kind === SourceKind.Trace
-      ? childSourceData
-      : parentSourceData?.kind === SourceKind.Trace
-        ? parentSourceData
+    parentSourceData?.kind === SourceKind.Trace
+      ? parentSourceData
+      : childSourceData?.kind === SourceKind.Trace
+        ? childSourceData
         : null;
 
   const isTraceSourceLoading =

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -297,8 +297,7 @@ export function DBTraceWaterfallChartContainer({
     if (!SpanId) continue;
 
     // log have duplicate span id, tag it with -log
-    const nodeSpanId =
-      type === SourceKind.Log ? `${SpanId}-log` : SpanId; // prevent log spanId overwrite trace spanId
+    const nodeSpanId = type === SourceKind.Log ? `${SpanId}-log` : SpanId; // prevent log spanId overwrite trace spanId
     const nodeParentSpanId =
       type === SourceKind.Log ? SpanId : ParentSpanId || '';
 

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -291,16 +291,14 @@ export function DBTraceWaterfallChartContainer({
   const rootNodes: Node[] = [];
   const nodesMap = new Map();
 
-  let logSpanCount = -1;
   for (const result of rows ?? []) {
     const { type, SpanId, ParentSpanId } = result;
     // ignore everything without spanId
     if (!SpanId) continue;
-    if (type === SourceKind.Log) logSpanCount += 1;
 
-    // log have dupelicate span id, tag it with -log-count
+    // log have duplicate span id, tag it with -log
     const nodeSpanId =
-      type === SourceKind.Log ? `${SpanId}-log-${logSpanCount}` : SpanId;
+      type === SourceKind.Log ? `${SpanId}-log` : SpanId; // prevent log spanId overwrite trace spanId
     const nodeParentSpanId =
       type === SourceKind.Log ? SpanId : ParentSpanId || '';
 
@@ -310,11 +308,11 @@ export function DBTraceWaterfallChartContainer({
       // In case we were created already previously, inherit the children built so far
       ...nodesMap.get(nodeSpanId),
     };
-    if (!nodesMap.has(nodeSpanId)) {
+    if (type === SourceKind.Trace && !nodesMap.has(nodeSpanId)) {
       nodesMap.set(nodeSpanId, curNode);
     }
 
-    // root if: is trace event, and (has no parent or parent id is not valiad)
+    // root if: is trace event, and (has no parent or parent id is not valid)
     const isRootNode =
       type === SourceKind.Trace &&
       (!nodeParentSpanId || !validSpanID.has(nodeParentSpanId));

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -73,7 +73,6 @@ export const SelectListSchema = z.array(DerivedColumnSchema).or(z.string());
 export const SortSpecificationSchema = z.intersection(
   RootValueExpressionSchema,
   z.object({
-    valueExpression: z.string().optional(),
     ordering: z.enum(['ASC', 'DESC']),
   }),
 );

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -73,6 +73,7 @@ export const SelectListSchema = z.array(DerivedColumnSchema).or(z.string());
 export const SortSpecificationSchema = z.intersection(
   RootValueExpressionSchema,
   z.object({
+    valueExpression: z.string().optional(),
     ordering: z.enum(['ASC', 'DESC']),
   }),
 );


### PR DESCRIPTION
- Add correlate span logs in traces waterfall chart
- `SeverityText: warn` will display as color yellow
- Some functions refactor
- Support both log tab and trace tab

Log Tab:
<img width="1282" alt="Screenshot 2025-02-10 at 8 58 40 AM" src="https://github.com/user-attachments/assets/837de0cc-6ec3-456d-9251-5f05697d6343" />

Trace Tab:
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/025613da-8efd-44ee-9258-a49c6ee84cb5" />


Ref: hdx-1181