### PR TITLE
docs: semantic design tokens guidance in code style

### DIFF
--- a/agent_docs/code_style.md
+++ b/agent_docs/code_style.md
@@ -127,6 +127,16 @@ This pattern cannot be enforced by ESLint and requires manual code review.
 
 **Title copy**: Treat `title` as a short headline (like `Title` in the UI). Do **not** end it with a period. Use `description` for full sentences, which should use normal punctuation including a trailing period when appropriate. Match listing pages (e.g. dashboards and saved searches use parallel phrasing such as “No matching … yet” / “No … yet” without dots).
 
+## Semantic design tokens (prefer over raw Mantine colors)
+
+The UI is built with **Mantine components**, but **colors and surfaces** should follow the **semantic CSS custom properties** in our themes (`--color-*`, etc.), not ad-hoc Mantine palette values. Those tokens are defined in `packages/app/src/theme/themes/**/_tokens.scss`, align with a **Click UI**–style system, and keep HyperDX and ClickStack visually consistent. They are the path toward a shared design system even while Mantine remains the component layer.
+
+- **Do**: Use Mantine for layout, components, and spacing; use **semantic tokens** for themed backgrounds, text colors, borders, and states (e.g. `style={{ color: 'var(--color-text-muted)' }}` or `style={{ border: '1px solid var(--color-border)' }}`).
+- **Do not**: Rely on raw Mantine color props for app chrome and content when a semantic token exists — e.g. `c="gray.5"`, `bg="dark.7"`, or arbitrary `color="blue.4"` for surfaces that should match the rest of the product.
+- **Reference**: `packages/app/src/theme/semanticColorsGrouped.ts` (token names), theme SCSS under `packages/app/src/theme/themes/`, and Storybook (`SemanticColors` and related theme stories) for a visual map.
+
+Mantine theme overrides in `packages/app/src/theme/**` may map Mantine’s scale to our palette; that does not replace using **`var(--color-...)`** in new styling where you need explicit color control.
+
 ## Refactoring
 
 - Edit files directly - don't create `component-v2.tsx` copies


### PR DESCRIPTION
## Why

We want new UI work to align with our semantic CSS tokens (Click UI–style) so HyperDX and ClickStack stay consistent and we can evolve toward a shared design system while Mantine remains the component layer.

## What

- Adds a **Semantic design tokens** section to `agent_docs/code_style.md`.
- Clarifies: Mantine for components, layout, and spacing; **`var(--color-*)`** for themed colors, surfaces, and borders when a token exists.
- Points to `semanticColorsGrouped.ts`, theme SCSS, and Storybook for reference.

## Notes

Documentation-only change; no code or tests.

Made with [Cursor](https://cursor.com)