### PR TITLE
fix: Keep k8s dashboard params up to date with defaulted sources

### DIFF
--- a/packages/app/src/KubernetesDashboardPage.tsx
+++ b/packages/app/src/KubernetesDashboardPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import cx from 'classnames';
@@ -832,6 +832,18 @@ function KubernetesDashboardPage() {
       metricSourceId,
     },
   });
+
+  useEffect(() => {
+    if (logSourceId && logSourceId !== _logSourceId) {
+      setLogSourceId(logSourceId);
+    }
+  }, [logSourceId, _logSourceId, setLogSourceId]);
+
+  useEffect(() => {
+    if (metricSourceId && metricSourceId !== _metricSourceId) {
+      setMetricSourceId(metricSourceId);
+    }
+  }, [metricSourceId, _metricSourceId, setMetricSourceId]);
 
   watch((data, { name, type }) => {
     if (name === 'logSourceId' && type === 'change') {


### PR DESCRIPTION
This PR fixes a bug in the K8s dashboard which causes the source selects to be out of sync with the sources that are actually used.

Before, any default-selected source would not be populated in the query parameters, and changing the log source to a connection without a metric source would cause the metric source to default to `undefined` without updating the metric source select.

https://github.com/user-attachments/assets/42261a9d-d84d-43ed-969c-8238581ceec5

Now, the default-selected sources are populated in the query parameters, and changing one source does not change what the other one was defaulted to.


https://github.com/user-attachments/assets/92b7242a-4023-441e-9c32-e5cd4f7ee386

