### PR TITLE
fix: delete huge z-index for tooltip

### DIFF
--- a/.changeset/hip-dolls-reply.md
+++ b/.changeset/hip-dolls-reply.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: delete huge z-value for tooltip

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -511,7 +511,7 @@ export const MemoChart = memo(function MemoChart({
         <Tooltip
           content={<HDXLineChartTooltip numberFormat={numberFormat} />}
           wrapperStyle={{
-            zIndex: 1000,
+            zIndex: 0.1,
           }}
           allowEscapeViewBox={{ y: true }}
         />


### PR DESCRIPTION
Z-index on tooltip was causing it to show over an open drawer. Deleted it and just letting the default value ride.

Before:
![image](https://github.com/user-attachments/assets/17561295-32be-45d7-ac38-161a55aa6ab1)

After:
![image](https://github.com/user-attachments/assets/3ed0152e-f2e3-45f5-b1c9-ac020e62acbb)

Ref: HDX-1540