### PR TITLE
fix: Prevent sampled events error when HAVING clause is specified

### DIFF
--- a/.changeset/light-shoes-joke.md
+++ b/.changeset/light-shoes-joke.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Prevent sampled events error when HAVING clause is specified

--- a/packages/app/src/components/DBEditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm.tsx
@@ -968,6 +968,7 @@ export default function EditTimeChartForm({
             filtersLogicalOperator: 'OR' as const,
             groupBy: undefined,
             granularity: undefined,
+            having: undefined,
           }
         : null,
     [queriedConfig, tableSource, dateRange, queryReady],
@@ -1527,6 +1528,7 @@ export default function EditTimeChartForm({
                     ? queriedConfig.select
                     : tableSource?.defaultTableSelectExpression || '',
                 groupBy: undefined,
+                having: undefined,
                 granularity: undefined,
               }}
               enabled


### PR DESCRIPTION
Closes HDX-3442

# Summary

This PR fixes an error in the sampled events panel when a HAVING clause is specified. To fix the error, the HAVING clause is removed from the sampled events config, similar to how the GROUP BY is removed.

## Before

<img width="1498" height="1251" alt="Screenshot 2026-02-19 at 7 33 19 AM" src="https://github.com/user-attachments/assets/6f5ca4d3-7954-4e74-86cc-a335663ca299" />

## After

<img width="1496" height="1272" alt="Screenshot 2026-02-19 at 7 33 32 AM" src="https://github.com/user-attachments/assets/f05101a5-e88f-4a6f-966a-e387c79b96d0" />

