### PR TITLE
Revert "fix: Make pattern sampling query random (#1600)"

### DIFF
--- a/packages/app/src/hooks/usePatterns.tsx
+++ b/packages/app/src/hooks/usePatterns.tsx
@@ -134,62 +134,26 @@ function usePatterns({
   severityTextExpression?: string;
   enabled?: boolean;
 }) {
-  // Create a sampling config with CTE for smart sampling
-  const samplingConfig = useMemo(() => {
-    // Build config with CTE for count check
-    const configWithCTE: ChartConfigWithDateRange = {
-      ...config,
-      // Add CTE to get table statistics for sampling
-      with: [
-        {
-          name: 'tableStats',
-          chartConfig: {
-            ...config,
-            select: 'count() as total',
-            groupBy: undefined,
-            orderBy: undefined,
-            limit: undefined,
-          },
-        },
-      ],
-      // Select the required columns
-      select: [
-        `${bodyValueExpression} as ${PATTERN_COLUMN_ALIAS}`,
-        `${getFirstTimestampValueExpression(config.timestampValueExpression)} as ${TIMESTAMP_COLUMN_ALIAS}`,
-        ...(severityTextExpression
-          ? [`${severityTextExpression} as ${SEVERITY_TEXT_COLUMN_ALIAS}`]
-          : []),
-      ].join(','),
-      // Add sampling condition as a filter
-      filters: [
-        ...(config.filters || []),
-        {
-          type: 'sql',
-          condition: `if(
-            (SELECT total FROM tableStats) <= ${samples},
-            1,
-            cityHash64(${getFirstTimestampValueExpression(config.timestampValueExpression)}, rand()) % greatest(
-              CAST((SELECT total FROM tableStats) / ${samples} AS UInt32),
-              1
-            ) = 0
-          )`,
-        },
-      ],
-      // Remove random ordering
-      orderBy: undefined,
-      limit: { limit: samples },
-    };
+  const configWithPrimaryAndPartitionKey = useConfigWithPrimaryAndPartitionKey({
+    ...config,
+    // TODO: User-configurable pattern columns and non-pattern/group by columns
+    select: [
+      `${bodyValueExpression} as ${PATTERN_COLUMN_ALIAS}`,
+      `${getFirstTimestampValueExpression(config.timestampValueExpression)} as ${TIMESTAMP_COLUMN_ALIAS}`,
+      ...(severityTextExpression
+        ? [`${severityTextExpression} as ${SEVERITY_TEXT_COLUMN_ALIAS}`]
+        : []),
+    ].join(','),
+    // TODO: Proper sampling
+    orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
+    limit: { limit: samples },
+  });
 
-    return configWithCTE;
-  }, [config, samples, bodyValueExpression, severityTextExpression]);
-
-  const configWithPrimaryAndPartitionKey =
-    useConfigWithPrimaryAndPartitionKey(samplingConfig);
-
-  const { data: sampleRows, isLoading: isLoadingSampleRows } =
-    useQueriedChartConfig(configWithPrimaryAndPartitionKey ?? samplingConfig, {
-      enabled: configWithPrimaryAndPartitionKey != null && enabled,
-    });
+  const { data: sampleRows, isLoading: isSampleLoading } =
+    useQueriedChartConfig(
+      configWithPrimaryAndPartitionKey ?? config, // `config` satisfying type, never used due to `enabled` check
+      { enabled: configWithPrimaryAndPartitionKey != null && enabled },
+    );
 
   const { data: pyodide, isLoading: isLoadingPyodide } = usePyodide({
     enabled,
@@ -236,7 +200,7 @@ function usePatterns({
 
   return {
     ...query,
-    isLoading: query.isLoading || isLoadingPyodide || isLoadingSampleRows,
+    isLoading: query.isLoading || isSampleLoading || isLoadingPyodide,
     patternQueryConfig: configWithPrimaryAndPartitionKey,
   };
 }


### PR DESCRIPTION
Closes HDX-3297

# Summary

This reverts commit de68052778bdd89a079706398db526d2cedc0cd6.

This PR reverts a change that backported a newer event patterns sampling query from EE to open source. It appears that this new sampling query returns only 1k rows when run against demo log data, rather than the intended 10k. Too few rows returned means the sample does not contain enough events to show a realistic distribution of rarer patterns.

It is still unclear to me why this new query is not working as expected for the demo log data. Against other connections, the query returns the expected 10k results. Also when running the same query with a `count()` instead of selecting columns, the count is the expected 10k.