### PR TITLE
fix: Fix double value for isRootSpan facet

### DIFF
--- a/.changeset/silent-terms-search.md
+++ b/.changeset/silent-terms-search.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix double value for isRootSpan facet

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1010,7 +1010,7 @@ const DBSearchPageFiltersComponent = ({
     for (const key of remainingFilterState) {
       _facets.push({
         key,
-        value: Array.from(filterState[key].included).map(v => v.toString()),
+        value: Array.from(filterState[key].included),
       });
     }
 


### PR DESCRIPTION
# Summary

This PR fixes a bug where the the `isRootSpan` filter facet would show duplicate `true` values, but (interestingly) only if the value had never been pinned before.

## Before

<img width="221" height="255" alt="Screenshot 2025-12-12 at 10 21 04 AM" src="https://github.com/user-attachments/assets/a92826c9-8bec-4e4a-b16c-8061e8624365" />

## After

<img width="223" height="227" alt="Screenshot 2025-12-12 at 10 20 33 AM" src="https://github.com/user-attachments/assets/72458cf4-1906-422b-ae20-6b44f0846da5" />
