### PR TITLE
feat: allow disabling otel exporter

### DIFF
--- a/.changeset/angry-emus-cry.md
+++ b/.changeset/angry-emus-cry.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/app": patch
+"@hyperdx/api": patch
+---
+
+feat: added configuration to disable frontend otel exporter

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -26,18 +26,19 @@ import {
 import { ibmPlexMono, inter, roboto, robotoMono } from '@/fonts';
 import { AppThemeProvider, useAppTheme } from '@/theme/ThemeProvider';
 import { ThemeWrapper } from '@/ThemeWrapper';
+import { NextApiConfigResponseData } from '@/types';
 import { useConfirmModal } from '@/useConfirm';
 import { QueryParamProvider as HDXQueryParamProvider } from '@/useQueryParam';
 import { useUserPreferences } from '@/useUserPreferences';
 
 import '@mantine/core/styles.css';
-import '@mantine/notifications/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/dropzone/styles.css';
-import '@styles/globals.css';
+import '@mantine/notifications/styles.css';
 import '@styles/app.scss';
-import 'uplot/dist/uPlot.min.css';
+import '@styles/globals.css';
 import '@xyflow/react/dist/style.css';
+import 'uplot/dist/uPlot.min.css';
 
 // Polyfill crypto.randomUUID for non-HTTPS environments
 if (typeof crypto !== 'undefined' && !crypto.randomUUID) {
@@ -137,15 +138,8 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     }
     fetch('/api/config')
       .then(res => res.json())
-      .then(_jsonData => {
+      .then((_jsonData?: NextApiConfigResponseData) => {
         if (_jsonData?.apiKey) {
-          let hostname;
-          try {
-            const url = new URL(_jsonData.apiServerUrl);
-            hostname = url.hostname;
-          } catch (err) {
-            // ignore
-          }
           HyperDX.init({
             apiKey: _jsonData.apiKey,
             consoleCapture: true,
@@ -156,7 +150,7 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
             url: _jsonData.collectorUrl,
           });
         } else {
-          console.warn('No API key found');
+          console.warn('No API key found to enable OTEL exporter');
         }
       })
       .catch(err => {

--- a/packages/app/pages/api/config.ts
+++ b/packages/app/pages/api/config.ts
@@ -1,6 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { HDX_API_KEY, HDX_COLLECTOR_URL, HDX_SERVICE_NAME } from '@/config';
+import {
+  HDX_API_KEY,
+  HDX_COLLECTOR_URL,
+  HDX_EXPORTER_ENABLED,
+  HDX_SERVICE_NAME,
+} from '@/config';
 import type { NextApiConfigResponseData } from '@/types';
 
 export default function handler(
@@ -8,7 +13,7 @@ export default function handler(
   res: NextApiResponse<NextApiConfigResponseData>,
 ) {
   res.status(200).json({
-    apiKey: HDX_API_KEY,
+    apiKey: HDX_EXPORTER_ENABLED ? HDX_API_KEY : undefined,
     collectorUrl: HDX_COLLECTOR_URL,
     serviceName: HDX_SERVICE_NAME,
   });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -16,6 +16,8 @@ export const NODE_ENV = process.env.NODE_ENV as string;
 export const HDX_API_KEY = process.env.HYPERDX_API_KEY as string; // for nextjs server
 export const HDX_SERVICE_NAME =
   process.env.NEXT_PUBLIC_OTEL_SERVICE_NAME ?? 'hdx-oss-dev-app';
+export const HDX_EXPORTER_ENABLED =
+  (process.env.HDX_EXPORTER_ENABLED ?? 'true') === 'true';
 export const HDX_COLLECTOR_URL =
   process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT ??
   'http://localhost:4318';

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -238,7 +238,7 @@ export enum KubePhase {
 }
 
 export type NextApiConfigResponseData = {
-  apiKey: string;
+  apiKey?: string;
   collectorUrl: string;
   serviceName: string;
 };


### PR DESCRIPTION
# Context

The default behavior to try to export logs/metrics/traces to an otel collector is causing issues in cases where this collector is not publicly accessible. Therefore adding an option to disable it would avoid having many errors in the Network tabs of the browser.

It has been briefly [discussed here](https://discord.com/channels/1149498480893640706/1440741118487691406) on discord

# Changes

Added a new `HDX_EXPORTER_ENABLED` configuration variable that prevents the instanciation of `HyperDX.init()` from `@hyperdx/browser`. Which disables sending metrics to the collector