### PR TITLE
fix: Fix histogram disappearing on event patterns page

### DIFF
--- a/.changeset/quiet-apples-fly.md
+++ b/.changeset/quiet-apples-fly.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix histogram disappearing and scrollbar issues on event patterns and search pages
+
+Fixes regression from PR #1598 by adding proper flex container constraints to prevent histogram from disappearing and scrollbar from cutting off 120px early.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1814,7 +1814,7 @@ function DBSearchPage() {
               </ErrorBoundary>
               {analysisMode === 'pattern' &&
                 histogramTimeChartConfig != null && (
-                  <Flex direction="column" w="100%" gap="0px">
+                  <Flex direction="column" w="100%" gap="0px" mih="0">
                     <Box className={searchPageStyles.searchStatsContainer}>
                       <Group justify="space-between" style={{ width: '100%' }}>
                         <SearchTotalCountChart
@@ -1831,7 +1831,10 @@ function DBSearchPage() {
                       </Group>
                     </Box>
                     {!hasQueryError && (
-                      <Box className={searchPageStyles.timeChartContainer}>
+                      <Box
+                        className={searchPageStyles.timeChartContainer}
+                        mih="0"
+                      >
                         <DBTimeChart
                           sourceId={searchedConfig.source ?? undefined}
                           showLegend={false}
@@ -1845,20 +1848,22 @@ function DBSearchPage() {
                         />
                       </Box>
                     )}
-                    <PatternTable
-                      source={searchedSource}
-                      config={{
-                        ...chartConfig,
-                        dateRange: searchedTimeRange,
-                      }}
-                      bodyValueExpression={
-                        searchedSource?.bodyExpression ??
-                        chartConfig.implicitColumnExpression ??
-                        ''
-                      }
-                      totalCountConfig={histogramTimeChartConfig}
-                      totalCountQueryKeyPrefix={QUERY_KEY_PREFIX}
-                    />
+                    <Box flex="1" mih="0">
+                      <PatternTable
+                        source={searchedSource}
+                        config={{
+                          ...chartConfig,
+                          dateRange: searchedTimeRange,
+                        }}
+                        bodyValueExpression={
+                          searchedSource?.bodyExpression ??
+                          chartConfig.implicitColumnExpression ??
+                          ''
+                        }
+                        totalCountConfig={histogramTimeChartConfig}
+                        totalCountQueryKeyPrefix={QUERY_KEY_PREFIX}
+                      />
+                    </Box>
                   </Flex>
                 )}
               {analysisMode === 'delta' && searchedSource != null && (
@@ -1872,7 +1877,7 @@ function DBSearchPage() {
                   source={searchedSource}
                 />
               )}
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <Flex direction="column" mih="0">
                 {analysisMode === 'results' &&
                   chartConfig &&
                   histogramTimeChartConfig && (
@@ -1908,7 +1913,7 @@ function DBSearchPage() {
                       {!hasQueryError && (
                         <Box
                           className={searchPageStyles.timeChartContainer}
-                          style={{ flexShrink: 0 }}
+                          mih="0"
                         >
                           <DBTimeChart
                             sourceId={searchedConfig.source ?? undefined}
@@ -2043,7 +2048,7 @@ function DBSearchPage() {
                     </div>
                   </>
                 ) : (
-                  <>
+                  <Box flex="1" mih="0">
                     {chartConfig &&
                       searchedConfig.source &&
                       dbSqlRowTableConfig &&
@@ -2065,9 +2070,9 @@ function DBSearchPage() {
                           initialSortBy={initialSortBy}
                         />
                       )}
-                  </>
+                  </Box>
                 )}
-              </div>
+              </Flex>
             </div>
           </>
         )}


### PR DESCRIPTION
Adding mih=0 to the histogram container and a couple places fixes it.

Fixes HDX-3293
Fixes HDX-3267


| Before | After|
|------|-----|
| <img width="3024" height="1964" alt="CleanShot 2026-01-28 at 13 10 50@2x" src="https://github.com/user-attachments/assets/4d9f09bf-7d8c-4d47-8dff-3f9b66c69ff6" /> | <img width="3024" height="1964" alt="CleanShot 2026-01-28 at 13 11 31@2x" src="https://github.com/user-attachments/assets/cd463761-b81b-4df1-a5ce-9ad8ef036794" /> |
