### PR TITLE
perf: disable CTE if disableRowLimit flag is true (getKeyValues method)

### DIFF
--- a/.changeset/little-games-change.md
+++ b/.changeset/little-games-change.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+perf: disable CTE if disableRowLimit flag is true (getKeyValues method)

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -580,46 +580,56 @@ export class Metadata {
     return this.cache.getOrFetch(
       `${chartConfig.from.databaseName}.${chartConfig.from.tableName}.${keys.join(',')}.${chartConfig.dateRange.toString()}.${disableRowLimit}.values`,
       async () => {
-        // Get all columns including materialized ones
-        const columns = await this.getColumns({
-          databaseName: chartConfig.from.databaseName,
-          tableName: chartConfig.from.tableName,
-          connectionId: chartConfig.connection,
-        });
+        const selectClause = keys
+          .map((k, i) => `groupUniqArray(${limit})(${k}) AS param${i}`)
+          .join(', ');
 
-        // Build select expression that includes all columns by name
-        // This ensures materialized columns are included
-        const selectExpr =
-          columns.map(col => `\`${col.name}\``).join(', ') || '*';
+        // When disableRowLimit is true, query directly without CTE
+        // Otherwise, use CTE with row limits for sampling
+        const sqlConfig = disableRowLimit
+          ? {
+              ...chartConfig,
+              select: selectClause,
+            }
+          : await (async () => {
+              // Get all columns including materialized ones
+              const columns = await this.getColumns({
+                databaseName: chartConfig.from.databaseName,
+                tableName: chartConfig.from.tableName,
+                connectionId: chartConfig.connection,
+              });
 
-        const sql = await renderChartConfig(
-          {
-            with: [
-              {
-                name: 'sampledData',
-                chartConfig: {
-                  ...chartConfig,
-                  select: selectExpr,
-                  limit: {
-                    limit: !disableRowLimit
-                      ? this.getClickHouseSettings().max_rows_to_read
-                        ? Number(this.getClickHouseSettings().max_rows_to_read)
-                        : DEFAULT_METADATA_MAX_ROWS_TO_READ
-                      : undefined,
+              // Build select expression that includes all columns by name
+              // This ensures materialized columns are included
+              const selectExpr =
+                columns.map(col => `\`${col.name}\``).join(', ') || '*';
+
+              return {
+                with: [
+                  {
+                    name: 'sampledData',
+                    chartConfig: {
+                      ...chartConfig,
+                      select: selectExpr,
+                      limit: {
+                        limit: this.getClickHouseSettings().max_rows_to_read
+                          ? Number(
+                              this.getClickHouseSettings().max_rows_to_read,
+                            )
+                          : DEFAULT_METADATA_MAX_ROWS_TO_READ,
+                      },
+                    },
+                    isSubquery: true,
                   },
-                },
-                isSubquery: true,
-              },
-            ],
-            select: keys
-              .map((k, i) => `groupUniqArray(${limit})(${k}) AS param${i}`)
-              .join(', '),
-            connection: chartConfig.connection,
-            from: { databaseName: '', tableName: 'sampledData' },
-            where: '',
-          },
-          this,
-        );
+                ],
+                select: selectClause,
+                connection: chartConfig.connection,
+                from: { databaseName: '', tableName: 'sampledData' },
+                where: '',
+              };
+            })();
+
+        const sql = await renderChartConfig(sqlConfig, this);
 
         const json = await this.clickhouseClient
           .query<'JSON'>({


### PR DESCRIPTION
To pull things like metric tags, `getKeyValues` method should fallback to the query w/o using CTE for better performance

Ref: HDX-2482