### PR TITLE
chore: Make passthrough_logs an envvar controlled setting in collector

### DIFF
--- a/docker/otel-collector/supervisor_docker.yaml
+++ b/docker/otel-collector/supervisor_docker.yaml
@@ -20,7 +20,7 @@ agent:
   executable: /otelcontribcol
   config_files:
     - /etc/otelcol-contrib/config.yaml
-  # passthrough_logs: true # enable to debug collector logs, can crash collector due to perf issues with this flag enabled
+  passthrough_logs: ${env:OTEL_SUPERVISOR_PASSTHROUGH_LOGS}
 
 storage:
   directory: /etc/otel/supervisor-data/


### PR DESCRIPTION
Adds environment variable to allow for passthrough_logs to be enabled in the supervisor config

Test locally with:
Edit docker-compose.dev.yaml
Add `OTEL_SUPERVISOR_PASSTHROUGH_LOGS: 'true'` under the otel environment variables

```
make dev-up
```

Ref: HDX-1859