### PR TITLE
fix: fetch password explictly

### DIFF
--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -388,6 +388,13 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
       alertCount: alerts.length,
     });
 
+    if (!conn.password) {
+      const className = this.provider.constructor.name;
+      throw new Error(
+        `provider ${className} did not fetch password for connection ${conn.id}`,
+      );
+    }
+
     const clickhouseClient = new clickhouse.ClickhouseClient({
       host: conn.host,
       username: conn.username,

--- a/packages/api/src/tasks/providers/default.ts
+++ b/packages/api/src/tasks/providers/default.ts
@@ -43,7 +43,10 @@ async function getSavedSearchDetails(
 
   const { source } = savedSearch;
   const connId = source.connection;
-  const conn = await Connection.findOne({ _id: connId, team: alert.team });
+  const conn = await Connection.findOne({
+    _id: connId,
+    team: alert.team,
+  }).select('+password');
   if (!conn) {
     logger.error({
       message: 'connection not found',
@@ -101,6 +104,7 @@ async function getTileDetails(
   }).populate<Omit<ISource, 'connection'> & { connection: IConnection }>({
     path: 'connection',
     match: { team: alert.team },
+    select: '+password',
   });
   if (!source) {
     logger.error({


### PR DESCRIPTION
Include the explicit select of the password field since the mongoose schema omits it by default. Includes test cases to verify the password against the mongo instance running in the test suite and an additional error check.