### PR TITLE
test(api/mcp): cover full heatmap save/get/update round-trip

### DIFF
--- a/packages/api/src/mcp/__tests__/dashboards.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards.test.ts
@@ -459,15 +459,37 @@ describe('MCP Dashboard Tools', () => {
       });
     });
 
-    // Brandon flagged on #2199 that the schema unit tests only assert that
-    // zod accepts the shape; what matters is that an agent-issued
-    // hyperdx_save_dashboard call actually persists a heatmap with every
-    // MCP-specific field. This test drives the full save -> get -> update
-    // -> get round-trip with heatmapScaleType, countExpression,
-    // numberFormat, where, and whereLanguage all set, then mutates them on
-    // PUT and re-reads to confirm the new values stick.
-    it('should round-trip a fully-specified heatmap tile through save, get, and update', async () => {
+    it('should round-trip every MCP-specific heatmap field through save, get, update, and re-get', async () => {
       const sourceId = traceSource._id.toString();
+
+      const createConfig = {
+        displayType: 'heatmap' as const,
+        sourceId,
+        select: [
+          {
+            valueExpression: 'Duration',
+            countExpression: 'count()',
+            heatmapScaleType: 'log' as const,
+          },
+        ],
+        where: 'level:error',
+        whereLanguage: 'lucene' as const,
+        numberFormat: { output: 'duration' as const, factor: 1e-9 },
+      };
+      // Mutate select + where on update; numberFormat, whereLanguage,
+      // and sourceId carry forward via the spread. Re-asserting against
+      // updatedConfig catches a regression where PUT silently drops any
+      // carried-forward field.
+      const updatedConfig = {
+        ...createConfig,
+        select: [
+          {
+            valueExpression: "SpanAttributes['http.duration']",
+            heatmapScaleType: 'linear' as const,
+          },
+        ],
+        where: 'level:error AND service:checkout',
+      };
 
       const saveResult = await callTool(client, 'hyperdx_save_dashboard', {
         name: 'Heatmap Full Round-Trip',
@@ -478,101 +500,42 @@ describe('MCP Dashboard Tools', () => {
             y: 0,
             w: 12,
             h: 4,
-            config: {
-              displayType: 'heatmap',
-              sourceId,
-              select: [
-                {
-                  valueExpression: 'Duration',
-                  countExpression: 'count()',
-                  heatmapScaleType: 'log',
-                },
-              ],
-              where: 'level:error',
-              whereLanguage: 'lucene',
-              numberFormat: { output: 'duration', factor: 1e-9 },
-            },
+            config: createConfig,
           },
         ],
       });
       expect(saveResult.isError).toBeFalsy();
       const saved = JSON.parse(getFirstText(saveResult));
       expect(saved.tiles).toHaveLength(1);
-      expect(saved.tiles[0].config).toMatchObject({
-        displayType: 'heatmap',
-        sourceId,
-        where: 'level:error',
-        whereLanguage: 'lucene',
-        numberFormat: { output: 'duration', factor: 1e-9 },
-      });
-      expect(saved.tiles[0].config.select[0]).toMatchObject({
-        valueExpression: 'Duration',
-        countExpression: 'count()',
-        heatmapScaleType: 'log',
-      });
+      expect(saved.tiles[0].config).toMatchObject(createConfig);
 
       const getResult = await callTool(client, 'hyperdx_get_dashboard', {
         id: saved.id,
       });
       expect(getResult.isError).toBeFalsy();
       const fetched = JSON.parse(getFirstText(getResult));
-      expect(fetched.tiles[0].config).toMatchObject({
-        displayType: 'heatmap',
-        where: 'level:error',
-        whereLanguage: 'lucene',
-        numberFormat: { output: 'duration', factor: 1e-9 },
-      });
-      expect(fetched.tiles[0].config.select[0]).toMatchObject({
-        valueExpression: 'Duration',
-        countExpression: 'count()',
-        heatmapScaleType: 'log',
-      });
+      expect(fetched.tiles[0].config).toMatchObject(createConfig);
 
-      // Update path: swap the scale, drop the count expression, change the
-      // value expression, and tighten the filter. Tile id carries forward
-      // so the update lands on the same tile rather than creating a new
-      // one.
       const updateResult = await callTool(client, 'hyperdx_save_dashboard', {
         id: saved.id,
         name: 'Heatmap Full Round-Trip',
         tiles: [
           {
             ...fetched.tiles[0],
-            config: {
-              ...fetched.tiles[0].config,
-              select: [
-                {
-                  valueExpression: "SpanAttributes['http.duration']",
-                  heatmapScaleType: 'linear',
-                },
-              ],
-              where: 'level:error AND service:checkout',
-            },
+            config: { ...fetched.tiles[0].config, ...updatedConfig },
           },
         ],
       });
       expect(updateResult.isError).toBeFalsy();
       const updated = JSON.parse(getFirstText(updateResult));
-      expect(updated.tiles[0].config.select[0]).toEqual({
-        valueExpression: "SpanAttributes['http.duration']",
-        heatmapScaleType: 'linear',
-      });
-      expect(updated.tiles[0].config.where).toBe(
-        'level:error AND service:checkout',
-      );
+      expect(updated.tiles[0].config).toMatchObject(updatedConfig);
 
       const getAfterUpdate = await callTool(client, 'hyperdx_get_dashboard', {
         id: saved.id,
       });
       expect(getAfterUpdate.isError).toBeFalsy();
       const refetched = JSON.parse(getFirstText(getAfterUpdate));
-      expect(refetched.tiles[0].config.select[0]).toEqual({
-        valueExpression: "SpanAttributes['http.duration']",
-        heatmapScaleType: 'linear',
-      });
-      expect(refetched.tiles[0].config.where).toBe(
-        'level:error AND service:checkout',
-      );
+      expect(refetched.tiles[0].config).toMatchObject(updatedConfig);
     });
 
     it('should reject heatmap tile with empty valueExpression at the schema layer', async () => {

--- a/packages/api/src/mcp/__tests__/dashboards.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards.test.ts
@@ -673,6 +673,160 @@ describe('MCP Dashboard Tools', () => {
       expect(text).toContain('Trace source');
       expect(text).toContain(logSource._id.toString());
     });
+
+    // Exercises the update-side source-kind gate via filterChangedHeatmapTiles
+    // (displayType changed to heatmap on an existing tile).
+    it('should reject update that changes a tile to heatmap on a non-Trace source', async () => {
+      const logSource = await Source.create({
+        kind: SourceKind.Log,
+        team: team._id,
+        from: { databaseName: DEFAULT_DATABASE, tableName: 'otel_logs' },
+        timestampValueExpression: 'Timestamp',
+        connection: connection._id,
+        name: 'Logs',
+      });
+
+      const created = await callTool(client, 'hyperdx_save_dashboard', {
+        name: 'Line on Log Source',
+        tiles: [
+          {
+            name: 'Line',
+            config: {
+              displayType: 'line',
+              sourceId: logSource._id.toString(),
+              select: [{ aggFn: 'count' }],
+            },
+          },
+        ],
+      });
+      expect(created.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(created));
+
+      const update = await callTool(client, 'hyperdx_save_dashboard', {
+        id: saved.id,
+        name: 'Line on Log Source',
+        tiles: [
+          {
+            ...saved.tiles[0],
+            config: {
+              ...saved.tiles[0].config,
+              displayType: 'heatmap',
+              select: [{ valueExpression: 'Duration' }],
+            },
+          },
+        ],
+      });
+      expect(update.isError).toBe(true);
+      const text = getFirstText(update);
+      expect(text).toContain('Trace source');
+      expect(text).toContain(logSource._id.toString());
+    });
+
+    // Exercises the update-side source-kind gate via filterChangedHeatmapTiles
+    // (sourceId changed on an existing heatmap tile).
+    it('should reject update that changes a heatmap tile source to a non-Trace source', async () => {
+      const logSource = await Source.create({
+        kind: SourceKind.Log,
+        team: team._id,
+        from: { databaseName: DEFAULT_DATABASE, tableName: 'otel_logs' },
+        timestampValueExpression: 'Timestamp',
+        connection: connection._id,
+        name: 'Logs',
+      });
+
+      const created = await callTool(client, 'hyperdx_save_dashboard', {
+        name: 'Heatmap re-pointed at Log',
+        tiles: [
+          {
+            name: 'Heatmap',
+            config: {
+              displayType: 'heatmap',
+              sourceId: traceSource._id.toString(),
+              select: [{ valueExpression: 'Duration' }],
+            },
+          },
+        ],
+      });
+      expect(created.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(created));
+
+      const update = await callTool(client, 'hyperdx_save_dashboard', {
+        id: saved.id,
+        name: 'Heatmap re-pointed at Log',
+        tiles: [
+          {
+            ...saved.tiles[0],
+            config: {
+              ...saved.tiles[0].config,
+              sourceId: logSource._id.toString(),
+            },
+          },
+        ],
+      });
+      expect(update.isError).toBe(true);
+      const text = getFirstText(update);
+      expect(text).toContain('Trace source');
+      expect(text).toContain(logSource._id.toString());
+    });
+
+    // Asserts each tile's config survives the serializer/deserializer cycle
+    // independently when mixed with other displayTypes on the same dashboard.
+    it('should round-trip a heatmap alongside line and number tiles in one dashboard', async () => {
+      const sourceId = traceSource._id.toString();
+
+      const heatmapConfig = {
+        displayType: 'heatmap' as const,
+        sourceId,
+        select: [
+          { valueExpression: 'Duration', heatmapScaleType: 'log' as const },
+        ],
+      };
+      const lineConfig = {
+        displayType: 'line' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const }],
+        groupBy: "SpanAttributes['service.name']",
+      };
+      const numberConfig = {
+        displayType: 'number' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const }],
+        numberFormat: { output: 'number' as const, average: true },
+      };
+
+      const save = await callTool(client, 'hyperdx_save_dashboard', {
+        name: 'Mixed Tile Round-Trip',
+        tiles: [
+          { name: 'Heatmap Tile', config: heatmapConfig },
+          { name: 'Line Tile', config: lineConfig },
+          { name: 'Number Tile', config: numberConfig },
+        ],
+      });
+      expect(save.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(save));
+      expect(saved.tiles).toHaveLength(3);
+
+      const byName: Record<string, ExternalDashboardTileWithId> =
+        Object.fromEntries(
+          saved.tiles.map((t: ExternalDashboardTileWithId) => [t.name, t]),
+        );
+      expect(byName['Heatmap Tile'].config).toMatchObject(heatmapConfig);
+      expect(byName['Line Tile'].config).toMatchObject(lineConfig);
+      expect(byName['Number Tile'].config).toMatchObject(numberConfig);
+
+      const fetched = JSON.parse(
+        getFirstText(
+          await callTool(client, 'hyperdx_get_dashboard', { id: saved.id }),
+        ),
+      );
+      const fetchedByName: Record<string, ExternalDashboardTileWithId> =
+        Object.fromEntries(
+          fetched.tiles.map((t: ExternalDashboardTileWithId) => [t.name, t]),
+        );
+      expect(fetchedByName['Heatmap Tile'].config).toMatchObject(heatmapConfig);
+      expect(fetchedByName['Line Tile'].config).toMatchObject(lineConfig);
+      expect(fetchedByName['Number Tile'].config).toMatchObject(numberConfig);
+    });
   });
 
   describe('hyperdx_save_dashboard - containers and tabs', () => {

--- a/packages/api/src/mcp/__tests__/dashboards.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards.test.ts
@@ -459,6 +459,122 @@ describe('MCP Dashboard Tools', () => {
       });
     });
 
