### PR TITLE
feat(api): log rendered ClickHouse SQL on alert trigger (HDX-4112)

### DIFF
--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -2314,6 +2314,112 @@ describe('checkAlerts', () => {
       );
     });
 
+    it('SAVED_SEARCH alert - logs rendered ClickHouse SQL on trigger (HDX-4112)', async () => {
+      // Verifies that when an alert fires, trySendNotification logs the exact
+      // rendered SQL (post-parameter substitution) along with the evaluation
+      // window, source, alertId, savedSearchId, and triggering value. This
+      // gives operators a way to reproduce the query that produced the
+      // triggering metric, which is otherwise lost in the existing
+      // "Triggering ... alarm!" log line.
+      const {
+        team,
+        webhook,
+        connection,
+        source,
+        savedSearch,
+        teamWebhooksById,
+        clickhouseClient,
+      } = await setupSavedSearchAlertTest();
+
+      const details = await createAlertDetails(
+        team,
+        source,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          savedSearchId: savedSearch.id,
+        },
+        {
+          taskType: AlertTaskType.SAVED_SEARCH,
+          savedSearch,
+        },
+      );
+
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      const eventMs = new Date('2023-11-16T22:05:00.000Z');
+
+      await bulkInsertLogs([
+        {
+          ServiceName: 'api',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Boom',
+        },
+        {
+          ServiceName: 'api',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Boom',
+        },
+      ]);
+
+      const logger = (await import('@/utils/logger')).default;
+      const infoSpy = jest.spyOn(logger, 'info');
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+
+      const triggerLogCall = infoSpy.mock.calls.find(
+        ([, msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('Alert notification dispatch'),
+      );
+      expect(triggerLogCall).toBeDefined();
+      const [logFields, logMessage] = triggerLogCall!;
+      expect(logMessage).toBe(
+        'Alert notification dispatch — rendered ClickHouse SQL',
+      );
+      expect(logFields).toMatchObject({
+        alertId: details.alert.id,
+        savedSearchId: savedSearch.id,
+        alertSource: AlertSource.SAVED_SEARCH,
+        state: 'ALERT',
+        totalCount: 2,
+        windowSizeInMins: 5,
+        sourceId: source.id,
+        sourceFrom: { databaseName: 'default', tableName: 'otel_logs' },
+      });
+      const renderedSqls = (logFields as { renderedSqls: string[] })
+        .renderedSqls;
+      expect(Array.isArray(renderedSqls)).toBe(true);
+      expect(renderedSqls.length).toBeGreaterThan(0);
+      const sql = renderedSqls[0];
+      // The rendered SQL should reference the source table and be fully
+      // expanded (no remaining `{name:Type}` parameter placeholders).
+      expect(sql).toContain('default');
+      expect(sql).toContain('otel_logs');
+      expect(sql).not.toMatch(/\{[^}]+:\w+\}/);
+      // The window timestamps from the alert evaluation should appear inlined
+      // in the rendered SQL (post-parameter substitution).
+      expect(sql).toContain('2023-11-16');
+
+      infoSpy.mockRestore();
+    });
+
     it('TILE alert (events) - slack webhook', async () => {
       const {
         team,

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -5,6 +5,7 @@ import PQueue from '@esm2cjs/p-queue';
 import * as clickhouse from '@hyperdx/common-utils/dist/clickhouse';
 import {
   chSqlToAliasMap,
+  parameterizedQueryToSql,
   ResponseJSON,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
@@ -13,7 +14,11 @@ import {
   getMetadata,
   Metadata,
 } from '@hyperdx/common-utils/dist/core/metadata';
-import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
+import {
+  renderChartConfig,
+  setChartSelectsAlias,
+  splitChartConfigs,
+} from '@hyperdx/common-utils/dist/core/renderChartConfig';
 import {
   aliasMapToWithClauses,
   displayTypeSupportsRawSqlAlerts,
@@ -916,6 +921,32 @@ export const processAlert = async (
       `Received alert metric [${alert.source} source]`,
     );
 
+    // Pre-render the exact SQL string(s) the alert evaluator sent to ClickHouse,
+    // so we can log them when a notification is dispatched (HDX-4112). This
+    // mirrors the behavior of ClickhouseClient.queryChartConfig: builder
+    // configs are passed through setChartSelectsAlias, then both builder and
+    // raw-sql configs go through splitChartConfigs (metric configs may produce
+    // multiple SQL strings). Failures here must not affect alert delivery.
+    let renderedAlertSqls: string[] = [];
+    try {
+      const renderInputConfig = isBuilderChartConfig(optimizedChartConfig)
+        ? setChartSelectsAlias(optimizedChartConfig)
+        : optimizedChartConfig;
+      const renderedQueries = await Promise.all(
+        splitChartConfigs(renderInputConfig).map(c =>
+          renderChartConfig(c, metadata, source?.querySettings),
+        ),
+      );
+      renderedAlertSqls = renderedQueries.map(q =>
+        parameterizedQueryToSql({ sql: q.sql, params: q.params }),
+      );
+    } catch (e) {
+      logger.warn(
+        { alertId: alert.id, error: serializeError(e) },
+        'Failed to render alert SQL for trigger logging',
+      );
+    }
+
     // Track state per group (or one history if no groupBy)
     const histories = new Map<string, IAlertHistory>();
 
@@ -934,6 +965,21 @@ export const processAlert = async (
       return histories.get(groupKey)!;
     };
 
+    // Identifiers for the source of the alert evaluation, used in trigger logs
+    // so the rendered SQL can be correlated back to the originating object.
+    const savedSearchIdForLog =
+      details.taskType === AlertTaskType.SAVED_SEARCH
+        ? details.savedSearch.id
+        : undefined;
+    const tileIdForLog =
+      details.taskType === AlertTaskType.TILE ? alert.tileId : undefined;
+    const dashboardIdForLog =
+      details.taskType === AlertTaskType.TILE
+        ? details.dashboard?.id
+        : undefined;
+    const sourceIdForLog = source?.id;
+    const sourceFromForLog = source?.from ?? undefined;
+
     // Helper to send a notification, catching and logging any errors.
     const trySendNotification = async ({
       group,
@@ -946,6 +992,34 @@ export const processAlert = async (
       group: string;
       startTime?: Date;
     }) => {
+      // Log the exact rendered SQL (with parameters substituted) sent to
+      // ClickHouse for this alert evaluation, alongside the evaluation window,
+      // source/table, and the metric value that triggered the notification.
+      // This is emitted from inside trySendNotification (HDX-4112) so it only
+      // fires on actual notification attempts and can be correlated with the
+      // companion "Triggering ... alarm!" log line via alertId/TraceId.
+      logger.info(
+        {
+          alertId: alert.id,
+          savedSearchId: savedSearchIdForLog,
+          tileId: tileIdForLog,
+          dashboardId: dashboardIdForLog,
+          sourceId: sourceIdForLog,
+          sourceFrom: sourceFromForLog,
+          alertSource: alert.source,
+          group,
+          state,
+          totalCount,
+          windowStart: startTime,
+          windowEnd: fns.addMinutes(startTime, windowSizeInMins),
+          checkStartTime: dateRange[0],
+          checkEndTime: dateRange[1],
+          windowSizeInMins,
+          renderedSqls: renderedAlertSqls,
+        },
+        'Alert notification dispatch — rendered ClickHouse SQL',
+      );
+
       logger.info(
         { alertId: alert.id, group, totalCount },
         state === AlertState.ALERT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When an alert fires, we currently log `Triggering webhook alarm!` and a higher-level `Received alert metric [...]` line, but neither contains the exact SQL the scheduled task sent to ClickHouse. That makes false-positive alerts (parent ticket HDX-4111) very hard to investigate: there is no way to paste the triggering query back into HyperDX / ClickHouse to compare against what the app shows for the same saved search and window.

This PR adds a single, structured `info` log emitted from **inside** `trySendNotification` (in `packages/api/src/tasks/checkAlerts/index.ts`) so it only fires on actual notification dispatches (alert and auto-resolve). The log carries:

- `renderedSqls` — the **exact** SQL string(s) sent to ClickHouse, post-parameter substitution (no `{name:Type}` placeholders left). Metric alerts produce multiple queries (one per `select`), so this is an array.
- `windowStart` / `windowEnd` — the bucket the notification is for.
- `checkStartTime` / `checkEndTime` — the overall evaluation window.
- `windowSizeInMins`.
- `alertId`, `savedSearchId` (saved-search alerts), `tileId` + `dashboardId` (tile alerts), `sourceId`, `sourceFrom` (database/table).
- `alertSource`, `state`, `group`, `totalCount`.

The SQL is rendered with the same pipeline `ClickhouseClient.queryChartConfig` uses (`setChartSelectsAlias` for builder configs, then `splitChartConfigs` + `renderChartConfig` per split, then `parameterizedQueryToSql`), so what we log matches what was actually executed. Render failures are caught and logged as a `warn` — they never block alert delivery.

The companion `Triggering ${channel} alarm!` log line is preserved unchanged for backward compatibility with existing dashboards/searches; the new line shares `alertId` (and the same TraceId) so it can be correlated with that line and with the upstream `Received alert metric` line.

### Why

The parent ticket investigates a false-positive alert on the private instance: the scheduled task reads `count = 1` from ClickHouse but the same saved search in the app returns 0. Without the rendered SQL, reproducing the discrepancy requires guessing how the scheduled task built its query (time bounds, filters, source resolution, FINAL semantics, etc.). With this log, an operator can copy the exact SQL out of the alert log and re-run it directly.

### Notes / trade-offs

- Log level is `info` to match `Triggering ... alarm!` and `Received alert metric` so it is easy to enable together, and so it is captured by default in the scheduled-task service.
- Saved-search SQL does not embed user secrets (saved searches are workspace-scoped configuration), and `parameterizedQueryToSql` only substitutes the same params already shown in the existing query-error path (`ClickHouseQueryError`). No new sensitive surface area is introduced.
- For metric alerts, the rendered SQL is logged as an array (one per split query) rather than concatenated, so each query can be copy-pasted independently.

### How to test locally

1. Stand up the dev stack and create a saved-search alert that fires (e.g., threshold `> 0` on a search that always matches).
2. Wait for the scheduled task to evaluate the alert. In the API logs, look for `Alert notification dispatch — rendered ClickHouse SQL`.
3. Confirm the `renderedSqls` field contains the expanded SQL with the alert window inlined and no `{name:Type}` placeholders, and that the SQL runs as-is in the ClickHouse client.
4. Integration test: `make dev-int FILE=checkAlerts` — the new test `SAVED_SEARCH alert - logs rendered ClickHouse SQL on trigger (HDX-4112)` asserts the log fields and that the SQL is fully expanded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92dd4192-2994-428c-b2c3-2ac35816b402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92dd4192-2994-428c-b2c3-2ac35816b402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

