### PR TITLE
Bump Nuqs & Typescript Versions

### DIFF
--- a/.changeset/gold-points-stare.md
+++ b/.changeset/gold-points-stare.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Bump Nuqs and Typescript Versions

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^10.8.1",
     "tsc-alias": "^1.8.8",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.9.3"
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "start": "node ./dist/index.js",

--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
-  transformIgnorePatterns: ['/node_modules/(?!(ky|ky-universal|flat))'],
+  transformIgnorePatterns: ['/node_modules/(?!(ky|ky-universal|flat|nuqs))'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,7 @@
     "ky-universal": "^0.10.1",
     "lodash": "^4.17.21",
     "next": "^14.2.32",
-    "next-query-params": "^4.1.0",
+    "next-query-params": "^4.3.1",
     "next-runtime-env": "1",
     "next-seo": "^4.28.1",
     "nextra": "2.0.1",
@@ -149,7 +149,7 @@
     "stylelint-config-standard-scss": "^13.1.0",
     "stylelint-prettier": "^5.0.0",
     "ts-jest": "^29.2.6",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.3"
   },
   "nx": {
     "targets": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -70,7 +70,7 @@
     "nextra": "2.0.1",
     "nextra-theme-docs": "^2.0.2",
     "numbro": "^2.4.0",
-    "nuqs": "^1.17.0",
+    "nuqs": "^2.7.1",
     "object-hash": "^3.0.0",
     "react": "18.3.1",
     "react-bootstrap": "^2.4.0",

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import { NextAdapter } from 'next-query-params';
 import randomUUID from 'crypto-randomuuid';
 import { enableMapSet } from 'immer';
+import { NuqsAdapter } from 'nuqs/adapters/next/pages';
 import SSRProvider from 'react-bootstrap/SSRProvider';
 import { QueryParamProvider } from 'use-query-params';
 import HyperDX from '@hyperdx/browser';
@@ -120,18 +121,25 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       </Head>
 
       <SSRProvider>
-        <HDXQueryParamProvider>
-          <QueryParamProvider adapter={NextAdapter}>
-            <QueryClientProvider client={queryClient}>
-              <ThemeWrapper fontFamily={userPreferences.font}>
-                {getLayout(<Component {...pageProps} />)}
-                {confirmModal}
-              </ThemeWrapper>
-              <ReactQueryDevtools initialIsOpen={true} />
-              {background}
-            </QueryClientProvider>
-          </QueryParamProvider>
-        </HDXQueryParamProvider>
+        <NuqsAdapter
+          defaultOptions={{
+            // adding this in to maintain v1->v2 compatibility. We can remove this in the future.
+            clearOnDefault: false,
+          }}
+        >
+          <HDXQueryParamProvider>
+            <QueryParamProvider adapter={NextAdapter}>
+              <QueryClientProvider client={queryClient}>
+                <ThemeWrapper fontFamily={userPreferences.font}>
+                  {getLayout(<Component {...pageProps} />)}
+                  {confirmModal}
+                </ThemeWrapper>
+                <ReactQueryDevtools initialIsOpen={true} />
+                {background}
+              </QueryClientProvider>
+            </QueryParamProvider>
+          </HDXQueryParamProvider>
+        </NuqsAdapter>
       </SSRProvider>
     </React.Fragment>
   );

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -33,7 +33,8 @@ import 'uplot/dist/uPlot.min.css';
 
 // Polyfill crypto.randomUUID for non-HTTPS environments
 if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
-  crypto.randomUUID = randomUUID;
+  crypto.randomUUID =
+    randomUUID as () => `${string}-${string}-${string}-${string}-${string}`;
 }
 
 enableMapSet();

--- a/packages/app/src/BenchmarkPage.tsx
+++ b/packages/app/src/BenchmarkPage.tsx
@@ -7,6 +7,7 @@ import {
   useQueryState,
 } from 'nuqs';
 import { useForm } from 'react-hook-form';
