### PR TITLE
fix: Set team and connection attributes on span instead of trace

### DIFF
--- a/.changeset/afraid-trains-sort.md
+++ b/.changeset/afraid-trains-sort.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: Set team and connection attributes on span instead of trace

--- a/packages/api/src/tasks/checkAlerts.ts
+++ b/packages/api/src/tasks/checkAlerts.ts
@@ -9,7 +9,6 @@ import {
   ChartConfigWithOptDateRange,
   DisplayType,
 } from '@hyperdx/common-utils/dist/types';
-import { setTraceAttributes } from '@hyperdx/node-opentelemetry';
 import * as fns from 'date-fns';
 import { chunk, isString } from 'lodash';
 import { ObjectId } from 'mongoose';
@@ -436,10 +435,11 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
     teamWebhooksById: Map<string, IWebhook>,
   ) {
     await tasksTracer.startActiveSpan('processAlertTask', async span => {
-      setTraceAttributes({
-        'hyperdx.alerts.team.id': alertTask.conn.team.toString(),
-        'hyperdx.alerts.connection.id': alertTask.conn.id,
-      });
+      span.setAttribute(
+        'hyperdx.alerts.team.id',
+        alertTask.conn.team.toString(),
+      );
+      span.setAttribute('hyperdx.alerts.connection.id', alertTask.conn.id);
 
       try {
         const { alerts, conn } = alertTask;
@@ -484,10 +484,6 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
       message: 'finished provider initialization',
       provider: this.provider.constructor.name,
       args: this.args,
-    });
-
-    setTraceAttributes({
-      'hyperdx.alerts.provider': this.provider.constructor.name,
     });
 
     const alertTasks = await this.provider.getAlertTasks();


### PR DESCRIPTION
Closes HDX-2506

`setTraceAttributes` is not working (see HDX-2599), so for now we will replace it with span attributes, to ensure that we have some way of correlating alert job logs to teams.

<img width="492" height="209" alt="Screenshot 2025-10-14 at 4 07 36 PM" src="https://github.com/user-attachments/assets/46f9391e-e4c9-4a12-bc6b-a37d53ecadf6" />
