### PR TITLE
fix: Ensure chartConfigs have metric tables passed to them

### DIFF
--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -183,6 +183,7 @@ const Tile = forwardRef(
             },
             implicitColumnExpression: source.implicitColumnExpression,
             filters,
+            metricTables: source.metricTables,
           });
         }
       }


### PR DESCRIPTION
Without metric tables being passed to the chartconfig, the underlying query will not filter by metric name, which creates very large values in the charts as it uses all metrics.

Ref: HDX-1432