### PR TITLE
feat(metrics): Support multiple OTEL tables

### DIFF
--- a/.changeset/metal-doors-burn.md
+++ b/.changeset/metal-doors-burn.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/api": minor
+"@hyperdx/app": minor
+---
+
+Support multiple OTEL metric types in source configuration setup.

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -1,4 +1,8 @@
-import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import {
+  MetricsDataType,
+  SourceKind,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
 import mongoose, { Schema } from 'mongoose';
 
 type ObjectId = mongoose.Types.ObjectId;
@@ -59,11 +63,11 @@ export const Source = mongoose.model<ISource>(
       statusCodeExpression: String,
       statusMessageExpression: String,
 
-      metricDiscriminator: String,
-      metricNameExpression: String,
-      metricUnitExpression: String,
-      flagsExpression: String,
-      valueExpression: String,
+      metricTables: {
+        [MetricsDataType.Gauge]: String,
+        [MetricsDataType.Histogram]: String,
+        [MetricsDataType.Sum]: String,
+      } as any,
     },
     {
       toJSON: { virtuals: true },

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -649,7 +649,7 @@ export function MetricTableModelForm({
   const connectionId = watch(`connection`);
 
   useEffect(() => {
-    setValue('timestampValueExpression', '');
+    setValue('timestampValueExpression', 'TimeUnix');
     const { unsubscribe } = watch(async (value, { name, type }) => {
       try {
         if (name && type === 'change') {

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -674,6 +674,10 @@ export function MetricTableModelForm({
         }
       } catch (e) {
         console.error(e);
+        notifications.show({
+          color: 'red',
+          message: e.message,
+        });
       }
     });
 

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -398,6 +398,13 @@ export enum SourceKind {
   Session = 'session',
   Metric = 'metric',
 }
+
+export enum MetricsDataType {
+  Gauge = 'gauge',
+  Histogram = 'histogram',
+  Sum = 'sum',
+}
+
 export const SourceSchema = z.object({
   from: z.object({
     databaseName: z.string(),
@@ -442,14 +449,14 @@ export const SourceSchema = z.object({
   statusMessageExpression: z.string().optional(),
   logSourceId: z.string().optional(),
 
-  // Common Metric Fields
-  metricDiscriminator: z.enum(['gauge']).optional(),
-  metricNameExpression: z.string().optional(),
-  metricUnitExpression: z.string().optional(),
-  flagsExpression: z.string().optional(),
-
-  // Gauge Metric Field
-  valueExpression: z.string().optional(),
+  // OTEL Metrics
+  metricTables: z
+    .object({
+      [MetricsDataType.Gauge]: z.string(),
+      [MetricsDataType.Histogram]: z.string(),
+      [MetricsDataType.Sum]: z.string(),
+    })
+    .optional(),
 });
 
 export type TSource = z.infer<typeof SourceSchema>;


### PR DESCRIPTION
Updated the source configuration dialog for metrics to handle multiple, supported OTEL metric tables in a single form.

<img width="818" alt="Screenshot 2025-02-12 at 8 43 05 AM" src="https://github.com/user-attachments/assets/0f9de2d7-815f-4c26-b5b9-6a0ca0ef5220" />

Ref: HDX-1390