### PR TITLE
feat: retain side nav collapse/expand status between sessions

### DIFF
--- a/.changeset/neat-scissors-hope.md
+++ b/.changeset/neat-scissors-hope.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": minor
+---
+
+Stores the collapse vs expand status of the side navigation in local storage so it's carried across browser windows/sessions.

--- a/packages/app/src/AppNav.tsx
+++ b/packages/app/src/AppNav.tsx
@@ -596,7 +596,7 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
               className={isCollapsed ? 'mt-4' : ''}
               style={{ marginRight: -4 }}
               title="Collapse/Expand Navigation"
-              onClick={() => setIsPreferCollapsed(v => !v)}
+              onClick={() => setIsPreferCollapsed((v: boolean) => !v)}
             >
               <i className="bi bi-layout-sidebar"></i>
             </Button>

--- a/packages/app/src/AppNav.tsx
+++ b/packages/app/src/AppNav.tsx
@@ -372,12 +372,13 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
   );
   const { width } = useWindowSize();
 
-  const [isPreferCollapsed, setIsPreferCollapsed] = useState<
-    undefined | boolean
-  >(undefined);
+  const [isPreferCollapsed, setIsPreferCollapsed] = useLocalStorage<boolean>(
+    'isNavCollapsed',
+    false,
+  );
 
   const isSmallScreen = (width ?? 1000) < 900;
-  const isCollapsed = isPreferCollapsed ?? isSmallScreen;
+  const isCollapsed = isSmallScreen || isPreferCollapsed;
 
   const navWidth = isCollapsed ? 50 : 230;
 


### PR DESCRIPTION
Stores the collapse vs expand status of the side navigation in local storage so it's carried across browser windows/sessions.

Ref: HDX-1539