### PR TITLE
fix(ci): pin compound-engineering plugin via local checkout

### DIFF
--- a/.github/workflows/compound-review.yml
+++ b/.github/workflows/compound-review.yml
@@ -90,6 +90,19 @@ jobs:
               git fetch --no-tags --depth=50 "$BASE_REPO_URL" "${{ steps.pr.outputs.base_ref }}"
           fi
 
+      # Pre-clone the plugin marketplace at a pinned tag and pass it to the
+      # action as a local path. The action's `plugin_marketplaces` input
+      # validator rejects the `#<ref>` suffix that the underlying
+      # `/plugin marketplace add` CLI accepts, so we cannot pin via URL.
+      # See base-action/src/install-plugins.ts:MARKETPLACE_URL_REGEX.
+      # Bump `ref` deliberately; do not track main.
+      - name: Checkout compound-engineering plugin
+        uses: actions/checkout@v6
+        with:
+          repository: EveryInc/compound-engineering-plugin
+          ref: v2.42.0
+          path: ce-plugin
+
       - name: Run Compound Engineering review
         id: review
         uses: anthropics/claude-code-action@v1
@@ -99,10 +112,8 @@ jobs:
           allowed_bots: dependabot,dependabot[bot],kodiakhq,kodiakhq[bot],github-actions,github-actions[bot],cursor,cursor[bot],claude,claude[bot]
           allowed_non_write_users: '*' # allow fork contributors to trigger via label
 
-          # Pin the plugin to a tagged release. Bump deliberately; do not track main.
-          # See https://github.com/EveryInc/compound-engineering-plugin/releases
           plugin_marketplaces: |
-            https://github.com/EveryInc/compound-engineering-plugin.git#v2.42.0
+            ./ce-plugin
           plugins: |
             compound-engineering@compound-engineering-plugin
 


### PR DESCRIPTION
## Summary

Fixes the `compound-review` workflow added in #2221, which fails on dispatch with `Invalid marketplace URL format: https://github.com/EveryInc/compound-engineering-plugin.git#v2.42.0`. The `claude-code-action` `plugin_marketplaces` input validator (regex requires the URL to end with `.git`) rejects the `#<ref>` git suffix that the underlying `/plugin marketplace add` CLI accepts. Pre-clones the marketplace repo at the pinned tag with `actions/checkout` and passes `./ce-plugin` as a local path instead — the validator allows local paths, so pinning is preserved.

### How to test locally or on Vercel

1. Merge to `main`.
2. Add the `compound-review` label to a small PR (or run via `workflow_dispatch`).
3. Verify the workflow no longer errors at the "Invalid marketplace URL format" step and posts a `## Compound Engineering Review` sticky comment on the PR.

### References

- Linear Issue:
- Related PRs: #2221
- Action validator: https://github.com/anthropics/claude-code-action/blob/main/base-action/src/install-plugins.ts