### PR TITLE
feat: remove useless session source fields

### DIFF
--- a/.changeset/violet-kiwis-cover.md
+++ b/.changeset/violet-kiwis-cover.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+feat: remove useless session source fields

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -501,8 +501,11 @@ const SourceBaseSchema = z.object({
     databaseName: z.string().min(1, 'Database is required'),
     tableName: z.string().min(1, 'Table is required'),
   }),
-  timestampValueExpression: z.string().min(1, 'Timestamp Column is required'),
 });
+
+const RequiredTimestampColumnSchema = z
+  .string()
+  .min(1, 'Timestamp Column is required');
 
 // Log source form schema
 const LogSourceAugmentation = {
@@ -510,6 +513,7 @@ const LogSourceAugmentation = {
   defaultTableSelectExpression: z.string({
     message: 'Default Table Select Expression is required',
   }),
+  timestampValueExpression: RequiredTimestampColumnSchema,
 
   // Optional fields for logs
   serviceNameExpression: z.string().optional(),
@@ -531,6 +535,7 @@ const LogSourceAugmentation = {
 const TraceSourceAugmentation = {
   kind: z.literal(SourceKind.Trace),
   defaultTableSelectExpression: z.string().optional(),
+  timestampValueExpression: RequiredTimestampColumnSchema,
 
   // Required fields for traces
   durationExpression: z.string().min(1, 'Duration Expression is required'),
@@ -561,18 +566,9 @@ const SessionSourceAugmentation = {
   kind: z.literal(SourceKind.Session),
 
   // Required fields for sessions
-  eventAttributesExpression: z
-    .string()
-    .min(1, 'Log Attributes Expression is required'),
-  resourceAttributesExpression: z
-    .string()
-    .min(1, 'Resource Attributes Expression is required'),
   traceSourceId: z
     .string({ message: 'Correlated Trace Source is required' })
     .min(1, 'Correlated Trace Source is required'),
-
-  // Optional fields for sessions
-  implicitColumnExpression: z.string().optional(),
 };
 
 // Metric source form schema
@@ -586,6 +582,7 @@ const MetricSourceAugmentation = {
 
   // Metric tables - at least one should be provided
   metricTables: MetricTableSchema,
+  timestampValueExpression: RequiredTimestampColumnSchema,
   resourceAttributesExpression: z
     .string()
     .min(1, 'Resource Attributes is required'),
@@ -659,4 +656,9 @@ type FlattenUnion<T> = {
     ? never
     : K]?: T extends infer U ? (K extends keyof U ? U[K] : never) : never;
 };
-export type TSource = FlattenUnion<z.infer<typeof SourceSchema>>;
+type TSourceWithoutDefaults = FlattenUnion<z.infer<typeof SourceSchema>>;
+
+// Type representing a TSourceWithoutDefaults object which has been augmented with default values
+export type TSource = TSourceWithoutDefaults & {
+  timestampValueExpression: string;
+};


### PR DESCRIPTION
Closes HDX-1678

This PR removes the Timestamp Column, Log Attributes Expression, Resource Attributes Expression, and Implicit Column Expression when editing or creating a Session-kind source. Default values are used for these fields when querying a Session-kind source.

To allow creating a source without resourceAttributesExpression, eventAttributesExpression, timestampValueExpression, or implicitColumnExpression, the SessionSourceAugmentation schema was updated, which resulted in an update to the `TSource` type. To prevent a cascade of changes throughout the app due to `timestampValueExpression` now being optional on `TSource`, the `useSource` and `useSources` queries were updated to set default `timestampValueExpression` for session-kind sources.

This PR also adds validation (similar to validation for metrics sources) to the session source form which validates that the selected table has the columns we expect it to (Body, LogAttributes, ResourceAttributes, and TimestampTime).

## Testing

<details>
<summary>Creating a Session source from the team page</summary>
<img width="952" height="875" alt="Screenshot 2025-09-03 at 10 50 58 AM" src="https://github.com/user-attachments/assets/366a110c-05c2-4dcb-863f-f990482aac81" />
</details>

<details>
<summary>Create a Session source from the Logs page</summary>
<img width="1505" height="550" alt="Screenshot 2025-09-03 at 10 52 23 AM" src="https://github.com/user-attachments/assets/f45836fb-0a2c-449a-ae4e-e4126d169890" />
</details>

<details>
<summary>Select an invalid Session source table</summary>
<img width="1354" height="597" alt="Screenshot 2025-09-03 at 2 10 21 PM" src="https://github.com/user-attachments/assets/892d8b45-d393-41a8-9d5f-6acbb61f8d3c" />
</details>

<details>
<summary>The `New Sessions` source works</summary>
<img width="1712" height="1193" alt="Screenshot 2025-09-03 at 10 51 24 AM" src="https://github.com/user-attachments/assets/51db117c-bda5-48a9-a940-0f13c9466c9a" />
<img width="1596" height="1260" alt="Screenshot 2025-09-03 at 10 51 31 AM" src="https://github.com/user-attachments/assets/9b2cab6b-59e4-48fa-b3b4-9c840fc7342f" />
<img width="1560" height="1234" alt="Screenshot 2025-09-03 at 10 51 38 AM" src="https://github.com/user-attachments/assets/85755e4e-2a60-4e79-bf49-6c34b6a3675e" />
</details>
