### PR TITLE
fix: display "temporary dashboard" banner until dashboard is created

### DIFF
--- a/.changeset/real-drinks-tap.md
+++ b/.changeset/real-drinks-tap.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: display "temporary dashboard" banner until dashboard is created

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -563,7 +563,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setDashboard,
     dashboardHash,
     isLocalDashboard,
-    isLocalDashboardEmpty,
     isFetching: isFetchingDashboard,
     isSetting: isSavingDashboard,
   } = useDashboard({
@@ -917,8 +916,8 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           );
         }}
       />
-      {IS_LOCAL_MODE === false && isLocalDashboard && isLocalDashboardEmpty && (
-        <Paper my="lg" p="md">
+      {IS_LOCAL_MODE === false && isLocalDashboard && (
+        <Paper my="lg" p="md" data-testid="temporary-dashboard-banner">
           <Flex justify="space-between" align="center">
             <Text size="sm">
               This is a temporary dashboard and can not be saved.

--- a/packages/app/src/dashboard.ts
+++ b/packages/app/src/dashboard.ts
@@ -166,7 +166,6 @@ export function useDashboard({
     setDashboard,
     dashboardHash,
     isLocalDashboard,
-    isLocalDashboardEmpty: localDashboard == null,
     isFetching: isFetchingRemoteDashboard,
     isSetting,
   };

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -10,6 +10,26 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
   });
 
   test(
+    'should display the "temporary dashboard" banner until the dashboard is created',
+    { tag: '@full-stack' },
+    async () => {
+      await test.step('Verify that banner is initially displayed', async () => {
+        await expect(dashboardPage.temporaryDashboardBanner).toBeVisible();
+      });
+
+      await test.step('Add a tile, verify that banner is still displayed', async () => {
+        await dashboardPage.addTileWithConfig('Test tile');
+        await expect(dashboardPage.temporaryDashboardBanner).toBeVisible();
+      });
+
+      await test.step('Create the dashboard, verify the banner is no longer displayed', async () => {
+        await dashboardPage.createNewDashboard();
+        await expect(dashboardPage.temporaryDashboardBanner).toBeHidden();
+      });
+    },
+  );
+
+  test(
     'should persist dashboard across page reloads',
     { tag: '@full-stack' },
     async () => {

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -19,6 +19,7 @@ export class DashboardPage {
   private readonly searchInput: Locator;
   private readonly searchSubmitButton: Locator;
   private readonly liveButton: Locator;
+  private readonly tempDashboardBanner: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -36,6 +37,9 @@ export class DashboardPage {
     this.liveButton = page.locator('button:has-text("Live")');
     this.dashboardNameHeading = page.getByRole('heading', { level: 3 });
     this.granularityPicker = page.getByTestId('granularity-picker');
+    this.tempDashboardBanner = page.locator(
+      '[data-testid="temporary-dashboard-banner"]',
+    );
   }
 
   /**
@@ -242,5 +246,9 @@ export class DashboardPage {
 
   get filterSubmitButton() {
     return this.searchSubmitButton;
+  }
+
+  get temporaryDashboardBanner() {
+    return this.tempDashboardBanner;
   }
 }


### PR DESCRIPTION
Closes HDX-2723

Keeps the banner containing "This is a temporary dashboard and can not be saved." text and "Create New Saved Dashboard" button visible even after a tile has been added to the unsaved dashboard.