### PR TITLE
fix: Session Replay tab not shown if no session source configured for trace

### DIFF
--- a/.changeset/strange-olives-rest.md
+++ b/.changeset/strange-olives-rest.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Session Replay tab for traces is disabled unless the source is configured with a sessionId

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -275,7 +275,7 @@ export default function DBRowSidePanel({
                     text: 'Surrounding Context',
                     value: Tab.Context,
                   },
-                  ...(rumSessionId != null
+                  ...(rumSessionId != null && source.sessionSourceId
                     ? [
                         {
                           text: 'Session Replay',


### PR DESCRIPTION
Ref: HDX-1496