### PR TITLE
fix: delimited column identifier for dynamic fields

### DIFF
--- a/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
+++ b/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
@@ -173,7 +173,7 @@ describe('processRowToWhereClause', () => {
     const row = { dynamic_field: '"quoted_value"' };
     const result = processRowToWhereClause(row, columnMap);
 
-    expect(result).toBe("toString(dynamic_field)='quoted_value'");
+    expect(result).toBe("toString(`dynamic_field`)='quoted_value'");
   });
 
   it('should handle Dynamic columns with escaped values', () => {
@@ -192,7 +192,27 @@ describe('processRowToWhereClause', () => {
     const row = { dynamic_field: '{\\"took\\":7, not a valid json' };
     const result = processRowToWhereClause(row, columnMap);
     expect(result).toBe(
-      'toString(dynamic_field)=\'{\\"took\\":7, not a valid json\'',
+      'toString(`dynamic_field`)=\'{\\"took\\":7, not a valid json\'',
+    );
+  });
+
+  it('should handle Dynamic columns with delimited identifier', () => {
+    const columnMap = new Map([
+      [
+        'dynamic_field.nested.needs\\toBeEscaped',
+        {
+          name: 'dynamic_field.nested\\ToBeEscaped',
+          type: 'Dynamic',
+          valueExpr: 'dynamic_field.nested.needs\\ToBeEscaped',
+          jsType: JSDataType.Dynamic,
+        },
+      ],
+    ]);
+
+    const row = { 'dynamic_field.nested.needs\\toBeEscaped': 'some string' };
+    const result = processRowToWhereClause(row, columnMap);
+    expect(result).toBe(
+      `toString(\`dynamic_field\`.\`nested\`.\`needs\\ToBeEscaped\`)='some string'`,
     );
   });
 

--- a/packages/app/src/hooks/useRowWhere.tsx
+++ b/packages/app/src/hooks/useRowWhere.tsx
@@ -68,17 +68,14 @@ export function processRowToWhereClause(
           if (value === 'null') {
             return SqlString.format(`isNull(??)`, [column]);
           }
-          if (value.length > 1000 || column.length > 1000) {
-            console.warn('Search value/object key too large.');
-          }
           // TODO: update when JSON type have new version
           // will not work for array/object dyanmic data
 
           // escaped strings needs raw, becuase sqlString will add another layer of escaping
           // data other than array/object will alwayas return with dobule quote(because of CH)
           // remove dobule qoute to search correctly
-          return SqlString.format(`toString(?)='?'`, [
-            SqlString.raw(valueExpr),
+          return SqlString.format(`toString(??)='?'`, [
+            valueExpr,
             SqlString.raw(
               value[0] === '"' && value[value.length - 1] === '"'
                 ? value.slice(1, -1)


### PR DESCRIPTION
Hi,
in dynamic fields there could be identifier like `log.ctxt.request.Symfony\Component\HttpFoundation\Request` (real world example from php logs).
Search query will be `toString(log.ctxt.request.Symfony\Component\HttpFoundation\Request)=` and backend will return 400 Bad request complaining about syntax error.
Escaping identifiers with `??`  which is shorthand to SqlString.escapeId() solves that problem. 

I've removed value length conditions as well. They are no more needed as was mentioned in my previous PR https://github.com/hyperdxio/hyperdx/pull/1064