### PR TITLE
feat: Add user-agent to alerts client

### DIFF
--- a/.changeset/thirty-seahorses-relax.md
+++ b/.changeset/thirty-seahorses-relax.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+chore: Customize user-agent for Alerts ClickHouse client

--- a/packages/api/src/tasks/providers/default.ts
+++ b/packages/api/src/tasks/providers/default.ts
@@ -313,6 +313,7 @@ export default class DefaultAlertProvider implements AlertProvider {
       host,
       username,
       password,
+      application: `hyperdx-alerts ${config.CODE_VERSION}`,
     });
   }
 }

--- a/packages/common-utils/src/clickhouse/browser.ts
+++ b/packages/common-utils/src/clickhouse/browser.ts
@@ -92,6 +92,7 @@ export class ClickhouseClient extends BaseClickhouseClient {
       },
       fetch: myFetch,
       request_timeout: this.requestTimeout,
+      application: this.application,
     });
   }
 

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -373,6 +373,8 @@ export type ClickhouseClientOptions = {
   username?: string;
   password?: string;
   queryTimeout?: number;
+  /** Application name, used as the client's HTTP user-agent header */
+  application?: string;
 };
 
 export abstract class BaseClickhouseClient {
@@ -381,6 +383,7 @@ export abstract class BaseClickhouseClient {
   protected readonly password?: string;
   protected readonly queryTimeout?: number;
   protected client?: WebClickHouseClient | NodeClickHouseClient;
+  protected readonly application?: string;
   /*
    * Some clickhouse db's (the demo instance for example) make the
    * max_rows_to_read setting readonly and the query will fail if you try to
@@ -394,12 +397,14 @@ export abstract class BaseClickhouseClient {
     username,
     password,
     queryTimeout,
+    application,
   }: ClickhouseClientOptions) {
     this.host = host!;
     this.username = username;
     this.password = password;
     this.queryTimeout = queryTimeout;
     this.maxRowReadOnly = false;
+    this.application = application;
   }
 
   protected getClient(): WebClickHouseClient | NodeClickHouseClient {

--- a/packages/common-utils/src/clickhouse/node.ts
+++ b/packages/common-utils/src/clickhouse/node.ts
@@ -13,11 +13,13 @@ export { createClient as createNativeClient };
 export class ClickhouseClient extends BaseClickhouseClient {
   constructor(options: ClickhouseClientOptions) {
     super(options);
+
     this.client = createClient({
       url: this.host,
       username: this.username,
       password: this.password,
       request_timeout: this.requestTimeout,
+      application: this.application,
     });
   }
 


### PR DESCRIPTION
Closes HDX-2481

# Summary

For browser-based queries, the clickhouse requests go through the clickhouse-proxy endpoint, which re-writes the user-agent header for analytics purposes.

Alerts queries don't go through the clickhouse-proxy, and clickhouse-js doesn't allow us to directly set the user-agent header. We can instead provide an `application` name, which is pre-pended to the default clickhouse-js user-agent, yielding a user-agent like:
```
hyperdx-alerts 2.5.0 clickhouse-js/1.12.1 (lv:nodejs/v22.19.0; os:darwin)
```

The user agent shows up in ClickHouse query logs:
<img width="607" height="279" alt="Screenshot 2025-09-25 at 1 27 36 PM" src="https://github.com/user-attachments/assets/8098648d-9245-42c5-a41c-d7a58186ad68" />
