### PR TITLE
fix: Fix issue with selecting existing connection

### DIFF
--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -476,7 +476,7 @@ export function isSingleTableConnection(
     !Array.isArray(obj) &&
     typeof obj?.databaseName === 'string' &&
     typeof obj?.tableName === 'string' &&
-    typeof obj?.connectionId === 'string'
+    (typeof obj?.connectionId === 'string' || obj?.connectionId == null)
   );
 }
 


### PR DESCRIPTION
After #713 was merged, a bug was introduced which manifests when a user clicks an existing connection while editing a source.

The issue is that a helper function (`isSingleTableConnection`) was introduced to check to see if a single connection was passed or an array of connections was passed. In this function, it also checks the schema if a single object is passed, which can cause the function to return `false` if the schema isn't exact. This poses a problem because the downstream code will think that it is an array of connections and error out.

In this particular scenario, there was another bug where if a user clicks on a selected value in the source dropdown, it unselects that value and returns null, which is what triggered this error to begin with.

Therefore there are two fixes here:
1) Add an option to disable un-selection of dropdowns and set that to true for the source dropdown.
2) Remove the helper code `isSingleTableConnection` as its behavior is confusing to downstream consumers.