### PR TITLE
Improve common-utils intellisense. Currently "Go to Definition" on an…

### DIFF
--- a/.changeset/metal-grapes-tease.md
+++ b/.changeset/metal-grapes-tease.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+Improve Intellisense on common-utils package

--- a/packages/common-utils/package.json
+++ b/packages/common-utils/package.json
@@ -48,7 +48,8 @@
     "typescript": "^4.9.5"
   },
   "scripts": {
-    "dev": "nodemon --watch ./src --ext ts --exec \"tsup\"",
+    "dev": "nodemon --watch ./src --ext ts --exec \"yarn dev:build\"",
+    "dev:build": "tsup && tsc --emitDeclarationOnly --declaration",
     "build": "tsup",
     "ci:build": "tsup",
     "lint": "npx eslint --quiet . --ext .ts",

--- a/packages/common-utils/tsconfig.json
+++ b/packages/common-utils/tsconfig.json
@@ -1,19 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": true,
     "baseUrl": "./src",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "declaration": true,
-    "outDir": "build",
+    "outDir": "dist"
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
 Currently, "Go to Definition" on anything for common-utils takes you to dist, and you must then find the definition manually. After this change, it will take you directly to the src definition.

Example, clicking into this definition:
<img width="651" height="193" alt="Screenshot 2025-09-11 at 11 11 48 AM" src="https://github.com/user-attachments/assets/24250268-d169-4ad3-9bb5-0b3e87ae0acd" />

Before (notice it's the compiled dist version):
<img width="983" height="495" alt="Screenshot 2025-09-11 at 11 11 53 AM" src="https://github.com/user-attachments/assets/6d085f3a-0edc-4ff6-bbc0-92f8737f6d37" />

After (notice its the source, allowing to debug/fix issues faster):
<img width="785" height="488" alt="Screenshot 2025-09-11 at 11 11 23 AM" src="https://github.com/user-attachments/assets/33c05825-87dc-41dc-a00a-884a63457cea" />

Reference: https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map

Fixes: HDX-2384