### PR TITLE
fix: controlled input warning

### DIFF
--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -1611,7 +1611,7 @@ export function TableSourceForm({
   onSave,
   onCreate,
   isNew = false,
-  defaultName,
+  defaultName = '',
   onCancel,
 }: {
   sourceId?: string;


### PR DESCRIPTION
Fixes the SourceForm `name` input switching from uncontrolled to controlled.

<img width="753" height="272" alt="image" src="https://github.com/user-attachments/assets/818a7489-d237-416b-8826-a584ddf49fe5" />
