### PR TITLE
fix: Prevent empty order by set in search page for certain sort/primary keys

### DIFF
--- a/.changeset/hip-moose-boil.md
+++ b/.changeset/hip-moose-boil.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Prevent empty order by set in search page for certain sort/primary keys

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -508,6 +508,7 @@ function optimizeDefaultOrderBy(
     defaultModifier,
   ];
   const fallbackOrderBy = fallbackOrderByItems.join(' ');
+
   if (!sortingKey) return fallbackOrderBy;
 
   const orderByArr = [];
@@ -528,6 +529,11 @@ function optimizeDefaultOrderBy(
         break;
       }
     }
+  }
+
+  // If we can't find an optimized order by, use the fallback/default
+  if (orderByArr.length === 0) {
+    return fallbackOrderBy;
   }
 
   return `(${orderByArr.join(', ')}) ${defaultModifier}`;

--- a/packages/app/src/__tests__/DBSearchPage.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.test.tsx
@@ -31,6 +31,11 @@ describe('useDefaultOrderBy', () => {
           expected: 'Timestamp DESC',
         },
         {
+          // Traces Table
+          input: 'ServiceName, SpanName, toDateTime(Timestamp)',
+          expected: 'Timestamp DESC',
+        },
+        {
           input: 'toStartOfHour(Timestamp), other_column, Timestamp',
           expected: '(toStartOfHour(Timestamp), Timestamp) DESC',
         },


### PR DESCRIPTION
When using a trace table with the default otel schema of `ServiceName, SpanName, toDateTime(Timestamp)`, we currently return a blank order by which breaks sorting in search page.

Instead, if we fail to optimize the order by based on the primary key, we should just return a default value instead of an empty value.