### PR TITLE
fix: Fix missing dashboard edit icons on search tile

### DIFF
--- a/.changeset/cold-seas-allow.md
+++ b/.changeset/cold-seas-allow.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix missing dashboard edit icons on search tile

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -74,6 +74,7 @@ import {
   useDeleteDashboard,
 } from '@/dashboard';
 
+import ChartContainer from './components/charts/ChartContainer';
 import DBSqlRowTableWithSideBar from './components/DBSqlRowTableWithSidebar';
 import OnboardingModal from './components/OnboardingModal';
 import { Tags } from './components/Tags';
@@ -394,30 +395,36 @@ const Tile = forwardRef(
               />
             )}
             {queriedConfig?.displayType === DisplayType.Search && (
-              <DBSqlRowTableWithSideBar
-                enabled
-                sourceId={chart.config.source}
-                config={{
-                  ...queriedConfig,
-                  orderBy: [
-                    {
-                      ordering: 'DESC',
-                      valueExpression: getFirstTimestampValueExpression(
-                        queriedConfig.timestampValueExpression,
-                      ),
-                    },
-                  ],
-                  dateRange,
-                  select:
-                    queriedConfig.select ||
-                    source?.defaultTableSelectExpression ||
-                    '',
-                  groupBy: undefined,
-                  granularity: undefined,
-                }}
-                isLive={false}
-                queryKeyPrefix={'search'}
-              />
+              <ChartContainer
+                title={title}
+                toolbarItems={[hoverToolbar]}
+                disableReactiveContainer
+              >
+                <DBSqlRowTableWithSideBar
+                  enabled
+                  sourceId={chart.config.source}
+                  config={{
+                    ...queriedConfig,
+                    orderBy: [
+                      {
+                        ordering: 'DESC',
+                        valueExpression: getFirstTimestampValueExpression(
+                          queriedConfig.timestampValueExpression,
+                        ),
+                      },
+                    ],
+                    dateRange,
+                    select:
+                      queriedConfig.select ||
+                      source?.defaultTableSelectExpression ||
+                      '',
+                    groupBy: undefined,
+                    granularity: undefined,
+                  }}
+                  isLive={false}
+                  queryKeyPrefix={'search'}
+                />
+              </ChartContainer>
             )}
           </ErrorBoundary>
         </div>


### PR DESCRIPTION
# Summary

This PR adds the hover edit/duplicate/delete buttons back to the search tile. They were inadvertently removed as part of #1560 .

## Before

<img width="813" height="430" alt="Screenshot 2026-01-09 at 11 48 32 AM" src="https://github.com/user-attachments/assets/393f402b-b64a-4633-8261-dd169ba2c011" />

## After

<img width="814" height="421" alt="Screenshot 2026-01-09 at 11 48 10 AM" src="https://github.com/user-attachments/assets/9afc368a-5b12-462e-8909-61fe6a581615" />
