### PR TITLE
fix: 'Failed to fetch' errors

### DIFF
--- a/.changeset/funny-crabs-whisper.md
+++ b/.changeset/funny-crabs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: 'Failed to fetch' errors

--- a/packages/common-utils/src/clickhouse.ts
+++ b/packages/common-utils/src/clickhouse.ts
@@ -457,9 +457,6 @@ export class ClickhouseClient {
           },
           username: '',
           password: '',
-          compression: {
-            response: true,
-          },
         });
         return clickhouseClient.query<Format>({
           query,


### PR DESCRIPTION
ref: HDX-1697

The response compression is only enabled on the browser side (regression: https://github.com/hyperdxio/hyperdx/commit/cfdd523516a1a3e39309a5de23828a30bb5b4b7f#diff-5b5bd864a2d51f72bb19df7630437c37e267b24de2a514fe486bd03653a09f32R458), which led to the fetch failed errors occasionally.

The root cause is still unclear. I'll file an issue in the SDK repo. Also we don't want an inconsistent behavior for the client settings anyway.

<img width="805" alt="image" src="https://github.com/user-attachments/assets/b7f0dd8e-f342-4ef1-9a6d-689d527d6b6a" />

<img width="922" alt="image" src="https://github.com/user-attachments/assets/591a938c-9111-477a-821c-9045d19c0d12" />

