### PR TITLE
feat: Add delta aggregation for gauge metrics

### DIFF
--- a/.changeset/honest-pens-bathe.md
+++ b/.changeset/honest-pens-bathe.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": minor
+---
+
+Add delta() function for gauge metrics

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -75,7 +75,11 @@ import HDXMarkdownChart from '../HDXMarkdownChart';
 
 import { AggFnSelectControlled } from './AggFnSelect';
 import DBNumberChart from './DBNumberChart';
-import { InputControlled, TextInputControlled } from './InputControlled';
+import {
+  CheckBoxControlled,
+  InputControlled,
+  TextInputControlled,
+} from './InputControlled';
 import { MetricNameSelect } from './MetricNameSelect';
 import { NumberFormatInput } from './NumberFormat';
 import { SourceSelectControlled } from './SourceSelect';
@@ -202,7 +206,7 @@ function ChartSeriesEditorComponent({
         mb={8}
         mt="sm"
       />
-      <Flex gap="sm" mt="xs" align="center">
+      <Flex gap="sm" mt="xs" align="start">
         <div
           style={{
             minWidth: 200,
@@ -214,6 +218,18 @@ function ChartSeriesEditorComponent({
             defaultValue={AGG_FNS[0].value}
             control={control}
           />
+          {tableSource?.kind === SourceKind.Metric &&
+            metricType === 'gauge' && (
+              <Flex justify="end">
+                <CheckBoxControlled
+                  control={control}
+                  name={`${namePrefix}isDelta`}
+                  label="Delta"
+                  size="xs"
+                  className="mt-2"
+                />
+              </Flex>
+            )}
         </div>
         {tableSource?.kind === SourceKind.Metric && (
           <MetricNameSelect
@@ -243,44 +259,46 @@ function ChartSeriesEditorComponent({
             />
           </div>
         )}
-        <Text size="sm">Where</Text>
-        {aggConditionLanguage === 'sql' ? (
-          <SQLInlineEditorControlled
-            tableConnections={{
-              databaseName,
-              tableName: tableName ?? '',
-              connectionId: connectionId ?? '',
-            }}
-            control={control}
-            name={`${namePrefix}aggCondition`}
-            placeholder="SQL WHERE clause (ex. column = 'foo')"
-            onLanguageChange={lang =>
-              setValue(`${namePrefix}aggConditionLanguage`, lang)
-            }
-            additionalSuggestions={attributeKeys}
-            language="sql"
-            onSubmit={onSubmit}
-          />
-        ) : (
-          <SearchInputV2
-            tableConnections={{
-              connectionId: connectionId ?? '',
-              databaseName: databaseName ?? '',
-              tableName: tableName ?? '',
-            }}
-            control={control}
-            name={`${namePrefix}aggCondition`}
-            onLanguageChange={lang =>
-              setValue(`${namePrefix}aggConditionLanguage`, lang)
-            }
-            language="lucene"
-            placeholder="Search your events w/ Lucene ex. column:foo"
-            onSubmit={onSubmit}
-            additionalSuggestions={attributeKeys}
-          />
-        )}
+        <Flex align={'center'} gap={'xs'} className="flex-grow-1">
+          <Text size="sm">Where</Text>
+          {aggConditionLanguage === 'sql' ? (
+            <SQLInlineEditorControlled
+              tableConnections={{
+                databaseName,
+                tableName: tableName ?? '',
+                connectionId: connectionId ?? '',
+              }}
+              control={control}
+              name={`${namePrefix}aggCondition`}
+              placeholder="SQL WHERE clause (ex. column = 'foo')"
+              onLanguageChange={lang =>
+                setValue(`${namePrefix}aggConditionLanguage`, lang)
+              }
+              additionalSuggestions={attributeKeys}
+              language="sql"
+              onSubmit={onSubmit}
+            />
+          ) : (
+            <SearchInputV2
+              tableConnections={{
+                connectionId: connectionId ?? '',
+                databaseName: databaseName ?? '',
+                tableName: tableName ?? '',
+              }}
+              control={control}
+              name={`${namePrefix}aggCondition`}
+              onLanguageChange={lang =>
+                setValue(`${namePrefix}aggConditionLanguage`, lang)
+              }
+              language="lucene"
+              placeholder="Search your events w/ Lucene ex. column:foo"
+              onSubmit={onSubmit}
+              additionalSuggestions={attributeKeys}
+            />
+          )}
+        </Flex>
         {showGroupBy && (
-          <>
+          <Flex align={'center'} gap={'xs'}>
             <Text size="sm" style={{ whiteSpace: 'nowrap' }}>
               Group By
             </Text>
@@ -303,7 +321,7 @@ function ChartSeriesEditorComponent({
                 onSubmit={onSubmit}
               />
             </div>
-          </>
+          </Flex>
         )}
       </Flex>
     </>

--- a/packages/app/src/components/InputControlled.tsx
+++ b/packages/app/src/components/InputControlled.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Control, Controller, FieldValues, Path } from 'react-hook-form';
 import {
+  Checkbox,
+  CheckboxProps,
   Input,
   InputProps,
   PasswordInput,
@@ -28,6 +30,17 @@ interface PasswordInputControlledProps<T extends FieldValues>
 interface TextInputControlledProps<T extends FieldValues>
   extends Omit<TextInputProps, 'name' | 'style'>,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'size'> {
+  name: Path<T>;
+  control: Control<T>;
+  rules?: Parameters<Control<T>['register']>[1];
+}
+
+interface CheckboxControlledProps<T extends FieldValues>
+  extends Omit<CheckboxProps, 'name' | 'style'>,
+    Omit<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      'name' | 'size' | 'color'
+    > {
   name: Path<T>;
   control: Control<T>;
   rules?: Parameters<Control<T>['register']>[1];
@@ -82,6 +95,29 @@ export function PasswordInputControlled<T extends FieldValues>({
       rules={rules}
       render={({ field, fieldState: { error } }) => (
         <PasswordInput {...props} {...field} error={error?.message} />
+      )}
+    />
+  );
+}
+
+export function CheckBoxControlled<T extends FieldValues>({
+  name,
+  control,
+  rules,
+  ...props
+}: CheckboxControlledProps<T>) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field: { value, ...field }, fieldState: { error } }) => (
+        <Checkbox
+          {...props}
+          {...field}
+          checked={value}
+          error={error?.message}
+        />
       )}
     />
   );

--- a/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -287,6 +287,41 @@ exports[`renderChartConfig should generate sql for a single gauge metric 1`] = `
           ) SELECT quantile(0.95)(toFloat64OrDefault(toString(LastValue))),toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` FROM Bucketed WHERE (__hdx_time_bucket2 >= fromUnixTimestamp64Milli(1739318400000) AND __hdx_time_bucket2 <= fromUnixTimestamp64Milli(1765670400000)) GROUP BY toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` LIMIT 10"
 `;
 
+exports[`renderChartConfig should generate sql for a single gauge metric with a delta() function applied 1`] = `
+"WITH Source AS (
+            SELECT
+              *,
+              cityHash64(mapConcat(ScopeAttributes, ResourceAttributes, Attributes)) AS AttributesHash
+            FROM default.otel_metrics_gauge
+            WHERE (TimeUnix >= fromUnixTimestamp64Milli(1739318400000) AND TimeUnix <= fromUnixTimestamp64Milli(1765670400000)) AND ((MetricName = 'nodejs.event_loop.utilization'))
+          ),Bucketed AS (
+            SELECT
+              toStartOfInterval(toDateTime(TimeUnix), INTERVAL 1 minute) AS \`__hdx_time_bucket2\`,
+              AttributesHash,
+              last_value(Value) AS LastValue,
+              any(ScopeAttributes) AS ScopeAttributes,
+              any(ResourceAttributes) AS ResourceAttributes,
+              any(Attributes) AS Attributes,
+              any(ResourceSchemaUrl) AS ResourceSchemaUrl,
+              any(ScopeName) AS ScopeName,
+              any(ScopeVersion) AS ScopeVersion,
+              any(ScopeDroppedAttrCount) AS ScopeDroppedAttrCount,
+              any(ScopeSchemaUrl) AS ScopeSchemaUrl,
+              any(ServiceName) AS ServiceName,
+              any(MetricDescription) AS MetricDescription,
+              any(MetricUnit) AS MetricUnit,
+              any(StartTimeUnix) AS StartTimeUnix,
+              any(Flags) AS Flags
+            FROM Source
+            GROUP BY AttributesHash, __hdx_time_bucket2
+            ORDER BY AttributesHash, __hdx_time_bucket2
+          ) SELECT max(
+      toFloat64OrDefault(toString(LastValue))
+    ) - lag(max(
+      toFloat64OrDefault(toString(LastValue))
+    )) OVER ( ORDER BY toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\`),toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` FROM Bucketed WHERE (__hdx_time_bucket2 >= fromUnixTimestamp64Milli(1739318400000) AND __hdx_time_bucket2 <= fromUnixTimestamp64Milli(1765670400000)) GROUP BY toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(__hdx_time_bucket2), INTERVAL 1 minute) AS \`__hdx_time_bucket\` LIMIT 10"
+`;
+
 exports[`renderChartConfig should generate sql for a single sum metric 1`] = `
 "WITH Source AS (
                 SELECT

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -76,6 +76,7 @@ export const RootValueExpressionSchema = z
     aggCondition: SearchConditionSchema,
     aggConditionLanguage: SearchConditionLanguageSchema,
     valueExpression: z.string(),
+    isDelta: z.boolean().optional(),
   })
   .or(
     z.object({
@@ -84,6 +85,7 @@ export const RootValueExpressionSchema = z
       aggCondition: SearchConditionSchema,
       aggConditionLanguage: SearchConditionLanguageSchema,
       valueExpression: z.string(),
+      isDelta: z.boolean().optional(),
     }),
   )
   .or(
@@ -93,6 +95,7 @@ export const RootValueExpressionSchema = z
       aggConditionLanguage: SearchConditionLanguageSchema,
       valueExpression: z.string(),
       metricType: z.nativeEnum(MetricsDataType).optional(),
+      isDelta: z.boolean().optional(),
     }),
   );
 export const DerivedColumnSchema = z.intersection(


### PR DESCRIPTION
This (draft) PR represents an alternative delta implementation for gauge metrics in which deltas are calculated _between_ buckets instead of within buckets, and by custom grouping instead of by time-series. This contrasts with the reference implementation in #1147, which does not work for HDX-2323.

This (draft) PR does not include updates to alerts which would likely be required so that consecutive time buckets are queried so that a delta can be calculated.

## Testing

Container restarts result in a new ResourceAttributes.container.id value, effectively creating a new timeseries. This results in the reference delta values (in #1147) for each timeseries being 0.
<img width="1495" height="880" alt="Screenshot 2025-09-09 at 2 08 47 PM" src="https://github.com/user-attachments/assets/eb938059-5284-48bb-9075-69f17172d542" />

At the pod-level grouping, there are deltas
<img width="1508" height="886" alt="Screenshot 2025-09-09 at 2 14 54 PM" src="https://github.com/user-attachments/assets/6c8f0a12-d6be-43e4-997e-a13d6d05fd1f" />

With this implementation, we can expose those deltas as something that could be alerted on.
<img width="1507" height="888" alt="Screenshot 2025-09-09 at 2 15 05 PM" src="https://github.com/user-attachments/assets/a405e659-cd75-4776-9b2f-5f6175364457" />



