### PR TITLE
feat: duplicate dashboard

### DIFF
--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -124,6 +124,7 @@ export class ChartEditorComponent {
   ) {
     // Wait for data sources to load before interacting
     await this.waitForDataToLoad();
+    await this.setChartName(chartName);
     await this.selectSource(sourceName);
     await this.selectMetric(metricName, metricValue);
     await this.runQuery();

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -14,6 +14,8 @@ export class DashboardPage {
   readonly chartEditor: ChartEditorComponent;
   readonly granularityPicker: Locator;
 
+  private readonly dashboardOptionsMenu: Locator;
+  private readonly duplicateDashboardButton: Locator;
   private readonly createDashboardButton: Locator;
   private readonly addTileButton: Locator;
   private readonly dashboardNameHeading: Locator;
@@ -32,6 +34,9 @@ export class DashboardPage {
     this.page = page;
     this.timePicker = new TimePickerComponent(page);
     this.chartEditor = new ChartEditorComponent(page);
+
+    this.dashboardOptionsMenu = page.getByTestId('dashboard-options-menu');
+    this.duplicateDashboardButton = page.getByTestId('duplicate-dashboard');
 
     this.createDashboardButton = page.locator(
       '[data-testid="create-dashboard-button"]',
@@ -326,6 +331,14 @@ export class DashboardPage {
       exact: true,
     });
     await optionLocator.click();
+  }
+
+  get dashboardOptions() {
+    return this.dashboardOptionsMenu;
+  }
+
+  get duplicateDashboard() {
+    return this.duplicateDashboardButton;
   }
 
   // Getters for assertions


### PR DESCRIPTION
Fixes #1253

https://github.com/user-attachments/assets/663823eb-be00-4399-bcc6-a6a7cf59d164

- [x] Does not copy existing alerts tied to dashboard tiles
- [x] Make sure dashboard tile ids are unique in copied dashboard
- [x] Add e2e tests to test functionality