### PR TITLE
return empty when table or databse is not set

### DIFF
--- a/packages/api/src/clickhouse/__tests__/getColumns.test.ts
+++ b/packages/api/src/clickhouse/__tests__/getColumns.test.ts
@@ -1,0 +1,101 @@
+import * as clickhouse from '..';
+
+describe('getColumns', () => {
+  it('returns empty result when database is empty', async () => {
+    const result = await clickhouse.getColumns({
+      database: '',
+      table: 'some_table',
+    });
+
+    expect(result).toEqual({
+      data: [],
+      meta: [],
+      rows: 0,
+      statistics: {
+        elapsed: 0,
+        rows_read: 0,
+        bytes_read: 0,
+      },
+    });
+  });
+
+  it('returns empty result when table is empty', async () => {
+    const result = await clickhouse.getColumns({
+      database: 'some_database',
+      table: '',
+    });
+
+    expect(result).toEqual({
+      data: [],
+      meta: [],
+      rows: 0,
+      statistics: {
+        elapsed: 0,
+        rows_read: 0,
+        bytes_read: 0,
+      },
+    });
+  });
+
+  it('returns empty result when both database and table are empty', async () => {
+    const result = await clickhouse.getColumns({
+      database: '',
+      table: '',
+    });
+
+    expect(result).toEqual({
+      data: [],
+      meta: [],
+      rows: 0,
+      statistics: {
+        elapsed: 0,
+        rows_read: 0,
+        bytes_read: 0,
+      },
+    });
+  });
+
+  it('calls client.query with correct parameters when inputs are valid', async () => {
+    // Mock the client.query method
+    const mockQuery = jest.spyOn(clickhouse.client, 'query').mockResolvedValueOnce({
+      json: () => Promise.resolve({
+        data: [{ name: 'test_column', type: 'String' }],
+        meta: [],
+        rows: 1,
+        statistics: {
+          elapsed: 0.1,
+          rows_read: 1,
+          bytes_read: 100,
+        },
+      }),
+    } as any);
+
+    const result = await clickhouse.getColumns({
+      database: 'test_database',
+      table: 'test_table',
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith({
+      query: 'DESCRIBE {database:Identifier}.{table:Identifier}',
+      format: 'JSON',
+      query_params: {
+        database: 'test_database',
+        table: 'test_table',
+      },
+    });
+
+    expect(result).toEqual({
+      data: [{ name: 'test_column', type: 'String' }],
+      meta: [],
+      rows: 1,
+      statistics: {
+        elapsed: 0.1,
+        rows_read: 1,
+        bytes_read: 100,
+      },
+    });
+
+    // Restore the original implementation
+    mockQuery.mockRestore();
+  });
+});

--- a/packages/api/src/clickhouse/index.ts
+++ b/packages/api/src/clickhouse/index.ts
@@ -330,6 +330,26 @@ export const getColumns = async ({
   database: string;
   table: string;
 }) => {
+  if (!database || !table) {
+    return {
+      data: [],
+      meta: [],
+      rows: 0,
+      statistics: {
+        elapsed: 0,
+        rows_read: 0,
+        bytes_read: 0,
+      },
+    } as ResponseJSON<{
+      name: string;
+      type: string;
+      default_type: string;
+      default_expression: string;
+      comment: string;
+      codec_expression: string;
+      ttl_expression: string;
+    }>;
+  }
   const rows = await client.query({
     query: 'DESCRIBE {database:Identifier}.{table:Identifier}',
     format: 'JSON',


### PR DESCRIPTION
resolve: https://github.com/hyperdxio/hyperdx/issues/931
This situation should not return an error; if nothing is selected, it would be appropriate to return an empty value and handle it as normal. Please let me know if you have any other opinions.

