### PR TITLE
Fix "Copy entire row as JSON" button TypeError on non-string values

### DIFF
--- a/.changeset/fix-copy-row-json-button.md
+++ b/.changeset/fix-copy-row-json-button.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix "Copy entire row as JSON" button crashing on rows with non-string values

--- a/packages/app/src/components/DBTable/DBRowTableRowButtons.tsx
+++ b/packages/app/src/components/DBTable/DBRowTableRowButtons.tsx
@@ -35,8 +35,8 @@ const DBRowTableRowButtons: React.FC<DBRowTableRowButtonsProps> = ({
       const parsedRow = Object.entries(cleanRow).reduce(
         (acc, [key, value]) => {
           if (
-            (typeof value === 'string' && value.startsWith('{')) ||
-            value.startsWith('[')
+            typeof value === 'string' &&
+            (value.startsWith('{') || value.startsWith('['))
           ) {
             try {
               acc[key] = JSON.parse(value);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes an operator-precedence bug in the "Copy entire row as JSON" button on the Search page. The `typeof value === 'string'` guard only applied to `value.startsWith('{')` but not `value.startsWith('[')`, so when a row contained a non-string value (number, boolean, etc.) the second `startsWith` call threw:

```
TypeError: s.startsWith is not a function
```

The fix moves the `typeof` check to guard both `startsWith` calls:

```diff
- (typeof value === 'string' && value.startsWith('{')) ||
- value.startsWith('[')
+ typeof value === 'string' &&
+ (value.startsWith('{') || value.startsWith('['))
```

### How to test locally or on Vercel

1. Open any Search page with results containing non-string column values (e.g. numeric or boolean fields).
2. Hover over a row and click the "Copy entire row as JSON" button (copy icon).
3. Verify the row is copied as valid JSON to the clipboard without a console error.

### References

- Related issue: HDX-4023
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa1e5f4-ced5-4ee0-9585-4f473c5fca69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa1e5f4-ced5-4ee0-9585-4f473c5fca69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

