### PR TITLE
fix: Fix error when saving Dashboards with null numberFormat

### DIFF
--- a/.changeset/hip-jars-shop.md
+++ b/.changeset/hip-jars-shop.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: Fix error when saving new Dashboard tile due to null numberFormat

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -406,7 +406,7 @@ export type Filter = z.infer<typeof FilterSchema>;
 
 export const _ChartConfigSchema = z.object({
   displayType: z.nativeEnum(DisplayType).optional(),
-  numberFormat: NumberFormatSchema.optional(),
+  numberFormat: NumberFormatSchema.optional().nullable(),
   timestampValueExpression: z.string(),
   implicitColumnExpression: z.string().optional(),
   granularity: z.union([SQLIntervalSchema, z.literal('auto')]).optional(),


### PR DESCRIPTION
# Summary

This PR fixes a bug that causes an error when saving a dashboard after removing a numberFormat from a tile, due to a null value instead of the expected undefined. The possibility of a null value was introduced in #1617, to allow react-hook-form to clear the number format.