### PR TITLE
feat: Store createdBy user ids on alert documents

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,6 @@
   "fixed": [["@hyperdx/api", "@hyperdx/app"]],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "v2",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/fluffy-squids-share.md
+++ b/.changeset/fluffy-squids-share.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/api": minor
+"@hyperdx/app": minor
+---
+
+Track the user id who created alerts and display the information in the UI.

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -44,13 +44,14 @@ export type AlertInput = {
   };
 };
 
-const makeAlert = (alert: AlertInput): Partial<IAlert> => {
+const makeAlert = (alert: AlertInput, userId?: ObjectId): Partial<IAlert> => {
   return {
     channel: alert.channel,
     interval: alert.interval,
     source: alert.source,
     threshold: alert.threshold,
     thresholdType: alert.thresholdType,
+    ...(userId && { createdBy: userId }),
 
     // Message template
     // If they're undefined/null, set it to null so we clear out the field
@@ -71,6 +72,7 @@ const makeAlert = (alert: AlertInput): Partial<IAlert> => {
 export const createAlert = async (
   teamId: ObjectId,
   alertInput: z.infer<typeof alertSchema>,
+  userId: ObjectId,
 ) => {
   if (alertInput.source === AlertSource.TILE) {
     if ((await Dashboard.findById(alertInput.dashboardId)) == null) {
@@ -85,7 +87,7 @@ export const createAlert = async (
   }
 
   return new Alert({
-    ...makeAlert(alertInput),
+    ...makeAlert(alertInput, userId),
     team: teamId,
   }).save();
 };
@@ -127,7 +129,7 @@ export const getTeamDashboardAlertsByTile = async (teamId: ObjectId) => {
   const alerts = await Alert.find({
     source: AlertSource.TILE,
     team: teamId,
-  });
+  }).populate('createdBy', 'email name');
   return groupBy(alerts, 'tileId');
 };
 
@@ -139,7 +141,7 @@ export const getDashboardAlertsByTile = async (
     dashboard: dashboardId,
     source: AlertSource.TILE,
     team: teamId,
-  });
+  }).populate('createdBy', 'email name');
   return groupBy(alerts, 'tileId');
 };
 
@@ -147,19 +149,26 @@ export const createOrUpdateDashboardAlerts = async (
   dashboardId: ObjectId | string,
   teamId: ObjectId,
   alertsByTile: Record<string, AlertInput>,
+  userId?: ObjectId,
 ) => {
   return Promise.all(
     Object.entries(alertsByTile).map(async ([tileId, alert]) => {
-      return await Alert.findOneAndUpdate(
-        {
-          dashboard: dashboardId,
-          tileId,
-          source: AlertSource.TILE,
-          team: teamId,
-        },
-        alert,
-        { new: true, upsert: true },
-      );
+      const filter = {
+        dashboard: dashboardId,
+        tileId,
+        source: AlertSource.TILE,
+        team: teamId,
+      };
+      const oldAlert = await Alert.findOne(filter);
+      const alertValues =
+        oldAlert && oldAlert.createdBy
+          ? makeAlert(alert)
+          : makeAlert(alert, userId);
+
+      return await Alert.findOneAndUpdate(filter, alertValues, {
+        new: true,
+        upsert: true,
+      });
     }),
   );
 };
