### PR TITLE
fix: Prevent non-windowed searches from querying infinitely

### DIFF
--- a/.changeset/short-turtles-change.md
+++ b/.changeset/short-turtles-change.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix infinite querying on non-windowed searches

--- a/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
+++ b/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
@@ -177,9 +177,10 @@ function getNextPageParam(
     };
   }
 
-  // If no more results in current window, move to next window
+  // If no more results in current window, move to next window (if windowing is being used)
+  const shouldUseWindowing = isTimestampExpressionInFirstOrderBy(config);
   const nextWindowIndex = currentWindow.windowIndex + 1;
-  if (nextWindowIndex < windows.length) {
+  if (shouldUseWindowing && nextWindowIndex < windows.length) {
     return {
       windowIndex: nextWindowIndex,
       offset: 0,


### PR DESCRIPTION
Fixes HDX-2548

This PR fixes an issue causing non-windowed searches to query the entire date range infinitely.

## Before

https://github.com/user-attachments/assets/13daed15-b862-4b12-95d4-43a88ecabade

## After

https://github.com/user-attachments/assets/058e6da8-1b2a-47e4-80ac-70ce76615a2f
