### PR TITLE
Revert "fix: json getKeyValues (useful for autocomplete) (#1186)"

### DIFF
--- a/.changeset/early-items-design.md
+++ b/.changeset/early-items-design.md
@@ -1,6 +1,0 @@
----
-"@hyperdx/common-utils": patch
-"@hyperdx/app": patch
----
-
-fix: json getKeyValues (useful for autocomplete)

--- a/packages/app/src/hooks/__tests__/useAutoCompleteOptions.test.tsx
+++ b/packages/app/src/hooks/__tests__/useAutoCompleteOptions.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 
 import { LuceneLanguageFormatter } from '../../SearchInputV2';
 import { useAutoCompleteOptions } from '../useAutoCompleteOptions';
-import { useAllFields, useGetKeyValues, useJsonColumns } from '../useMetadata';
+import { useAllFields, useGetKeyValues } from '../useMetadata';
 
 if (!globalThis.structuredClone) {
   globalThis.structuredClone = (obj: any) => {
@@ -17,7 +17,6 @@ jest.mock('../useMetadata', () => ({
   ...jest.requireActual('../useMetadata.tsx'),
   useAllFields: jest.fn(),
   useGetKeyValues: jest.fn(),
-  useJsonColumns: jest.fn(),
 }));
 
 const luceneFormatter = new LuceneLanguageFormatter();
@@ -59,10 +58,6 @@ describe('useAutoCompleteOptions', () => {
     });
 
     (useGetKeyValues as jest.Mock).mockReturnValue({
-      data: null,
-    });
-
-    (useJsonColumns as jest.Mock).mockReturnValue({
       data: null,
     });
   });

--- a/packages/app/src/hooks/useAutoCompleteOptions.tsx
+++ b/packages/app/src/hooks/useAutoCompleteOptions.tsx
@@ -6,9 +6,8 @@ import {
   deduplicate2dArray,
   useAllFields,
   useGetKeyValues,
-  useJsonColumns,
 } from '@/hooks/useMetadata';
-import { mergePath, toArray } from '@/utils';
+import { toArray } from '@/utils';
 
 export interface ILanguageFormatter {
   formatFieldValue: (f: Field) => string;
@@ -72,21 +71,16 @@ export function useAutoCompleteOptions(
       setSearchField(null);
     }
   }, [searchField, setSearchField, value, formatter]);
-  const { data: jsonColumns } = useJsonColumns(
-    Array.isArray(tableConnections)
-      ? tableConnections[0]
-      : (tableConnections ?? {
-          tableName: '',
-          databaseName: '',
-          connectionId: '',
-        }),
-  );
   const searchKeys = useMemo(
     () =>
-      searchField && jsonColumns
-        ? [mergePath(searchField.path, jsonColumns)]
+      searchField
+        ? [
+            searchField.path.length > 1
+              ? `${searchField.path[0]}['${searchField.path[1]}']`
+              : searchField.path[0],
+          ]
         : [],
-    [searchField, jsonColumns],
+    [searchField],
   );
 
   // hooks to get key values

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -48,7 +48,15 @@ export function useColumns(
 }
 
 export function useJsonColumns(
-  { databaseName, tableName, connectionId }: TableConnection,
+  {
+    databaseName,
+    tableName,
+    connectionId,
+  }: {
+    databaseName: string;
+    tableName: string;
+    connectionId: string;
+  },
   options?: Partial<UseQueryOptions<string[]>>,
 ) {
   return useQuery<string[]>({

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -357,7 +357,10 @@ export class Metadata {
                 );
               }
               keys.push({
-                key: key,
+                key: key
+                  .split('.')
+                  .map(v => `\`${v}\``)
+                  .join('.'),
                 chType: typeArr[0],
               });
             }


### PR DESCRIPTION
This reverts commit d60d92030dfa4473e0f7ea4f75178d1bc104af8b.

Commit breaks dashboards with: 
<img width="1179" height="779" alt="image" src="https://github.com/user-attachments/assets/bcb05f7a-6787-4a39-859f-92e6f6ffbe9e" />
