### PR TITLE
fix: remove noisy log message

### DIFF
--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -251,7 +251,6 @@ const fastifySQL = ({
 
     return parser.sqlify(ast);
   } catch (e) {
-    console.debug('[renderWhereExpression]feat: Failed to parse SQL AST', e);
     return rawSQL;
   }
 };


### PR DESCRIPTION
Now that the app has some complex queries that leverage CTEs, metrics for example, it's common for the logic in this optimization to throw an exception. When that happens, the query rendering logic continues without a problem but generates a noisy line in the console log. We can just remove this log message to clean up the debugging experience.

Ref: HDX-1763