### PR TITLE
fix: Schema modal displays default schema without requiring scroll

### DIFF
--- a/.changeset/fix-schema-modal-height.md
+++ b/.changeset/fix-schema-modal-height.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Schema modal now displays default schema without requiring scroll
+

--- a/packages/app/src/components/SourceSchemaPreview.tsx
+++ b/packages/app/src/components/SourceSchemaPreview.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
 import { Modal, Paper, Tabs, Text, TextProps, Tooltip } from '@mantine/core';
 import { IconCode } from '@tabler/icons-react';
+import { useState } from 'react';
 
 import { useTableMetadata } from '@/hooks/useMetadata';
 
@@ -156,6 +156,9 @@ const SourceSchemaPreview = ({
           onClose={() => setIsModalOpen(false)}
           size="auto"
           title={tables.length > 1 ? `Table Schemas` : `Table Schema`}
+          styles={{
+            body: { minHeight: '60vh', maxHeight: '90vh', overflowY: 'auto' },
+          }}
         >
           <Tabs
             defaultValue={`${tables[0]?.databaseName}.${tables[0]?.tableName}.${tables[0]?.title}`}


### PR DESCRIPTION
- Added minHeight: 60vh to ensure default log/trace schemas are fully visible
- Added maxHeight: 90vh with overflowY: auto for very large schemas

Fixes #1443

Now: 
<img width="1502" height="905" alt="image" src="https://github.com/user-attachments/assets/673ac090-5d73-4c83-9ea3-5750fd873ca8" />
