### PR TITLE
fix: Ensure we read more rows in order to get all metric names

### DIFF
--- a/packages/app/src/components/MetricNameSelect.tsx
+++ b/packages/app/src/components/MetricNameSelect.tsx
@@ -45,16 +45,19 @@ function useMetricNames(metricSource: TSource) {
     chartConfig: gaugeConfig,
     keys: ['MetricName'],
     limit: MAX_METRIC_NAME_OPTIONS,
+    disableRowLimit: true,
   });
   const { data: histogramMetrics } = useGetKeyValues({
     chartConfig: histogramConfig,
     keys: ['MetricName'],
     limit: MAX_METRIC_NAME_OPTIONS,
+    disableRowLimit: true,
   });
   const { data: sumMetrics } = useGetKeyValues({
     chartConfig: sumConfig,
     keys: ['MetricName'],
     limit: MAX_METRIC_NAME_OPTIONS,
+    disableRowLimit: true,
   });
 
   return {

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -92,10 +92,12 @@ export function useGetKeyValues({
   chartConfig,
   keys,
   limit,
+  disableRowLimit,
 }: {
   chartConfig: ChartConfigWithDateRange;
   keys: string[];
   limit?: number;
+  disableRowLimit?: boolean;
 }) {
   const metadata = getMetadata();
   return useQuery({
@@ -105,6 +107,7 @@ export function useGetKeyValues({
         chartConfig,
         keys: keys.slice(0, 20), // Limit to 20 keys for now, otherwise request fails (max header size)
         limit,
+        disableRowLimit,
       });
     },
     staleTime: 1000 * 60 * 5, // Cache every 5 min

--- a/packages/common-utils/src/__tests__/metadata.test.ts
+++ b/packages/common-utils/src/__tests__/metadata.test.ts
@@ -1,0 +1,144 @@
+import { ClickhouseClient } from '../clickhouse';
+import { Metadata } from '../metadata';
+import * as renderChartConfigModule from '../renderChartConfig';
+import { ChartConfigWithDateRange } from '../types';
+
+// Mock ClickhouseClient
+const mockClickhouseClient = {
+  query: jest.fn(),
+} as unknown as ClickhouseClient;
+
+const mockCache = {
+  get: jest.fn(),
+  getOrFetch: jest.fn(),
+  set: jest.fn(),
+} as any;
+
+jest.mock('../renderChartConfig', () => ({
+  renderChartConfig: jest
+    .fn()
+    .mockResolvedValue({ sql: 'SELECT 1', params: {} }),
+}));
+
+describe('Metadata', () => {
+  let metadata: Metadata;
+
+  beforeEach(() => {
+    metadata = new Metadata(mockClickhouseClient, mockCache);
+    jest.clearAllMocks();
+  });
+
+  describe('getKeyValues', () => {
+    const mockChartConfig: ChartConfigWithDateRange = {
+      from: {
+        databaseName: 'test_db',
+        tableName: 'test_table',
+      },
+      select: '',
+      where: '',
+      whereLanguage: 'sql',
+      timestampValueExpression: '',
+      connection: 'test_connection',
+      dateRange: [new Date('2024-01-01'), new Date('2024-01-02')],
+    };
+
+    beforeEach(() => {
+      // Mock the renderChartConfig result
+      (mockClickhouseClient.query as jest.Mock).mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                param0: ['value1', 'value2'],
+                param1: ['type1', 'type2'],
+              },
+            ],
+          }),
+      });
+    });
+
+    it('should apply row limit when disableRowLimit is false', async () => {
+      await metadata.getKeyValues({
+        chartConfig: mockChartConfig,
+        keys: ['column1', 'column2'],
+        limit: 10,
+        disableRowLimit: false,
+      });
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clickhouse_settings: {
+            max_rows_to_read: 1e6,
+            read_overflow_mode: 'break',
+          },
+        }),
+      );
+    });
+
+    it('should not apply row limit when disableRowLimit is true', async () => {
+      await metadata.getKeyValues({
+        chartConfig: mockChartConfig,
+        keys: ['column1', 'column2'],
+        limit: 10,
+        disableRowLimit: true,
+      });
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clickhouse_settings: undefined,
+        }),
+      );
+    });
+
+    it('should apply row limit by default when disableRowLimit is not specified', async () => {
+      await metadata.getKeyValues({
+        chartConfig: mockChartConfig,
+        keys: ['column1', 'column2'],
+        limit: 10,
+      });
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clickhouse_settings: {
+            max_rows_to_read: 1e6,
+            read_overflow_mode: 'break',
+          },
+        }),
+      );
+    });
+
+    it('should correctly transform the response data', async () => {
+      const result = await metadata.getKeyValues({
+        chartConfig: mockChartConfig,
+        keys: ['column1', 'column2'],
+        limit: 10,
+      });
+
+      expect(result).toEqual([
+        { key: 'column1', value: ['value1', 'value2'] },
+        { key: 'column2', value: ['type1', 'type2'] },
+      ]);
+    });
+
+    it('should filter out falsy values from the response', async () => {
+      (mockClickhouseClient.query as jest.Mock).mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                param0: ['value1', null, '', 'value2', undefined],
+              },
+            ],
+          }),
+      });
+
+      const result = await metadata.getKeyValues({
+        chartConfig: mockChartConfig,
+        keys: ['column1'],
+        limit: 10,
+      });
+
+      expect(result).toEqual([{ key: 'column1', value: ['value1', 'value2'] }]);
+    });
+  });
+});

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -406,10 +406,12 @@ export class Metadata {
     chartConfig,
     keys,
     limit = 20,
+    disableRowLimit = false,
   }: {
     chartConfig: ChartConfigWithDateRange;
     keys: string[];
     limit?: number;
+    disableRowLimit?: boolean;
   }) {
     const sql = await renderChartConfig(
       {
@@ -426,10 +428,12 @@ export class Metadata {
         query: sql.sql,
         query_params: sql.params,
         connectionId: chartConfig.connection,
-        clickhouse_settings: {
-          max_rows_to_read: DEFAULT_SAMPLE_SIZE,
-          read_overflow_mode: 'break',
-        },
+        clickhouse_settings: !disableRowLimit
+          ? {
+              max_rows_to_read: DEFAULT_SAMPLE_SIZE,
+              read_overflow_mode: 'break',
+            }
+          : undefined,
       })
       .then(res => res.json<any>());
 


### PR DESCRIPTION
The default max_rows_to_read clickhouse query setting was too low for the metrics table. Therefore, not enough rows were being scanned in order to fetch all possible metric names.

Ref: HDX-1451