### PR TITLE
fix: removed originalWhere from SurroundingContext tags

### DIFF
--- a/.changeset/spicy-windows-repeat.md
+++ b/.changeset/spicy-windows-repeat.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: remove originalWhere tag from view. not used anyways

--- a/packages/app/src/components/ContextSidePanel.tsx
+++ b/packages/app/src/components/ContextSidePanel.tsx
@@ -41,10 +41,8 @@ export default function ContextSubpanel({
 }: ContextSubpanelProps) {
   const QUERY_KEY_PREFIX = 'context';
   const { Timestamp: origTimestamp } = rowData;
-  const {
-    where: originalWhere = '',
-    whereLanguage: originalLanguage = 'lucene',
-  } = dbSqlRowTableConfig ?? {};
+  const { whereLanguage: originalLanguage = 'lucene' } =
+    dbSqlRowTableConfig ?? {};
   const [range, setRange] = useState<number>(ms('30s'));
   const [contextBy, setContextBy] = useState<ContextBy>(ContextBy.All);
   const { control, watch } = useForm({
@@ -232,11 +230,6 @@ export default function ContextSubpanel({
             {contextBy !== ContextBy.All && (
               <Badge size="md" variant="default">
                 {contextBy}:{CONTEXT_MAPPING[contextBy].value}
-              </Badge>
-            )}
-            {originalWhere && (
-              <Badge size="md" variant="default">
-                {originalWhere}
               </Badge>
             )}
             <Badge size="md" variant="default">


### PR DESCRIPTION
The originalWhere clause was never used in the surrounding context, there was just the tag displayed.
![image](https://github.com/user-attachments/assets/ce13c557-ef30-45ff-9135-cb3ef42f539b)


Fix: HDX-1570