### PR TITLE
fix: Fix a couple of visual bugs in Chart titles

### DIFF
--- a/.changeset/silver-rings-ring.md
+++ b/.changeset/silver-rings-ring.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix a couple of visual bugs in Chart titles

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -16,6 +16,7 @@ import {
   Grid,
   Group,
   SegmentedControl,
+  Stack,
   Tabs,
   Text,
   Tooltip,
@@ -196,14 +197,14 @@ function InfrastructureTab({
         <ChartBox style={{ height: 400 }}>
           <DBTimeChart
             title={
-              <>
+              <Stack gap={0}>
                 <Text size="sm" mb="xs">
                   Network
                 </Text>
                 <Text size="xs" mb="sm">
                   Network activity for the entire machine, not only Clickhouse.
                 </Text>
-              </>
+              </Stack>
             }
             config={{
               select: [
@@ -357,7 +358,7 @@ function InsertsTab({
         <ChartBox style={{ height: 400 }}>
           <DBTableChart
             title={
-              <>
+              <Stack gap={0}>
                 <Text size="sm" mb="sm">
                   Active Parts Per Partition
                 </Text>
@@ -366,7 +367,7 @@ function InsertsTab({
                   throttle inserts after 1,000 parts per partition and stop
                   inserts at 3,000 parts per partition.
                 </Text>
-              </>
+              </Stack>
             }
             config={{
               dateRange: searchedTimeRange,

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -225,11 +225,12 @@ const Tile = forwardRef(
     }, [alert]);
 
     const hoverToolbar = useMemo(() => {
-      return hovered ? (
+      return (
         <Flex
           gap="0px"
           onMouseDown={e => e.stopPropagation()}
           key="hover-toolbar"
+          style={{ visibility: hovered ? 'visible' : 'hidden' }}
         >
           {(chart.config.displayType === DisplayType.Line ||
             chart.config.displayType === DisplayType.StackedBar) && (
@@ -286,8 +287,6 @@ const Tile = forwardRef(
             <IconTrash size={14} />
           </Button>
         </Flex>
-      ) : (
-        <Box h={22} key="hover-empty-box" />
       );
     }, [
       alert,

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -16,9 +16,21 @@ function ChartContainer({
   return (
     <Stack h="100%" w="100%" style={{ flexGrow: 1 }}>
       {(!!title || !!toolbarItems?.length) && (
-        <Group justify="space-between" align="start">
-          {title || <span />}
-          {toolbarItems && <Group>{toolbarItems}</Group>}
+        <Group justify="space-between" align="start" wrap="nowrap">
+          <span
+            style={{
+              flex: 1,
+              flexShrink: 1,
+              overflow: 'hidden',
+            }}
+          >
+            {title}
+          </span>
+          {toolbarItems && (
+            <Group flex={0} wrap="nowrap">
+              {toolbarItems}
+            </Group>
+          )}
         </Group>
       )}
       {disableReactiveContainer ? (

--- a/packages/app/src/components/charts/DisplaySwitcher.tsx
+++ b/packages/app/src/components/charts/DisplaySwitcher.tsx
@@ -18,7 +18,12 @@ function DisplaySwitcher<T extends string>({
   options,
 }: DisplaySwitcherProps<T>) {
   return (
-    <Group className="bg-muted px-2 py-2 rounded fs-8" align="center" gap={0}>
+    <Group
+      className="bg-muted px-2 py-2 rounded fs-8"
+      align="center"
+      gap={0}
+      wrap="nowrap"
+    >
       {options.map(({ icon, label, value: optionValue, disabled }) => (
         <Tooltip label={label} key={optionValue}>
           <ActionIcon


### PR DESCRIPTION
# Summary

This PR fixes:

1. Dashboard tile buttons wrapping due to long titles
2. ClickHouse dashboard subtitles rendering inline

## Before

<img width="458" height="430" alt="Screenshot 2026-01-08 at 3 47 29 PM" src="https://github.com/user-attachments/assets/a2da49dd-8eab-4aa7-afe2-03927e09820a" />
<img width="1353" height="154" alt="Screenshot 2026-01-08 at 3 47 22 PM" src="https://github.com/user-attachments/assets/d132e625-fbf8-43f4-80f2-a82888261511" />
<img width="692" height="158" alt="Screenshot 2026-01-08 at 3 47 17 PM" src="https://github.com/user-attachments/assets/d8f5c02d-8b82-4cfc-af41-3f52c69be324" />


## After

<img width="463" height="431" alt="Screenshot 2026-01-08 at 3 46 15 PM" src="https://github.com/user-attachments/assets/45d4e917-0589-40b8-85f4-efc837370f1f" />
<img width="453" height="425" alt="Screenshot 2026-01-08 at 3 46 22 PM" src="https://github.com/user-attachments/assets/90bd89e2-96a5-4da4-8686-0adc15cc421d" />

<img width="1359" height="96" alt="Screenshot 2026-01-08 at 3 46 40 PM" src="https://github.com/user-attachments/assets/9282da0a-488c-46da-a564-4ce00bc6a5ee" />
<img width="703" height="210" alt="Screenshot 2026-01-08 at 3 46 33 PM" src="https://github.com/user-attachments/assets/d2d53585-d551-4a0b-bc78-633e4f84e9df" />