+    // Brandon flagged on #2199 that the schema unit tests only assert that
+    // zod accepts the shape; what matters is that an agent-issued
+    // hyperdx_save_dashboard call actually persists a heatmap with every
+    // MCP-specific field. This test drives the full save -> get -> update
+    // -> get round-trip with heatmapScaleType, countExpression,
+    // numberFormat, where, and whereLanguage all set, then mutates them on
+    // PUT and re-reads to confirm the new values stick.
+    it('should round-trip a fully-specified heatmap tile through save, get, and update', async () => {
+      const sourceId = traceSource._id.toString();
+
+      const saveResult = await callTool(client, 'hyperdx_save_dashboard', {
+        name: 'Heatmap Full Round-Trip',
+        tiles: [
+          {
+            name: 'Latency Heatmap',
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 4,
+            config: {
+              displayType: 'heatmap',
+              sourceId,
+              select: [
+                {
+                  valueExpression: 'Duration',
+                  countExpression: 'count()',
+                  heatmapScaleType: 'log',
+                },
+              ],
+              where: 'level:error',
+              whereLanguage: 'lucene',
+              numberFormat: { output: 'duration', factor: 1e-9 },
+            },
+          },
+        ],
+      });
+      expect(saveResult.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(saveResult));
+      expect(saved.tiles).toHaveLength(1);
+      expect(saved.tiles[0].config).toMatchObject({
+        displayType: 'heatmap',
+        sourceId,
+        where: 'level:error',
+        whereLanguage: 'lucene',
+        numberFormat: { output: 'duration', factor: 1e-9 },
+      });
+      expect(saved.tiles[0].config.select[0]).toMatchObject({
+        valueExpression: 'Duration',
+        countExpression: 'count()',
+        heatmapScaleType: 'log',
+      });
+
+      const getResult = await callTool(client, 'hyperdx_get_dashboard', {
+        id: saved.id,
+      });
+      expect(getResult.isError).toBeFalsy();
+      const fetched = JSON.parse(getFirstText(getResult));
+      expect(fetched.tiles[0].config).toMatchObject({
+        displayType: 'heatmap',
+        where: 'level:error',
+        whereLanguage: 'lucene',
+        numberFormat: { output: 'duration', factor: 1e-9 },
+      });
+      expect(fetched.tiles[0].config.select[0]).toMatchObject({
+        valueExpression: 'Duration',
+        countExpression: 'count()',
+        heatmapScaleType: 'log',
+      });
+
+      // Update path: swap the scale, drop the count expression, change the
+      // value expression, and tighten the filter. Tile id carries forward
+      // so the update lands on the same tile rather than creating a new
+      // one.
+      const updateResult = await callTool(client, 'hyperdx_save_dashboard', {
+        id: saved.id,
+        name: 'Heatmap Full Round-Trip',
+        tiles: [
+          {
+            ...fetched.tiles[0],
+            config: {
+              ...fetched.tiles[0].config,
+              select: [
+                {
+                  valueExpression: "SpanAttributes['http.duration']",
+                  heatmapScaleType: 'linear',
+                },
+              ],
+              where: 'level:error AND service:checkout',
+            },
+          },
+        ],
+      });
+      expect(updateResult.isError).toBeFalsy();
+      const updated = JSON.parse(getFirstText(updateResult));
+      expect(updated.tiles[0].config.select[0]).toEqual({
+        valueExpression: "SpanAttributes['http.duration']",
+        heatmapScaleType: 'linear',
+      });
+      expect(updated.tiles[0].config.where).toBe(
+        'level:error AND service:checkout',
+      );
+
+      const getAfterUpdate = await callTool(client, 'hyperdx_get_dashboard', {
+        id: saved.id,
+      });
+      expect(getAfterUpdate.isError).toBeFalsy();
+      const refetched = JSON.parse(getFirstText(getAfterUpdate));
+      expect(refetched.tiles[0].config.select[0]).toEqual({
+        valueExpression: "SpanAttributes['http.duration']",
+        heatmapScaleType: 'linear',
+      });
+      expect(refetched.tiles[0].config.where).toBe(
+        'level:error AND service:checkout',
+      );
+    });
+
     it('should reject heatmap tile with empty valueExpression at the schema layer', async () => {
       const sourceId = traceSource._id.toString();
       const result = await callTool(client, 'hyperdx_save_dashboard', {
@@ -653,7 +769,7 @@ describe('MCP Dashboard Tools', () => {
             containerId: 'service-health',
             tabId: 'latency',
           }),
-          // Tile inside a tabbed container without a tabId — renders in
+          // Tile inside a tabbed container without a tabId renders in
           // the container shell rather than under a tab. Guards that the
           // schema does not accidentally require tabId for every tile in
           // a tabbed container.


### PR DESCRIPTION
## Summary

Adds a thorough save → get → update → get round-trip test for the
heatmap MCP path. Brandon flagged on this PR that the schema unit
tests at `mcp/tools/dashboards/__tests__/schemas.test.ts` only assert
that zod accepts the shape and don't prove that an agent-issued
`hyperdx_save_dashboard` call actually persists a heatmap with every
MCP-specific field. The bare-minimum heatmap test that landed with
#2200 covers only the required `valueExpression`; this test
exercises `heatmapScaleType`, `countExpression`, `numberFormat`,
`where`, and `whereLanguage` all at once, then mutates them on PUT
and re-reads to confirm the new values stick.

## Backstory

The MCP heatmap schema work originally drafted on this branch
(`mcpHeatmapSelectItemSchema`, `mcpHeatmapTileSchema`, the few-shot
example, the prompt guides) was absorbed into #2200 during the
convergence on the deep-review feedback. #2200 has merged on `main`,
so the only delta this PR adds on top is the integration test.

## What's in this PR

- One new test in `packages/api/src/mcp/__tests__/dashboards.test.ts`:
  `should round-trip a fully-specified heatmap tile through save, get, and update`
- Drive-by: drops one em-dash from a sibling test comment in the
  same file so the prose-lint hook passes when this file is touched

## Test plan

- [x] `yarn workspace @hyperdx/api lint` clean
- [x] `yarn workspace @hyperdx/api tsc --noEmit` clean
- [x] `yarn workspace @hyperdx/api docgen` produces no openapi.json diff
- [ ] CI runs the integration suite. Local `make dev-int` needs
      Docker BuildKit which isn't available on this host.
