### PR TITLE
feat: improve query setting validation

### DIFF
--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -90,11 +90,10 @@ export const Source = mongoose.model<ISource>(
       querySettings: {
         type: [
           {
-            setting: { type: String, required: true },
-            value: { type: String, required: true },
+            setting: { type: String, required: true, minlength: 1 },
+            value: { type: String, required: true, minlength: 1 },
           },
         ],
-        default: undefined,
         maxlength: 10,
       },
     },

--- a/packages/app/src/hooks/useChartConfig.tsx
+++ b/packages/app/src/hooks/useChartConfig.tsx
@@ -5,7 +5,6 @@ import {
   ResponseJSON,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/browser';
-import { tryOptimizeConfigWithMaterializedView } from '@hyperdx/common-utils/dist/core/materializedViews';
 import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   isMetricChartConfig,
@@ -397,10 +396,6 @@ export function useAliasMapFromChartConfig(
 
   const metadata = useMetadataWithSettings();
 
-  const { data: source, isLoading: isSourceLoading } = useSource({
-    id: config?.source,
-  });
-
   return useQuery<Record<string, string>>({
     // Only include config properties that affect SELECT structure and aliases.
     // When adding new ChartConfig fields, check renderChartConfig.ts to see if they
@@ -432,7 +427,7 @@ export function useAliasMapFromChartConfig(
 
       return aliasMap;
     },
-    enabled: config != null && !isSourceLoading,
+    enabled: config != null,
     ...options,
   });
 }

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -604,7 +604,7 @@ export enum SourceKind {
 // --------------------------
 
 const QuerySettingsSchema = z.array(
-  z.object({ setting: z.string(), value: z.string() }),
+  z.object({ setting: z.string().min(1), value: z.string().min(1) }),
 );
 
 export type QuerySettings = z.infer<typeof QuerySettingsSchema>;


### PR DESCRIPTION
A few small changes as a follow up to https://github.com/hyperdxio/hyperdx/pull/1609:
1. Disallows empty strings for setting names or values.
2. Removes a redundant `useSource`.
3. Removes `default: undefined` on the `querySettings` field of the Source Mongoose model. This way, it will always default to an empty array unless explicitly removed. This change supports toggling the query feature in EE repo via a config value. We can simply hide the option in the source form when source.querySettings is undefined, removing the need for a config value in the nextjs app deployment.