### PR TITLE
feat: supporting quantile histogram metrics

### DIFF
--- a/.changeset/odd-hats-wash.md
+++ b/.changeset/odd-hats-wash.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": minor
+---
+
+Add chart support for querying OTEL histogram metric table

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -179,7 +179,7 @@ describe('renderChartConfig', () => {
         '          ),RawHist AS (\n' +
         '            SELECT *, toUInt64( 0.5 * arraySum(BucketRates)) AS Rank,\n' +
         '                   arrayCumSum(BucketRates) as CumRates,\n' +
-        '                   arrayFirstIndex(x -> if(x > Rank, 1, 0), CumRates) AS BucketLowIdx, -- b\n' +
+        '                   arrayFirstIndex(x -> if(x > Rank, 1, 0), CumRates) AS BucketLowIdx,\n' +
         '                   IF(BucketLowIdx = length(BucketRates),\n' +
         '                      ExplicitBounds[length(ExplicitBounds)],  -- if the low bound is the last bucket, use the last bound value\n' +
         '                      IF(BucketLowIdx > 1, -- indexes are 1-based\n' +

--- a/packages/common-utils/src/clickhouse.ts
+++ b/packages/common-utils/src/clickhouse.ts
@@ -186,7 +186,11 @@ export const concatChSql = (sep: string, ...args: (ChSql | ChSql[])[]) => {
         }
 
         acc.sql +=
-          (acc.sql.length > 0 ? sep : '') + arg.map(a => a.sql).join(sep);
+          (acc.sql.length > 0 ? sep : '') +
+          arg
+            .map(a => a.sql)
+            .filter(Boolean) // skip empty string expressions
+            .join(sep);
         acc.params = arg.reduce((acc, a) => {
           Object.assign(acc, a.params);
           return acc;

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -937,7 +937,7 @@ export async function renderChartConfig(
     chSql`${withClauses?.sql ? chSql`WITH ${withClauses}` : ''}`,
     chSql`SELECT ${select}`,
     chSql`FROM ${from}`,
-    chSql`WHERE ${where}`,
+    chSql`${where.sql ? chSql`WHERE ${where}` : ''}`,
     chSql`${groupBy?.sql ? chSql`GROUP BY ${groupBy}` : ''}`,
     chSql`${orderBy?.sql ? chSql`ORDER BY ${orderBy}` : ''}`,
     chSql`${fill?.sql ? chSql`WITH FILL ${fill}` : ''}`,

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -884,7 +884,7 @@ function translateMetricChartConfig(
           sql: chSql`
             SELECT *, toUInt64( ${{ Float64: level }} * arraySum(BucketRates)) AS Rank,
                    arrayCumSum(BucketRates) as CumRates,
-                   arrayFirstIndex(x -> if(x > Rank, 1, 0), CumRates) AS BucketLowIdx, -- b
+                   arrayFirstIndex(x -> if(x > Rank, 1, 0), CumRates) AS BucketLowIdx,
                    IF(BucketLowIdx = length(BucketRates),
                       ExplicitBounds[length(ExplicitBounds)],  -- if the low bound is the last bucket, use the last bound value
                       IF(BucketLowIdx > 1, -- indexes are 1-based

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -292,7 +292,7 @@ const aggFnExpr = ({
 
 async function renderSelectList(
   selectList: SelectList,
-  chartConfig: ChartConfigWithOptDateRateAndCte,
+  chartConfig: ChartConfigWithOptDateRangeEx,
   metadata: Metadata,
 ) {
   if (typeof selectList === 'string') {
@@ -467,7 +467,7 @@ async function timeFilterExpr({
 }
 
 async function renderSelect(
-  chartConfig: ChartConfigWithOptDateRateAndCte,
+  chartConfig: ChartConfigWithOptDateRangeEx,
   metadata: Metadata,
 ): Promise<ChSql> {
   /**
@@ -565,7 +565,7 @@ async function renderWhereExpression({
 }
 
 async function renderWhere(
-  chartConfig: ChartConfigWithOptDateRateAndCte,
+  chartConfig: ChartConfigWithOptDateRangeEx,
   metadata: Metadata,
 ): Promise<ChSql> {
   let whereSearchCondition: ChSql | [] = [];
@@ -729,20 +729,56 @@ function renderLimit(
 
 // CTE (Common Table Expressions) isn't exported at this time. It's only used internally
 // for metric SQL generation.
-type ChartConfigWithOptDateRateAndCte = ChartConfigWithOptDateRange & {
+type ChartConfigWithOptDateRangeEx = ChartConfigWithOptDateRange & {
   with?: { name: string; sql: ChSql }[];
 };
 
 function renderWith(
-  chartConfig: ChartConfigWithOptDateRateAndCte,
+  chartConfig: ChartConfigWithOptDateRangeEx,
   metadata: Metadata,
 ): ChSql | undefined {
   const { with: withClauses } = chartConfig;
   if (withClauses) {
     return concatChSql(
-      '',
-      withClauses.map(clause => chSql`WITH ${clause.name} AS (${clause.sql})`),
+      ',',
+      withClauses.map(clause => chSql`${clause.name} AS (${clause.sql})`),
     );
+  }
+
+  return undefined;
+}
+
+function intervalToSeconds(interval: SQLInterval): number {
+  // Parse interval string like "15 second" into number of seconds
+  const [amount, unit] = interval.split(' ');
+  const value = parseInt(amount, 10);
+  switch (unit) {
+    case 'second':
+      return value;
+    case 'minute':
+      return value * 60;
+    case 'hour':
+      return value * 60 * 60;
+    case 'day':
+      return value * 24 * 60 * 60;
+    default:
+      throw new Error(`Invalid interval unit ${unit} in interval ${interval}`);
+  }
+}
+
+function renderFill(
+  chartConfig: ChartConfigWithOptDateRangeEx,
+): ChSql | undefined {
+  const { granularity, dateRange } = chartConfig;
+  if (dateRange && granularity && granularity !== 'auto') {
+    const [start, end] = dateRange;
+    const step = intervalToSeconds(granularity);
+
+    return concatChSql(' ', [
+      chSql`FROM toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(${{ Int64: start.getTime() }}), INTERVAL ${granularity}))
+      TO toUnixTimestamp(toStartOfInterval(fromUnixTimestamp64Milli(${{ Int64: end.getTime() }}), INTERVAL ${granularity}))
+      STEP ${{ Int32: step }}`,
+    ]);
   }
 
   return undefined;
@@ -750,7 +786,7 @@ function renderWith(
 
 function translateMetricChartConfig(
   chartConfig: ChartConfigWithOptDateRange,
-): ChartConfigWithOptDateRateAndCte {
+): ChartConfigWithOptDateRangeEx {
   const metricTables = chartConfig.metricTables;
   if (!metricTables) {
     return chartConfig;
@@ -810,8 +846,78 @@ function translateMetricChartConfig(
         databaseName: '',
         tableName: 'RawSum',
       },
-      where: `MetricName = '${metricName}'`,
-      whereLanguage: 'sql',
+    };
+  } else if (metricType === MetricsDataType.Histogram && metricName) {
+    // histograms are only valid for quantile selections
+    const { aggFn, level, ..._selectRest } = _select as {
+      aggFn: string;
+      level?: number;
+    };
+
+    if (aggFn !== 'quantile' || level == null) {
+      throw new Error('quantile must be specified for histogram metrics');
+    }
+
+    return {
+      ...restChartConfig,
+      with: [
+        {
+          name: 'HistRate',
+          sql: chSql`SELECT Attributes, BucketCounts, ExplicitBounds, MetricName, TimeUnix, AggregationTemporality, CountLength, AttributesHash,
+            any(BucketCounts) OVER (ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS PrevBucketCounts,
+            any(CountLength) OVER (ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS PrevCountLength,
+            any(AttributesHash) OVER (ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS PrevAttributesHash,
+            IF(AggregationTemporality = 1,
+               BucketCounts,
+               IF(AttributesHash = PrevAttributesHash AND CountLength = PrevCountLength,
+                  arrayMap((prev, curr) -> IF(curr < prev, curr, toUInt64(toInt64(curr) - toInt64(prev))), PrevBucketCounts, BucketCounts),
+                  BucketCounts)) as BucketRates
+          FROM (
+            SELECT mapConcat(ScopeAttributes, ResourceAttributes, Attributes) AS Attributes,
+                   cityHash64(Attributes) AS AttributesHash,
+                   BucketCounts,
+                   length(BucketCounts) as CountLength,
+                   ExplicitBounds,
+                   MetricName,
+                   TimeUnix,
+                   AggregationTemporality
+            FROM ${renderFrom({ from: { ...from, tableName: metricTables[MetricsDataType.Histogram] } })})
+            WHERE MetricName = '${metricName}'
+            ORDER BY Attributes, TimeUnix ASC
+          `,
+        },
+        {
+          name: 'RawHist',
+          sql: chSql`
+            SELECT TimeUnix,
+                   MetricName,
+                   BucketRates,
+                   ExplicitBounds,
+                   toUInt64( ${{ Float64: level }} * arraySum(BucketRates)) AS Rank,
+                   arrayCumSum(BucketRates) as CumRates,
+                   arrayFirstIndex(x -> if(x > Rank, 1, 0), CumRates) AS BucketLowIdx, -- b
+                   IF(BucketLowIdx = length(BucketRates),
+                      ExplicitBounds[length(ExplicitBounds)],  -- if the low bound is the last bucket, use the last bound value
+                      IF(BucketLowIdx > 1, -- indexes are 1-based
+                         ExplicitBounds[BucketLowIdx] + (ExplicitBounds[BucketLowIdx + 1] - ExplicitBounds[BucketLowIdx]) *
+                         intDivOrZero(
+                             Rank - CumRates[BucketLowIdx - 1],
+                             CumRates[BucketLowIdx] - CumRates[BucketLowIdx - 1]),
+                    arrayElement(ExplicitBounds, BucketLowIdx + 1) * intDivOrZero(Rank, CumRates[BucketLowIdx]))) as Rate
+            FROM HistRate`,
+        },
+      ],
+      select: [
+        {
+          ..._selectRest,
+          aggFn: 'sum',
+          valueExpression: 'Rate',
+        },
+      ],
+      from: {
+        databaseName: '',
+        tableName: 'RawHist',
+      },
     };
   }
 
@@ -835,15 +941,19 @@ export async function renderChartConfig(
   const where = await renderWhere(chartConfig, metadata);
   const groupBy = await renderGroupBy(chartConfig, metadata);
   const orderBy = renderOrderBy(chartConfig);
+  const fill = renderFill(chartConfig);
   const limit = renderLimit(chartConfig);
 
-  return chSql`${
-    withClauses?.sql ? chSql`${withClauses}` : ''
-  }SELECT ${select} FROM ${from} ${where?.sql ? chSql`WHERE ${where}` : ''} ${
-    groupBy?.sql ? chSql`GROUP BY ${groupBy}` : ''
-  } ${orderBy?.sql ? chSql`ORDER BY ${orderBy}` : ''} ${
-    limit?.sql ? chSql`LIMIT ${limit}` : ''
-  }`;
+  return concatChSql(' ', [
+    chSql`${withClauses?.sql ? chSql`WITH ${withClauses}` : ''}`,
+    chSql`SELECT ${select}`,
+    chSql`FROM ${from}`,
+    chSql`WHERE ${where}`,
+    chSql`${groupBy?.sql ? chSql`GROUP BY ${groupBy}` : ''}`,
+    chSql`${orderBy?.sql ? chSql`ORDER BY ${orderBy}` : ''}`,
+    chSql`${fill?.sql ? chSql`WITH FILL ${fill}` : ''}`,
+    chSql`${limit?.sql ? chSql`LIMIT ${limit}` : ''}`,
+  ]);
 }
 
 // EditForm -> translateToQueriedChartConfig -> QueriedChartConfig


### PR DESCRIPTION
Additional `renderChartConfig` support to transform a histogram select into the correct SQL syntax to generate a chart. For parity with v1, this query only handles quantile queries.

<img width="1939" alt="Screenshot 2025-02-26 at 12 58 55 PM" src="https://github.com/user-attachments/assets/1126ac6c-c431-4d89-92d7-9df1e49e25cf" />

<img width="1960" alt="Screenshot 2025-02-26 at 3 11 07 PM" src="https://github.com/user-attachments/assets/e4fa09bf-1e27-4a90-ad25-6c6cb2890877" />

Ref: HDX-1339