### PR TITLE
fix: all sending in-app telemetry back to hdx

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,3 @@ HYPERDX_OPAMP_PORT=4320
 
 # Otel/Clickhouse config
 HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=default
-
-# TEMPORARY: local development
-HYPERDX_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,8 @@ services:
       MONGO_URI: 'mongodb://db:27017/hyperdx'
       NEXT_PUBLIC_SERVER_URL: http://127.0.0.1:${HYPERDX_API_PORT}
       OPAMP_PORT: ${HYPERDX_OPAMP_PORT}
-      OTEL_SERVICE_NAME: 'hdx-oss-api'
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://otel-collector:4318'
+      OTEL_SERVICE_NAME: 'hdx-oss-app'
       USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
       DEFAULT_CONNECTIONS:
         '[{"name":"Local


### PR DESCRIPTION
like v1, users should be able to specify `HYPERDX_API_KEY` to send export in-app telemetry back to hyperdx itself.
running command like
```
HYPERDX_API_KEY=XXX docker compose up -d
```