### PR TITLE
debug: notify SourceForm error path when message is 'Required':

### DIFF
--- a/.changeset/nervous-mayflies-hammer.md
+++ b/.changeset/nervous-mayflies-hammer.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+debug: notify SourceForm error path when message is 'Required'

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -1848,13 +1848,30 @@ export function TableSourceForm({
 
   const sourceFormSchema = sourceSchemaWithout({ id: true });
   const handleError = useCallback(
-    (error: z.ZodError<TSourceUnion>) => {
-      const errors = error.errors;
+    ({ errors }: z.ZodError<TSourceUnion>, eventName: 'create' | 'save') => {
+      const notificationMsgs: string[] = [];
+
+      // eslint-disable-next-line no-console
+      console.debug(
+        // HDX-3148
+        `[${eventName}] SourceForm validation error`,
+        JSON.stringify(errors),
+      );
+
       for (const err of errors) {
         const errorPath: string = err.path.join('.');
         // TODO: HDX-1768 get rid of this type assertion if possible
         setError(errorPath as any, { ...err });
+
+        const message =
+          // HDX-3148
+          err.message === 'Required'
+            ? `${errorPath}: ${err.message}`
+            : err.message;
+
+        notificationMsgs.push(message);
       }
+
       notifications.show({
         color: 'red',
         message: (
@@ -1862,9 +1879,9 @@ export function TableSourceForm({
             <Text size="sm">
               <b>Failed to create source</b>
             </Text>
-            {errors.map((err, i) => (
+            {notificationMsgs.map((message, i) => (
               <Text key={i} size="sm">
-                ✖ {err.message}
+                ✖ {message}
               </Text>
             ))}
           </Stack>
@@ -1879,7 +1896,7 @@ export function TableSourceForm({
     handleSubmit(async data => {
       const parseResult = sourceFormSchema.safeParse(data);
       if (parseResult.error) {
-        handleError(parseResult.error);
+        handleError(parseResult.error, 'create');
         return;
       }
 
@@ -1947,7 +1964,7 @@ export function TableSourceForm({
     handleSubmit(data => {
       const parseResult = sourceFormSchema.safeParse(data);
       if (parseResult.error) {
-        handleError(parseResult.error);
+        handleError(parseResult.error, 'save');
         return;
       }
       updateSource.mutate(


### PR DESCRIPTION
Closes HDX-3148

As discussed in HDX-3148, we will print the error path in the notification for `SourceForm` validation when the error message is "Required".