### PR TITLE
fix(dev): use async fluentd in the mongo container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,7 @@ x-hyperdx-logging: &hyperdx-logging
   driver: fluentd
   options:
     fluentd-address: tcp://localhost:24225
+    fluentd-async: 'true'
     labels: 'service.name'
 services:
   db:


### PR DESCRIPTION
Allows the mongo container to continue bootstrapping even if the otel collector container hasn't finished binding to the fluentd port.