### PR TITLE
fix: Improve search filter sorting, searching, and add exclude

### DIFF
--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -93,7 +93,9 @@ export const FilterCheckbox = ({
       </Group>
       <div className={classes.filterActions}>
         {onClickOnly && <TextButton onClick={onClickOnly} label="Only" />}
-        {onClickExclude && <TextButton onClick={onClickExclude} label="Not" />}
+        {onClickExclude && (
+          <TextButton onClick={onClickExclude} label="Exclude" />
+        )}
       </div>
     </div>
   );

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -128,8 +128,22 @@ export const FilterGroup = ({
       });
     }
 
+    const sortBySelectionAndAlpha = (
+      a: (typeof augmentedOptions)[0],
+      b: (typeof augmentedOptions)[0],
+    ) => {
+      if (selectedValues.has(a.value) && !selectedValues.has(b.value)) {
+        return -1;
+      }
+      if (!selectedValues.has(a.value) && selectedValues.has(b.value)) {
+        return 1;
+      }
+      return a.value.localeCompare(b.value);
+    };
+
+    // If expanded or small list, sort everything
     if (isExpanded || augmentedOptions.length <= MAX_FILTER_GROUP_ITEMS) {
-      return augmentedOptions;
+      return augmentedOptions.sort(sortBySelectionAndAlpha);
     }
 
     // Do not rearrange items if all selected values are visible without expanding
