### PR TITLE
chore: bump node version

### DIFF
--- a/.changeset/strong-zoos-ring.md
+++ b/.changeset/strong-zoos-ring.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+bump node version to 22.16.0

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=22.16.0"
   },
   "dependencies": {
     "@clickhouse/client": "^0.2.10",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=22.16.0"
   },
   "scripts": {
     "dev": "npx dotenv -e .env.development -- next dev",

--- a/packages/common-utils/package.json
+++ b/packages/common-utils/package.json
@@ -8,7 +8,7 @@
     "dist/*"
   ],
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=22.16.0"
   },
   "dependencies": {
     "@clickhouse/client": "^1.11.1",


### PR DESCRIPTION
Closes HDX-2031

This node version is already used as the docker image version, so I'm not expecting anything to break. Tested dev and all-in-one image