### PR TITLE
feat: team setting to disable fetching field metadata

### DIFF
--- a/.changeset/blue-months-switch.md
+++ b/.changeset/blue-months-switch.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+feat: add team setting to disable field metadata queries in app

--- a/packages/api/src/controllers/team.ts
+++ b/packages/api/src/controllers/team.ts
@@ -78,6 +78,17 @@ export function setTeamSearchRowLimit(
   return Team.findByIdAndUpdate(teamId, { searchRowLimit }, { new: true });
 }
 
+export function setTeamFieldMetadataDisabled(
+  teamId: ObjectId,
+  fieldMetadataDisabled: boolean,
+) {
+  return Team.findByIdAndUpdate(
+    teamId,
+    { fieldMetadataDisabled },
+    { new: true },
+  );
+}
+
 export async function getTags(teamId: ObjectId) {
   const [dashboardTags, savedSearchTags] = await Promise.all([
     Dashboard.aggregate([

--- a/packages/api/src/models/team.ts
+++ b/packages/api/src/models/team.ts
@@ -7,6 +7,7 @@ export interface ITeam {
   _id: ObjectId;
   name: string;
   searchRowLimit?: number;
+  fieldMetadataDisabled?: boolean;
   allowedAuthMethods?: 'password'[];
   apiKey: string;
   hookId: string;
@@ -20,6 +21,7 @@ export default mongoose.model<ITeam>(
     {
       name: String,
       searchRowLimit: Number,
+      fieldMetadataDisabled: Boolean,
       allowedAuthMethods: [String],
       hookId: {
         type: String,

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -9,6 +9,7 @@ import {
   getTags,
   getTeam,
   rotateTeamApiKey,
+  setTeamFieldMetadataDisabled,
   setTeamName,
   setTeamSearchRowLimit,
 } from '@/controllers/team';
@@ -104,6 +105,31 @@ router.patch(
       const { searchRowLimit } = req.body;
       const team = await setTeamSearchRowLimit(teamId, searchRowLimit);
       res.json({ searchRowLimit: team?.searchRowLimit });
+    } catch (e) {
+      next(e);
+    }
+  },
+);
+
+router.patch(
+  '/field-metadata',
+  validateRequest({
+    body: z.object({
+      fieldMetadataDisabled: z.boolean(),
+    }),
+  }),
+  async (req, res, next) => {
+    try {
+      const teamId = req.user?.team;
+      if (teamId == null) {
+        throw new Error(`User ${req.user?._id} not associated with a team`);
+      }
+      const { fieldMetadataDisabled } = req.body;
+      const team = await setTeamFieldMetadataDisabled(
+        teamId,
+        fieldMetadataDisabled,
+      );
+      res.json({ fieldMetadataDisabled: team?.fieldMetadataDisabled });
     } catch (e) {
       next(e);
     }

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -30,6 +30,7 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
+import { UseQueryResult } from '@tanstack/react-query';
 import CodeMirror, { placeholder } from '@uiw/react-codemirror';
 
 import { ConnectionForm } from '@/components/ConnectionForm';
@@ -1060,9 +1061,14 @@ function TeamNameSection() {
   );
 }
 
-function TeamQueryConfigSection() {
+function SearchRowLimitForm({
+  me,
+  refetchMe,
+}: {
+  me: UseQueryResult<any, Error>['data'];
+  refetchMe: UseQueryResult<any, Error>['refetch'];
+}) {
   const setSearchRowLimit = api.useSetTeamSearchRowLimit();
-  const { data: me, refetch: refetchMe } = api.useMe();
   const hasAdminAccess = true;
   const [isEditingQueryLimits, setIsEditingQueryLimits] = useState(false);
   const searchRowLimit = me?.team.searchRowLimit ?? DEFAULT_SEARCH_ROW_LIMIT;
@@ -1105,6 +1111,78 @@ function TeamQueryConfigSection() {
   );
 
   return (
+    <Stack gap="xs" mb="md">
+      <InputLabel c="gray.3" size="md">
+        Search Row Limit
+      </InputLabel>
+      {isEditingQueryLimits && hasAdminAccess ? (
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <Group>
+            <TextInput
+              size="xs"
+              type="number"
+              placeholder={searchRowLimit}
+              required
+              readOnly={!isEditingQueryLimits}
+              error={form.formState.errors.searchRowLimit?.message}
+              {...form.register('searchRowLimit', {
+                required: true,
+              })}
+              miw={300}
+              min={1}
+              max={100000}
+              autoFocus
+              onKeyDown={e => {
+                if (e.key === 'Escape') {
+                  setIsEditingQueryLimits(false);
+                }
+              }}
+            />
+            <Button
+              type="submit"
+              size="xs"
+              variant="light"
+              color="green"
+              loading={setSearchRowLimit.isPending}
+            >
+              Save
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="default"
+              disabled={setSearchRowLimit.isPending}
+              onClick={() => {
+                setIsEditingQueryLimits(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </Group>
+        </form>
+      ) : (
+        <Group>
+          <Text className="text-white">{searchRowLimit}</Text>
+          {hasAdminAccess && (
+            <Button
+              size="xs"
+              variant="default"
+              leftSection={<i className="bi bi-pencil text-slate-300" />}
+              onClick={() => setIsEditingQueryLimits(true)}
+            >
+              Change
+            </Button>
+          )}
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+function TeamQueryConfigSection() {
+  const { data: me, refetch: refetchMe } = api.useMe();
+
+  return (
     <Box id="team_name">
       <Text size="md" c="gray.4">
         Team Query Limits
@@ -1112,69 +1190,7 @@ function TeamQueryConfigSection() {
       <Divider my="md" />
       <Card>
         <Stack>
-          <InputLabel c="gray.3" size="md">
-            Search Row Limit
-          </InputLabel>
-          {isEditingQueryLimits && hasAdminAccess ? (
-            <form onSubmit={form.handleSubmit(onSubmit)}>
-              <Group>
-                <TextInput
-                  size="xs"
-                  type="number"
-                  placeholder={searchRowLimit}
-                  required
-                  readOnly={!isEditingQueryLimits}
-                  error={form.formState.errors.searchRowLimit?.message}
-                  {...form.register('searchRowLimit', {
-                    required: true,
-                  })}
-                  miw={300}
-                  min={1}
-                  max={100000}
-                  autoFocus
-                  onKeyDown={e => {
-                    if (e.key === 'Escape') {
-                      setIsEditingQueryLimits(false);
-                    }
-                  }}
-                />
-                <Button
-                  type="submit"
-                  size="xs"
-                  variant="light"
-                  color="green"
-                  loading={setSearchRowLimit.isPending}
-                >
-                  Save
-                </Button>
-                <Button
-                  type="button"
-                  size="xs"
-                  variant="default"
-                  disabled={setSearchRowLimit.isPending}
-                  onClick={() => {
-                    setIsEditingQueryLimits(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </Group>
-            </form>
-          ) : (
-            <Group>
-              <Text className="text-white">{searchRowLimit}</Text>
-              {hasAdminAccess && (
-                <Button
-                  size="xs"
-                  variant="default"
-                  leftSection={<i className="bi bi-pencil text-slate-300" />}
-                  onClick={() => setIsEditingQueryLimits(true)}
-                >
-                  Change
-                </Button>
-              )}
-            </Group>
-          )}
+          <SearchRowLimitForm me={me} refetchMe={refetchMe} />
         </Stack>
       </Card>
     </Box>

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -271,6 +271,15 @@ const api = {
         }).json(),
     });
   },
+  useSetFieldMetadataDisabled() {
+    return useMutation<any, HTTPError, { fieldMetadataDisabled: boolean }>({
+      mutationFn: async ({ fieldMetadataDisabled }) =>
+        hdxServer(`team/field-metadata`, {
+          method: 'PATCH',
+          json: { fieldMetadataDisabled },
+        }).json(),
+    });
+  },
   useTags() {
     return useQuery({
       queryKey: [`team/tags`],

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -27,8 +27,6 @@ export const IS_OSS = process.env.NEXT_PUBLIC_IS_OSS ?? 'true' === 'true';
 export const IS_LOCAL_MODE = //true;
   // @ts-ignore
   (process.env.NEXT_PUBLIC_IS_LOCAL_MODE ?? 'false') === 'true';
-export const IS_METADATA_FIELD_FETCH_DISABLED =
-  HDX_DISABLE_METADATA_FIELD_FETCH === 'true';
 
 // Features in development
 export const IS_K8S_DASHBOARD_ENABLED = true;

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -12,7 +12,7 @@ import {
   UseQueryOptions,
 } from '@tanstack/react-query';
 
-import { IS_METADATA_FIELD_FETCH_DISABLED } from '@/config';
+import api from '@/api';
 import { getMetadata } from '@/metadata';
 import { toArray } from '@/utils';
 
@@ -51,13 +51,14 @@ export function useAllFields(
     ? _tableConnections
     : [_tableConnections];
   const metadata = getMetadata();
+  const { data: me } = api.useMe();
   return useQuery<Field[]>({
     queryKey: [
       'useMetadata.useAllFields',
       ...tableConnections.map(tc => ({ ...tc })),
     ],
     queryFn: async () => {
-      if (IS_METADATA_FIELD_FETCH_DISABLED) {
+      if (me?.team.fieldMetadataDisabled) {
         return [];
       }
 
@@ -74,7 +75,8 @@ export function useAllFields(
       tableConnections.length > 0 &&
       tableConnections.every(
         tc => !!tc.databaseName && !!tc.tableName && !!tc.connectionId,
-      ),
+      ) &&
+      !!me,
     ...options,
   });
 }

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -51,7 +51,7 @@ export function useAllFields(
     ? _tableConnections
     : [_tableConnections];
   const metadata = getMetadata();
-  const { data: me } = api.useMe();
+  const { data: me, isFetched } = api.useMe();
   return useQuery<Field[]>({
     queryKey: [
       'useMetadata.useAllFields',
@@ -76,7 +76,7 @@ export function useAllFields(
       tableConnections.every(
         tc => !!tc.databaseName && !!tc.tableName && !!tc.connectionId,
       ) &&
-      !!me,
+      isFetched,
     ...options,
   });
 }


### PR DESCRIPTION
Closes HDX-2068

Allows a team to disable fetching field metadata across the app. Fetching is enabled by default. Here's the setting:
<img width="1115" height="346" alt="image" src="https://github.com/user-attachments/assets/100e5ae9-6946-4215-a418-295294154452" />

And here's what it looks like when the setting is disabled:
<img width="1627" height="829" alt="image" src="https://github.com/user-attachments/assets/0d020901-4b68-4239-baf3-f1c040074400" />

Notice that autocomplete is doing nothing and filters are not loaded