### PR TITLE
fix: Fix ascending order in windowed searches

### DIFF
--- a/.changeset/smooth-schools-ring.md
+++ b/.changeset/smooth-schools-ring.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+fix: Fix ascending order in windowed searches

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1261,6 +1261,11 @@ function DBSqlRowTableComponent({
       groupedPatterns.isLoading
     : isFetching;
 
+  const loadingDate =
+    data?.window?.direction === 'ASC'
+      ? data?.window?.endTime
+      : data?.window?.startTime;
+
   return (
     <>
       {denoiseResults && (
@@ -1299,7 +1304,7 @@ function DBSqlRowTableComponent({
         error={error ?? undefined}
         columnTypeMap={columnMap}
         dateRange={config.dateRange}
-        loadingDate={data?.window?.startTime}
+        loadingDate={loadingDate}
         config={config}
         onChildModalOpen={onChildModalOpen}
         source={source}

--- a/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
+++ b/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
@@ -210,8 +210,8 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
   const config = queryKey[1];
 
   // Get the time window for this page
-  const useWindowing = isTimestampExpressionInFirstOrderBy(config);
-  const timeWindow = useWindowing
+  const shouldUseWindowing = isTimestampExpressionInFirstOrderBy(config);
+  const timeWindow = shouldUseWindowing
     ? getTimeWindowFromPageParam(config, pageParam)
     : {
         startTime: config.dateRange[0],

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getFirstOrderingItem,
   isFirstOrderByAscending,
   isTimestampExpressionInFirstOrderBy,
+  removeTrailingDirection,
   splitAndTrimCSV,
   splitAndTrimWithBracket,
 } from '../utils';
@@ -272,6 +273,15 @@ describe('utils', () => {
       expect(isTimestampExpressionInFirstOrderBy(config)).toBe(false);
     });
 
+    it('should return false if empty orderBy is provided', () => {
+      const config = {
+        timestampValueExpression: 'Timestamp',
+        orderBy: '',
+      } as ChartConfigWithDateRange;
+
+      expect(isTimestampExpressionInFirstOrderBy(config)).toBe(false);
+    });
+
     it('should return false if the first ordering column is not in the timestampValueExpression', () => {
       const config = {
         timestampValueExpression: 'Timestamp',
@@ -342,6 +352,16 @@ describe('utils', () => {
       const config = {
         timestampValueExpression: 'toStartOfDay(Timestamp), Timestamp',
         orderBy: '(toStartOfHour(TimestampTime), TimestampTime) DESC',
+      } as ChartConfigWithDateRange;
+
+      expect(isTimestampExpressionInFirstOrderBy(config)).toBe(true);
+    });
+
+    it('should support functions with multiple parameters in the order by', () => {
+      const config = {
+        timestampValueExpression:
+          'toStartOfInterval(TimestampTime, INTERVAL 1 DAY)',
+        orderBy: 'toStartOfInterval(TimestampTime, INTERVAL 1 DAY) DESC',
       } as ChartConfigWithDateRange;
 
       expect(isTimestampExpressionInFirstOrderBy(config)).toBe(true);

--- a/packages/common-utils/src/utils.ts
+++ b/packages/common-utils/src/utils.ts
@@ -309,6 +309,17 @@ export const getFirstOrderingItem = (
     : orderBy[0];
 };
 
+export const removeTrailingDirection = (s: string) => {
+  const upper = s.trim().toUpperCase();
+  if (upper.endsWith('DESC')) {
+    return s.slice(0, upper.lastIndexOf('DESC')).trim();
+  } else if (upper.endsWith('ASC')) {
+    return s.slice(0, upper.lastIndexOf('ASC')).trim();
+  }
+
+  return s;
+};
+
 export const isTimestampExpressionInFirstOrderBy = (
   config: ChartConfigWithDateRange,
 ) => {
@@ -317,7 +328,7 @@ export const isTimestampExpressionInFirstOrderBy = (
 
   const firstOrderingExpression =
     typeof firstOrderingItem === 'string'
-      ? firstOrderingItem.replace(/\s+(ASC|DESC)$/i, '')
+      ? removeTrailingDirection(firstOrderingItem)
       : firstOrderingItem.valueExpression;
 
   const timestampValueExpressions = splitAndTrimWithBracket(
@@ -338,7 +349,7 @@ export const isFirstOrderByAscending = (
 
   const isDescending =
     typeof primaryOrderingItem === 'string'
-      ? /DESC$/.test(primaryOrderingItem.trim().toUpperCase())
+      ? primaryOrderingItem.trim().toUpperCase().endsWith('DESC')
       : primaryOrderingItem.ordering === 'DESC';
 
   return !isDescending;


### PR DESCRIPTION
Closes HDX-2407

This PR fixes searches which sort in ascending time order or do not order based on time. With this change, time-based "chunking" of queries (#1125) will only be used when the results are ordered by time. Further, when ordering by time _ascending_, the chunks will load in ascending time order (rather than descending time order).