### PR TITLE
fix: set value to emptystring when undefined

### DIFF
--- a/packages/app/src/components/SQLInlineEditor.tsx
+++ b/packages/app/src/components/SQLInlineEditor.tsx
@@ -367,7 +367,7 @@ function SQLInlineEditorControlledComponent({
   let stringValue = '';
   if (typeof value === 'string') {
     stringValue = value;
-  } else {
+  } else if (value !== undefined) {
     console.error('SQLInlineEditor: value is not a string', value);
   }
 


### PR DESCRIPTION
<img width="591" alt="image" src="https://github.com/user-attachments/assets/e9e33099-322d-45e3-ba48-0dac5e8a325e" />

Cleans up these errors from the console