### PR TITLE
ci: Create Dockerfile target for alerts-only image

### DIFF
--- a/.changeset/late-wasps-brake.md
+++ b/.changeset/late-wasps-brake.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+ci: Create Dockerfile target for alerts-only image

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -52,3 +52,10 @@ WORKDIR /app
 COPY --chown=node:node --from=builder /app/packages/api/dist ./
 
 ENTRYPOINT ["node", "-r", "./tracing", "./index"]
+
+## alerts ##########################################################################################
+
+FROM prod AS alerts
+
+COPY --chown=node:node ./packages/api/entry.alerts.sh ./
+ENTRYPOINT ["sh", "./entry.alerts.sh"]

--- a/packages/api/entry.alerts.sh
+++ b/packages/api/entry.alerts.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Starting alerts task with provider: ${ALERT_PROVIDER:-default}"
+
+exec node -r ./tracing ./tasks/index check-alerts --provider ${ALERT_PROVIDER:-default}


### PR DESCRIPTION
HDX-2375

This PR adds a target to the `packages/api/Dockerfile` which will be used to build an image that runs just the alerts task. The image contains all of the API code and has an entry point which starts the alerts task.

The `ALERT_PROVIDER` environment variable enables setting a provider which will be used. For EE/CHC, this will be used to select the ClickHouse Cloud provider.

## Testing

<details>
<summary>The image builds and runs locally with an updated docker-compose.dev.yaml</summary>

```yaml
  alerts:
    build:
      dockerfile: packages/api/Dockerfile
      context: .
      target: alerts
      args:
        CODE_VERSION: 0.0.1
    logging: *hyperdx-logging
    labels:
      service.name: 'hdx-oss-dev-alerts'
    environment:
      NODE_ENV: development
      MONGO_URI: 'mongodb://db:27017/hyperdx'
      HYPERDX_API_KEY: ${HYPERDX_API_KEY}
      HYPERDX_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://otel-collector:4317'
      OTEL_SERVICE_NAME: 'hdx-oss-dev-alerts'
      HYPERDX_APP_PORT: 8080
      ALERT_PROVIDER: clickHouseCloud
      RUN_SCHEDULED_TASKS_EXTERNALLY: false
    depends_on:
      - db
    networks:
      - internal
```
</details>

<details>
<summary>The alerts task starts with the given provider</summary>
<img width="887" height="576" alt="Screenshot 2025-09-15 at 8 55 45 AM" src="https://github.com/user-attachments/assets/719765c4-7dcf-4d94-8c43-f77e394bbc96" />
<img width="1290" height="771" alt="Screenshot 2025-09-15 at 8 54 17 AM" src="https://github.com/user-attachments/assets/bdfa0f24-ca2b-4bac-8d85-a41e47659f1c" />

It will log an error if the given provider cannot be found:
<img width="926" height="59" alt="Screenshot 2025-09-15 at 8 57 56 AM" src="https://github.com/user-attachments/assets/576bbb56-f875-48b5-bd40-b12013af8203" />
</details>