### PR TITLE
fix: Fix crash when navigating away from chart explorer search page

### DIFF
--- a/.changeset/nasty-fans-run.md
+++ b/.changeset/nasty-fans-run.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix crash when navigating away from chart explorer search page

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { omit } from 'lodash';
 import {
   Control,
   Controller,
@@ -385,6 +386,10 @@ export type SavedChartConfigWithSelectArray = Omit<
   select: Exclude<SavedChartConfig['select'], string>;
 };
 
+type SavedChartConfigWithSeries = SavedChartConfig & {
+  series: SavedChartConfigWithSelectArray['select'];
+};
+
 export default function EditTimeChartForm({
   dashboardId,
   chartConfig,
@@ -414,10 +419,20 @@ export default function EditTimeChartForm({
   'data-testid'?: string;
   submitRef?: React.MutableRefObject<(() => void) | undefined>;
 }) {
+  // useFieldArray only supports array type fields, and select can be either a string or array.
+  // To solve for this, we maintain an extra form field called 'series' which is always an array.
+  const configWithSeries: SavedChartConfigWithSeries = useMemo(
+    () => ({
+      ...chartConfig,
+      series: Array.isArray(chartConfig.select) ? chartConfig.select : [],
+    }),
+    [chartConfig],
+  );
+
   const { control, watch, setValue, handleSubmit, register } =
-    useForm<SavedChartConfig>({
-      defaultValues: chartConfig,
-      values: chartConfig,
+    useForm<SavedChartConfigWithSeries>({
+      defaultValues: configWithSeries,
+      values: configWithSeries,
       resolver: zodResolver(zSavedChartConfig),
     });
 
@@ -427,8 +442,8 @@ export default function EditTimeChartForm({
     remove: removeSeries,
     swap: swapSeries,
   } = useFieldArray({
-    control: control as Control<SavedChartConfigWithSelectArray>,
-    name: 'select',
+    control: control as Control<SavedChartConfigWithSeries>,
+    name: 'series',
   });
 
   const select = watch('select');
@@ -492,11 +507,18 @@ export default function EditTimeChartForm({
 
   const onSubmit = useCallback(() => {
     handleSubmit(form => {
-      setChartConfig(form);
+      // Merge the series and select fields back together, and prevent the series field from being submitted
+      const config = {
+        ...omit(form, ['series']),
+        select:
+          form.displayType === DisplayType.Search ? form.select : form.series,
+      };
+
+      setChartConfig(config);
       if (tableSource != null) {
-        const isSelectEmpty = !form.select || form.select.length === 0; // select is string or array
+        const isSelectEmpty = !config.select || config.select.length === 0; // select is string or array
         const newConfig = {
-          ...form,
+          ...config,
           from: tableSource.from,
           timestampValueExpression: tableSource.timestampValueExpression,
           dateRange,
@@ -505,7 +527,7 @@ export default function EditTimeChartForm({
           metricTables: tableSource.metricTables,
           select: isSelectEmpty
             ? tableSource.defaultTableSelectExpression || ''
-            : form.select,
+            : config.select,
         };
         setQueriedConfig(
           // WARNING: DON'T JUST ASSIGN OBJECTS OR DO SPREAD OPERATOR STUFF WHEN
@@ -525,12 +547,15 @@ export default function EditTimeChartForm({
   }, [onSubmit, submitRef]);
 
   const handleSave = useCallback(
-    (v: SavedChartConfig) => {
+    (v: SavedChartConfigWithSeries) => {
       // If the chart type is search, we need to ensure the select is a string
       if (displayType === DisplayType.Search && typeof v.select !== 'string') {
         v.select = '';
+      } else if (displayType !== DisplayType.Search) {
+        v.select = v.series;
       }
-      onSave?.(v);
+      // Avoid saving the series field. Series should be persisted in the select field.
+      onSave?.(omit(v, ['series']));
     },
     [onSave, displayType],
   );
@@ -543,17 +568,20 @@ export default function EditTimeChartForm({
     if (name === 'displayType' && type === 'change') {
       if (_.displayType === DisplayType.Search && typeof select !== 'string') {
         setValue('select', '');
+        setValue('series', []);
       }
       if (_.displayType !== DisplayType.Search && typeof select === 'string') {
-        setValue('where', '');
-        setValue('select', [
+        const defaultSeries: SavedChartConfigWithSelectArray['select'] = [
           {
             aggFn: 'count',
             aggCondition: '',
             aggConditionLanguage: 'lucene',
             valueExpression: '',
           },
-        ]);
+        ];
+        setValue('where', '');
+        setValue('select', defaultSeries);
+        setValue('series', defaultSeries);
       }
       onSubmit();
     }
@@ -711,7 +739,7 @@ export default function EditTimeChartForm({
                   index={index}
                   key={field.id}
                   parentRef={parentRef}
-                  namePrefix={`select.${index}.`}
+                  namePrefix={`series.${index}.`}
                   onRemoveSeries={removeSeries}
                   length={fields.length}
                   onSwapSeries={swapSeries}
@@ -773,7 +801,7 @@ export default function EditTimeChartForm({
                       Add Series
                     </Button>
                   )}
-                  {select.length == 2 && displayType !== DisplayType.Number && (
+                  {fields.length == 2 && displayType !== DisplayType.Number && (
                     <Switch
                       label="As Ratio"
                       size="sm"


### PR DESCRIPTION
Fixes HDX-2619

This PR fixes a full page crash whenever navigating away from the Chart Explorer search tab to another page. The issue was caused by the use of `useFieldArray` in the `DBEditTimeChart` component on a field (`select`) which can be either an array or a string. That hook is [known to crash](https://github.com/react-hook-form/react-hook-form/issues/11297) when used on fields which are not arrays of objects.

<details>
<summary>Crash example</summary>

https://github.com/user-attachments/assets/456ae41b-980b-4d7a-a90e-02f9ab055385
</details>

<details>
<summary>Fixed behavior</summary>

https://github.com/user-attachments/assets/517650a6-11d9-4820-b696-44efbb293485
</details>

The fix was to maintain a separate field (`series`) which is always an array. When `select` is an array, `series` matches `select`. Prior to saving or submitting the chart configuration, the `series` value is removed and stored in the `select` field (unless the `select` field is a string, which is the case on the search tab of chart explorer).

Validated:

✅ All tile types work in dashboards, without any change to the storage format (`series` is not persisted as a separate field)
✅ All chart explorer tabs work, without any change to the URL parameter format (`series` is not persisted as a separate URL parameter field)
✅ We aren't using useFieldArray anywhere else in the app
✅ AI Chart Assistant can still set the chart 