### PR TITLE
refactor: clean up cruft from test suite

### DIFF
--- a/smoke-tests/otel-collector/hdx-1453-auto-parse-json.bats
+++ b/smoke-tests/otel-collector/hdx-1453-auto-parse-json.bats
@@ -6,7 +6,7 @@ load 'test_helpers/assertions.bash'
 setup_file() {
     validate_env
     docker compose up --build --detach
-    wait_for_ready "otel-collector" "http://localhost:4318"
+    wait_for_ready "otel-collector"
 }
 
 teardown_file() {

--- a/smoke-tests/otel-collector/hdx-1514-inference.bats
+++ b/smoke-tests/otel-collector/hdx-1514-inference.bats
@@ -6,11 +6,11 @@ load 'test_helpers/assertions.bash'
 setup_file() {
     validate_env
     docker compose up --build --detach
-    wait_for_ready "otel-collector" "http://localhost:4318"
+    wait_for_ready "otel-collector"
 }
 
 teardown_file() {
-    docker compose down
+    attempt_env_cleanup
 }
 
 @test "should infer fatal log level" {

--- a/smoke-tests/otel-collector/test_helpers/utilities.bash
+++ b/smoke-tests/otel-collector/test_helpers/utilities.bash
@@ -23,7 +23,6 @@ validate_env() {
 
 wait_for_ready() {
     local container_name=$1
-    local endpoint=$2
     local max_attempts=10
     local wait_time=0
 


### PR DESCRIPTION
1. The wait_for_ready function does not need the endpoint param. We should remove it to make maintenance easier.

2. The hdx-1514-inference test should use the attempt_env_cleanup function to pick up the logic that skips container tear down.

Ref: HDX-1730