### PR TITLE
expand session replay time range correctly for context panel

### DIFF
--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -3,7 +3,6 @@ import {
   MouseEventHandler,
   useCallback,
   useContext,
-  useId,
   useMemo,
   useState,
 } from 'react';
@@ -191,10 +190,18 @@ export default function DBRowSidePanel({
     return tags;
   }, [serviceName, source.serviceNameExpression]);
 
-  const rng = useMemo(() => {
+  const oneHourRange = useMemo(() => {
     return [
       add(timestampDate, { minutes: -60 }),
       add(timestampDate, { minutes: 60 }),
+    ] as [Date, Date];
+  }, [timestampDate]);
+
+  // For session replay, we need +/-4 hours to get full session
+  const fourHourRange = useMemo(() => {
+    return [
+      add(timestampDate, { hours: -4 }),
+      add(timestampDate, { hours: 4 }),
     ] as [Date, Date];
   }, [timestampDate]);
 
@@ -214,7 +221,7 @@ export default function DBRowSidePanel({
   const { rumSessionId, rumServiceName } = useSessionId({
     sourceId: traceSourceId,
     traceId,
-    dateRange: rng,
+    dateRange: oneHourRange,
     enabled: rowId != null,
   });
 
@@ -343,7 +350,7 @@ export default function DBRowSidePanel({
                       parentSourceId={source.id}
                       childSourceId={childSourceId}
                       traceId={traceId}
-                      dateRange={rng}
+                      dateRange={oneHourRange}
                       focusDate={focusDate}
                     />
                   </Box>
@@ -395,7 +402,7 @@ export default function DBRowSidePanel({
                 >
                   <div className="overflow-hidden flex-grow-1">
                     <DBSessionPanel
-                      dateRange={rng}
+                      dateRange={fourHourRange}
                       focusDate={focusDate}
                       setSubDrawerOpen={setSubDrawerOpen}
                       traceSourceId={traceSourceId}


### PR DESCRIPTION
sessions can be up to 4 hours long so we need to search at least 4hr time frame.