### PR TITLE
fix: Fix side panel tab colors in ClickStack theme

### DIFF
--- a/.changeset/strange-islands-walk.md
+++ b/.changeset/strange-islands-walk.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix side panel tab colors in ClickStack theme

--- a/packages/app/src/TabItem.tsx
+++ b/packages/app/src/TabItem.tsx
@@ -28,7 +28,7 @@ export default function TabItem({
           className="h-100 w-100"
           style={{
             background: active
-              ? 'var(--color-bg-success)'
+              ? 'var(--color-text-brand)'
               : 'var(--color-border)',
           }}
         ></div>


### PR DESCRIPTION
# Before

The ClickStack theme had green underlines on the sidebar tabs, despite other tabs having yellow underlines.

<img width="759" height="73" alt="Screenshot 2026-02-03 at 6 19 06 PM" src="https://github.com/user-attachments/assets/753081b4-6e8a-49a2-b301-6535c7c5ee89" />


# After

The ClickStack theme has yellow underlines, the HyperDX theme has green.

<img width="542" height="95" alt="Screenshot 2026-02-03 at 6 24 17 PM" src="https://github.com/user-attachments/assets/52225926-cc1b-4fb4-8231-a24ed75a6395" />
<img width="579" height="76" alt="Screenshot 2026-02-03 at 6 27 02 PM" src="https://github.com/user-attachments/assets/06ae5635-b026-4e88-971b-07253e284e3b" />

