### PR TITLE
Add inline thumbs up/down feedback widget in app navigation

### DIFF
--- a/packages/app/src/components/AppNav/AppNav.module.scss
+++ b/packages/app/src/components/AppNav/AppNav.module.scss
@@ -449,6 +449,23 @@ $transition-slow: 0.2s ease;
   padding-bottom: $spacing-sm;
 }
 
+/* Feedback */
+
+.feedbackLabel {
+  @include text-truncate;
+
+  line-height: 1.2;
+}
+
+.feedbackHide {
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--color-text-sidenav-link-active);
+  }
+}
+
 /* Scrollbar Customization */
 
 .scrollbar {

--- a/packages/app/src/components/AppNav/AppNav.tsx
+++ b/packages/app/src/components/AppNav/AppNav.tsx
@@ -49,6 +49,7 @@ import {
   AppNavLink,
   AppNavUserMenu,
 } from './AppNav.components';
+import { AppNavFeedback } from './AppNavFeedback';
 
 import styles from './AppNav.module.scss';
 
@@ -475,6 +476,9 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
 
             {/* Help */}
             <AppNavHelpMenu version={APP_VERSION} />
+
+            {/* Feedback */}
+            <AppNavFeedback />
 
             {/* Team Settings (Cloud only) */}
             {!IS_LOCAL_MODE && (

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -18,6 +18,8 @@ import {
   IconThumbUpFilled,
 } from '@tabler/icons-react';
 
+import { IS_LOCAL_MODE } from '@/config';
+
 import { AppNavContext } from './AppNav.components';
 
 import styles from './AppNav.module.scss';
@@ -26,16 +28,27 @@ type FeedbackVote = 'up' | 'down' | null;
 
 type FeedbackState = 'idle' | 'voted' | 'thanks';
 
+const FORCE_ENABLE_KEY = 'hdx-feedback-enabled';
+
 export const AppNavFeedback = () => {
   const { isCollapsed } = React.useContext(AppNavContext);
+  const [forceEnabled] = useLocalStorage<string>({
+    key: FORCE_ENABLE_KEY,
+    defaultValue: '',
+  });
   const [hidden, setHidden] = useLocalStorage<boolean>({
     key: 'feedbackHidden',
     defaultValue: false,
   });
+
   const [vote, setVote] = useState<FeedbackVote>(null);
   const [comment, setComment] = useState('');
   const [state, setState] = useState<FeedbackState>('idle');
   const router = useRouter();
+
+  // Only show when HyperDX SDK is active (non-local mode),
+  // or when overridden via: localStorage.setItem('hdx-feedback-enabled', 'true')
+  const sdkEnabled = !IS_LOCAL_MODE || forceEnabled === 'true';
 
   const reset = useCallback(() => {
     setVote(null);
@@ -67,7 +80,7 @@ export const AppNavFeedback = () => {
     }, 1500);
   }, [vote, comment, router, reset, setHidden]);
 
-  if (hidden) return null;
+  if (!sdkEnabled || hidden) return null;
 
   if (isCollapsed) {
     return (

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -3,18 +3,15 @@ import { useRouter } from 'next/router';
 import HyperDX from '@hyperdx/browser';
 import {
   ActionIcon,
+  Box,
   Button,
   Group,
-  Popover,
-  Stack,
   Text,
   Textarea,
   Tooltip,
-  UnstyledButton,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useLocalStorage } from '@mantine/hooks';
 import {
-  IconMessageHeart,
   IconThumbDown,
   IconThumbDownFilled,
   IconThumbUp,
@@ -27,31 +24,29 @@ import styles from './AppNav.module.scss';
 
 type FeedbackVote = 'up' | 'down' | null;
 
-type FeedbackState = 'vote' | 'comment' | 'thanks';
+type FeedbackState = 'idle' | 'voted' | 'thanks';
 
 export const AppNavFeedback = () => {
   const { isCollapsed } = React.useContext(AppNavContext);
-  const [opened, { close, toggle }] = useDisclosure(false);
+  const [hidden, setHidden] = useLocalStorage<boolean>({
+    key: 'feedbackHidden',
+    defaultValue: false,
+  });
   const [vote, setVote] = useState<FeedbackVote>(null);
   const [comment, setComment] = useState('');
-  const [state, setState] = useState<FeedbackState>('vote');
+  const [state, setState] = useState<FeedbackState>('idle');
   const router = useRouter();
 
   const reset = useCallback(() => {
     setVote(null);
     setComment('');
-    setState('vote');
+    setState('idle');
   }, []);
-
-  const handleClose = useCallback(() => {
-    close();
-    setTimeout(reset, 200);
-  }, [close, reset]);
 
   const handleVote = useCallback(
     (newVote: FeedbackVote) => {
       setVote(newVote);
-      setState('comment');
+      setState('voted');
     },
     [setVote, setState],
   );
@@ -66,126 +61,152 @@ export const AppNavFeedback = () => {
     });
 
     setState('thanks');
-    setTimeout(handleClose, 1500);
-  }, [vote, comment, router, handleClose]);
+    setTimeout(() => {
+      reset();
+      setHidden(true);
+    }, 1500);
+  }, [vote, comment, router, reset, setHidden]);
+
+  if (hidden) return null;
+
+  if (isCollapsed) {
+    return (
+      <Tooltip label="Feedback" position="right">
+        <Group
+          data-testid="feedback-inline"
+          gap={0}
+          justify="center"
+          py={4}
+          wrap="nowrap"
+        >
+          <ActionIcon
+            data-testid="feedback-thumbs-up"
+            variant="subtle"
+            size="sm"
+            onClick={() => {
+              handleVote('up');
+              HyperDX.addAction('user feedback submitted', {
+                vote: 'up',
+                comment: '',
+                page: router.pathname,
+                route: router.asPath,
+                query: JSON.stringify(router.query),
+              });
+            }}
+            title="Thumbs up"
+          >
+            <IconThumbUp size={14} />
+          </ActionIcon>
+          <ActionIcon
+            data-testid="feedback-thumbs-down"
+            variant="subtle"
+            size="sm"
+            onClick={() => {
+              handleVote('down');
+              HyperDX.addAction('user feedback submitted', {
+                vote: 'down',
+                comment: '',
+                page: router.pathname,
+                route: router.asPath,
+                query: JSON.stringify(router.query),
+              });
+            }}
+            title="Thumbs down"
+          >
+            <IconThumbDown size={14} />
+          </ActionIcon>
+        </Group>
+      </Tooltip>
+    );
+  }
 
   return (
-    <Popover
-      opened={opened}
-      onClose={handleClose}
-      position="right-start"
-      shadow="md"
-      width={280}
-    >
-      <Popover.Target>
-        <Tooltip label="Feedback" position="right" disabled={!isCollapsed}>
-          <UnstyledButton
-            data-testid="feedback-trigger"
-            className={styles.navItem}
-            onClick={toggle}
-          >
-            <span className={styles.navItemContent}>
-              <span className={styles.navItemIcon}>
-                <IconMessageHeart size={16} />
-              </span>
-              {!isCollapsed && <span>Feedback</span>}
-            </span>
-          </UnstyledButton>
-        </Tooltip>
-      </Popover.Target>
-      <Popover.Dropdown>
-        {state === 'vote' && (
-          <Stack gap="sm">
-            <Text size="sm" fw={500}>
+    <Box data-testid="feedback-inline" px="lg" py={4}>
+      {state === 'thanks' ? (
+        <Text
+          size="xs"
+          c="dimmed"
+          data-testid="feedback-thanks"
+          className={styles.feedbackLabel}
+        >
+          Thanks for your feedback!
+        </Text>
+      ) : (
+        <>
+          <Group gap={6} wrap="nowrap" align="center">
+            <ActionIcon
+              data-testid="feedback-thumbs-up"
+              variant={vote === 'up' ? 'secondary' : 'subtle'}
+              size="sm"
+              onClick={() => handleVote('up')}
+              title="Thumbs up"
+            >
+              {vote === 'up' ? (
+                <IconThumbUpFilled size={14} />
+              ) : (
+                <IconThumbUp size={14} />
+              )}
+            </ActionIcon>
+            <ActionIcon
+              data-testid="feedback-thumbs-down"
+              variant={vote === 'down' ? 'secondary' : 'subtle'}
+              size="sm"
+              onClick={() => handleVote('down')}
+              title="Thumbs down"
+            >
+              {vote === 'down' ? (
+                <IconThumbDownFilled size={14} />
+              ) : (
+                <IconThumbDown size={14} />
+              )}
+            </ActionIcon>
+            <Text
+              size="xs"
+              c="dimmed"
+              className={styles.feedbackLabel}
+              style={{ flex: 1 }}
+            >
               How&apos;s your experience?
             </Text>
-            <Group gap="xs" justify="center">
-              <ActionIcon
-                data-testid="feedback-thumbs-up"
-                variant="subtle"
-                size="xl"
-                onClick={() => handleVote('up')}
-                title="Thumbs up"
-              >
-                {vote === 'up' ? (
-                  <IconThumbUpFilled size={24} />
-                ) : (
-                  <IconThumbUp size={24} />
-                )}
-              </ActionIcon>
-              <ActionIcon
-                data-testid="feedback-thumbs-down"
-                variant="subtle"
-                size="xl"
-                onClick={() => handleVote('down')}
-                title="Thumbs down"
-              >
-                {vote === 'down' ? (
-                  <IconThumbDownFilled size={24} />
-                ) : (
-                  <IconThumbDown size={24} />
-                )}
-              </ActionIcon>
-            </Group>
-          </Stack>
-        )}
-        {state === 'comment' && (
-          <Stack gap="sm">
-            <Group gap="xs" justify="center">
-              <ActionIcon
-                data-testid="feedback-thumbs-up"
-                variant="subtle"
-                size="lg"
-                onClick={() => handleVote('up')}
-                title="Thumbs up"
-              >
-                {vote === 'up' ? (
-                  <IconThumbUpFilled size={20} />
-                ) : (
-                  <IconThumbUp size={20} />
-                )}
-              </ActionIcon>
-              <ActionIcon
-                data-testid="feedback-thumbs-down"
-                variant="subtle"
-                size="lg"
-                onClick={() => handleVote('down')}
-                title="Thumbs down"
-              >
-                {vote === 'down' ? (
-                  <IconThumbDownFilled size={20} />
-                ) : (
-                  <IconThumbDown size={20} />
-                )}
-              </ActionIcon>
-            </Group>
-            <Textarea
-              data-testid="feedback-comment"
-              placeholder="Tell us more (optional)"
-              value={comment}
-              onChange={e => setComment(e.currentTarget.value)}
-              minRows={2}
-              maxRows={4}
-              autosize
-              autoFocus
-            />
-            <Button
-              data-testid="feedback-submit"
-              variant="primary"
+            <Text
+              data-testid="feedback-hide"
               size="xs"
-              fullWidth
-              onClick={handleSubmit}
+              c="dimmed"
+              className={styles.feedbackHide}
+              onClick={() => setHidden(true)}
+              role="button"
+              tabIndex={0}
             >
-              Submit Feedback
-            </Button>
-          </Stack>
-        )}
-        {state === 'thanks' && (
-          <Text size="sm" ta="center" py="sm" data-testid="feedback-thanks">
-            Thanks for your feedback!
-          </Text>
-        )}
-      </Popover.Dropdown>
-    </Popover>
+              Hide
+            </Text>
+          </Group>
+          {state === 'voted' && (
+            <Box pt={6}>
+              <Textarea
+                data-testid="feedback-comment"
+                placeholder="Tell us more (optional)"
+                value={comment}
+                onChange={e => setComment(e.currentTarget.value)}
+                minRows={2}
+                maxRows={4}
+                autosize
+                autoFocus
+                size="xs"
+              />
+              <Button
+                data-testid="feedback-submit"
+                variant="primary"
+                size="compact-xs"
+                fullWidth
+                mt={6}
+                onClick={handleSubmit}
+              >
+                Submit
+              </Button>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
   );
 };

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -56,21 +56,32 @@ export const AppNavFeedback = () => {
     setState('idle');
   }, []);
 
+  const pageContext = useCallback(
+    () => ({
+      page: router.pathname,
+      route: router.asPath,
+      query: JSON.stringify(router.query),
+    }),
+    [router],
+  );
+
   const handleVote = useCallback(
     (newVote: FeedbackVote) => {
       setVote(newVote);
       setState('voted');
+      HyperDX.addAction('user feedback vote', {
+        vote: newVote ?? '',
+        ...pageContext(),
+      });
     },
-    [setVote, setState],
+    [setVote, setState, pageContext],
   );
 
   const handleSubmit = useCallback(() => {
-    HyperDX.addAction('user feedback submitted', {
+    HyperDX.addAction('user feedback comment', {
       vote: vote ?? '',
       comment,
-      page: router.pathname,
-      route: router.asPath,
-      query: JSON.stringify(router.query),
+      ...pageContext(),
     });
 
     setState('thanks');
@@ -78,7 +89,7 @@ export const AppNavFeedback = () => {
       reset();
       setHidden(true);
     }, 1500);
-  }, [vote, comment, router, reset, setHidden]);
+  }, [vote, comment, pageContext, reset, setHidden]);
 
   if (!sdkEnabled || hidden) return null;
 
@@ -96,16 +107,7 @@ export const AppNavFeedback = () => {
             data-testid="feedback-thumbs-up"
             variant="subtle"
             size="sm"
-            onClick={() => {
-              handleVote('up');
-              HyperDX.addAction('user feedback submitted', {
-                vote: 'up',
-                comment: '',
-                page: router.pathname,
-                route: router.asPath,
-                query: JSON.stringify(router.query),
-              });
-            }}
+            onClick={() => handleVote('up')}
             title="Thumbs up"
           >
             <IconThumbUp size={14} />
@@ -114,16 +116,7 @@ export const AppNavFeedback = () => {
             data-testid="feedback-thumbs-down"
             variant="subtle"
             size="sm"
-            onClick={() => {
-              handleVote('down');
-              HyperDX.addAction('user feedback submitted', {
-                vote: 'down',
-                comment: '',
-                page: router.pathname,
-                route: router.asPath,
-                query: JSON.stringify(router.query),
-              });
-            }}
+            onClick={() => handleVote('down')}
             title="Thumbs down"
           >
             <IconThumbDown size={14} />

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useState } from 'react';
+import { useRouter } from 'next/router';
+import HyperDX from '@hyperdx/browser';
+import {
+  ActionIcon,
+  Button,
+  Group,
+  Popover,
+  Stack,
+  Text,
+  Textarea,
+  Tooltip,
+  UnstyledButton,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+  IconMessageHeart,
+  IconThumbDown,
+  IconThumbDownFilled,
+  IconThumbUp,
+  IconThumbUpFilled,
+} from '@tabler/icons-react';
+
+import { AppNavContext } from './AppNav.components';
+
+import styles from './AppNav.module.scss';
+
+type FeedbackVote = 'up' | 'down' | null;
+
+type FeedbackState = 'vote' | 'comment' | 'thanks';
+
+export const AppNavFeedback = () => {
+  const { isCollapsed } = React.useContext(AppNavContext);
+  const [opened, { close, toggle }] = useDisclosure(false);
+  const [vote, setVote] = useState<FeedbackVote>(null);
+  const [comment, setComment] = useState('');
+  const [state, setState] = useState<FeedbackState>('vote');
+  const router = useRouter();
+
+  const reset = useCallback(() => {
+    setVote(null);
+    setComment('');
+    setState('vote');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    close();
+    setTimeout(reset, 200);
+  }, [close, reset]);
+
+  const handleVote = useCallback(
+    (newVote: FeedbackVote) => {
+      setVote(newVote);
+      setState('comment');
+    },
+    [setVote, setState],
+  );
+
+  const handleSubmit = useCallback(() => {
+    HyperDX.addAction('user feedback submitted', {
+      vote: vote ?? '',
+      comment,
+      page: router.pathname,
+      route: router.asPath,
+      query: JSON.stringify(router.query),
+    });
+
+    setState('thanks');
+    setTimeout(handleClose, 1500);
+  }, [vote, comment, router, handleClose]);
+
+  return (
+    <Popover
+      opened={opened}
+      onClose={handleClose}
+      position="right-start"
+      shadow="md"
+      width={280}
+    >
+      <Popover.Target>
+        <Tooltip label="Feedback" position="right" disabled={!isCollapsed}>
+          <UnstyledButton
+            data-testid="feedback-trigger"
+            className={styles.navItem}
+            onClick={toggle}
+          >
+            <span className={styles.navItemContent}>
+              <span className={styles.navItemIcon}>
+                <IconMessageHeart size={16} />
+              </span>
+              {!isCollapsed && <span>Feedback</span>}
+            </span>
+          </UnstyledButton>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown>
+        {state === 'vote' && (
+          <Stack gap="sm">
+            <Text size="sm" fw={500}>
+              How&apos;s your experience?
+            </Text>
+            <Group gap="xs" justify="center">
+              <ActionIcon
+                data-testid="feedback-thumbs-up"
+                variant="subtle"
+                size="xl"
+                onClick={() => handleVote('up')}
+                title="Thumbs up"
+              >
+                {vote === 'up' ? (
+                  <IconThumbUpFilled size={24} />
+                ) : (
+                  <IconThumbUp size={24} />
+                )}
+              </ActionIcon>
+              <ActionIcon
+                data-testid="feedback-thumbs-down"
+                variant="subtle"
+                size="xl"
+                onClick={() => handleVote('down')}
+                title="Thumbs down"
+              >
+                {vote === 'down' ? (
+                  <IconThumbDownFilled size={24} />
+                ) : (
+                  <IconThumbDown size={24} />
+                )}
+              </ActionIcon>
+            </Group>
+          </Stack>
+        )}
+        {state === 'comment' && (
+          <Stack gap="sm">
+            <Group gap="xs" justify="center">
+              <ActionIcon
+                data-testid="feedback-thumbs-up"
+                variant="subtle"
+                size="lg"
+                onClick={() => handleVote('up')}
+                title="Thumbs up"
+              >
+                {vote === 'up' ? (
+                  <IconThumbUpFilled size={20} />
+                ) : (
+                  <IconThumbUp size={20} />
+                )}
+              </ActionIcon>
+              <ActionIcon
+                data-testid="feedback-thumbs-down"
+                variant="subtle"
+                size="lg"
+                onClick={() => handleVote('down')}
+                title="Thumbs down"
+              >
+                {vote === 'down' ? (
+                  <IconThumbDownFilled size={20} />
+                ) : (
+                  <IconThumbDown size={20} />
+                )}
+              </ActionIcon>
+            </Group>
+            <Textarea
+              data-testid="feedback-comment"
+              placeholder="Tell us more (optional)"
+              value={comment}
+              onChange={e => setComment(e.currentTarget.value)}
+              minRows={2}
+              maxRows={4}
+              autosize
+              autoFocus
+            />
+            <Button
+              data-testid="feedback-submit"
+              variant="primary"
+              size="xs"
+              fullWidth
+              onClick={handleSubmit}
+            >
+              Submit Feedback
+            </Button>
+          </Stack>
+        )}
+        {state === 'thanks' && (
+          <Text size="sm" ta="center" py="sm" data-testid="feedback-thanks">
+            Thanks for your feedback!
+          </Text>
+        )}
+      </Popover.Dropdown>
+    </Popover>
+  );
+};

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -30,7 +30,29 @@ type FeedbackState = 'idle' | 'voted' | 'thanks';
 
 const FORCE_ENABLE_KEY = 'hdx-feedback-enabled';
 
-export const AppNavFeedback = () => {
+class FeedbackErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export const AppNavFeedback = () => (
+  <FeedbackErrorBoundary>
+    <AppNavFeedbackInner />
+  </FeedbackErrorBoundary>
+);
+
+const AppNavFeedbackInner = () => {
   const { isCollapsed } = React.useContext(AppNavContext);
   const [forceEnabled] = useLocalStorage<boolean>({
     key: FORCE_ENABLE_KEY,

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -76,6 +76,8 @@ export const AppNavFeedback = () => {
     [setVote, setState, pageContext],
   );
 
+  const [dismissed, setDismissed] = useState(false);
+
   const handleSubmit = useCallback(() => {
     HyperDX.addAction('user feedback comment', {
       vote: vote ?? '',
@@ -86,11 +88,11 @@ export const AppNavFeedback = () => {
     setState('thanks');
     setTimeout(() => {
       reset();
-      setHidden(true);
+      setDismissed(true);
     }, 1500);
-  }, [vote, comment, pageContext, reset, setHidden]);
+  }, [vote, comment, pageContext, reset]);
 
-  if (!sdkEnabled || hidden) return null;
+  if (!sdkEnabled || hidden || dismissed) return null;
 
   if (isCollapsed) {
     return (
@@ -126,53 +128,60 @@ export const AppNavFeedback = () => {
   }
 
   return (
-    <Box data-testid="feedback-inline" px="lg" py={4}>
+    <Box data-testid="feedback-inline">
       {state === 'thanks' ? (
         <Text
           size="xs"
           c="dimmed"
           data-testid="feedback-thanks"
           className={styles.feedbackLabel}
+          px="lg"
+          py={4}
         >
           Thanks for your feedback!
         </Text>
       ) : (
         <>
-          <Group gap={6} wrap="nowrap" align="center">
-            <ActionIcon
-              data-testid="feedback-thumbs-up"
-              variant={vote === 'up' ? 'secondary' : 'subtle'}
-              size="sm"
-              onClick={() => handleVote('up')}
-              title="Thumbs up"
-            >
-              {vote === 'up' ? (
-                <IconThumbUpFilled size={14} />
-              ) : (
-                <IconThumbUp size={14} />
-              )}
-            </ActionIcon>
-            <ActionIcon
-              data-testid="feedback-thumbs-down"
-              variant={vote === 'down' ? 'secondary' : 'subtle'}
-              size="sm"
-              onClick={() => handleVote('down')}
-              title="Thumbs down"
-            >
-              {vote === 'down' ? (
-                <IconThumbDownFilled size={14} />
-              ) : (
-                <IconThumbDown size={14} />
-              )}
-            </ActionIcon>
-            <Text
-              size="xs"
-              c="dimmed"
-              className={styles.feedbackLabel}
-              style={{ flex: 1 }}
-            >
-              Feedback?
-            </Text>
+          <Group
+            gap={6}
+            wrap="nowrap"
+            align="center"
+            className={styles.navItem}
+          >
+            <span className={styles.navItemContent}>
+              <span className={styles.navItemIcon}>
+                <ActionIcon
+                  data-testid="feedback-thumbs-up"
+                  variant={vote === 'up' ? 'secondary' : 'subtle'}
+                  size="xs"
+                  onClick={() => handleVote('up')}
+                  title="Thumbs up"
+                >
+                  {vote === 'up' ? (
+                    <IconThumbUpFilled size={14} />
+                  ) : (
+                    <IconThumbUp size={14} />
+                  )}
+                </ActionIcon>
+              </span>
+              <ActionIcon
+                data-testid="feedback-thumbs-down"
+                variant={vote === 'down' ? 'secondary' : 'subtle'}
+                size="xs"
+                onClick={() => handleVote('down')}
+                title="Thumbs down"
+                mr={4}
+              >
+                {vote === 'down' ? (
+                  <IconThumbDownFilled size={14} />
+                ) : (
+                  <IconThumbDown size={14} />
+                )}
+              </ActionIcon>
+              <Text size="xs" c="dimmed" className={styles.feedbackLabel}>
+                Feedback?
+              </Text>
+            </span>
             <Text
               data-testid="feedback-hide"
               size="xs"
@@ -186,7 +195,7 @@ export const AppNavFeedback = () => {
             </Text>
           </Group>
           {state === 'voted' && (
-            <Box pt={6}>
+            <Box px="lg" pt={4} pb={2}>
               <Textarea
                 data-testid="feedback-comment"
                 placeholder="Tell us more (optional)"

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -32,9 +32,9 @@ const FORCE_ENABLE_KEY = 'hdx-feedback-enabled';
 
 export const AppNavFeedback = () => {
   const { isCollapsed } = React.useContext(AppNavContext);
-  const [forceEnabled] = useLocalStorage<string>({
+  const [forceEnabled] = useLocalStorage<boolean>({
     key: FORCE_ENABLE_KEY,
-    defaultValue: '',
+    defaultValue: false,
   });
   const [hidden, setHidden] = useLocalStorage<boolean>({
     key: 'feedbackHidden',
@@ -48,7 +48,7 @@ export const AppNavFeedback = () => {
 
   // Only show when HyperDX SDK is active (non-local mode),
   // or when overridden via: localStorage.setItem('hdx-feedback-enabled', 'true')
-  const sdkEnabled = !IS_LOCAL_MODE || forceEnabled === 'true';
+  const sdkEnabled = !IS_LOCAL_MODE || forceEnabled === true;
 
   const reset = useCallback(() => {
     setVote(null);

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -166,7 +166,7 @@ export const AppNavFeedback = () => {
               className={styles.feedbackLabel}
               style={{ flex: 1 }}
             >
-              How&apos;s your experience?
+              Feedback?
             </Text>
             <Text
               data-testid="feedback-hide"

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -60,7 +60,6 @@ export const AppNavFeedback = () => {
     () => ({
       page: router.pathname,
       route: router.asPath,
-      query: JSON.stringify(router.query),
     }),
     [router],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an inline feedback widget in the sidebar navigation that lets users give thumbs up or thumbs down feedback about their in-app experience. The widget renders directly in the sidebar (no flyout/popover) with the layout: `[thumbs up] [thumbs down] Feedback? [Hide]`.

**How it works:**
1. Thumbs up/down buttons are inline in the sidebar between Help and Team Settings, vertically aligned with other nav items
2. Clicking a thumb immediately emits a `user feedback vote` action and reveals an inline textarea + Submit button
3. Users can optionally add a comment and hit Submit, which emits a separate `user feedback comment` action
4. The vote signal is always captured, even if the user never submits a comment
5. Shows "Thanks for your feedback!" briefly, then hides for the rest of the session
6. Widget reappears on next page load — dismissal after submit is session-scoped
7. "Hide" button permanently opts out (persisted via `localStorage`)
8. When the sidebar is collapsed, shows just the two thumb icons with a tooltip

**Visibility:**
- Only shown when the HyperDX browser SDK is active (`!IS_LOCAL_MODE`)
- For local testing, run `localStorage.setItem('hdx-feedback-enabled', 'true')` in the browser console

**Implementation:**
- New `AppNavFeedback` component in `packages/app/src/components/AppNav/AppNavFeedback.tsx`
- Added `feedbackLabel` and `feedbackHide` styles to `AppNav.module.scss`
- Uses the same `navItem`/`navItemContent`/`navItemIcon` class structure for vertical alignment with other nav items
- Mantine `ActionIcon`, `Textarea`, `Button` with approved variants
- Tabler icons: `IconThumbUp/Down`, `IconThumbUpFilled/DownFilled`

### Screenshots

**Inline feedback — aligned with other nav items:**

[Inline feedback aligned](https://cursor.com/agents/bc-593294ab-6ecb-40cb-971d-4fadf00ddae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeedback_aligned_idle.png)

**After clicking thumbs up — comment form expanded:**

[Inline feedback with comment](https://cursor.com/agents/bc-593294ab-6ecb-40cb-971d-4fadf00ddae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeedback_aligned_comment.png)

### How to test locally or on Vercel

1. Start the dev stack with `yarn dev`
2. In the browser console, run: `localStorage.setItem('hdx-feedback-enabled', 'true')` then refresh
3. Look at the sidebar between "Help" and "Team Settings" for the inline feedback row
4. Click thumbs up or down, optionally add a comment, and submit
5. Verify the widget shows "Thanks for your feedback!" and then hides
6. Reload the page — the widget should reappear (session-scoped dismissal)
7. Click "Hide" to permanently opt out (undo with `localStorage.removeItem('feedbackHidden')`)

### References

- Linear Issue: HDX-4126

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4126](https://linear.app/clickhouse/issue/HDX-4126/add-thumbs-updown-feedback-for-in-app-experience)

<div><a href="https://cursor.com/agents/bc-593294ab-6ecb-40cb-971d-4fadf00ddae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-593294ab-6ecb-40cb-971d-4fadf00ddae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

