### PR TITLE
fix: k8s event property mappings

### DIFF
--- a/.changeset/fast-jeans-cough.md
+++ b/.changeset/fast-jeans-cough.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+fix: k8s event property mappings

--- a/packages/app/src/KubernetesDashboardPage.tsx
+++ b/packages/app/src/KubernetesDashboardPage.tsx
@@ -1060,19 +1060,19 @@ function KubernetesDashboardPage() {
                               alias: 'Timestamp',
                             },
                             {
-                              valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'type')`,
+                              valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'type')`,
                               alias: 'Severity',
                             },
                             {
-                              valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'regarding', 'kind')`,
+                              valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'regarding', 'kind')`,
                               alias: 'Kind',
                             },
                             {
-                              valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'regarding', 'name')`,
+                              valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'regarding', 'name')`,
                               alias: 'Name',
                             },
                             {
-                              valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'note')`,
+                              valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'note')`,
                               alias: 'Message',
                             },
                           ],

--- a/packages/app/src/components/KubeComponents.tsx
+++ b/packages/app/src/components/KubeComponents.tsx
@@ -188,43 +188,43 @@ export const KubeTimeline = ({
         alias: 'id',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'metadata', 'creationTimestamp')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'metadata', 'creationTimestamp')`,
         alias: 'object.metadata.creationTimestamp',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'reason')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'reason')`,
         alias: 'object.reason',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'note')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'note')`,
         alias: 'object.note',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'type')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'type')`,
         alias: 'object.type',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'message')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'message')`,
         alias: 'object.message',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'regarding', 'name')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'regarding', 'name')`,
         alias: 'k8s.pod.name',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'regarding', 'uid')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'regarding', 'uid')`,
         alias: 'k8s.pod.uid',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'type')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'type')`,
         alias: 'type',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'type')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'type')`,
         alias: 'severity_text',
       },
       {
-        valueExpression: `JSONExtractString(${getEventBody(logSource)}, 'object', 'note')`,
+        valueExpression: `JSONExtractString(${logSource.eventAttributesExpression}['object'], 'note')`,
         alias: 'body',
       },
     ],


### PR DESCRIPTION
Fix the regression due to otel collector version bump. 
The k8s event object should sit within the `LogAttributes` field instead of `Body` field

<img width="533" height="267" alt="image" src="https://github.com/user-attachments/assets/1e5624e0-380b-4ec9-bdf0-ccf455ef611b" />

Ref: HDX-2158