### PR TITLE
tweak search spec to use info instead of error

### DIFF
--- a/packages/app/tests/e2e/features/search/search.spec.ts
+++ b/packages/app/tests/e2e/features/search/search.spec.ts
@@ -76,7 +76,7 @@ test.describe('Search', { tag: '@search' }, () => {
           'cart',
           'ServiceName:"accounting"',
           '*info*',
-          'SeverityText:"error"',
+          'SeverityText:"info"',
         ];
 
         for (const query of queries) {


### PR DESCRIPTION
since there are several gaps where no errors are logged, causing e2e tests to fail