### PR TITLE
test: Update navigation tests with more pages and assertions

### DIFF
--- a/packages/app/src/AppNav.tsx
+++ b/packages/app/src/AppNav.tsx
@@ -838,6 +838,7 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
                           [styles.nestedLinkActive]:
                             pathname.startsWith('/clickhouse'),
                         })}
+                        data-testid="nav-link-clickhouse-dashboard"
                       >
                         ClickHouse
                       </Link>
@@ -848,6 +849,7 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
                           [styles.nestedLinkActive]:
                             pathname.startsWith('/services'),
                         })}
+                        data-testid="nav-link-services-dashboard"
                       >
                         Services
                       </Link>
@@ -859,7 +861,7 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
                             [styles.nestedLinkActive]:
                               pathname.startsWith('/kubernetes'),
                           })}
-                          data-testid="k8s-dashboard-nav-link"
+                          data-testid="nav-link-k8s-dashboard"
                         >
                           Kubernetes
                         </Link>

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -497,7 +497,7 @@ function ClickhousePage() {
   }, [latencyFilter]);
 
   return (
-    <Box p="sm">
+    <Box p="sm" data-testid="clickhouse-dashboard-page">
       <OnboardingModal requireSource={false} />
       <Group justify="space-between">
         <Group>

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -875,7 +875,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const hasTiles = dashboard && dashboard.tiles.length > 0;
 
   return (
-    <Box p="sm">
+    <Box p="sm" data-testid="dashboard-page">
       <Head>
         <title>Dashboard – HyperDX</title>
       </Head>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1519,7 +1519,12 @@ function DBSearchPage() {
   );
 
   return (
-    <Flex direction="column" h="100vh" style={{ overflow: 'hidden' }}>
+    <Flex
+      direction="column"
+      h="100vh"
+      style={{ overflow: 'hidden' }}
+      data-testid="search-page"
+    >
       <Head>
         <title>
           {savedSearch ? `${savedSearch.name} Search` : 'Search'} - HyperDX

--- a/packages/app/src/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage.tsx
@@ -1530,7 +1530,7 @@ function ServicesDashboardPage() {
   }, [service, onSubmit, previousService]);
 
   return (
-    <Box p="sm">
+    <Box p="sm" data-testid="services-dashboard-page">
       <OnboardingModal requireSource={false} />
       <ServiceDashboardEndpointSidePanel
         service={service}

--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -377,7 +377,7 @@ export default function SessionsPage() {
   const targetSession = sessions.find(s => s.sessionId === selectedSession?.id);
 
   return (
-    <div className="SessionsPage">
+    <div className="SessionsPage" data-testid="sessions-page">
       <Head>
         <title>Client Sessions - HyperDX</title>
       </Head>

--- a/packages/app/tests/e2e/core/navigation.spec.ts
+++ b/packages/app/tests/e2e/core/navigation.spec.ts
@@ -17,19 +17,73 @@ test.describe('Navigation', { tag: ['@core'] }, () => {
         ).toBeVisible();
       });
 
-      await test.step('Verify all main navigation links are present and have correct hrefs', async () => {
-        const navLinks = [
-          { testId: 'nav-link-search', href: '/search' },
-          { testId: 'nav-link-chart', href: '/chart' },
-          { testId: 'nav-link-sessions', href: '/sessions' },
-          { testId: 'nav-link-dashboards', href: '/dashboards' },
-        ];
+      const navLinks = [
+        {
+          testId: 'nav-link-search',
+          href: '/search',
+          contentTestId: 'search-page',
+        },
+        {
+          testId: 'nav-link-chart',
+          href: '/chart',
+          contentTestId: 'chart-explorer-page',
+        },
+        {
+          testId: 'nav-link-sessions',
+          href: '/sessions',
+          contentTestId: 'sessions-page',
+        },
+        {
+          testId: 'nav-link-service-map',
+          href: '/service-map',
+          contentTestId: 'service-map-page',
+        },
+        {
+          testId: 'nav-link-dashboards',
+          href: '/dashboards',
+          contentTestId: 'dashboard-page',
+        },
+        {
+          testId: 'nav-link-clickhouse-dashboard',
+          href: '/clickhouse',
+          contentTestId: 'clickhouse-dashboard-page',
+        },
+        {
+          testId: 'nav-link-services-dashboard',
+          href: '/services',
+          contentTestId: 'services-dashboard-page',
+        },
+        {
+          testId: 'nav-link-k8s-dashboard',
+          href: '/kubernetes',
+          contentTestId: 'kubernetes-dashboard-page',
+        },
+      ];
 
+      await test.step('Verify all main navigation links are present and have correct hrefs', async () => {
         for (const { testId, href } of navLinks) {
           const locator = page.locator(`[data-testid="${testId}"]`);
           await expect(locator).toBeVisible();
           await expect(locator).toHaveAttribute('href', href);
         }
+      });
+
+      await test.step('Navigate between each page', async () => {
+        for (const { testId, contentTestId } of navLinks) {
+          const link = page.locator(`[data-testid="${testId}"]`);
+          await link.click();
+
+          const content = page.locator(`[data-testid="${contentTestId}"]`);
+          await expect(content).toBeVisible();
+        }
+
+        // Navigate back to first page at the end to test navigation away from the last page
+        const firstLink = page.locator(`[data-testid="${navLinks[0].testId}"]`);
+        await firstLink.click();
+        const firstContent = page.locator(
+          `[data-testid="${navLinks[0].contentTestId}"]`,
+        );
+        await expect(firstContent).toBeVisible();
       });
     },
   );


### PR DESCRIPTION
# Summary

This PR updates the existing E2E navigation test so that it

1. Actually navigates to each page and asserts that the page loads
2. Checks additional pages which were not checked before (preset dashboards, service map)