### PR TITLE
fix: Optimize SearchInputV2 render

### DIFF
--- a/packages/app/src/SearchInputV2.tsx
+++ b/packages/app/src/SearchInputV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useController, UseControllerProps } from 'react-hook-form';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { Field, TableConnection } from '@hyperdx/common-utils/dist/metadata';
@@ -54,14 +54,12 @@ export default function SearchInputV2({
   const ref = useRef<HTMLInputElement>(null);
   const [parsedEnglishQuery, setParsedEnglishQuery] = useState<string>('');
 
-  const autoCompleteOptions = useAutoCompleteOptions(
-    new LuceneLanguageFormatter(),
-    value,
-    {
-      tableConnections,
-      additionalSuggestions,
-    },
-  );
+  const luceneFormatter = useMemo(() => new LuceneLanguageFormatter(), []);
+
+  const autoCompleteOptions = useAutoCompleteOptions(luceneFormatter, value, {
+    tableConnections,
+    additionalSuggestions,
+  });
 
   useEffect(() => {
     genEnglishExplanation(value).then(q => {


### PR DESCRIPTION
There's a small delay when opening event side panel from the search page caused by re-instantiating
lucene formatter every re-render.

Before / After:

![Screenshot 2025-05-25 at 11 16 11 PM](https://github.com/user-attachments/assets/e9c5b03b-f740-497f-ab8f-855a5bb7d2cb)


![Screenshot 2025-05-25 at 11 16 07 PM](https://github.com/user-attachments/assets/11210738-f72f-4bf7-bb68-40db0bb2d511)

