### PR TITLE
[HDX-3966] Improve TUI error message rendering and add SQL preview

### DIFF
--- a/.changeset/error-display-sql-preview.md
+++ b/.changeset/error-display-sql-preview.md
@@ -1,0 +1,12 @@
+---
+"@hyperdx/cli": patch
+---
+
+Improve error message rendering with visible highlighting and add SQL preview
+
+- Add ErrorDisplay component with bordered boxes, color-coded severity, and responsive terminal height adaptation
+- Preserve ClickHouseQueryError objects through the error chain to show sent query context
+- Surface previously silent errors: pagination failures, row detail fetch errors, trace span detail errors
+- Add Shift-D keybinding to view generated ClickHouse SQL (context-aware across all tabs)
+- Copy useSqlSuggestions from app package to detect common query mistakes
+- Disable follow mode toggle in event detail panel

--- a/packages/cli/src/App.tsx
+++ b/packages/cli/src/App.tsx
@@ -125,7 +125,7 @@ export default function App({ apiUrl, query, sourceName, follow }: AppProps) {
   if (error) {
     return (
       <Box paddingX={1}>
-        <ErrorDisplay message={error} severity="error" />
+        <ErrorDisplay error={error} severity="error" />
       </Box>
     );
   }

--- a/packages/cli/src/App.tsx
+++ b/packages/cli/src/App.tsx
@@ -9,6 +9,7 @@ import {
   type SourceResponse,
   type SavedSearchResponse,
 } from '@/api/client';
+import ErrorDisplay from '@/components/ErrorDisplay';
 import LoginForm from '@/components/LoginForm';
 import SourcePicker from '@/components/SourcePicker';
 import EventViewer from '@/components/EventViewer';
@@ -124,7 +125,7 @@ export default function App({ apiUrl, query, sourceName, follow }: AppProps) {
   if (error) {
     return (
       <Box paddingX={1}>
-        <Text color="red">Error: {error}</Text>
+        <ErrorDisplay message={error} severity="error" />
       </Box>
     );
   }

--- a/packages/cli/src/components/ErrorDisplay.tsx
+++ b/packages/cli/src/components/ErrorDisplay.tsx
@@ -4,20 +4,33 @@
  * Renders errors and warnings with clear visual highlighting
  * so they are immediately noticeable and distinguishable from
  * normal output.
+ *
+ * Mirrors the error rendering patterns from the web frontend:
+ * @source packages/app/src/DBSearchPage.tsx (queryError + ClickHouseQueryError rendering)
+ * @source packages/app/src/components/DBTableChart.tsx (error message + sent query)
  */
 
 import React from 'react';
 import { Box, Text } from 'ink';
 
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+
+import { useSqlSuggestions, type Suggestion } from '@/shared/useSqlSuggestions';
 import { parseError, type ErrorSeverity } from '@/utils/parseError';
 
 interface ErrorDisplayProps {
-  /** Raw error message string */
-  message: string;
+  /** The error — accepts a string, Error, or ClickHouseQueryError */
+  error: string | Error | ClickHouseQueryError;
   /** Severity level — defaults to 'error' */
   severity?: ErrorSeverity;
-  /** Optional additional context (e.g. the query that caused it) */
+  /** Optional additional context shown below the error message */
   detail?: string;
+  /**
+   * The user's search query — when provided alongside a ClickHouseQueryError,
+   * SQL suggestions (e.g. double-quote correction) will be shown.
+   * @source packages/app/src/DBSearchPage.tsx (whereSuggestions)
+   */
+  searchQuery?: string;
   /** Whether to render in compact (single-line) mode */
   compact?: boolean;
 }
@@ -41,23 +54,34 @@ const SEVERITY_CONFIG = {
  * Renders a visually prominent error or warning message.
  *
  * Full mode (default):
- * ┌─────────────────────────────────────┐
- * │ ✖ Error                             │
- * │ Syntax error: failed at position 5  │
- * │ Query: SELECT * FROM ...            │
- * └─────────────────────────────────────┘
+ * ╭─────────────────────────────────────────────────╮
+ * │ ✖ Error                                         │
+ * │ Syntax error: failed at position 5 ...          │
+ * │                                                 │
+ * │ Sent Query:                                     │
+ * │ SELECT * FROM default.logs WHERE "name" = 'foo' │
+ * │                                                 │
+ * │ 💡 ClickHouse does not support double quotes ... │
+ * ╰─────────────────────────────────────────────────╯
  *
  * Compact mode:
  * ✖ Error: Syntax error: failed at position 5
  */
 export default function ErrorDisplay({
-  message,
+  error,
   severity = 'error',
   detail,
+  searchQuery,
   compact = false,
 }: ErrorDisplayProps) {
   const config = SEVERITY_CONFIG[severity];
-  const parsed = parseError(message, severity);
+  const parsed = parseError(error, severity);
+
+  // SQL suggestions — only when we have a search query and there's an error
+  const suggestions = useSqlSuggestions({
+    input: searchQuery ?? '',
+    enabled: !!searchQuery && severity === 'error',
+  });
 
   if (compact) {
     return (
@@ -83,11 +107,36 @@ export default function ErrorDisplay({
         {config.icon} {config.label}
       </Text>
       <Text color={config.color}>{parsed.message}</Text>
+
+      {/* Original query — shown when the error is a ClickHouseQueryError */}
+      {parsed.query && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor bold>
+            Sent Query:
+          </Text>
+          <Text dimColor wrap="wrap">
+            {parsed.query}
+          </Text>
+        </Box>
+      )}
+
+      {/* Additional context */}
       {detail && (
         <Box marginTop={1}>
           <Text dimColor wrap="wrap">
             {detail}
           </Text>
+        </Box>
+      )}
+
+      {/* SQL suggestions */}
+      {suggestions && suggestions.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          {suggestions.map((s: Suggestion, i: number) => (
+            <Text key={i} color="cyan">
+              💡 {s.userMessage('where')}
+            </Text>
+          ))}
         </Box>
       )}
     </Box>

--- a/packages/cli/src/components/ErrorDisplay.tsx
+++ b/packages/cli/src/components/ErrorDisplay.tsx
@@ -5,18 +5,27 @@
  * so they are immediately noticeable and distinguishable from
  * normal output.
  *
+ * Responsive to terminal height:
+ *   - Small  (< 20 rows): compact single-line rendering
+ *   - Medium (20–35 rows): bordered box with message only
+ *   - Large  (> 35 rows):  full display with query context + suggestions
+ *
  * Mirrors the error rendering patterns from the web frontend:
  * @source packages/app/src/DBSearchPage.tsx (queryError + ClickHouseQueryError rendering)
  * @source packages/app/src/components/DBTableChart.tsx (error message + sent query)
  */
 
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 
 import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 
 import { useSqlSuggestions, type Suggestion } from '@/shared/useSqlSuggestions';
 import { parseError, type ErrorSeverity } from '@/utils/parseError';
+
+/** Terminal height breakpoints for responsive rendering */
+const COMPACT_THRESHOLD = 20;
+const FULL_THRESHOLD = 35;
 
 interface ErrorDisplayProps {
   /** The error — accepts a string, Error, or ClickHouseQueryError */
@@ -31,7 +40,7 @@ interface ErrorDisplayProps {
    * @source packages/app/src/DBSearchPage.tsx (whereSuggestions)
    */
   searchQuery?: string;
-  /** Whether to render in compact (single-line) mode */
+  /** Force compact (single-line) mode regardless of terminal size */
   compact?: boolean;
 }
 
@@ -53,7 +62,7 @@ const SEVERITY_CONFIG = {
 /**
  * Renders a visually prominent error or warning message.
  *
- * Full mode (default):
+ * Large terminal (> 35 rows):
  * ╭─────────────────────────────────────────────────╮
  * │ ✖ Error                                         │
  * │ Syntax error: failed at position 5 ...          │
@@ -64,7 +73,13 @@ const SEVERITY_CONFIG = {
  * │ 💡 ClickHouse does not support double quotes ... │
  * ╰─────────────────────────────────────────────────╯
  *
- * Compact mode:
+ * Medium terminal (20–35 rows):
+ * ╭─────────────────────────────────────────────────╮
+ * │ ✖ Error                                         │
+ * │ Syntax error: failed at position 5 ...          │
+ * ╰─────────────────────────────────────────────────╯
+ *
+ * Small terminal (< 20 rows) or compact=true:
  * ✖ Error: Syntax error: failed at position 5
  */
 export default function ErrorDisplay({
@@ -74,6 +89,9 @@ export default function ErrorDisplay({
   searchQuery,
   compact = false,
 }: ErrorDisplayProps) {
+  const { stdout } = useStdout();
+  const termHeight = stdout?.rows ?? 24;
+
   const config = SEVERITY_CONFIG[severity];
   const parsed = parseError(error, severity);
 
@@ -83,7 +101,12 @@ export default function ErrorDisplay({
     enabled: !!searchQuery && severity === 'error',
   });
 
-  if (compact) {
+  // Responsive: force compact when terminal is very small
+  const useCompact = compact || termHeight < COMPACT_THRESHOLD;
+  // Only show query context and suggestions in large terminals
+  const showFullDetails = !useCompact && termHeight >= FULL_THRESHOLD;
+
+  if (useCompact) {
     return (
       <Box>
         <Text color={config.color} bold>
@@ -108,8 +131,8 @@ export default function ErrorDisplay({
       </Text>
       <Text color={config.color}>{parsed.message}</Text>
 
-      {/* Original query — shown when the error is a ClickHouseQueryError */}
-      {parsed.query && (
+      {/* Original query — only in large terminals */}
+      {showFullDetails && parsed.query && (
         <Box flexDirection="column" marginTop={1}>
           <Text dimColor bold>
             Sent Query:
@@ -120,8 +143,8 @@ export default function ErrorDisplay({
         </Box>
       )}
 
-      {/* Additional context */}
-      {detail && (
+      {/* Additional context — only in large terminals */}
+      {showFullDetails && detail && (
         <Box marginTop={1}>
           <Text dimColor wrap="wrap">
             {detail}
@@ -129,8 +152,8 @@ export default function ErrorDisplay({
         </Box>
       )}
 
-      {/* SQL suggestions */}
-      {suggestions && suggestions.length > 0 && (
+      {/* SQL suggestions — only in large terminals */}
+      {showFullDetails && suggestions && suggestions.length > 0 && (
         <Box flexDirection="column" marginTop={1}>
           {suggestions.map((s: Suggestion, i: number) => (
             <Text key={i} color="cyan">

--- a/packages/cli/src/components/ErrorDisplay.tsx
+++ b/packages/cli/src/components/ErrorDisplay.tsx
@@ -1,0 +1,95 @@
+/**
+ * Reusable error/warning display component for the TUI.
+ *
+ * Renders errors and warnings with clear visual highlighting
+ * so they are immediately noticeable and distinguishable from
+ * normal output.
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { parseError, type ErrorSeverity } from '@/utils/parseError';
+
+interface ErrorDisplayProps {
+  /** Raw error message string */
+  message: string;
+  /** Severity level — defaults to 'error' */
+  severity?: ErrorSeverity;
+  /** Optional additional context (e.g. the query that caused it) */
+  detail?: string;
+  /** Whether to render in compact (single-line) mode */
+  compact?: boolean;
+}
+
+const SEVERITY_CONFIG = {
+  error: {
+    icon: '✖',
+    label: 'Error',
+    color: 'red' as const,
+    borderColor: 'red' as const,
+  },
+  warning: {
+    icon: '⚠',
+    label: 'Warning',
+    color: 'yellow' as const,
+    borderColor: 'yellow' as const,
+  },
+};
+
+/**
+ * Renders a visually prominent error or warning message.
+ *
+ * Full mode (default):
+ * ┌─────────────────────────────────────┐
+ * │ ✖ Error                             │
+ * │ Syntax error: failed at position 5  │
+ * │ Query: SELECT * FROM ...            │
+ * └─────────────────────────────────────┘
+ *
+ * Compact mode:
+ * ✖ Error: Syntax error: failed at position 5
+ */
+export default function ErrorDisplay({
+  message,
+  severity = 'error',
+  detail,
+  compact = false,
+}: ErrorDisplayProps) {
+  const config = SEVERITY_CONFIG[severity];
+  const parsed = parseError(message, severity);
+
+  if (compact) {
+    return (
+      <Box>
+        <Text color={config.color} bold>
+          {config.icon} {config.label}:{' '}
+        </Text>
+        <Text color={config.color} wrap="truncate">
+          {parsed.message}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={config.borderColor}
+      paddingX={1}
+    >
+      <Text color={config.color} bold>
+        {config.icon} {config.label}
+      </Text>
+      <Text color={config.color}>{parsed.message}</Text>
+      {detail && (
+        <Box marginTop={1}>
+          <Text dimColor wrap="wrap">
+            {detail}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/cli/src/components/EventViewer/DetailPanel.tsx
+++ b/packages/cli/src/components/EventViewer/DetailPanel.tsx
@@ -21,6 +21,7 @@ type DetailPanelProps = {
   detailTab: DetailTab;
   expandedRowData: Record<string, unknown> | null;
   expandedRowLoading: boolean;
+  expandedRowError: Error | null;
   expandedTraceId: string | null;
   expandedSpanId: string | null;
   traceSelectedIndex: number | null;
@@ -50,6 +51,7 @@ export function DetailPanel({
   detailTab,
   expandedRowData,
   expandedRowLoading,
+  expandedRowError,
   expandedTraceId,
   expandedSpanId,
   traceSelectedIndex,
@@ -138,13 +140,12 @@ export function DetailPanel({
             </Text>
           ) : expandedRowData ? (
             <>
-              {expandedRowData.__fetch_error && (
+              {expandedRowError && (
                 <Box marginBottom={1}>
                   <ErrorDisplay
-                    error={String(expandedRowData.__fetch_error)}
+                    error={expandedRowError}
                     severity="warning"
                     detail="Showing partial row data — full row fetch failed."
-                    compact
                   />
                 </Box>
               )}
@@ -231,13 +232,12 @@ export function DetailPanel({
             </Text>
           ) : expandedRowData ? (
             <>
-              {expandedRowData.__fetch_error && (
+              {expandedRowError && (
                 <Box marginBottom={1}>
                   <ErrorDisplay
-                    error={String(expandedRowData.__fetch_error)}
+                    error={expandedRowError}
                     severity="warning"
                     detail="Showing partial row data — full row fetch failed."
-                    compact
                   />
                 </Box>
               )}

--- a/packages/cli/src/components/EventViewer/DetailPanel.tsx
+++ b/packages/cli/src/components/EventViewer/DetailPanel.tsx
@@ -42,6 +42,10 @@ type DetailPanelProps = {
   };
   scrollOffset: number;
   expandedRow: number;
+  /** Callback when the trace tab's SQL changes */
+  onTraceChSqlChange?: (
+    chSql: { sql: string; params: Record<string, unknown> } | null,
+  ) => void;
 };
 
 export function DetailPanel({
@@ -69,6 +73,7 @@ export function DetailPanel({
   expandedFormattedRow,
   scrollOffset,
   expandedRow,
+  onTraceChSqlChange,
 }: DetailPanelProps) {
   const hasTrace =
     source.kind === 'trace' || (source.kind === 'log' && source.traceSourceId);
@@ -215,6 +220,7 @@ export function DetailPanel({
               wrapLines={wrapLines}
               detailScrollOffset={traceDetailScrollOffset}
               detailMaxRows={detailMaxRows}
+              onChSqlChange={onTraceChSqlChange}
             />
           );
         })()}

--- a/packages/cli/src/components/EventViewer/DetailPanel.tsx
+++ b/packages/cli/src/components/EventViewer/DetailPanel.tsx
@@ -141,7 +141,7 @@ export function DetailPanel({
               {expandedRowData.__fetch_error && (
                 <Box marginBottom={1}>
                   <ErrorDisplay
-                    message={String(expandedRowData.__fetch_error)}
+                    error={String(expandedRowData.__fetch_error)}
                     severity="warning"
                     detail="Showing partial row data — full row fetch failed."
                     compact
@@ -234,7 +234,7 @@ export function DetailPanel({
               {expandedRowData.__fetch_error && (
                 <Box marginBottom={1}>
                   <ErrorDisplay
-                    message={String(expandedRowData.__fetch_error)}
+                    error={String(expandedRowData.__fetch_error)}
                     severity="warning"
                     detail="Showing partial row data — full row fetch failed."
                     compact

--- a/packages/cli/src/components/EventViewer/DetailPanel.tsx
+++ b/packages/cli/src/components/EventViewer/DetailPanel.tsx
@@ -4,6 +4,7 @@ import Spinner from 'ink-spinner';
 
 import type { SourceResponse, ProxyClickhouseClient } from '@/api/client';
 import ColumnValues from '@/components/ColumnValues';
+import ErrorDisplay from '@/components/ErrorDisplay';
 import RowOverview from '@/components/RowOverview';
 import TraceWaterfall from '@/components/TraceWaterfall';
 
@@ -136,14 +137,26 @@ export function DetailPanel({
               <Spinner type="dots" /> Loading…
             </Text>
           ) : expandedRowData ? (
-            <RowOverview
-              source={source}
-              rowData={expandedRowData}
-              searchQuery={detailSearchQuery}
-              wrapLines={wrapLines}
-              maxRows={fullDetailMaxRows}
-              scrollOffset={columnValuesScrollOffset}
-            />
+            <>
+              {expandedRowData.__fetch_error && (
+                <Box marginBottom={1}>
+                  <ErrorDisplay
+                    message={String(expandedRowData.__fetch_error)}
+                    severity="warning"
+                    detail="Showing partial row data — full row fetch failed."
+                    compact
+                  />
+                </Box>
+              )}
+              <RowOverview
+                source={source}
+                rowData={expandedRowData}
+                searchQuery={detailSearchQuery}
+                wrapLines={wrapLines}
+                maxRows={fullDetailMaxRows}
+                scrollOffset={columnValuesScrollOffset}
+              />
+            </>
           ) : null}
         </Box>
       )}
@@ -217,13 +230,25 @@ export function DetailPanel({
               <Spinner type="dots" /> Loading all fields…
             </Text>
           ) : expandedRowData ? (
-            <ColumnValues
-              data={expandedRowData}
-              searchQuery={detailSearchQuery}
-              wrapLines={wrapLines}
-              maxRows={fullDetailMaxRows}
-              scrollOffset={columnValuesScrollOffset}
-            />
+            <>
+              {expandedRowData.__fetch_error && (
+                <Box marginBottom={1}>
+                  <ErrorDisplay
+                    message={String(expandedRowData.__fetch_error)}
+                    severity="warning"
+                    detail="Showing partial row data — full row fetch failed."
+                    compact
+                  />
+                </Box>
+              )}
+              <ColumnValues
+                data={expandedRowData}
+                searchQuery={detailSearchQuery}
+                wrapLines={wrapLines}
+                maxRows={fullDetailMaxRows}
+                scrollOffset={columnValuesScrollOffset}
+              />
+            </>
           ) : null}
         </Box>
       )}

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -183,8 +183,6 @@ export default function EventViewer({
     }));
   }, [events, scrollOffset, maxRows, columns]);
 
-  const errorMessage = error ?? null;
-
   // ---- Render ------------------------------------------------------
 
   if (showHelp) {
@@ -257,7 +255,8 @@ export default function EventViewer({
           focusSearch={focusSearch}
           wrapLines={wrapLines}
           maxRows={maxRows}
-          errorMessage={errorMessage}
+          error={error}
+          searchQuery={submittedQuery}
           loading={loading}
         />
       )}

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -5,7 +5,14 @@ import type { TimeRange } from '@/utils/editor';
 
 import type { EventViewerProps, SwitchItem } from './types';
 import { getColumns, getDynamicColumns, formatDynamicRow } from './utils';
-import { Header, TabBar, SearchBar, Footer, HelpScreen } from './SubComponents';
+import {
+  Header,
+  TabBar,
+  SearchBar,
+  Footer,
+  HelpScreen,
+  SqlPreviewScreen,
+} from './SubComponents';
 import { TableView } from './TableView';
 import { DetailPanel } from './DetailPanel';
 import { useEventData } from './useEventData';
@@ -39,6 +46,8 @@ export default function EventViewer({
   const [scrollOffset, setScrollOffset] = useState(0);
   const [focusSearch, setFocusSearch] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [showSql, setShowSql] = useState(false);
+  const [sqlScrollOffset, setSqlScrollOffset] = useState(0);
   const [wrapLines, setWrapLines] = useState(false);
   const [customSelectMap, setCustomSelectMap] = useState<
     Record<string, string>
@@ -75,6 +84,7 @@ export default function EventViewer({
     expandedRowError,
     expandedTraceId,
     expandedSpanId,
+    lastChSql,
     fetchNextPage,
   } = useEventData({
     clickhouseClient,
@@ -139,6 +149,7 @@ export default function EventViewer({
     focusSearch,
     focusDetailSearch,
     showHelp,
+    showSql,
     expandedRow,
     detailTab,
     selectedRow,
@@ -159,6 +170,8 @@ export default function EventViewer({
     setFocusSearch,
     setFocusDetailSearch,
     setShowHelp,
+    setShowSql,
+    setSqlScrollOffset,
     setSelectedRow,
     setScrollOffset,
     setExpandedRow,
@@ -190,6 +203,20 @@ export default function EventViewer({
     return (
       <Box flexDirection="column" paddingX={1} height={termHeight}>
         <HelpScreen />
+      </Box>
+    );
+  }
+
+  if (showSql) {
+    // Reserve lines for header, padding, footer hint
+    const sqlMaxRows = Math.max(5, termHeight - 6);
+    return (
+      <Box flexDirection="column" paddingX={1} height={termHeight}>
+        <SqlPreviewScreen
+          chSql={lastChSql}
+          scrollOffset={sqlScrollOffset}
+          maxRows={sqlMaxRows}
+        />
       </Box>
     );
   }

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -48,6 +48,10 @@ export default function EventViewer({
   const [showHelp, setShowHelp] = useState(false);
   const [showSql, setShowSql] = useState(false);
   const [sqlScrollOffset, setSqlScrollOffset] = useState(0);
+  const [traceChSql, setTraceChSql] = useState<{
+    sql: string;
+    params: Record<string, unknown>;
+  } | null>(null);
   const [wrapLines, setWrapLines] = useState(false);
   const [customSelectMap, setCustomSelectMap] = useState<
     Record<string, string>
@@ -85,6 +89,7 @@ export default function EventViewer({
     expandedTraceId,
     expandedSpanId,
     lastChSql,
+    lastExpandedChSql,
     fetchNextPage,
   } = useEventData({
     clickhouseClient,
@@ -142,6 +147,14 @@ export default function EventViewer({
 
   const activeIdx = findActiveIndex();
   const visibleRowCount = Math.min(events.length - scrollOffset, maxRows);
+
+  // Determine which SQL to show based on current context
+  const activeChSql = useMemo(() => {
+    if (expandedRow === null) return lastChSql;
+    if (detailTab === 'trace') return traceChSql;
+    // overview / columns tabs use the expanded row SELECT * query
+    return lastExpandedChSql;
+  }, [expandedRow, detailTab, lastChSql, lastExpandedChSql, traceChSql]);
 
   // ---- Keybindings -------------------------------------------------
 
@@ -213,7 +226,7 @@ export default function EventViewer({
     return (
       <Box flexDirection="column" paddingX={1} height={termHeight}>
         <SqlPreviewScreen
-          chSql={lastChSql}
+          chSql={activeChSql}
           scrollOffset={sqlScrollOffset}
           maxRows={sqlMaxRows}
         />
@@ -275,6 +288,7 @@ export default function EventViewer({
           )}
           scrollOffset={scrollOffset}
           expandedRow={expandedRow}
+          onTraceChSqlChange={setTraceChSql}
         />
       ) : (
         <TableView

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -72,6 +72,7 @@ export default function EventViewer({
     paginationError,
     expandedRowData,
     expandedRowLoading,
+    expandedRowError,
     expandedTraceId,
     expandedSpanId,
     fetchNextPage,
@@ -227,6 +228,7 @@ export default function EventViewer({
           detailTab={detailTab}
           expandedRowData={expandedRowData}
           expandedRowLoading={expandedRowLoading}
+          expandedRowError={expandedRowError}
           expandedTraceId={expandedTraceId}
           expandedSpanId={expandedSpanId}
           traceSelectedIndex={traceSelectedIndex}

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -212,107 +212,113 @@ export default function EventViewer({
 
   // ---- Render ------------------------------------------------------
 
-  if (showHelp) {
-    return (
-      <Box flexDirection="column" paddingX={1} height={termHeight}>
-        <HelpScreen />
-      </Box>
-    );
-  }
+  // Reserve lines for header, padding, footer hint in SQL preview
+  const sqlMaxRows = Math.max(5, termHeight - 6);
 
-  if (showSql) {
-    // Reserve lines for header, padding, footer hint
-    const sqlMaxRows = Math.max(5, termHeight - 6);
-    return (
-      <Box flexDirection="column" paddingX={1} height={termHeight}>
-        <SqlPreviewScreen
-          chSql={activeChSql}
-          scrollOffset={sqlScrollOffset}
-          maxRows={sqlMaxRows}
-        />
-      </Box>
-    );
-  }
+  // Overlays (help, SQL preview) hide the main content via display="none"
+  // instead of unmounting it, so hooks keep running and cached data
+  // (e.g. trace tab results) is preserved.
+  const overlay = showHelp ? 'help' : showSql ? 'sql' : null;
 
   return (
-    <Box flexDirection="column" paddingX={1} height={termHeight}>
-      <Header
-        sourceName={source.name}
-        dbName={source.from.databaseName}
-        tableName={source.from.tableName}
-        isFollowing={isFollowing}
-        loading={loading}
-        timeRange={timeRange}
-      />
-      {expandedRow === null && (
-        <>
-          <TabBar items={switchItems} activeIdx={activeIdx} />
-          <SearchBar
-            focused={focusSearch}
-            query={searchQuery}
-            onChange={setSearchQuery}
-            onSubmit={() => {
-              setSubmittedQuery(searchQuery);
-              setScrollOffset(0);
-              setFocusSearch(false);
-            }}
+    <Box flexDirection="column" height={termHeight}>
+      {overlay === 'help' && (
+        <Box flexDirection="column" paddingX={1} height={termHeight}>
+          <HelpScreen />
+        </Box>
+      )}
+      {overlay === 'sql' && (
+        <Box flexDirection="column" paddingX={1} height={termHeight}>
+          <SqlPreviewScreen
+            chSql={activeChSql}
+            scrollOffset={sqlScrollOffset}
+            maxRows={sqlMaxRows}
           />
-        </>
+        </Box>
       )}
-
-      {expandedRow !== null ? (
-        <DetailPanel
-          source={source}
-          sources={sources}
-          clickhouseClient={clickhouseClient}
-          detailTab={detailTab}
-          expandedRowData={expandedRowData}
-          expandedRowLoading={expandedRowLoading}
-          expandedRowError={expandedRowError}
-          expandedTraceId={expandedTraceId}
-          expandedSpanId={expandedSpanId}
-          traceSelectedIndex={traceSelectedIndex}
-          onTraceSelectedIndexChange={setTraceSelectedIndex}
-          detailSearchQuery={detailSearchQuery}
-          focusDetailSearch={focusDetailSearch}
-          onDetailSearchQueryChange={setDetailSearchQuery}
-          onDetailSearchSubmit={() => setFocusDetailSearch(false)}
-          wrapLines={wrapLines}
-          termHeight={termHeight}
-          fullDetailMaxRows={fullDetailMaxRows}
-          detailMaxRows={detailMaxRows}
-          columnValuesScrollOffset={columnValuesScrollOffset}
-          traceDetailScrollOffset={traceDetailScrollOffset}
-          expandedFormattedRow={visibleRows.find(
-            (_, i) => scrollOffset + i === expandedRow,
-          )}
-          scrollOffset={scrollOffset}
-          expandedRow={expandedRow}
-          onTraceChSqlChange={setTraceChSql}
-        />
-      ) : (
-        <TableView
-          columns={columns}
-          visibleRows={visibleRows}
-          selectedRow={selectedRow}
-          focusSearch={focusSearch}
-          wrapLines={wrapLines}
-          maxRows={maxRows}
-          error={error}
-          searchQuery={submittedQuery}
+      <Box
+        flexDirection="column"
+        paddingX={1}
+        display={overlay ? 'none' : 'flex'}
+      >
+        <Header
+          sourceName={source.name}
+          dbName={source.from.databaseName}
+          tableName={source.from.tableName}
+          isFollowing={isFollowing}
           loading={loading}
+          timeRange={timeRange}
         />
-      )}
+        {expandedRow === null && (
+          <>
+            <TabBar items={switchItems} activeIdx={activeIdx} />
+            <SearchBar
+              focused={focusSearch}
+              query={searchQuery}
+              onChange={setSearchQuery}
+              onSubmit={() => {
+                setSubmittedQuery(searchQuery);
+                setScrollOffset(0);
+                setFocusSearch(false);
+              }}
+            />
+          </>
+        )}
 
-      <Footer
-        rowCount={events.length}
-        cursorPos={scrollOffset + selectedRow + 1}
-        wrapLines={wrapLines}
-        isFollowing={isFollowing}
-        loadingMore={loadingMore}
-        paginationError={paginationError}
-        scrollInfo={expandedRow !== null ? `Ctrl+D/U to scroll` : undefined}
-      />
+        {expandedRow !== null ? (
+          <DetailPanel
+            source={source}
+            sources={sources}
+            clickhouseClient={clickhouseClient}
+            detailTab={detailTab}
+            expandedRowData={expandedRowData}
+            expandedRowLoading={expandedRowLoading}
+            expandedRowError={expandedRowError}
+            expandedTraceId={expandedTraceId}
+            expandedSpanId={expandedSpanId}
+            traceSelectedIndex={traceSelectedIndex}
+            onTraceSelectedIndexChange={setTraceSelectedIndex}
+            detailSearchQuery={detailSearchQuery}
+            focusDetailSearch={focusDetailSearch}
+            onDetailSearchQueryChange={setDetailSearchQuery}
+            onDetailSearchSubmit={() => setFocusDetailSearch(false)}
+            wrapLines={wrapLines}
+            termHeight={termHeight}
+            fullDetailMaxRows={fullDetailMaxRows}
+            detailMaxRows={detailMaxRows}
+            columnValuesScrollOffset={columnValuesScrollOffset}
+            traceDetailScrollOffset={traceDetailScrollOffset}
+            expandedFormattedRow={visibleRows.find(
+              (_, i) => scrollOffset + i === expandedRow,
+            )}
+            scrollOffset={scrollOffset}
+            expandedRow={expandedRow}
+            onTraceChSqlChange={setTraceChSql}
+          />
+        ) : (
+          <TableView
+            columns={columns}
+            visibleRows={visibleRows}
+            selectedRow={selectedRow}
+            focusSearch={focusSearch}
+            wrapLines={wrapLines}
+            maxRows={maxRows}
+            error={error}
+            searchQuery={submittedQuery}
+            loading={loading}
+          />
+        )}
+
+        <Footer
+          rowCount={events.length}
+          cursorPos={scrollOffset + selectedRow + 1}
+          wrapLines={wrapLines}
+          isFollowing={isFollowing}
+          loadingMore={loadingMore}
+          paginationError={paginationError}
+          scrollInfo={expandedRow !== null ? `Ctrl+D/U to scroll` : undefined}
+        />
+      </Box>
     </Box>
   );
 }

--- a/packages/cli/src/components/EventViewer/EventViewer.tsx
+++ b/packages/cli/src/components/EventViewer/EventViewer.tsx
@@ -69,6 +69,7 @@ export default function EventViewer({
     error,
     hasMore,
     loadingMore,
+    paginationError,
     expandedRowData,
     expandedRowLoading,
     expandedTraceId,
@@ -182,7 +183,7 @@ export default function EventViewer({
     }));
   }, [events, scrollOffset, maxRows, columns]);
 
-  const errorLine = error ? error.slice(0, 200) : '';
+  const errorMessage = error ?? null;
 
   // ---- Render ------------------------------------------------------
 
@@ -256,7 +257,7 @@ export default function EventViewer({
           focusSearch={focusSearch}
           wrapLines={wrapLines}
           maxRows={maxRows}
-          errorLine={errorLine}
+          errorMessage={errorMessage}
           loading={loading}
         />
       )}
@@ -267,6 +268,7 @@ export default function EventViewer({
         wrapLines={wrapLines}
         isFollowing={isFollowing}
         loadingMore={loadingMore}
+        paginationError={paginationError}
         scrollInfo={expandedRow !== null ? `Ctrl+D/U to scroll` : undefined}
       />
     </Box>

--- a/packages/cli/src/components/EventViewer/SubComponents.tsx
+++ b/packages/cli/src/components/EventViewer/SubComponents.tsx
@@ -3,6 +3,8 @@ import { Box, Text } from 'ink';
 import TextInput from 'ink-text-input';
 import Spinner from 'ink-spinner';
 
+import { parameterizedQueryToSql } from '@hyperdx/common-utils/dist/clickhouse';
+
 import ErrorDisplay from '@/components/ErrorDisplay';
 import type { TimeRange } from '@/utils/editor';
 
@@ -182,6 +184,7 @@ export const HelpScreen = React.memo(function HelpScreen() {
     ['Shift+Tab', 'Previous source / saved search'],
     ['t', 'Edit time range in $EDITOR'],
     ['s', 'Edit select clause in $EDITOR'],
+    ['D', 'Show generated SQL'],
     ['f', 'Toggle follow mode (live tail)'],
     ['w', 'Toggle line wrap'],
     ['?', 'Toggle this help'],
@@ -228,6 +231,67 @@ export const TableHeader = React.memo(function TableHeader({
           </Text>
         </Box>
       ))}
+    </Box>
+  );
+});
+
+// ---- SqlPreviewScreen ----------------------------------------------
+
+type SqlPreviewScreenProps = {
+  chSql: { sql: string; params: Record<string, unknown> } | null;
+  scrollOffset: number;
+  maxRows: number;
+};
+
+export const SqlPreviewScreen = React.memo(function SqlPreviewScreen({
+  chSql,
+  scrollOffset,
+  maxRows,
+}: SqlPreviewScreenProps) {
+  let resolvedSql = '';
+  if (chSql) {
+    try {
+      resolvedSql = parameterizedQueryToSql({
+        sql: chSql.sql,
+        params: chSql.params,
+      });
+    } catch {
+      // Fall back to the raw parameterized SQL if resolution fails
+      resolvedSql = chSql.sql;
+    }
+  }
+
+  const lines = resolvedSql ? resolvedSql.split('\n') : [];
+  const visibleLines = lines.slice(scrollOffset, scrollOffset + maxRows);
+  const totalLines = lines.length;
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      <Text bold color="cyan">
+        Generated SQL
+      </Text>
+      <Text> </Text>
+      {resolvedSql ? (
+        visibleLines.map((line, i) => (
+          <Text key={i} wrap="wrap">
+            {line}
+          </Text>
+        ))
+      ) : (
+        <Text dimColor>No query has been executed yet.</Text>
+      )}
+      {totalLines > maxRows && (
+        <>
+          <Text> </Text>
+          <Text dimColor>
+            Lines {scrollOffset + 1}–
+            {Math.min(scrollOffset + maxRows, totalLines)} of {totalLines}{' '}
+            (Ctrl+D/U to scroll)
+          </Text>
+        </>
+      )}
+      <Text> </Text>
+      <Text dimColor>Press D or Esc to close</Text>
     </Box>
   );
 });

--- a/packages/cli/src/components/EventViewer/SubComponents.tsx
+++ b/packages/cli/src/components/EventViewer/SubComponents.tsx
@@ -123,6 +123,7 @@ type FooterProps = {
   wrapLines: boolean;
   isFollowing: boolean;
   loadingMore: boolean;
+  paginationError?: string | null;
   scrollInfo?: string;
 };
 
@@ -132,19 +133,27 @@ export const Footer = React.memo(function Footer({
   wrapLines,
   isFollowing,
   loadingMore,
+  paginationError,
   scrollInfo,
 }: FooterProps) {
   return (
-    <Box marginTop={1} justifyContent="space-between">
-      <Text dimColor>
-        {isFollowing ? '[FOLLOWING] ' : ''}
-        {wrapLines ? '[WRAP] ' : ''}
-        {loadingMore ? '[LOADING…] ' : ''}?=help q=quit
-      </Text>
-      <Text dimColor>
-        {scrollInfo ? `${scrollInfo}  ` : ''}
-        {cursorPos}/{rowCount}
-      </Text>
+    <Box flexDirection="column" marginTop={1}>
+      {paginationError && (
+        <Text color="yellow" bold>
+          ⚠ Failed to load more results: {paginationError.slice(0, 120)}
+        </Text>
+      )}
+      <Box justifyContent="space-between">
+        <Text dimColor>
+          {isFollowing ? '[FOLLOWING] ' : ''}
+          {wrapLines ? '[WRAP] ' : ''}
+          {loadingMore ? '[LOADING…] ' : ''}?=help q=quit
+        </Text>
+        <Text dimColor>
+          {scrollInfo ? `${scrollInfo}  ` : ''}
+          {cursorPos}/{rowCount}
+        </Text>
+      </Box>
     </Box>
   );
 });

--- a/packages/cli/src/components/EventViewer/SubComponents.tsx
+++ b/packages/cli/src/components/EventViewer/SubComponents.tsx
@@ -3,7 +3,9 @@ import { Box, Text } from 'ink';
 import TextInput from 'ink-text-input';
 import Spinner from 'ink-spinner';
 
+import ErrorDisplay from '@/components/ErrorDisplay';
 import type { TimeRange } from '@/utils/editor';
+
 import type { Column, SwitchItem } from './types';
 import { formatShortDate } from './utils';
 
@@ -123,7 +125,7 @@ type FooterProps = {
   wrapLines: boolean;
   isFollowing: boolean;
   loadingMore: boolean;
-  paginationError?: string | null;
+  paginationError?: Error | null;
   scrollInfo?: string;
 };
 
@@ -139,9 +141,12 @@ export const Footer = React.memo(function Footer({
   return (
     <Box flexDirection="column" marginTop={1}>
       {paginationError && (
-        <Text color="yellow" bold>
-          ⚠ Failed to load more results: {paginationError.slice(0, 120)}
-        </Text>
+        <ErrorDisplay
+          error={paginationError}
+          severity="warning"
+          detail="Failed to load more results."
+          compact
+        />
       )}
       <Box justifyContent="space-between">
         <Text dimColor>

--- a/packages/cli/src/components/EventViewer/TableView.tsx
+++ b/packages/cli/src/components/EventViewer/TableView.tsx
@@ -15,7 +15,8 @@ type TableViewProps = {
   focusSearch: boolean;
   wrapLines: boolean;
   maxRows: number;
-  errorMessage: string | null;
+  error: Error | null;
+  searchQuery?: string;
   loading: boolean;
 };
 
@@ -26,15 +27,20 @@ export function TableView({
   focusSearch,
   wrapLines,
   maxRows,
-  errorMessage,
+  error,
+  searchQuery,
   loading,
 }: TableViewProps) {
   return (
     <Box flexDirection="column" marginTop={1} height={maxRows + 1}>
       <TableHeader columns={columns} />
 
-      {errorMessage ? (
-        <ErrorDisplay message={errorMessage} severity="error" />
+      {error ? (
+        <ErrorDisplay
+          error={error}
+          severity="error"
+          searchQuery={searchQuery}
+        />
       ) : visibleRows.length === 0 && !loading ? (
         <Text dimColor>No events found.</Text>
       ) : null}

--- a/packages/cli/src/components/EventViewer/TableView.tsx
+++ b/packages/cli/src/components/EventViewer/TableView.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 
+import ErrorDisplay from '@/components/ErrorDisplay';
+
 import type { Column, FormattedRow } from './types';
 import { TableHeader } from './SubComponents';
 
@@ -13,7 +15,7 @@ type TableViewProps = {
   focusSearch: boolean;
   wrapLines: boolean;
   maxRows: number;
-  errorLine: string;
+  errorMessage: string | null;
   loading: boolean;
 };
 
@@ -24,17 +26,15 @@ export function TableView({
   focusSearch,
   wrapLines,
   maxRows,
-  errorLine,
+  errorMessage,
   loading,
 }: TableViewProps) {
   return (
     <Box flexDirection="column" marginTop={1} height={maxRows + 1}>
       <TableHeader columns={columns} />
 
-      {errorLine ? (
-        <Text color="red" wrap="truncate">
-          {errorLine}
-        </Text>
+      {errorMessage ? (
+        <ErrorDisplay message={errorMessage} severity="error" />
       ) : visibleRows.length === 0 && !loading ? (
         <Text dimColor>No events found.</Text>
       ) : null}

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -33,6 +33,7 @@ export interface UseEventDataReturn {
   paginationError: Error | null;
   expandedRowData: Record<string, unknown> | null;
   expandedRowLoading: boolean;
+  expandedRowError: Error | null;
   expandedTraceId: string | null;
   expandedSpanId: string | null;
   fetchNextPage: () => Promise<void>;
@@ -64,6 +65,7 @@ export function useEventData({
     unknown
   > | null>(null);
   const [expandedRowLoading, setExpandedRowLoading] = useState(false);
+  const [expandedRowError, setExpandedRowError] = useState<Error | null>(null);
   const [expandedTraceId, setExpandedTraceId] = useState<string | null>(null);
   const [expandedSpanId, setExpandedSpanId] = useState<string | null>(null);
 
@@ -219,6 +221,7 @@ export function useEventData({
   useEffect(() => {
     if (expandedRow === null) {
       setExpandedRowData(null);
+      setExpandedRowError(null);
       setExpandedTraceId(null);
       setExpandedSpanId(null);
       return;
@@ -228,6 +231,7 @@ export function useEventData({
 
     let cancelled = false;
     setExpandedRowLoading(true);
+    setExpandedRowError(null);
 
     (async () => {
       try {
@@ -272,17 +276,14 @@ export function useEventData({
           }
         }
       } catch (err) {
-        // Non-fatal — fall back to partial row data, but include error
-        const errMsg = err instanceof Error ? err.message : String(err);
-        // Truncate HTML errors to a readable length
-        const shortErr = errMsg.startsWith('<!')
-          ? errMsg.slice(0, 200)
-          : errMsg;
+        // Non-fatal — fall back to partial row data, surface the error
+        // separately so ErrorDisplay can render query context from
+        // ClickHouseQueryError.
         if (!cancelled) {
-          setExpandedRowData({
-            ...(row as Record<string, unknown>),
-            __fetch_error: shortErr,
-          });
+          setExpandedRowData(row as Record<string, unknown>);
+          setExpandedRowError(
+            err instanceof Error ? err : new Error(String(err)),
+          );
         }
       } finally {
         if (!cancelled) setExpandedRowLoading(false);
@@ -303,6 +304,7 @@ export function useEventData({
     paginationError,
     expandedRowData,
     expandedRowLoading,
+    expandedRowError,
     expandedTraceId,
     expandedSpanId,
     fetchNextPage,

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -38,6 +38,8 @@ export interface UseEventDataReturn {
   expandedSpanId: string | null;
   /** The last rendered ChSql (parameterized SQL + params) for the table query */
   lastChSql: { sql: string; params: Record<string, unknown> } | null;
+  /** The last rendered ChSql for the expanded row (SELECT *) query */
+  lastExpandedChSql: { sql: string; params: Record<string, unknown> } | null;
   fetchNextPage: () => Promise<void>;
 }
 
@@ -80,6 +82,10 @@ export function useEventData({
   const lastTableMetaRef = useRef<Array<{ name: string; type: string }> | null>(
     null,
   );
+  const lastExpandedChSqlRef = useRef<{
+    sql: string;
+    params: Record<string, unknown>;
+  } | null>(null);
 
   // ---- fetchEvents -------------------------------------------------
 
@@ -226,6 +232,7 @@ export function useEventData({
       setExpandedRowError(null);
       setExpandedTraceId(null);
       setExpandedSpanId(null);
+      lastExpandedChSqlRef.current = null;
       return;
     }
     const row = events[expandedRow];
@@ -249,6 +256,7 @@ export function useEventData({
           tableMeta,
           metadata,
         });
+        lastExpandedChSqlRef.current = chSql;
         const resultSet = await clickhouseClient.query({
           query: chSql.sql,
           query_params: chSql.params,
@@ -310,6 +318,7 @@ export function useEventData({
     expandedTraceId,
     expandedSpanId,
     lastChSql: lastTableChSqlRef.current,
+    lastExpandedChSql: lastExpandedChSqlRef.current,
     fetchNextPage,
   };
 }

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -75,6 +75,12 @@ export function useEventData({
 
   const lastTimestampRef = useRef<string | null>(null);
   const dateRangeRef = useRef<{ start: Date; end: Date } | null>(null);
+  const [lastChSql, setLastChSql] = useState<{
+    sql: string;
+    params: Record<string, unknown>;
+  } | null>(null);
+  // Keep a ref copy for use inside the expanded row effect (which needs
+  // the table ChSql to build the WHERE clause for the SELECT * query).
   const lastTableChSqlRef = useRef<{
     sql: string;
     params: Record<string, unknown>;
@@ -82,7 +88,7 @@ export function useEventData({
   const lastTableMetaRef = useRef<Array<{ name: string; type: string }> | null>(
     null,
   );
-  const lastExpandedChSqlRef = useRef<{
+  const [lastExpandedChSql, setLastExpandedChSql] = useState<{
     sql: string;
     params: Record<string, unknown>;
   } | null>(null);
@@ -112,6 +118,7 @@ export function useEventData({
           metadata,
         );
         lastTableChSqlRef.current = chSql;
+        setLastChSql(chSql);
         const resultSet = await clickhouseClient.query({
           query: chSql.sql,
           query_params: chSql.params,
@@ -232,7 +239,7 @@ export function useEventData({
       setExpandedRowError(null);
       setExpandedTraceId(null);
       setExpandedSpanId(null);
-      lastExpandedChSqlRef.current = null;
+      setLastExpandedChSql(null);
       return;
     }
     const row = events[expandedRow];
@@ -256,7 +263,7 @@ export function useEventData({
           tableMeta,
           metadata,
         });
-        lastExpandedChSqlRef.current = chSql;
+        setLastExpandedChSql(chSql);
         const resultSet = await clickhouseClient.query({
           query: chSql.sql,
           query_params: chSql.params,
@@ -317,8 +324,8 @@ export function useEventData({
     expandedRowError,
     expandedTraceId,
     expandedSpanId,
-    lastChSql: lastTableChSqlRef.current,
-    lastExpandedChSql: lastExpandedChSqlRef.current,
+    lastChSql,
+    lastExpandedChSql,
     fetchNextPage,
   };
 }

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -30,6 +30,7 @@ export interface UseEventDataReturn {
   error: string | null;
   hasMore: boolean;
   loadingMore: boolean;
+  paginationError: string | null;
   expandedRowData: Record<string, unknown> | null;
   expandedRowLoading: boolean;
   expandedTraceId: string | null;
@@ -57,6 +58,7 @@ export function useEventData({
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [paginationError, setPaginationError] = useState<string | null>(null);
   const [expandedRowData, setExpandedRowData] = useState<Record<
     string,
     unknown
@@ -86,6 +88,7 @@ export function useEventData({
     ) => {
       setLoading(true);
       setError(null);
+      setPaginationError(null);
       try {
         const chSql = await buildEventSearchQuery(
           {
@@ -139,6 +142,7 @@ export function useEventData({
   const fetchNextPage = useCallback(async () => {
     if (!hasMore || loadingMore || !dateRangeRef.current) return;
     setLoadingMore(true);
+    setPaginationError(null);
     try {
       const { start, end } = dateRangeRef.current;
       const chSql = await buildEventSearchQuery(
@@ -166,9 +170,10 @@ export function useEventData({
         setEvents(prev => [...prev, ...rows]);
       }
       setHasMore(rows.length >= PAGE_SIZE);
-    } catch {
-      // Non-fatal — just stop pagination
+    } catch (err: unknown) {
+      // Non-fatal — stop pagination but surface the error
       setHasMore(false);
+      setPaginationError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoadingMore(false);
     }
@@ -295,6 +300,7 @@ export function useEventData({
     error,
     hasMore,
     loadingMore,
+    paginationError,
     expandedRowData,
     expandedRowLoading,
     expandedTraceId,

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -27,10 +27,10 @@ export interface UseEventDataParams {
 export interface UseEventDataReturn {
   events: EventRow[];
   loading: boolean;
-  error: string | null;
+  error: Error | null;
   hasMore: boolean;
   loadingMore: boolean;
-  paginationError: string | null;
+  paginationError: Error | null;
   expandedRowData: Record<string, unknown> | null;
   expandedRowLoading: boolean;
   expandedTraceId: string | null;
@@ -55,10 +55,10 @@ export function useEventData({
 
   const [events, setEvents] = useState<EventRow[]>([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [paginationError, setPaginationError] = useState<string | null>(null);
+  const [paginationError, setPaginationError] = useState<Error | null>(null);
   const [expandedRowData, setExpandedRowData] = useState<Record<
     string,
     unknown
@@ -129,7 +129,7 @@ export function useEventData({
           if (ts) lastTimestampRef.current = String(ts);
         }
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : String(err));
+        setError(err instanceof Error ? err : new Error(String(err)));
       } finally {
         setLoading(false);
       }
@@ -173,7 +173,7 @@ export function useEventData({
     } catch (err: unknown) {
       // Non-fatal — stop pagination but surface the error
       setHasMore(false);
-      setPaginationError(err instanceof Error ? err.message : String(err));
+      setPaginationError(err instanceof Error ? err : new Error(String(err)));
     } finally {
       setLoadingMore(false);
     }

--- a/packages/cli/src/components/EventViewer/useEventData.ts
+++ b/packages/cli/src/components/EventViewer/useEventData.ts
@@ -36,6 +36,8 @@ export interface UseEventDataReturn {
   expandedRowError: Error | null;
   expandedTraceId: string | null;
   expandedSpanId: string | null;
+  /** The last rendered ChSql (parameterized SQL + params) for the table query */
+  lastChSql: { sql: string; params: Record<string, unknown> } | null;
   fetchNextPage: () => Promise<void>;
 }
 
@@ -307,6 +309,7 @@ export function useEventData({
     expandedRowError,
     expandedTraceId,
     expandedSpanId,
+    lastChSql: lastTableChSqlRef.current,
     fetchNextPage,
   };
 }

--- a/packages/cli/src/components/EventViewer/useKeybindings.ts
+++ b/packages/cli/src/components/EventViewer/useKeybindings.ts
@@ -17,6 +17,7 @@ export interface KeybindingParams {
   focusSearch: boolean;
   focusDetailSearch: boolean;
   showHelp: boolean;
+  showSql: boolean;
   expandedRow: number | null;
   detailTab: 'overview' | 'columns' | 'trace';
   selectedRow: number;
@@ -41,6 +42,8 @@ export interface KeybindingParams {
   setFocusSearch: React.Dispatch<React.SetStateAction<boolean>>;
   setFocusDetailSearch: React.Dispatch<React.SetStateAction<boolean>>;
   setShowHelp: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowSql: React.Dispatch<React.SetStateAction<boolean>>;
+  setSqlScrollOffset: React.Dispatch<React.SetStateAction<number>>;
   setSelectedRow: React.Dispatch<React.SetStateAction<number>>;
   setScrollOffset: React.Dispatch<React.SetStateAction<number>>;
   setExpandedRow: React.Dispatch<React.SetStateAction<number | null>>;
@@ -73,6 +76,7 @@ export function useKeybindings(params: KeybindingParams): void {
     focusSearch,
     focusDetailSearch,
     showHelp,
+    showSql,
     expandedRow,
     detailTab,
     selectedRow,
@@ -93,6 +97,8 @@ export function useKeybindings(params: KeybindingParams): void {
     setFocusSearch,
     setFocusDetailSearch,
     setShowHelp,
+    setShowSql,
+    setSqlScrollOffset,
     setSelectedRow,
     setScrollOffset,
     setExpandedRow,
@@ -143,6 +149,25 @@ export function useKeybindings(params: KeybindingParams): void {
     // When help is showing, any key closes it
     if (showHelp) {
       setShowHelp(false);
+      return;
+    }
+
+    // When SQL preview is showing, D/Esc close it, Ctrl+D/U scroll
+    if (showSql) {
+      if (input === 'D' || key.escape) {
+        setShowSql(false);
+        setSqlScrollOffset(0);
+        return;
+      }
+      if (key.ctrl && input === 'd') {
+        setSqlScrollOffset(prev => prev + 5);
+        return;
+      }
+      if (key.ctrl && input === 'u') {
+        setSqlScrollOffset(prev => Math.max(0, prev - 5));
+        return;
+      }
+      if (input === 'q') process.exit(0);
       return;
     }
 
@@ -313,6 +338,12 @@ export function useKeybindings(params: KeybindingParams): void {
     }
     if (input === 'w') setWrapLines(w => !w);
     if (input === 'f') setIsFollowing(prev => !prev);
+    // D = show generated SQL
+    if (input === 'D') {
+      setShowSql(true);
+      setSqlScrollOffset(0);
+      return;
+    }
     if (input === '/') {
       if (expandedRow !== null) {
         setFocusDetailSearch(true);

--- a/packages/cli/src/components/EventViewer/useKeybindings.ts
+++ b/packages/cli/src/components/EventViewer/useKeybindings.ts
@@ -337,7 +337,11 @@ export function useKeybindings(params: KeybindingParams): void {
       return;
     }
     if (input === 'w') setWrapLines(w => !w);
-    if (input === 'f') setIsFollowing(prev => !prev);
+    // f = toggle follow mode (disabled in detail panel — follow is
+    // automatically paused on expand and restored on close)
+    if (input === 'f' && expandedRow === null) {
+      setIsFollowing(prev => !prev);
+    }
     // D = show generated SQL
     if (input === 'D') {
       setShowSql(true);

--- a/packages/cli/src/components/LoginForm.tsx
+++ b/packages/cli/src/components/LoginForm.tsx
@@ -46,7 +46,7 @@ export default function LoginForm({ apiUrl, onLogin }: LoginFormProps) {
       <Text dimColor>Server: {apiUrl}</Text>
       <Text> </Text>
 
-      {error && <ErrorDisplay message={error} severity="error" compact />}
+      {error && <ErrorDisplay error={error} severity="error" compact />}
 
       {loading ? (
         <Text>

--- a/packages/cli/src/components/LoginForm.tsx
+++ b/packages/cli/src/components/LoginForm.tsx
@@ -3,6 +3,8 @@ import { Box, Text } from 'ink';
 import TextInput from 'ink-text-input';
 import Spinner from 'ink-spinner';
 
+import ErrorDisplay from '@/components/ErrorDisplay';
+
 interface LoginFormProps {
   apiUrl: string;
   onLogin: (email: string, password: string) => Promise<boolean>;
@@ -44,7 +46,7 @@ export default function LoginForm({ apiUrl, onLogin }: LoginFormProps) {
       <Text dimColor>Server: {apiUrl}</Text>
       <Text> </Text>
 
-      {error && <Text color="red">{error}</Text>}
+      {error && <ErrorDisplay message={error} severity="error" compact />}
 
       {loading ? (
         <Text>

--- a/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
+++ b/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
@@ -59,6 +59,7 @@ export default function TraceWaterfall({
     error,
     selectedRowData,
     selectedRowLoading,
+    selectedRowError,
     fetchSelectedRow,
   } = useTraceData({ clickhouseClient, source, logSource, traceId });
 
@@ -308,6 +309,12 @@ export default function TraceWaterfall({
           <Text>
             <Spinner type="dots" /> Loading event details…
           </Text>
+        ) : selectedRowError ? (
+          <ErrorDisplay
+            error={selectedRowError}
+            severity="warning"
+            detail="Could not load event details for this span."
+          />
         ) : selectedRowData ? (
           <ColumnValues
             data={selectedRowData}

--- a/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
+++ b/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
@@ -17,6 +17,7 @@ import { Box, Text, useStdout } from 'ink';
 import Spinner from 'ink-spinner';
 
 import ColumnValues from '@/components/ColumnValues';
+import ErrorDisplay from '@/components/ErrorDisplay';
 
 import type { TraceWaterfallProps } from './types';
 import {
@@ -154,7 +155,7 @@ export default function TraceWaterfall({
   }
 
   if (error) {
-    return <Text color="red">Error loading trace: {error}</Text>;
+    return <ErrorDisplay message={error} severity="error" />;
   }
 
   if (flatNodes.length === 0) {

--- a/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
+++ b/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
@@ -45,6 +45,7 @@ export default function TraceWaterfall({
   detailMaxRows,
   width: propWidth,
   maxRows: propMaxRows,
+  onChSqlChange,
 }: TraceWaterfallProps) {
   const { stdout } = useStdout();
   const termWidth = propWidth ?? stdout?.columns ?? 80;
@@ -60,8 +61,14 @@ export default function TraceWaterfall({
     selectedRowData,
     selectedRowLoading,
     selectedRowError,
+    lastTraceChSql,
     fetchSelectedRow,
   } = useTraceData({ clickhouseClient, source, logSource, traceId });
+
+  // Notify parent when the trace SQL changes
+  useEffect(() => {
+    onChSqlChange?.(lastTraceChSql);
+  }, [lastTraceChSql, onChSqlChange]);
 
   // ---- Derived computations ----------------------------------------
 

--- a/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
+++ b/packages/cli/src/components/TraceWaterfall/TraceWaterfall.tsx
@@ -155,7 +155,7 @@ export default function TraceWaterfall({
   }
 
   if (error) {
-    return <ErrorDisplay message={error} severity="error" />;
+    return <ErrorDisplay error={error} severity="error" />;
   }
 
   if (flatNodes.length === 0) {

--- a/packages/cli/src/components/TraceWaterfall/types.ts
+++ b/packages/cli/src/components/TraceWaterfall/types.ts
@@ -48,4 +48,8 @@ export interface TraceWaterfallProps {
   width?: number;
   /** Max visible rows before truncation */
   maxRows?: number;
+  /** Callback when the trace query SQL changes (for SQL preview) */
+  onChSqlChange?: (
+    chSql: { sql: string; params: Record<string, unknown> } | null,
+  ) => void;
 }

--- a/packages/cli/src/components/TraceWaterfall/useTraceData.ts
+++ b/packages/cli/src/components/TraceWaterfall/useTraceData.ts
@@ -22,6 +22,7 @@ export interface UseTraceDataReturn {
   error: Error | null;
   selectedRowData: Record<string, unknown> | null;
   selectedRowLoading: boolean;
+  selectedRowError: Error | null;
   fetchSelectedRow: (node: SpanNode | null) => void;
 }
 
@@ -42,6 +43,7 @@ export function useTraceData({
     unknown
   > | null>(null);
   const [selectedRowLoading, setSelectedRowLoading] = useState(false);
+  const [selectedRowError, setSelectedRowError] = useState<Error | null>(null);
 
   const fetchIdRef = useRef(0);
 
@@ -166,6 +168,7 @@ export function useTraceData({
     const fetchId = ++fetchIdRef.current;
     // Don't clear existing data or set loading — keep old data visible
     // while fetching to avoid flashing
+    setSelectedRowError(null);
 
     (async () => {
       try {
@@ -180,10 +183,13 @@ export function useTraceData({
           setSelectedRowData(row ?? null);
           setSelectedRowLoading(false);
         }
-      } catch {
+      } catch (err) {
         if (fetchId === fetchIdRef.current) {
           setSelectedRowData(null);
           setSelectedRowLoading(false);
+          setSelectedRowError(
+            err instanceof Error ? err : new Error(String(err)),
+          );
         }
       }
     })();
@@ -196,6 +202,7 @@ export function useTraceData({
     error,
     selectedRowData,
     selectedRowLoading,
+    selectedRowError,
     fetchSelectedRow,
   };
 }

--- a/packages/cli/src/components/TraceWaterfall/useTraceData.ts
+++ b/packages/cli/src/components/TraceWaterfall/useTraceData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import SqlString from 'sqlstring';
 
 import type { ProxyClickhouseClient, SourceResponse } from '@/api/client';
@@ -46,10 +46,18 @@ export function useTraceData({
   > | null>(null);
   const [selectedRowLoading, setSelectedRowLoading] = useState(false);
   const [selectedRowError, setSelectedRowError] = useState<Error | null>(null);
-  const lastTraceChSqlRef = useRef<{
-    sql: string;
-    params: Record<string, unknown>;
-  } | null>(null);
+
+  // Compute the trace query eagerly so the SQL is available on the first
+  // render (before the async query dispatches). buildTraceSpansSql is
+  // synchronous.
+  const traceQuery = useMemo(
+    () => buildTraceSpansSql({ source, traceId }),
+    [source, traceId],
+  );
+  const lastTraceChSql = useMemo(
+    () => ({ sql: traceQuery.sql, params: {} as Record<string, unknown> }),
+    [traceQuery],
+  );
 
   const fetchIdRef = useRef(0);
 
@@ -62,9 +70,7 @@ export function useTraceData({
 
     (async () => {
       try {
-        // Fetch trace spans
-        const traceQuery = buildTraceSpansSql({ source, traceId });
-        lastTraceChSqlRef.current = { sql: traceQuery.sql, params: {} };
+        // Fetch trace spans — reuse the memoized query
         const traceResultSet = await clickhouseClient.query({
           query: traceQuery.sql,
           format: 'JSON',
@@ -112,7 +118,7 @@ export function useTraceData({
     return () => {
       cancelled = true;
     };
-  }, [clickhouseClient, source, logSource, traceId]);
+  }, [clickhouseClient, source, logSource, traceId, traceQuery]);
 
   // ---- Fetch SELECT * for the selected span/log --------------------
   // Stable scalar deps (SpanId, Timestamp, kind) are used to avoid
@@ -210,7 +216,7 @@ export function useTraceData({
     selectedRowData,
     selectedRowLoading,
     selectedRowError,
-    lastTraceChSql: lastTraceChSqlRef.current,
+    lastTraceChSql,
     fetchSelectedRow,
   };
 }

--- a/packages/cli/src/components/TraceWaterfall/useTraceData.ts
+++ b/packages/cli/src/components/TraceWaterfall/useTraceData.ts
@@ -23,6 +23,8 @@ export interface UseTraceDataReturn {
   selectedRowData: Record<string, unknown> | null;
   selectedRowLoading: boolean;
   selectedRowError: Error | null;
+  /** The SQL used to fetch trace spans (first query in the trace tab) */
+  lastTraceChSql: { sql: string; params: Record<string, unknown> } | null;
   fetchSelectedRow: (node: SpanNode | null) => void;
 }
 
@@ -44,6 +46,10 @@ export function useTraceData({
   > | null>(null);
   const [selectedRowLoading, setSelectedRowLoading] = useState(false);
   const [selectedRowError, setSelectedRowError] = useState<Error | null>(null);
+  const lastTraceChSqlRef = useRef<{
+    sql: string;
+    params: Record<string, unknown>;
+  } | null>(null);
 
   const fetchIdRef = useRef(0);
 
@@ -58,6 +64,7 @@ export function useTraceData({
       try {
         // Fetch trace spans
         const traceQuery = buildTraceSpansSql({ source, traceId });
+        lastTraceChSqlRef.current = { sql: traceQuery.sql, params: {} };
         const traceResultSet = await clickhouseClient.query({
           query: traceQuery.sql,
           format: 'JSON',
@@ -203,6 +210,7 @@ export function useTraceData({
     selectedRowData,
     selectedRowLoading,
     selectedRowError,
+    lastTraceChSql: lastTraceChSqlRef.current,
     fetchSelectedRow,
   };
 }

--- a/packages/cli/src/components/TraceWaterfall/useTraceData.ts
+++ b/packages/cli/src/components/TraceWaterfall/useTraceData.ts
@@ -19,7 +19,7 @@ export interface UseTraceDataReturn {
   traceSpans: TaggedSpanRow[];
   logEvents: TaggedSpanRow[];
   loading: boolean;
-  error: string | null;
+  error: Error | null;
   selectedRowData: Record<string, unknown> | null;
   selectedRowLoading: boolean;
   fetchSelectedRow: (node: SpanNode | null) => void;
@@ -36,7 +36,7 @@ export function useTraceData({
   const [traceSpans, setTraceSpans] = useState<TaggedSpanRow[]>([]);
   const [logEvents, setLogEvents] = useState<TaggedSpanRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const [selectedRowData, setSelectedRowData] = useState<Record<
     string,
     unknown
@@ -93,7 +93,7 @@ export function useTraceData({
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
+          setError(err instanceof Error ? err : new Error(String(err)));
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/packages/cli/src/shared/useSqlSuggestions.ts
+++ b/packages/cli/src/shared/useSqlSuggestions.ts
@@ -1,0 +1,110 @@
+/**
+ * SQL query suggestion engines for detecting and correcting common
+ * ClickHouse query mistakes (e.g. double quotes instead of single quotes).
+ *
+ * @source packages/app/src/hooks/useSqlSuggestions.tsx
+ *
+ * Copied verbatim from the web frontend. Will be moved to common-utils later.
+ */
+
+import { useMemo } from 'react';
+
+/// Interface for all suggestion engines
+interface ISuggestionEngine {
+  /// detect if a suggestion should be generated
+  detect(input: string): boolean;
+  /// message to display to user
+  userMessage(key: string): string;
+  /// return corrected text
+  correct(input: string): string;
+}
+
+// Detects and corrects a double quote to a single quote
+class DoubleQuoteSuggestion implements ISuggestionEngine {
+  detect(input: string): boolean {
+    let inSingleQuote = false;
+    let escaped = false;
+    for (const char of input) {
+      if (char === "'") {
+        if (escaped) {
+          escaped = false;
+        } else {
+          inSingleQuote = !inSingleQuote;
+        }
+      } else if (char === '"') {
+        if (inSingleQuote) continue;
+        return true;
+      } else if (char === '\\') {
+        escaped = true;
+      }
+    }
+    return false;
+  }
+
+  userMessage(key: string): string {
+    return `ClickHouse does not support double quotes (") but they were detected in ${key.toUpperCase()}. Switch to single quotes?`;
+  }
+
+  correct(input: string): string {
+    let inSingleQuote = false;
+    let correctedText = '';
+    let escaped = false;
+    for (let i = 0; i < input.length; i++) {
+      switch (input[i]) {
+        case "'":
+          if (escaped) {
+            inSingleQuote = !inSingleQuote;
+          } else {
+            escaped = false;
+          }
+          correctedText += input[i];
+          break;
+        case '"':
+          correctedText += inSingleQuote ? '"' : "'";
+          break;
+        case '\\':
+          escaped = true;
+          correctedText += input[i];
+          break;
+        default:
+          correctedText += input[i];
+          break;
+      }
+    }
+
+    return correctedText;
+  }
+}
+
+// Array of all suggestion engines. Expected to handle cases for select, where, and orderBy
+const suggestionEngines = [new DoubleQuoteSuggestion()];
+
+export type Suggestion = {
+  userMessage: (field: string) => string;
+  corrected: () => string;
+};
+
+export function useSqlSuggestions({
+  input,
+  enabled,
+}: {
+  input: string;
+  enabled: boolean;
+}): Suggestion[] | null {
+  return useMemo(() => {
+    if (!enabled) {
+      return null;
+    }
+
+    const suggestions: Suggestion[] = [];
+    for (const se of suggestionEngines) {
+      if (se.detect(input)) {
+        suggestions.push({
+          userMessage: field => se.userMessage(field),
+          corrected: () => se.correct(input),
+        });
+      }
+    }
+    return suggestions.length > 0 ? suggestions : null;
+  }, [input, enabled]);
+}

--- a/packages/cli/src/utils/parseError.ts
+++ b/packages/cli/src/utils/parseError.ts
@@ -1,0 +1,94 @@
+/**
+ * Utilities for parsing and classifying error messages,
+ * particularly ClickHouse DB errors that can be verbose HTML
+ * or include DB::Exception stack traces.
+ */
+
+export type ErrorSeverity = 'error' | 'warning';
+
+export interface ParsedError {
+  severity: ErrorSeverity;
+  /** Human-readable summary of the error */
+  message: string;
+  /** Optional additional context (e.g. the query that caused it) */
+  detail?: string;
+}
+
+const MAX_MESSAGE_LENGTH = 500;
+
+/**
+ * Extract a readable message from a ClickHouse DB::Exception string.
+ *
+ * ClickHouse errors typically look like:
+ *   "Code: 62. DB::Exception: Syntax error: failed at position 5 ... (SYNTAX_ERROR) (version 24.8.1.1)"
+ *
+ * We extract everything up to the first "(version" or the error code suffix.
+ */
+function parseClickHouseException(raw: string): string {
+  // Strip the leading "Code: NNN. " prefix for readability
+  let msg = raw.replace(/^Code:\s*\d+\.\s*/, '');
+
+  // Strip "DB::Exception: " prefix
+  msg = msg.replace(/^DB::Exception:\s*/, '');
+
+  // Strip trailing version info — e.g. "(version 24.8.1.1)"
+  msg = msg.replace(/\s*\(version\s+[^)]+\)\s*$/, '');
+
+  // Strip stack trace lines (lines starting with numbers like "0. ...")
+  msg = msg
+    .split('\n')
+    .filter(line => !/^\d+\.\s+0x/.test(line.trim()))
+    .join('\n')
+    .trim();
+
+  return msg;
+}
+
+/**
+ * Strip HTML tags from a string — ClickHouse proxy errors sometimes
+ * return full HTML error pages.
+ */
+function stripHtml(raw: string): string {
+  // Extract text from <title> if present (often has the best summary)
+  const titleMatch = raw.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch) {
+    return titleMatch[1].trim();
+  }
+
+  // Fall back to stripping all tags
+  return raw
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Parse a raw error message/string into a structured ParsedError.
+ */
+export function parseError(
+  raw: string,
+  severity: ErrorSeverity = 'error',
+): ParsedError {
+  if (!raw || raw.trim().length === 0) {
+    return { severity, message: 'An unknown error occurred.' };
+  }
+
+  let message = raw.trim();
+
+  // Handle HTML error responses
+  if (message.startsWith('<!') || message.startsWith('<html')) {
+    message = stripHtml(message);
+  }
+
+  // Handle ClickHouse DB::Exception
+  if (message.includes('DB::Exception')) {
+    message = parseClickHouseException(message);
+  }
+
+  // Truncate if still too long
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    message = message.slice(0, MAX_MESSAGE_LENGTH) + '…';
+  }
+
+  return { severity, message };
+}

--- a/packages/cli/src/utils/parseError.ts
+++ b/packages/cli/src/utils/parseError.ts
@@ -2,7 +2,13 @@
  * Utilities for parsing and classifying error messages,
  * particularly ClickHouse DB errors that can be verbose HTML
  * or include DB::Exception stack traces.
+ *
+ * Mirrors the error handling patterns from the web frontend:
+ * @source packages/app/src/DBSearchPage.tsx (queryError rendering)
+ * @source packages/app/src/components/DBTableChart.tsx (ClickHouseQueryError handling)
  */
+
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 
 export type ErrorSeverity = 'error' | 'warning';
 
@@ -10,8 +16,8 @@ export interface ParsedError {
   severity: ErrorSeverity;
   /** Human-readable summary of the error */
   message: string;
-  /** Optional additional context (e.g. the query that caused it) */
-  detail?: string;
+  /** The original SQL query that caused the error (from ClickHouseQueryError) */
+  query?: string;
 }
 
 const MAX_MESSAGE_LENGTH = 500;
@@ -63,16 +69,9 @@ function stripHtml(raw: string): string {
 }
 
 /**
- * Parse a raw error message/string into a structured ParsedError.
+ * Clean up a raw error message string (handle HTML, DB::Exception, truncation).
  */
-export function parseError(
-  raw: string,
-  severity: ErrorSeverity = 'error',
-): ParsedError {
-  if (!raw || raw.trim().length === 0) {
-    return { severity, message: 'An unknown error occurred.' };
-  }
-
+function cleanMessage(raw: string): string {
   let message = raw.trim();
 
   // Handle HTML error responses
@@ -90,5 +89,46 @@ export function parseError(
     message = message.slice(0, MAX_MESSAGE_LENGTH) + '…';
   }
 
-  return { severity, message };
+  return message;
+}
+
+/**
+ * Parse an error into a structured ParsedError.
+ *
+ * Accepts:
+ * - `ClickHouseQueryError` — extracts both `.message` and `.query`
+ *   (mirrors DBSearchPage.tsx and DBTableChart.tsx patterns)
+ * - `Error` — uses `.message`
+ * - `string` — raw message with heuristic parsing
+ */
+export function parseError(
+  err: string | Error | ClickHouseQueryError,
+  severity: ErrorSeverity = 'error',
+): ParsedError {
+  if (!err) {
+    return { severity, message: 'An unknown error occurred.' };
+  }
+
+  // ClickHouseQueryError — structured error with query context
+  if (err instanceof ClickHouseQueryError) {
+    return {
+      severity,
+      message: cleanMessage(err.message),
+      query: err.query,
+    };
+  }
+
+  // Generic Error object
+  if (err instanceof Error) {
+    return {
+      severity,
+      message: cleanMessage(err.message),
+    };
+  }
+
+  // Raw string
+  return {
+    severity,
+    message: cleanMessage(err),
+  };
 }


### PR DESCRIPTION
## Summary

Improves error message rendering in the CLI/TUI with visible highlighting, structured error display matching the web frontend patterns, and adds a SQL preview feature.

**Linear:** https://linear.app/hyperdx/issue/HDX-3966

## Changes

### Error Display
- **`ErrorDisplay` component** — Reusable error/warning display with bordered boxes, color-coded severity (red/yellow), icons, and responsive rendering based on terminal height (compact < 20 rows, medium 20-35, full > 35)
- **`parseError` utility** — Parses ClickHouse `DB::Exception` strings and HTML error responses into clean messages; accepts `Error | ClickHouseQueryError | string`
- **`useSqlSuggestions`** — Copied from `packages/app/src/hooks/useSqlSuggestions.tsx` to `packages/cli/src/shared/` for detecting common ClickHouse query mistakes (e.g. double quotes)

### Error Object Preservation
- **`useEventData` / `useTraceData`** — Error state changed from `string | null` to `Error | null`, preserving `ClickHouseQueryError` instances with their `.query` property through the entire chain
- **Row detail errors** — Added `expandedRowError` state (replaces `__fetch_error` string embedding in row data) and `selectedRowError` for trace span details
- **Pagination errors** — Now surfaced instead of silently swallowed

### SQL Preview (Shift-D)
- Press `D` to view the generated ClickHouse SQL for the current context
- Context-aware: shows table query, expanded row SELECT *, or trace spans query depending on which view is active
- Uses `parameterizedQueryToSql` from common-utils to resolve query parameters
- Scrollable with Ctrl+D/U for long queries
- Renders as an overlay (display=none) to preserve component state — no re-fetch when toggling

### Other Fixes
- Follow mode (`f` key) disabled in event detail panel (was incorrectly toggleable)
- All error display sites updated: TableView, DetailPanel, TraceWaterfall, Footer, App, LoginForm

## Files Created
| File | Purpose |
|------|---------|
| `packages/cli/src/components/ErrorDisplay.tsx` | Reusable error/warning display component |
| `packages/cli/src/utils/parseError.ts` | Error message parser (ClickHouse, HTML) |
| `packages/cli/src/shared/useSqlSuggestions.ts` | SQL suggestion engines (copied from app) |

## Files Modified
| File | Change |
|------|--------|
| `useEventData.ts` | Error objects, expandedRowError, lastChSql/lastExpandedChSql as state |
| `useTraceData.ts` | Error objects, selectedRowError, eager traceQuery via useMemo |
| `EventViewer.tsx` | showSql overlay, activeChSql, traceChSql state |
| `useKeybindings.ts` | D keybinding, showSql handling, f key guard |
| `SubComponents.tsx` | SqlPreviewScreen, Footer with ErrorDisplay, HelpScreen update |
| `TableView.tsx` | Error object + searchQuery props |
| `DetailPanel.tsx` | expandedRowError prop, onTraceChSqlChange |
| `TraceWaterfall.tsx` | onChSqlChange callback, selectedRowError display |
| `types.ts` (TraceWaterfall) | onChSqlChange prop |
| `App.tsx` | ErrorDisplay |
| `LoginForm.tsx` | ErrorDisplay |

## Testing
- `tsc --noEmit` — passes
- `yarn build` — passes
- `npx lint-staged` — passes
- Manual testing of all error display paths and SQL preview across tabs

## Demo 
<img width="1169" height="322" alt="image" src="https://github.com/user-attachments/assets/b0580f0a-c226-4297-9937-f263afd39f6a" />

<img width="1165" height="250" alt="image" src="https://github.com/user-attachments/assets/d7139a91-0c2e-4b60-b637-3e900447d3fa" />
