### PR TITLE
feat: introduce team 'clickhouse-settings' endpoint + `metadataMaxRowsToRead` setting

### DIFF
--- a/.changeset/forty-rabbits-share.md
+++ b/.changeset/forty-rabbits-share.md
@@ -4,4 +4,4 @@
 "@hyperdx/app": patch
 ---
 
-feat: introduce team 'clickhouse-settings' endpoint + maxRowsToRead setting
+feat: introduce team 'clickhouse-settings' endpoint + metadataMaxRowsToRead setting

--- a/.changeset/forty-rabbits-share.md
+++ b/.changeset/forty-rabbits-share.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+feat: introduce team 'clickhouse-settings' endpoint + maxRowsToRead setting

--- a/packages/api/src/controllers/team.ts
+++ b/packages/api/src/controllers/team.ts
@@ -4,7 +4,7 @@ import * as config from '@/config';
 import type { ObjectId } from '@/models';
 import Dashboard from '@/models/dashboard';
 import { SavedSearch } from '@/models/savedSearch';
-import Team from '@/models/team';
+import Team, { TeamCHSettings } from '@/models/team';
 
 const LOCAL_APP_TEAM_ID = '_local_team_';
 export const LOCAL_APP_TEAM = {
@@ -71,22 +71,11 @@ export function setTeamName(teamId: ObjectId, name: string) {
   return Team.findByIdAndUpdate(teamId, { name }, { new: true });
 }
 
-export function setTeamSearchRowLimit(
+export function updateTeamClickhouseSettings(
   teamId: ObjectId,
-  searchRowLimit: number,
+  settings: TeamCHSettings,
 ) {
-  return Team.findByIdAndUpdate(teamId, { searchRowLimit }, { new: true });
-}
-
-export function setTeamFieldMetadataDisabled(
-  teamId: ObjectId,
-  fieldMetadataDisabled: boolean,
-) {
-  return Team.findByIdAndUpdate(
-    teamId,
-    { fieldMetadataDisabled },
-    { new: true },
-  );
+  return Team.findByIdAndUpdate(teamId, settings, { new: true });
 }
 
 export async function getTags(teamId: ObjectId) {

--- a/packages/api/src/models/team.ts
+++ b/packages/api/src/models/team.ts
@@ -3,16 +3,20 @@ import { v4 as uuidv4 } from 'uuid';
 
 type ObjectId = mongoose.Types.ObjectId;
 
-export interface ITeam {
-  _id: ObjectId;
-  name: string;
+export type TeamCHSettings = {
+  maxRowsToRead?: number;
   searchRowLimit?: number;
   fieldMetadataDisabled?: boolean;
+};
+
+export type ITeam = {
+  _id: ObjectId;
+  name: string;
   allowedAuthMethods?: 'password'[];
   apiKey: string;
   hookId: string;
   collectorAuthenticationEnforced: boolean;
-}
+} & TeamCHSettings;
 export type TeamDocument = mongoose.HydratedDocument<ITeam>;
 
 export default mongoose.model<ITeam>(
@@ -20,8 +24,6 @@ export default mongoose.model<ITeam>(
   new Schema<ITeam>(
     {
       name: String,
-      searchRowLimit: Number,
-      fieldMetadataDisabled: Boolean,
       allowedAuthMethods: [String],
       hookId: {
         type: String,
@@ -39,6 +41,11 @@ export default mongoose.model<ITeam>(
         type: Boolean,
         default: false,
       },
+      // TODO: maybe add these to a top level Mixed type
+      // CH Client Settings
+      maxRowsToRead: Number,
+      searchRowLimit: Number,
+      fieldMetadataDisabled: Boolean,
     },
     {
       timestamps: true,

--- a/packages/api/src/models/team.ts
+++ b/packages/api/src/models/team.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 type ObjectId = mongoose.Types.ObjectId;
 
 export type TeamCHSettings = {
-  maxRowsToRead?: number;
+  metadataMaxRowsToRead?: number;
   searchRowLimit?: number;
   fieldMetadataDisabled?: boolean;
 };
@@ -43,7 +43,7 @@ export default mongoose.model<ITeam>(
       },
       // TODO: maybe add these to a top level Mixed type
       // CH Client Settings
-      maxRowsToRead: Number,
+      metadataMaxRowsToRead: Number,
       searchRowLimit: Number,
       fieldMetadataDisabled: Boolean,
     },

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -94,7 +94,7 @@ router.patch(
     body: z.object({
       fieldMetadataDisabled: z.boolean().optional(),
       searchRowLimit: z.number().optional(),
-      maxRowsToRead: z.number().optional(),
+      metadataMaxRowsToRead: z.number().optional(),
     }),
   }),
   async (req, res, next) => {
@@ -104,12 +104,13 @@ router.patch(
         throw new Error(`User ${req.user?._id} not associated with a team`);
       }
 
-      const { fieldMetadataDisabled, maxRowsToRead, searchRowLimit } = req.body;
+      const { fieldMetadataDisabled, metadataMaxRowsToRead, searchRowLimit } =
+        req.body;
 
       const settings = {
         ...(searchRowLimit !== undefined && { searchRowLimit }),
         ...(fieldMetadataDisabled !== undefined && { fieldMetadataDisabled }),
-        ...(maxRowsToRead !== undefined && { maxRowsToRead }),
+        ...(metadataMaxRowsToRead !== undefined && { metadataMaxRowsToRead }),
       };
 
       if (Object.keys(settings).length === 0) {
@@ -125,8 +126,8 @@ router.patch(
         ...(fieldMetadataDisabled !== undefined && {
           fieldMetadataDisabled: team?.fieldMetadataDisabled,
         }),
-        ...(maxRowsToRead !== undefined && {
-          maxRowsToRead: team?.maxRowsToRead,
+        ...(metadataMaxRowsToRead !== undefined && {
+          metadataMaxRowsToRead: team?.metadataMaxRowsToRead,
         }),
       });
     } catch (e) {

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -1064,7 +1064,7 @@ function TeamNameSection() {
 
 function SearchRowLimitForm() {
   const { data: me, refetch: refetchMe } = api.useMe();
-  const setSearchRowLimit = api.useSetTeamSearchRowLimit();
+  const updateClickhouseSettings = api.useUpdateClickhouseSettings();
   const hasAdminAccess = true;
   const [isEditing, setIsEditing] = useState(false);
   const searchRowLimit = me?.team.searchRowLimit ?? DEFAULT_SEARCH_ROW_LIMIT;
@@ -1077,7 +1077,7 @@ function SearchRowLimitForm() {
   const onSubmit: SubmitHandler<{ searchRowLimit: number }> = useCallback(
     async values => {
       try {
-        setSearchRowLimit.mutate(
+        updateClickhouseSettings.mutate(
           { searchRowLimit: Number(values.searchRowLimit) },
           {
             onError: e => {
@@ -1103,7 +1103,7 @@ function SearchRowLimitForm() {
         });
       }
     },
-    [refetchMe, setSearchRowLimit, me?.team?.searchRowLimit],
+    [refetchMe, updateClickhouseSettings, me?.team?.searchRowLimit],
   );
 
   return (
@@ -1139,7 +1139,7 @@ function SearchRowLimitForm() {
               size="xs"
               variant="light"
               color="green"
-              loading={setSearchRowLimit.isPending}
+              loading={updateClickhouseSettings.isPending}
             >
               Save
             </Button>
@@ -1147,7 +1147,7 @@ function SearchRowLimitForm() {
               type="button"
               size="xs"
               variant="default"
-              disabled={setSearchRowLimit.isPending}
+              disabled={updateClickhouseSettings.isPending}
               onClick={() => {
                 setIsEditing(false);
               }}
@@ -1177,7 +1177,7 @@ function SearchRowLimitForm() {
 
 function FieldMetadataForm() {
   const { data: me, refetch: refetchMe } = api.useMe();
-  const setFieldMetadataDisabled = api.useSetFieldMetadataDisabled();
+  const updateClickhouseSettings = api.useUpdateClickhouseSettings();
   const hasAdminAccess = true;
   const [isEditing, setIsEditing] = useState(false);
   const fieldMetadataDisabled = me?.team.fieldMetadataDisabled ?? false;
@@ -1191,7 +1191,7 @@ function FieldMetadataForm() {
   const onSubmit: SubmitHandler<{ fieldMetadata: string }> = useCallback(
     async values => {
       try {
-        setFieldMetadataDisabled.mutate(
+        updateClickhouseSettings.mutate(
           {
             fieldMetadataDisabled: values.fieldMetadata === 'Disabled',
           },
@@ -1219,7 +1219,7 @@ function FieldMetadataForm() {
         });
       }
     },
-    [refetchMe, setFieldMetadataDisabled, me?.team?.searchRowLimit],
+    [refetchMe, updateClickhouseSettings, me?.team?.searchRowLimit],
   );
 
   return (
@@ -1241,7 +1241,7 @@ function FieldMetadataForm() {
               size="xs"
               variant="light"
               color="green"
-              loading={setFieldMetadataDisabled.isPending}
+              loading={updateClickhouseSettings.isPending}
             >
               Save
             </Button>
@@ -1249,7 +1249,7 @@ function FieldMetadataForm() {
               type="button"
               size="xs"
               variant="default"
-              disabled={setFieldMetadataDisabled.isPending}
+              disabled={updateClickhouseSettings.isPending}
               onClick={() => {
                 setIsEditing(false);
               }}
@@ -1281,7 +1281,7 @@ function TeamQueryConfigSection() {
   return (
     <Box id="team_name">
       <Text size="md" c="gray.4">
-        Team Query Limits
+        ClickHouse Client Settings
       </Text>
       <Divider my="md" />
       <Card>

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -27,6 +27,7 @@ import {
   Table,
   Text,
   TextInput,
+  Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
@@ -1229,9 +1230,16 @@ function FieldMetadataForm() {
 
   return (
     <Stack gap="xs">
-      <InputLabel c="gray.3" size="md">
-        Field Metadata Queries
-      </InputLabel>
+      <Group gap="xs">
+        <InputLabel c="gray.3" size="md">
+          Field Metadata Queries
+        </InputLabel>
+        <Tooltip label="Enable to fetch field metadata from ClickHouse">
+          <Text c="gray.5" size="sm" style={{ cursor: 'help' }}>
+            <i className="bi bi-question-circle" />
+          </Text>
+        </Tooltip>
+      </Group>
       {isEditing && hasAdminAccess ? (
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <Group>
@@ -1328,9 +1336,16 @@ function MaxRowsToReadForm() {
 
   return (
     <Stack gap="xs" mb="md">
-      <InputLabel c="gray.3" size="md">
-        Max Rows to Read
-      </InputLabel>
+      <Group gap="xs">
+        <InputLabel c="gray.3" size="md">
+          Max Rows to Read
+        </InputLabel>
+        <Tooltip label="The maximum number of rows that can be read from a table when running a query (FIELD METADATA ONLY)">
+          <Text c="gray.5" size="sm" style={{ cursor: 'help' }}>
+            <i className="bi bi-question-circle" />
+          </Text>
+        </Tooltip>
+      </Group>
       {isEditing && hasAdminAccess ? (
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <Group>

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -1272,6 +1272,7 @@ function TeamQueryConfigSection() {
           <ClickhouseSettingForm
             settingKey="searchRowLimit"
             label="Search Row Limit"
+            tooltip="The number of rows per query for the Search page or search dashboard tiles"
             type="number"
             defaultValue={DEFAULT_SEARCH_ROW_LIMIT}
             placeholder={`Enter value (default: ${DEFAULT_SEARCH_ROW_LIMIT})`}
@@ -1281,8 +1282,8 @@ function TeamQueryConfigSection() {
           />
           <ClickhouseSettingForm
             settingKey="metadataMaxRowsToRead"
-            label="Max Rows to Read"
-            tooltip="The maximum number of rows that can be read from a table when running a query (FIELD METADATA ONLY)"
+            label="Max Rows to Read (METADATA ONLY)"
+            tooltip="The maximum number of rows that can be read from a table when running a query"
             type="number"
             defaultValue={DEFAULT_METADATA_MAX_ROWS_TO_READ}
             placeholder={`Enter value (default: ${DEFAULT_METADATA_MAX_ROWS_TO_READ.toLocaleString()}, 0 = unlimited)`}

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -1177,7 +1177,7 @@ function ClickhouseSettingForm({
         placeholder={placeholder || currentValue?.toString() || `Enter value`}
         required
         readOnly={!isEditing}
-        error={form.formState.errors.value?.message}
+        error={form.formState.errors.value?.message as string | undefined}
         {...form.register('value', {
           required: true,
         })}

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -1150,53 +1150,6 @@ function ClickhouseSettingForm({
     [refetchMe, updateClickhouseSettings, settingKey, label, type],
   );
 
-  const renderEditForm = () => {
-    if (type === 'boolean' && options) {
-      return (
-        <SelectControlled
-          control={form.control}
-          name="value"
-          value={form.watch('value')}
-          data={options}
-          size="xs"
-          placeholder="Please select"
-          withAsterisk
-          miw={300}
-          readOnly={!isEditing}
-          autoFocus
-          onKeyDown={e => {
-            if (e.key === 'Escape') {
-              setIsEditing(false);
-            }
-          }}
-        />
-      );
-    }
-
-    return (
-      <TextInput
-        size="xs"
-        type="number"
-        placeholder={placeholder || currentValue?.toString() || `Enter value`}
-        required
-        readOnly={!isEditing}
-        error={form.formState.errors.value?.message as string | undefined}
-        {...form.register('value', {
-          required: true,
-        })}
-        miw={300}
-        min={min}
-        max={max}
-        autoFocus
-        onKeyDown={e => {
-          if (e.key === 'Escape') {
-            setIsEditing(false);
-          }
-        }}
-      />
-    );
-  };
-
   return (
     <Stack gap="xs" mb="md">
       <Group gap="xs">
@@ -1214,7 +1167,50 @@ function ClickhouseSettingForm({
       {isEditing && hasAdminAccess ? (
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <Group>
-            {renderEditForm()}
+            {type === 'boolean' && options ? (
+              <SelectControlled
+                control={form.control}
+                name="value"
+                value={form.watch('value')}
+                data={options}
+                size="xs"
+                placeholder="Please select"
+                withAsterisk
+                miw={300}
+                readOnly={!isEditing}
+                autoFocus
+                onKeyDown={e => {
+                  if (e.key === 'Escape') {
+                    setIsEditing(false);
+                  }
+                }}
+              />
+            ) : (
+              <TextInput
+                size="xs"
+                type="number"
+                placeholder={
+                  placeholder || currentValue?.toString() || `Enter value`
+                }
+                required
+                readOnly={!isEditing}
+                error={
+                  form.formState.errors.value?.message as string | undefined
+                }
+                {...form.register('value', {
+                  required: true,
+                })}
+                miw={300}
+                min={min}
+                max={max}
+                autoFocus
+                onKeyDown={e => {
+                  if (e.key === 'Escape') {
+                    setIsEditing(false);
+                  }
+                }}
+              />
+            )}
             <Button
               type="submit"
               size="xs"

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -7,7 +7,7 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter } from '@codemirror/lint';
 import { EditorView } from '@codemirror/view';
-import { DEFAULT_MAX_ROWS_TO_READ } from '@hyperdx/common-utils/dist/metadata';
+import { DEFAULT_METADATA_MAX_ROWS_TO_READ } from '@hyperdx/common-utils/dist/metadata';
 import { SourceKind, WebhookService } from '@hyperdx/common-utils/dist/types';
 import {
   Alert,
@@ -1067,7 +1067,10 @@ function TeamNameSection() {
 type ClickhouseSettingType = 'number' | 'boolean';
 
 interface ClickhouseSettingFormProps {
-  settingKey: 'searchRowLimit' | 'maxRowsToRead' | 'fieldMetadataDisabled';
+  settingKey:
+    | 'searchRowLimit'
+    | 'metadataMaxRowsToRead'
+    | 'fieldMetadataDisabled';
   label: string;
   tooltip?: string;
   type: ClickhouseSettingType;
@@ -1277,16 +1280,16 @@ function TeamQueryConfigSection() {
             displayValue={value => value ?? 'System Default'}
           />
           <ClickhouseSettingForm
-            settingKey="maxRowsToRead"
+            settingKey="metadataMaxRowsToRead"
             label="Max Rows to Read"
             tooltip="The maximum number of rows that can be read from a table when running a query (FIELD METADATA ONLY)"
             type="number"
-            defaultValue={DEFAULT_MAX_ROWS_TO_READ}
-            placeholder={`Enter value (default: ${DEFAULT_MAX_ROWS_TO_READ.toLocaleString()}, 0 = unlimited)`}
+            defaultValue={DEFAULT_METADATA_MAX_ROWS_TO_READ}
+            placeholder={`Enter value (default: ${DEFAULT_METADATA_MAX_ROWS_TO_READ.toLocaleString()}, 0 = unlimited)`}
             min={0}
             displayValue={value =>
               value == null
-                ? `System Default (${DEFAULT_MAX_ROWS_TO_READ.toLocaleString()})`
+                ? `System Default (${DEFAULT_METADATA_MAX_ROWS_TO_READ.toLocaleString()})`
                 : value === 0
                   ? 'Unlimited'
                   : value.toLocaleString()

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -7,6 +7,7 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter } from '@codemirror/lint';
 import { EditorView } from '@codemirror/view';
+import { DEFAULT_MAX_ROWS_TO_READ } from '@hyperdx/common-utils/dist/metadata';
 import { SourceKind, WebhookService } from '@hyperdx/common-utils/dist/types';
 import {
   Alert,
@@ -1298,7 +1299,7 @@ function MaxRowsToReadForm() {
   const maxRowsToRead = me?.team.maxRowsToRead;
   const form = useForm<{ maxRowsToRead: number }>({
     defaultValues: {
-      maxRowsToRead: maxRowsToRead ?? 0,
+      maxRowsToRead: maxRowsToRead ?? DEFAULT_MAX_ROWS_TO_READ,
     },
   });
 
@@ -1353,7 +1354,8 @@ function MaxRowsToReadForm() {
               size="xs"
               type="number"
               placeholder={
-                maxRowsToRead?.toString() || 'Enter value (0 = unlimited)'
+                maxRowsToRead?.toString() ||
+                `Enter value (default: ${DEFAULT_MAX_ROWS_TO_READ.toLocaleString()}, 0 = unlimited)`
               }
               required
               readOnly={!isEditing}
@@ -1396,10 +1398,10 @@ function MaxRowsToReadForm() {
         <Group>
           <Text className="text-white">
             {maxRowsToRead == null
-              ? 'System Default'
+              ? `System Default (${DEFAULT_MAX_ROWS_TO_READ.toLocaleString()})`
               : maxRowsToRead === 0
                 ? 'Unlimited'
-                : maxRowsToRead}
+                : maxRowsToRead.toLocaleString()}
           </Text>
           {hasAdminAccess && (
             <Button

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -266,7 +266,11 @@ const api = {
     return useMutation<
       any,
       HTTPError,
-      { searchRowLimit?: number; fieldMetadataDisabled?: boolean }
+      {
+        searchRowLimit?: number;
+        fieldMetadataDisabled?: boolean;
+        maxRowsToRead?: number;
+      }
     >({
       mutationFn: async settings =>
         hdxServer(`team/clickhouse-settings`, {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -269,7 +269,7 @@ const api = {
       {
         searchRowLimit?: number;
         fieldMetadataDisabled?: boolean;
-        maxRowsToRead?: number;
+        metadataMaxRowsToRead?: number;
       }
     >({
       mutationFn: async settings =>

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -262,21 +262,16 @@ const api = {
         }).json(),
     });
   },
-  useSetTeamSearchRowLimit() {
-    return useMutation<any, HTTPError, { searchRowLimit: number }>({
-      mutationFn: async ({ searchRowLimit }) =>
-        hdxServer(`team/search-row-limit`, {
+  useUpdateClickhouseSettings() {
+    return useMutation<
+      any,
+      HTTPError,
+      { searchRowLimit?: number; fieldMetadataDisabled?: boolean }
+    >({
+      mutationFn: async settings =>
+        hdxServer(`team/clickhouse-settings`, {
           method: 'PATCH',
-          json: { searchRowLimit },
-        }).json(),
-    });
-  },
-  useSetFieldMetadataDisabled() {
-    return useMutation<any, HTTPError, { fieldMetadataDisabled: boolean }>({
-      mutationFn: async ({ fieldMetadataDisabled }) =>
-        hdxServer(`team/field-metadata`, {
-          method: 'PATCH',
-          json: { fieldMetadataDisabled },
+          json: settings,
         }).json(),
     });
   },

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -64,9 +64,9 @@ export function useAllFields(
       }
 
       // TODO: set the settings at the top level so that it doesn't have to be set for each useQuery
-      if (team?.maxRowsToRead) {
+      if (team?.metadataMaxRowsToRead) {
         metadata.setClickHouseSettings({
-          max_rows_to_read: team.maxRowsToRead,
+          max_rows_to_read: team.metadataMaxRowsToRead,
         });
       }
 
@@ -145,9 +145,9 @@ export function useGetKeyValues(
       const team = me?.team;
 
       // TODO: set the settings at the top level so that it doesn't have to be set for each useQuery
-      if (team?.maxRowsToRead) {
+      if (team?.metadataMaxRowsToRead) {
         metadata.setClickHouseSettings({
-          max_rows_to_read: team.maxRowsToRead,
+          max_rows_to_read: team.metadataMaxRowsToRead,
         });
       }
       return (

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -164,7 +164,7 @@ export function useGetKeyValues(
       ).flatMap(v => v);
     },
     staleTime: 1000 * 60 * 5, // Cache every 5 min
-    enabled: !!keys.length,
+    enabled: !!keys.length && isFetched,
     placeholderData: keepPreviousData,
     ...options,
   });

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -58,8 +58,16 @@ export function useAllFields(
       ...tableConnections.map(tc => ({ ...tc })),
     ],
     queryFn: async () => {
-      if (me?.team.fieldMetadataDisabled) {
+      const team = me?.team;
+      if (team?.fieldMetadataDisabled) {
         return [];
+      }
+
+      // TODO: set the settings at the top level so that it doesn't have to be set for each useQuery
+      if (team?.maxRowsToRead) {
+        metadata.setClickHouseSettings({
+          max_rows_to_read: team.maxRowsToRead,
+        });
       }
 
       const fields2d = await Promise.all(
@@ -125,6 +133,7 @@ export function useGetKeyValues(
 ) {
   const metadata = getMetadata();
   const chartConfigsArr = toArray(chartConfigs);
+  const { data: me, isFetched } = api.useMe();
   return useQuery<{ key: string; value: string[] }[]>({
     queryKey: [
       'useMetadata.useGetKeyValues',
@@ -132,8 +141,16 @@ export function useGetKeyValues(
       ...keys,
       disableRowLimit,
     ],
-    queryFn: async () =>
-      (
+    queryFn: async () => {
+      const team = me?.team;
+
+      // TODO: set the settings at the top level so that it doesn't have to be set for each useQuery
+      if (team?.maxRowsToRead) {
+        metadata.setClickHouseSettings({
+          max_rows_to_read: team.maxRowsToRead,
+        });
+      }
+      return (
         await Promise.all(
           chartConfigsArr.map(chartConfig =>
             metadata.getKeyValues({
@@ -144,7 +161,8 @@ export function useGetKeyValues(
             }),
           ),
         )
-      ).flatMap(v => v),
+      ).flatMap(v => v);
+    },
     staleTime: 1000 * 60 * 5, // Cache every 5 min
     enabled: !!keys.length,
     placeholderData: keepPreviousData,

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -275,7 +275,9 @@ export class Metadata {
           }}.keys AS keysArr
           FROM ${tableExpr({ database: databaseName, table: tableName })} ${where}
           LIMIT ${{
-            Int32: DEFAULT_MAX_ROWS_TO_READ,
+            Int32: this.clickhouseSettings.max_rows_to_read
+              ? Number(this.clickhouseSettings.max_rows_to_read)
+              : DEFAULT_MAX_ROWS_TO_READ,
           }}
         )
         SELECT DISTINCT lowCardinalityKeys(arrayJoin(keysArr)) as key

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -268,24 +268,13 @@ export class Metadata {
       }}) as keysArr
       FROM ${tableExpr({ database: databaseName, table: tableName })} ${where}`;
     } else {
-      sql = chSql`
-        WITH sampledKeys as (
-          SELECT ${{
-            Identifier: column,
-          }}.keys AS keysArr
-          FROM ${tableExpr({ database: databaseName, table: tableName })} ${where}
-          LIMIT ${{
-            Int32: this.clickhouseSettings.max_rows_to_read
-              ? Number(this.clickhouseSettings.max_rows_to_read)
-              : DEFAULT_METADATA_MAX_ROWS_TO_READ,
-          }}
-        )
-        SELECT DISTINCT lowCardinalityKeys(arrayJoin(keysArr)) as key
-        FROM sampledKeys
-        LIMIT ${{
-          Int32: maxKeys,
-        }}
-      `;
+      sql = chSql`SELECT DISTINCT lowCardinalityKeys(arrayJoin(${{
+        Identifier: column,
+      }}.keys)) as key
+      FROM ${tableExpr({ database: databaseName, table: tableName })} ${where}
+      LIMIT ${{
+        Int32: maxKeys,
+      }}`;
     }
 
     return this.cache.getOrFetch<string[]>(cacheKey, async () => {

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -15,7 +15,7 @@ import type { ChartConfig, ChartConfigWithDateRange, TSource } from '@/types';
 
 // If filters initially are taking too long to load, decrease this number.
 // Between 1e6 - 5e6 is a good range.
-export const DEFAULT_MAX_ROWS_TO_READ = 3e6;
+export const DEFAULT_METADATA_MAX_ROWS_TO_READ = 3e6;
 
 export class MetadataCache {
   private cache = new Map<string, any>();
@@ -277,7 +277,7 @@ export class Metadata {
           LIMIT ${{
             Int32: this.clickhouseSettings.max_rows_to_read
               ? Number(this.clickhouseSettings.max_rows_to_read)
-              : DEFAULT_MAX_ROWS_TO_READ,
+              : DEFAULT_METADATA_MAX_ROWS_TO_READ,
           }}
         )
         SELECT DISTINCT lowCardinalityKeys(arrayJoin(keysArr)) as key
@@ -295,7 +295,7 @@ export class Metadata {
           query_params: sql.params,
           connectionId,
           clickhouse_settings: {
-            max_rows_to_read: String(DEFAULT_MAX_ROWS_TO_READ),
+            max_rows_to_read: String(DEFAULT_METADATA_MAX_ROWS_TO_READ),
             read_overflow_mode: 'break',
             ...this.clickhouseSettings,
           },
@@ -369,7 +369,7 @@ export class Metadata {
             query_params: sql.params,
             connectionId,
             clickhouse_settings: {
-              max_rows_to_read: String(DEFAULT_MAX_ROWS_TO_READ),
+              max_rows_to_read: String(DEFAULT_METADATA_MAX_ROWS_TO_READ),
               read_overflow_mode: 'break',
               ...this.clickhouseSettings,
             },
@@ -487,7 +487,7 @@ export class Metadata {
             connectionId: chartConfig.connection,
             clickhouse_settings: !disableRowLimit
               ? {
-                  max_rows_to_read: String(DEFAULT_MAX_ROWS_TO_READ),
+                  max_rows_to_read: String(DEFAULT_METADATA_MAX_ROWS_TO_READ),
                   read_overflow_mode: 'break',
                   ...this.clickhouseSettings,
                 }


### PR DESCRIPTION
1. Merge all clickhouse client setting related endpoints into one `/clickhouse-settings` plus controllers
2. Add tooltips to the setting UIs
3. Introduce `metadataMaxRowsToRead` setting for tweaking metadata query perf

Ref: HDX-2075
Related: HDX-2023

<img width="871" height="374" alt="image" src="https://github.com/user-attachments/assets/1824452f-8045-430d-9e26-5d31bcf38dcf" />
