### PR TITLE
[HDX-4111] refactor(alerts/search): consolidate saved-search → chart-config builder

### DIFF
--- a/.changeset/hdx-4111-alert-table-filter-expression.md
+++ b/.changeset/hdx-4111-alert-table-filter-expression.md
@@ -4,19 +4,17 @@
 '@hyperdx/app': minor
 ---
 
-fix(alerts): apply `source.tableFilterExpression` in the scheduled alert task
-so saved-search alert counts reconcile with what users see in the app search
-page
+refactor(alerts/search): consolidate the saved-search → chart-config builder
+into a single shared helper, `buildSearchChartConfig`, in
+`@hyperdx/common-utils/core/searchChartConfig.ts`. The app search page, the
+alert preview chart, and the scheduled alert task's `SAVED_SEARCH` branch now
+all route through it, so `tableFilterExpression`, `implicitColumnExpression`,
+sample-weight expressions, SELECT precedence, and the `count()` default
+SELECT shape are applied identically by construction.
 
-The alert task's saved-search evaluator previously built its chart config
-inline and omitted `source.tableFilterExpression`, while the app search page
-prepended it as a SQL filter. When a Log source had that expression set, the
-alert task counted rows the app was hiding, producing false-positive alerts
-whose count did not match the app's results (HDX-4111).
-
-Consolidate the saved-search → chart config assembly into a single shared
-helper, `buildSearchChartConfig`, in `@hyperdx/common-utils`
-(`core/searchChartConfig.ts`). The app search page, the alert preview chart,
-and the scheduled alert task's `SAVED_SEARCH` branch now all route through
-that helper, so `tableFilterExpression` (and the other "source × saved
-search" fields) are applied identically across all three paths.
+Behavior fixes that fall out of consolidation:
+- The alert task and the alert preview now apply `source.tableFilterExpression`
+  on Log sources, matching what the search page already did.
+- A latent bug in the search-page builder is fixed: a non-null `filters`
+  array no longer silently drops the `tableFilterExpression` SQL filter via
+  spread-overwrite.

--- a/.changeset/hdx-4111-alert-table-filter-expression.md
+++ b/.changeset/hdx-4111-alert-table-filter-expression.md
@@ -1,0 +1,22 @@
+---
+'@hyperdx/common-utils': minor
+'@hyperdx/api': minor
+'@hyperdx/app': minor
+---
+
+fix(alerts): apply `source.tableFilterExpression` in the scheduled alert task
+so saved-search alert counts reconcile with what users see in the app search
+page
+
+The alert task's saved-search evaluator previously built its chart config
+inline and omitted `source.tableFilterExpression`, while the app search page
+prepended it as a SQL filter. When a Log source had that expression set, the
+alert task counted rows the app was hiding, producing false-positive alerts
+whose count did not match the app's results (HDX-4111).
+
+Consolidate the saved-search → chart config assembly into a single shared
+helper, `buildSearchChartConfig`, in `@hyperdx/common-utils`
+(`core/searchChartConfig.ts`). The app search page, the alert preview chart,
+and the scheduled alert task's `SAVED_SEARCH` branch now all route through
+that helper, so `tableFilterExpression` (and the other "source × saved
+search" fields) are applied identically across all three paths.

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -134,6 +134,7 @@ export const LogSource = Source.discriminator<ILogSource>(
     spanIdExpression: String,
     implicitColumnExpression: String,
     uniqueRowIdExpression: String,
+    /** @deprecated See LogSourceSchema in @hyperdx/common-utils/types.ts. */
     tableFilterExpression: String,
     highlightedTraceAttributeExpressions: {
       type: mongoose.Schema.Types.Array,

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -2314,12 +2314,13 @@ describe('checkAlerts', () => {
       );
     });
 
-    // Regression test for HDX-4111: the scheduled alert task was not
-    // applying the Log source's `tableFilterExpression`, while the app
-    // search page was. This caused false-positive alerts where the task
-    // counted rows that the app was hiding. The fix routes both paths
-    // through the shared `buildSearchChartConfig` helper.
-    it('SAVED_SEARCH alert honors source.tableFilterExpression (HDX-4111)', async () => {
+    // The scheduled alert task and the app search page both go through
+    // `buildSearchChartConfig`, which prepends the Log source's
+    // `tableFilterExpression` (when set) as a SQL filter. This regression
+    // test pins that contract for the alert task: rows excluded by
+    // `tableFilterExpression` must not be counted toward the alert
+    // threshold.
+    it('SAVED_SEARCH alert honors source.tableFilterExpression', async () => {
       const {
         team,
         webhook,
@@ -2366,13 +2367,13 @@ describe('checkAlerts', () => {
       const eventMs = new Date('2023-11-16T22:05:00.000Z');
 
       // Insert two log rows in the alert window:
-      //   1. 'excluded' service — matches the saved search `where` but would
-      //      be hidden in the app via `tableFilterExpression`.
-      //   2. 'api' service — matches the saved search `where` and is NOT
-      //      hidden. The threshold uses ABOVE_EXCLUSIVE (strict `>`), so with
-      //      the fix (count = 1) `1 > 1` is false and the alert stays OK.
-      //      Without the fix (count = 2) `2 > 1` would fire, matching the
-      //      reported HDX-4111 regression.
+      //   1. 'excluded' service — matches the saved search `where` but is
+      //      hidden by the source's `tableFilterExpression`.
+      //   2. 'api' service — matches the saved search `where` and passes
+      //      the table filter. Threshold uses ABOVE_EXCLUSIVE (strict `>`),
+      //      so with the filter applied (count = 1) `1 > 1` is false and
+      //      the alert stays OK. If the filter were dropped (count = 2),
+      //      `2 > 1` would fire — the failure mode this test guards.
       await bulkInsertLogs([
         {
           ServiceName: 'excluded',

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -2314,6 +2314,105 @@ describe('checkAlerts', () => {
       );
     });
 
+    // Regression test for HDX-4111: the scheduled alert task was not
+    // applying the Log source's `tableFilterExpression`, while the app
+    // search page was. This caused false-positive alerts where the task
+    // counted rows that the app was hiding. The fix routes both paths
+    // through the shared `buildSearchChartConfig` helper.
+    it('SAVED_SEARCH alert honors source.tableFilterExpression (HDX-4111)', async () => {
+      const {
+        team,
+        webhook,
+        connection,
+        source,
+        savedSearch,
+        teamWebhooksById,
+        clickhouseClient,
+      } = await setupSavedSearchAlertTest();
+
+      // Configure the source to hide the 'excluded' service, matching the
+      // semantics of a Log source whose UI view filters it out.
+      await Source.updateOne(
+        { _id: source._id },
+        { $set: { tableFilterExpression: "ServiceName != 'excluded'" } },
+      );
+      const filteredSource = await Source.findById(source._id);
+
+      const details = await createAlertDetails(
+        team,
+        filteredSource ?? undefined,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE_EXCLUSIVE,
+          threshold: 1,
+          savedSearchId: savedSearch.id,
+        },
+        {
+          taskType: AlertTaskType.SAVED_SEARCH,
+          savedSearch,
+        },
+      );
+
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      const eventMs = new Date('2023-11-16T22:05:00.000Z');
+
+      // Insert two log rows in the alert window:
+      //   1. 'excluded' service — matches the saved search `where` but would
+      //      be hidden in the app via `tableFilterExpression`.
+      //   2. 'api' service — matches the saved search `where` and is NOT
+      //      hidden. The threshold uses ABOVE_EXCLUSIVE (strict `>`), so with
+      //      the fix (count = 1) `1 > 1` is false and the alert stays OK.
+      //      Without the fix (count = 2) `2 > 1` would fire, matching the
+      //      reported HDX-4111 regression.
+      await bulkInsertLogs([
+        {
+          ServiceName: 'excluded',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'This row should be hidden by tableFilterExpression',
+        },
+        {
+          ServiceName: 'api',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'This row should pass the filter',
+        },
+      ]);
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      // Threshold is `> 1`, so with the fix (1 row counted) the alert stays
+      // OK. Without the fix (2 rows counted — including the excluded one),
+      // the alert would transition to ALERT and fire the webhook.
+      const alert = await Alert.findById(details.alert.id);
+      expect(alert!.state).toBe('OK');
+
+      const alertHistories = await AlertHistory.find({
+        alert: details.alert.id,
+      }).sort({ createdAt: 1 });
+      expect(alertHistories.length).toBe(1);
+      expect(alertHistories[0].state).toBe('OK');
+      // Exactly one row counted — the 'excluded' row is filtered out.
+      expect(alertHistories[0].lastValues).toEqual([
+        expect.objectContaining({ count: 1 }),
+      ]);
+
+      // No webhook should have fired.
+      expect(slack.postMessageToWebhook).not.toHaveBeenCalled();
+    });
+
     it('TILE alert (events) - slack webhook', async () => {
       const {
         team,

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -30,7 +30,7 @@ import AlertHistory from '@/models/alertHistory';
 import Connection, { IConnection } from '@/models/connection';
 import Dashboard, { IDashboard } from '@/models/dashboard';
 import { ISavedSearch, SavedSearch } from '@/models/savedSearch';
-import { ISource, Source } from '@/models/source';
+import { ISource, LogSource, Source } from '@/models/source';
 import { ITeam } from '@/models/team';
 import Webhook, { IWebhook } from '@/models/webhook';
 import * as checkAlert from '@/tasks/checkAlerts';
@@ -2332,7 +2332,11 @@ describe('checkAlerts', () => {
 
       // Configure the source to hide the 'excluded' service, matching the
       // semantics of a Log source whose UI view filters it out.
-      await Source.updateOne(
+      // `tableFilterExpression` is declared on the Log discriminator schema
+      // (not the base Source schema), so we must update through `LogSource`
+      // — `Source.updateOne` would silently drop the field under Mongoose's
+      // default strict mode.
+      await LogSource.updateOne(
         { _id: source._id },
         { $set: { tableFilterExpression: "ServiceName != 'excluded'" } },
       );

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -14,6 +14,7 @@ import {
   Metadata,
 } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
+import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import {
   aliasMapToWithClauses,
   displayTypeSupportsRawSqlAlerts,
@@ -35,6 +36,7 @@ import {
   getSampleWeightExpression,
   pickSampleWeightExpressionProps,
   SourceKind,
+  TSource,
 } from '@hyperdx/common-utils/dist/types';
 import * as fns from 'date-fns';
 import { isString, pick } from 'lodash';
@@ -512,32 +514,31 @@ const getChartConfigFromAlert = (
   if (details.taskType === AlertTaskType.SAVED_SEARCH) {
     const { source } = details;
     const savedSearch = details.savedSearch;
-    return {
-      connection,
+    // Delegate to the shared builder (in @hyperdx/common-utils) so the alert
+    // task, the alert preview chart, and the main app search page all
+    // assemble saved-search chart configs identically. This fixes HDX-4111,
+    // where the alert task omitted `source.tableFilterExpression` while the
+    // app applied it — producing false-positive alerts whose count did not
+    // reconcile with the rows visible in the app for the same saved search.
+    return buildSearchChartConfig(source as TSource, {
+      where: savedSearch.where,
+      whereLanguage: savedSearch.whereLanguage,
+      filters: savedSearch.filters?.map(f => ({ ...f })),
+      groupBy: alert.groupBy,
       displayType: DisplayType.Line,
+      connection,
       dateRange,
       dateRangeStartInclusive: true,
       dateRangeEndInclusive: false,
-      from: source.from,
       granularity: `${windowSizeInMins} minute`,
-      select: [
+      defaultSelect: [
         {
           aggFn: 'count',
           aggCondition: '',
           valueExpression: '',
         },
       ],
-      where: savedSearch.where,
-      whereLanguage: savedSearch.whereLanguage,
-      filters: savedSearch.filters?.map(f => ({ ...f })),
-      groupBy: alert.groupBy,
-      implicitColumnExpression:
-        source.kind === SourceKind.Log || source.kind === SourceKind.Trace
-          ? source.implicitColumnExpression
-          : undefined,
-      ...pickSampleWeightExpressionProps(source),
-      timestampValueExpression: source.timestampValueExpression,
-    };
+    });
   } else if (details.taskType === AlertTaskType.TILE) {
     const tile = details.tile;
 

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -519,10 +519,8 @@ const getChartConfigFromAlert = (
     const savedSearch = details.savedSearch;
     // Delegate to the shared builder (in @hyperdx/common-utils) so the alert
     // task, the alert preview chart, and the main app search page all
-    // assemble saved-search chart configs identically. This fixes HDX-4111,
-    // where the alert task omitted `source.tableFilterExpression` while the
-    // app applied it — producing false-positive alerts whose count did not
-    // reconcile with the rows visible in the app for the same saved search.
+    // assemble saved-search chart configs identically — keeping source-level
+    // fields like `tableFilterExpression` applied uniformly across paths.
     return buildSearchChartConfig(source as TSource, {
       where: savedSearch.where,
       whereLanguage: savedSearch.whereLanguage,

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -39,7 +39,6 @@ import {
   getSampleWeightExpression,
   pickSampleWeightExpressionProps,
   SourceKind,
-  TSource,
 } from '@hyperdx/common-utils/dist/types';
 import * as fns from 'date-fns';
 import { isString, pick } from 'lodash';
@@ -521,7 +520,7 @@ const getChartConfigFromAlert = (
     // task, the alert preview chart, and the main app search page all
     // assemble saved-search chart configs identically — keeping source-level
     // fields like `tableFilterExpression` applied uniformly across paths.
-    return buildSearchChartConfig(source as TSource, {
+    return buildSearchChartConfig(source, {
       where: savedSearch.where,
       whereLanguage: savedSearch.whereLanguage,
       filters: savedSearch.filters?.map(f => ({ ...f })),

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -14,7 +14,10 @@ import {
   Metadata,
 } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
-import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
+import {
+  ALERT_COUNT_DEFAULT_SELECT,
+  buildSearchChartConfig,
+} from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import {
   aliasMapToWithClauses,
   displayTypeSupportsRawSqlAlerts,
@@ -531,13 +534,7 @@ const getChartConfigFromAlert = (
       dateRangeStartInclusive: true,
       dateRangeEndInclusive: false,
       granularity: `${windowSizeInMins} minute`,
-      defaultSelect: [
-        {
-          aggFn: 'count',
-          aggCondition: '',
-          valueExpression: '',
-        },
-      ],
+      defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
     });
   } else if (details.taskType === AlertTaskType.TILE) {
     const tile = details.tile;

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -525,13 +525,13 @@ const getChartConfigFromAlert = (
       whereLanguage: savedSearch.whereLanguage,
       filters: savedSearch.filters?.map(f => ({ ...f })),
       groupBy: alert.groupBy,
+      select: ALERT_COUNT_DEFAULT_SELECT,
       displayType: DisplayType.Line,
       connection,
       dateRange,
       dateRangeStartInclusive: true,
       dateRangeEndInclusive: false,
       granularity: `${windowSizeInMins} minute`,
-      defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
     });
   } else if (details.taskType === AlertTaskType.TILE) {
     const tile = details.tile;

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1314,13 +1314,15 @@ export function DBSearchPage() {
     };
   }, [chartConfig, searchedTimeRange]);
 
-  const displayedColumns = useMemo(
-    () =>
-      splitAndTrimWithBracket(
-        dbSqlRowTableConfig?.select ?? defaultSearchConfig.select ?? '',
-      ),
-    [dbSqlRowTableConfig?.select, defaultSearchConfig.select],
-  );
+  const displayedColumns = useMemo(() => {
+    // `select` is typed as `string | DerivedColumn[]` upstream, but in the
+    // search page we always supply a string. Guard for type safety.
+    const rawSelect =
+      dbSqlRowTableConfig?.select ?? defaultSearchConfig.select ?? '';
+    return splitAndTrimWithBracket(
+      typeof rawSelect === 'string' ? rawSelect : '',
+    );
+  }, [dbSqlRowTableConfig?.select, defaultSearchConfig.select]);
 
   const toggleColumn = useCallback(
     (column: string) => {

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
+import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import {
   aliasMapToWithClauses,
   isBrowser,
@@ -37,9 +38,7 @@ import {
   ChartConfigWithDateRange,
   DisplayType,
   Filter,
-  isLogSource,
   isTraceSource,
-  pickSampleWeightExpressionProps,
   SourceKind,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
@@ -511,7 +510,7 @@ function SaveSearchModalComponent({
               <Text size="xs" mb="xs" mt="sm">
                 ORDER BY
               </Text>
-              <Text size="xs">{chartConfig.orderBy}</Text>
+              <Text size="xs">{`${chartConfig.orderBy ?? ''}`}</Text>
               {searchedConfig.filters && searchedConfig.filters.length > 0 && (
                 <>
                   <Text size="xs" mb="xs" mt="sm">
@@ -690,35 +689,26 @@ function useSearchedConfigToChartConfig(
 
   return useMemo(() => {
     if (sourceObj != null) {
+      // Use the shared builder (in @hyperdx/common-utils) so the search page,
+      // the alert preview, and the scheduled alert task all assemble the
+      // chart config identically. In particular, this is the single place
+      // `source.tableFilterExpression` is prepended as a SQL filter — the
+      // divergence that caused HDX-4111 (false-positive alerts where the
+      // task counted rows the app was hiding).
+      const resolvedOrderBy =
+        orderBy || defaultSearchConfig?.orderBy || defaultOrderBy;
+
+      const chartConfig = buildSearchChartConfig(sourceObj, {
+        where,
+        whereLanguage,
+        filters,
+        select: select || defaultSearchConfig?.select || null,
+        displayType: DisplayType.Search,
+        ...(resolvedOrderBy != null ? { orderBy: resolvedOrderBy } : {}),
+      });
+
       return {
-        data: {
-          select:
-            select ||
-            defaultSearchConfig?.select ||
-            sourceObj.defaultTableSelectExpression,
-          from: sourceObj.from,
-          source: sourceObj.id,
-          ...(isLogSource(sourceObj) && sourceObj.tableFilterExpression != null
-            ? {
-                filters: [
-                  {
-                    type: 'sql' as const,
-                    condition: sourceObj.tableFilterExpression,
-                  },
-                  ...(filters ?? []),
-                ],
-              }
-            : {}),
-          ...(filters != null ? { filters } : {}),
-          where: where ?? '',
-          whereLanguage: whereLanguage ?? 'sql',
-          timestampValueExpression: sourceObj.timestampValueExpression,
-          implicitColumnExpression: sourceObj.implicitColumnExpression,
-          ...pickSampleWeightExpressionProps(sourceObj),
-          connection: sourceObj.connection,
-          displayType: DisplayType.Search,
-          orderBy: orderBy || defaultSearchConfig?.orderBy || defaultOrderBy,
-        },
+        data: chartConfig,
       };
     }
 

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -689,12 +689,6 @@ function useSearchedConfigToChartConfig(
 
   return useMemo(() => {
     if (sourceObj != null) {
-      // Use the shared builder (in @hyperdx/common-utils) so the search page,
-      // the alert preview, and the scheduled alert task all assemble the
-      // chart config identically. In particular, this is the single place
-      // `source.tableFilterExpression` is prepended as a SQL filter — the
-      // divergence that caused HDX-4111 (false-positive alerts where the
-      // task counted rows the app was hiding).
       const resolvedOrderBy =
         orderBy || defaultSearchConfig?.orderBy || defaultOrderBy;
 

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   ALERT_COUNT_DEFAULT_SELECT,
   buildSearchChartConfig,
@@ -63,37 +63,44 @@ export const AlertPreviewChart = ({
     from: source.from,
     whereLanguage: whereLanguage || undefined,
   });
-  const aliasWith = aliasMapToWithClauses(aliasMap);
+  const aliasWith = useMemo(() => aliasMapToWithClauses(aliasMap), [aliasMap]);
 
-  // Delegate to the shared builder so this preview sees the same filters /
-  // sample weights / implicit columns as the scheduled alert task and the
-  // main app search page. The preview chart is rendered as a time series
-  // (DBTimeChart) so it overrides displayType to Line and supplies a count()
-  // default SELECT.
+  // Delegate to the shared builder so this preview sees the same filters,
+  // sample weights, and implicit columns as the scheduled alert task and
+  // the app search page. Overrides `displayType` to Line and supplies a
+  // count() default SELECT because the preview always renders the alert's
+  // count-over-time threshold view, regardless of the saved search's
+  // display columns.
   //
-  // Note: the `select` prop on this component is intentionally NOT forwarded
-  // to `buildSearchChartConfig`. The preview always renders the alert's
-  // count-over-time threshold view, which uses `ALERT_COUNT_DEFAULT_SELECT`.
-  // The `select` prop is only used above (for `useAliasMapFromChartConfig`)
-  // so the alias-WITH clauses match the saved search's display select even
-  // though the chart itself plots count(). This mirrors what the scheduled
-  // alert task does — both evaluate the same count() shape regardless of
-  // the saved search's display columns.
+  // The `select` prop is intentionally NOT forwarded to the builder — it's
+  // only used above (for `useAliasMapFromChartConfig`) so alias-WITH
+  // clauses match the saved search's display select.
   //
-  // Cast to ChartConfigWithDateRange because `dateRange` is always set in
-  // this code path (we pass `intervalToDateRange(interval)` below). The
-  // builder's return type widens `dateRange` to optional to support callers
-  // that omit it, so we narrow here at the consumption point.
-  const chartConfig = buildSearchChartConfig(source, {
-    where,
-    whereLanguage,
-    filters,
-    groupBy,
-    displayType: DisplayType.Line,
-    dateRange: intervalToDateRange(interval),
-    granularity: intervalToGranularity(interval),
-    defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
-  }) as ChartConfigWithDateRange;
+  // Cast to ChartConfigWithDateRange because the builder widens `dateRange`
+  // to optional, but it's always set here via `intervalToDateRange`.
+  const config = useMemo<ChartConfigWithDateRange>(() => {
+    const chartConfig = buildSearchChartConfig(source, {
+      where,
+      whereLanguage,
+      filters,
+      groupBy,
+      displayType: DisplayType.Line,
+      dateRange: intervalToDateRange(interval),
+      granularity: intervalToGranularity(interval),
+      defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
+    }) as ChartConfigWithDateRange;
+    return { ...chartConfig, with: aliasWith };
+  }, [source, where, whereLanguage, filters, groupBy, interval, aliasWith]);
+
+  const referenceLines = useMemo(
+    () =>
+      getAlertReferenceLines({
+        threshold,
+        thresholdMax,
+        thresholdType,
+      }),
+    [threshold, thresholdMax, thresholdType],
+  );
 
   return (
     <Paper w="100%" h={200}>
@@ -102,15 +109,8 @@ export const AlertPreviewChart = ({
         showDisplaySwitcher={false}
         showMVOptimizationIndicator={false}
         showDateRangeIndicator={false}
-        referenceLines={getAlertReferenceLines({
-          threshold,
-          thresholdMax,
-          thresholdType,
-        })}
-        config={{
-          ...chartConfig,
-          with: aliasWith,
-        }}
+        referenceLines={referenceLines}
+        config={config}
       />
     </Paper>
   );

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -71,6 +71,15 @@ export const AlertPreviewChart = ({
   // (DBTimeChart) so it overrides displayType to Line and supplies a count()
   // default SELECT.
   //
+  // Note: the `select` prop on this component is intentionally NOT forwarded
+  // to `buildSearchChartConfig`. The preview always renders the alert's
+  // count-over-time threshold view, which uses `ALERT_COUNT_DEFAULT_SELECT`.
+  // The `select` prop is only used above (for `useAliasMapFromChartConfig`)
+  // so the alias-WITH clauses match the saved search's display select even
+  // though the chart itself plots count(). This mirrors what the scheduled
+  // alert task does — both evaluate the same count() shape regardless of
+  // the saved search's display columns.
+  //
   // Cast to ChartConfigWithDateRange because `dateRange` is always set in
   // this code path (we pass `intervalToDateRange(interval)` below). The
   // builder's return type widens `dateRange` to optional to support callers

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -67,13 +67,13 @@ export const AlertPreviewChart = ({
 
   // Delegate to the shared builder so this preview sees the same filters,
   // sample weights, and implicit columns as the scheduled alert task and
-  // the app search page. Overrides `displayType` to Line and supplies a
-  // count() default SELECT because the preview always renders the alert's
+  // the app search page. Overrides `displayType` to Line and pins SELECT to
+  // a count() aggregate because the preview always renders the alert's
   // count-over-time threshold view, regardless of the saved search's
   // display columns.
   //
-  // The `select` prop is intentionally NOT forwarded to the builder — it's
-  // only used above (for `useAliasMapFromChartConfig`) so alias-WITH
+  // The `select` prop on this component is intentionally NOT forwarded —
+  // it's only used above (for `useAliasMapFromChartConfig`) so alias-WITH
   // clauses match the saved search's display select.
   //
   // Cast to ChartConfigWithDateRange because the builder widens `dateRange`
@@ -84,10 +84,10 @@ export const AlertPreviewChart = ({
       whereLanguage,
       filters,
       groupBy,
+      select: ALERT_COUNT_DEFAULT_SELECT,
       displayType: DisplayType.Line,
       dateRange: intervalToDateRange(interval),
       granularity: intervalToGranularity(interval),
-      defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
     }) as ChartConfigWithDateRange;
     return { ...chartConfig, with: aliasWith };
   }, [source, where, whereLanguage, filters, groupBy, interval, aliasWith]);

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
+import {
+  ALERT_COUNT_DEFAULT_SELECT,
+  buildSearchChartConfig,
+} from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import { aliasMapToWithClauses } from '@hyperdx/common-utils/dist/core/utils';
 import {
   AlertInterval,
@@ -33,18 +36,6 @@ type AlertPreviewChartProps = {
   thresholdMax?: number;
   select?: string | null;
 };
-
-// Default SELECT for alert preview when no caller-provided SELECT is set.
-// Mirrors what the scheduled alert task uses so the preview and the alert
-// evaluate the same shape of query.
-const DEFAULT_ALERT_SELECT = [
-  {
-    aggFn: 'count' as const,
-    aggCondition: '',
-    aggConditionLanguage: 'sql' as const,
-    valueExpression: '',
-  },
-];
 
 export const AlertPreviewChart = ({
   source,
@@ -92,7 +83,7 @@ export const AlertPreviewChart = ({
     displayType: DisplayType.Line,
     dateRange: intervalToDateRange(interval),
     granularity: intervalToGranularity(interval),
-    defaultSelect: DEFAULT_ALERT_SELECT,
+    defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
   }) as ChartConfigWithDateRange;
 
   return (

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import { aliasMapToWithClauses } from '@hyperdx/common-utils/dist/core/utils';
 import {
   AlertInterval,
   AlertThresholdType,
+  DisplayType,
   Filter,
-  getSampleWeightExpression,
   isLogSource,
   isTraceSource,
   SearchCondition,
@@ -31,6 +32,18 @@ type AlertPreviewChartProps = {
   thresholdMax?: number;
   select?: string | null;
 };
+
+// Default SELECT for alert preview when no caller-provided SELECT is set.
+// Mirrors what the scheduled alert task uses so the preview and the alert
+// evaluate the same shape of query.
+const DEFAULT_ALERT_SELECT = [
+  {
+    aggFn: 'count' as const,
+    aggCondition: '',
+    aggConditionLanguage: 'sql' as const,
+    valueExpression: '',
+  },
+];
 
 export const AlertPreviewChart = ({
   source,
@@ -60,6 +73,22 @@ export const AlertPreviewChart = ({
   });
   const aliasWith = aliasMapToWithClauses(aliasMap);
 
+  // Delegate to the shared builder so this preview sees the same filters /
+  // sample weights / implicit columns as the scheduled alert task and the
+  // main app search page. The preview chart is rendered as a time series
+  // (DBTimeChart) so it overrides displayType to Line and supplies a count()
+  // default SELECT.
+  const chartConfig = buildSearchChartConfig(source, {
+    where,
+    whereLanguage,
+    filters,
+    groupBy,
+    displayType: DisplayType.Line,
+    dateRange: intervalToDateRange(interval),
+    granularity: intervalToGranularity(interval),
+    defaultSelect: DEFAULT_ALERT_SELECT,
+  });
+
   return (
     <Paper w="100%" h={200}>
       <DBTimeChart
@@ -73,29 +102,8 @@ export const AlertPreviewChart = ({
           thresholdType,
         })}
         config={{
-          where: where || '',
-          whereLanguage: whereLanguage || undefined,
-          dateRange: intervalToDateRange(interval),
-          granularity: intervalToGranularity(interval),
-          filters: filters || undefined,
-          implicitColumnExpression:
-            isLogSource(source) || isTraceSource(source)
-              ? source.implicitColumnExpression
-              : undefined,
-          sampleWeightExpression: getSampleWeightExpression(source),
-          groupBy,
+          ...chartConfig,
           with: aliasWith,
-          select: [
-            {
-              aggFn: 'count' as const,
-              aggCondition: '',
-              aggConditionLanguage: 'sql',
-              valueExpression: '',
-            },
-          ],
-          timestampValueExpression: source.timestampValueExpression,
-          from: source.from,
-          connection: source.connection,
         }}
       />
     </Paper>

--- a/packages/app/src/components/AlertPreviewChart.tsx
+++ b/packages/app/src/components/AlertPreviewChart.tsx
@@ -4,6 +4,7 @@ import { aliasMapToWithClauses } from '@hyperdx/common-utils/dist/core/utils';
 import {
   AlertInterval,
   AlertThresholdType,
+  ChartConfigWithDateRange,
   DisplayType,
   Filter,
   isLogSource,
@@ -78,6 +79,11 @@ export const AlertPreviewChart = ({
   // main app search page. The preview chart is rendered as a time series
   // (DBTimeChart) so it overrides displayType to Line and supplies a count()
   // default SELECT.
+  //
+  // Cast to ChartConfigWithDateRange because `dateRange` is always set in
+  // this code path (we pass `intervalToDateRange(interval)` below). The
+  // builder's return type widens `dateRange` to optional to support callers
+  // that omit it, so we narrow here at the consumption point.
   const chartConfig = buildSearchChartConfig(source, {
     where,
     whereLanguage,
@@ -87,7 +93,7 @@ export const AlertPreviewChart = ({
     dateRange: intervalToDateRange(interval),
     granularity: intervalToGranularity(interval),
     defaultSelect: DEFAULT_ALERT_SELECT,
-  });
+  }) as ChartConfigWithDateRange;
 
   return (
     <Paper w="100%" h={200}>

--- a/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
+++ b/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
@@ -1,0 +1,329 @@
+import { DisplayType, Filter, SourceKind, TSource } from '../../types';
+import { buildSearchChartConfig } from '../searchChartConfig';
+
+// Factory helpers keep tests focused on the behavior under test rather than
+// the full source shape. We cast to TSource because most per-kind fields are
+// optional or ignored by buildSearchChartConfig.
+const makeLogSource = (overrides: Record<string, unknown> = {}): TSource =>
+  ({
+    id: 'log-source-1',
+    kind: SourceKind.Log,
+    name: 'logs',
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_logs' },
+    timestampValueExpression: 'TimestampTime',
+    defaultTableSelectExpression: 'Timestamp, Body',
+    implicitColumnExpression: 'Body',
+    ...overrides,
+  }) as unknown as TSource;
+
+const makeTraceSource = (overrides: Record<string, unknown> = {}): TSource =>
+  ({
+    id: 'trace-source-1',
+    kind: SourceKind.Trace,
+    name: 'traces',
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_traces' },
+    timestampValueExpression: 'Timestamp',
+    defaultTableSelectExpression: 'Timestamp, SpanName',
+    implicitColumnExpression: 'SpanName',
+    ...overrides,
+  }) as unknown as TSource;
+
+const makeMetricSource = (overrides: Record<string, unknown> = {}): TSource =>
+  ({
+    id: 'metric-source-1',
+    kind: SourceKind.Metric,
+    name: 'metrics',
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_metrics' },
+    timestampValueExpression: 'TimeUnix',
+    ...overrides,
+  }) as unknown as TSource;
+
+describe('buildSearchChartConfig', () => {
+  describe('tableFilterExpression', () => {
+    it('prepends tableFilterExpression as a SQL filter on Log sources', () => {
+      const source = makeLogSource({
+        tableFilterExpression: "ServiceName != 'noisy'",
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: 'Body:"error"',
+        whereLanguage: 'lucene',
+      });
+
+      expect(config.filters).toEqual([
+        { type: 'sql', condition: "ServiceName != 'noisy'" },
+      ]);
+    });
+
+    it('prepends tableFilterExpression before caller-supplied filters, preserving order', () => {
+      const source = makeLogSource({
+        tableFilterExpression: "ServiceName != 'noisy'",
+      });
+      const userFilters: Filter[] = [
+        { type: 'sql', condition: "Environment = 'prod'" },
+        { type: 'lucene', condition: 'SeverityText:error' },
+      ];
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        filters: userFilters,
+      });
+
+      expect(config.filters).toEqual([
+        { type: 'sql', condition: "ServiceName != 'noisy'" },
+        ...userFilters,
+      ]);
+    });
+
+    it('does not inject any filter when tableFilterExpression is not set', () => {
+      const source = makeLogSource();
+      const userFilters: Filter[] = [
+        { type: 'sql', condition: "Environment = 'prod'" },
+      ];
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        filters: userFilters,
+      });
+
+      expect(config.filters).toEqual(userFilters);
+    });
+
+    it('omits filters key entirely when neither tableFilterExpression nor caller filters are set', () => {
+      const config = buildSearchChartConfig(makeLogSource(), { where: '' });
+
+      expect(config.filters).toBeUndefined();
+    });
+
+    it('does not inject tableFilterExpression for Trace sources (field is Log-only)', () => {
+      // Sanity check: even if someone stuffs the field on a trace source at
+      // runtime, it should not be injected because `isLogSource` narrows the check.
+      const source = makeTraceSource({
+        tableFilterExpression: "ServiceName != 'noisy'",
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.filters).toBeUndefined();
+    });
+  });
+
+  describe('implicit column expression', () => {
+    it('sets implicitColumnExpression from Log source', () => {
+      const source = makeLogSource({
+        implicitColumnExpression: "concatWithSeparator(';', Body, Message)",
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.implicitColumnExpression).toBe(
+        "concatWithSeparator(';', Body, Message)",
+      );
+    });
+
+    it('sets implicitColumnExpression from Trace source', () => {
+      const source = makeTraceSource({ implicitColumnExpression: 'SpanName' });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.implicitColumnExpression).toBe('SpanName');
+    });
+
+    it('leaves implicitColumnExpression undefined for Metric sources', () => {
+      const source = makeMetricSource();
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.implicitColumnExpression).toBeUndefined();
+    });
+  });
+
+  describe('sample weight expression', () => {
+    it('sets sampleWeightExpression from Trace source when sampleRateExpression is set', () => {
+      const source = makeTraceSource({
+        sampleRateExpression: 'SpanAttributes.sampleWeight',
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.sampleWeightExpression).toBe('SpanAttributes.sampleWeight');
+    });
+
+    it('leaves sampleWeightExpression undefined for Trace source without sampleRateExpression', () => {
+      const source = makeTraceSource();
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.sampleWeightExpression).toBeUndefined();
+    });
+
+    it('leaves sampleWeightExpression undefined for Log source even if sampleRateExpression is present', () => {
+      const source = makeLogSource({
+        sampleRateExpression: 'LogAttributes.sampleWeight',
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.sampleWeightExpression).toBeUndefined();
+    });
+  });
+
+  describe('select precedence', () => {
+    it('prefers caller-provided select over all fallbacks', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        select: 'caller-select',
+        defaultSelect: 'caller-default',
+      });
+
+      expect(config.select).toBe('caller-select');
+    });
+
+    it('falls back to defaultSelect when select is empty string', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        select: '',
+        defaultSelect: 'caller-default',
+      });
+
+      expect(config.select).toBe('caller-default');
+    });
+
+    it('falls back to source defaultTableSelectExpression when caller fields are missing', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.select).toBe('source-default');
+    });
+
+    it('supports array-valued SELECT (count aggregate) for alert-style queries', () => {
+      const source = makeLogSource();
+      const selectList = [
+        { aggFn: 'count' as const, aggCondition: '', valueExpression: '' },
+      ];
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        defaultSelect: selectList,
+      });
+
+      expect(config.select).toEqual(selectList);
+    });
+  });
+
+  describe('whereLanguage default', () => {
+    it('defaults whereLanguage to "sql" when not provided', () => {
+      const config = buildSearchChartConfig(makeLogSource(), { where: '' });
+
+      expect(config.whereLanguage).toBe('sql');
+    });
+
+    it('passes through whereLanguage when provided', () => {
+      const config = buildSearchChartConfig(makeLogSource(), {
+        where: 'Body:"error"',
+        whereLanguage: 'lucene',
+      });
+
+      expect(config.whereLanguage).toBe('lucene');
+    });
+  });
+
+  describe('pass-through fields', () => {
+    it('passes through all time-range and display settings', () => {
+      const source = makeLogSource();
+      const dateRange: [Date, Date] = [
+        new Date('2026-04-24T09:50:00.000Z'),
+        new Date('2026-04-24T09:55:00.000Z'),
+      ];
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        displayType: DisplayType.Line,
+        dateRange,
+        dateRangeStartInclusive: true,
+        dateRangeEndInclusive: false,
+        granularity: '5 minute',
+        groupBy: 'ServiceName',
+      });
+
+      expect(config.displayType).toBe(DisplayType.Line);
+      expect(config.dateRange).toBe(dateRange);
+      expect(config.dateRangeStartInclusive).toBe(true);
+      expect(config.dateRangeEndInclusive).toBe(false);
+      expect(config.granularity).toBe('5 minute');
+      expect(config.groupBy).toBe('ServiceName');
+    });
+
+    it('pulls from, timestampValueExpression, and source id from the source', () => {
+      const source = makeLogSource();
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.from).toEqual({
+        databaseName: 'default',
+        tableName: 'otel_logs',
+      });
+      expect(config.timestampValueExpression).toBe('TimestampTime');
+      expect(config.source).toBe('log-source-1');
+    });
+
+    it('defaults connection to source.connection and allows override', () => {
+      const source = makeLogSource({ connection: 'source-conn' });
+
+      const fromSource = buildSearchChartConfig(source, { where: '' });
+      expect(fromSource.connection).toBe('source-conn');
+
+      const overridden = buildSearchChartConfig(source, {
+        where: '',
+        connection: 'override-conn',
+      });
+      expect(overridden.connection).toBe('override-conn');
+    });
+
+    it('defaults displayType to Search when not provided', () => {
+      const config = buildSearchChartConfig(makeLogSource(), { where: '' });
+
+      expect(config.displayType).toBe(DisplayType.Search);
+    });
+  });
+
+  describe('end-to-end shape parity with DBSearchPage', () => {
+    // Mirrors the key fields the app search page historically produced so
+    // downstream components depending on that shape keep working.
+    it('produces the same filters ordering as DBSearchPage for tableFilterExpression + user filters', () => {
+      const source = makeLogSource({
+        tableFilterExpression: "ServiceName NOT IN ('hidden')",
+      });
+      const userFilter: Filter = {
+        type: 'lucene',
+        condition: 'Level:error',
+      };
+
+      const config = buildSearchChartConfig(source, {
+        where: 'Body:"oops"',
+        whereLanguage: 'lucene',
+        filters: [userFilter],
+      });
+
+      expect(config.filters?.[0]).toEqual({
+        type: 'sql',
+        condition: "ServiceName NOT IN ('hidden')",
+      });
+      expect(config.filters?.[1]).toEqual(userFilter);
+    });
+  });
+});

--- a/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
+++ b/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
@@ -176,19 +176,17 @@ describe('buildSearchChartConfig', () => {
 
   // Covers every behavioral branch of the internal `resolveSelect` helper
   // by varying the inputs to `buildSearchChartConfig`. Precedence is:
-  //   caller `select` (non-empty) > caller `defaultSelect` (non-empty) >
-  //   `source.defaultTableSelectExpression` (Log/Trace only) > '' (empty).
+  //   caller `select` (non-empty) >
+  //   `source.defaultTableSelectExpression` (Log/Trace only) >
+  //   '' (empty).
   // "Non-empty" means `length > 0` for both string and array inputs.
   describe('select precedence', () => {
     // Reused single-row aggregate select-list for array-valued cases.
-    const aggSelectA = [
+    const aggSelect = [
       { aggFn: 'count' as const, aggCondition: '', valueExpression: '' },
     ];
-    const aggSelectB = [
-      { aggFn: 'sum' as const, aggCondition: '', valueExpression: 'x' },
-    ];
 
-    it('prefers caller-provided select over all fallbacks', () => {
+    it('prefers caller-provided string select over the source default', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
@@ -196,27 +194,25 @@ describe('buildSearchChartConfig', () => {
       const config = buildSearchChartConfig(source, {
         where: '',
         select: 'caller-select',
-        defaultSelect: 'caller-default',
       });
 
       expect(config.select).toBe('caller-select');
     });
 
-    it('returns a non-empty array `select` as-is, ahead of defaultSelect', () => {
+    it('returns a non-empty array `select` as-is', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
 
       const config = buildSearchChartConfig(source, {
         where: '',
-        select: aggSelectA,
-        defaultSelect: aggSelectB,
+        select: aggSelect,
       });
 
-      expect(config.select).toEqual(aggSelectA);
+      expect(config.select).toEqual(aggSelect);
     });
 
-    it('falls back to defaultSelect when select is empty string', () => {
+    it('falls back to source default when select is empty string', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
@@ -224,13 +220,12 @@ describe('buildSearchChartConfig', () => {
       const config = buildSearchChartConfig(source, {
         where: '',
         select: '',
-        defaultSelect: 'caller-default',
       });
 
-      expect(config.select).toBe('caller-default');
+      expect(config.select).toBe('source-default');
     });
 
-    it('falls back to defaultSelect when select is an empty array', () => {
+    it('falls back to source default when select is an empty array', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
@@ -238,13 +233,12 @@ describe('buildSearchChartConfig', () => {
       const config = buildSearchChartConfig(source, {
         where: '',
         select: [],
-        defaultSelect: 'caller-default',
       });
 
-      expect(config.select).toBe('caller-default');
+      expect(config.select).toBe('source-default');
     });
 
-    it('falls back to defaultSelect when select is null', () => {
+    it('falls back to source default when select is null', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
@@ -252,39 +246,12 @@ describe('buildSearchChartConfig', () => {
       const config = buildSearchChartConfig(source, {
         where: '',
         select: null,
-        defaultSelect: 'caller-default',
-      });
-
-      expect(config.select).toBe('caller-default');
-    });
-
-    it('falls back to source default when defaultSelect is empty string', () => {
-      const source = makeLogSource({
-        defaultTableSelectExpression: 'source-default',
-      });
-
-      const config = buildSearchChartConfig(source, {
-        where: '',
-        defaultSelect: '',
       });
 
       expect(config.select).toBe('source-default');
     });
 
-    it('falls back to source default when defaultSelect is an empty array', () => {
-      const source = makeLogSource({
-        defaultTableSelectExpression: 'source-default',
-      });
-
-      const config = buildSearchChartConfig(source, {
-        where: '',
-        defaultSelect: [],
-      });
-
-      expect(config.select).toBe('source-default');
-    });
-
-    it('falls back to source defaultTableSelectExpression when caller fields are missing', () => {
+    it('falls back to source defaultTableSelectExpression when select is missing', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
       });
@@ -292,17 +259,6 @@ describe('buildSearchChartConfig', () => {
       const config = buildSearchChartConfig(source, { where: '' });
 
       expect(config.select).toBe('source-default');
-    });
-
-    it('supports array-valued defaultSelect (count aggregate) for alert-style queries', () => {
-      const source = makeLogSource();
-
-      const config = buildSearchChartConfig(source, {
-        where: '',
-        defaultSelect: aggSelectA,
-      });
-
-      expect(config.select).toEqual(aggSelectA);
     });
 
     it('returns empty string when Log source has no defaultTableSelectExpression and caller provides nothing', () => {
@@ -449,10 +405,10 @@ describe('buildSearchChartConfig', () => {
       ]);
     });
 
-    it('flows through buildSearchChartConfig as the resolved SELECT when no caller select is provided', () => {
+    it('flows through buildSearchChartConfig as the resolved SELECT', () => {
       const config = buildSearchChartConfig(makeLogSource(), {
         where: '',
-        defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
+        select: ALERT_COUNT_DEFAULT_SELECT,
       });
 
       expect(config.select).toEqual(ALERT_COUNT_DEFAULT_SELECT);

--- a/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
+++ b/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
@@ -1,5 +1,8 @@
 import { DisplayType, Filter, SourceKind, TSource } from '../../types';
-import { buildSearchChartConfig } from '../searchChartConfig';
+import {
+  ALERT_COUNT_DEFAULT_SELECT,
+  buildSearchChartConfig,
+} from '../searchChartConfig';
 
 // Factory helpers keep tests focused on the behavior under test rather than
 // the full source shape. We cast to TSource because most per-kind fields are
@@ -324,6 +327,32 @@ describe('buildSearchChartConfig', () => {
         condition: "ServiceName NOT IN ('hidden')",
       });
       expect(config.filters?.[1]).toEqual(userFilter);
+    });
+  });
+
+  // Locks in the exact shape of the shared count() default SELECT used by
+  // both the alert task and the alert preview chart. Drift here would mean
+  // the two paths render queries differently — the original symptom of
+  // HDX-4111.
+  describe('ALERT_COUNT_DEFAULT_SELECT', () => {
+    it('exports a single count() aggregate with all required fields', () => {
+      expect(ALERT_COUNT_DEFAULT_SELECT).toEqual([
+        {
+          aggFn: 'count',
+          aggCondition: '',
+          aggConditionLanguage: 'sql',
+          valueExpression: '',
+        },
+      ]);
+    });
+
+    it('flows through buildSearchChartConfig as the resolved SELECT when no caller select is provided', () => {
+      const config = buildSearchChartConfig(makeLogSource(), {
+        where: '',
+        defaultSelect: ALERT_COUNT_DEFAULT_SELECT,
+      });
+
+      expect(config.select).toEqual(ALERT_COUNT_DEFAULT_SELECT);
     });
   });
 });

--- a/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
+++ b/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
@@ -174,7 +174,20 @@ describe('buildSearchChartConfig', () => {
     });
   });
 
+  // Covers every behavioral branch of the internal `resolveSelect` helper
+  // by varying the inputs to `buildSearchChartConfig`. Precedence is:
+  //   caller `select` (non-empty) > caller `defaultSelect` (non-empty) >
+  //   `source.defaultTableSelectExpression` (Log/Trace only) > '' (empty).
+  // "Non-empty" means `length > 0` for both string and array inputs.
   describe('select precedence', () => {
+    // Reused single-row aggregate select-list for array-valued cases.
+    const aggSelectA = [
+      { aggFn: 'count' as const, aggCondition: '', valueExpression: '' },
+    ];
+    const aggSelectB = [
+      { aggFn: 'sum' as const, aggCondition: '', valueExpression: 'x' },
+    ];
+
     it('prefers caller-provided select over all fallbacks', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
@@ -187,6 +200,20 @@ describe('buildSearchChartConfig', () => {
       });
 
       expect(config.select).toBe('caller-select');
+    });
+
+    it('returns a non-empty array `select` as-is, ahead of defaultSelect', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        select: aggSelectA,
+        defaultSelect: aggSelectB,
+      });
+
+      expect(config.select).toEqual(aggSelectA);
     });
 
     it('falls back to defaultSelect when select is empty string', () => {
@@ -203,6 +230,60 @@ describe('buildSearchChartConfig', () => {
       expect(config.select).toBe('caller-default');
     });
 
+    it('falls back to defaultSelect when select is an empty array', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        select: [],
+        defaultSelect: 'caller-default',
+      });
+
+      expect(config.select).toBe('caller-default');
+    });
+
+    it('falls back to defaultSelect when select is null', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        select: null,
+        defaultSelect: 'caller-default',
+      });
+
+      expect(config.select).toBe('caller-default');
+    });
+
+    it('falls back to source default when defaultSelect is empty string', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        defaultSelect: '',
+      });
+
+      expect(config.select).toBe('source-default');
+    });
+
+    it('falls back to source default when defaultSelect is an empty array', () => {
+      const source = makeLogSource({
+        defaultTableSelectExpression: 'source-default',
+      });
+
+      const config = buildSearchChartConfig(source, {
+        where: '',
+        defaultSelect: [],
+      });
+
+      expect(config.select).toBe('source-default');
+    });
+
     it('falls back to source defaultTableSelectExpression when caller fields are missing', () => {
       const source = makeLogSource({
         defaultTableSelectExpression: 'source-default',
@@ -213,18 +294,41 @@ describe('buildSearchChartConfig', () => {
       expect(config.select).toBe('source-default');
     });
 
-    it('supports array-valued SELECT (count aggregate) for alert-style queries', () => {
+    it('supports array-valued defaultSelect (count aggregate) for alert-style queries', () => {
       const source = makeLogSource();
-      const selectList = [
-        { aggFn: 'count' as const, aggCondition: '', valueExpression: '' },
-      ];
 
       const config = buildSearchChartConfig(source, {
         where: '',
-        defaultSelect: selectList,
+        defaultSelect: aggSelectA,
       });
 
-      expect(config.select).toEqual(selectList);
+      expect(config.select).toEqual(aggSelectA);
+    });
+
+    it('returns empty string when Log source has no defaultTableSelectExpression and caller provides nothing', () => {
+      const source = makeLogSource({ defaultTableSelectExpression: undefined });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.select).toBe('');
+    });
+
+    it('uses Trace source defaultTableSelectExpression when set', () => {
+      const source = makeTraceSource({
+        defaultTableSelectExpression: 'trace-default',
+      });
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.select).toBe('trace-default');
+    });
+
+    it('returns empty string for Metric source with no caller fields (non-Log/Trace branch)', () => {
+      const source = makeMetricSource();
+
+      const config = buildSearchChartConfig(source, { where: '' });
+
+      expect(config.select).toBe('');
     });
   });
 

--- a/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
+++ b/packages/common-utils/src/core/__tests__/searchChartConfig.test.ts
@@ -436,8 +436,7 @@ describe('buildSearchChartConfig', () => {
 
   // Locks in the exact shape of the shared count() default SELECT used by
   // both the alert task and the alert preview chart. Drift here would mean
-  // the two paths render queries differently — the original symptom of
-  // HDX-4111.
+  // the two paths render queries differently for the same alert.
   describe('ALERT_COUNT_DEFAULT_SELECT', () => {
     it('exports a single count() aggregate with all required fields', () => {
       expect(ALERT_COUNT_DEFAULT_SELECT).toEqual([

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -29,6 +29,32 @@ import {
 export type SearchChartConfig = BuilderChartConfig & Partial<DateRange>;
 
 /**
+ * Default SELECT used by alert evaluators when no caller-supplied SELECT
+ * is provided: a single `count()` aggregate.
+ *
+ * Shared between the scheduled alert task (`checkAlerts/index.ts`) and the
+ * alert preview chart (`AlertPreviewChart.tsx`) so the two paths produce
+ * byte-identical SELECT shapes. The `as const` annotations are required
+ * so TypeScript infers literal types (`'count'`, `'sql'`) that satisfy the
+ * strict branch of `RootValueExpressionSchema` (which requires
+ * `aggConditionLanguage` whenever `aggFn` is set).
+ *
+ * Today every field except `aggFn` is empty / no-op — but pinning the
+ * shape now prevents the alert task and the preview from drifting if
+ * someone later adds, e.g., a non-empty `aggCondition` to one site without
+ * also adding `aggConditionLanguage` (which would silently render under
+ * `lucene` vs `sql` in different code paths inside `renderChartConfig`).
+ */
+export const ALERT_COUNT_DEFAULT_SELECT: SelectList = [
+  {
+    aggFn: 'count' as const,
+    aggCondition: '',
+    aggConditionLanguage: 'sql' as const,
+    valueExpression: '',
+  },
+];
+
+/**
  * Saved-search-shaped inputs for assembling a chart config.
  *
  * Fields are primitives (not a persisted SavedSearch) so this can also be

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -65,8 +65,8 @@ export type SearchChartConfigInput = {
   whereLanguage?: SearchConditionLanguage | null;
   filters?: Filter[] | null;
   /**
-   * SELECT list. If null/undefined/empty, falls back to `defaultSelect`, then
-   * to `source.defaultTableSelectExpression` when the source kind supports it.
+   * SELECT list. If null/undefined/empty, falls back to
+   * `source.defaultTableSelectExpression` when the source kind supports it.
    */
   select?: SelectList | null;
   orderBy?: SortSpecificationList | null;
@@ -80,15 +80,12 @@ export type SearchChartConfigInput = {
   dateRangeStartInclusive?: boolean;
   dateRangeEndInclusive?: boolean;
   granularity?: SQLInterval;
-
-  /** Fallback SELECT when neither `select` nor the source's default is set. */
-  defaultSelect?: BuilderChartConfig['select'];
 };
 
 /**
  * Resolve the SELECT list, preferring caller-provided `select`, then the
- * caller's `defaultSelect`, then the source's `defaultTableSelectExpression`
- * (for Log / Trace sources), falling back to an empty string.
+ * source's `defaultTableSelectExpression` (for Log / Trace sources), falling
+ * back to an empty string.
  *
  * Both `string` and `DerivedColumn[]` SELECT shapes have a `.length` property,
  * so a single non-empty check covers "skip empty `''` strings and skip empty
@@ -97,13 +94,8 @@ export type SearchChartConfigInput = {
 function resolveSelect(
   source: TSource,
   select: SelectList | null | undefined,
-  defaultSelect: BuilderChartConfig['select'] | undefined,
 ): BuilderChartConfig['select'] {
-  const isNonEmpty = (v: SelectList | null | undefined): v is SelectList =>
-    v != null && v.length > 0;
-
-  if (isNonEmpty(select)) return select;
-  if (isNonEmpty(defaultSelect)) return defaultSelect;
+  if (select != null && select.length > 0) return select;
   if (isLogSource(source) || isTraceSource(source)) {
     return source.defaultTableSelectExpression ?? '';
   }
@@ -156,7 +148,7 @@ export function buildSearchChartConfig(
     displayType: input.displayType ?? DisplayType.Search,
     source: source.id,
     from: source.from,
-    select: resolveSelect(source, input.select, input.defaultSelect),
+    select: resolveSelect(source, input.select),
     where: input.where ?? '',
     whereLanguage: input.whereLanguage ?? 'sql',
     timestampValueExpression: source.timestampValueExpression,

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -88,30 +88,22 @@ export type SearchChartConfigInput = {
 /**
  * Resolve the SELECT list, preferring caller-provided `select`, then the
  * caller's `defaultSelect`, then the source's `defaultTableSelectExpression`
- * (for Log / Trace sources).
+ * (for Log / Trace sources), falling back to an empty string.
  *
- * Treats an empty string as "no select" so we fall through to the defaults
- * — matches the app's historical behavior.
+ * Both `string` and `DerivedColumn[]` SELECT shapes have a `.length` property,
+ * so a single non-empty check covers "skip empty `''` strings and skip empty
+ * `[]` arrays" symmetrically — matching the app's historical behavior.
  */
 function resolveSelect(
   source: TSource,
   select: SelectList | null | undefined,
   defaultSelect: BuilderChartConfig['select'] | undefined,
 ): BuilderChartConfig['select'] {
-  if (select != null) {
-    if (typeof select === 'string') {
-      if (select.length > 0) return select;
-    } else if (select.length > 0) {
-      return select;
-    }
-  }
-  if (defaultSelect != null) {
-    if (typeof defaultSelect === 'string') {
-      if (defaultSelect.length > 0) return defaultSelect;
-    } else if (defaultSelect.length > 0) {
-      return defaultSelect;
-    }
-  }
+  const isNonEmpty = (v: SelectList | null | undefined): v is SelectList =>
+    v != null && v.length > 0;
+
+  if (isNonEmpty(select)) return select;
+  if (isNonEmpty(defaultSelect)) return defaultSelect;
   if (isLogSource(source) || isTraceSource(source)) {
     return source.defaultTableSelectExpression ?? '';
   }

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -1,0 +1,140 @@
+import {
+  BuilderChartConfig,
+  BuilderChartConfigWithOptDateRange,
+  DisplayType,
+  Filter,
+  isLogSource,
+  isTraceSource,
+  pickSampleWeightExpressionProps,
+  SearchCondition,
+  SearchConditionLanguage,
+  SelectList,
+  SortSpecificationList,
+  SQLInterval,
+  TSource,
+} from '@/types';
+
+/**
+ * Saved-search-shaped inputs for assembling a chart config.
+ *
+ * Fields are primitives (not a persisted SavedSearch) so this can also be
+ * called from in-flight, unsaved contexts like the alert preview chart.
+ */
+export type SearchChartConfigInput = {
+  where: SearchCondition | null | undefined;
+  whereLanguage?: SearchConditionLanguage | null;
+  filters?: Filter[] | null;
+  /**
+   * SELECT list. If null/undefined/empty, falls back to `defaultSelect`, then
+   * to `source.defaultTableSelectExpression` when the source kind supports it.
+   */
+  select?: SelectList | null;
+  orderBy?: SortSpecificationList | null;
+  groupBy?: SelectList | null;
+
+  // Display / time-range knobs
+  displayType?: DisplayType;
+  /** Overrides `source.connection` when provided. */
+  connection?: string;
+  dateRange?: [Date, Date];
+  dateRangeStartInclusive?: boolean;
+  dateRangeEndInclusive?: boolean;
+  granularity?: SQLInterval;
+
+  /** Fallback SELECT when neither `select` nor the source's default is set. */
+  defaultSelect?: BuilderChartConfig['select'];
+};
+
+/**
+ * Resolve the SELECT list, preferring caller-provided `select`, then the
+ * caller's `defaultSelect`, then the source's `defaultTableSelectExpression`
+ * (for Log / Trace sources).
+ *
+ * Treats an empty string as "no select" so we fall through to the defaults
+ * — matches the app's historical behavior.
+ */
+function resolveSelect(
+  source: TSource,
+  select: SelectList | null | undefined,
+  defaultSelect: BuilderChartConfig['select'] | undefined,
+): BuilderChartConfig['select'] {
+  if (select != null) {
+    if (typeof select === 'string') {
+      if (select.length > 0) return select;
+    } else if (select.length > 0) {
+      return select;
+    }
+  }
+  if (defaultSelect != null) {
+    if (typeof defaultSelect === 'string') {
+      if (defaultSelect.length > 0) return defaultSelect;
+    } else if (defaultSelect.length > 0) {
+      return defaultSelect;
+    }
+  }
+  if (isLogSource(source) || isTraceSource(source)) {
+    return source.defaultTableSelectExpression ?? '';
+  }
+  return '';
+}
+
+/**
+ * Build a `BuilderChartConfigWithOptDateRange` from a source plus
+ * saved-search-style inputs.
+ *
+ * This is the single source of truth for "how do we translate a saved search
+ * (or unsaved alert preview) into a chart config?" and is shared by:
+ *   - the app search page (`DBSearchPage`)
+ *   - the alert preview chart in the alert editor (`AlertPreviewChart`)
+ *   - the scheduled alert task's SAVED_SEARCH evaluator
+ *
+ * Keeping this in one place prevents drift like HDX-4111, where the app
+ * applied `source.tableFilterExpression` and the alert task did not,
+ * producing false-positive alerts whose count did not reconcile with the
+ * app's results for the same saved search and window.
+ */
+export function buildSearchChartConfig(
+  source: TSource,
+  input: SearchChartConfigInput,
+): BuilderChartConfigWithOptDateRange {
+  // Prepend the Log source's `tableFilterExpression` as a SQL filter when set,
+  // so the alert query and the app search see the same row set.
+  // Log sources are the only kind that carries `tableFilterExpression` today.
+  const tableFilter: Filter[] =
+    isLogSource(source) && source.tableFilterExpression != null
+      ? [{ type: 'sql', condition: source.tableFilterExpression }]
+      : [];
+  const userFilters: Filter[] = input.filters ?? [];
+  const mergedFilters: Filter[] = [...tableFilter, ...userFilters];
+
+  const implicitColumnExpression =
+    isLogSource(source) || isTraceSource(source)
+      ? source.implicitColumnExpression
+      : undefined;
+
+  const config: BuilderChartConfigWithOptDateRange = {
+    connection: input.connection ?? source.connection,
+    displayType: input.displayType ?? DisplayType.Search,
+    source: source.id,
+    from: source.from,
+    select: resolveSelect(source, input.select, input.defaultSelect),
+    where: input.where ?? '',
+    whereLanguage: input.whereLanguage ?? 'sql',
+    timestampValueExpression: source.timestampValueExpression,
+    ...(implicitColumnExpression != null ? { implicitColumnExpression } : {}),
+    ...pickSampleWeightExpressionProps(source),
+    ...(mergedFilters.length > 0 ? { filters: mergedFilters } : {}),
+    ...(input.groupBy != null ? { groupBy: input.groupBy } : {}),
+    ...(input.orderBy != null ? { orderBy: input.orderBy } : {}),
+    ...(input.dateRange != null ? { dateRange: input.dateRange } : {}),
+    ...(input.dateRangeStartInclusive != null
+      ? { dateRangeStartInclusive: input.dateRangeStartInclusive }
+      : {}),
+    ...(input.dateRangeEndInclusive != null
+      ? { dateRangeEndInclusive: input.dateRangeEndInclusive }
+      : {}),
+    ...(input.granularity != null ? { granularity: input.granularity } : {}),
+  };
+
+  return config;
+}

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -120,10 +120,10 @@ function resolveSelect(
  *   - the alert preview chart in the alert editor (`AlertPreviewChart`)
  *   - the scheduled alert task's SAVED_SEARCH evaluator
  *
- * Keeping this in one place prevents drift like HDX-4111, where the app
- * applied `source.tableFilterExpression` and the alert task did not,
- * producing false-positive alerts whose count did not reconcile with the
- * app's results for the same saved search and window.
+ * Keeping the assembly in one place prevents drift between the three paths
+ * — for example, ensuring `source.tableFilterExpression` (and any future
+ * source-level fields) is applied uniformly, so the alert task and the app
+ * search produce the same row set for the same saved search and window.
  */
 export function buildSearchChartConfig(
   source: TSource,

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -1,6 +1,6 @@
 import {
   BuilderChartConfig,
-  BuilderChartConfigWithOptDateRange,
+  DateRange,
   DisplayType,
   Filter,
   isLogSource,
@@ -13,6 +13,20 @@ import {
   SQLInterval,
   TSource,
 } from '@/types';
+
+/**
+ * Return type for `buildSearchChartConfig`.
+ *
+ * The full `BuilderChartConfig` (with required `timestampValueExpression`,
+ * which we always set from the source) plus optional date-range knobs that
+ * are present iff the caller passed them.
+ *
+ * This is intentionally narrower than `BuilderChartConfigWithOptDateRange`
+ * (which makes `timestampValueExpression` optional). The narrower type lets
+ * downstream consumers spread the result into a `BuilderChartConfigWithDateRange`
+ * after adding `dateRange` without TS rejecting the timestamp field.
+ */
+export type SearchChartConfig = BuilderChartConfig & Partial<DateRange>;
 
 /**
  * Saved-search-shaped inputs for assembling a chart config.
@@ -96,7 +110,7 @@ function resolveSelect(
 export function buildSearchChartConfig(
   source: TSource,
   input: SearchChartConfigInput,
-): BuilderChartConfigWithOptDateRange {
+): SearchChartConfig {
   // Prepend the Log source's `tableFilterExpression` as a SQL filter when set,
   // so the alert query and the app search see the same row set.
   // Log sources are the only kind that carries `tableFilterExpression` today.
@@ -112,7 +126,7 @@ export function buildSearchChartConfig(
       ? source.implicitColumnExpression
       : undefined;
 
-  const config: BuilderChartConfigWithOptDateRange = {
+  const config: SearchChartConfig = {
     connection: input.connection ?? source.connection,
     displayType: input.displayType ?? DisplayType.Search,
     source: source.id,

--- a/packages/common-utils/src/core/searchChartConfig.ts
+++ b/packages/common-utils/src/core/searchChartConfig.ts
@@ -132,6 +132,13 @@ export function buildSearchChartConfig(
   // Prepend the Log source's `tableFilterExpression` as a SQL filter when set,
   // so the alert query and the app search see the same row set.
   // Log sources are the only kind that carries `tableFilterExpression` today.
+  //
+  // NOTE: `tableFilterExpression` is deprecated. It's an application-side SQL
+  // predicate (not a ClickHouse row policy), so it can't enforce real tenant
+  // isolation — anyone with direct SELECT access to the table bypasses it.
+  // For hard isolation, configure a ClickHouse ROW POLICY at the DB level
+  // instead. Existing values are still honored here for backward
+  // compatibility; new sources should not set the field.
   const tableFilter: Filter[] =
     isLogSource(source) && source.tableFilterExpression != null
       ? [{ type: 'sql', condition: source.tableFilterExpression }]

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1148,6 +1148,15 @@ export const LogSourceSchema = BaseSourceSchema.extend({
   spanIdExpression: z.string().optional(),
   implicitColumnExpression: z.string().optional(),
   uniqueRowIdExpression: z.string().optional(),
+  /**
+   * @deprecated Application-side SQL predicate AND'd into every query against
+   * the source. Not a security boundary — bypassable by direct table SELECT.
+   * For hard tenant isolation, use a ClickHouse ROW POLICY at the DB level:
+   * https://clickhouse.com/docs/sql-reference/statements/create/row-policy
+   *
+   * Existing values are still honored at query time; new sources should not
+   * set it. The Sources settings UI form input is disabled.
+   */
   tableFilterExpression: z.string().optional(),
   highlightedTraceAttributeExpressions:
     HighlightedAttributeExpressionsSchema.optional(),


### PR DESCRIPTION
## Summary

Refs [HDX-4111](https://linear.app/clickhouse/issue/HDX-4111/private-instance-alert-system-triggering-false-positive-alerts).

Consolidate the saved-search → chart-config builder into a single shared helper. The alert task, the alert preview chart, and the app search page each had their own inline builder, and only the search page applied `source.tableFilterExpression`. On Log sources where that field is set, the alert path could legitimately count rows the search page hides — same false-positive class as HDX-4111, different cause from the underlying ClickHouse bug. Routing all three paths through the shared builder eliminates this drift class.

## Changes

### Shared chart-config builder

`packages/common-utils/src/core/searchChartConfig.ts` (new) exports `buildSearchChartConfig(source, input)` — the single source of truth for assembling a `BuilderChartConfig` from a `TSource` plus saved-search-style fields. Three call sites now route through it:

| Call site | Before | After |
| --- | --- | --- |
| `packages/app/src/DBSearchPage.tsx` (`useSearchedConfigToChartConfig`) | inline; applied `tableFilterExpression`; latently dropped it when user filters were non-null | shared builder |
| `packages/app/src/components/AlertPreviewChart.tsx` | inline; did NOT apply `tableFilterExpression` | shared builder |
| `packages/api/src/tasks/checkAlerts/index.ts` (`SAVED_SEARCH` branch) | inline; did NOT apply `tableFilterExpression` | shared builder |

Behavior fixes that fall out of consolidation:
- `tableFilterExpression` is now applied uniformly on Log sources by the alert task and the alert preview.
- A latent bug in the search-page builder is fixed: a non-null `filters` array no longer silently drops the table filter via spread-overwrite.
- The alert preview chart now matches what the alert task will actually count.

### Shared default SELECT for count alerts

`ALERT_COUNT_DEFAULT_SELECT` (in the same module) — both the alert task and the alert preview chart use this constant for the `count()` aggregate, so the two paths produce byte-identical SELECT shapes.

### `SearchChartConfig` return type

Narrower than `BuilderChartConfigWithOptDateRange` (keeps `timestampValueExpression` required, since the builder always sets it from the source). Lets downstream callers spread-and-add `dateRange` into `BuilderChartConfigWithDateRange` without TS errors.

## Risk / behavior change

Alerts on Log sources with `tableFilterExpression` set will now evaluate against a strictly smaller row set — the same rows the search page was already showing. Any alert that was quietly firing only because of rows hidden by `tableFilterExpression` will stop firing. This is a correctness fix.

Follow-up structural work (TILE alert chart-config consolidation, `computeAliasWithClauses` extraction) is tracked in [HDX-4113](https://linear.app/clickhouse/issue/HDX-4113/consolidate-alert-chart-config-assembly-into-hyperdxcommon-utils).