### PR TITLE
chore: skip claude code review on draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -18,6 +18,9 @@ on:
 
 jobs:
   claude-review:
+    if:
+      github.event_name == 'workflow_dispatch' || github.event.action ==
+      'ready_for_review' || !github.event.pull_request.draft
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

Skip PR reviews if PR is in draft state. I usually push multiple times a day on the same PR. PR reviews are unnecessary when in draft state, and add to noise. It's better to review only PRs that are ready for review.
