### PR TITLE
feat: Add filter for root spans

### DIFF
--- a/.changeset/silent-ducks-crash.md
+++ b/.changeset/silent-ducks-crash.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: Add filter for root spans

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -13,7 +13,10 @@ import {
   tcFromChartConfig,
   tcFromSource,
 } from '@hyperdx/common-utils/dist/core/metadata';
-import { ChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
+import {
+  ChartConfigWithDateRange,
+  SourceKind,
+} from '@hyperdx/common-utils/dist/types';
 import {
   Accordion,
   ActionIcon,
@@ -186,7 +189,7 @@ export const FilterCheckbox = ({
               flex={1}
               title={label}
             >
-              {label}
+              {label || <span className="fst-italic">(empty)</span>}
             </Text>
             {percentage != null && (
               <FilterPercentage
@@ -907,6 +910,30 @@ const DBSearchPageFiltersComponent = ({
     [filterState],
   );
 
+  const setRootSpansOnly = useCallback(
+    (rootSpansOnly: boolean) => {
+      if (!source?.parentSpanIdExpression) return;
+
+      if (rootSpansOnly) {
+        setFilterValue(source.parentSpanIdExpression, '', 'only');
+      } else {
+        clearFilter(source.parentSpanIdExpression);
+      }
+    },
+    [setFilterValue, clearFilter, source],
+  );
+
+  const isRootSpansOnly = useMemo(() => {
+    if (!source?.parentSpanIdExpression || source.kind !== SourceKind.Trace)
+      return false;
+
+    const parentSpanIdFilter = filterState?.[source?.parentSpanIdExpression];
+    return (
+      parentSpanIdFilter?.included.size === 1 &&
+      parentSpanIdFilter?.included.has('')
+    );
+  }, [filterState, source]);
+
   return (
     <Box className={classes.filtersPanel} style={{ width: `${size}%` }}>
       <div className={resizeStyles.resizeHandle} onMouseDown={startResize} />
@@ -995,6 +1022,29 @@ const DBSearchPageFiltersComponent = ({
               onChange={() => setDenoiseResults(!denoiseResults)}
             />
           )}
+
+          {source?.kind === SourceKind.Trace &&
+            source.parentSpanIdExpression && (
+              <Checkbox
+                size={13 as any}
+                checked={isRootSpansOnly}
+                ms="6px"
+                label={
+                  <Tooltip
+                    openDelay={200}
+                    color="gray"
+                    position="right"
+                    withArrow
+                    label="Only show root spans (spans with no parent span)."
+                  >
+                    <Text size="xs" c="gray.3" mt="-1px">
+                      <i className="bi bi-diagram-3"></i> Root Spans Only
+                    </Text>
+                  </Tooltip>
+                }
+                onChange={event => setRootSpansOnly(event.target.checked)}
+              />
+            )}
 
           {isLoading || isFacetsLoading ? (
             <Flex align="center" justify="center">


### PR DESCRIPTION
Closes HDX-2772

This PR adds a filter that allows for quickly viewing just root spans from a Trace source.

Notes:
- The state of this filter is persisted in the URL Query Params
- This filter is not persisted in a saved search to match the behavior of other filters, which are not persisted in saved searches.

<img width="1237" height="833" alt="Screenshot 2025-11-12 at 3 56 18 PM" src="https://github.com/user-attachments/assets/9e6b461d-f201-4521-b546-15f986c7ec5b" />
<img width="1252" height="693" alt="Screenshot 2025-11-12 at 3 56 32 PM" src="https://github.com/user-attachments/assets/0aa02818-93ba-4f57-96fd-58c46aac3d9d" />


