### PR TITLE
fix: include common-utils node_modules (api dockerfile)

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -46,8 +46,9 @@ USER node
 
 WORKDIR /app
 
-COPY --chown=node:node --from=base /app/node_modules ./node_modules
+COPY --chown=node:node --from=builder /app/node_modules ./node_modules
 COPY --chown=node:node --from=builder /app/packages/api/build ./packages/api/build
 COPY --chown=node:node --from=builder /app/packages/common-utils/dist ./packages/common-utils/dist
+COPY --chown=node:node --from=base /app/packages/common-utils/node_modules ./packages/common-utils/node_modules
 
 ENTRYPOINT ["node", "-r", "@hyperdx/node-opentelemetry/build/src/tracing", "./packages/api/build/index.js"]


### PR DESCRIPTION
- perf: copy root node_modules from builder stage to cut the deps size by half 
- fix: include `common-utils` node_modules for conflicts pkg like '@clickhouse/client'