### PR TITLE
cleanup test-e2e additional flags so they're easier to add

### DIFF
--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -40,6 +40,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+
+# Build additional flags
+ADDITIONAL_FLAGS=""
+if [ -n "$TAGS" ]; then
+  ADDITIONAL_FLAGS="--grep $TAGS"
+fi
+if [ "$UI_MODE" = true ]; then
+  ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS --ui"
+fi
+
+
 cleanup_mongodb() {
   echo "Stopping MongoDB..."
   docker compose -p e2e -f "$DOCKER_COMPOSE_FILE" down -v
@@ -120,15 +131,6 @@ run_fullstack_mode() {
   cd "$REPO_ROOT/packages/app"
   yarn test:e2e $ADDITIONAL_FLAGS
 }
-
-# Build additional flags
-ADDITIONAL_FLAGS=""
-if [ -n "$TAGS" ]; then
-  ADDITIONAL_FLAGS="--grep $TAGS"
-fi
-if [ "$UI_MODE" = true ]; then
-  ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS --ui"
-fi
 
 # Main execution
 if [ "$LOCAL_MODE" = true ]; then


### PR DESCRIPTION
Also fixes issue where `--ui` passed incorrectly 

Feedback for Claude: we currently don't support any arguments with spaces at the makefile level, so no need for space parsing