### PR TITLE
fix(release): build common-utils before changesets publish (HDX-4075)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
           cache: 'yarn'
       - name: Install root dependencies
         run: yarn install
+      # Build @hyperdx/common-utils before changesets publish runs.
+      # @hyperdx/cli's `prepublishOnly` runs `yarn build` (tsup), which bundles
+      # imports from `@hyperdx/common-utils/dist/*`. Without this step those
+      # paths fail to resolve and the npm publish for @hyperdx/cli is skipped
+      # while the GitHub release/tag still succeeds. See HDX-4075.
+      - name: Build common-utils
+        run: make ci-build
       - name: Create Release Pull Request or Publish to npm
         if: always()
         continue-on-error: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the release workflow bug where the `cli-v*` git tag and GitHub Release are created successfully, but `@hyperdx/cli` never reaches npm.

### Root cause

The `check_changesets` job in `.github/workflows/release.yml` runs only `yarn install` before calling `changesets/action@v1` with `publish: yarn release`. When changesets attempts to publish `@hyperdx/cli`, the package's `prepublishOnly` hook runs `yarn build` (tsup). tsup bundles all `@hyperdx/common-utils/dist/*` imports, but because `common-utils` was never built in this job, esbuild fails with 14 "Could not resolve" errors and aborts the CLI publish. The release logs for `cli-v0.3.0` confirm this:

```
🦋  info Publishing "@hyperdx/cli" at "0.3.0"
🦋  error an error occurred while publishing @hyperdx/cli: 1 command failed
🦋  error sh -c yarn build
🦋  error ✘ [ERROR] Could not resolve "@hyperdx/common-utils/dist/clickhouse"
   (... 14 similar errors ...)
🦋  error packages failed to publish:
🦋  @hyperdx/cli@0.3.0
```

The rest of the release jobs (GitHub Release, Docker images, downstream notifications) proceeded because the changesets step has `continue-on-error: true`.

### Fix

Add a `Build common-utils` step (`make ci-build`, which runs `@hyperdx/common-utils:ci:build` via Nx) between `yarn install` and the changesets action. This populates `packages/common-utils/dist/`, so `@hyperdx/cli`'s `prepublishOnly` build can resolve its dist paths.

### Follow-up

`@hyperdx/cli@0.3.0` was never published to npm (`npm view @hyperdx/cli versions` shows only up to `0.2.0`). Because changesets calls `npm info` on each run and retries publishing any local version that isn't yet on npm, the next push to `main` with this fix will publish `0.3.0` automatically — no version bump needed.

### How to test locally

```bash
# From a clean workspace (no common-utils/dist yet)
rm -rf packages/common-utils/dist
cd packages/cli && yarn build
# => fails with "Could not resolve '@hyperdx/common-utils/dist/*'" (reproduces bug)

# With the fix applied:
cd ../..
make ci-build         # builds common-utils
cd packages/cli
yarn build            # succeeds, produces dist/cli.js
```

### References

- Failing release run: https://github.com/hyperdxio/hyperdx/actions/runs/24652970126
- Published release (CLI binaries only, npm skipped): https://github.com/hyperdxio/hyperdx/releases/tag/cli-v0.3.0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43427d62-7a6b-4d6a-b42e-74db8dc0d2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43427d62-7a6b-4d6a-b42e-74db8dc0d2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

