### PR TITLE
fix: Fix filter text cutoffs with resizable filter pane

### DIFF
--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -65,7 +65,7 @@ export const FilterCheckbox = ({
       <Group
         gap={8}
         onClick={() => onChange?.(!value)}
-        flex={1}
+        style={{ minWidth: 0 }}
         wrap="nowrap"
         align="flex-start"
       >
@@ -90,7 +90,7 @@ export const FilterCheckbox = ({
             size="xs"
             c={value === 'excluded' ? 'red.4' : 'gray.3'}
             truncate="end"
-            maw="150px"
+            w="100%"
             title={label}
           >
             {label}

--- a/packages/app/styles/SearchPage.module.scss
+++ b/packages/app/styles/SearchPage.module.scss
@@ -58,7 +58,8 @@
 
 .filterCheckbox {
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 20px;
   padding: 2px 6px;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
Fixes styles so that filter checkbox text can extend as the filter pane is resized.

Ref: HDX-1574