### PR TITLE
fix: log incorrect position in trace view

### DIFF
--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -12,10 +12,7 @@ import { Text } from '@mantine/core';
 import { useColumns } from '@/hooks/useMetadata';
 import useOffsetPaginatedQuery from '@/hooks/useOffsetPaginatedQuery';
 import useRowWhere from '@/hooks/useRowWhere';
-import {
-  getDurationSecondsExpression,
-  getSpanEventBody,
-} from '@/source';
+import { getDurationSecondsExpression, getSpanEventBody } from '@/source';
 import TimelineChart from '@/TimelineChart';
 
 import styles from '@/../styles/LogSidePanel.module.scss';


### PR DESCRIPTION
Fix an event order issue when log and trace table have different precision timestamp column.

With `timestamp` in default selection:
<img width="721" alt="image" src="https://github.com/user-attachments/assets/38d3c85f-db09-421a-a428-7385088ff6f2" />

Without `timestamp` in default selection:
<img width="681" alt="image" src="https://github.com/user-attachments/assets/5ef746ba-ae4c-44c2-8592-d9a3f0bfbd95" />



Ref: 1413