### PR TITLE
feat: handle k8s metrics semantic convention updates

### DIFF
--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -20,6 +20,7 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import { SegmentedControl, Select as MSelect } from '@mantine/core';
 
+import { getMetricNameSql } from './otelSemanticConventions';
 import {
   AggFn,
   ChartSeries,
@@ -707,6 +708,10 @@ export const convertV1ChartConfigToV2 = (
         const [metricName, rawMetricDataType] = field
           .split(' - ')
           .map(s => s.trim());
+
+        // Check if this metric name needs version-based SQL transformation
+        const metricNameSql = getMetricNameSql(metricName);
+
         const metricDataType = z
           .nativeEnum(MetricsDataTypeV2)
           .parse(rawMetricDataType?.toLowerCase());
@@ -715,6 +720,7 @@ export const convertV1ChartConfigToV2 = (
           metricType: metricDataType,
           valueExpression: field,
           metricName,
+          metricNameSql,
           aggConditionLanguage: 'lucene',
           aggCondition: s.where,
         };

--- a/packages/app/src/otelSemanticConventions.ts
+++ b/packages/app/src/otelSemanticConventions.ts
@@ -1,0 +1,47 @@
+/**
+ * OpenTelemetry Semantic Conventions utilities
+ * Handles transformations between different versions of OTel semantic conventions
+ */
+
+/**
+ * Mapping of old metric names to new metric names based on semantic convention version
+ */
+const METRIC_NAME_MIGRATIONS: Record<
+  string,
+  {
+    oldName: string;
+    newName: string;
+    versionThreshold: string;
+  }
+> = {
+  'k8s.pod.cpu.utilization': {
+    oldName: 'k8s.pod.cpu.utilization',
+    newName: 'k8s.pod.cpu.usage',
+    versionThreshold: '0.125.0',
+  },
+  'k8s.node.cpu.utilization': {
+    oldName: 'k8s.node.cpu.utilization',
+    newName: 'k8s.node.cpu.usage',
+    versionThreshold: '0.125.0',
+  },
+  'container.cpu.utilization': {
+    oldName: 'container.cpu.utilization',
+    newName: 'container.cpu.usage',
+    versionThreshold: '0.125.0',
+  },
+};
+
+/**
+ * Generates SQL expression to dynamically select metric name based on ScopeVersion
+ * @param metricName - The metric name to check for migrations
+ * @returns SQL expression if migration exists, undefined otherwise
+ */
+export function getMetricNameSql(metricName: string): string | undefined {
+  const migration = METRIC_NAME_MIGRATIONS[metricName];
+
+  if (!migration) {
+    return undefined;
+  }
+
+  return `if(greaterOrEquals(ScopeVersion, '${migration.versionThreshold}'), '${migration.newName}', '${migration.oldName}')`;
+}

--- a/packages/common-utils/src/renderChartConfig.ts
+++ b/packages/common-utils/src/renderChartConfig.ts
@@ -1,9 +1,24 @@
 import isPlainObject from 'lodash/isPlainObject';
 import * as SQLParser from 'node-sql-parser';
+import SqlString from 'sqlstring';
 
 import { ChSql, chSql, concatChSql, wrapChSqlIfNotEmpty } from '@/clickhouse';
 import { Metadata } from '@/metadata';
 import { CustomSchemaSQLSerializerV2, SearchQueryBuilder } from '@/queryParser';
+
+/**
+ * Helper function to create a MetricName filter condition.
+ * Uses metricNameSql if available (for dynamic SQL), otherwise falls back to metricName.
+ */
+function createMetricNameFilter(
+  metricName: string,
+  metricNameSql?: string,
+): string {
+  return SqlString.format(
+    'MetricName = ?',
+    metricNameSql ? SqlString.raw(metricNameSql) : [metricName],
+  );
+}
 import {
   AggregateFunction,
   AggregateFunctionWithCombinators,
@@ -940,7 +955,7 @@ async function translateMetricChartConfig(
     throw new Error('multi select or string select on metrics not supported');
   }
 
-  const { metricType, metricName, ..._select } = select[0]; // Initial impl only supports one metric select per chart config
+  const { metricType, metricName, metricNameSql, ..._select } = select[0]; // Initial impl only supports one metric select per chart config
   if (metricType === MetricsDataType.Gauge && metricName) {
     const timeBucketCol = '__hdx_time_bucket2';
     const timeExpr = timeBucketExpr({
@@ -963,7 +978,7 @@ async function translateMetricChartConfig(
           ...(filters ?? []),
           {
             type: 'sql',
-            condition: `MetricName = '${metricName}'`,
+            condition: createMetricNameFilter(metricName, metricNameSql),
           },
         ],
       },
@@ -1054,7 +1069,7 @@ async function translateMetricChartConfig(
           ...(filters ?? []),
           {
             type: 'sql',
-            condition: `MetricName = '${metricName}'`,
+            condition: createMetricNameFilter(metricName, metricNameSql),
           },
         ],
         includedDataInterval:
@@ -1168,7 +1183,7 @@ async function translateMetricChartConfig(
         ...(filters ?? []),
         {
           type: 'sql',
-          condition: `MetricName = '${metricName}'`,
+          condition: createMetricNameFilter(metricName, metricNameSql),
         },
       ],
       includedDataInterval:

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -105,6 +105,7 @@ export const DerivedColumnSchema = z.intersection(
     alias: z.string().optional(),
     metricType: z.nativeEnum(MetricsDataType).optional(),
     metricName: z.string().optional(),
+    metricNameSql: z.string().optional(),
   }),
 );
 export const SelectListSchema = z.array(DerivedColumnSchema).or(z.string());


### PR DESCRIPTION
Handle OpenTelemetry semantic versions based on the ScopeVersion field (metrics)

Old
<img width="818" height="317" alt="image" src="https://github.com/user-attachments/assets/ceea52c6-ad06-4295-afae-a44f21b2e962" />

New
<img width="568" height="329" alt="image" src="https://github.com/user-attachments/assets/d2e282b2-cfd7-490a-a64d-502881a360a2" />


