### PR TITLE
fix: update delta chart with clause

### DIFF
--- a/packages/app/src/components/DBDeltaChart.tsx
+++ b/packages/app/src/components/DBDeltaChart.tsx
@@ -258,7 +258,7 @@ export default function DBDeltaChart({
     with: [
       {
         name: 'PartIds',
-        sql: {
+        chartConfig: {
           ...config,
           select: 'tuple(_part, _part_offset)',
           filters: [
@@ -294,7 +294,7 @@ export default function DBDeltaChart({
     with: [
       {
         name: 'PartIds',
-        sql: {
+        chartConfig: {
           ...config,
           select: '_part, _part_offset',
           filters: [

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -12,6 +12,7 @@ import {
   ChartConfigWithDateRange,
   ChartConfigWithOptDateRange,
   ChSqlSchema,
+  CteChartConfig,
   MetricsDataType,
   SearchCondition,
   SearchConditionLanguage,
@@ -502,8 +503,11 @@ async function renderSelect(
   );
 }
 
-function renderFrom(chartConfig: ChartConfigWithDateRange): ChSql {
-  const from = chartConfig.from;
+function renderFrom({
+  from,
+}: {
+  from: ChartConfigWithDateRange['from'];
+}): ChSql {
   return concatChSql(
     '.',
     chSql`${from.databaseName === '' ? '' : { Identifier: from.databaseName }}`,
@@ -750,7 +754,7 @@ async function renderWith(
           const {
             sql,
             chartConfig,
-          }: { sql?: ChSql; chartConfig?: ChartConfig } = clause;
+          }: { sql?: ChSql; chartConfig?: CteChartConfig } = clause;
 
           // The sql logic can be specified as either a ChSql instance or a chart
           // config object. Due to type erasure and the recursive nature of ChartConfig
@@ -779,9 +783,12 @@ async function renderWith(
             throw new Error('non-conforming chartConfig object in CTE');
           }
 
+          // Note that every NonRecursiveChartConfig object is also a ChartConfig object
+          // without a `with` property. The type cast here prevents a type error but because
+          // results in schema conformance.
           const resolvedSql = sql
             ? sql
-            : await renderChartConfig(chartConfig, metadata);
+            : await renderChartConfig(chartConfig as ChartConfig, metadata);
 
           if (clause.isSubquery === false) {
             return chSql`(${resolvedSql}) AS ${{ Identifier: clause.name }}`;

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -121,26 +121,6 @@ export const SelectSQLStatementSchema = z.object({
   havingLanguage: SearchConditionLanguageSchema.optional(),
   orderBy: SortSpecificationListSchema.optional(),
   limit: LimitSchema.optional(),
-  with: z
-    .array(
-      z.object({
-        name: z.string(),
-
-        // Need to specify either a sql or chartConfig instance. To avoid
-        // the schema falling into an any type, the fields are separate
-        // and listed as optional.
-        sql: ChSqlSchema.optional(),
-        chartConfig: z.lazy(() => ChartConfigSchema).optional(),
-
-        // If true, it'll render as WITH ident AS (subquery)
-        // If false, it'll be a "variable" ex. WITH (sql) AS ident
-        // where sql can be any expression, ex. a constant string
-        // see: https://clickhouse.com/docs/sql-reference/statements/select/with#syntax
-        // default assume true
-        isSubquery: z.boolean().optional(),
-      }),
-    )
-    .optional(),
 });
 
 export type SQLInterval = z.infer<typeof SQLIntervalSchema>;
@@ -367,9 +347,44 @@ export const _ChartConfigSchema = z.object({
   metricTables: MetricTableSchema.optional(),
 });
 
-export const ChartConfigSchema = z.intersection(
-  _ChartConfigSchema,
+// This is a ChartConfig type without the `with` CTE clause included.
+// It needs to be a separate, named schema to avoid use ot z.lazy(...),
+// use of which allows for type mistakes to make it past linting.
+export const CteChartConfigSchema = z.intersection(
+  _ChartConfigSchema.partial({ timestampValueExpression: true }),
   SelectSQLStatementSchema,
+);
+
+export type CteChartConfig = z.infer<typeof CteChartConfigSchema>;
+
+// The `with` CTE property needs to be defined at this level, just above the
+// non-recursive chart config so that it can reference a complete chart config
+// schema. This structure does mean that we cannot nest `with` clauses but does
+// ensure the type system can catch more issues in the build pipeline.
+export const ChartConfigSchema = z.intersection(
+  z.intersection(_ChartConfigSchema, SelectSQLStatementSchema),
+  z
+    .object({
+      with: z.array(
+        z.object({
+          name: z.string(),
+
+          // Need to specify either a sql or chartConfig instance. To avoid
+          // the schema falling into an any type, the fields are separate
+          // and listed as optional.
+          sql: ChSqlSchema.optional(),
+          chartConfig: CteChartConfigSchema.optional(),
+
+          // If true, it'll render as WITH ident AS (subquery)
+          // If false, it'll be a "variable" ex. WITH (sql) AS ident
+          // where sql can be any expression, ex. a constant string
+          // see: https://clickhouse.com/docs/sql-reference/statements/select/with#syntax
+          // default assume true
+          isSubquery: z.boolean().optional(),
+        }),
+      ),
+    })
+    .partial(),
 );
 
 export type ChartConfig = z.infer<typeof ChartConfigSchema>;


### PR DESCRIPTION
Prior refactoring broke out the `sql` and `chartConfig` field names to allow each to be more strict in their types. The delta chart config call was missed in that refactoring.

After refactoring the schema:
<img width="1302" alt="Screenshot 2025-03-19 at 10 13 47 AM" src="https://github.com/user-attachments/assets/d4c5433c-751e-4561-9f52-72ccca64d301" />

After fixing the delta chart component:
<img width="896" alt="Screenshot 2025-03-19 at 10 14 23 AM" src="https://github.com/user-attachments/assets/3a183e1a-af68-4453-b4fc-8515a8e6734e" />

In the UI:
<img width="1417" alt="Screenshot 2025-03-18 at 5 22 25 PM" src="https://github.com/user-attachments/assets/4b720af6-ed11-444d-8602-c019f38facad" />

Ref: HDX-1517