### PR TITLE
feat: query sum metric without rate logic

### DIFF
--- a/.changeset/light-emus-allow.md
+++ b/.changeset/light-emus-allow.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": minor
+---
+
+Support querying a sum metric as a value instead of a rate

--- a/packages/api/src/clickhouse/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/api/src/clickhouse/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -24,12 +24,12 @@ Array [
 exports[`renderChartConfig Query Metrics calculates min_rate/max_rate correctly for sum metrics: maxSum 1`] = `
 Array [
   Object {
+    "Value": 24,
     "__hdx_time_bucket": "2022-01-05T00:00:00Z",
-    "max(toFloat64OrNull(toString(Value)))": 24,
   },
   Object {
+    "Value": 134,
     "__hdx_time_bucket": "2022-01-05T00:10:00Z",
-    "max(toFloat64OrNull(toString(Value)))": 134,
   },
 ]
 `;
@@ -37,12 +37,12 @@ Array [
 exports[`renderChartConfig Query Metrics calculates min_rate/max_rate correctly for sum metrics: minSum 1`] = `
 Array [
   Object {
+    "Value": 15,
     "__hdx_time_bucket": "2022-01-05T00:00:00Z",
-    "min(toFloat64OrNull(toString(Value)))": 15,
   },
   Object {
+    "Value": 52,
     "__hdx_time_bucket": "2022-01-05T00:10:00Z",
-    "min(toFloat64OrNull(toString(Value)))": 52,
   },
 ]
 `;
@@ -50,12 +50,12 @@ Array [
 exports[`renderChartConfig Query Metrics handles counter resets correctly for sum metrics 1`] = `
 Array [
   Object {
+    "Value": 15,
     "__hdx_time_bucket": "2022-01-05T00:00:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 15,
   },
   Object {
+    "Value": 52,
     "__hdx_time_bucket": "2022-01-05T00:10:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 52,
   },
 ]
 `;
@@ -140,20 +140,33 @@ Array [
 exports[`renderChartConfig Query Metrics single sum rate 1`] = `
 Array [
   Object {
+    "Value": 19,
     "__hdx_time_bucket": "2022-01-05T00:00:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 19,
   },
   Object {
+    "Value": 79,
     "__hdx_time_bucket": "2022-01-05T00:05:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 79,
   },
   Object {
+    "Value": 5813,
     "__hdx_time_bucket": "2022-01-05T00:10:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 5813,
   },
   Object {
+    "Value": 78754,
     "__hdx_time_bucket": "2022-01-05T00:15:00Z",
-    "sum(toFloat64OrNull(toString(Value)))": 78754,
+  },
+]
+`;
+
+exports[`renderChartConfig Query Metrics single sum value 1`] = `
+Array [
+  Object {
+    "Value": 950400,
+    "__hdx_time_bucket": "2022-01-05T00:00:00Z",
+  },
+  Object {
+    "Value": 1641600,
+    "__hdx_time_bucket": "2022-01-05T00:10:00Z",
   },
 ]
 `;

--- a/packages/api/src/clickhouse/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/api/src/clickhouse/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -158,7 +158,7 @@ Array [
 ]
 `;
 
-exports[`renderChartConfig Query Metrics single sum value 1`] = `
+exports[`renderChartConfig Query Metrics sum values as without rate computation 1`] = `
 Array [
   Object {
     "Value": 950400,

--- a/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -79,15 +79,17 @@ exports[`renderChartConfig should generate sql for a single sum metric 1`] = `
                   IF(AggregationTemporality = 1,
                     SUM(Value) OVER (PARTITION BY AttributesHash ORDER BY AttributesHash, TimeUnix ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
                     deltaSum(Value) OVER (PARTITION BY AttributesHash ORDER BY AttributesHash, TimeUnix ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-                  ) AS Value
+                  ) AS Rate,
+                  IF(AggregationTemporality = 1, Rate, Value) AS Sum
                 FROM default.otel_metrics_sum
                 WHERE (TimeUnix >= toStartOfInterval(fromUnixTimestamp64Milli(1739318400000), INTERVAL 5 minute) - INTERVAL 5 minute AND TimeUnix <= toStartOfInterval(fromUnixTimestamp64Milli(1765670400000), INTERVAL 5 minute) + INTERVAL 5 minute) AND ((MetricName = 'db.client.connections.usage'))),Bucketed AS (
             SELECT
               toStartOfInterval(toDateTime(TimeUnix), INTERVAL 5 minute) AS \`__hdx_time_bucket2\`,
               AttributesHash,
-              last_value(Source.Value) AS \`__hdx_value_high\`,
+              last_value(Source.Rate) AS \`__hdx_value_high\`,
               any(\`__hdx_value_high\`) OVER(PARTITION BY AttributesHash ORDER BY \`__hdx_time_bucket2\` ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS \`__hdx_value_high_prev\`,
-              \`__hdx_value_high\` - \`__hdx_value_high_prev\` AS Value,
+              \`__hdx_value_high\` - \`__hdx_value_high_prev\` AS Rate,
+              last_value(Source.Sum) AS Sum,
               any(ResourceAttributes) AS ResourceAttributes,
               any(ResourceSchemaUrl) AS ResourceSchemaUrl,
               any(ScopeName) AS ScopeName,
@@ -108,6 +110,6 @@ exports[`renderChartConfig should generate sql for a single sum metric 1`] = `
             GROUP BY AttributesHash, \`__hdx_time_bucket2\`
             ORDER BY AttributesHash, \`__hdx_time_bucket2\`
           ) SELECT avg(
-      toFloat64OrNull(toString(Value))
-    ),toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` FROM Bucketed WHERE (\`__hdx_time_bucket2\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket2\` <= fromUnixTimestamp64Milli(1765670400000)) GROUP BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` LIMIT 10"
+      toFloat64OrNull(toString(Rate))
+    ) AS \\"Value\\",toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` FROM Bucketed WHERE (\`__hdx_time_bucket2\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket2\` <= fromUnixTimestamp64Milli(1765670400000)) GROUP BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(\`__hdx_time_bucket2\`), INTERVAL 5 minute) AS \`__hdx_time_bucket\` LIMIT 10"
 `;


### PR DESCRIPTION
Add the ability to query a sum metric and obtain the underlying values instead of the rate of change between those points.

Ref: HDX-1543