@@ -190,10 +199,11 @@ export const getAlertsEnhanced = async (teamId: ObjectId) => {
   return Alert.find({ team: teamId }).populate<{
     savedSearch: ISavedSearch;
     dashboard: IDashboard;
+    createdBy?: IUser;
     silenced?: IAlert['silenced'] & {
       by: IUser;
     };
-  }>(['savedSearch', 'dashboard', 'silenced.by']);
+  }>(['savedSearch', 'dashboard', 'createdBy', 'silenced.by']);
 };
 
 export const deleteAlert = async (id: string, teamId: ObjectId) => {

--- a/packages/api/src/models/alert.ts
+++ b/packages/api/src/models/alert.ts
@@ -49,6 +49,7 @@ export interface IAlert {
   team: ObjectId;
   threshold: number;
   thresholdType: AlertThresholdType;
+  createdBy?: ObjectId;
 
   // Message template
   name?: string | null;
@@ -101,6 +102,11 @@ const AlertSchema = new Schema<IAlert>(
     team: {
       type: mongoose.Schema.Types.ObjectId,
       ref: Team.modelName,
+    },
+    createdBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: false,
     },
 
     // Message template

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -48,6 +48,9 @@ router.get('/', async (req, res, next) => {
                 until: alert.silenced.until,
               }
             : undefined,
+          createdBy: alert.createdBy
+            ? _.pick(alert.createdBy, ['email', 'name'])
+            : undefined,
           channel: _.pick(alert.channel, ['type']),
           ...(alert.dashboard && {
             dashboardId: alert.dashboard._id,
@@ -95,13 +98,14 @@ router.post(
   validateRequest({ body: alertSchema }),
   async (req, res, next) => {
     const teamId = req.user?.team;
-    if (teamId == null) {
+    const userId = req.user?._id;
+    if (teamId == null || userId == null) {
       return res.sendStatus(403);
     }
     try {
       const alertInput = req.body;
       return res.json({
-        data: await createAlert(teamId, alertInput),
+        data: await createAlert(teamId, alertInput, userId),
       });
     } catch (e) {
       next(e);

--- a/packages/api/src/routers/api/dashboards.ts
+++ b/packages/api/src/routers/api/dashboards.ts
@@ -40,11 +40,11 @@ router.post(
   }),
   async (req, res, next) => {
     try {
-      const { teamId } = getNonNullUserWithTeam(req);
+      const { teamId, userId } = getNonNullUserWithTeam(req);
 
       const dashboard = req.body;
 
-      const newDashboard = await createDashboard(teamId, dashboard);
+      const newDashboard = await createDashboard(teamId, dashboard, userId);
 
       res.json(newDashboard.toJSON());
     } catch (e) {
@@ -63,7 +63,7 @@ router.patch(
   }),
   async (req, res, next) => {
     try {
-      const { teamId } = getNonNullUserWithTeam(req);
+      const { teamId, userId } = getNonNullUserWithTeam(req);
       const { id: dashboardId } = req.params;
 
       const dashboard = await getDashboard(dashboardId, teamId);
@@ -78,6 +78,7 @@ router.patch(
         dashboardId,
         teamId,
         updates,
+        userId,
       );
 
       res.json(updatedDashboard);

--- a/packages/api/src/routers/external-api/v2/alerts.ts
+++ b/packages/api/src/routers/external-api/v2/alerts.ts
@@ -390,12 +390,13 @@ router.get('/', async (req, res, next) => {
  */
 router.post('/', async (req, res, next) => {
   const teamId = req.user?.team;
-  if (teamId == null) {
+  const userId = req.user?._id;
+  if (teamId == null || userId == null) {
     return res.sendStatus(403);
   }
   try {
     const alertInput = req.body;
-    const createdAlert = await createAlert(teamId, alertInput);
+    const createdAlert = await createAlert(teamId, alertInput, userId);
 
     return res.json({
       data: translateAlertDocumentToExternalAlert(createdAlert),

--- a/packages/api/src/tasks/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/__tests__/checkAlerts.test.ts
@@ -692,17 +692,22 @@ describe('checkAlerts', () => {
         source: source.id,
         tags: ['test'],
       }).save();
-      const alert = await createAlert(team._id, {
-        source: AlertSource.SAVED_SEARCH,
-        channel: {
-          type: 'webhook',
-          webhookId: webhook._id.toString(),
+      const mockUserId = new mongoose.Types.ObjectId();
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          savedSearchId: savedSearch.id,
         },
-        interval: '5m',
-        thresholdType: AlertThresholdType.ABOVE,
-        threshold: 1,
-        savedSearchId: savedSearch.id,
-      });
+        mockUserId,
+      );
 
       const enhancedAlert: any = await Alert.findById(alert._id).populate([
         'team',
@@ -867,18 +872,23 @@ describe('checkAlerts', () => {
           },
         ],
       }).save();
-      const alert = await createAlert(team._id, {
-        source: AlertSource.TILE,
-        channel: {
-          type: 'webhook',
-          webhookId: webhook._id.toString(),
+      const mockUserId = new mongoose.Types.ObjectId();
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.TILE,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          dashboardId: dashboard.id,
+          tileId: '17quud',
         },
-        interval: '5m',
-        thresholdType: AlertThresholdType.ABOVE,
-        threshold: 1,
-        dashboardId: dashboard.id,
-        tileId: '17quud',
-      });
+        mockUserId,
+      );
 
       const enhancedAlert: any = await Alert.findById(alert._id).populate([
         'team',
@@ -1035,18 +1045,23 @@ describe('checkAlerts', () => {
           },
         ],
       }).save();
-      const alert = await createAlert(team._id, {
-        source: AlertSource.TILE,
-        channel: {
-          type: 'webhook',
-          webhookId: webhook._id.toString(),
+      const mockUserId = new mongoose.Types.ObjectId();
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.TILE,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          dashboardId: dashboard.id,
+          tileId: '17quud',
         },
-        interval: '5m',
-        thresholdType: AlertThresholdType.ABOVE,
-        threshold: 1,
-        dashboardId: dashboard.id,
-        tileId: '17quud',
-      });
+        mockUserId,
+      );
 
       const enhancedAlert: any = await Alert.findById(alert._id).populate([
         'team',
@@ -1185,18 +1200,23 @@ describe('checkAlerts', () => {
           },
         ],
       }).save();
-      const alert = await createAlert(team._id, {
-        source: AlertSource.TILE,
-        channel: {
-          type: 'webhook',
-          webhookId: webhook._id.toString(),
+      const mockUserId = new mongoose.Types.ObjectId();
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.TILE,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          dashboardId: dashboard.id,
+          tileId: '17quud',
         },
-        interval: '5m',
-        thresholdType: AlertThresholdType.ABOVE,
-        threshold: 1,
-        dashboardId: dashboard.id,
-        tileId: '17quud',
-      });
+        mockUserId,
+      );
 
       const enhancedAlert: any = await Alert.findById(alert._id).populate([
         'team',

--- a/packages/api/src/tasks/__tests__/singleInvocationAlert.test.ts
+++ b/packages/api/src/tasks/__tests__/singleInvocationAlert.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from 'http';
+import mongoose from 'mongoose';
 import ms from 'ms';
 
 import * as config from '@/config';
@@ -130,18 +131,23 @@ describe('Single Invocation Alert Test', () => {
     }).save();
 
     // Create alert
-    const alert = await createAlert(team._id, {
-      source: AlertSource.SAVED_SEARCH,
-      channel: {
-        type: 'webhook',
-        webhookId: webhook._id.toString(),
+    const mockUserId = new mongoose.Types.ObjectId();
+    const alert = await createAlert(
+      team._id,
+      {
+        source: AlertSource.SAVED_SEARCH,
+        channel: {
+          type: 'webhook',
+          webhookId: webhook._id.toString(),
+        },
+        interval: '5m',
+        thresholdType: AlertThresholdType.ABOVE,
+        threshold: 1,
+        savedSearchId: savedSearch.id,
+        name: 'Test Alert Name',
       },
-      interval: '5m',
-      thresholdType: AlertThresholdType.ABOVE,
-      threshold: 1,
-      savedSearchId: savedSearch.id,
-      name: 'Test Alert Name',
-    });
+      mockUserId,
+    );
 
     // Insert test logs that will trigger the alert
     const now = new Date('2023-11-16T22:12:00.000Z');

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -183,6 +183,14 @@ function AlertDetails({ alert }: { alert: AlertsPageItem }) {
           <div className="text-slate-400 fs-8 d-flex gap-2">
             {alertType}
             {notificationMethod}
+            {alert.createdBy && (
+              <>
+                <span className="text-slate-400">&middot;</span>
+                <span>
+                  Created by {alert.createdBy.name || alert.createdBy.email}
+                </span>
+              </>
+            )}
           </div>
         </Stack>
       </Group>

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -43,7 +43,7 @@ import { AlertPreviewChart } from './components/AlertPreviewChart';
 import { AlertChannelForm } from './components/Alerts';
 import { SQLInlineEditorControlled } from './components/SQLInlineEditor';
 import api from './api';
-import { SearchConfig } from './types';
+import { AlertWithCreatedBy, SearchConfig } from './types';
 import { optionsToSelectData } from './utils';
 
 const SavedSearchAlertFormSchema = z
@@ -76,7 +76,7 @@ const AlertForm = ({
   where?: SearchCondition | null;
   whereLanguage?: SearchConditionLanguage | null;
   select?: string | null;
-  defaultValues?: null | Alert;
+  defaultValues?: null | AlertWithCreatedBy;
   loading?: boolean;
   deleteLoading?: boolean;
   hasSavedSearch?: boolean;
@@ -184,6 +184,22 @@ const AlertForm = ({
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
+
+      {defaultValues?.createdBy && (
+        <Paper px="md" py="sm" bg="dark.6" radius="xs" mt="sm">
+          <Text size="xxs" opacity={0.5} mb={4}>
+            Created by
+          </Text>
+          <Text size="sm" opacity={0.8}>
+            {defaultValues.createdBy.name || defaultValues.createdBy.email}
+          </Text>
+          {defaultValues.createdBy.name && (
+            <Text size="xs" opacity={0.6}>
+              {defaultValues.createdBy.email}
+            </Text>
+          )}
+        </Paper>
+      )}
 
       <Group mt="lg" justify="space-between" gap="xs">
         <div>

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -768,39 +768,50 @@ export default function EditTimeChartForm({
         <Paper my="sm">
           <Stack gap="xs">
             <Paper px="md" py="sm" bg="dark.6" radius="xs">
-              <Group gap="xs">
-                <Text size="sm" opacity={0.7}>
-                  Alert when the value
-                </Text>
-                <NativeSelect
-                  data={optionsToSelectData(TILE_ALERT_THRESHOLD_TYPE_OPTIONS)}
-                  size="xs"
-                  name={`alert.thresholdType`}
-                  control={control}
-                />
-                <NumberInput
-                  min={MINIMUM_THRESHOLD_VALUE}
-                  size="xs"
-                  w={80}
-                  control={control}
-                  name={`alert.threshold`}
-                />
-                over
-                <NativeSelect
-                  data={optionsToSelectData(TILE_ALERT_INTERVAL_OPTIONS)}
-                  size="xs"
-                  name={`alert.interval`}
-                  control={control}
-                />
-                <Text size="sm" opacity={0.7}>
-                  window via
-                </Text>
-                <NativeSelect
-                  data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}
-                  size="xs"
-                  name={`alert.channel.type`}
-                  control={control}
-                />
+              <Group gap="xs" justify="space-between">
+                <Group gap="xs">
+                  <Text size="sm" opacity={0.7}>
+                    Alert when the value
+                  </Text>
+                  <NativeSelect
+                    data={optionsToSelectData(
+                      TILE_ALERT_THRESHOLD_TYPE_OPTIONS,
+                    )}
+                    size="xs"
+                    name={`alert.thresholdType`}
+                    control={control}
+                  />
+                  <NumberInput
+                    min={MINIMUM_THRESHOLD_VALUE}
+                    size="xs"
+                    w={80}
+                    control={control}
+                    name={`alert.threshold`}
+                  />
+                  over
+                  <NativeSelect
+                    data={optionsToSelectData(TILE_ALERT_INTERVAL_OPTIONS)}
+                    size="xs"
+                    name={`alert.interval`}
+                    control={control}
+                  />
+                  <Text size="sm" opacity={0.7}>
+                    window via
+                  </Text>
+                  <NativeSelect
+                    data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}
+                    size="xs"
+                    name={`alert.channel.type`}
+                    control={control}
+                  />
+                </Group>
+                {(alert as any)?.createdBy && (
+                  <Text size="xs" opacity={0.6}>
+                    Created by{' '}
+                    {(alert as any).createdBy?.name ||
+                      (alert as any).createdBy?.email}
+                  </Text>
+                )}
               </Group>
               <Text size="xxs" opacity={0.5} mb={4} mt="xs">
                 Send to

--- a/packages/app/src/savedSearch.ts
+++ b/packages/app/src/savedSearch.ts
@@ -9,6 +9,7 @@ import {
 
 import { hdxServer } from './api';
 import { IS_LOCAL_MODE } from './config';
+import { SavedSearchWithEnhancedAlerts } from './types';
 
 export function useSavedSearches() {
   return useQuery({
@@ -17,7 +18,9 @@ export function useSavedSearches() {
       if (IS_LOCAL_MODE) {
         return [];
       } else {
-        return hdxServer('saved-search').json<SavedSearch[]>();
+        return hdxServer('saved-search').json<
+          SavedSearchWithEnhancedAlerts[]
+        >();
       }
     },
   });
@@ -25,7 +28,10 @@ export function useSavedSearches() {
 
 export function useSavedSearch(
   { id }: { id: string },
-  options: Omit<Partial<UseQueryOptions<SavedSearch[], Error>>, 'select'> = {},
+  options: Omit<
+    Partial<UseQueryOptions<SavedSearchWithEnhancedAlerts[], Error>>,
+    'select'
+  > = {},
 ) {
   return useQuery({
     queryKey: ['saved-search'],
@@ -33,7 +39,7 @@ export function useSavedSearch(
       if (IS_LOCAL_MODE) {
         return [];
       }
-      return hdxServer('saved-search').json<SavedSearch[]>();
+      return hdxServer('saved-search').json<SavedSearchWithEnhancedAlerts[]>();
     },
     select: data => data.find(s => s.id === id),
     ...options,

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -53,9 +53,24 @@ export type AlertsPageItem = Alert & {
   history: AlertHistory[];
   dashboard?: ServerDashboard;
   savedSearch?: SavedSearch;
+  createdBy?: {
+    email: string;
+    name?: string;
+  };
+};
+
+export type AlertWithCreatedBy = Alert & {
+  createdBy?: {
+    email: string;
+    name?: string;
+  };
 };
 
 export type SavedSearch = z.infer<typeof SavedSearchSchema>;
+
+export type SavedSearchWithEnhancedAlerts = Omit<SavedSearch, 'alerts'> & {
+  alerts?: AlertWithCreatedBy[];
+};
 
 export type SearchConfig = {
   select?: string | null;


### PR DESCRIPTION
We now store `createdBy` in the `Alert` document when the alert
is created. This new field references the `User` document of the
currently logged in user. The property is optional to support
existing alerts in the database.

This information is also displayed in various places where alert
details are displayed. Older documents without the new field should
display nothing, resulting in the existing UX.