### PR TITLE
feat: add microseconds and nanoseconds to time unit display

### DIFF
--- a/packages/app/src/components/NumberFormat.tsx
+++ b/packages/app/src/components/NumberFormat.tsx
@@ -179,6 +179,8 @@ export const NumberFormatForm: React.FC<{
               data={[
                 { value: '1', label: 'Seconds' },
                 { value: '0.001', label: 'Milliseconds' },
+                { value: '0.000001', label: 'Microseconds' },
+                { value: '0.000000001', label: 'Nanoseconds' },
               ]}
             />
           ) : (

--- a/packages/app/src/components/__tests__/NumberFormat.test.tsx
+++ b/packages/app/src/components/__tests__/NumberFormat.test.tsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { NumberFormatForm, NumberFormatInput } from '../NumberFormat';
+
+describe('NumberFormat', () => {
+  describe('NumberFormatForm', () => {
+    const mockOnApply = jest.fn();
+    const mockOnClose = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('renders time input unit dropdown with all options', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Find the Input unit select
+      const select = screen.getByLabelText('Input unit');
+      expect(select).toBeInTheDocument();
+
+      // Check that all time unit options are present
+      const options = (select as HTMLSelectElement).options;
+      expect(options).toHaveLength(4);
+      expect(options[0].value).toBe('1');
+      expect(options[0].text).toBe('Seconds');
+      expect(options[1].value).toBe('0.001');
+      expect(options[1].text).toBe('Milliseconds');
+      expect(options[2].value).toBe('0.000001');
+      expect(options[2].text).toBe('Microseconds');
+      expect(options[3].value).toBe('0.000000001');
+      expect(options[3].text).toBe('Nanoseconds');
+    });
+
+    it('correctly sets factor value for seconds', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit') as HTMLSelectElement;
+      expect(select.value).toBe('1');
+    });
+
+    it('correctly sets factor value for milliseconds', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 0.001,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit') as HTMLSelectElement;
+      expect(select.value).toBe('0.001');
+    });
+
+    it('correctly sets factor value for microseconds', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 0.000001,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit') as HTMLSelectElement;
+      expect(select.value).toBe('0.000001');
+    });
+
+    it('correctly sets factor value for nanoseconds', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 0.000000001,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit') as HTMLSelectElement;
+      expect(select.value).toBe('0.000000001');
+    });
+
+    it('calls onApply with microseconds factor when microseconds is selected', async () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit');
+      fireEvent.change(select, { target: { value: '0.000001' } });
+
+      const applyButton = screen.getByRole('button', { name: 'Apply' });
+      fireEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(mockOnApply).toHaveBeenCalledWith(
+          expect.objectContaining({
+            factor: 0.000001,
+          }),
+        );
+      });
+    });
+
+    it('calls onApply with nanoseconds factor when nanoseconds is selected', async () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={timeFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const select = screen.getByLabelText('Input unit');
+      fireEvent.change(select, { target: { value: '0.000000001' } });
+
+      const applyButton = screen.getByRole('button', { name: 'Apply' });
+      fireEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(mockOnApply).toHaveBeenCalledWith(
+          expect.objectContaining({
+            factor: 0.000000001,
+          }),
+        );
+      });
+    });
+
+    it('shows time input unit dropdown only when output is time', () => {
+      const numberFormat = {
+        output: 'number' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatForm
+          value={numberFormat}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(screen.queryByLabelText('Input unit')).not.toBeInTheDocument();
+    });
+
+    it('calls onClose when Cancel button is clicked', () => {
+      renderWithMantine(
+        <NumberFormatForm
+          value={undefined}
+          onApply={mockOnApply}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      fireEvent.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('NumberFormatInput', () => {
+    const mockOnChange = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('opens drawer when button is clicked', async () => {
+      renderWithMantine(
+        <NumberFormatInput value={undefined} onChange={mockOnChange} />,
+      );
+
+      const button = screen.getByText('Set number format');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Number format')).toBeInTheDocument();
+      });
+    });
+
+    it('displays format name when value is set', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 0.000001,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatInput value={timeFormat} onChange={mockOnChange} />,
+      );
+
+      expect(screen.getByText('Time')).toBeInTheDocument();
+    });
+
+    it('calls onChange with undefined when clear button is clicked', () => {
+      const timeFormat = {
+        output: 'time' as const,
+        factor: 1,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+
+      renderWithMantine(
+        <NumberFormatInput value={timeFormat} onChange={mockOnChange} />,
+      );
+
+      // Find the X button (clear button)
+      const clearButton = screen.getAllByRole('button')[1]; // Second button is the clear button
+      fireEvent.click(clearButton);
+
+      expect(mockOnChange).toHaveBeenCalledWith(undefined);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds microseconds and nanoseconds options to the time unit dropdown in charts.

## Changes
- Added microseconds (factor: 0.000001) option to time unit dropdown
- Added nanoseconds (factor: 0.000000001) option to time unit dropdown
- Created comprehensive tests for NumberFormat component
- Tests cover all time units and user interactions

Fixes #1601

Generated with [Claude Code](https://claude.ai/code)