### PR TITLE
fix queryParser.

### DIFF
--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -832,5 +832,9 @@ const mergeImplicitTerms = (node: any): any => {
     };
   }
 
-  return node;
+  return {
+    ...node,
+    left,
+    right,
+  };
 };


### PR DESCRIPTION
first, it fixed https://github.com/hyperdxio/hyperdx/issues/1202, escape space correctly.

second, it could recognized space without escape.

so the old lucene search:
"failed\\\\ to\\\\ do\\\\ something" could be converted to "failed to do something"