### PR TITLE
style: Fix color-bg references

### DIFF
--- a/.changeset/giant-moles-help.md
+++ b/.changeset/giant-moles-help.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+style: Fix missing AlertHistory colors

--- a/packages/app/styles/AlertsPage.module.scss
+++ b/packages/app/styles/AlertsPage.module.scss
@@ -32,11 +32,11 @@
   }
 
   &.ok {
-    background-color: var(--color-success);
+    background-color: var(--color-bg-success);
   }
 
   &.alarm {
-    background-color: var(--color-danger);
+    background-color: var(--color-bg-danger);
   }
 }
 

--- a/packages/app/styles/LogTable.module.scss
+++ b/packages/app/styles/LogTable.module.scss
@@ -172,7 +172,7 @@ $button-height: 18px;
   }
 
   &.copied {
-    color: var(--color-success);
+    color: var(--color-bg-success);
   }
 }
 


### PR DESCRIPTION
Closes HDX-2866

This PR updates references to background colors (color-success and color-danger no longer exist).

The background colors now render:

<img width="211" height="281" alt="Screenshot 2025-11-19 at 1 56 03 PM" src="https://github.com/user-attachments/assets/04102b3a-e03a-40b5-bd20-4bb2dc11edbe" />
<img width="210" height="128" alt="Screenshot 2025-11-19 at 1 56 49 PM" src="https://github.com/user-attachments/assets/4ca09e95-f078-4bad-9790-f6f76afccd55" />
