### PR TITLE
fix: Prevent dashboard infinite re-render

### DIFF
--- a/.changeset/clean-carrots-develop.md
+++ b/.changeset/clean-carrots-develop.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Prevent dashboard infinite re-render

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -650,11 +650,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     whereLanguage: SearchConditionLanguage;
   }>({
     defaultValues: {
-      granularity: 'auto',
-      where: '',
-      whereLanguage: 'lucene',
-    },
-    values: {
       granularity: granularity ?? 'auto',
       where: where ?? '',
       whereLanguage: (whereLanguage as SearchConditionLanguage) ?? 'lucene',
@@ -672,17 +667,10 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const [displayedTimeInputValue, setDisplayedTimeInputValue] =
     useState('Past 1h');
 
-  const {
-    searchedTimeRange,
-    // displayedTimeInputValue,
-    // setDisplayedTimeInputValue,
-    onSearch,
-    onTimeRangeSelect,
-  } = useNewTimeQuery({
+  const { searchedTimeRange, onSearch, onTimeRangeSelect } = useNewTimeQuery({
     initialDisplayValue: 'Past 1h',
     initialTimeRange: defaultTimeRange,
     setDisplayedTimeInputValue,
-    // showRelativeInterval: isLive,
   });
 
   const {


### PR DESCRIPTION
Closes HDX-3117

# Summary

This PR fixes a crash when loading or navigating away from the dashboard page. It occurred when a non-auto granularity was specified, and was caused by an infinite re-render loop due to continuously watching and resetting the granularity query parameter.

## Before

https://github.com/user-attachments/assets/f2bd0b48-5292-48b6-b27c-f007e5faef06

## After


https://github.com/user-attachments/assets/3bcd635a-1d14-4530-b08b-c737984133eb

