### PR TITLE
fix: ignore max_rows_to_read for filter values distribution

### DIFF
--- a/.changeset/short-owls-jog.md
+++ b/.changeset/short-owls-jog.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: ignore max_rows_to_read for filter values distribution

--- a/packages/common-utils/src/metadata.ts
+++ b/packages/common-utils/src/metadata.ts
@@ -633,6 +633,8 @@ export class Metadata {
               // Set max_rows_to_group_by to avoid using too much memory when grouping on high cardinality key columns
               max_rows_to_group_by: `${limit * 10}`,
               group_by_overflow_mode: 'any',
+              // disable max_rows_to_read limit since this is a sampled query that only happens after the user toggles it on
+              max_rows_to_read: '0',
             },
           })
           .then(res =>


### PR DESCRIPTION
This PR updates the filter values distribution functionality to ignore the max_rows_to_read limit, since (a) the query is already sampling and (b) the query only happens when the user toggles it on for a particular filter facet.

If the query takes too long, it will timeout and the functionality will toggle off for the offending filter.