### PR TITLE
Fixes inability to scroll in the TimePicker component

### DIFF
--- a/.changeset/grumpy-trees-mate.md
+++ b/.changeset/grumpy-trees-mate.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fixes scrolling in TimePicker

--- a/packages/app/src/components/TimePicker/TimePicker.tsx
+++ b/packages/app/src/components/TimePicker/TimePicker.tsx
@@ -265,7 +265,7 @@ export const TimePicker = ({
         </Group>
         <Group gap={1} align="stretch">
           <Card w={180} p={0}>
-            <ScrollArea mah={300} scrollbarSize={5}>
+            <ScrollArea h={300} scrollbarSize={5}>
               <Stack gap={0} p="xs">
                 {relativeTimeOptions.map((item, index) =>
                   item === 'divider' ? (


### PR DESCRIPTION
Before:
<img width="1010" height="784" alt="Screenshot 2025-10-02 at 2 34 13 PM" src="https://github.com/user-attachments/assets/d737393e-1a76-4750-8b03-61928284d217" />

After:
<img width="1020" height="844" alt="Screenshot 2025-10-02 at 2 34 21 PM" src="https://github.com/user-attachments/assets/82fe6ad2-d9c9-47bd-b01f-4b0d50f349a6" />


Fixes HDX-2546