### PR TITLE
fix+perf: filter rrweb events by service name and sort by timestamp

### DIFF
--- a/packages/app/src/DOMPlayer.tsx
+++ b/packages/app/src/DOMPlayer.tsx
@@ -71,7 +71,7 @@ const URLHoverCard = memo(({ url }: { url: string }) => {
 });
 
 export default function DOMPlayer({
-  config: { sourceId, dateRange, sessionId },
+  config: { dateRange, serviceName, sessionId, sourceId },
   focus,
   setPlayerTime,
   playerState,
@@ -85,9 +85,10 @@ export default function DOMPlayer({
   resizeKey,
 }: {
   config: {
-    sourceId: string;
-    sessionId: string;
     dateRange: [Date, Date];
+    serviceName: string;
+    sessionId: string;
+    sourceId: string;
   };
   focus: { ts: number; setBy: string } | undefined;
   setPlayerTime: (ts: number) => void;
@@ -123,6 +124,7 @@ export default function DOMPlayer({
 
   const { isFetching: isSearchResultsFetching, abort } = useRRWebEventStream(
     {
+      serviceName,
       sessionId,
       sourceId,
       startDate: dateRange?.[0] ?? new Date(),

--- a/packages/app/src/SessionSidePanel.tsx
+++ b/packages/app/src/SessionSidePanel.tsx
@@ -33,7 +33,7 @@ export default function SessionSidePanel({
   traceSource: TSource;
   sessionSource: TSource;
   sessionId: string;
-  session?: clickhouse.Session;
+  session: clickhouse.Session;
   dateRange: DateRange['dateRange'];
   onClose: () => void;
   onPropertyAddClick?: (name: string, value: string) => void;
@@ -139,6 +139,7 @@ export default function SessionSidePanel({
             <SessionSubpanel
               traceSource={traceSource}
               sessionSource={sessionSource}
+              session={session}
               start={dateRange[0]}
               end={dateRange[1]}
               rumSessionId={sessionId}

--- a/packages/app/src/SessionSubpanel.tsx
+++ b/packages/app/src/SessionSubpanel.tsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 
+import * as clickhouse from '@/clickhouse';
 import DBRowSidePanel from '@/components/DBRowSidePanel';
 import { RowSidePanelContext } from '@/components/DBRowSidePanel';
 
@@ -34,6 +35,7 @@ const MemoPlaybar = memo(Playbar);
 export default function SessionSubpanel({
   traceSource,
   sessionSource,
+  session,
   onPropertyAddClick,
   generateChartUrl,
   generateSearchUrl,
@@ -45,6 +47,7 @@ export default function SessionSubpanel({
 }: {
   traceSource: TSource;
   sessionSource: TSource;
+  session: clickhouse.Session;
   generateSearchUrl: (query?: string, timeRange?: [Date, Date]) => string;
   generateChartUrl: (config: {
     aggFn: string;
@@ -514,6 +517,7 @@ export default function SessionSubpanel({
             [focus, setFocus],
           )}
           config={{
+            serviceName: session.serviceName,
             sourceId: sessionSource.id,
             sessionId: rumSessionId,
             dateRange: [start, end],

--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -366,6 +366,7 @@ export default function SessionsPage() {
   });
 
   const sessions = tableData?.data ?? [];
+  const targetSession = sessions.find(s => s.sessionId === selectedSession?.id);
 
   return (
     <div className="SessionsPage">
@@ -374,14 +375,15 @@ export default function SessionsPage() {
       </Head>
       {selectedSession != null &&
         traceTrace != null &&
-        sessionSource != null && (
+        sessionSource != null &&
+        targetSession && (
           <SessionSidePanel
             key={`session-page-session-side-panel-${selectedSession.id}`}
             traceSource={traceTrace}
             sessionSource={sessionSource}
             sessionId={selectedSession.id}
             dateRange={selectedSession.dateRange}
-            session={sessions.find(s => s.sessionId === selectedSession.id)}
+            session={targetSession}
             onClose={() => {
               setSelectedSession(undefined);
             }}

--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -348,8 +348,9 @@ export default function SessionsPage() {
       } else {
         setSelectedSessionQuery({
           sid: session.sessionId,
-          sfrom: new Date(session.minTimestamp).getTime(),
-          sto: new Date(session.maxTimestamp).getTime(),
+          // WARNING: adding 4 hours offset to fetch the whole rrweb session
+          sfrom: sub(new Date(session.minTimestamp), { hours: 4 }).getTime(),
+          sto: sub(new Date(session.maxTimestamp), { hours: -4 }).getTime(),
         });
       }
     },

--- a/packages/app/src/clickhouse.ts
+++ b/packages/app/src/clickhouse.ts
@@ -4,6 +4,7 @@ import {
   chSql,
   ClickhouseClient,
   ColumnMeta,
+  tableExpr,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/renderChartConfig';
 import {
@@ -48,6 +49,7 @@ export type Session = {
   maxTimestamp: string;
   minTimestamp: string;
   recordingCount: string;
+  serviceName: string;
   sessionCount: string;
   sessionId: string;
   teamId: string;
@@ -99,6 +101,10 @@ export function useSessions(
           {
             select: [
               {
+                valueExpression: `${traceSource.serviceNameExpression}`,
+                alias: 'serviceName',
+              },
+              {
                 valueExpression: `${traceSource.resourceAttributesExpression}['rum.sessionId']`,
                 alias: 'sessionId',
               },
@@ -126,7 +132,7 @@ export function useSessions(
               {
                 aggFn: 'count',
                 aggConditionLanguage: 'lucene',
-                aggCondition: `${traceSource.statusCodeExpression}:"Error"`,
+                aggCondition: `${traceSource.statusCodeExpression}:error`,
                 valueExpression: '',
                 alias: 'errorCount',
               },
@@ -158,7 +164,7 @@ export function useSessions(
             timestampValueExpression: traceSource.timestampValueExpression,
             implicitColumnExpression: traceSource.implicitColumnExpression,
             connection: traceSource.connection,
-            groupBy: 'sessionId',
+            groupBy: 'serviceName, sessionId',
           },
           getMetadata(),
         ),
@@ -205,7 +211,11 @@ export function useSessions(
         ${SESSIONS_CTE_NAME} AS (
           SELECT * 
           FROM _${SESSIONS_CTE_NAME}
-          HAVING interactionCount > 0 OR recordingCount > 0
+          ${
+            // If the user is giving us an explicit query, we don't need to filter out sessions with no interactions
+            // this is because the events that match the query might not be user interactions, and we'll just show 0 results otherwise.
+            where ? '' : 'HAVING interactionCount > 0 OR recordingCount > 0'
+          }
           ORDER BY maxTimestamp DESC
           LIMIT 500
         )
@@ -301,6 +311,7 @@ const EventStreamContentType = 'text/event-stream';
 
 export function useRRWebEventStream(
   {
+    serviceName,
     sessionId,
     sourceId,
     startDate,
@@ -310,6 +321,7 @@ export function useRRWebEventStream(
     onEnd,
     resultsKey,
   }: {
+    serviceName: string;
     sessionId: string;
     sourceId: string;
     startDate: Date;
@@ -354,11 +366,12 @@ export function useRRWebEventStream(
       const endTime = endDate.getTime().toString();
 
       const searchParams = new URLSearchParams([
-        ['sourceId', sourceId],
         ['endTime', endTime],
-        ['startTime', startTime],
-        ['offset', pageParam.toString()],
         ['limit', (limitOverride ?? limit).toString()],
+        ['offset', pageParam.toString()],
+        ['serviceName', serviceName],
+        ['sourceId', sourceId],
+        ['startTime', startTime],
       ]);
 
       const ctrl = new AbortController();


### PR DESCRIPTION
1. Filter rrweb events by `ServiceName` (primary key)
2. Sort events by timestamp ASC
3. Add 4 hours offset to the original time range