### PR TITLE
feat: implement logs > metrics correlation flow

### DIFF
--- a/.changeset/fast-phones-scream.md
+++ b/.changeset/fast-phones-scream.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+feat: implement logs > metrics correlation flow + introduce convertV1ChartConfigToV2

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -52,6 +52,7 @@ export const Source = mongoose.model<ISource>(
       spanIdExpression: String,
       traceSourceId: String,
       sessionSourceId: String,
+      metricSourceId: String,
 
       durationExpression: String,
       durationPrecision: Number,

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -144,17 +144,15 @@ router.get(
       },
       error: (err, _req, _res) => {
         console.error('Proxy error:', err);
-        if (_res instanceof Response) {
-          (_res as Response).writeHead(500, {
-            'Content-Type': 'application/json',
-          });
-          _res.end(
-            JSON.stringify({
-              success: false,
-              error: err.message || 'Failed to connect to ClickHouse server',
-            }),
-          );
-        }
+        (_res as Response).writeHead(500, {
+          'Content-Type': 'application/json',
+        });
+        _res.end(
+          JSON.stringify({
+            success: false,
+            error: err.message || 'Failed to connect to ClickHouse server',
+          }),
+        );
       },
     },
     // ...(config.IS_DEV && {

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -18,20 +18,10 @@ import {
   SQLInterval,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
-import {
-  Divider,
-  Group,
-  SegmentedControl,
-  Select as MSelect,
-} from '@mantine/core';
+import { SegmentedControl, Select as MSelect } from '@mantine/core';
 
-import { MetricNameSelect } from './components/MetricNameSelect';
-import { NumberFormatInput } from './components/NumberFormat';
 import api from './api';
 import Checkbox from './Checkbox';
-import FieldMultiSelect from './FieldMultiSelect';
-import MetricTagFilterInput from './MetricTagFilterInput';
-import SearchInput from './SearchInput';
 import {
   AggFn,
   ChartSeries,

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -414,65 +414,6 @@ const api = {
       ...options,
     });
   },
