### PR TITLE
feat: Add ability to disable data sources

### DIFF
--- a/.changeset/clever-sources-disable.md
+++ b/.changeset/clever-sources-disable.md
@@ -1,0 +1,8 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+Add ability to disable data sources with improved UX
+

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -40,6 +40,10 @@ export const Source = mongoose.model<ISource>(
       },
 
       name: String,
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
       displayedTimestampValueExpression: String,
       implicitColumnExpression: String,
       serviceNameExpression: String,

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -171,17 +171,22 @@ type SearchConfigFromSchema = z.infer<typeof SearchConfigSchema>;
 
 // Helper function to get the default source id
 export function getDefaultSourceId(
-  sources: { id: string }[] | undefined,
+  sources: { id: string; disabled?: boolean }[] | undefined,
   lastSelectedSourceId: string | undefined,
 ): string {
   if (!sources || sources.length === 0) return '';
+  
+  // Filter out disabled sources
+  const enabledSources = sources.filter(s => !s.disabled);
+  if (enabledSources.length === 0) return '';
+  
   if (
     lastSelectedSourceId &&
-    sources.some(s => s.id === lastSelectedSourceId)
+    enabledSources.some(s => s.id === lastSelectedSourceId)
   ) {
     return lastSelectedSourceId;
   }
-  return sources[0].id;
+  return enabledSources[0].id;
 }
 
 function SourceEditMenu({

--- a/packages/app/src/KubernetesDashboardPage.tsx
+++ b/packages/app/src/KubernetesDashboardPage.tsx
@@ -944,7 +944,8 @@ const findSource = (
     s =>
       (kind === undefined || s.kind === kind) &&
       (id === undefined || s.id === id) &&
-      (connection === undefined || s.connection === connection),
+      (connection === undefined || s.connection === connection) &&
+      !s.disabled,
   );
 };
 
@@ -989,7 +990,8 @@ export const resolveSourceIds = (
     s =>
       s.kind === SourceKind.Log &&
       s.metricSourceId &&
-      findSource(sources, { id: s.metricSourceId }),
+      findSource(sources, { id: s.metricSourceId }) &&
+      !s.disabled,
   );
 
   if (logSourceWithMetricSource) {

--- a/packages/app/src/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage.tsx
@@ -1414,7 +1414,9 @@ function ServicesDashboardPage() {
   const appliedConfigWithoutFilters = useMemo(() => {
     if (!sources?.length) return appliedConfigParams;
 
-    const traceSources = sources?.filter(s => s.kind === SourceKind.Trace);
+    const traceSources = sources?.filter(
+      s => s.kind === SourceKind.Trace && !s.disabled,
+    );
     const paramsSourceIdIsTraceSource = traceSources?.find(
       s => s.id === appliedConfigParams.source,
     );

--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -257,9 +257,9 @@ export default function SessionsPage() {
   // Auto-select the first session source when the page loads
   useEffect(() => {
     if (sources && sources.length > 0 && !appliedConfig.sessionSource) {
-      // Find the first session source
+      // Find the first enabled session source
       const sessionSource = sources.find(
-        source => source.kind === SourceKind.Session,
+        source => source.kind === SourceKind.Session && !source.disabled,
       );
       if (sessionSource) {
         setValue('source', sessionSource.id);

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -66,7 +66,8 @@ function SourceSelectControlledComponent({
         data
           ?.filter(
             source =>
-              !allowedSourceKinds || allowedSourceKinds.includes(source.kind),
+              (!allowedSourceKinds || allowedSourceKinds.includes(source.kind)) &&
+              !source.disabled,
           )
           .map(d => ({
             value: d.id,

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -30,6 +30,7 @@ import {
   Select,
   Slider,
   Stack,
+  Switch,
   Text,
   Tooltip,
 } from '@mantine/core';
@@ -1453,6 +1454,37 @@ export function TableSourceForm({
 }) {
   const { data: source } = useSource({ id: sourceId });
   const { data: connections } = useConnections();
+  const updateSourceMutation = useUpdateSource();
+
+  const handleDisabledToggle = useCallback(
+    (newDisabledValue: boolean) => {
+      if (!source || isNew) return;
+
+      updateSourceMutation.mutate(
+        {
+          source: {
+            ...source,
+            disabled: newDisabledValue,
+          },
+        },
+        {
+          onSuccess: () => {
+            notifications.show({
+              color: 'green',
+              message: `Source ${newDisabledValue ? 'disabled' : 'enabled'} successfully`,
+            });
+          },
+          onError: error => {
+            notifications.show({
+              color: 'red',
+              message: `Failed to ${newDisabledValue ? 'disable' : 'enable'} source - ${error.message}`,
+            });
+          },
+        },
+      );
+    },
+    [source, isNew, updateSourceMutation],
+  );
 
   const { control, setValue, handleSubmit, resetField, setError, clearErrors } =
     useForm<TSourceUnion>({
@@ -1824,7 +1856,27 @@ export function TableSourceForm({
       }
     >
       <Stack gap="md" mb="md">
-        <Text mb="lg">Source Settings</Text>
+        <Flex justify="space-between" align="center" mb="lg">
+          <Text>Source Settings</Text>
+          {!isNew && (
+            <Controller
+              control={control}
+              name="disabled"
+              render={({ field: { value, onChange } }) => (
+                <Switch
+                  size="sm"
+                  checked={!value}
+                  onChange={(event) => {
+                    const newDisabledValue = !event.currentTarget.checked;
+                    onChange(newDisabledValue);
+                    handleDisabledToggle(newDisabledValue);
+                  }}
+                  label={value ? 'Disabled' : 'Enabled'}
+                />
+              )}
+            />
+          )}
+        </Flex>
         <FormRow label={'Name'}>
           <InputControlled
             control={control}

--- a/packages/app/src/components/Sources/SourcesList.tsx
+++ b/packages/app/src/components/Sources/SourcesList.tsx
@@ -156,30 +156,43 @@ export function SourcesList({
 
         {sources?.map((s, index) => (
           <React.Fragment key={s.id}>
-            <Flex justify="space-between" align="center">
-              <div>
-                <Text size={textSize} fw={500}>
-                  {s.name}
-                </Text>
-                <Text size={subtextSize} c="dimmed" mt={4}>
-                  <Group gap="xs">
-                    {capitalizeFirstLetter(s.kind)}
-                    <Group gap={4}>
-                      <IconServer size={iconSize} />
-                      {connections?.find(c => c.id === s.connection)?.name}
+            <Flex
+              justify="space-between"
+              align="center"
+              opacity={s.disabled ? 0.5 : 1}
+              style={{
+                transition: 'opacity 0.2s ease',
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <Flex align="center" gap="sm">
+                  <div>
+                    <Group gap="xs" align="center">
+                      <Text size={textSize} fw={500}>
+                        {s.name}
+                      </Text>
                     </Group>
-                    <Group gap={4}>
-                      {s.from && (
-                        <>
-                          <IconStack size={iconSize} />
-                          {s.from.databaseName}
-                          {s.kind === SourceKind.Metric ? '' : '.'}
-                          {s.from.tableName}
-                        </>
-                      )}
-                    </Group>
-                  </Group>
-                </Text>
+                    <Text size={subtextSize} c="dimmed" mt={4}>
+                      <Group gap="xs">
+                        {capitalizeFirstLetter(s.kind)}
+                        <Group gap={4}>
+                          <IconServer size={iconSize} />
+                          {connections?.find(c => c.id === s.connection)?.name}
+                        </Group>
+                        <Group gap={4}>
+                          {s.from && (
+                            <>
+                              <IconStack size={iconSize} />
+                              {s.from.databaseName}
+                              {s.kind === SourceKind.Metric ? '' : '.'}
+                              {s.from.tableName}
+                            </>
+                          )}
+                        </Group>
+                      </Group>
+                    </Text>
+                  </div>
+                </Flex>
               </div>
               <ActionIcon
                 variant="secondary"

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -612,6 +612,7 @@ const SourceBaseSchema = z.object({
     databaseName: z.string().min(1, 'Database is required'),
     tableName: z.string().min(1, 'Table is required'),
   }),
+  disabled: z.boolean().optional(),
 });
 
 const RequiredTimestampColumnSchema = z


### PR DESCRIPTION
## Summary
Fixes #1545

This PR implements the ability to enable/disable data sources from the UI. Disabled sources remain visible in the Sources management page but are automatically hidden from all dropdowns and selection menus throughout the application.

<img width="968" height="706" alt="image" src="https://github.com/user-attachments/assets/30e2c97e-e872-417c-be77-c917d3ee2389" />
<img width="944" height="705" alt="image" src="https://github.com/user-attachments/assets/f1889aec-8f2b-4a88-9b2d-61f6a08fe850" />
<img width="491" height="144" alt="image" src="https://github.com/user-attachments/assets/ea4ac716-b5fc-46b5-8ecb-f5379e6246c1" />

## Changes

### Backend
- **Added `disabled` field** to the Source model (MongoDB schema)
  - Type: `Boolean`
  - Default: `false`
  - Sources are enabled by default

### Frontend - Schema & Types
- **Updated `SourceBaseSchema`** in `common-utils` to include optional `disabled` field
- Type validation ensures backward compatibility with existing sources

### Frontend - UI Components

#### Sources Management Page
- **Added toggle switch** to enable/disable each source
- Switch displays current state: "Enabled" or "Disabled"
- Sources can be toggled on/off with a single click
- All sources (enabled and disabled) remain visible in this management view

#### Source Filtering
Updated all source selection dropdowns to filter out disabled sources:
- **Search Page**: Default source selection now excludes disabled sources
- **Sessions Page**: Auto-selection only considers enabled session sources
- **Services Dashboard**: Trace source dropdown filters out disabled sources
- **Kubernetes Dashboard**: Log and metric source selection excludes disabled sources
- **All dropdowns**: Generic source selector component filters disabled sources

### User Experience

**When a source is disabled:**
- ✅ Still visible in Team Settings → Sources (management page)
- ✅ Can be re-enabled via toggle switch
- ❌ Not shown in any source selection dropdowns
- ❌ Not auto-selected as default source
- ❌ Not available for new searches, dashboards, or queries

**When a source is enabled:**
- ✅ Visible everywhere (management page + all dropdowns)
- ✅ Available for selection in all features
- ✅ Can be auto-selected as default
- ✅ Normal behavior throughout the app

## Use Cases

This feature enables teams to:
1. **Temporarily hide data sources** without deleting them
2. **Keep development/staging sources** configured but hidden in production
3. **Manage seasonal data sources** that are only needed periodically
4. **Reduce clutter** in source selection dropdowns
5. **Maintain source configurations** while preventing accidental use

## Testing

Manually tested:
- ✅ Toggle switch works correctly in Sources list
- ✅ Disabled sources hidden from Search page dropdown
- ✅ Disabled sources hidden from Sessions page
- ✅ Disabled sources hidden from Services dashboard
- ✅ Disabled sources hidden from Kubernetes dashboard
- ✅ Default source selection skips disabled sources
- ✅ Re-enabling a source makes it immediately available
- ✅ Existing sources without the field work correctly (default enabled)

## Backward Compatibility

- ✅ Existing sources without `disabled` field are treated as enabled
- ✅ No database migration required
- ✅ No breaking changes to API
- ✅ Field is optional in schema validation

## Changelog

Updated changelogs for all affected packages:
- `@hyperdx/app` - UI components and filtering logic
- `@hyperdx/api` - Backend model changes
- `@hyperdx/common-utils` - Schema updates

