### PR TITLE
fix: Pollyfill crypto.randomUUID for non-secure connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
       "prettier --write --ignore-unknown"
     ]
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.5.1",
+  "dependencies": {
+    "crypto-randomuuid": "^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,5 @@
       "prettier --write --ignore-unknown"
     ]
   },
-  "packageManager": "yarn@4.5.1",
-  "dependencies": {
-    "crypto-randomuuid": "^1.0.0"
-  }
+  "packageManager": "yarn@4.5.1"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,6 +50,7 @@
     "chrono-node": "^2.7.8",
     "classnames": "^2.3.1",
     "crypto-js": "^4.2.0",
+    "crypto-randomuuid": "^1.0.0",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^2.0.0",
     "fuse.js": "^6.6.2",

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { NextAdapter } from 'next-query-params';
+import randomUUID from 'crypto-randomuuid';
 import { enableMapSet } from 'immer';
 import SSRProvider from 'react-bootstrap/SSRProvider';
 import { QueryParamProvider } from 'use-query-params';
@@ -28,6 +29,11 @@ import '@mantine/dates/styles.css';
 import '@styles/globals.css';
 import '@styles/app.scss';
 import 'uplot/dist/uPlot.min.css';
+
+// Polyfill crypto.randomUUID for non-HTTPS environments
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+  crypto.randomUUID = randomUUID;
+}
 
 enableMapSet();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,6 +4399,7 @@ __metadata:
     chrono-node: "npm:^2.7.8"
     classnames: "npm:^2.3.1"
     crypto-js: "npm:^4.2.0"
+    crypto-randomuuid: "npm:^1.0.0"
     date-fns: "npm:^2.28.0"
     date-fns-tz: "npm:^2.0.0"
     fuse.js: "npm:^6.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17558,7 +17558,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.7.0"
     "@typescript-eslint/parser": "npm:^8.7.0"
     concurrently: "npm:^9.1.2"
-    crypto-randomuuid: "npm:^1.0.0"
     dotenv: "npm:^16.4.7"
     dotenv-cli: "npm:^8.0.0"
     dotenv-expand: "npm:^12.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13554,6 +13554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypto-randomuuid@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "crypto-randomuuid@npm:1.0.0"
+  checksum: 10c0/6c8f7513f3b0c38b876b5011d91e21c284f7a695d27b6ef25a2a1ca89c362af23e321bf47953069b9fe56bc384de7880a13c390a4663ac5dcf525a1b4f937a1f
+  languageName: node
+  linkType: hard
+
 "css-functions-list@npm:^3.2.2":
   version: 3.2.2
   resolution: "css-functions-list@npm:3.2.2"
@@ -17550,6 +17557,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.7.0"
     "@typescript-eslint/parser": "npm:^8.7.0"
     concurrently: "npm:^9.1.2"
+    crypto-randomuuid: "npm:^1.0.0"
     dotenv: "npm:^16.4.7"
     dotenv-cli: "npm:^8.0.0"
     dotenv-expand: "npm:^12.0.1"


### PR DESCRIPTION
Adds a pollyfill to `crypto.randomUUID`

To verify this fix works:
* Checkout main
* Update `.env.development` to use your local ip address for the app url/api uri instead of `localhost`
* Load the app and notice you receive a `crypto.randomUUID is not a function` when you query for logs
* Checkout this branch
* Repeat the steps above. Profit

Ref: HDX-1809