### PR TITLE
fix: Fix session page source change on submit

### DIFF
--- a/.changeset/heavy-walls-suffer.md
+++ b/.changeset/heavy-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix session page source change on submit

--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -296,7 +296,8 @@ export default function SessionsPage() {
   const onSubmit = useCallback(() => {
     onSearch(displayedTimeInputValue);
     handleSubmit(values => {
-      setAppliedConfig(values);
+      const { source, ...rest } = values;
+      setAppliedConfig({ sessionSource: source, ...rest });
     })();
   }, [handleSubmit, setAppliedConfig, onSearch, displayedTimeInputValue]);
 


### PR DESCRIPTION
Closes HDX-2858

# Summary

This PR fixes a bug on the sessions page which caused any search submission to revert the source select back to its default. 

The cause of this bug was that the form submission was updating the wrong URL query parameter (source instead of sessionSource), and form submission would trigger the select to take whatever (original) value was set for sessionSource).