### PR TITLE
feat: Display original query to error messages in search page

### DIFF
--- a/.changeset/light-knives-drop.md
+++ b/.changeset/light-knives-drop.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": minor
+---
+
+feat: Display original query to error messages in search page

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -816,7 +816,9 @@ function DBSearchPage() {
   // query error handling
   const { hasQueryError, queryError } = useMemo(() => {
     const hasQueryError = Object.values(_queryErrors).length > 0;
-    const queryError = hasQueryError ? Object.values(_queryErrors)[0] : null;
+    const queryError: Error | ClickHouseQueryError | null = hasQueryError
+      ? Object.values(_queryErrors)[0]
+      : null;
     return { hasQueryError, queryError };
   }, [_queryErrors]);
   const inputWhere = watch('where');
@@ -1675,6 +1677,21 @@ function DBSearchPage() {
                           {queryError.message}
                         </Code>
                       </Box>
+                      {queryError instanceof ClickHouseQueryError && (
+                        <Box mt="lg">
+                          <Text my="sm" size="sm">
+                            Original Query:
+                          </Text>
+                          <Code
+                            block
+                            style={{
+                              whiteSpace: 'pre-wrap',
+                            }}
+                          >
+                            <SQLPreview data={queryError.query} formatData />
+                          </Code>
+                        </Box>
+                      )}
                     </div>
                   </>
                 ) : (


### PR DESCRIPTION
<img width="1621" height="979" alt="image" src="https://github.com/user-attachments/assets/0dff42a3-3223-4a1b-98cf-a171d4cf36f7" />
