### PR TITLE
feat: Set Button default variant to primary

### DIFF
--- a/.changeset/button-default-primary.md
+++ b/.changeset/button-default-primary.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Set Button component default variant to "primary" for consistent styling across the app

--- a/packages/app/src/theme/themes/clickstack/mantineTheme.ts
+++ b/packages/app/src/theme/themes/clickstack/mantineTheme.ts
@@ -214,6 +214,9 @@ export const makeTheme = ({
       },
     }),
     Button: Button.extend({
+      defaultProps: {
+        variant: 'primary',
+      },
       vars: (_theme, props) => {
         const baseVars: Record<string, string> = {};
 

--- a/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
+++ b/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
@@ -231,6 +231,9 @@ export const makeTheme = ({
       },
     }),
     Button: Button.extend({
+      defaultProps: {
+        variant: 'primary',
+      },
       vars: (_theme, props) => {
         const baseVars: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary

Sets the default Button variant to "primary" across both HyperDX and ClickStack themes, ensuring consistent button styling throughout the app.

## Changes

- Added `defaultProps: { variant: 'primary' }` to Button component in ClickStack theme
- Added `defaultProps: { variant: 'primary' }` to Button component in HyperDX theme

## Motivation

Previously, buttons without an explicit `variant` prop would use Mantine's default styling. This change ensures all buttons default to the primary variant for a more consistent user experience, reducing the need to explicitly set `variant="primary"` on every button.

## Screenshots

<img width="1982" height="909" alt="image" src="https://github.com/user-attachments/assets/35aaa6bc-9182-418e-9bad-6fd340a4a888" />


## Test Plan

- [ ] Verify buttons without variant prop now display with primary styling
- [ ] Verify buttons with explicit variant props (secondary, danger) still work correctly
- [ ] Test in both HyperDX and ClickStack themes