@@ -142,18 +156,11 @@ export const FilterGroup = ({
 
     return augmentedOptions
       .slice()
-      .sort((a, b) => {
-        if (!shouldSortBySelected) {
-          return 0;
-        }
-        if (selectedValues.has(a.value) && !selectedValues.has(b.value)) {
-          return -1;
-        }
-        if (!selectedValues.has(a.value) && selectedValues.has(b.value)) {
-          return 1;
-        }
-        return 0;
-      })
+      .sort((a, b) =>
+        shouldSortBySelected
+          ? sortBySelectionAndAlpha(a, b)
+          : a.value.localeCompare(b.value),
+      )
       .slice(0, Math.max(MAX_FILTER_GROUP_ITEMS, selectedValues.size));
   }, [search, isExpanded, augmentedOptions, selectedValues]);
 

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -211,27 +211,36 @@ export const FilterGroup = ({
 
   return (
     <Stack gap={0}>
-      <TextInput
-        size="xs"
-        placeholder={name}
-        value={search}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-          setSearch(event.currentTarget.value)
-        }
-        leftSectionWidth={27}
-        leftSection={<IconSearch size={15} stroke={2} />}
-        rightSection={
-          selectedValues.included.size + selectedValues.excluded.size > 0 ? (
-            <TextButton
-              label="Clear"
-              onClick={() => {
-                onClearClick();
-                setSearch('');
-              }}
-            />
-          ) : null
-        }
-      />
+      <Tooltip
+        openDelay={name.length > 26 ? 0 : 1500}
+        label={name}
+        position="top"
+        withArrow
+        fz="xxs"
+        color="gray"
+      >
+        <TextInput
+          size="xs"
+          placeholder={name}
+          value={search}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setSearch(event.currentTarget.value)
+          }
+          leftSectionWidth={27}
+          leftSection={<IconSearch size={15} stroke={2} />}
+          rightSection={
+            selectedValues.included.size + selectedValues.excluded.size > 0 ? (
+              <TextButton
+                label="Clear"
+                onClick={() => {
+                  onClearClick();
+                  setSearch('');
+                }}
+              />
+            ) : null
+          }
+        />
+      </Tooltip>
       <Stack gap={0}>
         {displayedOptions.map(option => (
           <FilterCheckbox

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -97,7 +97,7 @@ export const FilterCheckbox = ({
   );
 };
 
-type FilterGroupProps = {
+export type FilterGroupProps = {
   name: string;
   options: { value: string; label: string }[];
   optionsLoading?: boolean;

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -10,9 +10,11 @@ import {
   Stack,
   Tabs,
   Text,
+  TextInput,
   Tooltip,
   UnstyledButton,
 } from '@mantine/core';
+import { IconSearch } from '@tabler/icons-react';
 
 import { useAllFields, useGetKeyValues } from '@/hooks/useMetadata';
 import { useSearchPageFilterState } from '@/searchFilters';
@@ -209,46 +211,27 @@ export const FilterGroup = ({
 
   return (
     <Stack gap={0}>
-      <Group justify="space-between" wrap="nowrap">
-        <Tooltip
-          openDelay={name.length > 26 ? 0 : 1500}
-          label={name}
-          position="top"
-          withArrow
-          fz="xxs"
-          color="gray"
-        >
-          <Text
-            size="xxs"
-            c="gray.3"
-            fw="bold"
-            truncate="start"
-            maw="170px"
-            title={name}
-          >
-            {name}
-          </Text>
-        </Tooltip>
-        {/* <TextInput
-          size="xs"
-          variant="default"
-          placeholder={name}
-          leftSection={<span className="bi-search fs-8.5" />}
-          value={search}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-            setSearch(event.currentTarget.value)
-          }
-        /> */}
-        {selectedValues.included.size + selectedValues.excluded.size > 0 && (
-          <TextButton
-            label="Clear"
-            onClick={() => {
-              onClearClick();
-              setSearch('');
-            }}
-          />
-        )}
-      </Group>
+      <TextInput
+        size="xs"
+        placeholder={name}
+        value={search}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          setSearch(event.currentTarget.value)
+        }
+        leftSectionWidth={27}
+        leftSection={<IconSearch size={15} stroke={2} />}
+        rightSection={
+          selectedValues.included.size + selectedValues.excluded.size > 0 ? (
+            <TextButton
+              label="Clear"
+              onClick={() => {
+                onClearClick();
+                setSearch('');
+              }}
+            />
+          ) : null
+        }
+      />
       <Stack gap={0}>
         {displayedOptions.map(option => (
           <FilterCheckbox

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
@@ -131,26 +131,28 @@ describe('FilterGroup', () => {
     expect(onOnlyClick).toHaveBeenCalledWith('banana');
   });
 
-  // Type in search box (uncomment when search input is enabled)
-  //   it('should filter options when searching', async () => {
-  //     renderWithMantine(
-  //       <FilterGroup
-  //         {...defaultProps}
-  //         options={[
-  //           { value: 'apple123', label: 'apple123' },
-  //           { value: 'apple456', label: 'apple456' },
-  //           { value: 'banana', label: 'banana' },
-  //         ]}
-  //       />,
-  //     );
+  it('should filter options when searching', async () => {
+    renderWithMantine(
+      <FilterGroup
+        {...defaultProps}
+        options={[
+          { value: 'apple123', label: 'apple123' },
+          { value: 'apple456', label: 'apple456' },
+          { value: 'banana', label: 'banana' },
+        ]}
+      />,
+    );
 
-  //     // Type in search box (uncomment when search input is enabled)
-  //     // const searchInput = screen.getByPlaceholderText('Test Filter');
-  //     // await userEvent.type(searchInput, 'apple');
+    // Type in search box
+    const searchInput = screen.getByPlaceholderText('Test Filter');
+    await userEvent.type(searchInput, 'apple');
 
-  //     // const labels = screen.getAllByText(/apple123|apple456/);
-  //     // expect(labels).toHaveLength(2);
-  //     // expect(labels[0]).toHaveTextContent('apple123');
-  //     // expect(labels[1]).toHaveTextContent('apple456');
-  //   });
+    const labels = screen.getAllByText(/apple123|apple456/);
+    expect(labels).toHaveLength(2);
+    expect(labels[0]).toHaveTextContent('apple123');
+    expect(labels[1]).toHaveTextContent('apple456');
+
+    // Verify banana is not shown
+    expect(screen.queryByText('banana')).not.toBeInTheDocument();
+  });
 });

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
@@ -14,6 +14,7 @@ describe('FilterGroup', () => {
     onChange: jest.fn(),
     onClearClick: jest.fn(),
     onOnlyClick: jest.fn(),
+    onExcludeClick: jest.fn(),
   };
 
   it('should sort options alphabetically by default', () => {
@@ -31,7 +32,10 @@ describe('FilterGroup', () => {
     renderWithMantine(
       <FilterGroup
         {...defaultProps}
-        selectedValues={new Set(['zebra', 'apple'])}
+        selectedValues={{
+          included: new Set(['zebra', 'apple']),
+          excluded: new Set(),
+        }}
       />,
     );
 
@@ -41,6 +45,30 @@ describe('FilterGroup', () => {
     expect(labels[0]).toHaveTextContent('apple');
     expect(labels[1]).toHaveTextContent('zebra');
     expect(labels[2]).toHaveTextContent('banana');
+  });
+
+  it('should handle excluded items', () => {
+    renderWithMantine(
+      <FilterGroup
+        {...defaultProps}
+        selectedValues={{
+          included: new Set(['apple']),
+          excluded: new Set(['zebra']),
+        }}
+      />,
+    );
+
+    const options = screen.getAllByRole('checkbox');
+    expect(options).toHaveLength(3);
+    const labels = screen.getAllByText(/apple|banana|zebra/);
+    expect(labels[0]).toHaveTextContent('apple'); // included first
+    expect(labels[1]).toHaveTextContent('zebra'); // excluded second
+    expect(labels[2]).toHaveTextContent('banana'); // unselected last
+
+    // Check that zebra is marked as excluded
+    const excludedCheckbox = options[1];
+    expect(excludedCheckbox).toHaveAttribute('data-indeterminate', 'true');
+    expect(labels[1]).toHaveStyle({ color: expect.stringContaining('red') });
   });
 
   it('should handle more than MAX_FILTER_GROUP_ITEMS', async () => {
@@ -53,7 +81,10 @@ describe('FilterGroup', () => {
       <FilterGroup
         {...defaultProps}
         options={manyOptions}
-        selectedValues={new Set(['item14', 'item13'])}
+        selectedValues={{
+          included: new Set(['item14']),
+          excluded: new Set(['item13']),
+        }}
       />,
     );
 
@@ -63,8 +94,8 @@ describe('FilterGroup', () => {
 
     // Selected items should be visible even if they would be beyond MAX_FILTER_GROUP_ITEMS
     const labels = screen.getAllByText(/item13|item14/);
-    expect(labels[0]).toHaveTextContent('item13');
-    expect(labels[1]).toHaveTextContent('item14');
+    expect(labels[0]).toHaveTextContent('item14'); // included first
+    expect(labels[1]).toHaveTextContent('item13'); // excluded second
 
     // Click "Show more"
     const showMoreButton = screen.getByText(/Show more/);
@@ -88,13 +119,13 @@ describe('FilterGroup', () => {
   //       />,
   //     );
 
-  // Type in search box (uncomment when search input is enabled)
-  // const searchInput = screen.getByPlaceholderText('Test Filter');
-  // await userEvent.type(searchInput, 'apple');
+  //     // Type in search box (uncomment when search input is enabled)
+  //     // const searchInput = screen.getByPlaceholderText('Test Filter');
+  //     // await userEvent.type(searchInput, 'apple');
 
-  // const labels = screen.getAllByText(/apple123|apple456/);
-  // expect(labels).toHaveLength(2);
-  // expect(labels[0]).toHaveTextContent('apple123');
-  // expect(labels[1]).toHaveTextContent('apple456');
-  //});
+  //     // const labels = screen.getAllByText(/apple123|apple456/);
+  //     // expect(labels).toHaveLength(2);
+  //     // expect(labels[0]).toHaveTextContent('apple123');
+  //     // expect(labels[1]).toHaveTextContent('apple456');
+  //   });
 });

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
@@ -1,16 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { FilterGroup } from '../DBSearchPageFilters';
+import { FilterGroup, type FilterGroupProps } from '../DBSearchPageFilters';
 
 describe('FilterGroup', () => {
-  const defaultProps = {
+  const defaultProps: FilterGroupProps = {
     name: 'Test Filter',
     options: [
       { value: 'zebra', label: 'zebra' },
       { value: 'apple', label: 'apple' },
       { value: 'banana', label: 'banana' },
     ],
+    selectedValues: { included: new Set(), excluded: new Set() },
     onChange: jest.fn(),
     onClearClick: jest.fn(),
     onOnlyClick: jest.fn(),
@@ -104,6 +105,30 @@ describe('FilterGroup', () => {
     // Should show all items
     options = screen.getAllByRole('checkbox');
     expect(options).toHaveLength(15);
+  });
+
+  it('should clear excluded values when clicking Only', async () => {
+    const onOnlyClick = jest.fn();
+    renderWithMantine(
+      <FilterGroup
+        {...defaultProps}
+        selectedValues={{
+          included: new Set(['apple']),
+          excluded: new Set(['zebra']),
+        }}
+        onOnlyClick={onOnlyClick}
+      />,
+    );
+
+    // Find and click the "Only" button for banana
+    const bananaRow = screen
+      .getByText('banana')
+      .closest('.filterCheckbox') as HTMLElement;
+    const onlyButton = within(bananaRow).getByText('Only');
+    await userEvent.click(onlyButton);
+
+    // Verify onOnlyClick was called
+    expect(onOnlyClick).toHaveBeenCalledWith('banana');
   });
 
   // Type in search box (uncomment when search input is enabled)

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FilterGroup } from '../DBSearchPageFilters';
+
+describe('FilterGroup', () => {
+  const defaultProps = {
+    name: 'Test Filter',
+    options: [
+      { value: 'zebra', label: 'zebra' },
+      { value: 'apple', label: 'apple' },
+      { value: 'banana', label: 'banana' },
+    ],
+    onChange: jest.fn(),
+    onClearClick: jest.fn(),
+    onOnlyClick: jest.fn(),
+  };
+
+  it('should sort options alphabetically by default', () => {
+    renderWithMantine(<FilterGroup {...defaultProps} />);
+
+    const options = screen.getAllByRole('checkbox');
+    expect(options).toHaveLength(3);
+    const labels = screen.getAllByText(/apple|banana|zebra/);
+    expect(labels[0]).toHaveTextContent('apple');
+    expect(labels[1]).toHaveTextContent('banana');
+    expect(labels[2]).toHaveTextContent('zebra');
+  });
+
+  it('should show selected items first, then sort alphabetically', () => {
+    renderWithMantine(
+      <FilterGroup
+        {...defaultProps}
+        selectedValues={new Set(['zebra', 'apple'])}
+      />,
+    );
+
+    const options = screen.getAllByRole('checkbox');
+    expect(options).toHaveLength(3);
+    const labels = screen.getAllByText(/apple|banana|zebra/);
+    expect(labels[0]).toHaveTextContent('apple');
+    expect(labels[1]).toHaveTextContent('zebra');
+    expect(labels[2]).toHaveTextContent('banana');
+  });
+
+  it('should handle more than MAX_FILTER_GROUP_ITEMS', async () => {
+    const manyOptions = Array.from({ length: 15 }, (_, i) => ({
+      value: `item${i}`,
+      label: `item${i}`,
+    }));
+
+    renderWithMantine(
+      <FilterGroup
+        {...defaultProps}
+        options={manyOptions}
+        selectedValues={new Set(['item14', 'item13'])}
+      />,
+    );
+
+    // Should show MAX_FILTER_GROUP_ITEMS (10) by default
+    let options = screen.getAllByRole('checkbox');
+    expect(options).toHaveLength(10);
+
+    // Selected items should be visible even if they would be beyond MAX_FILTER_GROUP_ITEMS
+    const labels = screen.getAllByText(/item13|item14/);
+    expect(labels[0]).toHaveTextContent('item13');
+    expect(labels[1]).toHaveTextContent('item14');
+
+    // Click "Show more"
+    const showMoreButton = screen.getByText(/Show more/);
+    await userEvent.click(showMoreButton);
+
+    // Should show all items
+    options = screen.getAllByRole('checkbox');
+    expect(options).toHaveLength(15);
+  });
+
+  // Type in search box (uncomment when search input is enabled)
+  //   it('should filter options when searching', async () => {
+  //     renderWithMantine(
+  //       <FilterGroup
+  //         {...defaultProps}
+  //         options={[
+  //           { value: 'apple123', label: 'apple123' },
+  //           { value: 'apple456', label: 'apple456' },
+  //           { value: 'banana', label: 'banana' },
+  //         ]}
+  //       />,
+  //     );
+
+  // Type in search box (uncomment when search input is enabled)
+  // const searchInput = screen.getByPlaceholderText('Test Filter');
+  // await userEvent.type(searchInput, 'apple');
+
+  // const labels = screen.getAllByText(/apple123|apple456/);
+  // expect(labels).toHaveLength(2);
+  // expect(labels[0]).toHaveTextContent('apple123');
+  // expect(labels[1]).toHaveTextContent('apple456');
+  //});
+});

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -3,19 +3,36 @@ import produce from 'immer';
 import type { Filter } from '@hyperdx/common-utils/dist/types';
 
 export type FilterState = {
-  [key: string]: Set<string>;
+  [key: string]: {
+    included: Set<string>;
+    excluded: Set<string>;
+  };
 };
 
 export const filtersToQuery = (filters: FilterState): Filter[] => {
   return Object.entries(filters)
-    .filter(([_, values]) => values.size > 0)
-    .map(([key, values]) => {
-      return {
-        type: 'sql',
-        condition: `${key} IN (${Array.from(values)
-          .map(v => `'${v}'`)
-          .join(', ')})`,
-      };
+    .filter(
+      ([_, values]) => values.included.size > 0 || values.excluded.size > 0,
+    )
+    .flatMap(([key, values]) => {
+      const conditions = [];
+      if (values.included.size > 0) {
+        conditions.push({
+          type: 'sql' as const,
+          condition: `${key} IN (${Array.from(values.included)
+            .map(v => `'${v}'`)
+            .join(', ')})`,
+        });
+      }
+      if (values.excluded.size > 0) {
+        conditions.push({
+          type: 'sql' as const,
+          condition: `${key} NOT IN (${Array.from(values.excluded)
+            .map(v => `'${v}'`)
+            .join(', ')})`,
+        });
+      }
+      return conditions;
     });
 };
 
@@ -28,14 +45,18 @@ export const areFiltersEqual = (a: FilterState, b: FilterState) => {
   }
 
   for (const key of aKeys) {
-    if (!b[key] || a[key].size !== b[key].size) {
-      return false;
+    if (!b[key]) return false;
+
+    // Check included values
+    if (a[key].included.size !== b[key].included.size) return false;
+    for (const value of a[key].included) {
+      if (!b[key].included.has(value)) return false;
     }
 
-    for (const value of a[key]) {
-      if (!b[key].has(value)) {
-        return false;
-      }
+    // Check excluded values
+    if (a[key].excluded.size !== b[key].excluded.size) return false;
+    for (const value of a[key].excluded) {
+      if (!b[key].excluded.has(value)) return false;
     }
   }
 
@@ -47,20 +68,35 @@ export const parseQuery = (
 ): {
   filters: FilterState;
 } => {
-  const state = new Map<string, Set<string>>();
+  const state = new Map<
+    string,
+    { included: Set<string>; excluded: Set<string> }
+  >();
   for (const filter of q) {
-    if (filter.type !== 'sql' || filter.condition.indexOf(' IN ') === -1) {
-      continue;
-    }
+    if (filter.type !== 'sql') continue;
 
-    const [key, values] = filter.condition.split(' IN ');
+    const isExclude = filter.condition.includes('NOT IN');
+    const [key, values] = filter.condition.split(
+      isExclude ? ' NOT IN ' : ' IN ',
+    );
     const keyStr = key.trim();
     const valuesStr = values
       .replace('(', '')
       .replace(')', '')
       .split(',')
       .map(v => v.trim().replace(/'/g, ''));
-    state.set(keyStr, new Set(valuesStr));
+
+    if (!state.has(keyStr)) {
+      state.set(keyStr, { included: new Set(), excluded: new Set() });
+    }
+    const sets = state.get(keyStr)!;
+    valuesStr.forEach(v => {
+      if (isExclude) {
+        sets.excluded.add(v);
+      } else {
+        sets.included.add(v);
+      }
+    });
   }
   return { filters: Object.fromEntries(state) };
 };
@@ -102,22 +138,43 @@ export const useSearchPageFilterState = ({
   );
 
   const setFilterValue = React.useCallback(
-    (property: string, value: string, only?: boolean) => {
+    (
+      property: string,
+      value: string,
+      action?: 'only' | 'exclude' | 'include',
+    ) => {
       setFilters(prevFilters => {
         const newFilters = produce(prevFilters, draft => {
           if (!draft[property]) {
-            draft[property] = new Set();
+            draft[property] = { included: new Set(), excluded: new Set() };
           }
-          // if only is true, set the value as the only value
-          if (only) {
-            draft[property] = new Set([value]);
+
+          if (action === 'only') {
+            draft[property] = {
+              included: new Set([value]),
+              excluded: new Set(),
+            };
             return;
           }
-          const values = draft[property];
-          if (values.has(value)) {
-            values.delete(value);
+
+          if (action === 'exclude') {
+            // Remove from included if it was there
+            draft[property].included.delete(value);
+            // Toggle in excluded
+            if (draft[property].excluded.has(value)) {
+              draft[property].excluded.delete(value);
+            } else {
+              draft[property].excluded.add(value);
+            }
+            return;
+          }
+
+          // Regular toggle (include)
+          draft[property].excluded.delete(value);
+          if (draft[property].included.has(value)) {
+            draft[property].included.delete(value);
           } else {
-            values.add(value);
+            draft[property].included.add(value);
           }
         });
         updateFilterQuery(newFilters);

--- a/packages/app/styles/SearchPage.module.scss
+++ b/packages/app/styles/SearchPage.module.scss
@@ -1,5 +1,6 @@
 @import './variables';
 
+/* stylelint-disable selector-pseudo-class-no-unknown */
 .filtersPanel {
   width: 220px;
   max-height: 100%;
@@ -15,7 +16,6 @@
     .mantine-TextInput-input {
       height: 20px;
       min-height: 20px;
-      //padding: 0 4px;
       background-color: transparent;
       border: none !important;
       color: var(--mantine-color-gray-3);

--- a/packages/app/styles/SearchPage.module.scss
+++ b/packages/app/styles/SearchPage.module.scss
@@ -36,7 +36,7 @@
     opacity: 0.8;
   }
 
-  .textButton {
+  .filterActions {
     position: absolute;
     right: 0;
     top: 0;
@@ -44,15 +44,25 @@
     display: none;
     z-index: 1;
     backdrop-filter: blur(4px);
-    padding: 0 8px;
     border-radius: 4px;
+    align-items: center;
+    padding: 0 8px;
+    gap: 4px;
+    background-color: $slate-950;
 
-    &:hover {
-      background-color: $slate-900;
-    }
+    .textButton {
+      padding: 2px 6px;
+      border-radius: 3px;
 
-    &:active {
-      background-color: $slate-950;
+      &:hover {
+        background-color: $slate-800;
+        color: $slate-200;
+      }
+
+      &:active {
+        background-color: $slate-700;
+        color: $slate-100;
+      }
     }
   }
 
@@ -63,8 +73,8 @@
 
     background-color: $slate-950;
 
-    .textButton {
-      display: block;
+    .filterActions {
+      display: flex;
     }
   }
 }

--- a/packages/app/styles/SearchPage.module.scss
+++ b/packages/app/styles/SearchPage.module.scss
@@ -6,6 +6,32 @@
   background-color: #00000030;
   flex-shrink: 0;
   word-break: break-all;
+
+  :global {
+    .mantine-TextInput-wrapper {
+      background-color: transparent;
+    }
+
+    .mantine-TextInput-input {
+      height: 20px;
+      min-height: 20px;
+      //padding: 0 4px;
+      background-color: transparent;
+      border: none !important;
+      color: var(--mantine-color-gray-3);
+      font-size: var(--mantine-font-size-xs);
+
+      &::placeholder {
+        color: var(--mantine-color-gray-6);
+        font-weight: bold;
+      }
+
+      &:focus {
+        border: none;
+        outline: none;
+      }
+    }
+  }
 }
 
 .textButton {


### PR DESCRIPTION
Adds
* NOT button next to the "Only" button that appears on hover of a search filter item. This will exclude the item from the search
* Search Filter filtering - restores filtering the search filter options by the text entered by the user

Enhances:
* Search filter ordering - selected items will appear on top, followed by an alphabetically ordered list of search filter items

***New NOT option***
Before
![image](https://github.com/user-attachments/assets/37b93663-389f-4a7d-829f-711850d427b9)

After
![image](https://github.com/user-attachments/assets/74f03d2a-a059-4460-ae0a-cd57cc2aafc4)
![image](https://github.com/user-attachments/assets/984f1e97-3371-491d-8f68-7d8a04e7db3e)


***Search filter ordering***
Before
![image](https://github.com/user-attachments/assets/6f124823-bb16-4764-873f-45dce53a10af)

After
![image](https://github.com/user-attachments/assets/6659a35e-3f9f-4b74-8959-2a1c5d5f96a8)

***Searching within Filters***
![image](https://github.com/user-attachments/assets/86f1ff74-34c0-4b41-804b-b60c4d6eee84)
![image](https://github.com/user-attachments/assets/120ecfde-3da0-4ffd-97f8-7f1fe438884b)
