### PR TITLE
fix: use CTE instead of listing all index parts in query

### DIFF
--- a/.changeset/healthy-carpets-applaud.md
+++ b/.changeset/healthy-carpets-applaud.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": patch
+---
+
+Added support to CTE rendering where you can now specify a CTE using a full chart config object instance. This CTE capability is then used to avoid the URI too long error for delta event queries.

--- a/packages/app/src/components/DBDeltaChart.tsx
+++ b/packages/app/src/components/DBDeltaChart.tsx
@@ -253,83 +253,77 @@ export default function DBDeltaChart({
   config: ChartConfigWithOptDateRange;
   outlierSqlCondition: string;
 }) {
-  const { data: outlierPartIds } = useQueriedChartConfig({
+  const { data: outlierData } = useQueriedChartConfig({
     ...config,
-    select: '_part, _part_offset',
+    with: [
+      {
+        name: 'PartIds',
+        sql: {
+          ...config,
+          select: 'tuple(_part, _part_offset)',
+          filters: [
+            ...(config.filters ?? []),
+            {
+              type: 'sql',
+              condition: `${outlierSqlCondition}`,
+            },
+          ],
+          orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
+          limit: { limit: 1000 },
+        },
+      },
+    ],
+    select: '*',
     filters: [
       ...(config.filters ?? []),
       {
         type: 'sql',
         condition: `${outlierSqlCondition}`,
       },
-    ],
-    orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
-    limit: { limit: 1000 },
-  });
-
-  const { data: outlierData } = useQueriedChartConfig(
-    {
-      ...config,
-      select: '*',
-      filters: [
-        ...(config.filters ?? []),
-        {
-          type: 'sql',
-          condition: `${outlierSqlCondition}`,
-        },
-        {
-          type: 'sql',
-          condition: `indexHint((_part, _part_offset) IN (${outlierPartIds?.data
-            ?.map((r: any) => `('${r._part}', ${r._part_offset})`)
-            ?.join(',')}))`,
-        },
-      ],
-      orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
-      limit: { limit: 1000 },
-    },
-    {
-      enabled: (outlierPartIds?.data?.length ?? 0) > 0,
-    },
-  );
-
-  const { data: inlierPartIds } = useQueriedChartConfig({
-    ...config,
-    select: '_part, _part_offset',
-    filters: [
-      ...(config.filters ?? []),
       {
         type: 'sql',
-        condition: `NOT (${outlierSqlCondition})`,
+        condition: `indexHint((_part, _part_offset) IN PartIds)`,
       },
     ],
     orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
     limit: { limit: 1000 },
   });
 
-  const { data: inlierData } = useQueriedChartConfig(
-    {
-      ...config,
-      select: '*',
-      filters: [
-        ...(config.filters ?? []),
-        {
-          type: 'sql',
-          condition: `NOT (${outlierSqlCondition})`,
+  const { data: inlierData } = useQueriedChartConfig({
+    ...config,
+    with: [
+      {
+        name: 'PartIds',
+        sql: {
+          ...config,
+          select: '_part, _part_offset',
+          filters: [
+            ...(config.filters ?? []),
+            {
+              type: 'sql',
+              condition: `NOT (${outlierSqlCondition})`,
+            },
+          ],
+          orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
+          limit: { limit: 1000 },
         },
-        {
-          type: 'sql',
-          condition: `indexHint((_part, _part_offset) IN (${inlierPartIds?.data
-            ?.map((r: any) => `('${r._part}', ${r._part_offset})`)
-            ?.join(',')}))`,
-        },
-      ],
-      orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
-      limit: { limit: 1000 },
-    },
-    {
-      enabled: (inlierPartIds?.data?.length ?? 0) > 0,
-    },
-  );
+      },
+    ],
+    select: '*',
+    filters: [
+      ...(config.filters ?? []),
+      {
+        type: 'sql',
+        condition: `NOT (${outlierSqlCondition})`,
+      },
+      {
+        type: 'sql',
+        condition: `indexHint((_part, _part_offset) IN PartIds)`,
+      },
+    ],
+    orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
+    limit: { limit: 1000 },
+  });
 
   // TODO: Is loading state
   const { sortedProperties, outlierValueOccurences, inlierValueOccurences } =

--- a/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -107,3 +107,7 @@ exports[`renderChartConfig should generate sql for a single sum metric 1`] = `
       toFloat64OrNull(toString(Value))
     ),toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` FROM Bucketed WHERE (\`__hdx_time_bucket2\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket2\` <= fromUnixTimestamp64Milli(1765670400000)) GROUP BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` LIMIT 10"
 `;
+
+exports[`renderChartConfig should render a chart config CTE configuration correctly 1`] = `"WITH Parts AS (SELECT _part, _part_offset FROM default.some_table WHERE ((FieldA = 'test')) ORDER BY rand() DESC LIMIT 1000) SELECT * FROM Parts WHERE ((FieldA = 'test') AND (indexHint((_part, _part_offset) IN (SELECT tuple(_part, _part_offset) FROM Parts)))) ORDER BY rand() DESC LIMIT 1000"`;
+
+exports[`renderChartConfig should render a string CTE configuration correctly 1`] = `"WITH TestCte AS (SELECT TimeUnix, Line FROM otel_logs) SELECT Line FROM TestCte"`;

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -1,7 +1,6 @@
 import { parameterizedQueryToSql } from '@/clickhouse';
 import { Metadata } from '@/metadata';
 import {
-  ChartConfig,
   ChartConfigWithOptDateRange,
   DisplayType,
   MetricsDataType,

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -749,7 +749,7 @@ async function renderWith(
           // chart config object.
           let resolvedSql: ChSql;
           if (typeof clause.sql === 'string') {
-            resolvedSql = chSql`${{ UNSAFE_RAW_SQL: clause.sql }}`;
+            resolvedSql = chSql`${{ Identifier: clause.sql }}`;
           } else if (clause.sql && 'sql' in clause.sql) {
             resolvedSql = clause.sql;
           } else if (

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ChSql } from '@/clickhouse';
+
 // Basic Enums
 export enum MetricsDataType {
   Gauge = 'gauge',
@@ -102,6 +104,12 @@ export const LimitSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
 });
+
+export const ChSqlSchema = z.object({
+  sql: z.string(),
+  params: z.record(z.string(), z.any()),
+});
+
 export const SelectSQLStatementSchema = z.object({
   select: SelectListSchema,
   from: z.object({
@@ -119,10 +127,7 @@ export const SelectSQLStatementSchema = z.object({
     .array(
       z.object({
         name: z.string(),
-        sql: z.object({
-          sql: z.string(),
-          params: z.record(z.string(), z.any()),
-        }),
+        sql: z.lazy(() => ChSqlSchema.or(ChartConfigSchema)),
         // If true, it'll render as WITH ident AS (subquery)
         // If false, it'll be a "variable" ex. WITH (sql) AS ident
         // where sql can be any expression, ex. a constant string

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import { ChSql } from '@/clickhouse';
-
 // Basic Enums
 export enum MetricsDataType {
   Gauge = 'gauge',


### PR DESCRIPTION
## feat: allow CTE definitions to be nested chart configs

In order to easily use a CTE for fixing large index issues with delta
trace events, this commit updates the type and `renderWith` function to
render a nested chart config.

Ref: HDX-1343

---

## fix: use CTE instead of listing all index parts in query

Instead of sending 2 queries to the DB and enumerating all of parts
and offsets in the query, this change uses a CTE to select the parts.
This reduces the size of the HTTP request, which fixes the URI too
long response.

Ref: HDX-1343