### PR TITLE
Log Results Sorting

### DIFF
--- a/.changeset/young-eyes-build.md
+++ b/.changeset/young-eyes-build.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Add Sorting Feature to all search tables

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -363,6 +363,7 @@ function InsertsTab({
           </Text>
           <DBTableChart
             config={{
+              dateRange: searchedTimeRange,
               select: [
                 `count() as "Part Count"`,
                 `sum(rows) as Rows`,

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -365,12 +365,29 @@ function InsertsTab({
             config={{
               dateRange: searchedTimeRange,
               select: [
-                `count() as "Part Count"`,
-                `sum(rows) as Rows`,
-                'database as Database',
-                'table as Table',
-                'partition as Partition',
-              ].join(','),
+                {
+                  aggFn: 'count',
+                  valueExpression: '',
+                  alias: 'Part Count',
+                },
+                {
+                  aggFn: 'sum',
+                  valueExpression: 'rows',
+                  alias: 'Rows',
+                },
+                {
+                  valueExpression: 'database',
+                  alias: 'Database',
+                },
+                {
+                  valueExpression: 'table',
+                  alias: 'Table',
+                },
+                {
+                  valueExpression: 'partition',
+                  alias: 'Partition',
+                },
+              ],
               from: {
                 databaseName: 'system',
                 tableName: 'parts',
@@ -662,10 +679,22 @@ function ClickhousePage() {
                 <DBTableChart
                   config={{
                     select: [
-                      `count() as "Count"`,
-                      `sum(query_duration_ms) as "Total Duration (ms)"`,
-                      `any(query) as "Query Example"`,
-                    ].join(','),
+                      {
+                        aggFn: 'count',
+                        valueExpression: '',
+                        alias: `Count`,
+                      },
+                      {
+                        aggFn: 'sum',
+                        valueExpression: 'query_duration_ms',
+                        alias: `Total Duration (ms)`,
+                      },
+                      {
+                        aggFn: 'any',
+                        valueExpression: 'query',
+                        alias: `Query Example`,
+                      },
+                    ],
                     dateRange: searchedTimeRange,
                     from,
                     where: `(

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -102,7 +102,10 @@ import PatternTable from './components/PatternTable';
 import SourceSchemaPreview from './components/SourceSchemaPreview';
 import { useTableMetadata } from './hooks/useMetadata';
 import { useSqlSuggestions } from './hooks/useSqlSuggestions';
-import { parseAsStringWithNewLines } from './utils/queryParsers';
+import {
+  parseAsSortingStateString,
+  parseAsStringWithNewLines,
+} from './utils/queryParsers';
 import api from './api';
 import { LOCAL_STORE_CONNECTIONS_KEY } from './connection';
 import { DBSearchPageAlertModal } from './DBSearchPageAlertModal';
@@ -1165,6 +1168,11 @@ function DBSearchPage() {
     },
     [setIsLive, defaultOrderBy, setSearchedConfig],
   );
+  // Parse the orderBy string into a SortingState. We need the string
+  // version in other places so we keep this parser separate.
+  const orderByConfig = parseAsSortingStateString.parse(
+    searchedConfig.orderBy ?? '',
+  );
 
   const handleTimeRangeSelect = useCallback(
     (d1: Date, d2: Date) => {
@@ -1843,6 +1851,7 @@ function DBSearchPage() {
                           denoiseResults={denoiseResults}
                           collapseAllRows={collapseAllRows}
                           onSortingChange={onSortingChange}
+                          initialSortBy={orderByConfig ? [orderByConfig] : []}
                         />
                       )}
                   </>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -56,6 +56,7 @@ import {
 } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { useIsFetching } from '@tanstack/react-query';
+import { SortingState } from '@tanstack/react-table';
 import CodeMirror from '@uiw/react-codemirror';
 
 import { ContactSupportText } from '@/components/ContactSupportText';
@@ -75,10 +76,7 @@ import { Tags } from '@/components/Tags';
 import { TimePicker } from '@/components/TimePicker';
 import WhereLanguageControlled from '@/components/WhereLanguageControlled';
 import { IS_LOCAL_MODE } from '@/config';
-import {
-  useAliasMapFromChartConfig,
-  useQueriedChartConfig,
-} from '@/hooks/useChartConfig';
+import { useAliasMapFromChartConfig } from '@/hooks/useChartConfig';
 import { useExplainQuery } from '@/hooks/useExplainQuery';
 import { withAppNav } from '@/layout';
 import {
@@ -1154,6 +1152,19 @@ function DBSearchPage() {
     [onSubmit],
   );
 
+  const onSortingChange = useCallback(
+    (sortState: SortingState | null) => {
+      setIsLive(false);
+      const sort = sortState?.at(0);
+      setSearchedConfig({
+        orderBy: sort
+          ? `${sort.id} ${sort.desc ? 'DESC' : 'ASC'}`
+          : defaultOrderBy,
+      });
+    },
+    [setIsLive, defaultOrderBy, setSearchedConfig],
+  );
+
   const handleTimeRangeSelect = useCallback(
     (d1: Date, d2: Date) => {
       onTimeRangeSelect(d1, d2);
@@ -1830,6 +1841,7 @@ function DBSearchPage() {
                           onError={handleTableError}
                           denoiseResults={denoiseResults}
                           collapseAllRows={collapseAllRows}
+                          onSortingChange={onSortingChange}
                         />
                       )}
                   </>

--- a/packages/app/src/HDXMultiSeriesTableChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTableChart.tsx
@@ -8,12 +8,14 @@ import {
   Getter,
   Row,
   Row as TableRow,
+  SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { ColumnDef } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { CsvExportButton } from './components/CsvExportButton';
+import TableHeader from './components/DBTable/TableHeader';
 import { useCsvExport } from './hooks/useCsvExport';
 import { UNDEFINED_WIDTH } from './tableUtils';
 import type { NumberFormat } from './types';
@@ -24,11 +26,13 @@ export const Table = ({
   groupColumnName,
   columns,
   getRowSearchLink,
-  onSortClick,
   tableBottom,
+  sorting,
+  onSortingChange,
 }: {
   data: any[];
   columns: {
+    id: string;
     dataKey: string;
     displayName: string;
     sortOrder?: 'asc' | 'desc';
@@ -38,8 +42,9 @@ export const Table = ({
   }[];
   groupColumnName?: string;
   getRowSearchLink?: (row: any) => string;
-  onSortClick?: (columnNumber: number) => void;
   tableBottom?: React.ReactNode;
+  sorting: SortingState;
+  onSortingChange: (sorting: SortingState) => void;
 }) => {
   const MIN_COLUMN_WIDTH_PX = 100;
   //we need a reference to the scrolling element for logic down below
@@ -78,54 +83,60 @@ export const Table = ({
       : []),
     ...columns
       .filter(c => c.visible !== false)
-      .map(({ dataKey, displayName, numberFormat, columnWidthPercent }, i) => ({
-        accessorKey: dataKey,
-        header: displayName,
-        accessorFn: (row: any) => row[dataKey],
-        cell: ({
-          getValue,
-          row,
-        }: {
-          getValue: Getter<number>;
-          row: Row<any>;
-        }) => {
-          const value = getValue();
-          let formattedValue: string | number | null = value ?? null;
-          if (numberFormat) {
-            formattedValue = formatNumber(value, numberFormat);
-          }
-          if (getRowSearchLink == null) {
-            return formattedValue;
-          }
+      .map(
+        (
+          { id, dataKey, displayName, numberFormat, columnWidthPercent },
+          i,
+        ) => ({
+          id: id,
+          accessorKey: dataKey,
+          header: displayName,
+          accessorFn: (row: any) => row[dataKey],
+          cell: ({
+            getValue,
+            row,
+          }: {
+            getValue: Getter<number>;
+            row: Row<any>;
+          }) => {
+            const value = getValue();
+            let formattedValue: string | number | null = value ?? null;
+            if (numberFormat) {
+              formattedValue = formatNumber(value, numberFormat);
+            }
+            if (getRowSearchLink == null) {
+              return formattedValue;
+            }
 
-          return (
-            <Link
-              href={getRowSearchLink(row.original)}
-              passHref
-              className={'align-top overflow-hidden py-1 pe-3'}
-              style={{
-                display: 'block',
-                color: 'inherit',
-                textDecoration: 'none',
-              }}
-            >
-              {formattedValue}
-            </Link>
-          );
-        },
-        size:
-          i === numColumns - 2
-            ? UNDEFINED_WIDTH
-            : tableWidth != null && columnWidthPercent != null
-              ? Math.max(
-                  tableWidth * (columnWidthPercent / 100),
-                  MIN_COLUMN_WIDTH_PX,
-                )
-              : tableWidth != null
-                ? tableWidth / numColumns
-                : 200,
-        enableResizing: i !== numColumns - 2,
-      })),
+            return (
+              <Link
+                href={getRowSearchLink(row.original)}
+                passHref
+                className={'align-top overflow-hidden py-1 pe-3'}
+                style={{
+                  display: 'block',
+                  color: 'inherit',
+                  textDecoration: 'none',
+                }}
+              >
+                {formattedValue}
+              </Link>
+            );
+          },
+          size:
+            i === numColumns - 2
+              ? UNDEFINED_WIDTH
+              : tableWidth != null && columnWidthPercent != null
+                ? Math.max(
+                    tableWidth * (columnWidthPercent / 100),
+                    MIN_COLUMN_WIDTH_PX,
+                  )
+                : tableWidth != null
+                  ? tableWidth / numColumns
+                  : 200,
+          enableResizing: i !== numColumns - 2,
+        }),
+      ),
   ];
 
   const table = useReactTable({
@@ -134,6 +145,19 @@ export const Table = ({
     getCoreRowModel: getCoreRowModel(),
     enableColumnResizing: true,
     columnResizeMode: 'onChange',
+    enableSorting: true,
+    manualSorting: true,
+    onSortingChange: v => {
+      if (typeof v === 'function') {
+        const newSortVal = v(sorting);
+        onSortingChange?.(newSortVal ?? null);
+      } else {
+        onSortingChange?.(v ?? null);
+      }
+    },
+    state: {
+      sorting,
+    },
   });
 
   const { rows } = table.getRowModel();
@@ -172,7 +196,7 @@ export const Table = ({
 
   return (
     <div
-      className="overflow-auto h-100 fs-8 bg-inherit"
+      className="overflow-auto h-100 fs-8 bg-inherit dark:bg-dark"
       ref={tableContainerRef}
     >
       <table className="w-100 bg-inherit" style={{ tableLayout: 'fixed' }}>
@@ -187,87 +211,33 @@ export const Table = ({
           {table.getHeaderGroups().map(headerGroup => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header, headerIndex) => {
-                const sortOrder = columns[headerIndex - 1]?.sortOrder;
                 return (
-                  <th
-                    className="overflow-hidden text-truncate"
+                  <TableHeader
                     key={header.id}
-                    colSpan={header.colSpan}
-                    style={{
-                      width:
-                        header.getSize() === UNDEFINED_WIDTH
-                          ? '100%'
-                          : header.getSize(),
-                      minWidth: 100,
-                      position: 'relative',
-                    }}
-                  >
-                    {header.isPlaceholder ? null : (
-                      <Flex justify="space-between">
-                        <div>
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                        </div>
-                        <Flex gap="sm">
-                          {headerIndex > 0 && onSortClick != null && (
-                            <div
-                              role="button"
-                              onClick={() => onSortClick(headerIndex - 1)}
+                    header={header}
+                    isLast={headerIndex === headerGroup.headers.length - 1}
+                    lastItemButtons={
+                      <>
+                        {headerIndex === headerGroup.headers.length - 1 && (
+                          <div className="d-flex align-items-center">
+                            <UnstyledButton
+                              onClick={() => setWrapLinesEnabled(prev => !prev)}
                             >
-                              {sortOrder === 'asc' ? (
-                                <Text c="green">
-                                  <i className="bi bi-sort-numeric-up-alt"></i>
-                                </Text>
-                              ) : sortOrder === 'desc' ? (
-                                <Text c="green">
-                                  <i className="bi bi-sort-numeric-down-alt"></i>
-                                </Text>
-                              ) : (
-                                <Text c="dark.2">
-                                  <i className="bi bi-sort-numeric-down-alt"></i>
-                                </Text>
-                              )}
-                            </div>
-                          )}
-                          {header.column.getCanResize() &&
-                            headerIndex !== headerGroup.headers.length - 1 && (
-                              <div
-                                onMouseDown={header.getResizeHandler()}
-                                onTouchStart={header.getResizeHandler()}
-                                className={`resizer text-gray-600 cursor-grab ${
-                                  header.column.getIsResizing()
-                                    ? 'isResizing'
-                                    : ''
-                                }`}
-                              >
-                                <i className="bi bi-three-dots-vertical" />
-                              </div>
-                            )}
-                          {headerIndex === headerGroup.headers.length - 1 && (
-                            <div className="d-flex align-items-center">
-                              <UnstyledButton
-                                onClick={() =>
-                                  setWrapLinesEnabled(prev => !prev)
-                                }
-                              >
-                                <i className="bi bi-text-wrap" />
-                              </UnstyledButton>
-                              <CsvExportButton
-                                data={csvData}
-                                filename="HyperDX_table_results"
-                                className="fs-8 text-muted-hover ms-2"
-                                title="Download table as CSV"
-                              >
-                                <i className="bi bi-download" />
-                              </CsvExportButton>
-                            </div>
-                          )}
-                        </Flex>
-                      </Flex>
-                    )}
-                  </th>
+                              <i className="bi bi-text-wrap" />
+                            </UnstyledButton>
+                            <CsvExportButton
+                              data={csvData}
+                              filename="HyperDX_table_results"
+                              className="fs-8 text-muted-hover ms-2"
+                              title="Download table as CSV"
+                            >
+                              <i className="bi bi-download" />
+                            </CsvExportButton>
+                          </div>
+                        )}
+                      </>
+                    }
+                  />
                 );
               })}
             </tr>

--- a/packages/app/src/components/CsvExportButton.tsx
+++ b/packages/app/src/components/CsvExportButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useCSVDownloader } from 'react-papaparse';
+import { UnstyledButton } from '@mantine/core';
 
 interface CsvExportButtonProps {
   data: Record<string, any>[];
@@ -57,9 +58,8 @@ export const CsvExportButton: React.FC<CsvExportButtonProps> = ({
   }
 
   return (
-    <div
+    <UnstyledButton
       className={className}
-      role="button"
       title={title}
       onClick={handleClick}
       {...props}
@@ -88,6 +88,6 @@ export const CsvExportButton: React.FC<CsvExportButtonProps> = ({
       >
         {children}
       </CSVDownloader>
-    </div>
+    </UnstyledButton>
   );
 };

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -812,7 +812,7 @@ export const RawLogTable = memo(
                               <IconDotsVertical size={12} />
                             </div>
                           )}
-                          {isLast && (
+                          {!isLoading && isLast && (
                             <Group gap={2}>
                               {tableId &&
                                 Object.keys(columnSizeStorage).length > 0 && (

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -87,6 +87,7 @@ import {
   useWindowSize,
 } from '@/utils';
 
+import TableHeader from './DBTable/TableHeader';
 import { SQLPreview } from './ChartSQLPreview';
 import { CsvExportButton } from './CsvExportButton';
 import {
@@ -743,148 +744,63 @@ export const RawLogTable = memo(
                 {headerGroup.headers.map((header, headerIndex) => {
                   const isLast = headerIndex === headerGroup.headers.length - 1;
                   return (
-                    <th
-                      className="overflow-hidden bg-hdx-dark"
+                    <TableHeader
                       key={header.id}
-                      colSpan={header.colSpan}
-                      style={{
-                        width:
-                          header.getSize() === UNDEFINED_WIDTH
-                            ? '100%'
-                            : header.getSize(),
-                        // Allow unknown width columns to shrink to 0
-                        minWidth:
-                          header.getSize() === UNDEFINED_WIDTH
-                            ? 0
-                            : header.getSize(),
-                      }}
-                    >
-                      <Group wrap="nowrap" gap={0} align="center">
-                        {!header.column.getCanSort() ? (
-                          <Text truncate="end" size="xs" flex="1">
-                            {flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
+                      header={header}
+                      isLast={isLast}
+                      lastItemButtons={
+                        <>
+                          {tableId &&
+                            Object.keys(columnSizeStorage).length > 0 && (
+                              <div
+                                className="fs-8 text-muted-hover disabled"
+                                role="button"
+                                onClick={() => setColumnSizeStorage({})}
+                                title="Reset Column Widths"
+                              >
+                                <i className="bi bi-arrow-clockwise" />
+                              </div>
                             )}
-                          </Text>
-                        ) : (
-                          <Button
-                            size="xxs"
-                            p={1}
-                            variant="subtle"
-                            color="gray"
-                            onClick={header.column.getToggleSortingHandler()}
-                            flex="1"
-                            justify="space-between"
-                            data-testid="raw-log-table-sort-button"
-                          >
-                            <>
-                              {header.isPlaceholder ? null : (
-                                <Text
-                                  truncate="end"
-                                  size="xs"
-                                  flex="1"
-                                  c="white"
-                                >
-                                  {flexRender(
-                                    header.column.columnDef.header,
-                                    header.getContext(),
-                                  )}
-                                </Text>
-                              )}
-
-                              {header.column.getIsSorted() && (
-                                <div
-                                  data-testid="raw-log-table-sort-indicator"
-                                  className={
-                                    header.column.getIsSorted() === 'asc'
-                                      ? 'sorted-asc'
-                                      : 'sorted-desc'
-                                  }
-                                >
-                                  <>
-                                    {header.column.getIsSorted() === 'asc' ? (
-                                      <IconChevronUp size={16} />
-                                    ) : (
-                                      <IconChevronDown size={16} />
-                                    )}
-                                  </>
-                                </div>
-                              )}
-                            </>
-                          </Button>
-                        )}
-
-                        <Group gap={0} wrap="nowrap" align="center">
-                          {header.column.getCanResize() && !isLast && (
-                            <div
-                              onMouseDown={header.getResizeHandler()}
-                              onTouchStart={header.getResizeHandler()}
-                              className={cx(
-                                `resizer text-gray-600 cursor-col-resize`,
-                                header.column.getIsResizing() && 'isResizing',
-                              )}
+                          {config && (
+                            <UnstyledButton
+                              onClick={() => handleSqlModalOpen(true)}
                             >
-                              <IconDotsVertical size={12} />
+                              <MantineTooltip label="Show generated SQL">
+                                <i className="bi bi-code-square" />
+                              </MantineTooltip>
+                            </UnstyledButton>
+                          )}
+                          <UnstyledButton
+                            onClick={() => setWrapLinesEnabled(prev => !prev)}
+                          >
+                            <MantineTooltip label="Wrap lines">
+                              <i className="bi bi-text-wrap" />
+                            </MantineTooltip>
+                          </UnstyledButton>
+
+                          <CsvExportButton
+                            data={csvData}
+                            filename={`hyperdx_search_results_${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`}
+                            className="fs-6 text-muted-hover "
+                          >
+                            <MantineTooltip
+                              label={`Download table as CSV (max ${maxRows.toLocaleString()} rows)${isLimited ? ' - data truncated' : ''}`}
+                            >
+                              <i className="bi bi-download" />
+                            </MantineTooltip>
+                          </CsvExportButton>
+                          {onSettingsClick != null && (
+                            <div
+                              className="fs-8 text-muted-hover"
+                              role="button"
+                              onClick={() => onSettingsClick()}
+                            >
+                              <i className="bi bi-gear-fill" />
                             </div>
                           )}
-                          {!isLoading && isLast && (
-                            <Group gap={2} wrap="nowrap">
-                              {tableId &&
-                                Object.keys(columnSizeStorage).length > 0 && (
-                                  <div
-                                    className="fs-8 text-muted-hover disabled"
-                                    role="button"
-                                    onClick={() => setColumnSizeStorage({})}
-                                    title="Reset Column Widths"
-                                  >
-                                    <i className="bi bi-arrow-clockwise" />
-                                  </div>
-                                )}
-                              {config && (
-                                <UnstyledButton
-                                  onClick={() => handleSqlModalOpen(true)}
-                                >
-                                  <MantineTooltip label="Show generated SQL">
-                                    <i className="bi bi-code-square" />
-                                  </MantineTooltip>
-                                </UnstyledButton>
-                              )}
-                              <UnstyledButton
-                                onClick={() =>
-                                  setWrapLinesEnabled(prev => !prev)
-                                }
-                              >
-                                <MantineTooltip label="Wrap lines">
-                                  <i className="bi bi-text-wrap" />
-                                </MantineTooltip>
-                              </UnstyledButton>
-
-                              <CsvExportButton
-                                data={csvData}
-                                filename={`hyperdx_search_results_${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`}
-                                className="fs-6 text-muted-hover "
-                              >
-                                <MantineTooltip
-                                  label={`Download table as CSV (max ${maxRows.toLocaleString()} rows)${isLimited ? ' - data truncated' : ''}`}
-                                >
-                                  <i className="bi bi-download" />
-                                </MantineTooltip>
-                              </CsvExportButton>
-                              {onSettingsClick != null && (
-                                <div
-                                  className="fs-8 text-muted-hover"
-                                  role="button"
-                                  onClick={() => onSettingsClick()}
-                                >
-                                  <i className="bi bi-gear-fill" />
-                                </div>
-                              )}
-                            </Group>
-                          )}
-                        </Group>
-                      </Group>
-                    </th>
+                        </>
+                      }
+                    />
                   );
                 })}
               </tr>
@@ -1252,7 +1168,7 @@ function DBSqlRowTableComponent({
       onSortingChange?.(v);
       setOrderBy(v?.[0] ?? null);
     },
-    [setOrderBy],
+    [setOrderBy, onSortingChange],
   );
 
   const mergedConfigObj = useMemo(() => {

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -458,8 +458,8 @@ export const RawLogTable = memo(
               column,
               jsColumnType,
             },
-            // Prefer real column name over alias when possible for ID
-            id: aliasMap?.[column] ?? column,
+            // If the column is an alias, wrap in quotes.
+            id: aliasMap?.[column] ? `"${column}"` : column,
             // TODO: add support for sorting on Dynamic JSON fields
             enableSorting: jsColumnType !== JSDataType.Dynamic,
             accessorFn: curry(retrieveColumnValue)(column), // Columns can contain '.' and will not work with accessorKey

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -317,7 +317,7 @@ export const RawLogTable = memo(
     sortOrder,
     showExpandButton = true,
   }: {
-    wrapLines: boolean;
+    wrapLines?: boolean;
     displayedColumns: string[];
     onSettingsClick?: () => void;
     onInstructionsClick?: () => void;
@@ -333,7 +333,7 @@ export const RawLogTable = memo(
     hasNextPage?: boolean;
     highlightedLineId?: string;
     onScroll?: (scrollTop: number) => void;
-    isLive: boolean;
+    isLive?: boolean;
     onShowPatternsClick?: () => void;
     tableId?: string;
     columnNameMap?: Record<string, string>;
@@ -740,7 +740,6 @@ export const RawLogTable = memo(
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header, headerIndex) => {
                   const isLast = headerIndex === headerGroup.headers.length - 1;
-
                   return (
                     <th
                       className="overflow-hidden bg-hdx-dark"
@@ -775,6 +774,7 @@ export const RawLogTable = memo(
                             onClick={header.column.getToggleSortingHandler()}
                             flex="1"
                             justify="space-between"
+                            data-testid="raw-log-table-sort-button"
                           >
                             <>
                               {header.isPlaceholder ? null : (
@@ -787,7 +787,14 @@ export const RawLogTable = memo(
                               )}
 
                               {header.column.getIsSorted() && (
-                                <div>
+                                <div
+                                  data-testid="raw-log-table-sort-indicator"
+                                  className={
+                                    header.column.getIsSorted() === 'asc'
+                                      ? 'sorted-asc'
+                                      : 'sorted-desc'
+                                  }
+                                >
                                   <>
                                     {header.column.getIsSorted() === 'asc' ? (
                                       <IconChevronUp size={16} />
@@ -1061,7 +1068,7 @@ export const RawLogTable = memo(
                   ) : hasNextPage == false &&
                     isLoading == false &&
                     dedupedRows.length === 0 ? (
-                    <div className="my-3">
+                    <div className="my-3" data-testid="db-row-table-no-results">
                       No results found.
                       <Text mt="sm" c="gray.3">
                         Try checking the query explainer in the search bar if

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -810,9 +810,9 @@ export const RawLogTable = memo(
                                 <div>
                                   <>
                                     {header.column.getIsSorted() === 'asc' ? (
-                                      <IconChevronDown size={16} />
-                                    ) : (
                                       <IconChevronUp size={16} />
+                                    ) : (
+                                      <IconChevronDown size={16} />
                                     )}
                                   </>
                                 </div>

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1136,6 +1136,7 @@ function DBSqlRowTableComponent({
   showExpandButton = true,
   renderRowDetails,
   onSortingChange,
+  initialSortBy,
 }: {
   config: ChartConfigWithDateRange;
   sourceId?: string;
@@ -1152,15 +1153,20 @@ function DBSqlRowTableComponent({
   onExpandedRowsChange?: (hasExpandedRows: boolean) => void;
   collapseAllRows?: boolean;
   showExpandButton?: boolean;
+  initialSortBy?: SortingState;
   onSortingChange?: (v: SortingState | null) => void;
 }) {
   const { data: me } = api.useMe();
 
-  const [orderBy, setOrderBy] = useState<SortingState[number] | null>(null);
+  const [orderBy, setOrderBy] = useState<SortingState[number] | null>(
+    initialSortBy?.[0] ?? null,
+  );
+
   const orderByArray = useMemo(() => (orderBy ? [orderBy] : []), [orderBy]);
 
   useEffect(() => {
-    setOrderBy(null);
+    setOrderBy(initialSortBy?.at(0) ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceId]);
 
   const _onSortingChange = useCallback(

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -459,6 +459,8 @@ export const RawLogTable = memo(
             },
             // Prefer real column name over alias when possible for ID
             id: aliasMap?.[column] ?? column,
+            // TODO: add support for sorting on Dynamic JSON fields
+            enableSorting: jsColumnType !== JSDataType.Dynamic,
             accessorFn: curry(retrieveColumnValue)(column), // Columns can contain '.' and will not work with accessorKey
             header: `${columnNameMap?.[column] ?? column}${isDate ? (isUTC ? ' (UTC)' : ' (Local)') : ''}`,
             cell: info => {
@@ -778,7 +780,12 @@ export const RawLogTable = memo(
                           >
                             <>
                               {header.isPlaceholder ? null : (
-                                <Text truncate="end" size="xs" flex="1">
+                                <Text
+                                  truncate="end"
+                                  size="xs"
+                                  flex="1"
+                                  c="white"
+                                >
                                   {flexRender(
                                     header.column.columnDef.header,
                                     header.getContext(),

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -42,8 +42,8 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import { splitAndTrimWithBracket } from '@hyperdx/common-utils/dist/utils';
 import {
-  ActionIcon,
   Box,
+  Button,
   Code,
   Flex,
   Group,
@@ -601,7 +601,7 @@ export const RawLogTable = memo(
         },
         enableColumnResizing: true,
         columnResizeMode: 'onChange' as ColumnResizeMode,
-      };
+      } satisfies TableOptions<any>;
 
       const columnSizeProps = {
         state: {
@@ -779,30 +779,49 @@ export const RawLogTable = memo(
                       }}
                     >
                       <Group wrap="nowrap" gap={0} align="center">
-                        {header.isPlaceholder ? null : (
+                        {!header.column.getCanSort() ? (
                           <Text truncate="end" size="xs" flex="1">
                             {flexRender(
                               header.column.columnDef.header,
                               header.getContext(),
                             )}
                           </Text>
-                        )}
-                        <Group gap={0} wrap="nowrap" align="center">
-                          {header.column.getCanSort() && (
-                            <ActionIcon
-                              size="xxs"
-                              variant="subtle"
-                              color="gray"
-                              onClick={header.column.getToggleSortingHandler()}
-                            >
-                              {header.column.getIsSorted() ? (
-                                <IconChevronDown size={16} />
-                              ) : (
-                                <IconChevronUp size={16} />
+                        ) : (
+                          <Button
+                            size="xxs"
+                            p={1}
+                            variant="subtle"
+                            color="gray"
+                            onClick={header.column.getToggleSortingHandler()}
+                            flex="1"
+                            justify="space-between"
+                          >
+                            <>
+                              {header.isPlaceholder ? null : (
+                                <Text truncate="end" size="xs" flex="1">
+                                  {flexRender(
+                                    header.column.columnDef.header,
+                                    header.getContext(),
+                                  )}
+                                </Text>
                               )}
-                            </ActionIcon>
-                          )}
 
+                              {header.column.getIsSorted() && (
+                                <div>
+                                  <>
+                                    {header.column.getIsSorted() === 'asc' ? (
+                                      <IconChevronDown size={16} />
+                                    ) : (
+                                      <IconChevronUp size={16} />
+                                    )}
+                                  </>
+                                </div>
+                              )}
+                            </>
+                          </Button>
+                        )}
+
+                        <Group gap={0} wrap="nowrap" align="center">
                           {header.column.getCanResize() && !isLast && (
                             <div
                               onMouseDown={header.getResizeHandler()}
@@ -816,7 +835,7 @@ export const RawLogTable = memo(
                             </div>
                           )}
                           {!isLoading && isLast && (
-                            <Group gap={2}>
+                            <Group gap={2} wrap="nowrap">
                               {tableId &&
                                 Object.keys(columnSizeStorage).length > 0 && (
                                   <div

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1164,11 +1164,6 @@ function DBSqlRowTableComponent({
 
   const orderByArray = useMemo(() => (orderBy ? [orderBy] : []), [orderBy]);
 
-  useEffect(() => {
-    setOrderBy(initialSortBy?.at(0) ?? null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourceId]);
-
   const _onSortingChange = useCallback(
     (v: SortingState | null) => {
       onSortingChange?.(v);
@@ -1176,6 +1171,14 @@ function DBSqlRowTableComponent({
     },
     [setOrderBy, onSortingChange],
   );
+
+  const prevSourceId = usePrevious(sourceId);
+  useEffect(() => {
+    if (prevSourceId && prevSourceId !== sourceId) {
+      _onSortingChange(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceId]);
 
   const mergedConfigObj = useMemo(() => {
     const base = {

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -597,9 +597,7 @@ export const RawLogTable = memo(
         state: {
           sorting: orderByArray,
         },
-        // onSortingChange: (helo: any) => {
         enableColumnResizing: true,
-
         columnResizeMode: 'onChange' as ColumnResizeMode,
       } satisfies TableOptions<any>;
 

--- a/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
+++ b/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
@@ -37,6 +37,7 @@ interface Props {
   isNestedPanel?: boolean;
   breadcrumbPath?: BreadcrumbEntry[];
   onSortingChange?: (v: SortingState | null) => void;
+  initialSortBy?: SortingState;
 }
 
 export default function DBSqlRowTableWithSideBar({
@@ -54,6 +55,7 @@ export default function DBSqlRowTableWithSideBar({
   breadcrumbPath,
   onSidebarOpen,
   onSortingChange,
+  initialSortBy,
 }: Props) {
   const { data: sourceData } = useSource({ id: sourceId });
   const [rowId, setRowId] = useQueryState('rowWhere');
@@ -94,6 +96,7 @@ export default function DBSqlRowTableWithSideBar({
         queryKeyPrefix={'dbSqlRowTable'}
         onSortingChange={onSortingChange}
         denoiseResults={denoiseResults}
+        initialSortBy={initialSortBy}
         renderRowDetails={r => {
           if (!sourceData) {
             return <div className="p-3 text-muted">Loading...</div>;

--- a/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
+++ b/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChartConfigWithDateRange,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
+import { SortingState } from '@tanstack/react-table';
 
 import { useSource } from '@/source';
 import TabBar from '@/TabBar';
@@ -35,6 +36,7 @@ interface Props {
   collapseAllRows?: boolean;
   isNestedPanel?: boolean;
   breadcrumbPath?: BreadcrumbEntry[];
+  onSortingChange?: (v: SortingState | null) => void;
 }
 
 export default function DBSqlRowTableWithSideBar({
@@ -51,6 +53,7 @@ export default function DBSqlRowTableWithSideBar({
   isNestedPanel,
   breadcrumbPath,
   onSidebarOpen,
+  onSortingChange,
 }: Props) {
   const { data: sourceData } = useSource({ id: sourceId });
   const [rowId, setRowId] = useQueryState('rowWhere');
@@ -89,6 +92,7 @@ export default function DBSqlRowTableWithSideBar({
         enabled={enabled}
         isLive={isLive ?? true}
         queryKeyPrefix={'dbSqlRowTable'}
+        onSortingChange={onSortingChange}
         denoiseResults={denoiseResults}
         renderRowDetails={r => {
           if (!sourceData) {

--- a/packages/app/src/components/DBTable/TableHeader.tsx
+++ b/packages/app/src/components/DBTable/TableHeader.tsx
@@ -1,0 +1,102 @@
+import cx from 'classnames';
+import { Button, Group, Text, UnstyledButton } from '@mantine/core';
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconDotsVertical,
+} from '@tabler/icons-react';
+import { flexRender, Header } from '@tanstack/react-table';
+
+import { UNDEFINED_WIDTH } from '@/tableUtils';
+
+export default function TableHeader({
+  isLast,
+  header,
+  lastItemButtons,
+}: {
+  isLast: boolean;
+  header: Header<any, any>;
+  lastItemButtons?: React.ReactNode;
+}) {
+  return (
+    <th
+      className="overflow-hidden bg-hdx-dark"
+      key={header.id}
+      colSpan={header.colSpan}
+      style={{
+        width: header.getSize() === UNDEFINED_WIDTH ? '100%' : header.getSize(),
+        // Allow unknown width columns to shrink to 0
+        minWidth: header.getSize() === UNDEFINED_WIDTH ? 0 : header.getSize(),
+      }}
+    >
+      <Group wrap="nowrap" gap={0} align="center">
+        {!header.column.getCanSort() ? (
+          <Text truncate="end" size="xs" flex="1">
+            {flexRender(header.column.columnDef.header, header.getContext())}
+          </Text>
+        ) : (
+          <Button
+            size="xxs"
+            p={1}
+            variant="subtle"
+            color="gray"
+            onClick={header.column.getToggleSortingHandler()}
+            flex="1"
+            justify="space-between"
+            data-testid="raw-log-table-sort-button"
+          >
+            <>
+              {header.isPlaceholder ? null : (
+                <Text truncate="end" size="xs" flex="1" c="white">
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                </Text>
+              )}
+
+              {header.column.getIsSorted() && (
+                <div
+                  data-testid="raw-log-table-sort-indicator"
+                  className={
+                    header.column.getIsSorted() === 'asc'
+                      ? 'sorted-asc'
+                      : 'sorted-desc'
+                  }
+                >
+                  <>
+                    {header.column.getIsSorted() === 'asc' ? (
+                      <IconChevronUp size={16} />
+                    ) : (
+                      <IconChevronDown size={16} />
+                    )}
+                  </>
+                </div>
+              )}
+            </>
+          </Button>
+        )}
+
+        <Group gap={0} wrap="nowrap" align="center">
+          {header.column.getCanResize() && !isLast && (
+            <div
+              onMouseDown={header.getResizeHandler()}
+              onTouchStart={header.getResizeHandler()}
+              className={cx(
+                `resizer text-gray-600 cursor-col-resize`,
+                header.column.getIsResizing() && 'isResizing',
+              )}
+            >
+              <IconDotsVertical size={12} />
+            </div>
+          )}
+          {isLast && (
+            <Group gap={2} wrap="nowrap">
+              {lastItemButtons}
+            </Group>
+          )}
+        </Group>
+      </Group>
+    </th>
+  );
+}

--- a/packages/app/src/components/DBTable/TableHeader.tsx
+++ b/packages/app/src/components/DBTable/TableHeader.tsx
@@ -1,8 +1,8 @@
 import cx from 'classnames';
-import { Button, Group, Text, UnstyledButton } from '@mantine/core';
+import { Button, Group, Text } from '@mantine/core';
 import {
-  IconChevronDown,
-  IconChevronUp,
+  IconArrowDown,
+  IconArrowUp,
   IconDotsVertical,
 } from '@tabler/icons-react';
 import { flexRender, Header } from '@tanstack/react-table';
@@ -66,9 +66,9 @@ export default function TableHeader({
                 >
                   <>
                     {header.column.getIsSorted() === 'asc' ? (
-                      <IconChevronUp size={16} />
+                      <IconArrowUp size={12} />
                     ) : (
-                      <IconChevronDown size={16} />
+                      <IconArrowDown size={12} />
                     )}
                   </>
                 </div>

--- a/packages/app/src/components/DBTableChart.tsx
+++ b/packages/app/src/components/DBTableChart.tsx
@@ -3,6 +3,7 @@ import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import {
   ChartConfigWithDateRange,
   ChartConfigWithOptDateRange,
+  ChatConfigWithOptTimestamp,
 } from '@hyperdx/common-utils/dist/types';
 import { Box, Code, Text } from '@mantine/core';
 import { SortingState } from '@tanstack/react-table';
@@ -20,7 +21,7 @@ export default function DBTableChart({
   enabled = true,
   queryKeyPrefix,
 }: {
-  config: ChartConfigWithOptDateRange;
+  config: ChatConfigWithOptTimestamp;
   getRowSearchLink?: (row: any) => string;
   queryKeyPrefix?: string;
   enabled?: boolean;

--- a/packages/app/src/components/ExpandableRowTable.tsx
+++ b/packages/app/src/components/ExpandableRowTable.tsx
@@ -196,6 +196,7 @@ export const createExpandButtonColumn = (
   },
   size: 32,
   enableResizing: false,
+  enableSorting: false,
   meta: {
     className: 'text-center',
   },

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -8,7 +8,7 @@ import {
 
 import * as useChartConfigModule from '../../hooks/useChartConfig';
 
-describe.only('RawLogTable', () => {
+describe('RawLogTable', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest
@@ -130,7 +130,7 @@ describe.only('RawLogTable', () => {
       expect(callback).toHaveBeenCalledWith([
         {
           desc: false,
-          id: 'col1_alias',
+          id: '"col1"',
         },
       ]);
     });

--- a/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
+++ b/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
@@ -7,7 +7,7 @@ import {
   ColumnMetaType,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/renderChartConfig';
-import { ChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
+import { ChatConfigWithOptTimestamp } from '@hyperdx/common-utils/dist/types';
 import {
   isFirstOrderByAscending,
   isTimestampExpressionInFirstOrderBy,
@@ -26,12 +26,12 @@ import { omit } from '@/utils';
 
 type TQueryKey = readonly [
   string,
-  ChartConfigWithDateRange,
+  ChatConfigWithOptTimestamp,
   number | undefined,
 ];
 function queryKeyFn(
   prefix: string,
-  config: ChartConfigWithDateRange,
+  config: ChatConfigWithOptTimestamp,
   queryTimeout?: number,
 ): TQueryKey {
   return [prefix, config, queryTimeout];
@@ -130,7 +130,7 @@ function generateTimeWindowsAscending(startDate: Date, endDate: Date) {
 
 // Get time window from page param
 function getTimeWindowFromPageParam(
-  config: ChartConfigWithDateRange,
+  config: ChatConfigWithOptTimestamp,
   pageParam: TPageParam,
 ): TimeWindow {
   const [startDate, endDate] = config.dateRange;
@@ -148,7 +148,7 @@ function getTimeWindowFromPageParam(
 function getNextPageParam(
   lastPage: TQueryFnData | null,
   allPages: TQueryFnData[],
-  config: ChartConfigWithDateRange,
+  config: ChatConfigWithOptTimestamp,
 ): TPageParam | undefined {
   if (lastPage == null) {
     return undefined;
@@ -427,7 +427,7 @@ function flattenData(data: TData | undefined): TQueryFnData | null {
 }
 
 export default function useOffsetPaginatedQuery(
-  config: ChartConfigWithDateRange,
+  config: ChatConfigWithOptTimestamp,
   {
     isLive,
     enabled = true,

--- a/packages/app/src/utils/queryParsers.ts
+++ b/packages/app/src/utils/queryParsers.ts
@@ -1,8 +1,30 @@
 import { createParser } from 'nuqs';
+import { SortingState } from '@tanstack/react-table';
 
 // Note: this can be deleted once we upgrade to nuqs v2.2.3
 // https://github.com/47ng/nuqs/pull/783
 export const parseAsStringWithNewLines = createParser<string>({
   parse: value => value.replace(/%0A/g, '\n'),
   serialize: value => value.replace(/\n/g, '%0A'),
+});
+
+export const parseAsSortingStateString = createParser<SortingState[number]>({
+  parse: value => {
+    if (!value) {
+      return null;
+    }
+    const keys = value.split(' ');
+    const direction = keys.pop();
+    const key = keys.join(' ');
+    return {
+      id: key,
+      desc: direction === 'DESC',
+    };
+  },
+  serialize: value => {
+    if (!value) {
+      return '';
+    }
+    return `${value.id} ${value.desc ? 'DESC' : 'ASC'}`;
+  },
 });

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -428,11 +428,11 @@ export abstract class BaseClickhouseClient {
     }
 
     // eslint-disable-next-line no-console
-    console.log('--------------------------------------------------------');
+    console.debug('--------------------------------------------------------');
     // eslint-disable-next-line no-console
-    console.log('Sending Query:', debugSql);
+    console.debug('Sending Query:', debugSql);
     // eslint-disable-next-line no-console
-    console.log('--------------------------------------------------------');
+    console.debug('--------------------------------------------------------');
   }
 
   protected processClickhouseSettings(

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -421,6 +421,13 @@ export type DateRange = {
 };
 
 export type ChartConfigWithDateRange = ChartConfig & DateRange;
+
+export type ChatConfigWithOptTimestamp = Omit<
+  ChartConfigWithDateRange,
+  'timestampValueExpression'
+> & {
+  timestampValueExpression?: string;
+};
 // For non-time-based searches (ex. grab 1 row)
 export type ChartConfigWithOptDateRange = Omit<
   ChartConfig,

--- a/packages/common-utils/src/utils.ts
+++ b/packages/common-utils/src/utils.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import {
   ChartConfigWithDateRange,
+  ChatConfigWithOptTimestamp,
   DashboardFilter,
   DashboardFilterSchema,
   DashboardSchema,
@@ -418,10 +419,11 @@ export const removeTrailingDirection = (s: string) => {
 };
 
 export const isTimestampExpressionInFirstOrderBy = (
-  config: ChartConfigWithDateRange,
+  config: ChatConfigWithOptTimestamp,
 ) => {
   const firstOrderingItem = getFirstOrderingItem(config.orderBy);
-  if (!firstOrderingItem) return false;
+  if (!firstOrderingItem || config.timestampValueExpression == null)
+    return false;
 
   const firstOrderingExpression =
     typeof firstOrderingItem === 'string'


### PR DESCRIPTION
Adds support for ordering logs by clicking on the respective header. 

- Toggles between three states (unset, asc, desc).
- Leverages the column aliases correctly so if aliases have special characters (ex `DURATION as "Duration (ms)"`) they are correctly ordered as expected
- Supports nested tables 
- Supports query params (on search page)
- Adds tests for db row table and sorting logic

Demo:

https://github.com/user-attachments/assets/46aa0299-1ed3-480b-a35f-315d921e47ba




Fixes HDX-2317

