### PR TITLE
feat(app): add system color scheme option and make it the default

### DIFF
--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -7,7 +7,6 @@ import randomUUID from 'crypto-randomuuid';
 import { enableMapSet } from 'immer';
 import { QueryParamProvider } from 'use-query-params';
 import HyperDX from '@hyperdx/browser';
-import { ColorSchemeScript } from '@mantine/core';
 import {
   MutationCache,
   QueryCache,
@@ -29,7 +28,11 @@ import { ThemeWrapper } from '@/ThemeWrapper';
 import { NextApiConfigResponseData } from '@/types';
 import { ConfirmProvider } from '@/useConfirm';
 import { QueryParamProvider as HDXQueryParamProvider } from '@/useQueryParam';
-import { useUserPreferences } from '@/useUserPreferences';
+import {
+  SystemColorSchemeScript,
+  useResolvedColorScheme,
+  useUserPreferences,
+} from '@/useUserPreferences';
 
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
@@ -68,7 +71,6 @@ type AppPropsWithLayout = AppProps & {
 // Component that renders Head content requiring user preferences
 // Must be rendered inside AppThemeProvider to avoid hydration mismatch
 function AppHeadContent() {
-  const { userPreferences } = useUserPreferences();
   const { theme } = useAppTheme();
 
   return (
@@ -76,11 +78,7 @@ function AppHeadContent() {
       <title>{theme.displayName}</title>
       <meta name="viewport" content="width=device-width, initial-scale=0.75" />
       <meta name="google" content="notranslate" />
-      <ColorSchemeScript
-        forceColorScheme={
-          userPreferences.colorMode === 'dark' ? 'dark' : 'light'
-        }
-      />
+      <SystemColorSchemeScript />
     </Head>
   );
 }
@@ -95,6 +93,7 @@ function AppContent({
   pageProps: AppProps['pageProps'];
 }) {
   const { userPreferences } = useUserPreferences();
+  const resolvedColorScheme = useResolvedColorScheme();
   const { themeName } = useAppTheme();
 
   // ClickStack theme always uses Inter font - user preference is ignored
@@ -118,7 +117,7 @@ function AppContent({
   return (
     <ThemeWrapper
       fontFamily={selectedMantineFont}
-      colorScheme={userPreferences.colorMode === 'dark' ? 'dark' : 'light'}
+      colorScheme={resolvedColorScheme}
     >
       <ConfirmProvider>
         {getLayout(<Component {...pageProps} />)}

--- a/packages/app/src/UserPreferencesModal.tsx
+++ b/packages/app/src/UserPreferencesModal.tsx
@@ -19,8 +19,9 @@ import { isValidThemeName, themes } from './theme';
 import { UserPreferences, useUserPreferences } from './useUserPreferences';
 
 const OPTIONS_COLOR_MODE = [
-  { label: 'Dark', value: 'dark' },
+  { label: 'System', value: 'system' },
   { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
 ];
 
 // Brand theme options (generated from theme registry)
@@ -121,7 +122,7 @@ export const UserPreferencesModal = ({
         />
         <SettingContainer
           label="Color Mode"
-          description="Switch between light and dark mode"
+          description="Use system setting, or choose light or dark"
         >
           <Select
             value={userPreferences.colorMode}

--- a/packages/app/src/__tests__/useUserPreferences.test.tsx
+++ b/packages/app/src/__tests__/useUserPreferences.test.tsx
@@ -267,6 +267,20 @@ describe('migrateUserPreferences', () => {
       expect(localStorageMock.setItem).not.toHaveBeenCalled();
     });
 
+    it('should accept colorMode "system" as valid', () => {
+      const dataWithSystem: UserPreferences = {
+        isUTC: false,
+        timeFormat: '12h',
+        colorMode: 'system',
+        font: 'IBM Plex Mono',
+      };
+
+      const result = migrateUserPreferences(JSON.stringify(dataWithSystem));
+
+      expect(result).toEqual(dataWithSystem);
+      expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    });
+
     it('should handle data with both theme and colorMode (edge case)', () => {
       // If somehow both exist, prefer colorMode (already migrated)
       const mixedData = JSON.stringify({

--- a/packages/app/src/theme/types.ts
+++ b/packages/app/src/theme/types.ts
@@ -8,8 +8,9 @@ import { MantineThemeOverride } from '@mantine/core';
  *
  * This codebase has TWO separate theming concepts:
  *
- * 1. COLOR MODE (light/dark)
+ * 1. COLOR MODE (light/dark/system)
  *    - User-selectable preference stored in `useUserPreferences().colorMode`
+ *    - 'system' follows OS prefers-color-scheme; default is 'system'
  *    - Affects visual appearance: backgrounds, text colors, etc.
  *    - Managed by Mantine's color scheme system
  *    - Persisted to localStorage via `hdx-user-preferences`


### PR DESCRIPTION
## Summary

Add a **System** color mode that follows the OS/browser `prefers-color-scheme` setting, and make it the **default** for new and migrated users. Users can still choose **Light** or **Dark** explicitly.

## Changes

### User preferences
- **`colorMode`** type is now `'light' | 'dark' | 'system'` (exported as `ColorModePreference`).
- **Default** is **`'system'`** (was `'dark'`).
- Legacy migration (theme → colorMode) unchanged; invalid/missing theme still falls back to `'dark'`.

### Resolved scheme and initial paint
- **`useResolvedColorScheme()`** – Hook that returns `'light' | 'dark'`. When preference is `'system'`, uses `matchMedia('(prefers-color-scheme: dark)')` and updates when the OS setting changes.
- **`SystemColorSchemeScript`** – Inline script in `<head>` that reads `hdx-user-preferences`, resolves system when `colorMode === 'system'`, and sets `data-mantine-color-scheme` before React so the first paint matches the OS (no flash).

### App wiring
- **_app.tsx** – Replaces Mantine’s `ColorSchemeScript` with `SystemColorSchemeScript`. `ThemeWrapper` receives `colorScheme` from `useResolvedColorScheme()` so System is applied correctly.

### UI
- **UserPreferencesModal** – Color mode options: **System**, **Light**, **Dark** (System first). Description: “Use system setting, or choose light or dark”.

### Docs and tests
- **theme/types.ts** – Comment updated for light/dark/system and default.
- **useUserPreferences.test.tsx** – New test that `colorMode: 'system'` is valid; existing migration tests unchanged.

## Testing

- **System (default)** – New users or cleared prefs see System; UI follows OS light/dark and updates when OS setting changes.
- **Light/Dark** – Explicit choice overrides system and persists.
- **No flash** – With System, first paint should match OS (script runs before React).
- **Legacy** – Stored `theme`/`colorMode` light/dark still migrates and works.

## Notes

- Mantine’s `ColorSchemeScript` is no longer used; we set `data-mantine-color-scheme` ourselves so we can read from `hdx-user-preferences` and support `'system'`.
- `ThemeWrapper` still receives a resolved `'light' | 'dark'`; no API change there.
