### PR TITLE
fix: Pollyfill crypto.randomUUID

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,6 +50,7 @@
     "chrono-node": "^2.7.8",
     "classnames": "^2.3.1",
     "crypto-js": "^4.2.0",
+    "crypto-randomuuid": "^1.0.0",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^2.0.0",
     "fuse.js": "^6.6.2",

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { NextAdapter } from 'next-query-params';
+import randomUUID from 'crypto-randomuuid';
 import { enableMapSet } from 'immer';
 import SSRProvider from 'react-bootstrap/SSRProvider';
 import { QueryParamProvider } from 'use-query-params';
@@ -28,6 +29,11 @@ import '@mantine/dates/styles.css';
 import '@styles/globals.css';
 import '@styles/app.scss';
 import 'uplot/dist/uPlot.min.css';
+
+// Polyfill crypto.randomUUID for non-HTTPS environments
+if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
+  crypto.randomUUID = randomUUID;
+}
 
 enableMapSet();
 

--- a/packages/app/types/crypto-randomuuid.d.ts
+++ b/packages/app/types/crypto-randomuuid.d.ts
@@ -1,0 +1,4 @@
+declare module 'crypto-randomuuid' {
+  function randomUUID(): string;
+  export = randomUUID;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,6 +4399,7 @@ __metadata:
     chrono-node: "npm:^2.7.8"
     classnames: "npm:^2.3.1"
     crypto-js: "npm:^4.2.0"
+    crypto-randomuuid: "npm:^1.0.0"
     date-fns: "npm:^2.28.0"
     date-fns-tz: "npm:^2.0.0"
     fuse.js: "npm:^6.6.2"
@@ -13551,6 +13552,13 @@ __metadata:
   dependencies:
     type-fest: "npm:^1.0.1"
   checksum: 10c0/16e11a3c8140398f5408b7fded35a961b9423c5dac39a60cbbd08bd3f0e07d7de130e87262adea7db03ec1a7a4b7551054e0db07ee5408b012bac5400cfc07a5
+  languageName: node
+  linkType: hard
+
+"crypto-randomuuid@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "crypto-randomuuid@npm:1.0.0"
+  checksum: 10c0/6c8f7513f3b0c38b876b5011d91e21c284f7a695d27b6ef25a2a1ca89c362af23e321bf47953069b9fe56bc384de7880a13c390a4663ac5dcf525a1b4f937a1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a pollyfill to crypto.randomUUID to allow for non-secure connections.

To verify this fix works:

1. Checkout main
2. Update .env.development to use your local ip address for the app url/api uri instead of localhost
3. Load the app and notice you receive a crypto.randomUUID is not a function when you query for logs
4. Checkout this branch
5. Repeat the steps 2-3 and notice the error no longer exists and the app works.

Ref: HDX-1809