### PR TITLE
fix: falsy filter values

### DIFF
--- a/packages/common-utils/src/__tests__/metadata.test.ts
+++ b/packages/common-utils/src/__tests__/metadata.test.ts
@@ -329,13 +329,13 @@ describe('Metadata', () => {
       ]);
     });
 
-    it('should filter out falsy values from the response', async () => {
+    it('should filter out empty and nullish values from the response', async () => {
       (mockClickhouseClient.query as jest.Mock).mockResolvedValue({
         json: () =>
           Promise.resolve({
             data: [
               {
-                param0: ['value1', null, '', 'value2', undefined],
+                param0: ['value1', null, '', 'value2', undefined, 0, 10],
               },
             ],
           }),
@@ -348,7 +348,9 @@ describe('Metadata', () => {
         source,
       });
 
-      expect(result).toEqual([{ key: 'column1', value: ['value1', 'value2'] }]);
+      expect(result).toEqual([
+        { key: 'column1', value: ['value1', 'value2', 0, 10] },
+      ]);
     });
 
     it('should return an empty list when no keys are provided', async () => {

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -945,7 +945,7 @@ export class Metadata {
         return Object.entries(json?.data?.[0]).map(([key, value]) => ({
           key: keys[parseInt(key.replace('param', ''))],
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentional, see HDX-1548
-          value: (value as string[])?.filter(Boolean), // remove nulls
+          value: (value as string[])?.filter(v => v != null && v !== ''), // remove nulls and empty strings
         }));
       },
     );


### PR DESCRIPTION
I noticed while testing https://github.com/hyperdxio/hyperdx/pull/1650 that `0` values were not appearing in the list of filter values.

This PR is branched from the above PR, and updates `metadata.getKeyValues` to not filter out falsy number values.