### PR TITLE
fix: Ensure dashboard tiles use corresponding metric table

### DIFF
--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -83,7 +83,7 @@ import {
 import { Tags } from './Tags';
 import { parseTimeQuery, useNewTimeQuery } from './timeQuery';
 import { useConfirm } from './useConfirm';
-import { hashCode, omit } from './utils';
+import { getMetricTableName, hashCode, omit } from './utils';
 import { ZIndexContext } from './zIndex';
 
 import 'react-grid-layout/css/styles.css';
@@ -166,16 +166,24 @@ const Tile = forwardRef(
 
     useEffect(() => {
       if (source != null) {
-        setQueriedConfig({
-          ...chart.config,
-          connection: source.connection,
-          dateRange,
-          granularity,
-          timestampValueExpression: source.timestampValueExpression,
-          from: source.from,
-          implicitColumnExpression: source.implicitColumnExpression,
-          filters,
-        });
+        // TODO: will need to update this when we allow for multiple metrics per chart
+        const metricType = (chart.config.select as Array<any>)[0].metricType;
+        const tableName = getMetricTableName(source, metricType);
+        if (source.connection) {
+          setQueriedConfig({
+            ...chart.config,
+            connection: source.connection,
+            dateRange,
+            granularity,
+            timestampValueExpression: source.timestampValueExpression,
+            from: {
+              databaseName: source.from?.databaseName || 'default',
+              tableName: tableName || '',
+            },
+            implicitColumnExpression: source.implicitColumnExpression,
+            filters,
+          });
+        }
       }
     }, [source, chart, dateRange, granularity, filters]);
 

--- a/packages/app/src/__tests__/utils.test.ts
+++ b/packages/app/src/__tests__/utils.test.ts
@@ -85,14 +85,14 @@ describe('getMetricTableName', () => {
   // Base source object with required properties
   const createBaseSource = () => ({
     from: {
-      tableName: 'default_table',
+      tableName: '',
       databaseName: 'test_db',
     },
     id: 'test-id',
     name: 'test-source',
     timestampValueExpression: 'timestamp',
     connection: 'test-connection',
-    kind: 'logs' as const,
+    kind: 'metric' as const,
   });
 
   // Source with metric tables
@@ -107,8 +107,8 @@ describe('getMetricTableName', () => {
   it('returns the default table name when metricType is null', () => {
     const source = createSourceWithMetrics() as unknown as TSource;
 
-    expect(getMetricTableName(source)).toBe('default_table');
-    expect(getMetricTableName(source, undefined)).toBe('default_table');
+    expect(getMetricTableName(source)).toBe('');
+    expect(getMetricTableName(source, undefined)).toBe('');
   });
 
   it('returns the specific metric table when metricType is provided', () => {
@@ -149,7 +149,7 @@ describe('getMetricTableName', () => {
   it('handles sources without metricTables property', () => {
     const source = createBaseSource() as unknown as TSource;
 
-    expect(getMetricTableName(source)).toBe('default_table');
+    expect(getMetricTableName(source)).toBe('');
     expect(
       getMetricTableName(source, 'gauge' as MetricsDataType),
     ).toBeUndefined();

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -135,7 +135,7 @@ function ChartSeriesEditor({
 
   const { data: attributeKeys } = useFetchMetricResourceAttrs({
     databaseName,
-    tableName,
+    tableName: tableName || '',
     metricType,
     metricName: watch(`${namePrefix}metricName`),
     tableSource,

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -50,7 +50,7 @@ import { useFetchMetricResourceAttrs } from '@/hooks/useFetchMetricResourceAttrs
 import SearchInputV2 from '@/SearchInputV2';
 import { getFirstTimestampValueExpression, useSource } from '@/source';
 import { parseTimeQuery } from '@/timeQuery';
-import { optionsToSelectData } from '@/utils';
+import { getMetricTableName, optionsToSelectData } from '@/utils';
 import {
   ALERT_CHANNEL_OPTIONS,
   DEFAULT_TILE_ALERT,
@@ -76,12 +76,6 @@ const isQueryReady = (queriedConfig: ChartConfigWithDateRange | undefined) =>
   // tableName is emptry for metric sources
   (queriedConfig?.from?.tableName || queriedConfig?.metricTables) &&
   queriedConfig?.timestampValueExpression;
-
-const getMetricTableName = (source: TSource, metricType?: MetricsDataType) =>
-  metricType == null
-    ? source.from.tableName
-    : // @ts-ignore
-      (source.metricTables?.[metricType.toLowerCase()] as any);
 
 const NumberFormatInputControlled = ({
   control,

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -4,6 +4,7 @@ import { format as fnsFormat, formatDistanceToNowStrict } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import numbro from 'numbro';
 import type { MutableRefObject } from 'react';
+import { TSource } from '@hyperdx/common-utils/dist/types';
 
 import { dateRangeToString } from './timeQuery';
 import { MetricsDataType, NumberFormat } from './types';
@@ -599,4 +600,21 @@ export function formatAttributeClause(
   return isSql
     ? `${column}['${field}']='${value}'`
     : `${column}.${field}:"${value}"`;
+}
+
+/**
+ * Gets the appropriate table name for a source based on metric type
+ * @param source The data source
+ * @param metricType Optional metric type to determine which table to use
+ * @returns The table name to use for the given source and metric type
+ */
+export function getMetricTableName(
+  source: TSource,
+  metricType?: MetricsDataType,
+): string | undefined {
+  return metricType == null
+    ? source.from.tableName
+    : source.metricTables?.[
+        metricType.toLowerCase() as keyof typeof source.metricTables
+      ];
 }


### PR DESCRIPTION
Uses existing functionality to grab correct metrics table based on metrics type and adds it to the from statement.

Ref: HDX-1418