### PR TITLE
test: Add missing mocks to prevent test error logs

### DIFF
--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -143,6 +143,8 @@ describe('checkAlerts', () => {
       getTableMetadata: jest.fn().mockResolvedValue({}),
       getClickHouseSettings: jest.fn().mockReturnValue({}),
       setClickHouseSettings: jest.fn(),
+      getSkipIndices: jest.fn().mockResolvedValue([]),
+      getSetting: jest.fn().mockResolvedValue(undefined),
     } as any;
 
     // Create a mock clickhouse client


### PR DESCRIPTION
# Summary

This PR adds a couple of missing functions to a metadata mock, which eliminates some unwanted error logs while running the tests