### PR TITLE
feat: Enhance display for map fields in filter list

### DIFF
--- a/.changeset/eight-stingrays-joke.md
+++ b/.changeset/eight-stingrays-joke.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: Enhance display for map fields in filter list

--- a/packages/app/styles/SearchPage.module.scss
+++ b/packages/app/styles/SearchPage.module.scss
@@ -26,11 +26,6 @@
       color: var(--color-text-secondary);
       font-size: var(--mantine-font-size-xs);
 
-      &::placeholder {
-        color: var(--color-text-muted);
-        font-weight: bold;
-      }
-
       &:focus {
         border: none;
         outline: none;


### PR DESCRIPTION
Fixes: HDX-2841

Also moves the filter search into the expand/collapse to avoid visual clutter (per recommendation from Elizabet)

Before:
<img width="446" height="435" alt="image" src="https://github.com/user-attachments/assets/4be6edb5-cf1c-4518-a444-05ffdaf6b8bd" />

After:
<img width="479" height="360" alt="image" src="https://github.com/user-attachments/assets/b7beb63e-a06c-48cd-960c-596648954a61" />
