### PR TITLE
docs: update integration test instructions to use make dev-int

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,9 @@ yarn test:e2e:ci       # Run end-to-end tests in CI
 **packages/api** (integration tests only):
 
 ```bash
-docker compose -f ./docker-compose.ci.yml up -d # Start the integration test docker services
-cd packages/api
-yarn ci:int            # Run integration tests
-yarn dev:int           # Watch mode for integration tests
-cd ../.. && docker compose -f ./docker-compose.ci.yml down # Stop the integration test docker services
+make dev-int-build                  # Build dependencies (run once before tests)
+make dev-int FILE=<TEST_FILE_NAME>  # Spins up Docker services and runs tests.
+                                    # Ctrl-C to stop and wait for all services to tear down.
 ```
 
 **packages/common-utils** (both unit and integration tests):

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ ci-lint:
 
 .PHONY: dev-int-build
 dev-int-build:
+	npx nx run-many -t ci:build
 	docker compose -p int -f ./docker-compose.ci.yml build
 
 .PHONY: dev-int


### PR DESCRIPTION
## Summary
- Simplified `CLAUDE.md` integration test instructions to use `make dev-int-build` and `make dev-int FILE=<TEST_FILE_NAME>` instead of manual docker compose steps
- Added `npx nx run-many -t ci:build` to `dev-int-build` Makefile target to ensure common-utils is built before running tests

You can now prompt 
```
run int tests for renderChartConfig
```