### PR TITLE
change configuration so otel collector logs go to stdout by default

### DIFF
--- a/.changeset/bright-geckos-boil.md
+++ b/.changeset/bright-geckos-boil.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+change configuration so otel collector logs go to stdout by default

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,8 +32,8 @@ services:
       HYPERDX_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
       OPAMP_SERVER_URL: 'http://host.docker.internal:${HYPERDX_OPAMP_PORT}'
       CUSTOM_OTELCOL_CONFIG_FILE: '/etc/otelcol-contrib/custom.config.yaml'
-      # Uncomment to enable stdout logging for the OTel collector
-      OTEL_SUPERVISOR_PASSTHROUGH_LOGS: 'false'
+      # Uncomment to disable stdout logging for the OTel collector
+      # OTEL_SUPERVISOR_PASSTHROUGH_LOGS: 'false'
       # Uncomment to enable JSON schema in ClickHouse
       # Be sure to also set BETA_CH_OTEL_JSON_SCHEMA_ENABLED to 'true' in ch-server
       # OTEL_AGENT_FEATURE_GATE_ARG: '--feature-gates=clickhouse.json'

--- a/docker/otel-collector/supervisor_docker.yaml.tmpl
+++ b/docker/otel-collector/supervisor_docker.yaml.tmpl
@@ -16,6 +16,13 @@ capabilities:
   accepts_remote_config: true
   reports_remote_config: true
 
+telemetry:
+  logs:
+    output_paths:
+      - stdout
+      # Ensures the logs are written to disk as well as stdout if passthrough_logs is enabled
+      - /etc/otel/supervisor-data/agent.log
+
 agent:
   executable: /otelcontribcol
   config_files:
@@ -27,7 +34,7 @@ agent:
 {{- if getenv "OTEL_AGENT_FEATURE_GATE_ARG" }}
     - {{ getenv "OTEL_AGENT_FEATURE_GATE_ARG" }}
 {{- end }}
-  passthrough_logs: {{ getenv "OTEL_SUPERVISOR_PASSTHROUGH_LOGS" | default "false" }}
+  passthrough_logs: {{ getenv "OTEL_SUPERVISOR_PASSTHROUGH_LOGS" | default "true" }}
 
 storage:
   directory: /etc/otel/supervisor-data/


### PR DESCRIPTION
@wrn14897 would love your eyes on this, not sure if this will introduce some performance regressions so I'd love to hear about your decision to set to false by default.

This was flagged in https://discord.com/channels/1149498480893640706/1149500035403350036/1420043050725539941

Before (or with set to false)
<img width="1332" height="632" alt="false" src="https://github.com/user-attachments/assets/0aae5ad3-cf2e-4627-a3df-a61e841611ef" />

After (with unset or set to 'true'):
<img width="1345" height="485" alt="true" src="https://github.com/user-attachments/assets/aaf932fd-c196-47f4-bea8-03a9e28ce4fc" />

fixes HDX-2478