### PR TITLE
Saved search time range fix

### DIFF
--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -264,7 +264,7 @@ function SaveSearchModal({
           },
           {
             onSuccess: savedSearch => {
-              router.push(`/search/${savedSearch.id}`);
+              router.push(`/search/${savedSearch.id}${window.location.search}`);
               onClose();
             },
           },


### PR DESCRIPTION
When a saved search is saved, router was not maintaining any query params, including those such as "from" or "to", which caused the timeframe to reset back to "Live Tail". Added the current search params when routing to /search/{saved_search} after saving a search.

Ref: HDX-1393