### PR TITLE
fix(ci): unwrap double-nested JSON in claude-code-review output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -102,7 +102,11 @@ jobs:
             Note: If the team wants a more thorough review, they can comment on the PR requesting one.
 
             CRITICAL OUTPUT REQUIREMENTS:
-            1. Return a JSON object with a single "review" field containing your full markdown review.
+            1. Return a JSON object with a single "review" field whose VALUE
+               is a plain markdown STRING. Do NOT put another JSON object
+               inside the "review" string -- doing so posts raw JSON in the
+               comment instead of rendered markdown. The `review` value must
+               be markdown text only, not a stringified JSON envelope.
             2. The review markdown must start with EXACTLY these two lines:
                <!-- claude-code-review -->
                ## PR Review
@@ -127,16 +131,28 @@ jobs:
 
       # fromJSON() in a `with:` expression has been observed to leave the
       # structured_output JSON string unparsed, posting the raw envelope as
-      # the comment body. Extract the review field via jq for reliability.
+      # the comment body. Extract via jq.
+      #
+      # Defensive double-unwrap: the model has been observed to return
+      # `{"review": "{\"review\": \"<markdown>\"}"}` -- wrapping its own JSON
+      # output a second time so the comment body posts as raw JSON. Detect
+      # that case (the inner string parses as an object with a `review` key)
+      # and unwrap once more so we post markdown, not JSON. Mirrors the same
+      # fix applied to compound-review.yml.
       - name: Extract review from structured output
         id: extract-review
         env:
           STRUCTURED_OUTPUT:
             ${{ steps.claude-review.outputs.structured_output }}
         run: |
+          REVIEW="$(printf '%s' "$STRUCTURED_OUTPUT" | jq -r '.review')"
+          if printf '%s' "$REVIEW" | jq -e 'type == "object" and has("review")' >/dev/null 2>&1; then
+            REVIEW="$(printf '%s' "$REVIEW" | jq -r '.review')"
+          fi
           {
             echo 'review<<CLAUDE_REVIEW_EOF'
-            printf '%s' "$STRUCTURED_OUTPUT" | jq -r '.review'
+            printf '%s' "$REVIEW"
+            echo
             echo 'CLAUDE_REVIEW_EOF'
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Same bug as #2223, applied to the default `claude-code-review.yml` workflow. The PR review comment posted raw JSON because the model returned `{"review": "{\"review\": \"<markdown>\"}"}` — wrapping its own JSON output a second time — and `jq -r '.review'` only peeled one layer, so the inner JSON-as-string got posted as the comment body.

The fix mirrors #2223: the extract step now defensively detects a second envelope (`type == "object" and has("review")`) and unwraps once more, and the prompt explicitly forbids putting JSON inside the `review` string. Verified locally that the unwrap is a no-op for correctly-shaped payloads and recovers clean markdown for the broken double-wrapped case.

### How to test locally or on Vercel

1. Merge to `main`.
2. Open or update a PR; verify the `## PR Review` sticky comment renders as actual markdown headings/bullets, not as a `{"review":"..."}` blob.

### References

- Linear Issue:
- Related PRs: #2219 (initial markdown extraction fix), #2223 (same fix on the compound-review workflow)