### PR TITLE
enhancement row actions.

### DIFF
--- a/packages/app/src/components/DBRowJsonViewer.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.tsx
@@ -253,6 +253,7 @@ export function DBRowJsonViewer({
         keyPath.length > 0 && jsonColumns?.includes(keyPath[0]);
 
       let where = searchParams.get('where') || '';
+      where = where.trim();
       let whereLanguage = searchParams.get('whereLanguage');
       if (whereLanguage == '') {
         whereLanguage = 'lucene';
@@ -279,6 +280,12 @@ export function DBRowJsonViewer({
         } else {
           where += ' AND ';
         }
+      }
+
+      // if removedFilterWhere is '', use ' '
+      // cause generateSearchUrl would use searchedConfig.where if where is ''
+      if (removedFilterWhere === '') {
+        removedFilterWhere = ' ';
       }
 
       if (generateSearchUrl && typeof value !== 'object' && hadFilter) {


### PR DESCRIPTION
row actions both support lucene and sql.

if search is 'ServiceName:"kup-cluster-kube-system-ns"'

- add filter, add filter would add new key:value condition
<img width="1148" height="104" alt="截屏2025-09-11 20 55 41" src="https://github.com/user-attachments/assets/6ad7d44d-bba1-4812-9b37-5e7019221956" />
<img width="715" height="116" alt="截屏2025-09-11 20 55 53" src="https://github.com/user-attachments/assets/135c9f22-2d2a-456b-82f4-1678a802b1d0" />

- remove filter, remove filter would removed existed key:value condition use ast lucene parse.
<img width="1139" height="86" alt="截屏2025-09-11 20 56 57" src="https://github.com/user-attachments/assets/8407a055-e620-44f0-9777-f530bc994dec" />

- replace filter, replace filter would search for this field only.
<img width="1167" height="75" alt="截屏2025-09-11 20 57 30" src="https://github.com/user-attachments/assets/f43870e4-345c-4e37-a16b-8e8b6114537b" />

<img width="884" height="69" alt="截屏2025-09-11 20 58 21" src="https://github.com/user-attachments/assets/aac69963-38e3-43fc-9c9e-0e2a5c82ce88" />



@knudtty @MikeShi42 cc

