### PR TITLE
fix double scrollbar issue in some nested panels

### DIFF
--- a/.changeset/sixty-trainers-give.md
+++ b/.changeset/sixty-trainers-give.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix double scrollbars in some nested panels

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -559,7 +559,6 @@ export default function DBRowSidePanelErrorBoundary({
     <Drawer
       opened={rowId != null}
       withCloseButton={false}
-      withinPortal={!isNestedPanel}
       onClose={() => {
         if (!subDrawerOpen) {
           _onClose();


### PR DESCRIPTION
Some nested panels would receive double scrollbars after https://github.com/hyperdxio/hyperdx/pull/1290 shipped. This logic around withinPortal was originally added due to focus trapping issues, however, mantine drawer handles these automatically for us so we don't need this prop anymore.

Issue:
<img width="1494" height="1292" alt="image" src="https://github.com/user-attachments/assets/2b8b1742-4838-4b70-a1c0-b916dc48b636" />

Fix:
https://github.com/user-attachments/assets/cf221ee3-239f-49d2-8cea-0959449e4101

Fixes HDX-2856