### PR TITLE
chore: pre-approve @hyperdx npm packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,6 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.13.0.cjs
 
 npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages:
+  - '@hyperdx/*'


### PR DESCRIPTION
## Summary

Exclude our own npm packages from 7 day age gate.
