### PR TITLE
feat: group tasks by connection

### DIFF
--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -8,23 +8,22 @@ import {
   DisplayType,
 } from '@hyperdx/common-utils/dist/types';
 import * as fns from 'date-fns';
-import _ from 'lodash';
 import { isString } from 'lodash';
 import ms from 'ms';
 import { serializeError } from 'serialize-error';
 
-import { getConnectionById } from '@/controllers/connection';
-import {
-  AlertDocument,
-  AlertSource,
-  AlertState,
-  AlertThresholdType,
-} from '@/models/alert';
+import Alert, { AlertState, AlertThresholdType, IAlert } from '@/models/alert';
 import AlertHistory, { IAlertHistory } from '@/models/alertHistory';
-import Dashboard, { IDashboard } from '@/models/dashboard';
-import { ISavedSearch, SavedSearch } from '@/models/savedSearch';
-import { ISource, Source } from '@/models/source';
-import { AlertProvider, loadProvider } from '@/tasks/providers';
+import { IDashboard } from '@/models/dashboard';
+import { ISavedSearch } from '@/models/savedSearch';
+import { ISource } from '@/models/source';
+import {
+  AlertDetails,
+  AlertProvider,
+  AlertTask,
+  AlertTaskType,
+  loadProvider,
+} from '@/tasks/providers';
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
@@ -64,7 +63,7 @@ const fireChannelEvent = async ({
   totalCount,
   windowSizeInMins,
 }: {
-  alert: AlertDocument;
+  alert: IAlert;
   alertProvider: AlertProvider;
   attributes: Record<string, string>; // TODO: support other types than string
   clickhouseClient: clickhouse.ClickhouseClient;
@@ -86,7 +85,7 @@ const fireChannelEvent = async ({
   if ((alert.silenced?.until?.getTime() ?? 0) > Date.now()) {
     logger.info({
       message: 'Skipped firing alert due to silence',
-      alertId: alert.id,
+      alertId: alert._id,
       silenced: alert.silenced,
     });
     return;
@@ -137,9 +136,12 @@ const fireChannelEvent = async ({
 
 export const processAlert = async (
   now: Date,
-  alert: AlertDocument,
+  details: AlertDetails,
+  clickhouseClient: clickhouse.ClickhouseClient,
+  connectionId: string,
   alertProvider: AlertProvider,
 ) => {
+  const { alert, source } = details;
   try {
     const previous: IAlertHistory | undefined = (
       await AlertHistory.find({ alert: alert._id })
@@ -159,7 +161,7 @@ export const processAlert = async (
         nowInMinsRoundDown,
         previous,
         now,
-        alertId: alert.id,
+        alertId: alert._id,
       });
       return;
     }
@@ -169,30 +171,8 @@ export const processAlert = async (
     const checkEndTime = nowInMinsRoundDown;
 
     let chartConfig: ChartConfigWithOptDateRange | undefined;
-    let connectionId: string | undefined;
-    let savedSearch: ISavedSearch | undefined | null;
-    let dashboard: IDashboard | undefined | null;
-    let source: ISource | undefined | null;
-    // SAVED_SEARCH Source
-    if (alert.source === AlertSource.SAVED_SEARCH && alert.savedSearch) {
-      savedSearch = await SavedSearch.findById(alert.savedSearch);
-      if (savedSearch == null) {
-        logger.error({
-          message: 'SavedSearch not found',
-          alertId: alert.id,
-        });
-        return;
-      }
-      source = await Source.findById(savedSearch.source);
-      if (source == null) {
-        logger.error({
-          message: 'Source not found',
-          alertId: alert.id,
-          savedSearch: alert.savedSearch,
-        });
-        return;
-      }
-      connectionId = source.connection.toString();
+    if (details.taskType === AlertTaskType.SAVED_SEARCH) {
+      const savedSearch = details.savedSearch;
       chartConfig = {
         connection: connectionId,
         displayType: DisplayType.Line,
@@ -214,99 +194,45 @@ export const processAlert = async (
         implicitColumnExpression: source.implicitColumnExpression,
         timestampValueExpression: source.timestampValueExpression,
       };
-    }
-    // TILE Source
-    else if (
-      alert.source === AlertSource.TILE &&
-      alert.dashboard &&
-      alert.tileId
-    ) {
-      dashboard = await Dashboard.findById(alert.dashboard);
-      if (dashboard == null) {
-        logger.error({
-          message: 'Dashboard not found',
-          alertId: alert.id,
-          dashboardId: alert.dashboard,
-        });
-        return;
-      }
-      // filter tiles
-      dashboard.tiles = dashboard.tiles.filter(
-        tile => tile.id === alert.tileId,
-      );
-
-      if (dashboard.tiles.length === 1) {
-        // Doesn't work for metric alerts yet
-        const MAX_NUM_GROUPS = 20;
-        // TODO: assuming that the chart has only 1 series for now
-        const firstTile = dashboard.tiles[0];
-        if (firstTile.config.displayType === DisplayType.Line) {
-          // fetch source data
-          source = await Source.findById(firstTile.config.source);
-          if (!source) {
-            logger.error({
-              message: 'Source not found',
-              dashboardId: alert.dashboard,
-              tile: firstTile,
-            });
-            return;
-          }
-          connectionId = source.connection.toString();
-          chartConfig = {
-            connection: connectionId,
-            dateRange: [checkStartTime, checkEndTime],
-            dateRangeStartInclusive: true,
-            dateRangeEndInclusive: false,
-            displayType: firstTile.config.displayType,
-            from: source.from,
-            granularity: `${windowSizeInMins} minute`,
-            groupBy: firstTile.config.groupBy,
-            implicitColumnExpression: source.implicitColumnExpression,
-            metricTables: source.metricTables,
-            select: firstTile.config.select,
-            timestampValueExpression: source.timestampValueExpression,
-            where: firstTile.config.where,
-            seriesReturnType: firstTile.config.seriesReturnType,
-          };
-        }
+    } else if (details.taskType === AlertTaskType.TILE) {
+      const tile = details.tile;
+      // Doesn't work for metric alerts yet
+      if (tile.config.displayType === DisplayType.Line) {
+        chartConfig = {
+          connection: connectionId,
+          dateRange: [checkStartTime, checkEndTime],
+          dateRangeStartInclusive: true,
+          dateRangeEndInclusive: false,
+          displayType: tile.config.displayType,
+          from: source.from,
+          granularity: `${windowSizeInMins} minute`,
+          groupBy: tile.config.groupBy,
+          implicitColumnExpression: source.implicitColumnExpression,
+          metricTables: source.metricTables,
+          select: tile.config.select,
+          timestampValueExpression: source.timestampValueExpression,
+          where: tile.config.where,
+          seriesReturnType: tile.config.seriesReturnType,
+        };
       }
     } else {
       logger.error({
         message: `Unsupported alert source: ${alert.source}`,
-        alertId: alert.id,
+        alertId: alert._id,
       });
       return;
     }
 
     // Fetch data
-    if (chartConfig == null || connectionId == null) {
+    if (chartConfig == null) {
       logger.error({
         message: 'Failed to build chart config',
         chartConfig,
-        connectionId,
-        alertId: alert.id,
+        alertId: alert._id,
       });
       return;
     }
 
-    const connection = await getConnectionById(
-      alert.team._id.toString(),
-      connectionId,
-      true,
-    );
-
-    if (connection == null) {
-      logger.error({
-        message: 'Connection not found',
-        alertId: alert.id,
-      });
-      return;
-    }
-    const clickhouseClient = new clickhouse.ClickhouseClient({
-      host: connection.host,
-      username: connection.username,
-      password: connection.password,
-    });
     const metadata = getMetadata(clickhouseClient);
     const checksData = await clickhouseClient.queryChartConfig({
       config: chartConfig,
@@ -315,7 +241,7 @@ export const processAlert = async (
 
     logger.info({
       message: `Received alert metric [${alert.source} source]`,
-      alertId: alert.id,
+      alertId: alert._id,
       checksData,
       checkStartTime,
       checkEndTime,
@@ -350,7 +276,7 @@ export const processAlert = async (
         logger.error({
           message: 'Failed to find timestamp column',
           meta,
-          alertId: alert.id,
+          alertId: alert._id,
         });
         return;
       }
@@ -358,7 +284,7 @@ export const processAlert = async (
         logger.error({
           message: 'Failed to find value column',
           meta,
-          alertId: alert.id,
+          alertId: alert._id,
         });
         return;
       }
@@ -385,22 +311,26 @@ export const processAlert = async (
           alertState = AlertState.ALERT;
           logger.info({
             message: `Triggering ${alert.channel.type} alarm!`,
-            alertId: alert.id,
+            alertId: alert._id,
             totalCount: _value,
             checkData,
           });
 
           try {
+            // Casts to any here because this is where I stopped unraveling the
+            // alert logic requiring large, nested objects. We should look at
+            // cleaning this up next. fireChannelEvent guards against null values
+            // for these properties.
             await fireChannelEvent({
               alert,
               alertProvider,
               attributes: {}, // FIXME: support attributes (logs + resources ?)
               clickhouseClient,
-              dashboard,
+              dashboard: (details as any).dashboard,
               endTime: fns.addMinutes(bucketStart, windowSizeInMins),
               group: extraFields.join(', '),
               metadata,
-              savedSearch,
+              savedSearch: (details as any)?.savedSearch,
               source,
               startTime: bucketStart,
               totalCount: _value,
@@ -409,7 +339,7 @@ export const processAlert = async (
           } catch (e) {
             logger.error({
               message: 'Failed to fire channel event',
-              alertId: alert.id,
+              alertId: alert._id,
               error: serializeError(e),
             });
           }
@@ -423,17 +353,45 @@ export const processAlert = async (
       await history.save();
     }
 
-    alert.state = alertState;
-    await alert.save();
+    await Alert.updateOne({ _id: alert._id }, { $set: { state: alertState } });
   } catch (e) {
     // Uncomment this for better error messages locally
     // console.error(e);
     logger.error({
       message: 'Failed to process alert',
-      alertId: alert.id,
+      alertId: alert._id,
       error: serializeError(e),
     });
   }
+};
+
+export const processAlertTask = async (
+  now: Date,
+  alertTask: AlertTask,
+  alertProvider: AlertProvider,
+) => {
+  const { alerts, conn } = alertTask;
+  logger.info(`Processing ${alerts.length} alerts in batch`);
+
+  const clickhouseClient = new clickhouse.ClickhouseClient({
+    host: conn.host,
+    username: conn.username,
+    password: conn.password,
+  });
+
+  const p: Promise<void>[] = [];
+  for (const alert of alerts) {
+    p.push(
+      processAlert(
+        now,
+        alert,
+        clickhouseClient,
+        conn._id.toString(),
+        alertProvider,
+      ),
+    );
+  }
+  await Promise.all(p);
 };
 
 // Re-export handleSendGenericWebhook for testing
@@ -448,11 +406,11 @@ export default class CheckAlertTask implements HdxTask {
 
     const now = new Date();
     const alertTasks = await this.provider.getAlertTasks();
-    const alerts = alertTasks[0].alerts;
-    logger.info(`Going to process ${alerts.length} alerts`);
-    await Promise.all(
-      alerts.map(alert => processAlert(now, alert, this.provider)),
-    );
+    logger.info(`Fetched ${alertTasks.length} alert tasks to process`);
+
+    for (const task of alertTasks) {
+      await processAlertTask(now, task, this.provider);
+    }
   }
 
   async asyncDispose(): Promise<void> {

--- a/packages/api/src/tasks/providers/__tests__/default.test.ts
+++ b/packages/api/src/tasks/providers/__tests__/default.test.ts
@@ -1,7 +1,18 @@
 import mongoose from 'mongoose';
 
-import * as config from '@/config';
-import { AlertProvider, loadProvider } from '@/tasks/providers/index';
+import { createAlert } from '@/controllers/alerts';
+import { createTeam } from '@/controllers/team';
+import { getServer, makeTile } from '@/fixtures';
+import Alert, { AlertSource, AlertThresholdType } from '@/models/alert';
+import Connection from '@/models/connection';
+import Dashboard from '@/models/dashboard';
+import { SavedSearch } from '@/models/savedSearch';
+import { Source } from '@/models/source';
+import {
+  AlertProvider,
+  AlertTaskType,
+  loadProvider,
+} from '@/tasks/providers/index';
 
 const MOCK_SAVED_SEARCH: any = {
   id: 'fake-saved-search-id',
@@ -9,9 +20,562 @@ const MOCK_SAVED_SEARCH: any = {
 
 describe('DefaultAlertProvider', () => {
   let provider: AlertProvider;
+  const server = getServer();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     provider = await loadProvider('default');
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.clearDBs();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  describe('getAlertTasks', () => {
+    it('should return empty array when no alerts exist', async () => {
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should process a single saved search alert', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create connection
+      const connection = await Connection.create({
+        team: team._id,
+        name: 'Test Connection',
+        host: 'http://localhost:8123',
+        username: 'test',
+        password: 'test',
+      });
+
+      // Create source
+      const source = await Source.create({
+        team: team._id,
+        name: 'Test Source',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: connection._id,
+      });
+
+      // Create saved search
+      const savedSearch = await SavedSearch.create({
+        team: team._id,
+        name: 'Test Search',
+        select: 'message',
+        where: 'level: error',
+        whereLanguage: 'lucene',
+        orderBy: 'timestamp',
+        source: source._id,
+        tags: [],
+      });
+
+      // Create alert
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 10,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '5m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      const result = await provider.getAlertTasks();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].conn._id.toString()).toBe(connection._id.toString());
+      expect(result[0].alerts).toHaveLength(1);
+      expect(result[0].alerts[0].taskType).toBe(AlertTaskType.SAVED_SEARCH);
+      expect(result[0].alerts[0].alert._id.toString()).toBe(
+        alert._id.toString(),
+      );
+
+      // Type narrowing for SAVED_SEARCH alert
+      if (result[0].alerts[0].taskType === AlertTaskType.SAVED_SEARCH) {
+        expect(result[0].alerts[0].savedSearch.name).toBe('Test Search');
+      }
+    });
+
+    it('should process a single tile alert', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create connection
+      const connection = await Connection.create({
+        team: team._id,
+        name: 'Test Connection',
+        host: 'http://localhost:8123',
+        username: 'test',
+        password: 'test',
+      });
+
+      // Create source
+      const source = await Source.create({
+        team: team._id,
+        name: 'Test Source',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: connection._id,
+      });
+
+      // Create tile with source
+      const tile = makeTile({ id: 'test-tile-123' });
+      tile.config.source = source._id.toString();
+
+      // Create dashboard
+      const dashboard = await Dashboard.create({
+        team: team._id,
+        name: 'Test Dashboard',
+        tiles: [tile],
+      });
+
+      // Create alert
+      const alert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.TILE,
+          dashboardId: dashboard._id.toString(),
+          tileId: tile.id,
+          threshold: 10,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '5m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      const result = await provider.getAlertTasks();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].conn._id.toString()).toBe(connection._id.toString());
+      expect(result[0].alerts).toHaveLength(1);
+      expect(result[0].alerts[0].taskType).toBe(AlertTaskType.TILE);
+      expect(result[0].alerts[0].alert._id.toString()).toBe(
+        alert._id.toString(),
+      );
+
+      // Type narrowing for TILE alert
+      if (result[0].alerts[0].taskType === AlertTaskType.TILE) {
+        expect(result[0].alerts[0].tile.id).toBe(tile.id);
+        expect(result[0].alerts[0].dashboard.name).toBe('Test Dashboard');
+      }
+    });
+
+    it('should skip alerts with missing saved search', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create alert directly in database with non-existent saved search
+      // This simulates an alert that exists but references a deleted saved search
+      await Alert.create({
+        team: team._id,
+        source: AlertSource.SAVED_SEARCH,
+        savedSearch: new mongoose.Types.ObjectId(), // Non-existent ID
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should skip alerts with no source field', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create alert directly without source
+      await Alert.create({
+        team: team._id,
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+        // Missing source field
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should group multiple alerts with the same connection', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create single connection
+      const connection = await Connection.create({
+        team: team._id,
+        name: 'Shared Connection',
+        host: 'http://localhost:8123',
+        username: 'test',
+        password: 'test',
+      });
+
+      // Create source
+      const source = await Source.create({
+        team: team._id,
+        name: 'Test Source',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: connection._id,
+      });
+
+      // Create saved search and alert
+      const savedSearch = await SavedSearch.create({
+        team: team._id,
+        name: 'Test Search',
+        select: 'message',
+        where: 'level: error',
+        whereLanguage: 'lucene',
+        orderBy: 'timestamp',
+        source: source._id,
+        tags: [],
+      });
+
+      const savedSearchAlert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 10,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '5m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      // Create tile and alert
+      const tile = makeTile({ id: 'test-tile-123' });
+      tile.config.source = source._id.toString();
+
+      const dashboard = await Dashboard.create({
+        team: team._id,
+        name: 'Test Dashboard',
+        tiles: [tile],
+      });
+
+      const tileAlert = await createAlert(
+        team._id,
+        {
+          source: AlertSource.TILE,
+          dashboardId: dashboard._id.toString(),
+          tileId: tile.id,
+          threshold: 15,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '15m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      const result = await provider.getAlertTasks();
+
+      expect(result).toHaveLength(1); // Should group into one task
+      expect(result[0].conn._id.toString()).toBe(connection._id.toString());
+      expect(result[0].alerts).toHaveLength(2); // Both alerts should be in the same task
+
+      const alertIds = result[0].alerts.map(a => a.alert._id.toString()).sort();
+      expect(alertIds).toEqual(
+        [savedSearchAlert._id.toString(), tileAlert._id.toString()].sort(),
+      );
+    });
+
+    it('should create separate tasks for different connections', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create two different connections
+      const connection1 = await Connection.create({
+        team: team._id,
+        name: 'Connection 1',
+        host: 'http://localhost:8123',
+        username: 'test1',
+        password: 'test1',
+      });
+
+      const connection2 = await Connection.create({
+        team: team._id,
+        name: 'Connection 2',
+        host: 'http://localhost:8124',
+        username: 'test2',
+        password: 'test2',
+      });
+
+      // Create sources for each connection
+      const source1 = await Source.create({
+        team: team._id,
+        name: 'Source 1',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: connection1._id,
+      });
+
+      const source2 = await Source.create({
+        team: team._id,
+        name: 'Source 2',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: connection2._id,
+      });
+
+      // Create saved searches and alerts
+      const savedSearch1 = await SavedSearch.create({
+        team: team._id,
+        name: 'Search 1',
+        select: 'message',
+        where: 'level: error',
+        whereLanguage: 'lucene',
+        orderBy: 'timestamp',
+        source: source1._id,
+        tags: [],
+      });
+
+      const savedSearch2 = await SavedSearch.create({
+        team: team._id,
+        name: 'Search 2',
+        select: 'message',
+        where: 'level: warn',
+        whereLanguage: 'lucene',
+        orderBy: 'timestamp',
+        source: source2._id,
+        tags: [],
+      });
+
+      await createAlert(
+        team._id,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          savedSearchId: savedSearch1._id.toString(),
+          threshold: 10,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '5m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      await createAlert(
+        team._id,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          savedSearchId: savedSearch2._id.toString(),
+          threshold: 15,
+          thresholdType: AlertThresholdType.ABOVE,
+          interval: '15m',
+          channel: {
+            type: 'webhook',
+            webhookId: new mongoose.Types.ObjectId().toString(),
+          },
+        },
+        new mongoose.Types.ObjectId(),
+      );
+
+      const result = await provider.getAlertTasks();
+
+      expect(result).toHaveLength(2); // Should create separate tasks
+
+      const connectionIds = result.map(task => task.conn._id.toString()).sort();
+      expect(connectionIds).toEqual(
+        [connection1._id.toString(), connection2._id.toString()].sort(),
+      );
+
+      // Each task should have one alert
+      expect(result[0].alerts).toHaveLength(1);
+      expect(result[1].alerts).toHaveLength(1);
+    });
+
+    it('should skip alerts with missing dashboard', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create alert directly in database with non-existent dashboard
+      // This simulates an alert that exists but references a deleted dashboard
+      await Alert.create({
+        team: team._id,
+        source: AlertSource.TILE,
+        dashboard: new mongoose.Types.ObjectId(), // Non-existent ID
+        tileId: 'some-tile-id',
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should skip alerts with missing tile in dashboard', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      const dashboard = await Dashboard.create({
+        team: team._id,
+        name: 'Test Dashboard',
+        tiles: [makeTile({ id: 'existing-tile' })],
+      });
+
+      // Create alert directly in database with non-existent tile ID
+      await Alert.create({
+        team: team._id,
+        source: AlertSource.TILE,
+        dashboard: dashboard._id,
+        tileId: 'non-existent-tile', // Non-existent tile ID
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should skip alerts with missing source', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      const tile = makeTile({ id: 'test-tile' });
+      tile.config.source = new mongoose.Types.ObjectId().toString(); // Non-existent source
+
+      const dashboard = await Dashboard.create({
+        team: team._id,
+        name: 'Test Dashboard',
+        tiles: [tile],
+      });
+
+      // Create alert directly in database
+      await Alert.create({
+        team: team._id,
+        source: AlertSource.TILE,
+        dashboard: dashboard._id,
+        tileId: tile.id,
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should skip alerts with missing connection', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create source with non-existent connection
+      const source = await Source.create({
+        team: team._id,
+        name: 'Test Source',
+        kind: 'log',
+        from: {
+          databaseName: 'default',
+          tableName: 'logs',
+        },
+        timestampValueExpression: 'timestamp',
+        connection: new mongoose.Types.ObjectId(), // Non-existent connection
+      });
+
+      const savedSearch = await SavedSearch.create({
+        team: team._id,
+        name: 'Test Search',
+        select: 'message',
+        where: 'level: error',
+        whereLanguage: 'lucene',
+        orderBy: 'timestamp',
+        source: source._id,
+        tags: [],
+      });
+
+      // Create alert directly in database
+      await Alert.create({
+        team: team._id,
+        source: AlertSource.SAVED_SEARCH,
+        savedSearch: savedSearch._id,
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
+
+    it('should skip alerts with unsupported source type', async () => {
+      const team = await createTeam({ name: 'Test Team' });
+
+      // Create alert with invalid source
+      await Alert.create({
+        team: team._id,
+        source: 'UNSUPPORTED_SOURCE' as any,
+        threshold: 10,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: {
+          type: 'webhook',
+          webhookId: new mongoose.Types.ObjectId().toString(),
+        },
+      });
+
+      const result = await provider.getAlertTasks();
+      expect(result).toEqual([]);
+    });
   });
 
   describe('buildLogSearchLink', () => {

--- a/packages/api/src/tasks/providers/default.ts
+++ b/packages/api/src/tasks/providers/default.ts
@@ -1,3 +1,4 @@
+import { Tile } from '@hyperdx/common-utils/dist/types';
 import mongoose from 'mongoose';
 import ms from 'ms';
 import { URLSearchParams } from 'url';
@@ -5,11 +6,101 @@ import { URLSearchParams } from 'url';
 import * as config from '@/config';
 import { LOCAL_APP_TEAM } from '@/controllers/team';
 import { connectDB, mongooseConnection } from '@/models';
-import Alert from '@/models/alert';
-import { ISavedSearch } from '@/models/savedSearch';
+import Alert, { AlertSource, type IAlert } from '@/models/alert';
+import Connection, { IConnection } from '@/models/connection';
+import Dashboard from '@/models/dashboard';
+import { type ISavedSearch, SavedSearch } from '@/models/savedSearch';
+import { type ISource, Source } from '@/models/source';
+import {
+  type AlertDetails,
+  type AlertProvider,
+  type AlertTask,
+  AlertTaskType,
+} from '@/tasks/providers';
 import { convertMsToGranularityString } from '@/utils/common';
+import logger from '@/utils/logger';
 
-import { AlertProvider, AlertTask } from './index';
+async function getSavedSearchDetails(
+  alert: IAlert,
+): Promise<[IConnection, AlertDetails] | []> {
+  const savedSearchId = alert.savedSearch;
+  const savedSearch = await SavedSearch.findById(savedSearchId).populate<
+    Omit<ISavedSearch, 'source'> & { source: ISource }
+  >('source');
+
+  if (!savedSearch) {
+    logger.error(`savedSearch not found: id=${savedSearchId}`);
+    return [];
+  }
+
+  const { source } = savedSearch;
+  const connId = source.connection;
+  const conn = await Connection.findById(connId);
+  if (!conn) {
+    logger.error(
+      `connection not found: alertId=${alert._id}, connId=${connId}, savedSearchId=${savedSearchId}`,
+    );
+    return [];
+  }
+
+  return [
+    conn,
+    {
+      alert,
+      source,
+      taskType: AlertTaskType.SAVED_SEARCH,
+      savedSearch,
+    },
+  ];
+}
+
+async function getTileDetails(
+  alert: IAlert,
+): Promise<[IConnection, AlertDetails] | []> {
+  const dashboardId = alert.dashboard;
+  const tileId = alert.tileId;
+
+  const dashboard = await Dashboard.findById(dashboardId);
+  if (!dashboard) {
+    logger.error(`dashboard not found: id=${dashboardId}`);
+    return [];
+  }
+
+  const tile = dashboard.tiles?.find((t: Tile) => t.id === tileId);
+  if (!tile) {
+    logger.error(
+      `tile matching alert not found: tile=${tileId},alert=${alert._id}`,
+    );
+    return [];
+  }
+
+  const source = await Source.findById(tile.config.source).populate<
+    Omit<ISource, 'connection'> & { connection: IConnection }
+  >('connection');
+  if (!source) {
+    logger.error(`source not found: id=${tile.config.source}`);
+    return [];
+  }
+
+  const { connection, ...restSource } = source;
+  if (!connection) {
+    logger.error(
+      `connection not found: alert=${alert._id}, source=${source.id}`,
+    );
+    return [];
+  }
+
+  return [
+    connection,
+    {
+      alert,
+      source: { connection: connection._id, ...restSource },
+      taskType: AlertTaskType.TILE,
+      tile,
+      dashboard,
+    },
+  ];
+}
 
 export default class DefaultAlertProvider implements AlertProvider {
   async init() {
@@ -21,16 +112,57 @@ export default class DefaultAlertProvider implements AlertProvider {
   }
 
   async getAlertTasks(): Promise<AlertTask[]> {
+    const groupedTasks = new Map<string, AlertTask>();
     const alerts = await Alert.find({});
-    if (config.IS_LOCAL_APP_MODE) {
-      alerts.forEach(_alert => {
+    for (const alert of alerts) {
+      if (!alert.source) {
+        logger.error(`alert does not have a source: alertId=${alert._id}`);
+        continue;
+      }
+
+      if (config.IS_LOCAL_APP_MODE) {
         // The id is the 12 character string `_local_team_', which will become an ObjectId
         // as the ASCII hex values, so 5f6c6f63616c5f7465616d5f.
-        _alert.team = new mongoose.Types.ObjectId(LOCAL_APP_TEAM.id);
-      });
+        alert.team = new mongoose.Types.ObjectId(LOCAL_APP_TEAM.id);
+      }
+
+      let conn: IConnection | undefined;
+      let details: AlertDetails | undefined;
+      switch (alert.source) {
+        case AlertSource.SAVED_SEARCH:
+          [conn, details] = await getSavedSearchDetails(alert);
+          break;
+
+        case AlertSource.TILE:
+          [conn, details] = await getTileDetails(alert);
+          break;
+
+        default:
+          logger.error(
+            `unsupported source: alertId=${alert._id}, source=${alert.source}`,
+          );
+          continue;
+      }
+
+      if (!details) {
+        logger.error(`failed to fetch alert details: alertId=${alert._id}`);
+        continue;
+      }
+
+      if (!conn) {
+        logger.error(`failed to fetch alert connection: alertId=${alert._id}`);
+        continue;
+      }
+
+      const k = conn._id.toString();
+      if (!groupedTasks.has(k)) {
+        groupedTasks.set(k, { alerts: [], conn });
+      }
+      groupedTasks.get(k)?.alerts.push(details);
     }
 
-    return [{ alerts }];
+    // Flatten out our groupings for execution
+    return Array.from(groupedTasks.values());
   }
 
   buildLogSearchLink({

--- a/packages/api/src/tasks/providers/index.ts
+++ b/packages/api/src/tasks/providers/index.ts
@@ -1,11 +1,45 @@
-import { AlertDocument } from '@/models/alert';
+import { Tile } from '@hyperdx/common-utils/dist/types';
+
+import { IAlert } from '@/models/alert';
+import { IConnection } from '@/models/connection';
+import { IDashboard } from '@/models/dashboard';
 import { ISavedSearch } from '@/models/savedSearch';
+import { ISource } from '@/models/source';
+import DefaultAlertProvider from '@/tasks/providers/default';
 
-import DefaultAlertProvider from './default';
+export enum AlertTaskType {
+  SAVED_SEARCH,
+  TILE,
+}
 
-export type AlertTask = {
-  alerts: AlertDocument[];
-};
+// Details about the alert and the source for the alert. Depending on
+// the taskType either:
+//   1. the savedSearch field is required or
+//   2. the tile and dashboard field are required
+//
+// The dependent typing means less null checks when using these values as
+// the are required when the type is set accordingly.
+export type AlertDetails = {
+  alert: IAlert;
+  source: ISource;
+} & (
+  | {
+      taskType: AlertTaskType.SAVED_SEARCH;
+      savedSearch: Omit<ISavedSearch, 'source'>;
+    }
+  | {
+      taskType: AlertTaskType.TILE;
+      tile: Tile;
+      dashboard: IDashboard;
+    }
+);
+
+// AlertTask instances can carry metadata, of type T, for the provider that created
+// them. The `metadata` field is only valid when T is defined to be a legal type.
+export type AlertTask<T = never> = {
+  alerts: AlertDetails[];
+  conn: IConnection;
+} & ([T] extends [never] ? unknown : { metadata: T });
 
 export interface AlertProvider {
   init(): Promise<void>;


### PR DESCRIPTION
Group the alert tasks fetched from mongo into groups based on what needs to run from the same connection. This sets up for further optimizations and connection reuse.