### PR TITLE
chore(heatmap): drop unused export of HeatmapChartConfig type

### DIFF
--- a/packages/app/src/components/DBHeatmapChart.tsx
+++ b/packages/app/src/components/DBHeatmapChart.tsx
@@ -286,7 +286,7 @@ function buildSeriesForPalette(colors: string[]): Partial<uPlot.Series> {
   };
 }
 
-export type HeatmapChartConfig = {
+type HeatmapChartConfig = {
   displayType: DisplayType.Heatmap;
   select: [
     {


### PR DESCRIPTION
## Summary

- Drop the `export` from `HeatmapChartConfig` in `packages/app/src/components/DBHeatmapChart.tsx`. No external file imports the type by name; consumers (`DBDashboardPage`, `ChartPreviewPanel`, `DBSearchHeatmapChart`) use the inferred return of `toHeatmapChartConfig(...)`. The type stays in use locally for the function return shape and prop annotations.

## Why

Cleanup of an unused public surface. `HeatmapChartConfig` is only ever consumed via inference from `toHeatmapChartConfig(...)`; nothing imports it by name. The current knip pin (6.0.1) does not flag inferred-only exports, but stricter knip versions do, so this is a latent unused-export. Dropping the export keeps the type local to the file where it is actually used.

Behavior-neutral. No runtime impact. No changeset (not user-visible).

## Test plan

- [x] `yarn nx run @hyperdx/common-utils:ci:build`
- [x] `yarn nx run @hyperdx/app:ci:lint`
- [x] `yarn knip:ci` (`{"issues":[]}`, exit 0)
