### PR TITLE
feat: Format byte numbers on ClickHouse page

### DIFF
--- a/.changeset/bright-shoes-smile.md
+++ b/.changeset/bright-shoes-smile.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: Format byte numbers on ClickHouse page

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -109,6 +109,10 @@ function InfrastructureTab({
               dateRange: searchedTimeRange,
               timestampValueExpression: 'event_time',
               displayType: DisplayType.Line,
+              numberFormat: {
+                output: 'byte',
+                mantissa: 2,
+              },
             }}
             onTimeRangeSelect={onTimeRangeSelect}
           />
@@ -142,6 +146,10 @@ function InfrastructureTab({
               dateRange: searchedTimeRange,
               timestampValueExpression: 'event_time',
               displayType: DisplayType.Line,
+              numberFormat: {
+                output: 'byte',
+                mantissa: 2,
+              },
             }}
             onTimeRangeSelect={onTimeRangeSelect}
           />
@@ -229,6 +237,10 @@ function InfrastructureTab({
               dateRange: searchedTimeRange,
               timestampValueExpression: 'event_time',
               displayType: DisplayType.Line,
+              numberFormat: {
+                output: 'byte',
+                mantissa: 2,
+              },
             }}
             onTimeRangeSelect={onTimeRangeSelect}
           />
@@ -324,6 +336,13 @@ function InsertsTab({
       filters,
       groupBy: [{ valueExpression: 'tables' }],
       connection,
+      numberFormat:
+        insertsBy === 'bytes'
+          ? {
+              output: 'byte',
+              mantissa: 2,
+            }
+          : undefined,
     };
   }, [insertsBy, searchedTimeRange, connection]);
 


### PR DESCRIPTION
# Summary

This PR formats numbers as bytes on the preset ClickHouse Dashboard page, for charts displaying byte metrics.

<img width="1812" height="421" alt="Screenshot 2026-02-06 at 9 20 33 AM" src="https://github.com/user-attachments/assets/62fd4d99-7f96-4404-bde2-e68344faedcb" />
<img width="916" height="420" alt="Screenshot 2026-02-06 at 9 20 25 AM" src="https://github.com/user-attachments/assets/2b4d6c72-b27a-4c55-84be-2cc706af2eeb" />
