### PR TITLE
fix: Prevent Popover infinite re-render on production Search page (HDX-4089)

### DIFF
--- a/.changeset/hdx-4089-popover-infinite-loop.md
+++ b/.changeset/hdx-4089-popover-infinite-loop.md
@@ -1,0 +1,18 @@
+---
+'@hyperdx/app': patch
+---
+
+Fix hard crash (React error #185 — "Maximum update depth exceeded") when
+navigating to the Search page in production. The crash was caused by
+Mantine `Popover`'s internal `reference`/`floating` `useCallback`s depending
+on `popover.floating.refs.setReference`/`setFloating`. When those callback
+identities changed across renders, React 19 invoked them with `null` and
+then again with the node, which (via `useMergedRef`) triggered
+`setTargetNode(null) → setTargetNode(node)` on every render and looped
+until React bailed out with error #185.
+
+Applied via a `yarn patch` on `@mantine/core` 9.0.0 that stabilizes the
+`reference` and `floating` callback identities using `useRef`, which is
+the same approach used upstream for similar ref patterns. The behavior is
+unchanged for consumers of `Popover`, `Menu`, `Tooltip`, etc., but the
+callbacks no longer get torn down and recreated between renders.

--- a/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch
+++ b/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch
@@ -1,0 +1,66 @@
+diff --git a/cjs/components/Popover/Popover.cjs b/cjs/components/Popover/Popover.cjs
+index 0b982e85374d4a176d72d9b7441ffb00acaf54e5..acb736942cce3c8cf2f042e07044cf1da435c372 100644
+--- a/cjs/components/Popover/Popover.cjs
++++ b/cjs/components/Popover/Popover.cjs
+@@ -110,14 +110,24 @@ function Popover(_props) {
+ 			onDismiss?.();
+ 		}
+ 	}, clickOutsideEvents, [targetNode, dropdownNode]);
++	// HDX-4089: Use stable callback identities for `reference` and `floating` so
++	// that the ref passed to Popover.Target's child never changes between
++	// renders. When these callbacks change identity, React 19 invokes them with
++	// `null` (and then again with the node), which triggers `setTargetNode(null)
++	// → setTargetNode(node)` and can cause an infinite re-render loop in
++	// production (#185) when combined with `@mantine/hooks` useMergedRef.
++	const setReferenceRef = (0, react.useRef)(popover.floating.refs.setReference);
++	setReferenceRef.current = popover.floating.refs.setReference;
++	const setFloatingRef = (0, react.useRef)(popover.floating.refs.setFloating);
++	setFloatingRef.current = popover.floating.refs.setFloating;
+ 	const reference = (0, react.useCallback)((node) => {
+ 		setTargetNode(node);
+-		popover.floating.refs.setReference(node);
+-	}, [popover.floating.refs.setReference]);
++		setReferenceRef.current(node);
++	}, []);
+ 	const floating = (0, react.useCallback)((node) => {
+ 		setDropdownNode(node);
+-		popover.floating.refs.setFloating(node);
+-	}, [popover.floating.refs.setFloating]);
++		setFloatingRef.current(node);
++	}, []);
+ 	const onExited = (0, react.useCallback)(() => {
+ 		transitionProps?.onExited?.();
+ 		onExitTransitionEnd?.();
+diff --git a/esm/components/Popover/Popover.mjs b/esm/components/Popover/Popover.mjs
+index b87c44f4299c5196995f93ff12f8f43bb1ef0312..f9a62e1214d8258fe2d5e7d2c6dd39eff6eb4432 100644
+--- a/esm/components/Popover/Popover.mjs
++++ b/esm/components/Popover/Popover.mjs
+@@ -109,14 +109,24 @@ function Popover(_props) {
+ 			onDismiss?.();
+ 		}
+ 	}, clickOutsideEvents, [targetNode, dropdownNode]);
++	// HDX-4089: Use stable callback identities for `reference` and `floating` so
++	// that the ref passed to Popover.Target's child never changes between
++	// renders. When these callbacks change identity, React 19 invokes them with
++	// `null` (and then again with the node), which triggers `setTargetNode(null)
++	// → setTargetNode(node)` and can cause an infinite re-render loop in
++	// production (#185) when combined with `@mantine/hooks` useMergedRef.
++	const setReferenceRef = useRef(popover.floating.refs.setReference);
++	setReferenceRef.current = popover.floating.refs.setReference;
++	const setFloatingRef = useRef(popover.floating.refs.setFloating);
++	setFloatingRef.current = popover.floating.refs.setFloating;
+ 	const reference = useCallback((node) => {
+ 		setTargetNode(node);
+-		popover.floating.refs.setReference(node);
+-	}, [popover.floating.refs.setReference]);
++		setReferenceRef.current(node);
++	}, []);
+ 	const floating = useCallback((node) => {
+ 		setDropdownNode(node);
+-		popover.floating.refs.setFloating(node);
+-	}, [popover.floating.refs.setFloating]);
++		setFloatingRef.current(node);
++	}, []);
+ 	const onExited = useCallback(() => {
+ 		transitionProps?.onExited?.();
+ 		onExitTransitionEnd?.();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,7 +36,7 @@
     "@hyperdx/browser": "^0.22.0",
     "@hyperdx/common-utils": "^0.18.0",
     "@hyperdx/node-opentelemetry": "^0.9.0",
-    "@mantine/core": "^9.0.0",
+    "@mantine/core": "patch:@mantine/core@npm%3A9.0.0#~/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch",
     "@mantine/dates": "^9.0.0",
     "@mantine/dropzone": "^9.0.0",
     "@mantine/form": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,7 +4368,7 @@ __metadata:
     "@hyperdx/common-utils": "npm:^0.18.0"
     "@hyperdx/node-opentelemetry": "npm:^0.9.0"
     "@jedmao/location": "npm:^3.0.0"
-    "@mantine/core": "npm:^9.0.0"
+    "@mantine/core": "patch:@mantine/core@npm%3A9.0.0#~/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch"
     "@mantine/dates": "npm:^9.0.0"
     "@mantine/dropzone": "npm:^9.0.0"
     "@mantine/form": "npm:^9.0.0"
@@ -5574,7 +5574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mantine/core@npm:^9.0.0":
+"@mantine/core@npm:9.0.0":
   version: 9.0.0
   resolution: "@mantine/core@npm:9.0.0"
   dependencies:
@@ -5588,6 +5588,23 @@ __metadata:
     react: ^19.2.0
     react-dom: ^19.2.0
   checksum: 10c0/7310fbb15d03fb8c5ba7941553e4ef33e61f4213d64416b56e0a053316e43b406a4df5bb66368f977c3c42944eb7d764d741e31d2cda9444fd167647e8b159c1
+  languageName: node
+  linkType: hard
+
+"@mantine/core@patch:@mantine/core@npm%3A9.0.0#~/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch":
+  version: 9.0.0
+  resolution: "@mantine/core@patch:@mantine/core@npm%3A9.0.0#~/.yarn/patches/@mantine-core-npm-9.0.0-3c72f03e17.patch::version=9.0.0&hash=5c5015"
+  dependencies:
+    "@floating-ui/react": "npm:^0.27.19"
+    clsx: "npm:^2.1.1"
+    react-number-format: "npm:^5.4.5"
+    react-remove-scroll: "npm:^2.7.2"
+    type-fest: "npm:^5.5.0"
+  peerDependencies:
+    "@mantine/hooks": 9.0.0
+    react: ^19.2.0
+    react-dom: ^19.2.0
+  checksum: 10c0/fd5c6b22e52bd1381157239b5dda12af966bcf5d00d30a82a3e9b92dd24bf3e61412fda643faa9009f8e809cc45e0172568c118e8e878e2ba6ae0923f4515498
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production users were seeing a hard crash (`A client-side exception has occurred`) immediately after clicking **Search** in the left nav. The minified stack trace pointed into Mantine's `Popover`:

```
Error: Minified React error #185   // Maximum update depth exceeded
  at Popover.mjs:113    setTargetNode(node)
  at use-merged-ref.mjs:5   assignRef
  at use-merged-ref.mjs:12  mergeRefs forEach
```

### Root cause

`@mantine/core`'s `Popover` defines its target ref callbacks like this:

```ts
const reference = useCallback((node) => {
  setTargetNode(node);
  popover.floating.refs.setReference(node);
}, [popover.floating.refs.setReference]);

const floating = useCallback((node) => {
  setDropdownNode(node);
  popover.floating.refs.setFloating(node);
}, [popover.floating.refs.setFloating]);
```

`popover.floating.refs.setReference` / `setFloating` come from `@floating-ui/react`'s `useFloating`, whose `refs` object is memoized but whose identity can churn when middleware/config changes every render (which Mantine's `usePopover` does — it rebuilds the middleware array per render and reacts to `dropdownVisible`/`opened` transitions).

When those dep identities change, the outer `reference` callback is recreated, and **React 19 ref semantics** kick in:

1. React calls the old ref with `null` → `setTargetNode(null)` → re-render
2. React calls the new ref with the node → `setTargetNode(node)` → re-render
3. Next render the callback is recreated again via `useMergedRef` / ref prop churn → goto 1

…which compounds until React aborts with **error #185** ("Maximum update depth exceeded"). This only surfaces in production because dev builds use a slower render path that de-duplicates some of the re-renders and because React's dev warnings let you spot it earlier.

### Fix

Patch `@mantine/core@9.0.0` (via `yarn patch`) so `Popover`'s `reference` and `floating` callbacks have **stable identities**:

```diff
-  const reference = useCallback((node) => {
-    setTargetNode(node);
-    popover.floating.refs.setReference(node);
-  }, [popover.floating.refs.setReference]);
+  const setReferenceRef = useRef(popover.floating.refs.setReference);
+  setReferenceRef.current = popover.floating.refs.setReference;
+  const reference = useCallback((node) => {
+    setTargetNode(node);
+    setReferenceRef.current(node);
+  }, []);
```

Same treatment for the `floating` callback. The ref indirection lets the callbacks always call the latest `setReference`/`setFloating` without changing their own identity, so React no longer tears the ref down and re-attaches it every render.

This is a minimal in-place patch against the published 9.0.0 bundle (both ESM and CJS builds) — no behavior change for `Popover`, `Menu`, `Tooltip`, `Combobox`, etc. consumers. The patch is keyed to `@mantine/core` 9.0.0 specifically; if/when we bump Mantine the patch file will either need to be refreshed or dropped (if upstream picks up an equivalent fix).

### How to test locally or on Vercel

1. `yarn install && yarn build:common-utils`
2. `cd packages/app && yarn build && yarn start`
3. Navigate to http://localhost:3000, register/login, click **Search** in the nav.
4. Interact with multiple Popovers on the Search page — search autocomplete, time picker, filter settings gear, language toggle. All should open, close, and accept input without crashing.
5. Chrome DevTools console should show **no** "Minified React error #185" / "Maximum update depth exceeded".

### Screenshots or video

Smoke test in the patched production build:

| Search autocomplete Popover | Time picker Popover |
| :-------------------------- | :------------------ |
| [Search autocomplete popover open with suggestions](https://cursor.com/agents/bc-d84a9a10-9fc6-4094-aefb-4e8096013565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_autocomplete_popover.webp) | [Time picker popover open with presets and date inputs](https://cursor.com/agents/bc-d84a9a10-9fc6-4094-aefb-4e8096013565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftime_picker_popover.webp) |

Console after exercising all of the above (zero React errors; remaining noise is 504s from the unrelated local telemetry backend):

[DevTools console with no React errors after extensive Popover interaction](https://cursor.com/agents/bc-d84a9a10-9fc6-4094-aefb-4e8096013565/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_final_state_no_errors.webp)

### References

- Related upstream: mantinedev/mantine#8809 (similar React-19/production ref-loop pattern)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d84a9a10-9fc6-4094-aefb-4e8096013565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d84a9a10-9fc6-4094-aefb-4e8096013565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