-  useLogBatch(
-    {
-      q,
-      startDate,
-      endDate,
-      extraFields,
-      order,
-      limit = 100,
-    }: {
-      q: string;
-      startDate: Date;
-      endDate: Date;
-      extraFields: string[];
-      order: 'asc' | 'desc' | null;
-      limit?: number;
-    },
-    options?: Partial<
-      UseInfiniteQueryOptions<
-        any,
-        Error,
-        InfiniteData<{ data: any[] }>,
-        any,
-        QueryKey,
-        number
-      >
-    >,
-  ) {
-    const startTime = startDate.getTime();
-    const endTime = endDate.getTime();
-    return useInfiniteQuery<
-      { data: any[] },
-      Error,
-      InfiniteData<{ data: any[] }>,
-      QueryKey,
-      number
-    >({
-      queryKey: ['logs', q, startTime, endTime, extraFields, order, limit],
-      initialPageParam: 0,
-      getNextPageParam: (lastPage: any, allPages: any) => {
-        if (lastPage.rows === 0) return undefined;
-        // @ts-ignore
-        return allPages.flatMap(page => page.data).length;
-      },
-      queryFn: async ({ pageParam }: { pageParam: number }) =>
-        hdxServer('logs', {
-          method: 'GET',
-          searchParams: [
-            ['endTime', endTime],
-            ['offset', pageParam],
-            ['q', q],
-            ['startTime', startTime],
-            ['order', order],
-            ['limit', limit],
-            ...extraFields.map(field => ['extraFields[]', field] as const),
-          ] as Array<Array<string | number | boolean>>,
-        }).json(),
-      ...options,
-    });
-  },
   useCreateAlert() {
     return useMutation<any, Error, ApiAlertInput>({
       mutationFn: async alert =>

--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { add, min, sub } from 'date-fns';
-import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
+import { TSource } from '@hyperdx/common-utils/dist/types';
 import {
   Box,
   Card,
@@ -11,6 +11,7 @@ import {
   Stack,
 } from '@mantine/core';
 
+import { convertV1ChartConfigToV2 } from '@/ChartUtils';
 import { getEventBody, useSource } from '@/source';
 
 import {
@@ -107,27 +108,27 @@ const InfraSubpanelGroup = ({
           </Card.Section>
           <Card.Section py={8} px={4} h={height}>
             <DBTimeChart
-              config={{
-                select: [
-                  {
-                    aggFn: 'avg',
-                    metricType: MetricsDataType.Gauge,
-                    valueExpression: 'Value',
-                    metricName: `${fieldPrefix}cpu.utilization`,
-                    aggConditionLanguage: 'lucene',
-                    aggCondition: where,
-                  },
-                ],
-                from: metricSource.from,
-                numberFormat: K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
-                dateRange,
-                connection: metricSource.connection,
-                metricTables: metricSource.metricTables,
-                timestampValueExpression: metricSource.timestampValueExpression,
-                granularity,
-                where: '',
-                fillNulls: false,
-              }}
+              config={convertV1ChartConfigToV2(
+                {
+                  dateRange,
+                  granularity,
+                  seriesReturnType: 'column',
+                  series: [
+                    {
+                      type: 'time',
+                      where,
+                      groupBy: [],
+                      aggFn: 'avg',
+                      field: `${fieldPrefix}cpu.utilization - Gauge`,
+                      table: 'metrics',
+                      numberFormat: K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
+                    },
+                  ],
+                },
+                {
+                  metric: metricSource,
+                },
+              )}
               showDisplaySwitcher={false}
               logReferenceTimestamp={timestamp / 1000}
             />
@@ -139,27 +140,27 @@ const InfraSubpanelGroup = ({
           </Card.Section>
           <Card.Section py={8} px={4} h={height}>
             <DBTimeChart
-              config={{
-                select: [
-                  {
-                    aggFn: 'avg',
-                    metricType: MetricsDataType.Gauge,
-                    valueExpression: 'Value',
-                    metricName: `${fieldPrefix}memory.usage`,
-                    aggConditionLanguage: 'lucene',
-                    aggCondition: where,
-                  },
-                ],
-                from: metricSource.from,
-                numberFormat: K8S_MEM_NUMBER_FORMAT,
-                dateRange,
-                connection: metricSource.connection,
-                metricTables: metricSource.metricTables,
-                timestampValueExpression: metricSource.timestampValueExpression,
-                granularity,
-                where: '',
-                fillNulls: false,
-              }}
+              config={convertV1ChartConfigToV2(
+                {
+                  dateRange,
+                  granularity,
+                  seriesReturnType: 'column',
+                  series: [
+                    {
+                      type: 'time',
+                      where,
+                      groupBy: [],
+                      aggFn: 'avg',
+                      field: `${fieldPrefix}memory.usage - Gauge`,
+                      table: 'metrics',
+                      numberFormat: K8S_MEM_NUMBER_FORMAT,
+                    },
+                  ],
+                },
+                {
+                  metric: metricSource,
+                },
+              )}
               showDisplaySwitcher={false}
               logReferenceTimestamp={timestamp / 1000}
             />
@@ -171,27 +172,27 @@ const InfraSubpanelGroup = ({
           </Card.Section>
           <Card.Section py={8} px={4} h={height}>
             <DBTimeChart
-              config={{
-                select: [
-                  {
-                    aggCondition: where,
-                    aggConditionLanguage: 'lucene',
-                    aggFn: 'avg',
-                    metricName: `${fieldPrefix}filesystem.available`,
-                    metricType: MetricsDataType.Gauge,
-                    valueExpression: 'Value',
-                  },
-                ],
-                from: metricSource.from,
-                numberFormat: K8S_FILESYSTEM_NUMBER_FORMAT,
-                dateRange,
-                connection: metricSource.connection,
-                metricTables: metricSource.metricTables,
-                timestampValueExpression: metricSource.timestampValueExpression,
-                granularity,
-                where: '',
-                fillNulls: false,
-              }}
+              config={convertV1ChartConfigToV2(
+                {
+                  dateRange,
+                  granularity,
+                  seriesReturnType: 'column',
+                  series: [
+                    {
+                      type: 'time',
+                      where,
+                      groupBy: [],
+                      aggFn: 'avg',
+                      field: `${fieldPrefix}filesystem.available - Gauge`,
+                      table: 'metrics',
+                      numberFormat: K8S_FILESYSTEM_NUMBER_FORMAT,
+                    },
+                  ],
+                },
+                {
+                  metric: metricSource,
+                },
+              )}
               showDisplaySwitcher={false}
               logReferenceTimestamp={timestamp / 1000}
             />

--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -1,26 +1,28 @@
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { add, min, sub } from 'date-fns';
+import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
 import {
+  Box,
   Card,
   Group,
+  ScrollArea,
   SegmentedControl,
   SimpleGrid,
   Stack,
-  ScrollArea,
-  Box,
 } from '@mantine/core';
-import { add, sub, min } from 'date-fns';
 
-import { KubeTimeline } from './KubeComponents';
+import { getEventBody, useSource } from '@/source';
+
 import {
+  convertDateRangeToGranularityString,
   Granularity,
   K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
   K8S_FILESYSTEM_NUMBER_FORMAT,
   K8S_MEM_NUMBER_FORMAT,
-  convertDateRangeToGranularityString,
 } from '../ChartUtils';
-import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
+
 import { DBTimeChart } from './DBTimeChart';
-import { useSource } from '@/source';
+import { KubeTimeline } from './KubeComponents';
 
 const InfraSubpanelGroup = ({
   fieldPrefix,
@@ -229,32 +231,36 @@ export default ({
               metricSource={metricSource}
             />
           )}
-          <Card p="md" mt="xl">
-            <Card.Section p="md" py="xs" withBorder>
-              Pod Timeline
-            </Card.Section>
-            <Card.Section>
-              <ScrollArea
-                viewportProps={{
-                  style: { maxHeight: 280 },
-                }}
-              >
-                <Box p="md" py="sm">
-                  <KubeTimeline
-                    q={`k8s.pod.uid:"${podUid}"`}
-                    dateRange={[
-                      sub(new Date(timestamp), { days: 1 }),
-                      add(new Date(timestamp), { days: 1 }),
-                    ]}
-                    anchorEvent={{
-                      label: <div className="text-success">This Event</div>,
-                      timestamp: new Date(timestamp).toISOString(),
-                    }}
-                  />
-                </Box>
-              </ScrollArea>
-            </Card.Section>
-          </Card>
+
+          {source && (
+            <Card p="md" mt="xl">
+              <Card.Section p="md" py="xs" withBorder>
+                Pod Timeline
+              </Card.Section>
+              <Card.Section>
+                <ScrollArea
+                  viewportProps={{
+                    style: { maxHeight: 280 },
+                  }}
+                >
+                  <Box p="md" py="sm">
+                    <KubeTimeline
+                      logSource={source}
+                      q={`${getEventBody(source)}.object.regarding.uid:"${podUid}"`}
+                      dateRange={[
+                        sub(new Date(timestamp), { days: 1 }),
+                        add(new Date(timestamp), { days: 1 }),
+                      ]}
+                      anchorEvent={{
+                        label: <div className="text-success">This Event</div>,
+                        timestamp: new Date(timestamp).toISOString(),
+                      }}
+                    />
+                  </Box>
+                </ScrollArea>
+              </Card.Section>
+            </Card>
+          )}
         </div>
       )}
       {nodeName && metricSource && (

--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -231,7 +231,6 @@ export default ({
               metricSource={metricSource}
             />
           )}
-
           {source && (
             <Card p="md" mt="xl">
               <Card.Section p="md" py="xs" withBorder>

--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -1,0 +1,271 @@
+import { useState, useMemo } from 'react';
+import {
+  Card,
+  Group,
+  SegmentedControl,
+  SimpleGrid,
+  Stack,
+  ScrollArea,
+  Box,
+} from '@mantine/core';
+import { add, sub, min } from 'date-fns';
+
+import { KubeTimeline } from './KubeComponents';
+import {
+  Granularity,
+  K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
+  K8S_FILESYSTEM_NUMBER_FORMAT,
+  K8S_MEM_NUMBER_FORMAT,
+  convertDateRangeToGranularityString,
+} from '../ChartUtils';
+import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
+import { DBTimeChart } from './DBTimeChart';
+import { useSource } from '@/source';
+
+const InfraSubpanelGroup = ({
+  fieldPrefix,
+  metricSource,
+  timestamp,
+  title,
+  where,
+}: {
+  fieldPrefix: string;
+  metricSource: TSource;
+  timestamp: any;
+  title: string;
+  where: string;
+}) => {
+  const [range, setRange] = useState<'30m' | '1h' | '1d'>('30m');
+  const [size, setSize] = useState<'sm' | 'md' | 'lg'>('sm');
+
+  const dateRange = useMemo<[Date, Date]>(() => {
+    const duration = {
+      '30m': { minutes: 15 },
+      '1h': { minutes: 30 },
+      '1d': { hours: 12 },
+    }[range];
+    return [
+      sub(new Date(timestamp), duration),
+      min([add(new Date(timestamp), duration), new Date()]),
+    ];
+  }, [timestamp, range]);
+
+  const { cols, height } = useMemo(() => {
+    switch (size) {
+      case 'sm':
+        return { cols: 3, height: 200 };
+      case 'md':
+        return { cols: 2, height: 250 };
+      case 'lg':
+        return { cols: 1, height: 320 };
+    }
+  }, [size]);
+
+  const granularity = useMemo<Granularity>(() => {
+    return convertDateRangeToGranularityString(dateRange, 60);
+  }, [dateRange]);
+
+  return (
+    <div>
+      <Group justify="space-between" align="center">
+        <Group align="center">
+          <h4 className="text-slate-300 fs-6 m-0">{title}</h4>
+          <SegmentedControl
+            bg="dark.7"
+            color="dark.5"
+            size="xs"
+            data={[
+              { label: '30m', value: '30m' },
+              { label: '1h', value: '1h' },
+              { label: '1d', value: '1d' },
+            ]}
+            value={range}
+            onChange={value => setRange(value as any)}
+          />
+        </Group>
+        <Group align="center">
+          <SegmentedControl
+            bg="dark.7"
+            color="dark.5"
+            size="xs"
+            data={[
+              { label: 'SM', value: 'sm' },
+              { label: 'MD', value: 'md' },
+              { label: 'LG', value: 'lg' },
+            ]}
+            value={size}
+            onChange={value => setSize(value as any)}
+          />
+        </Group>
+      </Group>
+      <SimpleGrid mt="md" cols={cols}>
+        <Card p="md">
+          <Card.Section p="md" py="xs" withBorder>
+            CPU Usage (%)
+          </Card.Section>
+          <Card.Section py={8} px={4} h={height}>
+            <DBTimeChart
+              config={{
+                select: [
+                  {
+                    aggFn: 'avg',
+                    metricType: MetricsDataType.Gauge,
+                    valueExpression: 'Value',
+                    metricName: `${fieldPrefix}cpu.utilization`,
+                    aggConditionLanguage: 'lucene',
+                    aggCondition: where,
+                  },
+                ],
+                from: metricSource.from,
+                numberFormat: K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
+                dateRange,
+                connection: metricSource.connection,
+                metricTables: metricSource.metricTables,
+                timestampValueExpression: metricSource.timestampValueExpression,
+                granularity,
+                where: '',
+                fillNulls: false,
+              }}
+              showDisplaySwitcher={false}
+              logReferenceTimestamp={timestamp / 1000}
+            />
+          </Card.Section>
+        </Card>
+        <Card p="md">
+          <Card.Section p="md" py="xs" withBorder>
+            Memory Used
+          </Card.Section>
+          <Card.Section py={8} px={4} h={height}>
+            <DBTimeChart
+              config={{
+                select: [
+                  {
+                    aggFn: 'avg',
+                    metricType: MetricsDataType.Gauge,
+                    valueExpression: 'Value',
+                    metricName: `${fieldPrefix}memory.usage`,
+                    aggConditionLanguage: 'lucene',
+                    aggCondition: where,
+                  },
+                ],
+                from: metricSource.from,
+                numberFormat: K8S_MEM_NUMBER_FORMAT,
+                dateRange,
+                connection: metricSource.connection,
+                metricTables: metricSource.metricTables,
+                timestampValueExpression: metricSource.timestampValueExpression,
+                granularity,
+                where: '',
+                fillNulls: false,
+              }}
+              showDisplaySwitcher={false}
+              logReferenceTimestamp={timestamp / 1000}
+            />
+          </Card.Section>
+        </Card>
+        <Card p="md">
+          <Card.Section p="md" py="xs" withBorder>
+            Disk Available
+          </Card.Section>
+          <Card.Section py={8} px={4} h={height}>
+            <DBTimeChart
+              config={{
+                select: [
+                  {
+                    aggCondition: where,
+                    aggConditionLanguage: 'lucene',
+                    aggFn: 'avg',
+                    metricName: `${fieldPrefix}filesystem.available`,
+                    metricType: MetricsDataType.Gauge,
+                    valueExpression: 'Value',
+                  },
+                ],
+                from: metricSource.from,
+                numberFormat: K8S_FILESYSTEM_NUMBER_FORMAT,
+                dateRange,
+                connection: metricSource.connection,
+                metricTables: metricSource.metricTables,
+                timestampValueExpression: metricSource.timestampValueExpression,
+                granularity,
+                where: '',
+                fillNulls: false,
+              }}
+              showDisplaySwitcher={false}
+              logReferenceTimestamp={timestamp / 1000}
+            />
+          </Card.Section>
+        </Card>
+      </SimpleGrid>
+    </div>
+  );
+};
+
+export default ({
+  rowData,
+  rowId,
+  source,
+}: {
+  rowData?: Record<string, any>;
+  rowId: string | undefined | null;
+  source: TSource;
+}) => {
+  const { data: metricSource } = useSource({ id: source.metricSourceId });
+
+  const podUid = rowData?.__hdx_resource_attributes['k8s.pod.uid'];
+  const nodeName = rowData?.__hdx_resource_attributes['k8s.node.name'];
+
+  const timestamp = new Date(rowData?.__hdx_timestamp).getTime();
+
+  return (
+    <Stack my="md" gap={40}>
+      {podUid && (
+        <div>
+          {metricSource && (
+            <InfraSubpanelGroup
+              title="Pod"
+              where={`${metricSource.resourceAttributesExpression}.k8s.pod.uid:"${podUid}"`}
+              fieldPrefix="k8s.pod."
+              timestamp={timestamp}
+              metricSource={metricSource}
+            />
+          )}
+          <Card p="md" mt="xl">
+            <Card.Section p="md" py="xs" withBorder>
+              Pod Timeline
+            </Card.Section>
+            <Card.Section>
+              <ScrollArea
+                viewportProps={{
+                  style: { maxHeight: 280 },
+                }}
+              >
+                <Box p="md" py="sm">
+                  <KubeTimeline
+                    q={`k8s.pod.uid:"${podUid}"`}
+                    dateRange={[
+                      sub(new Date(timestamp), { days: 1 }),
+                      add(new Date(timestamp), { days: 1 }),
+                    ]}
+                    anchorEvent={{
+                      label: <div className="text-success">This Event</div>,
+                      timestamp: new Date(timestamp).toISOString(),
+                    }}
+                  />
+                </Box>
+              </ScrollArea>
+            </Card.Section>
+          </Card>
+        </div>
+      )}
+      {nodeName && metricSource && (
+        <InfraSubpanelGroup
+          metricSource={metricSource}
+          title="Node"
+          where={`${metricSource.resourceAttributesExpression}.k8s.node.name:"${nodeName}"`}
+          fieldPrefix="k8s.node."
+          timestamp={timestamp}
+        />
+      )}
+    </Stack>
+  );
+};

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -26,11 +26,11 @@ import { SearchConfig } from '@/types';
 import { useZIndex, ZIndexContext } from '@/zIndex';
 
 import ContextSubpanel from './ContextSidePanel';
+import DBInfraPanel from './DBInfraPanel';
 import { RowDataPanel, useRowData } from './DBRowDataPanel';
 import { RowOverviewPanel } from './DBRowOverviewPanel';
 import { DBSessionPanel, useSessionId } from './DBSessionPanel';
 import DBTracePanel from './DBTracePanel';
-import DBInfraPanel from './DBInfraPanel';
 
 import 'react-modern-drawer/dist/index.css';
 import styles from '@/../styles/LogSidePanel.module.scss';

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -30,6 +30,7 @@ import { RowDataPanel, useRowData } from './DBRowDataPanel';
 import { RowOverviewPanel } from './DBRowOverviewPanel';
 import { DBSessionPanel, useSessionId } from './DBSessionPanel';
 import DBTracePanel from './DBTracePanel';
+import DBInfraPanel from './DBInfraPanel';
 
 import 'react-modern-drawer/dist/index.css';
 import styles from '@/../styles/LogSidePanel.module.scss';
@@ -90,6 +91,7 @@ export default function DBRowSidePanel({
     Trace = 'trace',
     Context = 'context',
     Replay = 'replay',
+    Infrastructure = 'infrastructure',
   }
 
   const [queryTab, setQueryTab] = useQueryState(
@@ -216,6 +218,18 @@ export default function DBRowSidePanel({
     enabled: rowId != null,
   });
 
+  const hasK8sContext = useMemo(() => {
+    if (!source?.resourceAttributesExpression || !normalizedRow) {
+      return false;
+    }
+    return (
+      normalizedRow[source.resourceAttributesExpression]['k8s.pod.uid'] !=
+        null ||
+      normalizedRow[source.resourceAttributesExpression]['k8s.node.name'] !=
+        null
+    );
+  }, [source, normalizedRow]);
+
   return (
     <Drawer
       customIdSuffix={`log-side-panel-${rowId}`}
@@ -280,6 +294,14 @@ export default function DBRowSidePanel({
                         {
                           text: 'Session Replay',
                           value: Tab.Replay,
+                        },
+                      ]
+                    : []),
+                  ...(hasK8sContext
+                    ? [
+                        {
+                          text: 'Infrastructure',
+                          value: Tab.Infrastructure,
                         },
                       ]
                     : []),
@@ -377,6 +399,26 @@ export default function DBRowSidePanel({
                       rumSessionId={rumSessionId}
                     />
                   </div>
+                </ErrorBoundary>
+              )}
+              {displayedTab === Tab.Infrastructure && (
+                <ErrorBoundary
+                  onError={err => {
+                    console.error(err);
+                  }}
+                  fallbackRender={() => (
+                    <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent p-4">
+                      An error occurred while rendering this event.
+                    </div>
+                  )}
+                >
+                  <Box style={{ overflowY: 'auto' }} p="sm" h="100%">
+                    <DBInfraPanel
+                      source={source}
+                      rowData={normalizedRow}
+                      rowId={rowId}
+                    />
+                  </Box>
                 </ErrorBoundary>
               )}
               <LogSidePanelKbdShortcuts />

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -26,28 +26,30 @@ import { SQLPreview } from './ChartSQLPreview';
 
 export function DBTimeChart({
   config,
-  sourceId,
-  onSettled,
-  onError,
-  referenceLines,
-  showDisplaySwitcher = true,
-  setDisplayType,
-  queryKeyPrefix,
   enabled = true,
+  logReferenceTimestamp,
+  onError,
+  onSettled,
   onTimeRangeSelect,
+  queryKeyPrefix,
+  referenceLines,
+  setDisplayType,
+  showDisplaySwitcher = true,
   showLegend = true,
+  sourceId,
 }: {
   config: ChartConfigWithDateRange;
-  sourceId?: string;
-  onSettled?: () => void;
-  onError?: (error: Error | ClickHouseQueryError) => void;
-  showDisplaySwitcher?: boolean;
-  setDisplayType?: (type: DisplayType) => void;
-  referenceLines?: React.ReactNode;
-  queryKeyPrefix?: string;
   enabled?: boolean;
+  logReferenceTimestamp?: number;
+  onError?: (error: Error | ClickHouseQueryError) => void;
+  onSettled?: () => void;
   onTimeRangeSelect?: (start: Date, end: Date) => void;
+  queryKeyPrefix?: string;
+  referenceLines?: React.ReactNode;
+  setDisplayType?: (type: DisplayType) => void;
+  showDisplaySwitcher?: boolean;
   showLegend?: boolean;
+  sourceId?: string;
 }) {
   const {
     displayType: displayTypeProp,
@@ -283,16 +285,17 @@ export function DBTimeChart({
           displayType={displayType}
           graphResults={graphResults}
           groupKeys={groupKeys}
+          isClickActive={false}
           isLoading={isLoadingOrPlaceholder}
           lineColors={lineColors}
           lineNames={lineNames}
-          timestampKey={timestampColumn?.name}
-          setIsClickActive={setActiveClickPayload}
-          isClickActive={false}
-          onTimeRangeSelect={onTimeRangeSelect}
-          showLegend={showLegend}
+          logReferenceTimestamp={logReferenceTimestamp}
           numberFormat={config.numberFormat}
+          onTimeRangeSelect={onTimeRangeSelect}
           referenceLines={referenceLines}
+          setIsClickActive={setActiveClickPayload}
+          showLegend={showLegend}
+          timestampKey={timestampColumn?.name}
         />
       </div>
     </div>

--- a/packages/app/src/components/KubeComponents.tsx
+++ b/packages/app/src/components/KubeComponents.tsx
@@ -24,10 +24,11 @@ type KubeEvent = {
   id: string;
   timestamp: string;
   severity_text?: string;
-  'object.reason'?: string;
-  'object.note'?: string;
-  'object.type'?: string;
   'k8s.pod.name'?: string;
+  'object.message'?: string;
+  'object.note'?: string;
+  'object.reason'?: string;
+  'object.type'?: string;
 };
 
 type AnchorEvent = {
@@ -130,12 +131,12 @@ const renderKubeEvent = (source: TSource) => (event: KubeEvent) => {
   return (
     <Timeline.Item key={event.id}>
       <Link href={href} passHref legacyBehavior>
-        <Anchor size="11" c="gray.6" title={event.timestamp}>
+        <Anchor size="xs" fz={11} c="gray.6" title={event.timestamp}>
           <FormatTime value={event.timestamp} />
         </Anchor>
       </Link>
       <Group gap="xs" my={4}>
-        <Text size="12" color="white" fw="bold">
+        <Text size="sm" fz={12} c="white" fw="bold">
           {event['object.reason']}
         </Text>
         {event['object.type'] && (
@@ -149,7 +150,7 @@ const renderKubeEvent = (source: TSource) => (event: KubeEvent) => {
           </Badge>
         )}
       </Group>
-      <Text size="xs">{event['object.note']}</Text>
+      <Text size="xs">{event['object.note'] || event['object.message']}</Text>
     </Timeline.Item>
   );
 };
@@ -280,11 +281,11 @@ export const KubeTimeline = ({
       <Timeline bulletSize={12} lineWidth={1}>
         {podEventsAfterAnchor.map(renderKubeEvent(logSource))}
         <Timeline.Item key={anchorEvent.timestamp} ref={anchorRef}>
-          <Text size="11" c="gray.6" title={anchorEvent.timestamp}>
+          <Text size="xs" fz={11} c="gray.6" title={anchorEvent.timestamp}>
             <FormatTime value={anchorEvent.timestamp} />
           </Text>
           <Group gap="xs" my={4}>
-            <Text size="12" c="white" fw="bold">
+            <Text size="sm" fz={12} c="white" fw="bold">
               {anchorEvent.label}
             </Text>
           </Group>

--- a/packages/app/src/components/KubeComponents.tsx
+++ b/packages/app/src/components/KubeComponents.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { sub } from 'date-fns';
+import type { ResponseJSON } from '@clickhouse/client';
+import { renderChartConfig } from '@hyperdx/common-utils/dist/renderChartConfig';
+import {
+  ChartConfigWithDateRange,
+  DateRange,
+  SearchCondition,
+  SearchConditionLanguage,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
 import { Anchor, Badge, Group, Text, Timeline } from '@mantine/core';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-import api from '../api';
+import { getClickhouseClient } from '@/clickhouse';
+import { getMetadata } from '@/metadata';
+import { getDisplayedTimestampValueExpression, getEventBody } from '@/source';
+
 import { KubePhase } from '../types';
 import { FormatTime } from '../useFormatTime';
 
@@ -22,13 +35,92 @@ type AnchorEvent = {
   label: React.ReactNode;
 };
 
-const renderKubeEvent = (event: KubeEvent) => {
+const useV2LogBatch = (
+  {
+    dateRange,
+    extraSelects,
+    limit,
+    logSource,
+    order,
+    where,
+    whereLanguage,
+  }: {
+    dateRange: DateRange['dateRange'];
+    extraSelects?: ChartConfigWithDateRange['select'];
+    limit?: number;
+    logSource: TSource;
+    order: 'asc' | 'desc';
+    where: SearchCondition;
+    whereLanguage: SearchConditionLanguage;
+  },
+  options?: Omit<UseQueryOptions<any>, 'queryKey' | 'queryFn'>,
+) => {
+  const clickhouseClient = getClickhouseClient();
+  return useQuery<ResponseJSON<KubeEvent>, Error>({
+    queryKey: [
+      'v2LogBatch',
+      logSource.id,
+      extraSelects,
+      dateRange,
+      where,
+      whereLanguage,
+      limit,
+      order,
+    ],
+    queryFn: async () => {
+      const query = await renderChartConfig(
+        {
+          select: [
+            {
+              valueExpression: getDisplayedTimestampValueExpression(logSource),
+              alias: 'timestamp',
+            },
+            {
+              valueExpression: `${logSource.serviceNameExpression}`,
+              alias: '_service',
+            },
+            ...(extraSelects && Array.isArray(extraSelects)
+              ? extraSelects
+              : []),
+          ],
+          from: logSource.from,
+          dateRange,
+          timestampValueExpression: logSource.timestampValueExpression,
+          implicitColumnExpression: logSource.implicitColumnExpression,
+          where,
+          whereLanguage,
+          connection: logSource.connection,
+          limit: {
+            limit: limit ?? 50,
+            offset: 0,
+          },
+          orderBy: `${logSource.timestampValueExpression} ${order}`,
+        },
+        getMetadata(),
+      );
+
+      const json = await clickhouseClient
+        .query({
+          query: query.sql,
+          query_params: query.params,
+          connectionId: logSource.connection,
+        })
+        .then(res => res.json());
+
+      return json as ResponseJSON<KubeEvent>;
+    },
+    staleTime: 1000 * 60 * 5, // Cache every 5 min
+    ...options,
+  });
+};
+
+const renderKubeEvent = (source: TSource) => (event: KubeEvent) => {
   let href = '#';
   try {
     // FIXME: should check if it works in v2
     href = `/search?q=${encodeURIComponent(
-      `k8s.pod.name:"${event['k8s.pod.name']}"`,
-    )}&from=${new Date(event.timestamp).getTime() - 1000 * 60 * 15}&to=${
+      `${source.resourceAttributesExpression}.k8s.pod.name:"${event['k8s.pod.name']}"`,
+    )}&source=${source.id}&from=${new Date(event.timestamp).getTime() - 1000 * 60 * 15}&to=${
       new Date(event.timestamp).getTime() + 1
     }`;
   } catch (_) {
@@ -64,10 +156,12 @@ const renderKubeEvent = (event: KubeEvent) => {
 
 export const KubeTimeline = ({
   q,
+  logSource,
   anchorEvent,
   dateRange,
 }: {
   q: string;
+  logSource: TSource;
   dateRange?: [Date, Date];
   anchorEvent?: AnchorEvent;
 }) => {
@@ -80,26 +174,60 @@ export const KubeTimeline = ({
     [dateRange],
   );
 
-  // FIXME: use renderChartConfig
-  const { data, isLoading } = api.useLogBatch({
-    q: `k8s.resource.name:"events" ${q}`,
+  const { data, isLoading } = useV2LogBatch({
+    dateRange: [startDate, endDate],
     limit: 50,
-    startDate,
-    endDate,
-    extraFields: [
-      'object.metadata.creationTimestamp',
-      'object.reason',
-      'object.note',
-      'object.type',
-      'type',
-      'k8s.pod.name',
-    ],
+    logSource,
     order: 'desc',
+    where: `${logSource.eventAttributesExpression}.k8s.resource.name:"events" ${q}`,
+    whereLanguage: 'lucene',
+    extraSelects: [
+      {
+        valueExpression: `generateUUIDv4()`,
+        alias: 'id',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'metadata', 'creationTimestamp')`,
+        alias: 'object.metadata.creationTimestamp',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'reason')`,
+        alias: 'object.reason',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'note')`,
+        alias: 'object.note',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'type')`,
+        alias: 'object.type',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'message')`,
+        alias: 'object.message',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'regarding', 'name')`,
+        alias: 'k8s.pod.name',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'type')`,
+        alias: 'type',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'type')`,
+        alias: 'severity_text',
+      },
+      {
+        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'note')`,
+        alias: 'body',
+      },
+    ],
   });
 
   const allPodEvents: KubeEvent[] = React.useMemo(
     () =>
-      (data?.pages?.[0]?.data || []).sort(
+      (data?.data || []).sort(
         (a, b) =>
           new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
       ),
@@ -150,7 +278,7 @@ export const KubeTimeline = ({
   if (anchorEvent) {
     return (
       <Timeline bulletSize={12} lineWidth={1}>
-        {podEventsAfterAnchor.map(renderKubeEvent)}
+        {podEventsAfterAnchor.map(renderKubeEvent(logSource))}
         <Timeline.Item key={anchorEvent.timestamp} ref={anchorRef}>
           <Text size="11" c="gray.6" title={anchorEvent.timestamp}>
             <FormatTime value={anchorEvent.timestamp} />
@@ -161,13 +289,13 @@ export const KubeTimeline = ({
             </Text>
           </Group>
         </Timeline.Item>
-        {podEventsBeforeAnchor.map(renderKubeEvent)}
+        {podEventsBeforeAnchor.map(renderKubeEvent(logSource))}
       </Timeline>
     );
   } else {
     return (
       <Timeline bulletSize={12} lineWidth={1}>
-        {allPodEvents.map(renderKubeEvent)}
+        {allPodEvents.map(renderKubeEvent(logSource))}
       </Timeline>
     );
   }

--- a/packages/app/src/components/KubeComponents.tsx
+++ b/packages/app/src/components/KubeComponents.tsx
@@ -25,6 +25,7 @@ type AnchorEvent = {
 const renderKubeEvent = (event: KubeEvent) => {
   let href = '#';
   try {
+    // FIXME: should check if it works in v2
     href = `/search?q=${encodeURIComponent(
       `k8s.pod.name:"${event['k8s.pod.name']}"`,
     )}&from=${new Date(event.timestamp).getTime() - 1000 * 60 * 15}&to=${
@@ -79,6 +80,7 @@ export const KubeTimeline = ({
     [dateRange],
   );
 
+  // FIXME: use renderChartConfig
   const { data, isLoading } = api.useLogBatch({
     q: `k8s.resource.name:"events" ${q}`,
     limit: 50,

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -233,6 +233,16 @@ export function LogTableModelForm({
             connectionId={connectionId}
           />
         </FormRow>
+        <FormRow label={'Body Expression'}>
+          <SQLInlineEditorControlled
+            database={databaseName}
+            table={tableName}
+            control={control}
+            name="bodyExpression"
+            placeholder="Body"
+            connectionId={connectionId}
+          />
+        </FormRow>
         <FormRow label={'Log Attributes Expression'}>
           <SQLInlineEditorControlled
             database={databaseName}
@@ -268,6 +278,12 @@ export function LogTableModelForm({
         </FormRow>
         <Divider />
         <FormRow
+          label={'Correlated Metric Source'}
+          helpText="HyperDX Source for metrics associated with logs. Optional"
+        >
+          <SourceSelectControlled control={control} name="metricSourceId" />
+        </FormRow>
+        <FormRow
           label={'Correlated Trace Source'}
           helpText="HyperDX Source for traces associated with logs. Optional"
         >
@@ -295,12 +311,6 @@ export function LogTableModelForm({
           />
         </FormRow>
 
-        <FormRow
-          label={'Correlated Metric Source'}
-          helpText="HyperDX Source for metrics associated with logs. Optional"
-        >
-          <SourceSelectControlled control={control} name="metricSourceId" />
-        </FormRow>
         <Divider />
         {/* <FormRow
           label={'Unique Row ID Expression'}

--- a/packages/app/src/components/SourceForm.tsx
+++ b/packages/app/src/components/SourceForm.tsx
@@ -294,6 +294,13 @@ export function LogTableModelForm({
             connectionId={connectionId}
           />
         </FormRow>
+
+        <FormRow
+          label={'Correlated Metric Source'}
+          helpText="HyperDX Source for metrics associated with logs. Optional"
+        >
+          <SourceSelectControlled control={control} name="metricSourceId" />
+        </FormRow>
         <Divider />
         {/* <FormRow
           label={'Unique Row ID Expression'}
@@ -732,6 +739,12 @@ export function MetricTableModelForm({
             />
           </FormRow>
         ))}
+        <FormRow
+          label={'Correlated Log Source'}
+          helpText="HyperDX Source for logs associated with metrics. Optional"
+        >
+          <SourceSelectControlled control={control} name="logSourceId" />
+        </FormRow>
       </Stack>
     </>
   );

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -508,6 +508,7 @@ export const SourceSchema = z.object({
 
   // OTEL Metrics
   metricTables: MetricTableSchema.optional(),
+  metricSourceId: z.string().optional(),
 });
 
 export type TSource = z.infer<typeof SourceSchema>;


### PR DESCRIPTION
1. users now should be able to go from k8s logs to metrics through 'Infrastructure' tab within details panel
2. introduce `convertV1ChartConfigToV2` to convert V1 multi-series chart config to V2 (only metrics)

Ref: HDX-1333, HDX-1536

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/c7f893b3-794c-4e23-9aa0-9ab37532a57f" />


