### PR TITLE
Truncate user name and team name in AppNavUserMenu

### DIFF
--- a/packages/app/src/AppNav.components.tsx
+++ b/packages/app/src/AppNav.components.tsx
@@ -78,18 +78,17 @@ export const AppNavUserMenu = ({
             </Avatar>
             {!isCollapsed && (
               <>
-                <div style={{ flex: 1 }}>
-                  <Text size="xs" fw="bold" lh={1.1} c="gray.3">
+                <div style={{ flex: 1, minWidth: '0' }}>
+                  <Text size="xs" fw="bold" lh={1.1} c="gray.3" truncate="end">
                     {userName}
                   </Text>
                   <Text
                     size="xs"
                     c="dimmed"
+                    truncate="end"
                     style={{
                       fontSize: 11,
                       maxWidth: '100%',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
                       maxHeight: 16,
                     }}
                   >

--- a/packages/app/src/AppNav.components.tsx
+++ b/packages/app/src/AppNav.components.tsx
@@ -79,10 +79,11 @@ export const AppNavUserMenu = ({
             {!isCollapsed && (
               <>
                 <div style={{ flex: 1, minWidth: '0' }}>
-                  <Text size="xs" fw="bold" lh={1.1} c="gray.3" truncate="end">
+                  <Text title={userName} size="xs" fw="bold" lh={1.1} c="gray.3" truncate="end">
                     {userName}
                   </Text>
                   <Text
+                    title={teamName}
                     size="xs"
                     c="dimmed"
                     truncate="end"


### PR DESCRIPTION
Closes #617 
* Truncates user name and team name
* Sets containing div `minWidth` to 0 so that `truncate` takes effect
* Removed redundant styles