### PR TITLE
feat: add displayedTimestampValueExpression

### DIFF
--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -168,6 +168,19 @@ export function LogTableModelForm({
           />
         </FormRow>
         <FormRow
+          label={'Displayed Timestamp Column'}
+          helpText="This DateTime column is used for display."
+        >
+          <SQLInlineEditorControlled
+            database={databaseName}
+            table={tableName}
+            control={control}
+            name="displayedTimestampValueExpression"
+            disableKeywordAutocomplete
+            connectionId={connectionId}
+          />
+        </FormRow>
+        <FormRow
           label={'Default Select'}
           helpText="Default columns selected in search results (this can be customized per search later)"
         >

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -168,19 +168,6 @@ export function LogTableModelForm({
           />
         </FormRow>
         <FormRow
-          label={'Displayed Timestamp Column'}
-          helpText="This DateTime column is used to display search results."
-        >
-          <SQLInlineEditorControlled
-            database={databaseName}
-            table={tableName}
-            control={control}
-            name="displayedTimestampValueExpression"
-            disableKeywordAutocomplete
-            connectionId={connectionId}
-          />
-        </FormRow>
-        <FormRow
           label={'Default Select'}
           helpText="Default columns selected in search results (this can be customized per search later)"
         >
@@ -263,6 +250,19 @@ export function LogTableModelForm({
             control={control}
             name="resourceAttributesExpression"
             placeholder="ResourceAttributes"
+            connectionId={connectionId}
+          />
+        </FormRow>
+        <FormRow
+          label={'Displayed Timestamp Column'}
+          helpText="This DateTime column is used to display search results."
+        >
+          <SQLInlineEditorControlled
+            database={databaseName}
+            table={tableName}
+            control={control}
+            name="displayedTimestampValueExpression"
+            disableKeywordAutocomplete
             connectionId={connectionId}
           />
         </FormRow>

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -169,7 +169,7 @@ export function LogTableModelForm({
         </FormRow>
         <FormRow
           label={'Displayed Timestamp Column'}
-          helpText="This DateTime column is used for display."
+          helpText="This DateTime column is used to display search results."
         >
           <SQLInlineEditorControlled
             database={databaseName}


### PR DESCRIPTION
Add displayedTimestampValueExpression in source form, using `Timestamp` as default.
<img width="919" alt="image" src="https://github.com/user-attachments/assets/e264f735-70af-46c9-a9a4-9f1a5df0caf8" />


This field fix an issue where log and trace have different time column as primary key.
<img width="799" alt="image" src="https://github.com/user-attachments/assets/90c99363-49d8-41ad-8ffa-b10fe8138372" />



Ref: hdx-1438