### PR TITLE
refactor(tasks): create subdirectory for alerts code

### DIFF
--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -27,7 +27,11 @@ import {
   getPreviousAlertHistories,
   processAlert,
 } from '@/tasks/checkAlerts';
-import { AlertDetails, AlertTaskType, loadProvider } from '@/tasks/providers';
+import {
+  AlertDetails,
+  AlertTaskType,
+  loadProvider,
+} from '@/tasks/checkAlerts/providers';
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateHdxLink,
@@ -35,7 +39,7 @@ import {
   getDefaultExternalAction,
   renderAlertTemplate,
   translateExternalActionsToInternal,
-} from '@/tasks/template';
+} from '@/tasks/checkAlerts/template';
 import * as slack from '@/utils/slack';
 
 // Create provider instance for tests

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
@@ -6,20 +6,19 @@ import { ObjectId } from '@/models';
 import { AlertSource, AlertThresholdType, IAlert } from '@/models/alert';
 import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
-import CheckAlertTask from '@/tasks/checkAlerts';
 import * as checkAlerts from '@/tasks/checkAlerts';
+import CheckAlertTask from '@/tasks/checkAlerts';
 import {
   AlertDetails,
   AlertProvider,
   AlertTaskType,
   loadProvider,
-} from '@/tasks/providers';
+} from '@/tasks/checkAlerts/providers';
+import { CheckAlertsTaskArgs } from '@/tasks/types';
 
-import { CheckAlertsTaskArgs } from '../types';
-
-jest.mock('@/tasks/providers', () => {
+jest.mock('@/tasks/checkAlerts/providers', () => {
   return {
-    ...jest.requireActual('@/tasks/providers'),
+    ...jest.requireActual('@/tasks/checkAlerts/providers'),
     loadProvider: jest.fn(),
   };
 });

--- a/packages/api/src/tasks/checkAlerts/__tests__/singleInvocationAlert.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/singleInvocationAlert.test.ts
@@ -15,7 +15,11 @@ import { SavedSearch } from '@/models/savedSearch';
 import { Source } from '@/models/source';
 import Webhook from '@/models/webhook';
 import { processAlert } from '@/tasks/checkAlerts';
-import { AlertDetails, AlertTaskType, loadProvider } from '@/tasks/providers';
+import {
+  AlertDetails,
+  AlertTaskType,
+  loadProvider,
+} from '@/tasks/checkAlerts/providers';
 import * as slack from '@/utils/slack';
 
 describe('Single Invocation Alert Test', () => {

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -28,13 +28,14 @@ import {
   AlertTask,
   AlertTaskType,
   loadProvider,
-} from '@/tasks/providers';
+} from '@/tasks/checkAlerts/providers';
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
   handleSendGenericWebhook,
   renderAlertTemplate,
-} from '@/tasks/template';
+} from '@/tasks/checkAlerts/template';
+import { tasksTracer } from '@/tasks/tracer';
 import { CheckAlertsTaskArgs, HdxTask } from '@/tasks/types';
 import {
   calcAlertDateRange,
@@ -42,8 +43,6 @@ import {
   unflattenObject,
 } from '@/tasks/util';
 import logger from '@/utils/logger';
-
-import { tasksTracer } from './tracer';
 
 export const doesExceedThreshold = (
   thresholdType: AlertThresholdType,

--- a/packages/api/src/tasks/checkAlerts/providers/__tests__/default.test.ts
+++ b/packages/api/src/tasks/checkAlerts/providers/__tests__/default.test.ts
@@ -12,7 +12,7 @@ import {
   AlertProvider,
   AlertTaskType,
   loadProvider,
-} from '@/tasks/providers/index';
+} from '@/tasks/checkAlerts/providers';
 
 const MOCK_SAVED_SEARCH: any = {
   id: 'fake-saved-search-id',

--- a/packages/api/src/tasks/checkAlerts/providers/default.ts
+++ b/packages/api/src/tasks/checkAlerts/providers/default.ts
@@ -19,15 +19,12 @@ import {
   type AlertProvider,
   type AlertTask,
   AlertTaskType,
-} from '@/tasks/providers';
+} from '@/tasks/checkAlerts/providers';
+import { MappedOmit } from '@/tasks/types';
 import { convertMsToGranularityString } from '@/utils/common';
 import logger from '@/utils/logger';
 
-import {
-  AggregatedAlertHistory,
-  getPreviousAlertHistories,
-} from '../checkAlerts';
-import { MappedOmit } from '../types';
+import { AggregatedAlertHistory, getPreviousAlertHistories } from '..';
 
 type PartialAlertDetails = MappedOmit<AlertDetails, 'previous'>;
 

--- a/packages/api/src/tasks/checkAlerts/providers/index.ts
+++ b/packages/api/src/tasks/checkAlerts/providers/index.ts
@@ -10,11 +10,10 @@ import { IDashboard } from '@/models/dashboard';
 import { ISavedSearch } from '@/models/savedSearch';
 import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
-import DefaultAlertProvider from '@/tasks/providers/default';
+import DefaultAlertProvider from '@/tasks/checkAlerts/providers/default';
 import logger from '@/utils/logger';
 
-import { AggregatedAlertHistory } from '../checkAlerts';
-import { CheckAlertsTaskArgs } from '../types';
+import { AggregatedAlertHistory } from '..';
 
 export enum AlertTaskType {
   SAVED_SEARCH,

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -24,7 +24,10 @@ import { ISavedSearch } from '@/models/savedSearch';
 import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
 import { doesExceedThreshold } from '@/tasks/checkAlerts';
-import { AlertProvider, PopulatedAlertChannel } from '@/tasks/providers';
+import {
+  AlertProvider,
+  PopulatedAlertChannel,
+} from '@/tasks/checkAlerts/providers';
 import { escapeJsonString, unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
 import logger from '@/utils/logger';


### PR DESCRIPTION
The alerts code and some of our private source tasks are becoming complex enough for multiple files. In order to keep the code clearer to debug and read, this commit moves the check alerts tasks into a sub-directory for just alert related code.