### PR TITLE
fix: Prevent dashboard error when metricName is defined for non-metric source

### DIFF
--- a/.changeset/short-camels-hug.md
+++ b/.changeset/short-camels-hug.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Prevent dashboard error when metricName is defined for non-metric source

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -20,6 +20,7 @@ import { convertToDashboardTemplate } from '@hyperdx/common-utils/dist/core/util
 import {
   AlertState,
   DashboardFilter,
+  SourceKind,
   TSourceUnion,
 } from '@hyperdx/common-utils/dist/types';
 import {
@@ -182,10 +183,14 @@ const Tile = forwardRef(
 
     useEffect(() => {
       if (source != null) {
+        const isMetricSource = source.kind === SourceKind.Metric;
+
         // TODO: will need to update this when we allow for multiple metrics per chart
         const firstSelect = chart.config.select[0];
         const metricType =
-          typeof firstSelect !== 'string' ? firstSelect?.metricType : undefined;
+          isMetricSource && typeof firstSelect !== 'string'
+            ? firstSelect?.metricType
+            : undefined;
         const tableName = getMetricTableName(source, metricType);
         if (source.connection) {
           setQueriedConfig({
@@ -200,7 +205,7 @@ const Tile = forwardRef(
             },
             implicitColumnExpression: source.implicitColumnExpression,
             filters,
-            metricTables: source.metricTables,
+            metricTables: isMetricSource ? source.metricTables : undefined,
           });
         }
       }


### PR DESCRIPTION
Closes HDX-3236

# Summary

This PR fixes an error that occurs when a metricName/metricType is set for a dashboard tile configuration, despite the queried source not being a metric source.

1. Updates in DBEditTimeChartForm prevent us from saving configurations with metricName/metricType for non metric sources
2. Updates in DBDashboardPage ensure that metricName/metricType is ignored for any saved configurations for non-metric sources.

## Demo

A new tile would be saved with a metricName/Type incorrectly when

1. Create the tile
2. Select a metric source
3. Select a metric name
4. Switch back to a non-metric source
5. Save

And the Dashboard tile would then error:

<img width="1288" height="1012" alt="Screenshot 2026-01-23 at 2 39 38 PM" src="https://github.com/user-attachments/assets/4fa4b0bf-355e-47bb-a504-cd03e0dca2d0" />

Now, the configuration is not saved with metricName/Type, and the dashboard does not error for a saved configuration that has a metricName/Type:

<img width="769" height="423" alt="Screenshot 2026-01-23 at 2 43 04 PM" src="https://github.com/user-attachments/assets/92af36aa-dd46-47b8-ae59-d0e4bfcb28af" />

