### PR TITLE
test: Add E2E tests for Dashboard Filters

### DIFF
--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1131,6 +1131,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
               variant="default"
               px="xs"
               onClick={() => setShowFiltersModal(true)}
+              data-testid="edit-filters-button"
             >
               <IconFilterEdit strokeWidth={1} />
             </Button>

--- a/packages/app/src/DashboardFilters.tsx
+++ b/packages/app/src/DashboardFilters.tsx
@@ -40,6 +40,7 @@ const DashboardFilterSelect = ({
       w={200}
       limit={20}
       onChange={onChange}
+      data-testid={`dashboard-filter-select-${filter.name}`}
     />
   );
 };

--- a/packages/app/src/DashboardFiltersModal.tsx
+++ b/packages/app/src/DashboardFiltersModal.tsx
@@ -138,6 +138,7 @@ const DashboardFilterEditForm = ({
             <CustomInputWrapper label="Name" error={formState.errors.name}>
               <TextInput
                 placeholder="Name"
+                data-testid="filter-name-input"
                 {...register('name', { required: true, minLength: 1 })}
               />
             </CustomInputWrapper>
@@ -206,7 +207,9 @@ const DashboardFilterEditForm = ({
               <Button variant="default" onClick={onCancel}>
                 Cancel
               </Button>
-              <Button type="submit">Save filter</Button>
+              <Button type="submit" data-testid="save-filter-button">
+                Save filter
+              </Button>
             </Group>
           </Stack>
         </form>
@@ -223,14 +226,24 @@ interface EmptyStateProps {
 const EmptyState = ({ onCreateFilter, onClose }: EmptyStateProps) => {
   return (
     <Modal opened onClose={onClose} size={MODAL_SIZE}>
-      <Stack align="center" justify="center" pt="lg" pb="xl">
+      <Stack
+        align="center"
+        justify="center"
+        pt="lg"
+        pb="xl"
+        data-testid="dashboard-filters-empty-state"
+      >
         <IconFilter />
         <Title order={4}>No filters yet.</Title>
         <Text size="sm" ta="center" px="xl">
           Add filters to let users quickly narrow data on key columns. Saved
           filters will stay with this dashboard.
         </Text>
-        <Button variant="filled" onClick={onCreateFilter}>
+        <Button
+          variant="filled"
+          onClick={onCreateFilter}
+          data-testid="add-filter-button"
+        >
           Add new filter
         </Button>
       </Stack>
@@ -265,7 +278,11 @@ const DashboardFiltersList = ({
       size={MODAL_SIZE}
       className={styles.modal}
     >
-      <Stack className={styles.filtersContainer} gap="xs">
+      <Stack
+        className={styles.filtersContainer}
+        gap="xs"
+        data-testid="dashboard-filters-list"
+      >
         {filters.map(filter => (
           <Paper
             key={filter.id}
@@ -273,6 +290,7 @@ const DashboardFiltersList = ({
             className={styles.filterPaper}
             p="xs"
             variant="muted"
+            data-testid={`dashboard-filter-item-${filter.name}`}
           >
             <Group justify="space-between" className={styles.filterHeader}>
               <Text size="xs">{filter.name}</Text>
@@ -280,12 +298,14 @@ const DashboardFiltersList = ({
                 <UnstyledButton
                   onClick={() => onEdit(filter)}
                   className={styles.filterActionButton}
+                  data-testid={`edit-filter-button-${filter.name}`}
                 >
                   <IconPencil size={16} />
                 </UnstyledButton>
                 <UnstyledButton
                   onClick={() => onRemove(filter.id)}
                   className={`${styles.filterActionButton} ${styles.deleteButton}`}
+                  data-testid={`delete-filter-button-${filter.name}`}
                 >
                   <IconTrash size={16} />
                 </UnstyledButton>
@@ -307,10 +327,18 @@ const DashboardFiltersList = ({
       </Stack>
 
       <Group justify="space-between" my="sm">
-        <Button variant="default" onClick={onClose}>
+        <Button
+          variant="default"
+          onClick={onClose}
+          data-testid="close-filters-button"
+        >
           Close
         </Button>
-        <Button variant="filled" onClick={onAddNew}>
+        <Button
+          variant="filled"
+          onClick={onAddNew}
+          data-testid="add-filter-button"
+        >
           Add new filter
         </Button>
       </Group>

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -252,4 +252,93 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       });
     },
   );
+
+  test('should create and populate filters', async () => {
+    test.setTimeout(30000);
+
+    await test.step('Create new dashboard', async () => {
+      await expect(dashboardPage.createButton).toBeVisible();
+      await dashboardPage.createNewDashboard();
+    });
+
+    await test.step('Create a table tile to filter', async () => {
+      await dashboardPage.addTile();
+
+      await dashboardPage.chartEditor.createTable({
+        chartName: 'Test Table',
+        sourceName: 'Demo Logs',
+        groupBy: 'ServiceName',
+      });
+
+      const accountCell = dashboardPage.page.getByTitle('accounting', {
+        exact: true,
+      });
+      const adCell = dashboardPage.page.getByTitle('ad', { exact: true });
+      await expect(accountCell).toBeVisible();
+      await expect(adCell).toBeVisible();
+    });
+
+    await test.step('Add ServiceName filter to dashboard', async () => {
+      await dashboardPage.openEditFiltersModal();
+      await expect(dashboardPage.emptyFiltersList).toBeVisible();
+
+      await dashboardPage.addFilterToDashboard(
+        'Service',
+        'Demo Logs',
+        'ServiceName',
+      );
+
+      await expect(dashboardPage.getFilterItemByName('Service')).toBeVisible();
+
+      await dashboardPage.closeFiltersModal();
+    });
+
+    await test.step('Add MetricName filter to dashboard', async () => {
+      await dashboardPage.openEditFiltersModal();
+      await expect(dashboardPage.filtersList).toBeVisible();
+
+      await dashboardPage.addFilterToDashboard(
+        'Metric',
+        'Demo Metrics',
+        'MetricName',
+        'gauge',
+      );
+
+      await expect(dashboardPage.getFilterItemByName('Metric')).toBeVisible();
+
+      await dashboardPage.closeFiltersModal();
+    });
+
+    await test.step('Verify tiles are filtered', async () => {
+      // Select 'accounting' in Service filter
+      await dashboardPage.clickFilterOption('Service', 'accounting');
+
+      const accountCell = dashboardPage.page.getByTitle('accounting', {
+        exact: true,
+      });
+      await expect(accountCell).toBeVisible();
+
+      // 'ad' ServiceName row should be filtered out
+      const adCell = dashboardPage.page.getByTitle('ad', { exact: true });
+      await expect(adCell).toHaveCount(0);
+    });
+
+    await test.step('Verify metric filter is populated', async () => {
+      await dashboardPage.clickFilterOption(
+        'Metric',
+        'container.cpu.utilization',
+      );
+    });
+
+    await test.step('Delete a filter and verify it is removed', async () => {
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.deleteFilterFromDashboard('Metric');
+
+      // Service filter should still be visible
+      await expect(dashboardPage.getFilterItemByName('Service')).toBeVisible();
+
+      // Metric filter should be gone
+      await expect(dashboardPage.getFilterItemByName('Metric')).toHaveCount(0);
+    });
+  });
 });

--- a/packages/app/tests/e2e/utils/locators.ts
+++ b/packages/app/tests/e2e/utils/locators.ts
@@ -1,0 +1,8 @@
+import { Page } from '@playwright/test';
+
+export const getSqlEditor = (page: Page, placeholder?: string) => {
+  const locator = placeholder
+    ? `div.cm-editor:has-text("${placeholder}")`
+    : 'div.cm-editor';
+  return page.locator(locator).first();
+};


### PR DESCRIPTION
Closes HDX-2501

# Summary

This PR adds tests for dashboard filters.
- Create filter (from both log and metric sources)
- Delete filter
- Filters are populated with values from the source
- Filters are applied to dashboard tiles