### PR TITLE
fix: Always enable query analyzer to fix compatibility issues with old ClickHouse versions.

### DIFF
--- a/.changeset/curvy-buses-kick.md
+++ b/.changeset/curvy-buses-kick.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+fix: Always enable query analyzer to fix compatibility issues with old ClickHouse versions.

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -447,6 +447,7 @@ export abstract class BaseClickhouseClient {
     }
 
     return {
+      enable_analyzer: 1,
       date_time_output_format: 'iso',
       wait_end_of_query: 0,
       cancel_http_readonly_queries_on_client_close: 1,


### PR DESCRIPTION
I do not expect this to be a breaking change - effectively all newer versions of ClickHouse already have this enabled and therefore this was already default behavior. This is simply forcing the analyzer to be true for servers with an older `compatibility` server setting enabled to fix certain queries that break on the old analyzer.

Resolves HDX-2433