### PR TITLE
style: Update icon used to show source schema

### DIFF
--- a/.changeset/cuddly-toys-cheat.md
+++ b/.changeset/cuddly-toys-cheat.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+style: Update icon used to show source schema

--- a/packages/app/src/components/SourceSchemaPreview.tsx
+++ b/packages/app/src/components/SourceSchemaPreview.tsx
@@ -35,7 +35,7 @@ const SourceSchemaInfoIcon = ({
     >
       <Text {...iconStyles}>
         <i
-          className={`bi bi-info-circle ${isEnabled ? 'cursor-pointer' : ''}`}
+          className={`bi bi-code-square ${isEnabled ? 'cursor-pointer' : ''}`}
         />
       </Text>
     </Tooltip>


### PR DESCRIPTION
This PR updates the icon used to show a sources SQL schema, based on team feedback. The new icon matches the icon used to show search SQL.

## Before

<img width="240" height="49" alt="Screenshot 2025-09-19 at 2 51 19 PM" src="https://github.com/user-attachments/assets/e46f0dae-73b2-4b52-b5d7-86142cffab41" />
<img width="366" height="61" alt="Screenshot 2025-09-19 at 2 51 14 PM" src="https://github.com/user-attachments/assets/017b9678-88d1-4eef-bc1b-c8bc5974c7ae" />


## After

<img width="1085" height="469" alt="Screenshot 2025-09-19 at 2 49 14 PM" src="https://github.com/user-attachments/assets/d76a36f1-a527-4879-95b9-031efba8f50a" />
<img width="246" height="51" alt="Screenshot 2025-09-19 at 2 49 02 PM" src="https://github.com/user-attachments/assets/69599f99-b508-42e4-995d-8a895ca8a385" />
<img width="377" height="56" alt="Screenshot 2025-09-19 at 2 48 56 PM" src="https://github.com/user-attachments/assets/48e799cf-f99a-46ba-bcc8-6e9b7b5cdd22" />
