### PR TITLE
feat: Add dashboard tile tags for organization and filtering

### DIFF
--- a/.changeset/chart-legend-filtering.md
+++ b/.changeset/chart-legend-filtering.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': minor
+---
+
+Add chart legend series filtering with click and shift-click selection
+

--- a/.changeset/dashboard-tile-tags.md
+++ b/.changeset/dashboard-tile-tags.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/app': minor
+'@hyperdx/common-utils': minor
+---
+
+Add dashboard tile tags for organization and filtering
+

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -790,28 +790,29 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
         .map(chart => {
         const isHidden = selectedTag && !chart.tags?.includes(selectedTag);
         return (
-          <div key={chart.id} style={{ display: isHidden ? 'none' : 'block' }}>
-            <Tile
-              chart={chart}
-              dateRange={searchedTimeRange}
-              onEditClick={() => setEditedTile(chart)}
-              granularity={
-                isRefreshEnabled
-                  ? granularityOverride
-                  : (granularity ?? undefined)
-              }
-              filters={[
-                {
-                  type: whereLanguage === 'sql' ? 'sql' : 'lucene',
-                  condition: where,
-                },
-                ...(filterQueries ?? []),
-              ]}
-              onTimeRangeSelect={onTimeRangeSelect}
+          <Tile
+            key={chart.id}
+            chart={chart}
+            dateRange={searchedTimeRange}
+            onEditClick={() => setEditedTile(chart)}
+            granularity={
+              isRefreshEnabled
+                ? granularityOverride
+                : (granularity ?? undefined)
+            }
+            filters={[
+              {
+                type: whereLanguage === 'sql' ? 'sql' : 'lucene',
+                condition: where,
+              },
+              ...(filterQueries ?? []),
+            ]}
+            onTimeRangeSelect={onTimeRangeSelect}
             isHighlighted={highlightedTileId === chart.id}
             onTagClick={(tag) => {
               setSelectedTag(tag === selectedTag ? null : tag);
             }}
+            style={{ display: isHidden ? 'none' : undefined }}
             onUpdateChart={newChart => {
               if (!dashboard) {
                 return;
@@ -864,7 +865,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
               }
             }}
           />
-          </div>
         );
       }),
     [

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -787,31 +787,27 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const tiles = useMemo(
     () =>
       (dashboard?.tiles ?? [])
-        .filter(chart => {
-          // Filter tiles based on selected tag
-          if (!selectedTag) return true;
-          return chart.tags?.includes(selectedTag);
-        })
         .map(chart => {
+        const isHidden = selectedTag && !chart.tags?.includes(selectedTag);
         return (
-          <Tile
-            key={chart.id}
-            chart={chart}
-            dateRange={searchedTimeRange}
-            onEditClick={() => setEditedTile(chart)}
-            granularity={
-              isRefreshEnabled
-                ? granularityOverride
-                : (granularity ?? undefined)
-            }
-            filters={[
-              {
-                type: whereLanguage === 'sql' ? 'sql' : 'lucene',
-                condition: where,
-              },
-              ...(filterQueries ?? []),
-            ]}
-            onTimeRangeSelect={onTimeRangeSelect}
+          <div key={chart.id} style={{ display: isHidden ? 'none' : 'block' }}>
+            <Tile
+              chart={chart}
+              dateRange={searchedTimeRange}
+              onEditClick={() => setEditedTile(chart)}
+              granularity={
+                isRefreshEnabled
+                  ? granularityOverride
+                  : (granularity ?? undefined)
+              }
+              filters={[
+                {
+                  type: whereLanguage === 'sql' ? 'sql' : 'lucene',
+                  condition: where,
+                },
+                ...(filterQueries ?? []),
+              ]}
+              onTimeRangeSelect={onTimeRangeSelect}
             isHighlighted={highlightedTileId === chart.id}
             onTagClick={(tag) => {
               setSelectedTag(tag === selectedTag ? null : tag);
@@ -868,6 +864,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
               }
             }}
           />
+          </div>
         );
       }),
     [
@@ -1237,7 +1234,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             }
           >
             <ReactGridLayout
-              key={selectedTag || 'all-tiles'}
               layout={layout}
               containerPadding={[0, 0]}
               onLayoutChange={newLayout => {

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -140,6 +140,7 @@ const Tile = forwardRef(
       onTouchEnd,
       children,
       isHighlighted,
+      isHidden,
     }: {
       chart: Tile;
       dateRange: [Date, Date];
@@ -162,6 +163,7 @@ const Tile = forwardRef(
       onTouchEnd?: (e: React.TouchEvent) => void;
       children?: React.ReactNode; // Resizer tooltip
       isHighlighted?: boolean;
+      isHidden?: boolean;
     },
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
@@ -267,6 +269,7 @@ const Tile = forwardRef(
         ref={ref}
         style={{
           ...style,
+          ...(isHidden ? { display: 'none' } : {}),
         }}
         onMouseDown={onMouseDown}
         onMouseUp={onMouseUp}
@@ -813,6 +816,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             onTagClick={(tag) => {
               setSelectedTag(tag === selectedTag ? null : tag);
             }}
+            isHidden={isHidden}
             style={{ display: isHidden ? 'none' : undefined }}
             onUpdateChart={newChart => {
               if (!dashboard) {

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1023,7 +1023,10 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
                 <IconX
                   size={12}
                   style={{ cursor: 'pointer' }}
-                  onClick={() => setSelectedTag(null)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedTag(null);
+                  }}
                 />
               }
             >

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -789,6 +789,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       (dashboard?.tiles ?? [])
         .map(chart => {
         const isHidden = selectedTag && !chart.tags?.includes(selectedTag);
+        console.log('Tile:', chart.config.name, 'Tags:', chart.tags, 'SelectedTag:', selectedTag, 'isHidden:', isHidden);
         return (
           <Tile
             key={chart.id}

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1237,6 +1237,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             }
           >
             <ReactGridLayout
+              key={selectedTag || 'all-tiles'}
               layout={layout}
               containerPadding={[0, 0]}
               onLayoutChange={newLayout => {

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -221,17 +221,44 @@ function CopyableLegendItem({ entry }: any) {
   );
 }
 
-function ExpandableLegendItem({ entry, expanded }: any) {
+function ExpandableLegendItem({ 
+  entry, 
+  expanded, 
+  isSelected,
+  isDisabled,
+  onToggle 
+}: { 
+  entry: any; 
+  expanded?: boolean; 
+  isSelected?: boolean;
+  isDisabled?: boolean;
+  onToggle?: (isShiftKey: boolean) => void;
+}) {
   const [_expanded, setExpanded] = useState(false);
   const isExpanded = _expanded || expanded;
 
   return (
     <span
       className={`d-flex gap-1 items-center justify-center ${styles.legendItem}`}
-      style={{ color: entry.color }}
+      style={{ 
+        color: entry.color,
+        opacity: isDisabled ? 0.3 : 1,
+        fontWeight: isSelected ? 600 : 400,
+        cursor: 'pointer',
+      }}
       role="button"
-      onClick={() => setExpanded(v => !v)}
-      title="Click to expand"
+      onClick={(e) => {
+        if (onToggle) {
+          onToggle(e.shiftKey);
+        } else {
+          setExpanded(v => !v);
+        }
+      }}
+      title={
+        isSelected 
+          ? "Click to show all (Shift+click to deselect)" 
+          : "Click to show only this (Shift+click for multi-select)"
+      }
     >
       <div>
         <svg width="12" height="4">
@@ -241,8 +268,9 @@ function ExpandableLegendItem({ entry, expanded }: any) {
             x2="12"
             y2="2"
             stroke={entry.color}
-            opacity={entry.opacity}
+            opacity={isDisabled ? 0.3 : 1}
             strokeDasharray={entry.payload?.strokeDasharray}
+            strokeWidth={isSelected ? 2.5 : 1.5}
           />
         </svg>
       </div>
@@ -258,13 +286,31 @@ export const LegendRenderer = memo<{
     color: string;
   }[];
   lineDataMap: { [key: string]: LineData };
+  allLineData?: LineData[];
+  selectedSeries?: Set<string>;
+  onToggleSeries?: (seriesName: string, isShiftKey?: boolean) => void;
 }>(props => {
-  const { payload = [], lineDataMap } = props;
+  const { payload = [], lineDataMap, allLineData = [], selectedSeries = new Set(), onToggleSeries } = props;
+  
+  const hasSelection = selectedSeries.size > 0;
+
+  // Use allLineData to ensure all series are always shown in legend
+  const allSeriesPayload = useMemo(() => {
+    if (allLineData.length > 0) {
+      return allLineData.map(ld => ({
+        dataKey: ld.dataKey,
+        value: ld.displayName || ld.dataKey,
+        color: ld.color,
+        payload: { strokeDasharray: ld.isDashed ? '4 3' : '0' }
+      }));
+    }
+    return payload;
+  }, [allLineData, payload]);
 
   const sortedLegendItems = useMemo(() => {
     // Order items such that current and previous period lines are consecutive
     const currentPeriodKeyIndex = new Map<string, number>();
-    payload.forEach((line, index) => {
+    allSeriesPayload.forEach((line, index) => {
       const currentPeriodKey =
         lineDataMap[line.dataKey]?.currentPeriodKey || '';
       if (!currentPeriodKeyIndex.has(currentPeriodKey)) {
@@ -272,7 +318,7 @@ export const LegendRenderer = memo<{
       }
     });
 
-    return payload.sort((a, b) => {
+    return allSeriesPayload.sort((a, b) => {
       const keyA = lineDataMap[a.dataKey]?.currentPeriodKey ?? '';
       const keyB = lineDataMap[b.dataKey]?.currentPeriodKey ?? '';
 
@@ -288,13 +334,20 @@ export const LegendRenderer = memo<{
 
   return (
     <div className={styles.legend}>
-      {shownItems.map((entry, index) => (
-        <ExpandableLegendItem
-          key={`item-${index}`}
-          value={entry.value}
-          entry={entry}
-        />
-      ))}
+      {shownItems.map((entry, index) => {
+        const isSelected = selectedSeries.has(entry.value);
+        const isDisabled = hasSelection && !isSelected;
+        return (
+          <ExpandableLegendItem
+            key={`item-${index}`}
+            value={entry.value}
+            entry={entry}
+            isSelected={isSelected}
+            isDisabled={isDisabled}
+            onToggle={(isShiftKey) => onToggleSeries?.(entry.value, isShiftKey)}
+          />
+        );
+      })}
       {restItems.length ? (
         <Popover withinPortal withArrow closeOnEscape closeOnClickOutside>
           <Popover.Target>
@@ -304,13 +357,20 @@ export const LegendRenderer = memo<{
           </Popover.Target>
           <Popover.Dropdown p="xs">
             <div className={styles.legendTooltipContent}>
-              {restItems.map((entry, index) => (
-                <CopyableLegendItem
-                  key={`item-${index}`}
-                  value={entry.value}
-                  entry={entry}
-                />
-              ))}
+              {restItems.map((entry, index) => {
+                const isSelected = selectedSeries.has(entry.value);
+                const isDisabled = hasSelection && !isSelected;
+                return (
+                  <ExpandableLegendItem
+                    key={`item-${index}`}
+                    value={entry.value}
+                    entry={entry}
+                    isSelected={isSelected}
+                    isDisabled={isDisabled}
+                    onToggle={(isShiftKey) => onToggleSeries?.(entry.value, isShiftKey)}
+                  />
+                );
+              })}
             </div>
           </Popover.Dropdown>
         </Popover>
@@ -336,6 +396,8 @@ export const MemoChart = memo(function MemoChart({
   onTimeRangeSelect,
   showLegend = true,
   previousPeriodOffsetSeconds,
+  selectedSeriesNames,
+  onToggleSeries,
 }: {
   graphResults: any[];
   setIsClickActive: (v: any) => void;
@@ -351,6 +413,8 @@ export const MemoChart = memo(function MemoChart({
   onTimeRangeSelect?: (start: Date, end: Date) => void;
   showLegend?: boolean;
   previousPeriodOffsetSeconds?: number;
+  selectedSeriesNames?: Set<string>;
+  onToggleSeries?: (seriesName: string, isShiftKey?: boolean) => void;
 }) {
   const _id = useId();
   const id = _id.replace(/:/g, '');
@@ -361,13 +425,23 @@ export const MemoChart = memo(function MemoChart({
     displayType === DisplayType.StackedBar ? BarChart : AreaChart; // LineChart;
 
   const lines = useMemo(() => {
+    const hasSelection = selectedSeriesNames && selectedSeriesNames.size > 0;
+    
     const limitedGroupKeys = lineData
       .map(ld => ld.dataKey)
-      .slice(0, HARD_LINES_LIMIT);
+      .slice(0, HARD_LINES_LIMIT)
+      .filter((key, i) => {
+        const seriesName = lineData[i]?.displayName ?? key;
+        // If there's a selection, only show selected series
+        // If no selection, show all series
+        return !hasSelection || selectedSeriesNames.has(seriesName);
+      });
 
     return limitedGroupKeys.map((key, i) => {
-      const color = lineData[i]?.color;
-      const strokeDasharray = lineData[i]?.isDashed ? '4 3' : '0';
+      const lineDataIndex = lineData.findIndex(ld => ld.dataKey === key);
+      const color = lineData[lineDataIndex]?.color;
+      const strokeDasharray = lineData[lineDataIndex]?.isDashed ? '4 3' : '0';
+      const seriesName = lineData[lineDataIndex]?.displayName ?? key;
 
       const StackedBarWithOverlap = (props: BarProps) => {
         const { x, y, width, height, fill } = props;
@@ -388,7 +462,7 @@ export const MemoChart = memo(function MemoChart({
           key={key}
           type="monotone"
           dataKey={key}
-          name={lineData[i]?.displayName ?? key}
+          name={seriesName}
           fill={color}
           opacity={1}
           stackId="1"
@@ -408,12 +482,50 @@ export const MemoChart = memo(function MemoChart({
                 fill: `url(#time-chart-lin-grad-${id}-${color.replace('#', '').toLowerCase()})`,
                 strokeDasharray,
               })}
-          name={lineData[i]?.displayName ?? key}
+          name={seriesName}
           isAnimationActive={false}
         />
       );
     });
-  }, [lineData, displayType, id, isHovered]);
+  }, [lineData, displayType, id, isHovered, selectedSeriesNames]);
+
+  const yAxisDomain = useMemo(() => {
+    const hasSelection = selectedSeriesNames && selectedSeriesNames.size > 0;
+    
+    if (!hasSelection) {
+      // No selection, let Recharts auto-calculate based on all data
+      return ['auto', 'auto'];
+    }
+
+    // When series are selected, calculate domain based only on visible series
+    let minValue = Infinity;
+    let maxValue = -Infinity;
+
+    graphResults.forEach(dataPoint => {
+      lineData.forEach(ld => {
+        const seriesName = ld.displayName || ld.dataKey;
+        // Only consider selected series
+        if (selectedSeriesNames.has(seriesName)) {
+          const value = dataPoint[ld.dataKey];
+          if (typeof value === 'number' && !isNaN(value)) {
+            minValue = Math.min(minValue, value);
+            maxValue = Math.max(maxValue, value);
+          }
+        }
+      });
+    });
+
+    // If we found valid values, return them with some padding
+    if (minValue !== Infinity && maxValue !== -Infinity) {
+      const padding = (maxValue - minValue) * 0.1; // 10% padding
+      return [
+        Math.max(0, minValue - padding), // Don't go below 0
+        maxValue + padding
+      ];
+    }
+
+    return ['auto', 'auto'];
+  }, [graphResults, lineData, selectedSeriesNames]);
 
   const sizeRef = useRef<[number, number]>([0, 0]);
 
@@ -606,6 +718,7 @@ export const MemoChart = memo(function MemoChart({
           minTickGap={25}
           tickFormatter={tickFormatter}
           tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
+          domain={yAxisDomain}
         />
         {lines}
         {isClickActive == null && (
@@ -635,7 +748,14 @@ export const MemoChart = memo(function MemoChart({
           <Legend
             iconSize={10}
             verticalAlign="bottom"
-            content={<LegendRenderer lineDataMap={lineDataMap} />}
+            content={
+              <LegendRenderer 
+                lineDataMap={lineDataMap}
+                allLineData={lineData}
+                selectedSeries={selectedSeriesNames || new Set()}
+                onToggleSeries={onToggleSeries}
+              />
+            }
             offset={-100}
           />
         )}

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -243,6 +243,34 @@ function DBTimeChartComponent({
   showMVOptimizationIndicator = true,
 }: DBTimeChartComponentProps) {
   const [isErrorExpanded, errorExpansion] = useDisclosure(false);
+  const [selectedSeriesSet, setSelectedSeriesSet] = useState<Set<string>>(new Set());
+  
+  const handleToggleSeries = useCallback((seriesName: string, isShiftKey?: boolean) => {
+    setSelectedSeriesSet(prev => {
+      const newSet = new Set(prev);
+      
+      if (isShiftKey) {
+        // Shift-click: add to selection
+        if (newSet.has(seriesName)) {
+          newSet.delete(seriesName);
+        } else {
+          newSet.add(seriesName);
+        }
+      } else {
+        // Regular click: toggle selection
+        if (newSet.has(seriesName) && newSet.size === 1) {
+          // If this is the only selected item, clear selection (show all)
+          newSet.clear();
+        } else {
+          // Otherwise, select only this one
+          newSet.clear();
+          newSet.add(seriesName);
+        }
+      }
+      
+      return newSet;
+    });
+  }, []);
 
   const originalDateRange = config.dateRange;
   const {
@@ -683,6 +711,8 @@ function DBTimeChartComponent({
             showLegend={showLegend}
             timestampKey={timestampColumn?.name}
             previousPeriodOffsetSeconds={previousPeriodOffsetSeconds}
+            selectedSeriesNames={selectedSeriesSet}
+            onToggleSeries={handleToggleSeries}
           />
         </>
       )}

--- a/packages/app/src/dashboard.ts
+++ b/packages/app/src/dashboard.ts
@@ -20,6 +20,7 @@ export type Tile = {
   w: number;
   h: number;
   config: SavedChartConfig;
+  tags?: string[];
 };
 
 export type Dashboard = {

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -520,6 +520,7 @@ export const TileSchema = z.object({
   w: z.number(),
   h: z.number(),
   config: SavedChartConfigSchema,
+  tags: z.array(z.string()).optional(),
 });
 export const TileTemplateSchema = TileSchema.extend({
   config: TileSchema.shape.config.omit({ alert: true }),


### PR DESCRIPTION
## Changes

This PR implements dashboard tile tags feature as part of #1558.

> **Note**: This PR builds on top of #1572 (Chart Legend Series Filtering). Please merge #1572 first.

## Features

**Dashboard Tile Tags & Filtering**
- Added `tags` field to dashboard tiles for organization
- Tiles can be tagged in the edit modal
- Click on tile tags to filter the dashboard view to show only tiles with that tag
- Visual filter indicator shows active tag filter
- URL state preservation for sharing filtered views

### How It Works

- Edit a tile and add tags in the "Tile Tags" section
- Tags appear as badges on the tile
- Click any tag to filter the dashboard to show only tiles with that tag
- Click the close button on the filter indicator to clear the filter

### Technical Changes

- Updated `TileSchema` in common-utils to include optional tags field
- Modified `DBDashboardPage` to support tag filtering with URL state
- Added tag editor in the tile edit modal
- Implemented clickable tag badges with filter toggle

Part of #1558