### PR TITLE
fix: Update Alerts when creating user is deleted

### DIFF
--- a/.changeset/sweet-boats-study.md
+++ b/.changeset/sweet-boats-study.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: Update Alerts when creating user is deleted

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -1,6 +1,8 @@
-import type { ObjectId } from '@/models';
-import User from '@/models/user';
+import mongoose from 'mongoose';
 
+import type { ObjectId } from '@/models';
+import Alert from '@/models/alert';
+import User from '@/models/user';
 export function findUserByAccessKey(accessKey: string) {
   return User.findOne({ accessKey });
 }
@@ -24,9 +26,25 @@ export function findUsersByTeam(team: string | ObjectId) {
   return User.find({ team }).sort({ createdAt: 1 });
 }
 
-export function deleteTeamMember(teamId: string | ObjectId, userId: string) {
-  return User.findOneAndDelete({
-    team: teamId,
-    _id: userId,
-  });
+export async function deleteTeamMember(
+  teamId: string | ObjectId,
+  userIdToDelete: string,
+  userIdRequestingDelete: string | ObjectId,
+) {
+  const [, deletedUser] = await Promise.all([
+    Alert.updateMany(
+      { createdBy: new mongoose.Types.ObjectId(userIdToDelete), team: teamId },
+      {
+        $set: {
+          createdBy: new mongoose.Types.ObjectId(userIdRequestingDelete),
+        },
+      },
+    ),
+    User.findOneAndDelete({
+      team: teamId,
+      _id: userIdToDelete,
+    }),
+  ]);
+
+  return deletedUser;
 }

--- a/packages/api/src/routers/api/team.ts
+++ b/packages/api/src/routers/api/team.ts
@@ -283,13 +283,18 @@ router.delete(
   }),
   async (req, res, next) => {
     try {
-      const id = req.params.id;
+      const userIdToDelete = req.params.id;
       const teamId = req.user?.team;
       if (teamId == null) {
         throw new Error(`User ${req.user?._id} not associated with a team`);
       }
 
-      await deleteTeamMember(teamId, id);
+      const userIdRequestingDelete = req.user?._id;
+      if (!userIdRequestingDelete) {
+        throw new Error(`Requesting user has no id`);
+      }
+
+      await deleteTeamMember(teamId, userIdToDelete, userIdRequestingDelete);
 
       res.json({ message: 'User deleted' });
     } catch (e) {


### PR DESCRIPTION
# Summary

Closes HDX-2188

This PR updates the user deletion functionality so that Alerts that were created by the deleted user are updated with a new `createdBy` value referencing the user that is doing the deleting.

## Testing

Alert was created by `test1234@clickhouse.com`:

<img width="661" height="134" alt="Screenshot 2025-09-08 at 1 36 21 PM" src="https://github.com/user-attachments/assets/f56027e0-f093-4131-9050-9bbec13b1965" />

`drew.davis@clickhouse.com` deletes `test1234@clickhouse.com`:

<img width="963" height="269" alt="Screenshot 2025-09-08 at 1 36 37 PM" src="https://github.com/user-attachments/assets/477dab47-596b-4728-b48b-e791a06e04d0" />

The Alert now shows createdBy `drew.davis@clickhouse.com`:

<img width="686" height="135" alt="Screenshot 2025-09-08 at 1 36 44 PM" src="https://github.com/user-attachments/assets/d2049107-8609-440c-afdf-1a16480d4aaf" />
