### PR TITLE
fix: set min-height on charts to fix flex shrink issues

### DIFF
--- a/.changeset/rare-pianos-beam.md
+++ b/.changeset/rare-pianos-beam.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: set min-height on charts to fix flex shrink/grow issues

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -14,7 +14,7 @@ function ChartContainer({
   disableReactiveContainer,
 }: ChartContainerProps) {
   return (
-    <Stack h="100%" w="100%" style={{ flexGrow: 1 }}>
+    <Stack h="100%" w="100%" style={{ flexGrow: 1, minHeight: 0 }}>
       {(!!title || !!toolbarItems?.length) && (
         <Group justify="space-between" align="start" wrap="nowrap">
           <span
@@ -34,7 +34,7 @@ function ChartContainer({
         </Group>
       )}
       {disableReactiveContainer ? (
-        children
+        <div style={{ flex: 1, minHeight: 0 }}>{children}</div>
       ) : (
         <div
           // Hack, recharts will release real fix soon https://github.com/recharts/recharts/issues/172
@@ -42,6 +42,8 @@ function ChartContainer({
             position: 'relative',
             width: '100%',
             height: '100%',
+            flex: 1,
+            minHeight: 0,
           }}
         >
           <div


### PR DESCRIPTION
Fixes [HDX-3123](https://linear.app/clickhouse/issue/HDX-3123/notebook-tile-overflow-bug)