### PR TITLE
fix: require checkout before env load

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Load Environment Variables from .env
         uses: xom9ikk/dotenv@v2
       - name: Notify ClickHouse/clickhouse-clickstack Downstream


### PR DESCRIPTION
This action failed because we forgot to checkout the repo before env var loading https://github.com/hyperdxio/hyperdx/actions/runs/22159537898/job/64089154901