### PR TITLE
fix: severity colors assigned only if data has name severitytextexpression

### DIFF
--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -13,6 +13,7 @@ import {
   DisplayType,
   SavedChartConfig,
   SQLInterval,
+  TSource,
 } from '@hyperdx/common-utils/dist/types';
 import {
   Divider,
@@ -787,11 +788,13 @@ export function formatResponseForTimeChart({
   dateRange,
   granularity,
   generateEmptyBuckets = true,
+  source,
 }: {
   dateRange: [Date, Date];
   granularity?: SQLInterval;
   res: ResponseJSON<Record<string, any>>;
   generateEmptyBuckets?: boolean;
+  source?: TSource;
 }) {
   const meta = res.meta;
   const data = res.data;
@@ -846,10 +849,13 @@ export function formatResponseForTimeChart({
         [keyName]: value,
       });
 
-      const color =
-        groupColumns.length === 1
-          ? logLevelColor(row[groupColumns[0].name])
-          : undefined;
+      let color: string | undefined = undefined;
+      if (
+        groupColumns.length === 1 &&
+        groupColumns[0].name === source?.severityTextExpression
+      ) {
+        color = logLevelColor(row[groupColumns[0].name]);
+      }
       // TODO: Set name and color correctly
       lineDataMap[keyName] = {
         dataKey: keyName,

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -19,6 +19,7 @@ import {
 import { convertGranularityToSeconds } from '@/ChartUtils';
 import { MemoChart } from '@/HDXMultiSeriesTimeChart';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
+import { useSource } from '@/source';
 
 import { SQLPreview } from './ChartSQLPreview';
 
@@ -71,6 +72,7 @@ export function DBTimeChart({
     });
 
   const isLoadingOrPlaceholder = isLoading || isPlaceholderData;
+  const { data: source } = useSource({ id: sourceId });
 
   const { graphResults, timestampColumn, groupKeys, lineNames, lineColors } =
     useMemo(() => {
@@ -80,6 +82,7 @@ export function DBTimeChart({
             dateRange,
             granularity,
             generateEmptyBuckets: fillNulls !== false,
+            source,
           })
         : {
             graphResults: [],


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9c319f22-c020-447b-90e0-686df06f53dc)
![image](https://github.com/user-attachments/assets/67ab9f5b-b62e-4ecb-afb6-0a99d8754534)

After:
![image](https://github.com/user-attachments/assets/785aa90e-ade5-4eed-9485-c16d7aa806ba)
![image](https://github.com/user-attachments/assets/640d97e5-fe2b-4d1f-9e74-2f147a64f914)


Also maintains coloring for SeverityText #695 established.

Ref: HDX-1523