### PR TITLE
feat(alert): allow defining ClickHouse request timeout

### DIFF
--- a/packages/api/src/tasks/__tests__/types.test.ts
+++ b/packages/api/src/tasks/__tests__/types.test.ts
@@ -1,191 +1,109 @@
 import { asTaskArgs } from '../types';
 
 describe('asTaskArgs', () => {
-  it('should return valid TaskArgs for valid input', () => {
-    const validArgs = {
-      _: ['command', 'arg1', 'arg2'],
-      provider: 'default',
-    };
-
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'command',
-      provider: 'default',
+  describe('invalid inputs', () => {
+    it('should throw error for null input', () => {
+      expect(() => asTaskArgs(null)).toThrow(
+        'Arguments cannot be null or undefined',
+      );
     });
-    expect(result.taskName).toBe('command');
-    // For non-check-alerts tasks, we need to use type assertion to access provider
-    expect((result as any).provider).toBe('default');
-  });
 
-  it('should return valid TaskArgs when provider is undefined', () => {
-    const validArgs = {
-      _: ['command'],
-    };
-
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'command',
-      provider: undefined,
+    it('should throw error for undefined input', () => {
+      expect(() => asTaskArgs(undefined)).toThrow(
+        'Arguments cannot be null or undefined',
+      );
     });
-    expect(result.taskName).toBe('command');
-    // For non-check-alerts tasks, we need to use type assertion to access provider
-    expect((result as any).provider).toBeUndefined();
-  });
 
-  it('should throw error for null input', () => {
-    expect(() => asTaskArgs(null)).toThrow(
-      'Arguments cannot be null or undefined',
-    );
-  });
-
-  it('should throw error for undefined input', () => {
-    expect(() => asTaskArgs(undefined)).toThrow(
-      'Arguments cannot be null or undefined',
-    );
-  });
-
-  it('should throw error for non-object input', () => {
-    expect(() => asTaskArgs('string')).toThrow('Arguments must be an object');
-    expect(() => asTaskArgs(123)).toThrow('Arguments must be an object');
-    expect(() => asTaskArgs(true)).toThrow('Arguments must be an object');
-    expect(() => asTaskArgs(false)).toThrow('Arguments must be an object');
-    expect(() => asTaskArgs([])).toThrow('Arguments must be an object');
-  });
-
-  it('should throw error when _ property is missing', () => {
-    const invalidArgs = {
-      provider: 'default',
-    };
-
-    expect(() => asTaskArgs(invalidArgs)).toThrow(
-      'Arguments must have a "_" property that is an array',
-    );
-  });
-
-  it('should throw error when _ property is not an array', () => {
-    const invalidArgs = {
-      _: 'not an array',
-      provider: 'default',
-    };
-
-    expect(() => asTaskArgs(invalidArgs)).toThrow(
-      'Arguments must have a "_" property that is an array',
-    );
-  });
-
-  it('should throw error when _ property is null', () => {
-    const invalidArgs = {
-      _: null,
-      provider: 'default',
-    };
-
-    expect(() => asTaskArgs(invalidArgs)).toThrow(
-      'Arguments must have a "_" property that is an array',
-    );
-  });
-
-  it('should handle empty array for _ property', () => {
-    const validArgs = {
-      _: [],
-      provider: 'default',
-    };
-
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: undefined,
-      provider: 'default',
+    it('should throw error for non-object input', () => {
+      expect(() => asTaskArgs('string')).toThrow('Arguments must be an object');
+      expect(() => asTaskArgs(123)).toThrow('Arguments must be an object');
+      expect(() => asTaskArgs(true)).toThrow('Arguments must be an object');
+      expect(() => asTaskArgs(false)).toThrow('Arguments must be an object');
+      expect(() => asTaskArgs([])).toThrow('Arguments must be an object');
     });
-    expect(result.taskName).toBeUndefined();
-  });
 
-  it('should accept array with only strings for _ property', () => {
-    const validArgs = {
-      _: ['string', '123', 'true', 'null', 'undefined'],
-      provider: 'default',
-    };
+    it('should throw error when _ property is missing', () => {
+      const invalidArgs = {
+        provider: 'default',
+      };
 
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'string',
-      provider: 'default',
+      expect(() => asTaskArgs(invalidArgs)).toThrow(
+        'Arguments must have a "_" property that is an array',
+      );
     });
-    expect(result.taskName).toBe('string');
-  });
 
-  it('should extract taskName from first argument', () => {
-    const validArgs = {
-      _: ['command'],
-      provider: 'default',
-      extraProperty: 'value',
-      anotherProperty: 123,
-    };
+    it('should throw error when _ property is not an array', () => {
+      const invalidArgs = {
+        _: 'not an array',
+        provider: 'default',
+      };
 
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'command',
-      provider: 'default',
+      expect(() => asTaskArgs(invalidArgs)).toThrow(
+        'Arguments must have a "_" property that is an array',
+      );
     });
-    expect(result.taskName).toBe('command');
-  });
 
-  it('should accept check-alerts task with provider', () => {
-    const validArgs = {
-      _: ['check-alerts'],
-      provider: 'default',
-    };
+    it('should throw error when _ property is null', () => {
+      const invalidArgs = {
+        _: null,
+        provider: 'default',
+      };
 
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'check-alerts',
-      provider: 'default',
+      expect(() => asTaskArgs(invalidArgs)).toThrow(
+        'Arguments must have a "_" property that is an array',
+      );
     });
-    expect(result.taskName).toBe('check-alerts');
-    // For check-alerts tasks, provider property is directly accessible
-    if (result.taskName === 'check-alerts') {
-      expect(result.provider).toBe('default');
-    }
-  });
 
-  it('should accept check-alerts task without provider', () => {
-    const validArgs = {
-      _: ['check-alerts'],
-    };
+    it('should throw error when _ is empty', () => {
+      const validArgs = {
+        _: [],
+        provider: 'default',
+      };
 
-    const result = asTaskArgs(validArgs);
-
-    expect(result).toEqual({
-      taskName: 'check-alerts',
-      provider: undefined,
+      expect(() => asTaskArgs(validArgs)).toThrow(
+        'Task name needs to be specified',
+      );
     });
-    expect(result.taskName).toBe('check-alerts');
-    // For check-alerts tasks, provider property is directly accessible
-    if (result.taskName === 'check-alerts') {
-      expect(result.provider).toBeUndefined();
-    }
   });
 
-  it('should accept ping-pong task without provider', () => {
-    const validArgs = {
-      _: ['ping-pong'],
-    };
+  describe('check-alerts task', () => {
+    it('should accept check-alerts task with provider', () => {
+      const validArgs = {
+        _: ['check-alerts'],
+        provider: 'default',
+      };
 
-    const result = asTaskArgs(validArgs);
+      const result = asTaskArgs(validArgs);
 
-    expect(result).toEqual({
-      taskName: 'ping-pong',
+      expect(result).toEqual({
+        taskName: 'check-alerts',
+        provider: 'default',
+      });
+      expect(result.taskName).toBe('check-alerts');
+      // For check-alerts tasks, provider property is directly accessible
+      if (result.taskName === 'check-alerts') {
+        expect(result.provider).toBe('default');
+      }
     });
-    expect(result.taskName).toBe('ping-pong');
-    // Ping-pong tasks should not have a provider property
-    expect('provider' in result).toBe(false);
-  });
 
-  describe('concurrency parameter validation', () => {
+    it('should accept check-alerts task without provider', () => {
+      const validArgs = {
+        _: ['check-alerts'],
+      };
+
+      const result = asTaskArgs(validArgs);
+
+      expect(result).toEqual({
+        taskName: 'check-alerts',
+        provider: undefined,
+      });
+      expect(result.taskName).toBe('check-alerts');
+      // For check-alerts tasks, provider property is directly accessible
+      if (result.taskName === 'check-alerts') {
+        expect(result.provider).toBeUndefined();
+      }
+    });
+
     it('should accept check-alerts task with valid concurrency', () => {
       const validArgs = {
         _: ['check-alerts'],
@@ -224,7 +142,7 @@ describe('asTaskArgs', () => {
       }
     });
 
-    it('should accept check-alerts task with large concurrency values', () => {
+    it('should accept check-alerts task with a concurrency value', () => {
       const validArgs = {
         _: ['check-alerts'],
         concurrency: 100,
@@ -243,78 +161,13 @@ describe('asTaskArgs', () => {
       }
     });
 
-    it('should accept check-alerts task without concurrency parameter', () => {
-      const validArgs = {
-        _: ['check-alerts'],
-        provider: 'default',
-      };
-
-      const result = asTaskArgs(validArgs);
-
-      expect(result).toEqual({
-        taskName: 'check-alerts',
-        provider: 'default',
-        concurrency: undefined,
-      });
-      expect(result.taskName).toBe('check-alerts');
-      if (result.taskName === 'check-alerts') {
-        expect(result.concurrency).toBeUndefined();
-      }
-    });
-
     it('should throw error when concurrency is not a number', () => {
       const invalidArgs = {
         _: ['check-alerts'],
         concurrency: 'invalid',
       };
 
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be a number if provided',
-      );
-    });
-
-    it('should throw error when concurrency is boolean', () => {
-      const invalidArgs = {
-        _: ['check-alerts'],
-        concurrency: true,
-      };
-
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be a number if provided',
-      );
-    });
-
-    it('should throw error when concurrency is null', () => {
-      const invalidArgs = {
-        _: ['check-alerts'],
-        concurrency: null,
-      };
-
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be a number if provided',
-      );
-    });
-
-    it('should throw error when concurrency is an object', () => {
-      const invalidArgs = {
-        _: ['check-alerts'],
-        concurrency: { value: 4 },
-      };
-
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be a number if provided',
-      );
-    });
-
-    it('should throw error when concurrency is an array', () => {
-      const invalidArgs = {
-        _: ['check-alerts'],
-        concurrency: [4],
-      };
-
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be a number if provided',
-      );
+      expect(() => asTaskArgs(invalidArgs)).toThrow('Expected number');
     });
 
     it('should throw error when concurrency is zero', () => {
@@ -324,7 +177,7 @@ describe('asTaskArgs', () => {
       };
 
       expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency cannot be less than 1',
+        'concurrency must be at least 1',
       );
     });
 
@@ -335,18 +188,7 @@ describe('asTaskArgs', () => {
       };
 
       expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency cannot be less than 1',
-      );
-    });
-
-    it('should throw error when concurrency is a negative decimal', () => {
-      const invalidArgs = {
-        _: ['check-alerts'],
-        concurrency: -0.5,
-      };
-
-      expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be an integer if provided',
+        'concurrency must be at least 1',
       );
     });
 
@@ -357,36 +199,86 @@ describe('asTaskArgs', () => {
       };
 
       expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be an integer if provided',
+        'concurrency must be an integer',
       );
     });
 
-    it('should throw error when concurrency is a small decimal', () => {
+    it('should accept check-alerts task with valid sourceTimeoutMs', () => {
+      const validArgs = {
+        _: ['check-alerts'],
+        sourceTimeoutMs: 5000,
+      };
+
+      const result = asTaskArgs(validArgs);
+
+      expect(result).toEqual({
+        taskName: 'check-alerts',
+        provider: undefined,
+        concurrency: undefined,
+        sourceTimeoutMs: 5000,
+      });
+      expect(result.taskName).toBe('check-alerts');
+      if (result.taskName === 'check-alerts') {
+        expect(result.sourceTimeoutMs).toBe(5000);
+      }
+    });
+
+    it('should accept check-alerts task with sourceTimeoutMs of 0', () => {
+      const validArgs = {
+        _: ['check-alerts'],
+        sourceTimeoutMs: 0,
+      };
+
+      const result = asTaskArgs(validArgs);
+
+      expect(result).toEqual({
+        taskName: 'check-alerts',
+        provider: undefined,
+        concurrency: undefined,
+        sourceTimeoutMs: 0,
+      });
+      expect(result.taskName).toBe('check-alerts');
+      if (result.taskName === 'check-alerts') {
+        expect(result.sourceTimeoutMs).toBe(0);
+      }
+    });
+
+    it('should throw error when sourceTimeoutMs is not a number', () => {
       const invalidArgs = {
         _: ['check-alerts'],
-        concurrency: 1.1,
+        sourceTimeoutMs: 'invalid',
+      };
+
+      expect(() => asTaskArgs(invalidArgs)).toThrow('Expected number');
+    });
+
+    it('should throw error when sourceTimeoutMs is negative', () => {
+      const invalidArgs = {
+        _: ['check-alerts'],
+        sourceTimeoutMs: -1,
       };
 
       expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be an integer if provided',
+        'sourceTimeoutMs must be a non-negative value',
       );
     });
 
-    it('should throw error when concurrency is a large decimal', () => {
+    it('should throw error when sourceTimeoutMs is a small decimal', () => {
       const invalidArgs = {
         _: ['check-alerts'],
-        concurrency: 100.999,
+        sourceTimeoutMs: 1.1,
       };
 
       expect(() => asTaskArgs(invalidArgs)).toThrow(
-        'Concurrency must be an integer if provided',
+        'sourceTimeoutMs must be an int',
       );
     });
+  });
 
-    it('should ignore concurrency parameter for non-check-alerts tasks', () => {
+  describe('ping-pong task', () => {
+    it('should accept ping-pong task without provider', () => {
       const validArgs = {
         _: ['ping-pong'],
-        concurrency: 4,
       };
 
       const result = asTaskArgs(validArgs);
@@ -395,25 +287,8 @@ describe('asTaskArgs', () => {
         taskName: 'ping-pong',
       });
       expect(result.taskName).toBe('ping-pong');
-      // Ping-pong tasks should not have a concurrency property
-      expect('concurrency' in result).toBe(false);
-    });
-
-    it('should ignore concurrency parameter for unknown task types', () => {
-      const validArgs = {
-        _: ['unknown-task'],
-        concurrency: 4,
-      };
-
-      const result = asTaskArgs(validArgs);
-
-      expect(result).toEqual({
-        taskName: 'unknown-task',
-        provider: undefined,
-      });
-      expect(result.taskName).toBe('unknown-task');
-      // Unknown task types should not process concurrency parameter
-      expect('concurrency' in result).toBe(false);
+      // Ping-pong tasks should not have a provider property
+      expect('provider' in result).toBe(false);
     });
   });
 });

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -448,7 +448,10 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
           alertCount: alerts.length,
         });
 
-        const clickhouseClient = await this.provider.getClickHouseClient(conn);
+        const clickhouseClient = await this.provider.getClickHouseClient(
+          conn,
+          this.args.sourceTimeoutMs,
+        );
 
         for (const alert of alerts) {
           await this.task_queue.add(() =>

--- a/packages/api/src/tasks/providers/default.ts
+++ b/packages/api/src/tasks/providers/default.ts
@@ -297,12 +297,10 @@ export default class DefaultAlertProvider implements AlertProvider {
     return new Map<string, IWebhook>(webhooks.map(w => [w.id, w]));
   }
 
-  async getClickHouseClient({
-    host,
-    username,
-    password,
-    id,
-  }: IConnection): Promise<ClickhouseClient> {
+  async getClickHouseClient(
+    { host, username, password, id }: IConnection,
+    requestTimeout?: number,
+  ): Promise<ClickhouseClient> {
     if (!password && password !== '') {
       logger.info({
         message: `connection password not found`,
@@ -316,6 +314,7 @@ export default class DefaultAlertProvider implements AlertProvider {
       username,
       password,
       application: `hyperdx-alerts ${config.CODE_VERSION}`,
+      requestTimeout: requestTimeout ?? 30_000,
     });
   }
 }

--- a/packages/api/src/tasks/providers/index.ts
+++ b/packages/api/src/tasks/providers/index.ts
@@ -14,6 +14,7 @@ import DefaultAlertProvider from '@/tasks/providers/default';
 import logger from '@/utils/logger';
 
 import { AggregatedAlertHistory } from '../checkAlerts';
+import { CheckAlertsTaskArgs } from '../types';
 
 export enum AlertTaskType {
   SAVED_SEARCH,
@@ -81,7 +82,10 @@ export interface AlertProvider {
   getWebhooks(teamId: string | ObjectId): Promise<Map<string, IWebhook>>;
 
   /** Create and return an authenticated ClickHouse client */
-  getClickHouseClient(connection: IConnection): Promise<ClickhouseClient>;
+  getClickHouseClient(
+    connection: IConnection,
+    requestTimeout?: number,
+  ): Promise<ClickhouseClient>;
 }
 
 const ADDITIONAL_PROVIDERS: Record<string, () => AlertProvider> = {

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -408,6 +408,8 @@ export type ClickhouseClientOptions = {
   queryTimeout?: number;
   /** Application name, used as the client's HTTP user-agent header */
   application?: string;
+  /** Defines how long the client will wait for a response from the ClickHouse server before aborting the request */
+  requestTimeout?: number;
 };
 
 export abstract class BaseClickhouseClient {
@@ -431,6 +433,7 @@ export abstract class BaseClickhouseClient {
     password,
     queryTimeout,
     application,
+    requestTimeout,
   }: ClickhouseClientOptions) {
     this.host = host!;
     this.username = username;
@@ -438,6 +441,9 @@ export abstract class BaseClickhouseClient {
     this.queryTimeout = queryTimeout;
     this.maxRowReadOnly = false;
     this.application = application;
+    if (requestTimeout != null && requestTimeout >= 0) {
+      this.requestTimeout = requestTimeout;
+    }
   }
 
   protected getClient(): WebClickHouseClient | NodeClickHouseClient {


### PR DESCRIPTION
Provides support for defining the ClickHouse client request timeout from a command line arg. Uses a default value of 30 seconds if the argument is not defined.

Refactors the task arg validation and parsing to leverage zod now that we have more than a few parameters.