### PR TITLE
chore: resolve collector CVE-2025-15467

### DIFF
--- a/.changeset/young-lobsters-cheat.md
+++ b/.changeset/young-lobsters-cheat.md
@@ -2,4 +2,4 @@
 "@hyperdx/otel-collector": patch
 ---
 
-chore: upgrade libssl3/libcrypto3 to address CVE-2025-15467
+chore: bump base alpine 3.23 to address CVE-2025-15467

--- a/docker/otel-collector/Dockerfile
+++ b/docker/otel-collector/Dockerfile
@@ -14,14 +14,13 @@ COPY packages/otel-collector/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /migrate ./cmd/migrate
 
 # From: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/aa5c3aa4c7ec174361fcaf908de8eaca72263078/cmd/opampsupervisor/Dockerfile#L18
-FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709 AS base
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS base
 
 ARG USER_UID=10001
 ARG USER_GID=10001
 
 # Install certs, create user/group, and make the writable data dir
-RUN apk upgrade --no-cache libssl3 libcrypto3 && \
-  apk add --no-cache ca-certificates && \
+RUN apk add --no-cache ca-certificates && \
   addgroup -S -g ${USER_GID} otel && \
   adduser  -S -u ${USER_UID} -G otel otel && \
   install -d -m 0777 -o ${USER_UID} -g ${USER_GID} /etc/otel/supervisor-data && \


### PR DESCRIPTION
bump base alpine to 3.23 (libcrypto3 and libssl3 to 3.5.5-r0)

Ref: HDX-3452