### PR TITLE
perf: reuse existing queries promises to avoid duplicate requests

### DIFF
--- a/.changeset/popular-ants-ring.md
+++ b/.changeset/popular-ants-ring.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+perf: reuse existing queries promises to avoid duplicate requests


### PR DESCRIPTION
In this example, the 'DESCRIBE' query should be fired twice only (for two different tables)
REF: HDX-1527

BEFORE:

<img width="1068" alt="Screenshot 2025-03-21 at 12 00 43 AM" src="https://github.com/user-attachments/assets/ee2d7613-1100-46a3-a5b0-7bfde0118dc0" />

AFTER:

<img width="1048" alt="Screenshot 2025-03-21 at 12 00 11 AM" src="https://github.com/user-attachments/assets/0899a884-1beb-4a18-8140-96c9728ca4f0" />

