### PR TITLE
fix: Fix sidebar when selecting JSON property

### DIFF
--- a/.changeset/sharp-phones-travel.md
+++ b/.changeset/sharp-phones-travel.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+fix: Fix sidebar when selecting JSON property

--- a/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
+++ b/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
@@ -154,7 +154,7 @@ describe('processRowToWhereClause', () => {
     const row = { dynamic_field: 'null' };
     const result = processRowToWhereClause(row, columnMap);
 
-    expect(result).toBe('isNull(`dynamic_field`)');
+    expect(result).toBe('isNull(dynamic_field)');
   });
 
   it('should handle Dynamic columns with quoted string', () => {

--- a/packages/app/src/hooks/useRowWhere.tsx
+++ b/packages/app/src/hooks/useRowWhere.tsx
@@ -66,7 +66,7 @@ export function processRowToWhereClause(
 
           // Currently we can't distinguish null or 'null'
           if (value === 'null') {
-            return SqlString.format(`isNull(??)`, [column]);
+            return SqlString.format(`isNull(?)`, [SqlString.raw(valueExpr)]);
           }
           if (value.length > 1000 || column.length > 1000) {
             console.warn('Search value/object key too large.');

--- a/packages/common-utils/src/__tests__/clickhouse.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouse.test.ts
@@ -200,6 +200,26 @@ describe('chSqlToAliasMap - alias unit test', () => {
     };
     expect(res).toEqual(aliasMap);
   });
+
+  it('Alias, with JSON expressions', () => {
+    const chSqlInput: ChSql = {
+      sql: "SELECT Timestamp as ts,ResourceAttributes.service.name as service,Body,TimestampTime,ServiceName,TimestampTime FROM {HYPERDX_PARAM_1544803905:Identifier}.{HYPERDX_PARAM_129845054:Identifier} WHERE (TimestampTime >= fromUnixTimestamp64Milli({HYPERDX_PARAM_1456399765:Int64}) AND TimestampTime <= fromUnixTimestamp64Milli({HYPERDX_PARAM_1719057412:Int64})) AND (`ResourceAttributes`.`service`.`name` = 'serviceName') ORDER BY TimestampTime DESC LIMIT {HYPERDX_PARAM_49586:Int32} OFFSET {HYPERDX_PARAM_48:Int32}",
+      params: {
+        HYPERDX_PARAM_1544803905: 'default',
+        HYPERDX_PARAM_129845054: 'otel_logs',
+        HYPERDX_PARAM_1456399765: 1743038742000,
+        HYPERDX_PARAM_1719057412: 1743040542000,
+        HYPERDX_PARAM_49586: 200,
+        HYPERDX_PARAM_48: 0,
+      },
+    };
+    const res = chSqlToAliasMap(chSqlInput);
+    const aliasMap = {
+      ts: 'Timestamp',
+      service: 'ResourceAttributes.service.name',
+    };
+    expect(res).toEqual(aliasMap);
+  });
 });
 
 describe('computeRatio', () => {

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -7,7 +7,6 @@ import type {
   ResponseJSON,
   Row,
 } from '@clickhouse/client-common';
-import { isSuccessfulResponse } from '@clickhouse/client-common';
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
 import * as SQLParser from 'node-sql-parser';
 import objectHash from 'object-hash';
@@ -18,8 +17,12 @@ import {
   setChartSelectsAlias,
   splitChartConfigs,
 } from '@/renderChartConfig';
-import { ChartConfigWithOptDateRange, SQLInterval } from '@/types';
-import { hashCode, splitAndTrimWithBracket } from '@/utils';
+import { ChartConfigWithOptDateRange } from '@/types';
+import {
+  hashCode,
+  replaceJsonExpressions,
+  splitAndTrimWithBracket,
+} from '@/utils';
 
 // export @clickhouse/client-common types
 export type {
@@ -680,8 +683,13 @@ export function chSqlToAliasMap(
 
   try {
     const sql = parameterizedQueryToSql(chSql);
+
+    // Replace JSON expressions with replacement tokens so that node-sql-parser can parse the SQL
+    const { sqlWithReplacements, replacements: jsonReplacementsToExpressions } =
+      replaceJsonExpressions(sql);
+
     const parser = new SQLParser.Parser();
-    const ast = parser.astify(sql, {
+    const ast = parser.astify(sqlWithReplacements, {
       database: 'Postgresql',
       parseOptions: { includeLocations: true },
     }) as SQLParser.Select;
@@ -697,7 +705,7 @@ export function chSqlToAliasMap(
                 : // normal alias
                   column.expr.column.expr.value;
           } else if (column.expr.loc != null) {
-            aliasMap[column.as] = sql.slice(
+            aliasMap[column.as] = sqlWithReplacements.slice(
               column.expr.loc.start.offset,
               column.expr.loc.end.offset,
             );
@@ -706,6 +714,13 @@ export function chSqlToAliasMap(
           }
         }
       });
+    }
+
+    // Replace the JSON replacement tokens with the original JSON expressions
+    for (const [alias, expression] of Object.entries(aliasMap)) {
+      if (jsonReplacementsToExpressions.has(expression)) {
+        aliasMap[alias] = jsonReplacementsToExpressions.get(expression)!;
+      }
     }
   } catch (e) {
     console.error('Error parsing alias map', e, 'for query', chSql);

--- a/packages/common-utils/src/utils.ts
+++ b/packages/common-utils/src/utils.ts
@@ -87,6 +87,112 @@ export function getFirstTimestampValueExpression(valueExpression: string) {
   return splitAndTrimWithBracket(valueExpression)[0];
 }
 
+/** Returns true if the given expression is a JSON expression, eg. `col.key.nestedKey` or "json_col"."key" */
+const isJsonExpression = (expr: string) => {
+  if (!expr.includes('.')) return false;
+
+  let isInDoubleQuote = false;
+  let isInBacktick = false;
+
+  const parts: string[] = [];
+  let current = '';
+  for (const c of expr) {
+    if (c === '"' && !isInBacktick) {
+      isInDoubleQuote = !isInDoubleQuote;
+      current += c;
+      continue;
+    } else if (c === '`' && !isInDoubleQuote) {
+      isInBacktick = !isInBacktick;
+      current += c;
+      continue;
+    } else if (c === '.' && !isInDoubleQuote && !isInBacktick) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+  }
+
+  if (!isInDoubleQuote && !isInBacktick) {
+    parts.push(current);
+  }
+
+  return parts.length > 1;
+};
+
+/**
+ * Finds and returns expressions within the given SQL string that represent JSON references (eg. `col.key.nestedKey`)
+ *
+ * Note - This function does not distinguish between json references and `table.column` references - both are returned.
+ */
+export function findJsonExpressions(sql: string) {
+  const expressions: { index: number; expr: string }[] = [];
+
+  let currentExpr = '';
+  const finishExpression = (expr: string, endIndex: number) => {
+    if (isJsonExpression(expr)) {
+      expressions.push({ index: endIndex - expr.length, expr });
+    }
+    currentExpr = '';
+  };
+
+  let i = 0;
+  let isInJsonTypeSpecifier = false;
+  while (i < sql.length) {
+    const c = sql.charAt(i);
+    if (c === "'") {
+      // Skip string literals
+      while (i < sql.length && sql.charAt(i) !== c) {
+        i++;
+      }
+      currentExpr = '';
+    } else if (/[\s{},+*/[\]]/.test(c)) {
+      isInJsonTypeSpecifier = false;
+      finishExpression(currentExpr, i);
+    } else if ('()'.includes(c) && !isInJsonTypeSpecifier) {
+      finishExpression(currentExpr, i);
+    } else if (c === ':') {
+      isInJsonTypeSpecifier = true;
+      currentExpr += c;
+    } else {
+      currentExpr += c;
+    }
+
+    i++;
+  }
+
+  finishExpression(currentExpr, i);
+  return expressions;
+}
+
+/**
+ * Replaces expressions within the given SQL string that represent JSON expressions (eg. `col.key.nestedKey`).
+ * Such expression are replaced with placeholders like `__hdx_json_replacement_0`. The resulting string and a
+ * map of replacements --> original expressions is returned.
+ *
+ * Note - This function does not distinguish between json references and `table.column` references - both are replaced.
+ */
+export function replaceJsonExpressions(sql: string) {
+  const jsonExpressions = findJsonExpressions(sql);
+
+  const replacements = new Map<string, string>();
+  let sqlWithReplacements = sql;
+  let indexOffsetFromInserts = 0;
+  let replacementCounter = 0;
+  for (const { expr, index } of jsonExpressions) {
+    const replacement = `__hdx_json_replacement_${replacementCounter++}`;
+    replacements.set(replacement, expr);
+
+    const effectiveIndex = index + indexOffsetFromInserts;
+    sqlWithReplacements =
+      sqlWithReplacements.slice(0, effectiveIndex) +
+      replacement +
+      sqlWithReplacements.slice(effectiveIndex + expr.length);
+    indexOffsetFromInserts += replacement.length - expr.length;
+  }
+
+  return { sqlWithReplacements, replacements };
+}
+
 export enum Granularity {
   FifteenSecond = '15 second',
   ThirtySecond = '30 second',


### PR DESCRIPTION
Closes HDX-2042
Closes HDX-2524
Closes #1010 

# Summary

This PR fixes errors that occurred when attempting to open the sidebar by clicking a log table row using a JSON logs table schema.

The error was caused by `node-sql-parser` throwing exceptions when parsing SQL with JSON Expressions, resulting in HyperDX being unable to extract aliases from the SQL. In the long term, we'll want to have a true ClickHouse SQL parser. In the short term, this is fixed by:

1. Finding and replacing all JSON expressions in the sql with placeholder tokens, prior to parsing with node-sql-parser
2. Parsing with node-sql-parser to find aliases correctly
3. Replacing the placeholder tokens with the original JSON expressions

## Testing

(All of the following use a JSON schema)

### Before

<details>
<summary>When selecting a JSON column with an alias</summary>
<img width="1126" height="96" alt="Screenshot 2025-10-01 at 2 28 19 PM" src="https://github.com/user-attachments/assets/c35ed870-9986-4b30-9890-e1ca8ff6c92c" />
<img width="372" height="142" alt="Screenshot 2025-10-01 at 2 28 06 PM" src="https://github.com/user-attachments/assets/d65fdce4-6625-4308-b5d0-6f845a0f2f05" />
</details>

<details>
<summary>When filtering by a JSON column and using an alias on a non-JSON property</summary>
<img width="800" height="103" alt="Screenshot 2025-10-01 at 2 29 44 PM" src="https://github.com/user-attachments/assets/aa7faabb-316b-4103-8840-74ac08519efb" />
<img width="372" height="142" alt="Screenshot 2025-10-01 at 2 28 06 PM" src="https://github.com/user-attachments/assets/eb86cce5-eee4-40f9-af93-2451bff32444" />
</details>

### After


<details>
<summary>When selecting a JSON column with an alias</summary>
<img width="1126" height="96" alt="Screenshot 2025-10-01 at 2 28 19 PM" src="https://github.com/user-attachments/assets/678ba290-5215-4cc5-8fee-1bf67955aaa2" />
<img width="725" height="696" alt="Screenshot 2025-10-01 at 2 30 42 PM" src="https://github.com/user-attachments/assets/5da48109-a0cd-4b5f-a5e3-bd700116d81b" />
</details>

<details>
<summary>When filtering by a JSON column and using an alias on a non-JSON property</summary>
<img width="800" height="103" alt="Screenshot 2025-10-01 at 2 29 44 PM" src="https://github.com/user-attachments/assets/715de816-639e-4ffd-9e09-341bd0b2ee4a" />
<img width="1271" height="888" alt="Screenshot 2025-10-01 at 2 30 24 PM" src="https://github.com/user-attachments/assets/b3b766de-be70-4161-b9ca-8aae9330b5f2" />
</details>