### PR TITLE
fix(ci): post claude-code-review comments as markdown instead of raw JSON

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,12 +125,25 @@ jobs:
           body-includes: '<!-- claude-code-review -->'
           direction: last
 
+      # fromJSON() in a `with:` expression has been observed to leave the
+      # structured_output JSON string unparsed, posting the raw envelope as
+      # the comment body. Extract the review field via jq for reliability.
+      - name: Extract review from structured output
+        id: extract-review
+        env:
+          STRUCTURED_OUTPUT:
+            ${{ steps.claude-review.outputs.structured_output }}
+        run: |
+          {
+            echo 'review<<CLAUDE_REVIEW_EOF'
+            printf '%s' "$STRUCTURED_OUTPUT" | jq -r '.review'
+            echo 'CLAUDE_REVIEW_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Post or update Claude review
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-claude-comment.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.number }}
-          body:
-            ${{ fromJSON(steps.claude-review.outputs.structured_output).review
-            }}
+          body: ${{ steps.extract-review.outputs.review }}
           edit-mode: replace


### PR DESCRIPTION
## Summary

The Claude Code Review GitHub Action has been posting comments like:

```json
{"review": "<!-- claude-code-review -->\n## PR Review\n\n- ⚠️ ..."}
```

instead of rendered markdown. The workflow used `${{ fromJSON(steps.claude-review.outputs.structured_output).review }}` in the comment-poster's `with: body:` parameter, but that expression was evaluating to the raw JSON envelope rather than the unwrapped `review` string. (Confirmed by inspecting an actual posted comment — the JSON parses fine; only the YAML expression unwrap was failing.)

This PR replaces the in-place `fromJSON(...)` with a small intermediate step that uses `jq -r '.review'` to extract the field into a step output via the heredoc form of `$GITHUB_OUTPUT`, then references that output in the comment body. This is the same pattern `anthropics/claude-code-action`'s own [`test-structured-output.yml`](https://github.com/anthropics/claude-code-action/blob/main/.github/workflows/test-structured-output.yml) uses.

### How to test

1. Open or re-trigger any non-draft PR against `main` after this lands.
2. Confirm the `Claude Code Review` workflow's comment renders as markdown (headings, bullet list with `⚠️`/`💡`/`❌`, etc.) rather than as a raw JSON object.

### References

- Example of the broken comment: https://github.com/hyperdxio/hyperdx/pull/2210#issuecomment-4391384896