### PR TITLE
fix: disable keep_alive on the browser side (ch client)

### DIFF
--- a/.changeset/long-goats-fail.md
+++ b/.changeset/long-goats-fail.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: disable keep_alive on the browser side (ch client)

--- a/packages/common-utils/src/clickhouse.ts
+++ b/packages/common-utils/src/clickhouse.ts
@@ -457,6 +457,10 @@ export class ClickhouseClient {
           },
           username: '',
           password: '',
+          // Disable keep-alive to prevent multiple concurrent dashboard requests from exceeding the 64KB payload size limit.
+          keep_alive: {
+            enabled: false,
+          },
         });
         return clickhouseClient.query<Format>({
           query,


### PR DESCRIPTION
We should disable 'keep_alive' for the clickhouse browser client due to fetch API limit. Users would likely to hit the error in dashboard when there are many concurrent requests.

ref: HDX-1697

From https://fetch.spec.whatwg.org/

```
If contentLength is non-null and httpRequest’s [keepalive](https://fetch.spec.whatwg.org/#request-keepalive-flag) is true, then:

Let inflightKeepaliveBytes be 0.

Let group be httpRequest’s [client](https://fetch.spec.whatwg.org/#concept-request-client)’s [fetch group](https://fetch.spec.whatwg.org/#concept-fetch-group).

Let inflightRecords be the set of [fetch records](https://fetch.spec.whatwg.org/#concept-fetch-record) in group whose [request](https://fetch.spec.whatwg.org/#concept-fetch-record-request)’s [keepalive](https://fetch.spec.whatwg.org/#request-keepalive-flag) is true and [done flag](https://fetch.spec.whatwg.org/#done-flag) is unset.

[For each](https://infra.spec.whatwg.org/#list-iterate) fetchRecord of inflightRecords:

Let inflightRequest be fetchRecord’s [request](https://fetch.spec.whatwg.org/#concept-fetch-record-request).

Increment inflightKeepaliveBytes by inflightRequest’s [body](https://fetch.spec.whatwg.org/#concept-request-body)’s [length](https://fetch.spec.whatwg.org/#concept-body-total-bytes).

If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a [network error](https://fetch.spec.whatwg.org/#concept-network-error).
```
