### PR TITLE
chore: update VSCode configuration and ESLint settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
     "clinyong.vscode-css-modules",
     "streetsidesoftware.code-spell-checker",
     "dbaeumer.vscode-eslint",
-    "hossaini.bootstrap-intellisense",
-    "stylelint.vscode-stylelint"
+    "stylelint.vscode-stylelint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,18 +7,17 @@
     "source.fixAll.eslint": "always",
     "source.fixAll.stylelint": "always"
   },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
   "[scss]": {
     "editor.defaultFormatter": "stylelint.vscode-stylelint"
   },
   "[css]": {
     "editor.defaultFormatter": "stylelint.vscode-stylelint"
   },
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
   "stylelint.validate": ["css", "postcss", "scss"],
   "cssVariables.lookupFiles": [
     "**/*.css",
@@ -30,6 +29,7 @@
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,
+    "**/.next": true,
     "**/*.code-search": true,
     "**/*.map": true,
     "**/yarn.lock": true,
@@ -42,6 +42,5 @@
     "opamp",
     "pyimport",
     "pyodide"
-  ],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  ]
 }

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -30,9 +30,9 @@ export default [
     plugins: {
       '@typescript-eslint': tseslint.plugin,
       'simple-import-sort': simpleImportSort,
-      'prettier': prettierPlugin,
-      'n': nodePlugin,
-      'security': securityPlugin,
+      prettier: prettierPlugin,
+      n: nodePlugin,
+      security: securityPlugin,
     },
     rules: {
       ...nodePlugin.configs.recommended.rules,
@@ -96,4 +96,3 @@ export default [
     },
   },
 ];
-

--- a/packages/app/eslint.config.mjs
+++ b/packages/app/eslint.config.mjs
@@ -77,6 +77,7 @@ export default [
         ecmaFeatures: {
           jsx: true,
         },
+        tsconfigRootDir: import.meta.dirname,
       },
       globals: {
         React: 'readonly',


### PR DESCRIPTION
- Allow IDE to determine the best formatter based on settings, not force ESLint formatter (which has issues in v9)
- Added Prettier extension to VSCode extensions list.
- Updated ESLint settings to include working directories for better integration.
- Removed redundant TypeScript formatter settings.
- Excluded `.next` directory from search results in VSCode settings.
- Minor formatting adjustments in ESLint configuration files for consistency.

References: https://github.com/microsoft/vscode-eslint/issues/1826