### PR TITLE
ci: fixes linting and release-local-ui target

### DIFF
--- a/.changeset/quiet-dryers-taste.md
+++ b/.changeset/quiet-dryers-taste.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+Fixed CI linting and UI release task.

--- a/packages/api/.eslintrc.js
+++ b/packages/api/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'simple-import-sort'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.json', './tsconfig.test.json'],
   },
   extends: [
     'eslint:recommended',

--- a/packages/api/tsconfig.test.json
+++ b/packages/api/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules"]
+}

--- a/packages/app/.eslintrc.js
+++ b/packages/app/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   plugins: ['simple-import-sort', '@typescript-eslint', 'prettier'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.json', './tsconfig.test.json'],
   },
   extends: [
     'next',

--- a/packages/app/.stylelintignore
+++ b/packages/app/.stylelintignore
@@ -1,3 +1,4 @@
 .next
 .storybook
 node_modules
+coverage

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY .yarn ./.yarn
 COPY .yarnrc.yml yarn.lock package.json nx.json .prettierrc .prettierignore ./
 COPY ./packages/common-utils ./packages/common-utils
-COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/package.json ./packages/app/next.config.js ./packages/app/mdx.d.ts ./packages/app/.eslintrc.js ./packages/app/
+COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.test.json ./packages/app/package.json ./packages/app/next.config.js ./packages/app/mdx.d.ts ./packages/app/.eslintrc.js ./packages/app/
 RUN yarn install --mode=skip-build && yarn cache clean
 
 

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -422,7 +422,7 @@ export default function EditTimeChartForm({
 
   // Emulate the date range picker auto-searching similar to dashboards
   useEffect(() => {
-    setQueriedConfig(config => {
+    setQueriedConfig((config: ChartConfigWithDateRange | undefined) => {
       if (config == null) {
         return config;
       }

--- a/packages/app/tsconfig.test.json
+++ b/packages/app/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules"]
+}

--- a/packages/common-utils/.eslintrc.js
+++ b/packages/common-utils/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'simple-import-sort'],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.json', './tsconfig.test.json'],
   },
   extends: [
     'eslint:recommended',

--- a/packages/common-utils/tsconfig.json
+++ b/packages/common-utils/tsconfig.json
@@ -25,5 +25,6 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/common-utils/tsconfig.test.json
+++ b/packages/common-utils/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
1. Created separate tsconfig files for tests and prod code, including the test files in the test config.

2. Fixed linting error in DBEditTimeChartForm found while running local linting.

3. Excluded coverage CSS from the style lint task.

4. Updated app Dockerfile with test configuration and ran locally to ensure it was working.

Ref: HDX-1502