### PR TITLE
fix: Set better Chart Axis Bounds

### DIFF
--- a/.changeset/long-pumas-draw.md
+++ b/.changeset/long-pumas-draw.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Set better Chart Axis Bounds

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -750,6 +750,8 @@ function DBTimeChartComponent({
             previousPeriodOffsetSeconds={previousPeriodOffsetSeconds}
             selectedSeriesNames={selectedSeriesSet}
             onToggleSeries={handleToggleSeries}
+            granularity={granularity}
+            dateRangeEndInclusive={queriedConfig.dateRangeEndInclusive}
           />
         </>
       )}


### PR DESCRIPTION
Closes HDX-3180

# Summary

This PR makes a couple of changes to TimeChart axis bounds

1. Y Axis lower bound is now always 0 unless a series is selected (partial revert of #1572)
2. X-Axis bounds have been adjusted so that
   1. There is no longer an empty partial interval's worth of space at the end of line charts
   2. The first bar of a bar chart no longer overlaps with the Y Axis


## Before

- The first Bar in bar charts overlaps the Y Axis

<img width="1600" height="495" alt="Screenshot 2026-01-09 at 2 55 27 PM" src="https://github.com/user-attachments/assets/13087084-4847-46d5-98d3-85340101d7f3" />

- There is an empty partial (or full) interval at the end of charts

<img width="1611" height="483" alt="Screenshot 2026-01-09 at 2 55 21 PM" src="https://github.com/user-attachments/assets/a286966b-ccfa-485c-8d26-7090f75120e0" />

- Y Axis lower bound is non-zero when no series are selected

<img width="1603" height="388" alt="Screenshot 2026-01-09 at 2 38 54 PM" src="https://github.com/user-attachments/assets/4ca2743a-d484-40b1-b2e6-352aad838070" />
<img width="1623" height="373" alt="Screenshot 2026-01-09 at 2 37 26 PM" src="https://github.com/user-attachments/assets/4a8b9490-9efb-4c75-93b4-edb3321ee0a2" />

## After

- Bars fit fully within the chart domain

<img width="1610" height="503" alt="Screenshot 2026-01-09 at 2 55 42 PM" src="https://github.com/user-attachments/assets/42ab1f62-4c1e-475f-b3be-4bf6ed147dc4" />

- There is no empty space at the end of the line charts
- Y Axis lower bound is always 0 when no series are selected

<img width="1613" height="490" alt="Screenshot 2026-01-09 at 2 55 50 PM" src="https://github.com/user-attachments/assets/ed723a99-2a24-47f2-8ac8-93901f7fbf88" />