+import z from 'zod';
 import { DataFormat } from '@hyperdx/common-utils/dist/clickhouse';
 import { DisplayType } from '@hyperdx/common-utils/dist/types';
 import {
@@ -147,15 +148,15 @@ function useIndexes(
 }
 
 function BenchmarkPage() {
-  const [queries, setQueries] = useQueryState<string[]>(
+  const [queries, setQueries] = useQueryState(
     'queries',
-    parseAsJson(),
+    parseAsJson(z.array(z.string())),
   );
-  const [connections, setConnections] = useQueryState<string[]>(
+  const [connections, setConnections] = useQueryState(
     'connections',
-    parseAsJson(),
+    parseAsJson(z.array(z.string())),
   );
-  const [iterations, setIterations] = useQueryState<number>(
+  const [iterations, setIterations] = useQueryState(
     'iterations',
     parseAsInteger.withDefault(3),
   );

--- a/packages/app/src/DBChartPage.tsx
+++ b/packages/app/src/DBChartPage.tsx
@@ -3,7 +3,10 @@ import dynamic from 'next/dynamic';
 import { parseAsJson, parseAsStringEnum, useQueryState } from 'nuqs';
 import { useForm } from 'react-hook-form';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { SavedChartConfig } from '@hyperdx/common-utils/dist/types';
+import {
+  SavedChartConfig,
+  SavedChartConfigSchema,
+} from '@hyperdx/common-utils/dist/types';
 import {
   Box,
   Button,
@@ -180,7 +183,7 @@ function DBChartExplorerPage() {
 
   const [chartConfig, setChartConfig] = useQueryState(
     'config',
-    parseAsJson<SavedChartConfig>().withDefault({
+    parseAsJson(SavedChartConfigSchema).withDefault({
       ...DEFAULT_CHART_CONFIG,
       source: sources?.[0]?.id ?? '',
     }),

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -66,7 +66,6 @@ import OnboardingModal from './components/OnboardingModal';
 import { Tags } from './components/Tags';
 import useDashboardFilters from './hooks/useDashboardFilters';
 import { useDashboardRefresh } from './hooks/useDashboardRefresh';
-import { parseAsStringWithNewLines } from './utils/queryParsers';
 import api from './api';
 import { DEFAULT_CHART_CONFIG } from './ChartUtils';
 import { IS_LOCAL_MODE } from './config';
@@ -558,7 +557,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   ) as [SQLInterval | undefined, (value: SQLInterval | undefined) => void];
   const [where, setWhere] = useQueryState(
     'where',
-    parseAsStringWithNewLines.withDefault(''),
+    parseAsString.withDefault(''),
   );
   const [whereLanguage, setWhereLanguage] = useQueryState(
     'whereLanguage',

--- a/packages/app/src/__tests__/timeQuery.test.tsx
+++ b/packages/app/src/__tests__/timeQuery.test.tsx
@@ -69,6 +69,7 @@ describe.skip('useTimeQuery tests', () => {
     jest.resetAllMocks();
     locationMock = new LocationMock('https://www.hyperdx.io/');
     testRouter = new TestRouter(locationMock);
+    // @ts-ignore - this is a mock
     window.location = locationMock;
 
     (useRouter as jest.Mock).mockReturnValue(testRouter);
@@ -77,6 +78,7 @@ describe.skip('useTimeQuery tests', () => {
   });
 
   afterAll(() => {
+    // @ts-ignore - this is a mock
     window.location = savedLocation;
   });
 

--- a/packages/app/src/__tests__/timeQuery.test.tsx
+++ b/packages/app/src/__tests__/timeQuery.test.tsx
@@ -60,7 +60,7 @@ const { location: savedLocation } = window;
 // This was originally disabled for nuqs v2 upgrade,
 // however, after upgrading it seems that the code has diverged from the tests
 // and the tests are no longer valid.
-// We should improve or re-write the tests to be more in line with the code.
+// TODO: We should improve or re-write the tests to be more in line with the code.
 describe.skip('useTimeQuery tests', () => {
   let testRouter: TestRouter;
   let locationMock: LocationMock;

--- a/packages/app/src/__tests__/timeQuery.test.tsx
+++ b/packages/app/src/__tests__/timeQuery.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useImperativeHandle } from 'react';
 import { useRouter } from 'next/router';
 import { NextAdapter } from 'next-query-params';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { QueryParamProvider } from 'use-query-params';
 import { LocationMock } from '@jedmao/location';
 import { render } from '@testing-library/react';
@@ -37,7 +38,9 @@ function TestWrapper({
     setUserPreference({ isUTC });
   }, [setUserPreference, isUTC]);
   return (
-    <QueryParamProvider adapter={NextAdapter}>{children}</QueryParamProvider>
+    <NuqsTestingAdapter>
+      <QueryParamProvider adapter={NextAdapter}>{children}</QueryParamProvider>
+    </NuqsTestingAdapter>
   );
 }
 
@@ -54,14 +57,16 @@ const TestComponent = React.forwardRef(function Component(
 
 const { location: savedLocation } = window;
 
-// TODO: Issues with testing nuqs :(
-// https://github.com/47ng/nuqs/issues/259
+// This was originally disabled for nuqs v2 upgrade,
+// however, after upgrading it seems that the code has diverged from the tests
+// and the tests are no longer valid.
+// We should improve or re-write the tests to be more in line with the code.
 describe.skip('useTimeQuery tests', () => {
   let testRouter: TestRouter;
   let locationMock: LocationMock;
 
   beforeAll(() => {
-    // @ts-ignore - This complains because we can only delete optional operands
+    // @ts-expect-error - This complains because we can only delete optional operands
     delete window.location;
   });
 
@@ -69,7 +74,7 @@ describe.skip('useTimeQuery tests', () => {
     jest.resetAllMocks();
     locationMock = new LocationMock('https://www.hyperdx.io/');
     testRouter = new TestRouter(locationMock);
-    // @ts-ignore - this is a mock
+    // @ts-expect-error - this is a mock
     window.location = locationMock;
 
     (useRouter as jest.Mock).mockReturnValue(testRouter);
@@ -78,7 +83,7 @@ describe.skip('useTimeQuery tests', () => {
   });
 
   afterAll(() => {
-    // @ts-ignore - this is a mock
+    // @ts-expect-error - this is a mock
     window.location = savedLocation;
   });
 

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { parseAsJson, useQueryState } from 'nuqs';
 import { useForm } from 'react-hook-form';
+import z from 'zod';
 import { tcFromSource } from '@hyperdx/common-utils/dist/metadata';
 import { SourceKind } from '@hyperdx/common-utils/dist/types';
 import {
@@ -92,7 +93,7 @@ export default function DBTracePanel({
 
   const [eventRowWhere, setEventRowWhere] = useQueryState(
     'eventRowWhere',
-    parseAsJson<{ id: string; type: string }>(),
+    parseAsJson(z.object({ id: z.string(), type: z.string() })),
   );
 
   const {

--- a/packages/app/src/dashboard.ts
+++ b/packages/app/src/dashboard.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { parseAsJson, useQueryState } from 'nuqs';
 import {
   DashboardFilter,
+  DashboardSchema,
   SavedChartConfig,
 } from '@hyperdx/common-utils/dist/types';
 import { notifications } from '@mantine/notifications';
@@ -96,7 +97,7 @@ export function useDashboard({
 
   const [localDashboard, setLocalDashboard] = useQueryState(
     'dashboard',
-    parseAsJson<Dashboard>(),
+    parseAsJson(DashboardSchema),
   );
 
   const updateDashboard = useUpdateDashboard();

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -1,13 +1,17 @@
 import { useCallback, useMemo } from 'react';
 import { parseAsJson, useQueryState } from 'nuqs';
-import { DashboardFilter, Filter } from '@hyperdx/common-utils/dist/types';
+import z from 'zod';
+import {
+  DashboardFilter,
+  FilterSchema,
+} from '@hyperdx/common-utils/dist/types';
 
 import { FilterState, filtersToQuery, parseQuery } from '@/searchFilters';
 
 const useDashboardFilters = (filters: DashboardFilter[]) => {
   const [filterQueries, setFilterQueries] = useQueryState(
     'filters',
-    parseAsJson<Filter[]>(),
+    parseAsJson(z.array(FilterSchema)),
   );
 
   const setFilterValue = useCallback(

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -217,7 +217,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
   useEffect(() => {
     const handleCustomStorageChange = (event: Event) => {
       if (
-        event instanceof CustomEvent<CustomStorageChangeDetail> &&
+        event instanceof CustomEvent &&
         event.detail.key === key &&
         event.detail.instanceId !== instanceId
       ) {

--- a/packages/app/src/utils/queryParsers.ts
+++ b/packages/app/src/utils/queryParsers.ts
@@ -1,13 +1,6 @@
 import { createParser } from 'nuqs';
 import { SortingState } from '@tanstack/react-table';
 
-// Note: this can be deleted once we upgrade to nuqs v2.2.3
-// https://github.com/47ng/nuqs/pull/783
-export const parseAsStringWithNewLines = createParser<string>({
-  parse: value => value.replace(/%0A/g, '\n'),
-  serialize: value => value.replace(/\n/g, '%0A'),
-});
-
 export const parseAsSortingStateString = createParser<SortingState[number]>({
   parse: value => {
     if (!value) {

--- a/packages/common-utils/package.json
+++ b/packages/common-utils/package.json
@@ -45,7 +45,7 @@
     "tsc-alias": "^1.8.8",
     "tsconfig-paths": "^4.2.0",
     "tsup": "^8.4.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "dev": "nodemon --watch ./src --ext ts --exec \"yarn dev:build\"",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "Node16",
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
     "lib": ["ES2022", "dom"],
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,7 +4555,7 @@ __metadata:
     ts-node: "npm:^10.8.1"
     tsc-alias: "npm:^1.8.8"
     tsconfig-paths: "npm:^4.2.0"
-    typescript: "npm:5.9.3"
+    typescript: "npm:^5.9.3"
     uuid: "npm:^8.3.2"
     winston: "npm:^3.10.0"
     zod: "npm:3.25"
@@ -4642,7 +4642,7 @@ __metadata:
     msw: "npm:^2.3.0"
     msw-storybook-addon: "npm:^2.0.2"
     next: "npm:^14.2.32"
-    next-query-params: "npm:^4.1.0"
+    next-query-params: "npm:^4.3.1"
     next-runtime-env: "npm:1"
     next-seo: "npm:^4.28.1"
     nextra: "npm:2.0.1"
@@ -4685,7 +4685,7 @@ __metadata:
     stylelint-prettier: "npm:^5.0.0"
     timestamp-nano: "npm:^1.0.1"
     ts-jest: "npm:^29.2.6"
-    typescript: "npm:^4.9.5"
+    typescript: "npm:^5.9.3"
     uplot: "npm:^1.6.31"
     uplot-react: "npm:^1.2.2"
     use-query-params: "npm:^2.1.2"
@@ -4737,7 +4737,7 @@ __metadata:
     tsc-alias: "npm:^1.8.8"
     tsconfig-paths: "npm:^4.2.0"
     tsup: "npm:^8.4.0"
-    typescript: "npm:^4.9.5"
+    typescript: "npm:^5.9.3"
     uuid: "npm:^8.3.2"
     zod: "npm:3.25"
   languageName: unknown
@@ -22214,16 +22214,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-query-params@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "next-query-params@npm:4.1.0"
+"next-query-params@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "next-query-params@npm:4.3.1"
   dependencies:
     tslib: "npm:^2.0.3"
   peerDependencies:
-    next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
+    next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     use-query-params: ^2.0.0
-  checksum: 10c0/0e1c0cd270956742be0f17cfded0fead834bee966ca350d5dd5a17a6109d9da9ad101cae4f68065b20ebfd3da89f05121ccb7eeb3424977fb20305ced70e486f
+  checksum: 10c0/d5752b77b7d3606f36703ac664cf95a75fe0bf1c297c1f06083fe61883a6c037d633558208d4f3e03744b31a079a712ced025da7bdb6f90216eb0ec17b7509a3
   languageName: node
   linkType: hard
 
@@ -22642,13 +22642,13 @@ __metadata:
   linkType: hard
 
 "nuqs@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "nuqs@npm:1.17.0"
+  version: 1.20.0
+  resolution: "nuqs@npm:1.20.0"
   dependencies:
     mitt: "npm:^3.0.1"
   peerDependencies:
     next: ">=13.4 <14.0.2 || ^14.0.3"
-  checksum: 10c0/98e26518fdeda9518defe8abb34fd722f9fbc6d62dc7713dbc7bf365b5afc4c7c934088d7c7ed528621c222017841411241f0cfe97c615a3e7fb4d80354e8349
+  checksum: 10c0/8e1b67a96c6fda21023924db03b31f3eecf387097ee23685f35fbd1118ff202d1f8f3efd5e1e45bb5736e701a13da0d6cefc98cbe813315dc6462c2e38e2c93f
   languageName: node
   linkType: hard
 
@@ -28505,7 +28505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
+"typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -28515,33 +28515,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=cef18b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^4.9.5#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4648,7 +4648,7 @@ __metadata:
     nextra: "npm:2.0.1"
     nextra-theme-docs: "npm:^2.0.2"
     numbro: "npm:^2.4.0"
-    nuqs: "npm:^1.17.0"
+    nuqs: "npm:^2.7.1"
     object-hash: "npm:^3.0.0"
     postcss: "npm:^8.4.38"
     postcss-preset-mantine: "npm:^1.15.0"
@@ -8444,7 +8444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:1.0.0, @standard-schema/spec@npm:^1.0.0":
   version: 1.0.0
   resolution: "@standard-schema/spec@npm:1.0.0"
   checksum: 10c0/a1ab9a8bdc09b5b47aa8365d0e0ec40cc2df6437be02853696a0e377321653b0d3ac6f079a8c67d5ddbe9821025584b1fb71d9cc041a6666a96f1fadf2ece15f
@@ -21915,13 +21915,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mitt@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mitt@npm:3.0.1"
-  checksum: 10c0/3ab4fdecf3be8c5255536faa07064d05caa3dd332bd318ff02e04621f7b3069ca1de9106cfe8e7ced675abfc2bec2ce4c4ef321c4a1bb1fb29df8ae090741913
-  languageName: node
-  linkType: hard
-
 "mixme@npm:^0.5.1":
   version: 0.5.9
   resolution: "mixme@npm:0.5.9"
@@ -22641,14 +22634,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nuqs@npm:^1.17.0":
-  version: 1.20.0
-  resolution: "nuqs@npm:1.20.0"
+"nuqs@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "nuqs@npm:2.7.1"
   dependencies:
-    mitt: "npm:^3.0.1"
+    "@standard-schema/spec": "npm:1.0.0"
   peerDependencies:
-    next: ">=13.4 <14.0.2 || ^14.0.3"
-  checksum: 10c0/8e1b67a96c6fda21023924db03b31f3eecf387097ee23685f35fbd1118ff202d1f8f3efd5e1e45bb5736e701a13da0d6cefc98cbe813315dc6462c2e38e2c93f
+    "@remix-run/react": ">=2"
+    "@tanstack/react-router": ^1
+    next: ">=14.2.0"
+    react: ">=18.2.0 || ^19.0.0-0"
+    react-router: ^6 || ^7
+    react-router-dom: ^6 || ^7
+  peerDependenciesMeta:
+    "@remix-run/react":
+      optional: true
+    "@tanstack/react-router":
+      optional: true
+    next:
+      optional: true
+    react-router:
+      optional: true
+    react-router-dom:
+      optional: true
+  checksum: 10c0/dbc7affc1a4cf19dc4d4dd327baa4ac6d1e998dd6303a44d916316433cf71e1c2d2e1ff1b3808c4729a78a8b9b89b65b78814cda003621768ce8f695527b8a82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Originally planned on just bumping `nuqs` but it requirest a later version of Typescript. 

This PR does 3 things:

1. Upgrades Typescript from 4.9.5 to latest 5.x (and fixes a few new correctly flagged ts errors)
2. Upgrades `nuqs` to v2 and fixed all issues following [upgrade docs](https://nuqs.dev/blog/nuqs-2)
3. Updated tests to use the new nuqs config where possible

Fixes HDX-2558
