### PR TITLE
[HDX-3482] Tune OTel Collector batch processor for ClickHouse and make it configurable

### DIFF
--- a/.changeset/hdx-3482-otel-batch-processor-config.md
+++ b/.changeset/hdx-3482-otel-batch-processor-config.md
@@ -1,0 +1,20 @@
+---
+'@hyperdx/otel-collector': patch
+---
+
+feat(otel-collector): tune batch processor defaults for ClickHouse and make
+them configurable
+
+The bundled OTel Collector config now sets `processors.batch.send_batch_size`
+to `10000` and `timeout` to `5s` (was upstream defaults of `8192` / `200ms`),
+matching the values recommended by the ClickHouse exporter and ClickStack
+docs. The upstream defaults were too aggressive for ClickHouse — they
+produced very small inserts under low load, hurting insert performance and
+inflating the number of MergeTree parts.
+
+Each setting can also be overridden via environment variables:
+
+- `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE` (default: `10000`)
+- `HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE` (default: `0`, meaning no upper
+  bound)
+- `HYPERDX_OTEL_BATCH_TIMEOUT` (default: `5s`)

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -52,6 +52,20 @@ processors:
     timeout: 5s
     override: false
   batch:
+    # Defaults are tuned for ClickHouse, which prefers fewer, larger inserts.
+    # ClickHouse recommends inserting in packets of at least 1000 rows or no
+    # more than 1 request per second. The upstream collector defaults
+    # (send_batch_size: 8192, timeout: 200ms) can yield very small batches
+    # under low load, which hurts ClickHouse insert performance and creates
+    # excess parts in MergeTree tables.
+    #
+    # Each setting can be overridden via env vars (mirroring the upstream
+    # batch processor options). Set HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE
+    # to a positive value if you need to enforce an upper bound; the default
+    # of 0 means "no upper limit".
+    send_batch_size: ${env:HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE:-10000}
+    send_batch_max_size: ${env:HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE:-0}
+    timeout: ${env:HYPERDX_OTEL_BATCH_TIMEOUT:-5s}
   memory_limiter:
     # 80% of maximum memory up to 2G
     limit_mib: 1500

--- a/smoke-tests/otel-collector/docker-compose.yaml
+++ b/smoke-tests/otel-collector/docker-compose.yaml
@@ -33,6 +33,12 @@ services:
       - CLICKHOUSE_PASSWORD=
       - HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=default
       - HYPERDX_LOG_LEVEL=info
+      # Flush batches quickly so the smoke tests' short sleep (~1s) after
+      # emitting data is enough for records to arrive in ClickHouse. The
+      # production default (5s) is ClickHouse-friendly but too slow for
+      # these tests, which emit a handful of records per case and assert
+      # shortly afterwards.
+      - HYPERDX_OTEL_BATCH_TIMEOUT=100ms
       # OPAMP_SERVER_URL is intentionally not set to run in standalone mode
     ports:
       - 4318:4318 # OTLP http receiver
@@ -59,6 +65,8 @@ services:
       - HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=otel_json
       - HYPERDX_OTEL_EXPORTER_CLICKHOUSE_JSON_ENABLE=true
       - HYPERDX_LOG_LEVEL=info
+      # See the note on the otel-collector service above for rationale.
+      - HYPERDX_OTEL_BATCH_TIMEOUT=100ms
       # OPAMP_SERVER_URL is intentionally not set to run in standalone mode
     ports:
       - 14318:4318 # OTLP http receiver


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The OpenTelemetry Collector that ships with HyperDX defines `processors.batch` with no overrides, which means it uses the upstream defaults of `send_batch_size: 8192` and `timeout: 200ms`. Those defaults are not great for the ClickHouse exporter:

- **Too small / too frequent inserts** — under low or moderate load the 200ms timeout fires long before the 8192-record threshold, producing tiny inserts.
- **MergeTree part inflation** — many small inserts create many small parts, which forces ClickHouse to do extra background merging and can trigger "Too many parts" pressure.
- **ClickHouse guidance** — both the upstream [ClickHouse exporter README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/README.md) and [ClickStack docs](https://clickhouse.com/docs/use-cases/observability/clickstack/ingesting-data/opentelemetry) recommend inserting in packets of at least ~1000 rows or no more than one request per second.

This PR does two things:

1. **Better defaults**: sets `send_batch_size: 10000` and `timeout: 5s`, matching the values recommended in the upstream ClickHouse exporter docs and the ClickStack agent example. We deliberately leave `send_batch_max_size` at `0` (no upper bound) so the exporter can flush larger batches when traffic spikes — ClickHouse generally prefers fewer, larger inserts.
2. **Configurable via env vars**: each setting can be overridden without having to swap out the whole config file, mirroring the existing `HYPERDX_OTEL_EXPORTER_TABLES_TTL` pattern.

```yaml
processors:
  batch:
    send_batch_size:     ${env:HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE:-10000}
    send_batch_max_size: ${env:HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE:-0}
    timeout:             ${env:HYPERDX_OTEL_BATCH_TIMEOUT:-5s}
```

| Env var | Default | Notes |
| --- | --- | --- |
| `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE` | `10000` | Trigger size; batch is flushed when this many records have accumulated. |
| `HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE` | `0` | Hard cap on batch size. `0` = no cap. If set, must be >= `send_batch_size`. |
| `HYPERDX_OTEL_BATCH_TIMEOUT` | `5s` | Maximum time to wait before flushing a partial batch. |

The change only touches `docker/otel-collector/config.yaml`, which is the base config loaded in **both** standalone mode (entrypoint passes `--config /etc/otelcol-contrib/config.yaml --config .../standalone-config.yaml`) and OpAMP supervisor mode (the supervisor template lists `config.yaml` as the first `config_files` entry). The dynamic config produced by `opampController.ts` only references `batch` from pipelines and does not redefine its settings, so the new defaults / env overrides apply there too.

The otel-collector smoke tests emit a tiny amount of data and assert ~1s later; the 5s production timeout would break them, so we set `HYPERDX_OTEL_BATCH_TIMEOUT=100ms` in `smoke-tests/otel-collector/docker-compose.yaml`. That also validates the env override path end-to-end.

### How to test locally or on Vercel

1. Build/run the all-in-one or standalone otel-collector image and point it at a ClickHouse instance.
2. Send some OTLP traffic (e.g. `telemetrygen`) at low rate.
3. Inspect ClickHouse `system.query_log` / `system.parts` for the `otel_*` tables — inserts should arrive ~every 5s with up to 10k rows per batch instead of every ~200ms.
4. Confirm overrides work by setting e.g. `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE=20000` / `HYPERDX_OTEL_BATCH_TIMEOUT=10s` and observing the new behavior.
5. Confirm the collector starts without config errors (`Everything is ready. Begin running and processing data.`).

Validated locally with `otel/opentelemetry-collector-contrib:0.149.0` (the version pinned in the Dockerfile):

- ✅ `otelcol-contrib validate --config config.yaml --config config.standalone.yaml` — exits 0 with default env.
- ✅ Same validate command with `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE=20000`, `HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE=50000`, `HYPERDX_OTEL_BATCH_TIMEOUT=10s` — exits 0.
- ✅ `bats smoke-tests/otel-collector` — all 15 smoke tests pass.

### References

- ClickHouse exporter README: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/README.md
- Batch processor README: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69ef1af5-7411-4c6a-8b40-66d42932e2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69ef1af5-7411-4c6a-8b40-66d42932e2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

