### PR TITLE
ci: update `notify_helm_charts` target to ClickHouse/ClickStack-helm-charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,12 +165,12 @@ jobs:
         env:
           TAG: ${{ env.IMAGE_VERSION }}${{ env.IMAGE_VERSION_SUB_TAG }}
         with:
-          github-token: ${{ secrets.HYPERDX_INTERNAL_TOKEN }}
+          github-token: ${{ secrets.CH_BOT_PAT }}
           script: |
             const { TAG } = process.env;
             const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'hyperdxio',
-              repo: 'helm-charts',
+              owner: 'ClickHouse',
+              repo: 'ClickStack-helm-charts',
               workflow_id: '${{ secrets.DOWNSTREAM_HC_WORKFLOW_ID }}',
               ref: 'main',
               inputs: {


### PR DESCRIPTION
## Summary
- Update `notify_helm_charts` workflow to target `ClickHouse/ClickStack-helm-charts` repo
- Switch auth token from `HYPERDX_INTERNAL_TOKEN` to `CH_BOT_PAT`

Ref: HDX-3485