### PR TITLE
fix: use block_number/block_offset to uniquely identify log rows

### DIFF
--- a/.changeset/tidy-pets-shout.md
+++ b/.changeset/tidy-pets-shout.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+fix: use block_number/block_offset to uniquely identify log rows

--- a/docker/otel-collector/schema/seed/00002_otel_logs.sql
+++ b/docker/otel-collector/schema/seed/00002_otel_logs.sql
@@ -39,5 +39,5 @@ PARTITION BY toDate(TimestampTime)
 PRIMARY KEY (ServiceName, TimestampTime)
 ORDER BY (ServiceName, TimestampTime, Timestamp)
 TTL TimestampTime + ${TABLES_TTL}
-SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1, enable_block_number_column = 1, enable_block_offset_column = 1;
 

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -133,7 +133,6 @@ export const LogSource = Source.discriminator<ILogSource>(
     traceIdExpression: String,
     spanIdExpression: String,
     implicitColumnExpression: String,
-    uniqueRowIdExpression: String,
     /** @deprecated See LogSourceSchema in @hyperdx/common-utils/types.ts. */
     tableFilterExpression: String,
     highlightedTraceAttributeExpressions: {

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -75,7 +75,7 @@ import {
   useRenderedSqlChartConfig,
 } from '@/hooks/useChartConfig';
 import { useCsvExport } from '@/hooks/useCsvExport';
-import { useTableMetadata } from '@/hooks/useMetadata';
+import { useColumns, useTableMetadata } from '@/hooks/useMetadata';
 import useOffsetPaginatedQuery from '@/hooks/useOffsetPaginatedQuery';
 import { useGroupedPatterns } from '@/hooks/usePatterns';
 import useRowWhere, {
@@ -1362,14 +1362,15 @@ export const RawLogTable = memo(
   },
 );
 
-export function appendSelectWithPrimaryAndPartitionKey(
+export function appendSelectWithAdditionalKeys(
   select: SelectList,
   primaryKeys: string,
   partitionKey: string,
+  extraKeys: string[] = [],
 ): { select: SelectList; additionalKeysLength: number } {
   const partitionKeyArr = extractColumnReferencesFromKey(partitionKey);
   const primaryKeyArr = extractColumnReferencesFromKey(primaryKeys);
-  const allKeys = new Set([...partitionKeyArr, ...primaryKeyArr]);
+  const allKeys = new Set([...partitionKeyArr, ...primaryKeyArr, ...extraKeys]);
   if (typeof select === 'string') {
     const selectSplit = splitAndTrimWithBracket(select);
     const selectColumns = new Set(selectSplit);
@@ -1395,8 +1396,9 @@ function getSelectLength(select: SelectList): number {
   }
 }
 
-export function useConfigWithPrimaryAndPartitionKey(
+export function useConfigWithAdditionalSelect(
   config: BuilderChartConfigWithDateRange,
+  sourceId?: string,
 ) {
   const { data: tableMetadata } = useTableMetadata({
     databaseName: config.from.databaseName,
@@ -1404,24 +1406,50 @@ export function useConfigWithPrimaryAndPartitionKey(
     connectionId: config.connection,
   });
 
+  // Only check for row-ID columns for row-level queries (sourceId present).
+  // Skip for aggregate queries (e.g. patterns) where extra keys are irrelevant.
+  const { data: columns } = useColumns(
+    {
+      databaseName: config.from.databaseName,
+      tableName: config.from.tableName,
+      connectionId: config.connection,
+    },
+    { enabled: !!sourceId },
+  );
+
   const primaryKey = tableMetadata?.primary_key;
   const partitionKey = tableMetadata?.partition_key;
 
-  const mergedConfig = useMemo(() => {
+  return useMemo(() => {
     if (primaryKey == null || partitionKey == null) {
       return undefined;
     }
 
-    const { select, additionalKeysLength } =
-      appendSelectWithPrimaryAndPartitionKey(
-        config.select,
-        primaryKey,
-        partitionKey,
-      );
-    return { ...config, select, additionalKeysLength };
-  }, [primaryKey, partitionKey, config]);
+    let extraKeys: string[] = [];
 
-  return mergedConfig;
+    if (sourceId) {
+      const engineFull = tableMetadata?.engine_full ?? '';
+
+      const hasBlockColumns =
+        engineFull.includes('enable_block_number_column = 1') &&
+        engineFull.includes('enable_block_offset_column = 1');
+
+      if (hasBlockColumns) {
+        extraKeys = ['_block_number', '_block_offset'];
+      } else if (columns?.some(c => c.name === '__hdx_id')) {
+        extraKeys = ['__hdx_id'];
+      }
+    }
+
+    const { select, additionalKeysLength } = appendSelectWithAdditionalKeys(
+      config.select,
+      primaryKey,
+      partitionKey,
+      extraKeys,
+    );
+
+    return { ...config, select, additionalKeysLength };
+  }, [primaryKey, partitionKey, config, tableMetadata, columns, sourceId]);
 }
 
 function selectColumnMapWithoutAdditionalKeys(
@@ -1552,7 +1580,7 @@ function DBSqlRowTableComponent({
     return base;
   }, [me, config, orderByArray]);
 
-  const mergedConfig = useConfigWithPrimaryAndPartitionKey(mergedConfigObj);
+  const mergedConfig = useConfigWithAdditionalSelect(mergedConfigObj, sourceId);
 
   const { data, fetchNextPage, hasNextPage, isFetching, isError, error } =
     useOffsetPaginatedQuery(mergedConfig ?? config, {

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -1256,21 +1256,6 @@ function LogTableModelForm(props: TableModelProps) {
         </FormRow>
 
         <Divider />
-        {/* <FormRow
-          label={'Unique Row ID Expression'}
-          helpText="Unique identifier for a given row, will be primary key if not specified. Used for showing full row details in search results."
-        >
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="uniqueRowIdExpression"
-            placeholder="Timestamp, ServiceName, Body"
-          />
-        </FormRow> */}
         {/* <FormRow label={'Table Filter Expression'}>
           <SQLInlineEditorControlled
             tableConnection={{

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
-  appendSelectWithPrimaryAndPartitionKey,
+  appendSelectWithAdditionalKeys,
   RawLogTable,
 } from '@/components/DBRowTable';
 import { RowWhereResult } from '@/hooks/useRowWhere';
@@ -145,9 +145,9 @@ describe('RawLogTable', () => {
   });
 });
 
-describe('appendSelectWithPrimaryAndPartitionKey', () => {
+describe('appendSelectWithAdditionalKeys', () => {
   it('should extract columns from partition key with nested function call', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       'id, created_at',
       ' toStartOfInterval(timestamp, toIntervalDay(3))',
@@ -159,7 +159,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract no columns from empty primary key and partition key', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey('col1, col2', '', '');
+    const result = appendSelectWithAdditionalKeys('col1, col2', '', '', []);
     expect(result).toEqual({
       additionalKeysLength: 0,
       select: 'col1,col2',
@@ -167,7 +167,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract columns from complex primary key', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       'id, timestamp, toStartOfInterval(timestamp2, toIntervalDay(3))',
       "toStartOfInterval(timestamp, toIntervalDay(3)), date_diff('DAY', col3, col4), now(), toDate(col5 + INTERVAL 1 DAY)",
@@ -179,7 +179,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract map columns', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `map['key']`,
       `map2['key'], map1['key3 ']`,
@@ -191,7 +191,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract map columns', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       ``,
       `map2['key.2']`,
@@ -203,7 +203,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract array columns', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `array[1]`,
       `array[2], array[3]`,
@@ -215,7 +215,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract json columns', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `json.b`,
       `json.a, json.b.c, toStartOfDay(timestamp, json_2.d)`,
@@ -227,7 +227,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should extract json columns with type specifiers', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `json.b.:Int64`,
       `toStartOfDay(json.a.b.:DateTime)`,
@@ -239,7 +239,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should skip json columns with hard-to-parse type specifiers', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `json.b.:Array(String), col3`,
       ``,
@@ -251,7 +251,7 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
   });
 
   it('should skip nested map references', () => {
-    const result = appendSelectWithPrimaryAndPartitionKey(
+    const result = appendSelectWithAdditionalKeys(
       'col1, col2',
       `map['key']['key2'], col3`,
       ``,
@@ -259,6 +259,55 @@ describe('appendSelectWithPrimaryAndPartitionKey', () => {
     expect(result).toEqual({
       additionalKeysLength: 1,
       select: `col1,col2,col3`,
+    });
+  });
+
+  it('should append extraKeys to string select', () => {
+    const result = appendSelectWithAdditionalKeys('col1, col2', 'id', '', [
+      '__hdx_id',
+    ]);
+    expect(result).toEqual({
+      additionalKeysLength: 2,
+      select: 'col1,col2,id,__hdx_id',
+    });
+  });
+
+  it('should not duplicate extraKeys already in select', () => {
+    const result = appendSelectWithAdditionalKeys('col1, __hdx_id', 'id', '', [
+      '__hdx_id',
+    ]);
+    expect(result).toEqual({
+      additionalKeysLength: 1,
+      select: 'col1,__hdx_id,id',
+    });
+  });
+
+  it('should deduplicate extraKeys that overlap with primary/partition keys', () => {
+    const result = appendSelectWithAdditionalKeys('col1, col2', 'id', '', [
+      'id',
+      '__hdx_id',
+    ]);
+    expect(result).toEqual({
+      additionalKeysLength: 2,
+      select: 'col1,col2,id,__hdx_id',
+    });
+  });
+
+  it('should append extraKeys to array-style select', () => {
+    const result = appendSelectWithAdditionalKeys(
+      [{ valueExpression: 'col1' }, { valueExpression: 'col2' }],
+      'id',
+      '',
+      ['__hdx_id'],
+    );
+    expect(result).toEqual({
+      additionalKeysLength: 2,
+      select: [
+        { valueExpression: 'col1' },
+        { valueExpression: 'col2' },
+        { valueExpression: 'id' },
+        { valueExpression: '__hdx_id' },
+      ],
     });
   });
 });

--- a/packages/app/src/hooks/usePatterns.tsx
+++ b/packages/app/src/hooks/usePatterns.tsx
@@ -5,7 +5,7 @@ import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/type
 import { useQuery } from '@tanstack/react-query';
 
 import { timeBucketByGranularity, toStartOfInterval } from '@/ChartUtils';
-import { useConfigWithPrimaryAndPartitionKey } from '@/components/DBRowTable';
+import { useConfigWithAdditionalSelect } from '@/components/DBRowTable';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { getFirstTimestampValueExpression } from '@/source';
 
@@ -134,7 +134,7 @@ function usePatterns({
   statusCodeExpression?: string;
   enabled?: boolean;
 }) {
-  const configWithPrimaryAndPartitionKey = useConfigWithPrimaryAndPartitionKey({
+  const configWithPrimaryAndPartitionKey = useConfigWithAdditionalSelect({
     ...config,
     // TODO: User-configurable pattern columns and non-pattern/group by columns
     select: [

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1147,7 +1147,6 @@ export const LogSourceSchema = BaseSourceSchema.extend({
   traceIdExpression: z.string().optional(),
   spanIdExpression: z.string().optional(),
   implicitColumnExpression: z.string().optional(),
-  uniqueRowIdExpression: z.string().optional(),
   /**
    * @deprecated Application-side SQL predicate AND'd into every query against
    * the source. Not a security boundary — bypassable by direct table SELECT.


### PR DESCRIPTION
## Summary

Fixes an issue where clicking a log row to expand it could show the **wrong row's details** when multiple rows share identical visible column values (Timestamp, ServiceName, Body, etc.).

**Root cause:** The detail panel query reconstructs a WHERE clause from only the visible columns, without the original search filters. When rows collide on those columns, `LIMIT 1` returns whichever row ClickHouse finds first — not necessarily the one clicked.

**Fix:** Detect and inject ClickHouse's built-in `_block_number` and `_block_offset` virtual columns as hidden tiebreakers in the row SELECT. These are available when the table engine was created with `enable_block_number_column = 1` and `enable_block_offset_column = 1`. Since the row WHERE clause builder already iterates all columns in the row data, the block columns are automatically included in detail queries — disambiguating rows without surfacing them in the UI.

A fallback to `__hdx_id` (a custom materialized column from the prior approach) is retained for any tables that already have that column.

**No schema migration required** for the primary fix — the approach relies entirely on engine-level settings that already exist on the `otel_logs` table.

## Key changes

- **`DBRowTable.tsx`**: Rename `appendSelectWithPrimaryAndPartitionKey` → `appendSelectWithAdditionalKeys` adding an `extraKeys: string[]` param. Rename `useConfigWithPrimaryAndPartitionKey` → `useConfigWithAdditionalSelect`; when a `sourceId` is present (row-level query), inspect `engine_full` metadata for block column flags and inject `_block_number`/`_block_offset` as extra keys, falling back to `__hdx_id` if present.
- **`types.ts` / `source.ts` / `SourceForm.tsx`**: Remove `uniqueRowIdExpression` — the tiebreaker is now auto-detected from the table engine, not manually configured.
- **Schema seed**: Remove the `__hdx_id` materialized column addition from `otel_logs`; the block column engine flags are sufficient.
- **Tests**: New `appendSelectWithAdditionalKeys` cases covering `extraKeys` append, deduplication against primary/partition keys, and array-style selects. Scaffold for `inferTableSourceConfig` tests.

## How to test locally

### Reproduce the bug on `main`

1. Pick any log row from `otel_logs`. In the ClickHouse UI, run the query that fires when you click a row to open its sidebar.
2. Insert the same row into `otel_logs` but change one nested value — e.g. change `ResourceAttributes.host.arch` from `arm64` to `arm65`.
3. On the search page, filter for `ResourceAttributes.host.arch = arm65`. One result appears. Click it to open the sidebar.
4. The sidebar shows `arm64` — it selected the wrong row.

### Verify the fix on this branch

1. Confirm `otel_logs` was created with `enable_block_number_column = 1` and `enable_block_offset_column = 1` (check via `SHOW CREATE TABLE default.otel_logs`).
2. Repeat steps 1–3 above.
3. The sidebar now shows `arm65` — correct row selected.

### Verify fallback path

1. On a table that has `__hdx_id` but no block columns, the app still injects `__hdx_id` as the tiebreaker (same behavior as the previous approach).

## References

- Linear: Closes HDX-2372, Closes HDX-3489
- GitHub: Closes https://github.com/hyperdxio/hyperdx/issues/1155
