### PR TITLE
feat: Resizable span name column in timeline chart

### DIFF
--- a/packages/app/src/TimelineChart.tsx
+++ b/packages/app/src/TimelineChart.tsx
@@ -376,14 +376,12 @@ export default function TimelineChart({
   const [offset, setOffset] = useState(0);
   const prevScale = usePrevious(scale);
 
-  // Convert initialLabelWidth to a percentage for the resizable hook
   const initialWidthPercent = (initialLabelWidth / window.innerWidth) * 100;
   const { width: labelWidthPercent, startResize } = useResizable(
     initialWidthPercent,
     'left',
   );
 
-  // Convert percentage back to pixels for rendering
   const labelWidth = (labelWidthPercent / 100) * window.innerWidth;
 
   const timelineRef = useRef<HTMLDivElement>(null);
@@ -578,10 +576,9 @@ export default function TimelineChart({
                   style={{
                     width: labelWidth,
                     minWidth: labelWidth,
-                    position: 'relative',
                   }}
                 >
-                  <div className="text-truncate">{row.label}</div>
+                  {row.label}
                   <div
                     className={resizeStyles.resizeHandle}
                     onMouseDown={startResize}

--- a/packages/app/src/TimelineChart.tsx
+++ b/packages/app/src/TimelineChart.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { Tooltip } from '@mantine/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
+import useResizable from './hooks/useResizable';
 import { useDrag, usePrevious } from './utils';
 
 import styles from '../styles/TimelineChart.module.scss';
@@ -344,7 +345,7 @@ export default function TimelineChart({
   rowHeight,
   onMouseMove,
   onEventClick,
-  labelWidth,
+  labelWidth: initialLabelWidth,
   className,
   style,
   onClick,
@@ -373,6 +374,16 @@ export default function TimelineChart({
 }) {
   const [offset, setOffset] = useState(0);
   const prevScale = usePrevious(scale);
+
+  // Convert initialLabelWidth to a percentage for the resizable hook
+  const initialWidthPercent = (initialLabelWidth / window.innerWidth) * 100;
+  const { width: labelWidthPercent, startResize } = useResizable(
+    initialWidthPercent,
+    'left',
+  );
+
+  // Convert percentage back to pixels for rendering
+  const labelWidth = (labelWidthPercent / 100) * window.innerWidth;
 
   const timelineRef = useRef<HTMLDivElement>(null);
   const onMouseEvent = (
@@ -561,8 +572,19 @@ export default function TimelineChart({
                   ...row.style,
                 }}
               >
-                <div style={{ width: labelWidth, minWidth: labelWidth }}>
-                  {row.label}
+                <div
+                  className={styles.labelContainer}
+                  style={{
+                    width: labelWidth,
+                    minWidth: labelWidth,
+                    position: 'relative',
+                  }}
+                >
+                  <div className="text-truncate">{row.label}</div>
+                  <div
+                    className={styles.resizeHandle}
+                    onMouseDown={startResize}
+                  />
                 </div>
                 <NewTimelineRow
                   events={row.events}

--- a/packages/app/src/TimelineChart.tsx
+++ b/packages/app/src/TimelineChart.tsx
@@ -6,6 +6,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import useResizable from './hooks/useResizable';
 import { useDrag, usePrevious } from './utils';
 
+import resizeStyles from '../styles/ResizablePanel.module.scss';
 import styles from '../styles/TimelineChart.module.scss';
 
 type TimelineEventT = {
@@ -582,7 +583,7 @@ export default function TimelineChart({
                 >
                   <div className="text-truncate">{row.label}</div>
                   <div
-                    className={styles.resizeHandle}
+                    className={resizeStyles.resizeHandle}
                     onMouseDown={startResize}
                   />
                 </div>

--- a/packages/app/src/TimelineChart.tsx
+++ b/packages/app/src/TimelineChart.tsx
@@ -585,6 +585,7 @@ export default function TimelineChart({
                   <div
                     className={resizeStyles.resizeHandle}
                     onMouseDown={startResize}
+                    style={{ backgroundColor: '#3a3a44' }}
                   />
                 </div>
                 <NewTimelineRow

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -487,7 +487,7 @@ export function DBTraceWaterfallChartContainer({
                   title="Correlated Log Line"
                 />
               ) : null}
-              {serviceName ? `${serviceName} | ` : ''}
+              {/* {serviceName ? `${serviceName} | ` : ''} */}
               {displayText}
             </Text>
           </div>

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -487,7 +487,7 @@ export function DBTraceWaterfallChartContainer({
                   title="Correlated Log Line"
                 />
               ) : null}
-              {/* {serviceName ? `${serviceName} | ` : ''} */}
+              {serviceName ? `${serviceName} | ` : ''}
               {displayText}
             </Text>
           </div>

--- a/packages/app/styles/TimelineChart.module.scss
+++ b/packages/app/styles/TimelineChart.module.scss
@@ -12,9 +12,4 @@
   white-space: nowrap;
   padding-right: 8px;
   position: relative;
-  
-  /* Make imported resize handle appear on hover */
-  &:hover :global(div[class*="resizeHandle"]) {
-    opacity: 1;
-  }
 }

--- a/packages/app/styles/TimelineChart.module.scss
+++ b/packages/app/styles/TimelineChart.module.scss
@@ -13,28 +13,8 @@
   padding-right: 8px;
   position: relative;
   
-  &:hover .resizeHandle {
+  /* Make imported resize handle appear on hover */
+  &:hover :global(div[class*="resizeHandle"]) {
     opacity: 1;
-  }
-}
-
-.resizeHandle {
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  width: 4px;
-  cursor: col-resize;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
-  z-index: 10;
-  
-  &:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-  }
-  
-  &:active {
-    opacity: 1;
-    background-color: rgba(255, 255, 255, 0.3);
   }
 }

--- a/packages/app/styles/TimelineChart.module.scss
+++ b/packages/app/styles/TimelineChart.module.scss
@@ -5,3 +5,36 @@
     background-color: #aaaaff07;
   }
 }
+
+.labelContainer {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 8px;
+  position: relative;
+  
+  &:hover .resizeHandle {
+    opacity: 1;
+  }
+}
+
+.resizeHandle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: col-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+  z-index: 10;
+  
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+  
+  &:active {
+    opacity: 1;
+    background-color: rgba(255, 255, 255, 0.3);
+  }
+}


### PR DESCRIPTION
Utilizes resizable hook so that span names can be resized in timeline waterfall view.

[screen-capture (7).webm](https://github.com/user-attachments/assets/5b56e7fd-839d-434d-80f6-08fd3503a08a)

Ref: HDX-1534