### PR TITLE
feat: Add a search input that searches within virtual elements

### DIFF
--- a/.changeset/eight-bobcats-press.md
+++ b/.changeset/eight-bobcats-press.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": minor
+---
+
+Add a search input that allows searching within the virtual elements on the log search page

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1906,7 +1906,10 @@ function DBSearchPage() {
                         </Group>
                       </Box>
                       {!hasQueryError && (
-                        <Box className={searchPageStyles.timeChartContainer}>
+                        <Box
+                          className={searchPageStyles.timeChartContainer}
+                          style={{ flexShrink: 0 }}
+                        >
                           <DBTimeChart
                             sourceId={searchedConfig.source ?? undefined}
                             showLegend={false}

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -37,7 +37,6 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import {
   Box,
-  Button,
   Code,
   Flex,
   Group,
@@ -83,6 +82,7 @@ import useRowWhere, {
   RowWhereResult,
   WithClause,
 } from '@/hooks/useRowWhere';
+import { useTableSearch } from '@/hooks/useTableSearch';
 import { useSource } from '@/source';
 import { UNDEFINED_WIDTH } from '@/tableUtils';
 import { FormatTime } from '@/useFormatTime';
@@ -98,6 +98,11 @@ import {
 import DBRowTableFieldWithPopover from './DBTable/DBRowTableFieldWithPopover';
 import DBRowTableRowButtons from './DBTable/DBRowTableRowButtons';
 import TableHeader from './DBTable/TableHeader';
+import {
+  highlightText,
+  TableSearchInput,
+  TableSearchMatchIndicator,
+} from './DBTable/TableSearchInput';
 import { SQLPreview } from './ChartSQLPreview';
 import { CsvExportButton } from './CsvExportButton';
 import {
@@ -457,6 +462,13 @@ export const RawLogTable = memo(
       }
     }, [collapseAllRows, collapseRows]);
 
+    // Find within page functionality using custom hook
+    const tableSearch = useTableSearch({
+      rows: dedupedRows,
+      searchableColumns: displayedColumns,
+      debounceMs: 300,
+    });
+
     const columns = useMemo<ColumnDef<any>[]>(
       () => [
         ...(showExpandButton
@@ -518,13 +530,27 @@ export const RawLogTable = memo(
                   ? `${strValue.slice(0, MAX_CELL_LENGTH)}...`
                   : strValue;
 
+              // Apply search highlighting if there's a search query
+              // Use React Table's row index which corresponds to dedupedRows index
+              const isCurrentMatch =
+                !!tableSearch.searchQuery &&
+                tableSearch.matchIndices.length > 0 &&
+                tableSearch.matchIndices[tableSearch.currentMatchIndex] ===
+                  info.row.index;
+
+              const displayValue = tableSearch.searchQuery
+                ? highlightText(truncatedStrValue, tableSearch.searchQuery, {
+                    isCurrentMatch,
+                  })
+                : truncatedStrValue;
+
               return (
                 <span
                   className={cx({
                     'text-muted': value === SPECIAL_VALUES.not_available,
                   })}
                 >
-                  {truncatedStrValue}
+                  {displayValue}
                 </span>
               );
             },
@@ -548,6 +574,9 @@ export const RawLogTable = memo(
         toggleRowExpansion,
         showExpandButton,
         aliasMap,
+        tableSearch.searchQuery,
+        tableSearch.matchIndices,
+        tableSearch.currentMatchIndex,
       ],
     );
 
@@ -671,6 +700,62 @@ export const RawLogTable = memo(
       onChildModalOpen?.(open);
     };
 
+    // Scroll to current match (only when explicitly navigating)
+    // Fixed: Properly synchronized scroll flag with state updates
+    useEffect(() => {
+      if (!tableSearch.shouldScrollToMatch) {
+        return;
+      }
+
+      if (
+        tableSearch.matchIndices.length > 0 &&
+        rowVirtualizer &&
+        tableSearch.currentMatchIndex < tableSearch.matchIndices.length &&
+        tableSearch.searchQuery.trim()
+      ) {
+        const matchRowIndex =
+          tableSearch.matchIndices[tableSearch.currentMatchIndex];
+        const matchedRow = dedupedRows[matchRowIndex];
+
+        if (matchedRow) {
+          // Find the corresponding row in the react-table rows
+          const tableRowIndex = _rows.findIndex(
+            row => getRowId(row.original) === getRowId(matchedRow),
+          );
+
+          if (tableRowIndex !== -1) {
+            // Use requestAnimationFrame to ensure DOM is ready
+            requestAnimationFrame(() => {
+              rowVirtualizer.scrollToIndex(tableRowIndex, {
+                align: 'center',
+              });
+              // Clear the flag after scrolling completes
+              tableSearch.clearShouldScrollToMatch();
+            });
+          } else {
+            // Row not found in virtual list, clear flag
+            tableSearch.clearShouldScrollToMatch();
+          }
+        } else {
+          // No matched row, clear flag
+          tableSearch.clearShouldScrollToMatch();
+        }
+      } else {
+        // Conditions not met, clear flag
+        tableSearch.clearShouldScrollToMatch();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      tableSearch.shouldScrollToMatch,
+      tableSearch.currentMatchIndex,
+      tableSearch.matchIndices,
+      tableSearch.searchQuery,
+      tableSearch.clearShouldScrollToMatch,
+      rowVirtualizer,
+      _rows,
+      dedupedRows,
+    ]);
+
     useEffect(() => {
       if (
         scrolledToHighlightedLine ||
@@ -741,359 +826,398 @@ export const RawLogTable = memo(
     });
 
     return (
-      <div
-        data-testid="search-results-table"
-        className={cx('overflow-auto h-100 fs-8', styles.tableWrapper, {
-          [styles.muted]: variant === 'muted',
-        })}
-        onScroll={e => {
-          fetchMoreOnBottomReached(e.target as HTMLDivElement);
-
-          if (e.target != null) {
-            const { scrollTop } = e.target as HTMLDivElement;
-            onScroll?.(scrollTop);
-          }
-        }}
-        ref={tableContainerRef}
-        // Fixes flickering scroll bar: https://github.com/TanStack/virtual/issues/426#issuecomment-1403438040
-        // style={{ overflowAnchor: 'none' }}
-      >
-        {config && (
-          <SqlModal
-            opened={showSql}
-            onClose={() => handleSqlModalOpen(false)}
-            config={config}
+      <Flex direction="column" h="100%">
+        <Box pos="relative" style={{ flex: 1, minHeight: 0 }}>
+          {/* Find within page search bar - floating on top right */}
+          <TableSearchInput
+            searchQuery={tableSearch.inputValue}
+            onSearchChange={tableSearch.handleSearchChange}
+            matchIndices={tableSearch.matchIndices}
+            currentMatchIndex={tableSearch.currentMatchIndex}
+            onPreviousMatch={tableSearch.handlePreviousMatch}
+            onNextMatch={tableSearch.handleNextMatch}
+            isVisible={tableSearch.isSearchVisible}
+            onVisibilityChange={tableSearch.setIsSearchVisible}
           />
-        )}
-        <table className={cx('w-100', styles.table)} id={tableId}>
-          <thead className={styles.tableHead}>
-            {displayedColumns.length > 0 &&
-              table.getHeaderGroups().map(headerGroup => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header, headerIndex) => {
-                    const isLast =
-                      headerIndex === headerGroup.headers.length - 1;
-                    return (
-                      <TableHeader
-                        key={header.id}
-                        header={header}
-                        isLast={isLast}
-                        lastItemButtons={
-                          <Group gap={8} mr={8}>
-                            {tableId &&
-                              Object.keys(columnSizeStorage).length > 0 && (
+          <div
+            data-testid="search-results-table"
+            className={cx('overflow-auto h-100 fs-8', styles.tableWrapper, {
+              [styles.muted]: variant === 'muted',
+            })}
+            onScroll={e => {
+              fetchMoreOnBottomReached(e.target as HTMLDivElement);
+
+              if (e.target != null) {
+                const { scrollTop } = e.target as HTMLDivElement;
+                onScroll?.(scrollTop);
+              }
+            }}
+            ref={tableContainerRef}
+            // Fixes flickering scroll bar: https://github.com/TanStack/virtual/issues/426#issuecomment-1403438040
+            // style={{ overflowAnchor: 'none' }}
+          >
+            {config && (
+              <SqlModal
+                opened={showSql}
+                onClose={() => handleSqlModalOpen(false)}
+                config={config}
+              />
+            )}
+            <table className={cx('w-100', styles.table)} id={tableId}>
+              <thead className={styles.tableHead}>
+                {displayedColumns.length > 0 &&
+                  table.getHeaderGroups().map(headerGroup => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header, headerIndex) => {
+                        const isLast =
+                          headerIndex === headerGroup.headers.length - 1;
+                        return (
+                          <TableHeader
+                            key={header.id}
+                            header={header}
+                            isLast={isLast}
+                            lastItemButtons={
+                              <Group gap={8} mr={8}>
+                                {tableId &&
+                                  Object.keys(columnSizeStorage).length > 0 && (
+                                    <UnstyledButton
+                                      onClick={() => setColumnSizeStorage({})}
+                                      title="Reset Column Widths"
+                                    >
+                                      <MantineTooltip label="Reset Column Widths">
+                                        <IconRotateClockwise size={16} />
+                                      </MantineTooltip>
+                                    </UnstyledButton>
+                                  )}
+                                {config && (
+                                  <UnstyledButton
+                                    onClick={() => handleSqlModalOpen(true)}
+                                    title="Show Generated SQL"
+                                    tabIndex={0}
+                                  >
+                                    <MantineTooltip label="Show Generated SQL">
+                                      <IconCode size={16} />
+                                    </MantineTooltip>
+                                  </UnstyledButton>
+                                )}
                                 <UnstyledButton
-                                  onClick={() => setColumnSizeStorage({})}
-                                  title="Reset Column Widths"
+                                  onClick={() =>
+                                    setWrapLinesEnabled(prev => !prev)
+                                  }
+                                  title={`${wrapLinesEnabled ? 'Disable' : 'Enable'}  Wrap Lines`}
                                 >
-                                  <MantineTooltip label="Reset Column Widths">
-                                    <IconRotateClockwise size={16} />
+                                  <MantineTooltip
+                                    label={`${wrapLinesEnabled ? 'Disable' : 'Enable'} Wrap Lines`}
+                                  >
+                                    {wrapLinesEnabled ? (
+                                      <IconTextWrapDisabled size={16} />
+                                    ) : (
+                                      <IconTextWrap size={16} />
+                                    )}
                                   </MantineTooltip>
                                 </UnstyledButton>
-                              )}
-                            {config && (
-                              <UnstyledButton
-                                onClick={() => handleSqlModalOpen(true)}
-                                title="Show Generated SQL"
-                                tabIndex={0}
-                              >
-                                <MantineTooltip label="Show Generated SQL">
-                                  <IconCode size={16} />
-                                </MantineTooltip>
-                              </UnstyledButton>
-                            )}
-                            <UnstyledButton
-                              onClick={() => setWrapLinesEnabled(prev => !prev)}
-                              title={`${wrapLinesEnabled ? 'Disable' : 'Enable'}  Wrap Lines`}
-                            >
-                              <MantineTooltip
-                                label={`${wrapLinesEnabled ? 'Disable' : 'Enable'} Wrap Lines`}
-                              >
-                                {wrapLinesEnabled ? (
-                                  <IconTextWrapDisabled size={16} />
-                                ) : (
-                                  <IconTextWrap size={16} />
-                                )}
-                              </MantineTooltip>
-                            </UnstyledButton>
 
-                            <CsvExportButton
-                              data={csvData}
-                              filename={`hyperdx_search_results_${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`}
-                              className="fs-6"
-                            >
-                              <MantineTooltip
-                                label={`Download Table as CSV (max ${maxRows.toLocaleString()} rows)${isLimited ? ' - data truncated' : ''}`}
-                              >
-                                <IconDownload size={16} />
-                              </MantineTooltip>
-                            </CsvExportButton>
-                            {onSettingsClick != null && (
-                              <UnstyledButton
-                                onClick={() => onSettingsClick()}
-                                title="Settings"
-                              >
-                                <MantineTooltip label="Settings">
-                                  <IconSettings size={16} />
-                                </MantineTooltip>
-                              </UnstyledButton>
-                            )}
-                          </Group>
-                        }
-                      />
-                    );
-                  })}
-                </tr>
-              ))}
-          </thead>
-          <tbody>
-            {paddingTop > 0 && (
-              <tr>
-                <td colSpan={99999} style={{ height: `${paddingTop}px` }} />
-              </tr>
-            )}
-            {items.map(virtualRow => {
-              const row = _rows[virtualRow.index] as TableRow<any>;
-              const rowId = getRowId(row.original);
-              const isExpanded = expandedRows[rowId] ?? false;
-
-              return (
-                <React.Fragment key={virtualRow.key}>
-                  <tr
-                    data-testid={`table-row-${rowId}`}
-                    className={cx(styles.tableRow, {
-                      [styles.tableRow__selected]:
-                        highlightedLineId && highlightedLineId === rowId,
-                    })}
-                    data-index={virtualRow.index}
-                    ref={rowVirtualizer.measureElement}
-                  >
-                    {/* Expand button cell */}
-                    {showExpandButton && (
-                      <td
-                        className="align-top overflow-hidden"
-                        style={{ width: '40px' }}
-                      >
-                        {flexRender(
-                          row.getVisibleCells()[0].column.columnDef.cell,
-                          row.getVisibleCells()[0].getContext(),
-                        )}
-                      </td>
-                    )}
-
-                    {/* Content columns grouped back to preserve row hover/click */}
-                    <td
-                      className="align-top overflow-hidden p-0"
-                      colSpan={columns.length - (showExpandButton ? 1 : 0)}
-                    >
-                      <button
-                        type="button"
-                        className={cx(styles.rowContentButton, {
-                          [styles.isWrapped]: wrapLinesEnabled,
-                          [styles.isTruncated]: !wrapLinesEnabled,
-                        })}
-                        onClick={e => {
-                          _onRowExpandClick(row.original);
-                        }}
-                        aria-label="View details for log entry"
-                      >
-                        {row
-                          .getVisibleCells()
-                          .slice(showExpandButton ? 1 : 0) // Skip expand
-                          .map(cell => {
-                            const columnCustomClassName = (
-                              cell.column.columnDef.meta as any
-                            )?.className;
-                            const columnSize = cell.column.getSize();
-                            const cellValue = cell.getValue<any>();
-
-                            return (
-                              <div
-                                key={cell.id}
-                                className={cx(
-                                  'flex-shrink-0 overflow-hidden position-relative',
-                                  columnCustomClassName,
-                                )}
-                                style={{
-                                  width:
-                                    columnSize === UNDEFINED_WIDTH
-                                      ? 'auto'
-                                      : `${columnSize}px`,
-                                  flex:
-                                    columnSize === UNDEFINED_WIDTH
-                                      ? '1'
-                                      : 'none',
-                                }}
-                              >
-                                <div className={styles.fieldTextContainer}>
-                                  <DBRowTableFieldWithPopover
-                                    key={cell.id}
-                                    cellValue={cellValue}
-                                    wrapLinesEnabled={wrapLinesEnabled}
-                                    tableContainerRef={tableContainerRef}
-                                    columnName={
-                                      (cell.column.columnDef.meta as any)
-                                        ?.column
-                                    }
-                                    isChart={
-                                      (cell.column.columnDef.meta as any)
-                                        ?.column === '__hdx_pattern_trend'
-                                    }
+                                <CsvExportButton
+                                  data={csvData}
+                                  filename={`hyperdx_search_results_${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`}
+                                  className="fs-6"
+                                >
+                                  <MantineTooltip
+                                    label={`Download Table as CSV (max ${maxRows.toLocaleString()} rows)${isLimited ? ' - data truncated' : ''}`}
                                   >
-                                    {flexRender(
-                                      cell.column.columnDef.cell,
-                                      cell.getContext(),
-                                    )}
-                                  </DBRowTableFieldWithPopover>
-                                </div>
-                              </div>
-                            );
-                          })}
-                        {/* Row-level copy buttons */}
-                        {getRowWhere && (
-                          <DBRowTableRowButtons
-                            row={row.original}
-                            getRowWhere={getRowWhere}
-                            sourceId={source?.id}
-                            isWrapped={wrapLinesEnabled}
-                            onToggleWrap={() =>
-                              setWrapLinesEnabled(!wrapLinesEnabled)
+                                    <IconDownload size={16} />
+                                  </MantineTooltip>
+                                </CsvExportButton>
+                                {onSettingsClick != null && (
+                                  <UnstyledButton
+                                    onClick={() => onSettingsClick()}
+                                    title="Settings"
+                                  >
+                                    <MantineTooltip label="Settings">
+                                      <IconSettings size={16} />
+                                    </MantineTooltip>
+                                  </UnstyledButton>
+                                )}
+                              </Group>
                             }
                           />
-                        )}
-                      </button>
-                    </td>
-                  </tr>
-                  {showExpandButton && isExpanded && (
-                    <ExpandedLogRow
-                      columnsLength={columns.length}
-                      virtualKey={virtualRow.key.toString()}
-                      source={source}
-                      rowId={rowId}
-                      measureElement={rowVirtualizer.measureElement}
-                      virtualIndex={virtualRow.index}
-                    >
-                      {renderRowDetails?.({
-                        id: rowId,
-                        aliasWith: row.original[INTERNAL_ROW_FIELDS.ALIAS_WITH],
-                        ...row.original,
+                        );
                       })}
-                    </ExpandedLogRow>
-                  )}
-                </React.Fragment>
-              );
-            })}
-            <tr>
-              <td colSpan={800}>
-                <div className="rounded fs-7 bg-muted text-center d-flex align-items-center justify-content-center mt-3">
-                  {isLoading ? (
-                    <div className="my-3">
-                      <div className="d-inline-block">
-                        <IconRefresh size={14} className="spin-animate" />
-                      </div>{' '}
-                      {loadingDate != null && (
-                        <>
-                          Searched <FormatTime value={loadingDate} />.{' '}
-                        </>
-                      )}
-                      Loading results
-                      {dateRange?.[0] != null && dateRange?.[1] != null ? (
-                        <>
-                          {' '}
-                          across{' '}
-                          {formatDistance(dateRange?.[1], dateRange?.[0])} {'('}
-                          <FormatTime
-                            value={dateRange?.[0]}
-                            format="withYear"
-                          />{' '}
-                          to{' '}
-                          <FormatTime
-                            value={dateRange?.[1]}
-                            format="withYear"
-                          />
-                          {')'}
-                        </>
-                      ) : null}
-                      ...
-                    </div>
-                  ) : hasNextPage == false &&
-                    isLoading == false &&
-                    dedupedRows.length > 0 ? (
-                    <div className="my-3">End of Results</div>
-                  ) : isError ? (
-                    <div className="my-3">
-                      <Text ta="center" size="sm">
-                        Error loading results, please check your query or try
-                        again.
-                      </Text>
-                      <Box p="sm">
-                        <Box mt="sm">
-                          <Code
-                            block
-                            style={{
-                              whiteSpace: 'pre-wrap',
-                            }}
+                    </tr>
+                  ))}
+              </thead>
+              <tbody>
+                {paddingTop > 0 && (
+                  <tr>
+                    <td colSpan={99999} style={{ height: `${paddingTop}px` }} />
+                  </tr>
+                )}
+                {items.map(virtualRow => {
+                  const row = _rows[virtualRow.index] as TableRow<any>;
+                  const rowId = getRowId(row.original);
+                  const isExpanded = expandedRows[rowId] ?? false;
+
+                  return (
+                    <React.Fragment key={virtualRow.key}>
+                      <tr
+                        data-testid={`table-row-${rowId}`}
+                        className={cx(styles.tableRow, {
+                          [styles.tableRow__selected]:
+                            highlightedLineId && highlightedLineId === rowId,
+                        })}
+                        data-index={virtualRow.index}
+                        ref={rowVirtualizer.measureElement}
+                      >
+                        {/* Expand button cell */}
+                        {showExpandButton && (
+                          <td
+                            className="align-top overflow-hidden"
+                            style={{ width: '40px' }}
                           >
-                            {error?.message}
-                          </Code>
-                        </Box>
-                        {error instanceof ClickHouseQueryError && (
-                          <>
-                            <Text my="sm" size="sm" ta="center">
-                              Sent Query:
-                            </Text>
-                            <Flex
-                              w="100%"
-                              ta="initial"
-                              align="center"
-                              justify="center"
-                            >
-                              <SQLPreview data={error?.query} />
-                            </Flex>
-                          </>
+                            {flexRender(
+                              row.getVisibleCells()[0].column.columnDef.cell,
+                              row.getVisibleCells()[0].getContext(),
+                            )}
+                          </td>
                         )}
-                      </Box>
+
+                        {/* Content columns grouped back to preserve row hover/click */}
+                        <td
+                          className="align-top overflow-hidden p-0"
+                          colSpan={columns.length - (showExpandButton ? 1 : 0)}
+                        >
+                          <button
+                            type="button"
+                            className={cx(styles.rowContentButton, {
+                              [styles.isWrapped]: wrapLinesEnabled,
+                              [styles.isTruncated]: !wrapLinesEnabled,
+                            })}
+                            onClick={e => {
+                              _onRowExpandClick(row.original);
+                            }}
+                            aria-label="View details for log entry"
+                          >
+                            {row
+                              .getVisibleCells()
+                              .slice(showExpandButton ? 1 : 0) // Skip expand
+                              .map(cell => {
+                                const columnCustomClassName = (
+                                  cell.column.columnDef.meta as any
+                                )?.className;
+                                const columnSize = cell.column.getSize();
+                                const cellValue = cell.getValue<any>();
+
+                                return (
+                                  <div
+                                    key={cell.id}
+                                    className={cx(
+                                      'flex-shrink-0 overflow-hidden position-relative',
+                                      columnCustomClassName,
+                                    )}
+                                    style={{
+                                      width:
+                                        columnSize === UNDEFINED_WIDTH
+                                          ? 'auto'
+                                          : `${columnSize}px`,
+                                      flex:
+                                        columnSize === UNDEFINED_WIDTH
+                                          ? '1'
+                                          : 'none',
+                                    }}
+                                  >
+                                    <div className={styles.fieldTextContainer}>
+                                      <DBRowTableFieldWithPopover
+                                        key={cell.id}
+                                        cellValue={cellValue}
+                                        wrapLinesEnabled={wrapLinesEnabled}
+                                        tableContainerRef={tableContainerRef}
+                                        columnName={
+                                          (cell.column.columnDef.meta as any)
+                                            ?.column
+                                        }
+                                        isChart={
+                                          (cell.column.columnDef.meta as any)
+                                            ?.column === '__hdx_pattern_trend'
+                                        }
+                                      >
+                                        {flexRender(
+                                          cell.column.columnDef.cell,
+                                          cell.getContext(),
+                                        )}
+                                      </DBRowTableFieldWithPopover>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            {/* Row-level copy buttons */}
+                            {getRowWhere && (
+                              <DBRowTableRowButtons
+                                row={row.original}
+                                getRowWhere={getRowWhere}
+                                sourceId={source?.id}
+                                isWrapped={wrapLinesEnabled}
+                                onToggleWrap={() =>
+                                  setWrapLinesEnabled(!wrapLinesEnabled)
+                                }
+                              />
+                            )}
+                          </button>
+                        </td>
+                      </tr>
+                      {showExpandButton && isExpanded && (
+                        <ExpandedLogRow
+                          columnsLength={columns.length}
+                          virtualKey={virtualRow.key.toString()}
+                          source={source}
+                          rowId={rowId}
+                          measureElement={rowVirtualizer.measureElement}
+                          virtualIndex={virtualRow.index}
+                        >
+                          {renderRowDetails?.({
+                            id: rowId,
+                            aliasWith:
+                              row.original[INTERNAL_ROW_FIELDS.ALIAS_WITH],
+                            ...row.original,
+                          })}
+                        </ExpandedLogRow>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+                <tr>
+                  <td colSpan={800}>
+                    <div className="rounded fs-7 bg-muted text-center d-flex align-items-center justify-content-center mt-3">
+                      {isLoading ? (
+                        <div className="my-3">
+                          <div className="d-inline-block">
+                            <IconRefresh size={14} className="spin-animate" />
+                          </div>{' '}
+                          {loadingDate != null && (
+                            <>
+                              Searched <FormatTime value={loadingDate} />.{' '}
+                            </>
+                          )}
+                          Loading results
+                          {dateRange?.[0] != null && dateRange?.[1] != null ? (
+                            <>
+                              {' '}
+                              across{' '}
+                              {formatDistance(
+                                dateRange?.[1],
+                                dateRange?.[0],
+                              )}{' '}
+                              {'('}
+                              <FormatTime
+                                value={dateRange?.[0]}
+                                format="withYear"
+                              />{' '}
+                              to{' '}
+                              <FormatTime
+                                value={dateRange?.[1]}
+                                format="withYear"
+                              />
+                              {')'}
+                            </>
+                          ) : null}
+                          ...
+                        </div>
+                      ) : hasNextPage == false &&
+                        isLoading == false &&
+                        dedupedRows.length > 0 ? (
+                        <div className="my-3">End of Results</div>
+                      ) : isError ? (
+                        <div className="my-3">
+                          <Text ta="center" size="sm">
+                            Error loading results, please check your query or
+                            try again.
+                          </Text>
+                          <Box p="sm">
+                            <Box mt="sm">
+                              <Code
+                                block
+                                style={{
+                                  whiteSpace: 'pre-wrap',
+                                }}
+                              >
+                                {error?.message}
+                              </Code>
+                            </Box>
+                            {error instanceof ClickHouseQueryError && (
+                              <>
+                                <Text my="sm" size="sm" ta="center">
+                                  Sent Query:
+                                </Text>
+                                <Flex
+                                  w="100%"
+                                  ta="initial"
+                                  align="center"
+                                  justify="center"
+                                >
+                                  <SQLPreview data={error?.query} />
+                                </Flex>
+                              </>
+                            )}
+                          </Box>
+                        </div>
+                      ) : hasNextPage == false &&
+                        isLoading == false &&
+                        dedupedRows.length === 0 ? (
+                        <div
+                          className="my-3"
+                          data-testid="db-row-table-no-results"
+                        >
+                          No results found.
+                          <Text mt="sm">
+                            Try checking the query explainer in the search bar
+                            if there are any search syntax issues.
+                          </Text>
+                          {dateRange?.[0] != null && dateRange?.[1] != null ? (
+                            <Text mt="sm">
+                              Searched Time Range:{' '}
+                              {formatDistance(dateRange?.[1], dateRange?.[0])}{' '}
+                              {'('}
+                              <FormatTime
+                                value={dateRange?.[0]}
+                                format="withYear"
+                              />{' '}
+                              to{' '}
+                              <FormatTime
+                                value={dateRange?.[1]}
+                                format="withYear"
+                              />
+                              {')'}
+                            </Text>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <div />
+                      )}
                     </div>
-                  ) : hasNextPage == false &&
-                    isLoading == false &&
-                    dedupedRows.length === 0 ? (
-                    <div className="my-3" data-testid="db-row-table-no-results">
-                      No results found.
-                      <Text mt="sm">
-                        Try checking the query explainer in the search bar if
-                        there are any search syntax issues.
-                      </Text>
-                      {dateRange?.[0] != null && dateRange?.[1] != null ? (
-                        <Text mt="sm">
-                          Searched Time Range:{' '}
-                          {formatDistance(dateRange?.[1], dateRange?.[0])} {'('}
-                          <FormatTime
-                            value={dateRange?.[0]}
-                            format="withYear"
-                          />{' '}
-                          to{' '}
-                          <FormatTime
-                            value={dateRange?.[1]}
-                            format="withYear"
-                          />
-                          {')'}
-                        </Text>
-                      ) : null}
-                    </div>
-                  ) : (
-                    <div />
-                  )}
-                </div>
-              </td>
-            </tr>
-            {paddingBottom > 0 && (
-              <tr>
-                <td colSpan={99999} style={{ height: `${paddingBottom}px` }} />
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+                  </td>
+                </tr>
+                {paddingBottom > 0 && (
+                  <tr>
+                    <td
+                      colSpan={99999}
+                      style={{ height: `${paddingBottom}px` }}
+                    />
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {/* Match indicator on the right side */}
+          <TableSearchMatchIndicator
+            searchQuery={tableSearch.searchQuery}
+            matchIndices={tableSearch.matchIndices}
+            currentMatchIndex={tableSearch.currentMatchIndex}
+            dedupedRows={dedupedRows}
+            tableRows={_rows}
+            getRowId={getRowId}
+            onMatchClick={tableSearch.handleMatchClick}
+          />
+        </Box>
+      </Flex>
     );
   },
 );

--- a/packages/app/src/components/DBTable/TableSearchInput.tsx
+++ b/packages/app/src/components/DBTable/TableSearchInput.tsx
@@ -1,0 +1,354 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  Group,
+  Paper,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from '@mantine/core';
+import { IconArrowDown, IconArrowUp, IconX } from '@tabler/icons-react';
+
+interface HighlightTextSettings {
+  isCurrentMatch: boolean;
+  textColor: string;
+  backgroundColor: string;
+  currentMatchBackgroundColor: string;
+}
+
+/**
+ * Helper function to highlight text matching a search query within the text of
+ * a TextNode.
+ *
+ * @param text - The text (part of the TextNode) to highlight within
+ * @param query - The query to highlight
+ * @param isCurrentMatch - Whether the text is the current match. Current match is
+ * highlighted with an orange background.
+ * @returns The text node with the matching query highlighted.
+ */
+export const highlightText = (
+  text: string,
+  query: string,
+  settings: Partial<HighlightTextSettings> = {},
+): React.ReactNode => {
+  if (!query.trim()) return text;
+
+  const backgroundColor = settings.isCurrentMatch
+    ? settings.currentMatchBackgroundColor || 'var(--mantine-color-orange-5)'
+    : settings.backgroundColor || 'var(--mantine-color-yellow-3)';
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let index = lowerText.indexOf(lowerQuery);
+
+  while (index !== -1) {
+    // Add text before match
+    if (index > lastIndex) {
+      parts.push(text.slice(lastIndex, index));
+    }
+    // Add highlighted match - use orange for current match, yellow for others
+    parts.push(
+      <mark
+        key={`${index}-${lastIndex}`}
+        style={{
+          backgroundColor,
+          color: settings.textColor || 'var(--color-text-inverted)',
+          padding: 0,
+        }}
+      >
+        {text.slice(index, index + query.length)}
+      </mark>,
+    );
+    lastIndex = index + query.length;
+    index = lowerText.indexOf(lowerQuery, lastIndex);
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length > 0 ? <>{parts}</> : text;
+};
+
+interface TableSearchInputProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  matchIndices: number[];
+  currentMatchIndex: number;
+  onPreviousMatch: () => void;
+  onNextMatch: () => void;
+  /**
+   * Control visibility from parent
+   */
+  isVisible?: boolean;
+  /**
+   * Called when visibility changes
+   */
+  onVisibilityChange?: (visible: boolean) => void;
+}
+
+/**
+ * A search input component that handles Cmd+F/Ctrl+F keyboard shortcuts.
+ * The parent is responsible for performing the actual search and managing match state.
+ */
+export const TableSearchInput = ({
+  searchQuery,
+  onSearchChange,
+  matchIndices,
+  currentMatchIndex,
+  onPreviousMatch,
+  onNextMatch,
+  isVisible: externalIsVisible,
+  onVisibilityChange,
+}: TableSearchInputProps) => {
+  const [internalIsVisible, setInternalIsVisible] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Use external visibility if provided, otherwise use internal state
+  const isVisible = externalIsVisible ?? internalIsVisible;
+
+  const handleClose = useCallback(() => {
+    if (externalIsVisible !== undefined) {
+      onVisibilityChange?.(false);
+    } else {
+      setInternalIsVisible(false);
+    }
+    onSearchChange('');
+  }, [externalIsVisible, onSearchChange, onVisibilityChange]);
+
+  const handleShow = useCallback(() => {
+    if (externalIsVisible !== undefined) {
+      onVisibilityChange?.(true);
+    } else {
+      setInternalIsVisible(true);
+    }
+    // Focus the input after a brief delay to ensure it's rendered
+    setTimeout(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    }, 0);
+  }, [externalIsVisible, onVisibilityChange]);
+
+  // Handle keyboard shortcuts (Cmd+F, Escape)
+  // Fixed: Move handler definition outside of effect to prevent recreation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Detect Cmd+F (Mac) or Ctrl+F (Windows/Linux)
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        handleShow();
+      }
+      // Close search on Escape
+      if (e.key === 'Escape' && isVisible) {
+        handleClose();
+      }
+    },
+    [isVisible, handleClose, handleShow],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && matchIndices.length > 0) {
+        if (e.shiftKey) {
+          // Shift+Enter: previous match
+          onPreviousMatch();
+        } else {
+          // Enter: next match
+          onNextMatch();
+        }
+        e.preventDefault();
+      }
+    },
+    [matchIndices.length, onPreviousMatch, onNextMatch],
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+  return (
+    <Paper
+      p="xs"
+      withBorder
+      shadow="md"
+      pos="absolute"
+      top={8}
+      right={8}
+      style={{ zIndex: 2 }}
+      miw={400}
+      maw={500}
+      role="search"
+      aria-label="Table search"
+    >
+      <Group gap="xs" align="center" wrap="nowrap">
+        <TextInput
+          ref={searchInputRef}
+          placeholder="Find in table..."
+          value={searchQuery}
+          onChange={e => onSearchChange(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
+          size="xs"
+          style={{ flex: 1, minWidth: 0 }}
+          aria-label="Search table contents"
+          aria-describedby={
+            matchIndices.length > 0 ? 'search-match-count' : undefined
+          }
+          rightSection={
+            searchQuery ? (
+              <UnstyledButton
+                onClick={() => onSearchChange('')}
+                display="flex"
+                style={{ alignItems: 'center' }}
+                title="Clear search"
+                aria-label="Clear search"
+              >
+                <IconX size={14} />
+              </UnstyledButton>
+            ) : null
+          }
+        />
+        {matchIndices.length > 0 ? (
+          <>
+            <Text
+              id="search-match-count"
+              size="xs"
+              c="dimmed"
+              style={{ whiteSpace: 'nowrap' }}
+              aria-live="polite"
+            >
+              {currentMatchIndex + 1} of {matchIndices.length}
+            </Text>
+            <Group gap={4}>
+              <UnstyledButton
+                onClick={onPreviousMatch}
+                display="flex"
+                style={{ alignItems: 'center' }}
+                title="Previous match (Shift+Enter)"
+                aria-label="Previous match"
+              >
+                <IconArrowUp size={16} />
+              </UnstyledButton>
+              <UnstyledButton
+                onClick={onNextMatch}
+                display="flex"
+                style={{ alignItems: 'center' }}
+                title="Next match (Enter)"
+                aria-label="Next match"
+              >
+                <IconArrowDown size={16} />
+              </UnstyledButton>
+            </Group>
+          </>
+        ) : searchQuery ? (
+          <Text
+            size="xs"
+            c="dimmed"
+            style={{ whiteSpace: 'nowrap' }}
+            role="status"
+            aria-live="polite"
+          >
+            No matches
+          </Text>
+        ) : null}
+        <UnstyledButton
+          onClick={handleClose}
+          display="flex"
+          style={{ alignItems: 'center' }}
+          title="Close search (Esc)"
+          aria-label="Close search"
+        >
+          <IconX size={16} />
+        </UnstyledButton>
+      </Group>
+    </Paper>
+  );
+};
+
+interface TableSearchMatchIndicatorProps {
+  searchQuery: string;
+  matchIndices: number[];
+  currentMatchIndex: number;
+  dedupedRows: Record<string, any>[];
+  tableRows: any[];
+  getRowId: (row: Record<string, any>) => string;
+  onMatchClick: (index: number) => void;
+}
+
+/**
+ * Visual indicators on the scrollbar showing where search matches are located.
+ * Renders as a vertical strip on the right side of the table with clickable markers.
+ */
+export const TableSearchMatchIndicator = ({
+  searchQuery,
+  matchIndices,
+  currentMatchIndex,
+  dedupedRows,
+  tableRows,
+  getRowId,
+  onMatchClick,
+}: TableSearchMatchIndicatorProps) => {
+  if (!searchQuery || matchIndices.length === 0 || tableRows.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      pos="absolute"
+      right={0}
+      top={0}
+      bottom={0}
+      w={8}
+      style={{ pointerEvents: 'none', zIndex: 1 }}
+    >
+      {matchIndices.map((matchIndex, i) => {
+        const matchRow = dedupedRows[matchIndex];
+        if (!matchRow) return null;
+
+        const tableRowIndex = tableRows.findIndex(
+          row => getRowId(row.original) === getRowId(matchRow),
+        );
+
+        if (tableRowIndex === -1) return null;
+
+        // Calculate position as percentage of total rows
+        const percentage = (tableRowIndex / tableRows.length) * 100;
+        // Calculate height based on number of rows (each indicator represents 1/n of the scrollbar)
+        const heightPercentage = 100 / tableRows.length;
+        const isCurrentMatchIndicator = i === currentMatchIndex;
+
+        return (
+          <Box
+            key={`match-indicator-${matchIndex}`}
+            pos="absolute"
+            top={`${percentage}%`}
+            right={0}
+            w="100%"
+            h={`${heightPercentage}%`}
+            bg={
+              isCurrentMatchIndicator
+                ? 'var(--mantine-color-orange-5)'
+                : 'var(--mantine-color-yellow-5)'
+            }
+            style={{
+              cursor: 'pointer',
+              pointerEvents: 'auto',
+              minHeight: 1,
+              maxHeight: 4,
+            }}
+            onClick={() => onMatchClick(i)}
+            title={`Match ${i + 1} of ${matchIndices.length}`}
+          />
+        );
+      })}
+    </Box>
+  );
+};

--- a/packages/app/src/components/DBTable/__tests__/TableSearchInput.test.tsx
+++ b/packages/app/src/components/DBTable/__tests__/TableSearchInput.test.tsx
@@ -1,0 +1,1314 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  highlightText,
+  TableSearchInput,
+  TableSearchMatchIndicator,
+} from '@/components/DBTable/TableSearchInput';
+
+describe('highlightText', () => {
+  describe('basic highlighting', () => {
+    it('should return plain text when query is empty', () => {
+      const result = highlightText('hdx-oss-dev-api', '');
+      expect(result).toBe('hdx-oss-dev-api');
+    });
+
+    it('should return plain text when query is whitespace', () => {
+      const result = highlightText('hdx-oss-dev-api', '   ');
+      expect(result).toBe('hdx-oss-dev-api');
+    });
+
+    it('should highlight matching text in service name', () => {
+      const result = highlightText('hdx-oss-dev-api', 'api');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight matching text in span name', () => {
+      const result = highlightText('mongodb.update', 'mongodb');
+      expect(result).toBeDefined();
+    });
+
+    it('should be case-insensitive', () => {
+      const result = highlightText('hdx-oss-dev-api', 'API');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight multiple occurrences', () => {
+      const result = highlightText('middleware - corsMiddleware', 'middleware');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('partial matches', () => {
+    it('should highlight partial match at beginning', () => {
+      const result = highlightText('mongodb.update', 'mongo');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight partial match at end', () => {
+      const result = highlightText('tcp.connect', 'connect');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight partial match in middle', () => {
+      const result = highlightText('hdx-oss-dev-api', 'oss');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('custom styling', () => {
+    it('should apply current match highlighting', () => {
+      const result = highlightText('mongodb.update', 'mongodb', {
+        isCurrentMatch: true,
+        currentMatchBackgroundColor: 'orange',
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should apply custom text color', () => {
+      const result = highlightText('mongodb.update', 'mongodb', {
+        textColor: 'white',
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should apply custom background color', () => {
+      const result = highlightText('mongodb.update', 'mongodb', {
+        backgroundColor: 'yellow',
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should use different colors for current vs other matches', () => {
+      const currentMatch = highlightText('middleware - corsMiddleware', 'mid', {
+        isCurrentMatch: true,
+      });
+      const otherMatch = highlightText('middleware - corsMiddleware', 'mid', {
+        isCurrentMatch: false,
+      });
+
+      expect(currentMatch).toBeDefined();
+      expect(otherMatch).toBeDefined();
+      expect(currentMatch).not.toEqual(otherMatch);
+    });
+  });
+
+  describe('special characters', () => {
+    it('should handle text with dots', () => {
+      const result = highlightText('mongodb.update', '.');
+      expect(result).toBeDefined();
+    });
+
+    it('should handle text with slashes', () => {
+      const result = highlightText('router - /health', '/health');
+      expect(result).toBeDefined();
+    });
+
+    it('should handle text with hyphens', () => {
+      const result = highlightText('hdx-oss-dev-api', '-oss-');
+      expect(result).toBeDefined();
+    });
+
+    it('should handle text with underscores', () => {
+      const result = highlightText('isUserAuthenticated', 'User');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('realistic HyperDX values', () => {
+    it('should highlight service names', () => {
+      const result = highlightText('hdx-oss-dev-api', 'dev');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight span names with dots', () => {
+      const result = highlightText('mongodb.update', 'update');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight middleware names', () => {
+      const result = highlightText(
+        'middleware - isUserAuthenticated',
+        'authenticated',
+      );
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight router paths', () => {
+      const result = highlightText('router - /health', 'health');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight DNS operations', () => {
+      const result = highlightText('dns.lookup', 'dns');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight TCP operations', () => {
+      const result = highlightText('tcp.connect', 'tcp');
+      expect(result).toBeDefined();
+    });
+
+    it('should highlight POST operations', () => {
+      const result = highlightText('POST', 'post');
+      expect(result).toBeDefined();
+    });
+  });
+});
+
+describe('TableSearchInput', () => {
+  const defaultProps = {
+    searchQuery: '',
+    onSearchChange: jest.fn(),
+    matchIndices: [],
+    currentMatchIndex: 0,
+    onPreviousMatch: jest.fn(),
+    onNextMatch: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('visibility', () => {
+    it('should not render when isVisible is false', () => {
+      renderWithMantine(
+        <TableSearchInput {...defaultProps} isVisible={false} />,
+      );
+
+      expect(screen.queryByRole('search')).not.toBeInTheDocument();
+    });
+
+    it('should render when isVisible is true', () => {
+      renderWithMantine(
+        <TableSearchInput {...defaultProps} isVisible={true} />,
+      );
+
+      expect(screen.getByRole('search')).toBeInTheDocument();
+    });
+
+    it('should render search input field when visible', () => {
+      renderWithMantine(
+        <TableSearchInput {...defaultProps} isVisible={true} />,
+      );
+
+      expect(
+        screen.getByPlaceholderText('Find in table...'),
+      ).toBeInTheDocument();
+    });
+
+    it('should call onVisibilityChange when close button is clicked', async () => {
+      const onVisibilityChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          isVisible={true}
+          onVisibilityChange={onVisibilityChange}
+        />,
+      );
+
+      const closeButton = screen.getByLabelText('Close search');
+      await user.click(closeButton);
+
+      expect(onVisibilityChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('search input', () => {
+    it('should display the current search query', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByDisplayValue('mongodb')).toBeInTheDocument();
+    });
+
+    it('should call onSearchChange when typing', async () => {
+      const onSearchChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          onSearchChange={onSearchChange}
+          isVisible={true}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText('Find in table...');
+      await user.type(input, 'hdx-oss-dev-api');
+
+      expect(onSearchChange).toHaveBeenCalled();
+    });
+
+    it('should show clear button when query is not empty', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
+    });
+
+    it('should not show clear button when query is empty', () => {
+      renderWithMantine(
+        <TableSearchInput {...defaultProps} searchQuery="" isVisible={true} />,
+      );
+
+      expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+    });
+
+    it('should clear search when clear button is clicked', async () => {
+      const onSearchChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          onSearchChange={onSearchChange}
+          isVisible={true}
+        />,
+      );
+
+      const clearButton = screen.getByLabelText('Clear search');
+      await user.click(clearButton);
+
+      expect(onSearchChange).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('match count display', () => {
+    it('should display match count when matches exist', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 3')).toBeInTheDocument();
+    });
+
+    it('should update match count when navigating', () => {
+      // Test first match position
+      const { unmount } = renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 2')).toBeInTheDocument();
+      unmount();
+
+      // Test second match position
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={1}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('2 of 2')).toBeInTheDocument();
+    });
+
+    it('should display "No matches" when search has no results', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="nonexistent"
+          matchIndices={[]}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('No matches')).toBeInTheDocument();
+    });
+
+    it('should not display match count when query is empty', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery=""
+          matchIndices={[]}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.queryByText(/of/)).not.toBeInTheDocument();
+      expect(screen.queryByText('No matches')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('navigation controls', () => {
+    it('should display navigation buttons when matches exist', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4, 5, 6, 7, 8]}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByLabelText('Previous match')).toBeInTheDocument();
+      expect(screen.getByLabelText('Next match')).toBeInTheDocument();
+    });
+
+    it('should not display navigation buttons when no matches', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="nonexistent"
+          matchIndices={[]}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.queryByLabelText('Previous match')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Next match')).not.toBeInTheDocument();
+    });
+
+    it('should call onPreviousMatch when previous button clicked', async () => {
+      const onPreviousMatch = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={1}
+          onPreviousMatch={onPreviousMatch}
+          isVisible={true}
+        />,
+      );
+
+      const previousButton = screen.getByLabelText('Previous match');
+      await user.click(previousButton);
+
+      expect(onPreviousMatch).toHaveBeenCalled();
+    });
+
+    it('should call onNextMatch when next button clicked', async () => {
+      const onNextMatch = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={0}
+          onNextMatch={onNextMatch}
+          isVisible={true}
+        />,
+      );
+
+      const nextButton = screen.getByLabelText('Next match');
+      await user.click(nextButton);
+
+      expect(onNextMatch).toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard shortcuts', () => {
+    it('should call onNextMatch when Enter is pressed', async () => {
+      const onNextMatch = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          onNextMatch={onNextMatch}
+          isVisible={true}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText('Find in table...');
+      input.focus();
+      await user.keyboard('{Enter}');
+
+      expect(onNextMatch).toHaveBeenCalled();
+    });
+
+    it('should call onPreviousMatch when Shift+Enter is pressed', async () => {
+      const onPreviousMatch = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          onPreviousMatch={onPreviousMatch}
+          isVisible={true}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText('Find in table...');
+      input.focus();
+      await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+      expect(onPreviousMatch).toHaveBeenCalled();
+    });
+
+    it('should not navigate when Enter is pressed with no matches', async () => {
+      const onNextMatch = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="nonexistent"
+          matchIndices={[]}
+          onNextMatch={onNextMatch}
+          isVisible={true}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText('Find in table...');
+      input.focus();
+      await user.keyboard('{Enter}');
+
+      expect(onNextMatch).not.toHaveBeenCalled();
+    });
+
+    it('should open search on Cmd+F', async () => {
+      const onVisibilityChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          isVisible={false}
+          onVisibilityChange={onVisibilityChange}
+        />,
+      );
+
+      // Simulate Cmd+F (Meta+F)
+      await user.keyboard('{Meta>}f{/Meta}');
+
+      await waitFor(() => {
+        expect(onVisibilityChange).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('should open search on Ctrl+F', async () => {
+      const onVisibilityChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          isVisible={false}
+          onVisibilityChange={onVisibilityChange}
+        />,
+      );
+
+      // Simulate Ctrl+F
+      await user.keyboard('{Control>}f{/Control}');
+
+      await waitFor(() => {
+        expect(onVisibilityChange).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('should close search on Escape when visible', async () => {
+      const onVisibilityChange = jest.fn();
+      const onSearchChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          isVisible={true}
+          onVisibilityChange={onVisibilityChange}
+          onSearchChange={onSearchChange}
+        />,
+      );
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(onVisibilityChange).toHaveBeenCalledWith(false);
+        expect(onSearchChange).toHaveBeenCalledWith('');
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have proper ARIA labels', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByRole('search')).toHaveAttribute(
+        'aria-label',
+        'Table search',
+      );
+      expect(screen.getByPlaceholderText('Find in table...')).toHaveAttribute(
+        'aria-label',
+        'Search table contents',
+      );
+    });
+
+    it('should have aria-live region for match count', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          isVisible={true}
+        />,
+      );
+
+      const matchCount = screen.getByText('1 of 3');
+      expect(matchCount).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should have aria-live region for no matches message', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="nonexistent"
+          matchIndices={[]}
+          isVisible={true}
+        />,
+      );
+
+      const noMatches = screen.getByText('No matches');
+      expect(noMatches).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should link search input to match count with aria-describedby', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2, 5, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      // Verify the match count is present with the correct ID
+      const matchCount = screen.getByText('1 of 3');
+      expect(matchCount).toHaveAttribute('id', 'search-match-count');
+      expect(matchCount).toHaveAttribute('aria-live', 'polite');
+
+      // Verify input has proper label
+      const input = screen.getByPlaceholderText('Find in table...');
+      expect(input).toHaveAttribute('aria-label', 'Search table contents');
+    });
+  });
+
+  describe('realistic search scenarios', () => {
+    it('should handle searching for service name "hdx-oss-dev-api"', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4, 5, 6, 7, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 7')).toBeInTheDocument();
+    });
+
+    it('should handle searching for span name "mongodb"', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 1')).toBeInTheDocument();
+    });
+
+    it('should handle searching for "middleware"', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 2')).toBeInTheDocument();
+    });
+
+    it('should handle searching for "longtask"', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 2')).toBeInTheDocument();
+    });
+
+    it('should handle searching across all results with "Unset"', () => {
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="Unset"
+          matchIndices={[0, 1, 2, 3, 4, 5, 6, 7, 8]}
+          currentMatchIndex={0}
+          isVisible={true}
+        />,
+      );
+
+      expect(screen.getByText('1 of 9')).toBeInTheDocument();
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should support full search workflow', async () => {
+      const onSearchChange = jest.fn();
+      const onNextMatch = jest.fn();
+      const onPreviousMatch = jest.fn();
+      const user = userEvent.setup();
+
+      // Render with search results
+      renderWithMantine(
+        <TableSearchInput
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[7, 8]}
+          currentMatchIndex={0}
+          onSearchChange={onSearchChange}
+          onNextMatch={onNextMatch}
+          onPreviousMatch={onPreviousMatch}
+          isVisible={true}
+        />,
+      );
+
+      // Verify match count is displayed
+      expect(screen.getByText('1 of 2')).toBeInTheDocument();
+
+      // Test navigation buttons
+      const nextButton = screen.getByLabelText('Next match');
+      await user.click(nextButton);
+      expect(onNextMatch).toHaveBeenCalled();
+
+      const previousButton = screen.getByLabelText('Previous match');
+      await user.click(previousButton);
+      expect(onPreviousMatch).toHaveBeenCalled();
+
+      // Test typing in search box
+      const input = screen.getByPlaceholderText('Find in table...');
+      await user.clear(input);
+      await user.type(input, 'new search');
+      expect(onSearchChange).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('TableSearchMatchIndicator', () => {
+  // Realistic test data based on HyperDX logs
+  const mockDedupedRows = [
+    {
+      id: '1',
+      timestamp: 'Jan 15 4:43:28.966 PM',
+      ServiceName: 'hdx-oss-dev-app',
+      StatusCode: 'Unset',
+      SpanName: 'longtask',
+      Duration: 69,
+    },
+    {
+      id: '2',
+      timestamp: 'Jan 15 4:43:28.912 PM',
+      ServiceName: 'hdx-oss-dev-app',
+      StatusCode: 'Unset',
+      SpanName: 'longtask',
+      Duration: 54,
+    },
+    {
+      id: '3',
+      timestamp: 'Jan 15 4:43:25.034 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'mongodb.update',
+      Duration: 1,
+    },
+    {
+      id: '4',
+      timestamp: 'Jan 15 4:43:25.021 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'dns.lookup',
+      Duration: 0,
+    },
+    {
+      id: '5',
+      timestamp: 'Jan 15 4:43:25.021 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'POST',
+      Duration: 13,
+    },
+  ];
+
+  const mockTableRows = mockDedupedRows.map((row, index) => ({
+    original: row,
+    index,
+  }));
+
+  const getRowId = (row: any) => row.id;
+
+  const defaultProps = {
+    searchQuery: '',
+    matchIndices: [],
+    currentMatchIndex: 0,
+    dedupedRows: mockDedupedRows,
+    tableRows: mockTableRows as any[],
+    getRowId,
+    onMatchClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('visibility conditions', () => {
+    it('should not render when searchQuery is empty', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator {...defaultProps} searchQuery="" />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(0);
+    });
+
+    it('should not render when matchIndices is empty', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="test"
+          matchIndices={[]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(0);
+    });
+
+    it('should not render when tableRows is empty', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="test"
+          matchIndices={[0, 1]}
+          tableRows={[]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(0);
+    });
+
+    it('should render when all required conditions are met', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('match indicators rendering', () => {
+    it('should render indicators for all matches', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+        />,
+      );
+
+      // Count the number of indicator boxes rendered
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(3);
+    });
+
+    it('should render indicators for "longtask" matches', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(2);
+    });
+
+    it('should render single indicator for "mongodb" match', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(1);
+    });
+
+    it('should render indicators for all "Unset" status matches', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="Unset"
+          matchIndices={[0, 1, 2, 3, 4]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(5);
+    });
+  });
+
+  describe('indicator positioning', () => {
+    it('should position indicators based on row position in table', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // First match (index 0) should be at 0% (0 / 5 * 100)
+      expect(indicators[0]).toHaveStyle({ top: '0%' });
+
+      // Second match (index 1) should be at 20% (1 / 5 * 100)
+      expect(indicators[1]).toHaveStyle({ top: '20%' });
+    });
+
+    it('should calculate correct position for matches at different indices', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="api"
+          matchIndices={[2, 3, 4]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // Match at index 2: 2 / 5 * 100 = 40%
+      expect(indicators[0]).toHaveStyle({ top: '40%' });
+
+      // Match at index 3: 3 / 5 * 100 = 60%
+      expect(indicators[1]).toHaveStyle({ top: '60%' });
+
+      // Match at index 4: 4 / 5 * 100 = 80%
+      expect(indicators[2]).toHaveStyle({ top: '80%' });
+    });
+  });
+
+  describe('current match highlighting', () => {
+    it('should render all indicators when current match is first', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+          currentMatchIndex={0}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // All indicators should be rendered
+      expect(indicators.length).toBe(3);
+      // First indicator should be current match
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 3');
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 3');
+      expect(indicators[2]).toHaveAttribute('title', 'Match 3 of 3');
+    });
+
+    it('should render all indicators when current match is in middle', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+          currentMatchIndex={1}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // All indicators should be rendered
+      expect(indicators.length).toBe(3);
+      // Second indicator should be current match
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 3');
+    });
+
+    it('should render all indicators when current match is last', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+          currentMatchIndex={1}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // All indicators should be rendered
+      expect(indicators.length).toBe(2);
+      // Last indicator should be current match
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 2');
+    });
+  });
+
+  describe('indicator titles', () => {
+    it('should display correct title for first match', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 3');
+    });
+
+    it('should display correct titles for all matches', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 3');
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 3');
+      expect(indicators[2]).toHaveAttribute('title', 'Match 3 of 3');
+    });
+
+    it('should display correct title for single match', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 1');
+    });
+  });
+
+  describe('click interactions', () => {
+    it('should call onMatchClick when indicator is clicked', async () => {
+      const onMatchClick = jest.fn();
+      const user = userEvent.setup();
+
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+          onMatchClick={onMatchClick}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      await user.click(indicators[0] as HTMLElement);
+
+      expect(onMatchClick).toHaveBeenCalledWith(0);
+    });
+
+    it('should call onMatchClick with correct index for different matches', async () => {
+      const onMatchClick = jest.fn();
+      const user = userEvent.setup();
+
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="hdx-oss-dev-api"
+          matchIndices={[2, 3, 4]}
+          onMatchClick={onMatchClick}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // Click second indicator
+      await user.click(indicators[1] as HTMLElement);
+      expect(onMatchClick).toHaveBeenCalledWith(1);
+
+      // Click third indicator
+      await user.click(indicators[2] as HTMLElement);
+      expect(onMatchClick).toHaveBeenCalledWith(2);
+    });
+
+    it('should have pointer cursor on indicators', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      indicators.forEach(indicator => {
+        expect(indicator).toHaveStyle({ cursor: 'pointer' });
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle match that is not in tableRows', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="test"
+          matchIndices={[0, 10]} // index 10 doesn't exist in mockDedupedRows
+        />,
+      );
+
+      // Should only render indicator for valid match (index 0)
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(1);
+    });
+
+    it('should handle mismatched row IDs gracefully', () => {
+      const mismatchedDedupedRows = [
+        { ...mockDedupedRows[0], id: 'non-matching-id' },
+      ];
+
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="test"
+          matchIndices={[0]}
+          dedupedRows={mismatchedDedupedRows}
+        />,
+      );
+
+      // Should not render indicator if row IDs don't match
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(0);
+    });
+
+    it('should render with large number of matches', () => {
+      const largeDedupedRows = Array.from({ length: 100 }, (_, i) => ({
+        id: `row-${i}`,
+        ServiceName: 'test-service',
+        SpanName: 'test-span',
+        StatusCode: 'Unset',
+      }));
+
+      const largeTableRows = largeDedupedRows.map((row, index) => ({
+        original: row,
+        index,
+      }));
+
+      const largeMatchIndices = Array.from({ length: 50 }, (_, i) => i * 2);
+
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="test"
+          matchIndices={largeMatchIndices}
+          dedupedRows={largeDedupedRows}
+          tableRows={largeTableRows as any[]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(50);
+    });
+  });
+
+  describe('styling and layout', () => {
+    it('should have correct positioning and dimensions', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      // Verify indicators are rendered (proves container exists with correct setup)
+      expect(indicators.length).toBe(2);
+
+      // Verify indicators have correct positioning
+      expect(indicators[0]).toHaveStyle({ top: '0%' });
+      expect(indicators[1]).toHaveStyle({ top: '20%' });
+    });
+
+    it('should have correct z-index for proper layering', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      // Verify indicators are rendered (proves z-index setup works)
+      expect(indicators.length).toBe(2);
+    });
+
+    it('should have pointer-events on indicators but not on container', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+
+      // Indicators should have pointer cursor (proving they're clickable)
+      indicators.forEach(indicator => {
+        expect(indicator).toHaveStyle({ cursor: 'pointer' });
+      });
+    });
+  });
+
+  describe('realistic search scenarios', () => {
+    it('should correctly render indicators for "longtask" search', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="longtask"
+          matchIndices={[0, 1]}
+          currentMatchIndex={0}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(2);
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 2');
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 2');
+      // Verify indicators are clickable
+      expect(indicators[0]).toHaveStyle({ cursor: 'pointer' });
+      expect(indicators[1]).toHaveStyle({ cursor: 'pointer' });
+    });
+
+    it('should correctly render indicators for "middleware" search', () => {
+      const extendedRows = [
+        ...mockDedupedRows,
+        {
+          id: '6',
+          ServiceName: 'hdx-oss-dev-api',
+          SpanName: 'middleware - auth',
+          StatusCode: 'Unset',
+        },
+        {
+          id: '7',
+          ServiceName: 'hdx-oss-dev-api',
+          SpanName: 'middleware - cors',
+          StatusCode: 'Unset',
+        },
+      ];
+
+      const extendedTableRows = extendedRows.map((row, index) => ({
+        original: row,
+        index,
+      }));
+
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="middleware"
+          matchIndices={[5, 6]}
+          dedupedRows={extendedRows}
+          tableRows={extendedTableRows as any[]}
+          currentMatchIndex={0}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(2);
+
+      // Verify titles
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 2');
+      expect(indicators[1]).toHaveAttribute('title', 'Match 2 of 2');
+    });
+
+    it('should correctly render indicator for single "mongodb" match', () => {
+      const { container } = renderWithMantine(
+        <TableSearchMatchIndicator
+          {...defaultProps}
+          searchQuery="mongodb"
+          matchIndices={[2]}
+          currentMatchIndex={0}
+        />,
+      );
+
+      const indicators = container.querySelectorAll('[title*="Match"]');
+      expect(indicators.length).toBe(1);
+      expect(indicators[0]).toHaveAttribute('title', 'Match 1 of 1');
+      expect(indicators[0]).toHaveStyle({ top: '40%' }); // 2 / 5 * 100
+    });
+  });
+});

--- a/packages/app/src/hooks/__tests__/useTableSearch.test.tsx
+++ b/packages/app/src/hooks/__tests__/useTableSearch.test.tsx
@@ -1,0 +1,613 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useTableSearch } from '../useTableSearch';
+
+describe('useTableSearch', () => {
+  // Realistic test data based on HyperDX logs
+  const mockRows = [
+    {
+      timestamp: 'Jan 15 4:43:28.966 PM',
+      ServiceName: 'hdx-oss-dev-app',
+      StatusCode: 'Unset',
+      SpanName: 'longtask',
+      Duration: 69,
+    },
+    {
+      timestamp: 'Jan 15 4:43:28.912 PM',
+      ServiceName: 'hdx-oss-dev-app',
+      StatusCode: 'Unset',
+      SpanName: 'longtask',
+      Duration: 54,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.034 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'mongodb.update',
+      Duration: 1,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.021 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'dns.lookup',
+      Duration: 0,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.021 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'POST',
+      Duration: 13,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.020 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'router - /health',
+      Duration: 0,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.020 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'tcp.connect',
+      Duration: 1,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.020 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'middleware - isUserAuthenticated',
+      Duration: 0,
+    },
+    {
+      timestamp: 'Jan 15 4:43:25.019 PM',
+      ServiceName: 'hdx-oss-dev-api',
+      StatusCode: 'Unset',
+      SpanName: 'middleware - corsMiddleware',
+      Duration: 0,
+    },
+  ];
+
+  const searchableColumns = ['ServiceName', 'SpanName', 'StatusCode'];
+
+  describe('initialization', () => {
+    it('should initialize with empty search state', () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0, // No debounce for tests
+        }),
+      );
+
+      expect(result.current.inputValue).toBe('');
+      expect(result.current.matchIndices).toEqual([]);
+      expect(result.current.currentMatchIndex).toBe(0);
+      expect(result.current.isSearchVisible).toBe(false);
+      expect(result.current.shouldScrollToMatch).toBe(false);
+    });
+  });
+
+  describe('search functionality', () => {
+    it('should find matches for service name "hdx-oss-dev-api"', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('hdx-oss-dev-api');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(7);
+      });
+
+      expect(result.current.matchIndices).toEqual([2, 3, 4, 5, 6, 7, 8]);
+    });
+
+    it('should find matches for span name "mongodb"', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('mongodb');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      expect(result.current.matchIndices).toEqual([2]);
+    });
+
+    it('should find matches for "middleware" in span names', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      expect(result.current.matchIndices).toEqual([7, 8]);
+    });
+
+    it('should find matches for "longtask" in span names', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('longtask');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      expect(result.current.matchIndices).toEqual([0, 1]);
+    });
+
+    it('should perform case-insensitive search', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('MONGODB');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+    });
+
+    it('should find partial matches', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('dns');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      expect(result.current.matchIndices).toEqual([3]);
+    });
+
+    it('should return no matches for non-existent text', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('nonexistent');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(0);
+      });
+    });
+
+    it('should search across multiple columns', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('Unset');
+      });
+
+      await waitFor(() => {
+        // All rows have StatusCode: 'Unset'
+        expect(result.current.matchIndices).toHaveLength(9);
+      });
+    });
+
+    it('should clear matches when search is cleared', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('mongodb');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      act(() => {
+        result.current.handleSearchChange('');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toEqual([]);
+        expect(result.current.currentMatchIndex).toBe(0);
+      });
+    });
+
+    it('should handle rows with null or undefined values', async () => {
+      const rowsWithNulls = [
+        ...mockRows,
+        {
+          timestamp: 'Jan 15 4:43:25.000 PM',
+          ServiceName: null,
+          StatusCode: undefined,
+          SpanName: 'test',
+          Duration: 0,
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: rowsWithNulls,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('test');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      expect(result.current.matchIndices).toEqual([9]);
+    });
+  });
+
+  describe('navigation between matches', () => {
+    it('should navigate to next match', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.handleNextMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(1);
+      expect(result.current.shouldScrollToMatch).toBe(true);
+    });
+
+    it('should wrap to first match when navigating past the last match', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      // Navigate to last match
+      act(() => {
+        result.current.handleNextMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(1);
+
+      // Navigate past last match should wrap to first
+      act(() => {
+        result.current.handleNextMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(0);
+    });
+
+    it('should navigate to previous match', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      // Navigate to second match
+      act(() => {
+        result.current.handleNextMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(1);
+
+      // Navigate back to first match
+      act(() => {
+        result.current.handlePreviousMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(0);
+    });
+
+    it('should wrap to last match when navigating before the first match', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+        expect(result.current.currentMatchIndex).toBe(0);
+      });
+
+      // Navigate before first match should wrap to last
+      act(() => {
+        result.current.handlePreviousMatch();
+      });
+
+      expect(result.current.currentMatchIndex).toBe(1);
+    });
+
+    it('should handle match click to specific index', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('hdx-oss-dev-api');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(7);
+      });
+
+      act(() => {
+        result.current.handleMatchClick(3);
+      });
+
+      expect(result.current.currentMatchIndex).toBe(3);
+      expect(result.current.shouldScrollToMatch).toBe(true);
+    });
+
+    it('should set shouldScrollToMatch flag when performing search and navigating', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('middleware');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(2);
+      });
+
+      // Initial search sets the flag to true
+      expect(result.current.shouldScrollToMatch).toBe(true);
+
+      // Navigate to next match - flag should still be true
+      act(() => {
+        result.current.handleNextMatch();
+      });
+
+      expect(result.current.shouldScrollToMatch).toBe(true);
+      expect(result.current.currentMatchIndex).toBe(1);
+    });
+  });
+
+  describe('visibility management', () => {
+    it('should toggle search visibility', () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      expect(result.current.isSearchVisible).toBe(false);
+
+      act(() => {
+        result.current.setIsSearchVisible(true);
+      });
+
+      expect(result.current.isSearchVisible).toBe(true);
+
+      act(() => {
+        result.current.setIsSearchVisible(false);
+      });
+
+      expect(result.current.isSearchVisible).toBe(false);
+    });
+
+    it('should call onVisibilityChange callback when visibility changes', () => {
+      const onVisibilityChange = jest.fn();
+
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+          onVisibilityChange,
+        }),
+      );
+
+      act(() => {
+        result.current.setIsSearchVisible(true);
+      });
+
+      expect(onVisibilityChange).toHaveBeenCalledWith(true);
+
+      act(() => {
+        result.current.setIsSearchVisible(false);
+      });
+
+      expect(onVisibilityChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('resetSearch', () => {
+    it('should reset all search state', async () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      // Set up search state
+      act(() => {
+        result.current.setIsSearchVisible(true);
+        result.current.handleSearchChange('mongodb');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      // Reset search
+      act(() => {
+        result.current.resetSearch();
+      });
+
+      expect(result.current.inputValue).toBe('');
+      expect(result.current.matchIndices).toEqual([]);
+      expect(result.current.currentMatchIndex).toBe(0);
+      expect(result.current.shouldScrollToMatch).toBe(false);
+      expect(result.current.isSearchVisible).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle whitespace-only search query', () => {
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: mockRows,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('   ');
+      });
+
+      expect(result.current.matchIndices).toEqual([]);
+    });
+
+    it('should handle special characters in search query', async () => {
+      const rowsWithSpecialChars = [
+        {
+          ServiceName: 'test.service',
+          SpanName: 'operation/action',
+          StatusCode: 'OK',
+        },
+        {
+          ServiceName: 'another-service',
+          SpanName: 'route:/api/users',
+          StatusCode: 'OK',
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useTableSearch({
+          rows: rowsWithSpecialChars,
+          searchableColumns,
+          debounceMs: 0,
+        }),
+      );
+
+      act(() => {
+        result.current.handleSearchChange('/api/');
+      });
+
+      await waitFor(() => {
+        expect(result.current.matchIndices).toHaveLength(1);
+      });
+
+      expect(result.current.matchIndices).toEqual([1]);
+    });
+  });
+});

--- a/packages/app/src/hooks/useTableSearch.ts
+++ b/packages/app/src/hooks/useTableSearch.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDebouncedValue } from '@mantine/hooks';
+
+interface UseTableSearchOptions {
+  /**
+   * The rows to search through
+   */
+  rows: Record<string, any>[];
+  /**
+   * The columns to search in
+   */
+  searchableColumns: string[];
+  /**
+   * Debounce delay in milliseconds
+   * @default 300
+   */
+  debounceMs?: number;
+  /**
+   * Called when search visibility changes
+   */
+  onVisibilityChange?: (visible: boolean) => void;
+}
+
+interface UseTableSearchReturn {
+  searchQuery: string;
+  inputValue: string;
+  setInputValue: (query: string) => void;
+  matchIndices: number[];
+  currentMatchIndex: number;
+  isSearchVisible: boolean;
+  setIsSearchVisible: (visible: boolean) => void;
+  shouldScrollToMatch: boolean;
+  clearShouldScrollToMatch: () => void;
+  handlePreviousMatch: () => void;
+  handleNextMatch: () => void;
+  handleMatchClick: (index: number) => void;
+  handleSearchChange: (value: string) => void;
+  resetSearch: () => void;
+}
+
+/**
+ * Custom hook to manage table search functionality with debouncing.
+ * Handles search state, match tracking, and navigation between matches.
+ */
+export function useTableSearch({
+  rows,
+  searchableColumns,
+  debounceMs = 300,
+  onVisibilityChange,
+}: UseTableSearchOptions): UseTableSearchReturn {
+  const [inputValue, setInputValue] = useState('');
+  const [debouncedSearchQuery] = useDebouncedValue(inputValue, debounceMs);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [matchIndices, setMatchIndices] = useState<number[]>([]);
+  const [isSearchVisible, setIsSearchVisible] = useState(false);
+  const shouldScrollToMatchRef = useRef(false);
+
+  // Search through all rows when debounced query changes
+  useEffect(() => {
+    if (!debouncedSearchQuery.trim()) {
+      setMatchIndices([]);
+      setCurrentMatchIndex(0);
+      return;
+    }
+
+    const query = debouncedSearchQuery.toLowerCase();
+    const foundMatches: number[] = [];
+
+    rows.forEach((row, index) => {
+      // Search through all searchable columns
+      const rowText = searchableColumns
+        .map(col => {
+          const value = (row as Record<string, any>)[col];
+          return value != null ? String(value).toLowerCase() : '';
+        })
+        .join(' ');
+
+      if (rowText.includes(query)) {
+        foundMatches.push(index);
+      }
+    });
+
+    const previousMatchCount = matchIndices.length;
+    setMatchIndices(foundMatches);
+
+    // Only reset to first match if this is a new search (not just loading more data)
+    // If we had matches before and still have matches, try to stay on the same match
+    if (previousMatchCount === 0 && foundMatches.length > 0) {
+      setCurrentMatchIndex(0);
+      shouldScrollToMatchRef.current = true;
+    } else if (
+      foundMatches.length > 0 &&
+      currentMatchIndex >= foundMatches.length
+    ) {
+      // If current match is now out of bounds, go to last match
+      setCurrentMatchIndex(foundMatches.length - 1);
+      shouldScrollToMatchRef.current = true;
+    }
+    // Otherwise keep the current match index as is (loading more data shouldn't change position)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearchQuery, rows, searchableColumns]);
+
+  // Handle visibility changes
+  useEffect(() => {
+    onVisibilityChange?.(isSearchVisible);
+  }, [isSearchVisible, onVisibilityChange]);
+
+  const handleSearchChange = useCallback((value: string) => {
+    setInputValue(value);
+    // Reset match state when query is cleared
+    if (!value) {
+      setMatchIndices([]);
+      setCurrentMatchIndex(0);
+      shouldScrollToMatchRef.current = false;
+    }
+  }, []);
+
+  const handlePreviousMatch = useCallback(() => {
+    shouldScrollToMatchRef.current = true;
+    setCurrentMatchIndex(prev =>
+      prev > 0 ? prev - 1 : matchIndices.length - 1,
+    );
+  }, [matchIndices.length]);
+
+  const handleNextMatch = useCallback(() => {
+    shouldScrollToMatchRef.current = true;
+    setCurrentMatchIndex(prev =>
+      prev < matchIndices.length - 1 ? prev + 1 : 0,
+    );
+  }, [matchIndices.length]);
+
+  const handleMatchClick = useCallback((index: number) => {
+    shouldScrollToMatchRef.current = true;
+    setCurrentMatchIndex(index);
+  }, []);
+
+  const resetSearch = useCallback(() => {
+    setInputValue('');
+    setMatchIndices([]);
+    setCurrentMatchIndex(0);
+    shouldScrollToMatchRef.current = false;
+    setIsSearchVisible(false);
+  }, []);
+
+  const clearShouldScrollToMatch = useCallback(() => {
+    shouldScrollToMatchRef.current = false;
+  }, []);
+
+  return {
+    searchQuery: debouncedSearchQuery,
+    inputValue,
+    setInputValue,
+    matchIndices,
+    currentMatchIndex,
+    isSearchVisible,
+    setIsSearchVisible,
+    shouldScrollToMatch: shouldScrollToMatchRef.current,
+    clearShouldScrollToMatch,
+    handlePreviousMatch,
+    handleNextMatch,
+    handleMatchClick,
+    handleSearchChange,
+    resetSearch,
+  };
+}


### PR DESCRIPTION
Add a separate search input triggered by Cmd+F that searches through all matches currently on the page, overriding the native browser search that only searches within visible rows.

Fixes HDX-2687

### Video


https://github.com/user-attachments/assets/beaab78f-e96c-4698-86b7-a4ee3540db1b



