### PR TITLE
Fix AppNavUserMenu display bug 

### DIFF
--- a/packages/app/src/AppNav.components.tsx
+++ b/packages/app/src/AppNav.components.tsx
@@ -61,13 +61,13 @@ export const AppNavUserMenu = ({
     <Menu position="top-start" transitionProps={{ transition: 'fade-up' }}>
       <Menu.Target>
         <Paper
-          m="sm"
-          mt={8}
           px={8}
           py={4}
           radius="md"
           {...(isCollapsed && {
-            p: 2,
+            m: 'auto',
+            mb: 'sm',
+            boxShadow: 'none',
             bg: 'transparent',
           })}
           className={`${styles.appNavMenu} ${!isCollapsed && styles.appNavMenuUserInfo}`}
@@ -173,14 +173,12 @@ export const AppNavHelpMenu = ({
   return (
     <>
       <Paper
-        mb={8}
-        ml="sm"
         withBorder
         w={size}
         h={size}
         radius="xl"
         {...(isCollapsed && {
-          ml: 'sm',
+          m: 'auto',
         })}
         className={styles.appNavMenu}
       >

--- a/packages/app/src/AppNav.components.tsx
+++ b/packages/app/src/AppNav.components.tsx
@@ -79,17 +79,15 @@ export const AppNavUserMenu = ({
             {!isCollapsed && (
               <>
                 <div style={{ flex: 1 }}>
-                  <Text size="xs" fw="bold" lh={1.1} c="gray.3">
+                  <Text size="xs" fw="bold" lh={1.1} c="gray.3" truncate="end">
                     {userName}
                   </Text>
                   <Text
                     size="xs"
                     c="dimmed"
+                    truncate="end"
                     style={{
                       fontSize: 11,
-                      maxWidth: '100%',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
                       maxHeight: 16,
                     }}
                   >

--- a/packages/app/src/AppNav.components.tsx
+++ b/packages/app/src/AppNav.components.tsx
@@ -70,7 +70,7 @@ export const AppNavUserMenu = ({
             p: 2,
             bg: 'transparent',
           })}
-          className={styles.appNavMenu}
+          className={`${styles.appNavMenu} ${!isCollapsed && styles.appNavMenuUserInfo}`}
         >
           <Group gap="xs" wrap="nowrap" miw={0}>
             <Avatar size="sm" radius="xl" color="green">
@@ -78,7 +78,7 @@ export const AppNavUserMenu = ({
             </Avatar>
             {!isCollapsed && (
               <>
-                <div style={{ flex: 1 }}>
+                <div style={{ minWidth: 0 }}>
                   <Text size="xs" fw="bold" lh={1.1} c="gray.3" truncate="end">
                     {userName}
                   </Text>

--- a/packages/app/src/AppNav.tsx
+++ b/packages/app/src/AppNav.tsx
@@ -1021,6 +1021,10 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
             position: 'absolute',
             bottom: 0,
             pointerEvents: 'none',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: isCollapsed ? 4 : 8,
+            padding: isCollapsed ? 0 : 16,
           }}
         >
           <AppNavHelpMenu isCollapsed={isCollapsed} version={version} />

--- a/packages/app/styles/AppNav.module.scss
+++ b/packages/app/styles/AppNav.module.scss
@@ -131,3 +131,8 @@
     transform: translate(0, 1px);
   }
 }
+
+.appNavMenuUserInfo {
+  width: 100%;    
+}
+

--- a/packages/app/styles/AppNav.module.scss
+++ b/packages/app/styles/AppNav.module.scss
@@ -134,5 +134,11 @@
 
 .appNavMenuUserInfo {
   width: 100%;    
+  transition: width 0.2s ease;
+  interpolate-size: allow-keywords; //alows animation of fit-content
+    
+  &:hover {
+    width: fit-content;
+  }
 }
 

--- a/packages/app/styles/AppNav.module.scss
+++ b/packages/app/styles/AppNav.module.scss
@@ -136,9 +136,11 @@
   width: 100%;    
   transition: width 0.2s ease;
   interpolate-size: allow-keywords; //alows animation of fit-content
-    
   &:hover {
     width: fit-content;
   }
 }
 
+.wrapper {
+  z-index: 100; //magic number to allow appNavMenuUserInfo to be above the main content when expanded
+}


### PR DESCRIPTION
Closes #617 

* Resolves user name and user team text overflowing from container
* Adds hover state width expansion to display full text
* Switched some hard-coded margin and padding values from the `AppNavUserMenu` component to reactive values and moved the spacing logic up a level to the containing `div` in`AppNav`

⚠️ Note that I added a magic number to the `z-index` of `.wrapper` at the bottom of `AppNav.module.scss`. This value lets the expanded `AppNavUserMenu` component render over certain elements in the main viewport (such as the Service Dashboard panels).  As far as I can tell this magic number is inconsequential to the rest of the display logic, but I am new to the codebase and product so please verify.

#### Before
<img width="360" alt="Screenshot 2025-02-17 at 10 53 18 PM" src="https://github.com/user-attachments/assets/45857d14-43b8-4374-ab3d-691a671bf0b5" />

#### After
<img width="358" alt="Screenshot 2025-02-17 at 10 53 59 PM" src="https://github.com/user-attachments/assets/b90187ec-01ad-4b85-a3f3-e675b4f6cba5" />
