### PR TITLE
fix issue where select box does not update when changing saved searches.

### DIFF
--- a/.changeset/stale-suits-cover.md
+++ b/.changeset/stale-suits-cover.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix issue where select is not updating when loading saved searches

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1003,7 +1003,12 @@ function DBSearchPage() {
     onFilterChange: handleSetFilters,
   });
 
-  const watchedSource = useWatch({ control, name: 'source' });
+  const watchedSource = useWatch({
+    control,
+    name: 'source',
+    // Watch will reset when changing saved search, so we need to default to the URL
+    defaultValue: searchedConfig.source ?? undefined,
+  });
   const prevSourceRef = useRef(watchedSource);
 
   useEffect(() => {


### PR DESCRIPTION
Reproduction:
1. create a saved search with a custom select ex. Timestamp, Body
2. go to another saved search with a default select (or anywhere with a default select)
3. go back to initial saved search with custom select

Before: observe the SELECT statement is now the default select statement
After: observe that the SELECT statement is now updated as expected

Fixes HDX-3127