### PR TITLE
fix: Respect date range URL params on Services dashboard

### DIFF
--- a/.changeset/fair-pugs-melt.md
+++ b/.changeset/fair-pugs-melt.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Respect date range URL params on Services dashboard

--- a/packages/app/src/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage.tsx
@@ -1480,19 +1480,22 @@ function ServicesDashboardPage() {
     isLive,
   });
 
-  const onSubmit = useCallback(() => {
-    onSearch(displayedTimeInputValue);
-    handleSubmit(values => {
-      setAppliedConfigParams(values);
-    })();
-  }, [handleSubmit, setAppliedConfigParams, onSearch, displayedTimeInputValue]);
+  const onSubmit = useCallback(
+    (submitTime: boolean = true) => {
+      if (submitTime) onSearch(displayedTimeInputValue);
+      handleSubmit(values => {
+        setAppliedConfigParams(values);
+      })();
+    },
+    [handleSubmit, setAppliedConfigParams, onSearch, displayedTimeInputValue],
+  );
 
   // Auto-submit when source changes
   // Note: do not include appliedConfig.source in the deps,
   // to avoid infinite render loops when navigating away from the page
   useEffect(() => {
     if (sourceId && sourceId != previousSourceId) {
-      onSubmit();
+      onSubmit(false);
     }
   }, [sourceId, onSubmit, previousSourceId]);
 
@@ -1501,7 +1504,7 @@ function ServicesDashboardPage() {
   // to avoid infinite render loops when navigating away from the page
   useEffect(() => {
     if (service != previousService) {
-      onSubmit();
+      onSubmit(false);
     }
   }, [service, onSubmit, previousService]);
 


### PR DESCRIPTION
Closes HDX-3189

# Summary

This PR fixes a bug that caused the services dashboard to reset to the default time range on each page load, rather than respecting the URL date range params.

The cause was that a couple of `useEffects` were firing at page load, and submitting a new date range.