### PR TITLE
chore: Replace deprecated ubuntu runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   lint:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
         run: make ci-lint
   unit:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
         run: make ci-unit
   integration:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes
GitHub Actions has encountered an internal error when running your job integration.

This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. 

For more details, see https://github.com/actions/runner-images/issues/11101