### PR TITLE
fix: add json compatibility for infrastructure tab

### DIFF
--- a/.changeset/tricky-dodos-report.md
+++ b/.changeset/tricky-dodos-report.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: add json compatibility for infrastructure tab

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useMemo } from 'react';
-import { flatten } from 'flat';
 import isString from 'lodash/isString';
 import pickBy from 'lodash/pickBy';
 import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
@@ -70,17 +69,9 @@ export function RowOverviewPanel({
     return false;
   });
 
-  // memo
-  const resourceAttributes = useMemo(() => {
-    return flatten<string, Record<string, string>>(
-      firstRow?.__hdx_resource_attributes ?? EMPTY_OBJ,
-    );
-  }, [firstRow?.__hdx_resource_attributes]);
-
-  const _eventAttributes = firstRow?.__hdx_event_attributes ?? EMPTY_OBJ;
-  const flattenedEventAttributes = useMemo(() => {
-    return flatten<string, Record<string, string>>(_eventAttributes);
-  }, [_eventAttributes]);
+  const resourceAttributes = firstRow?.__hdx_resource_attributes ?? EMPTY_OBJ;
+  const flattenedEventAttributes =
+    firstRow?.__hdx_event_attributes ?? EMPTY_OBJ;
 
   const dataAttributes =
     eventAttributesExpr &&

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -233,11 +233,11 @@ const DBRowSidePanel = ({
       if (!source?.resourceAttributesExpression || !normalizedRow) {
         return false;
       }
+
+      const resourceAttrs = normalizedRow['__hdx_resource_attributes'];
       return (
-        normalizedRow[source.resourceAttributesExpression]?.['k8s.pod.uid'] !=
-          null ||
-        normalizedRow[source.resourceAttributesExpression]?.['k8s.node.name'] !=
-          null
+        resourceAttrs?.['k8s.pod.uid'] != null ||
+        resourceAttrs?.['k8s.node.name'] != null
       );
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Hi! This PR fixes two things to improve the infrastructure context panel.

1. Change the CPU field used from utilization to usage, since [utilization has been deprecated](https://opentelemetry.io/blog/2025/kubeletstats-receiver-metrics-deprecation/)
2. Make the infrastructure panel work with JSON-based schemas

Feel free to make suggestions about a different approach, I wasn't sure about the current idiomatic way to handle the JSON<>Map distinction.