### PR TITLE
ci(ui-preview-smoke): checkout base branch before agent runs

### DIFF
--- a/.github/workflows/ui-preview-smoke.yml
+++ b/.github/workflows/ui-preview-smoke.yml
@@ -31,6 +31,17 @@ jobs:
       actions: read
 
     steps:
+      # claude-code-action requires a valid git working tree (it configures
+      # git user before running). We only drive Playwright at the Vercel
+      # preview URL — we never execute repo code — so checking out the base
+      # branch is sufficient and avoids running any fork-supplied code under
+      # pull_request_target.
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Resolve PR metadata + body
         id: pr
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

Fixes the brand-new `ui-preview-smoke` workflow (#2238). On its first run it failed with:

```
fatal: not in a git directory
Failed to configure git authentication
  at configureGitAuth (.../claude-code-action/v1/src/github/operations/git-config.ts:41:9)
```

`claude-code-action` configures `git config user.name` as one of its first steps and requires a valid working tree to run. The original workflow skipped `actions/checkout` because the agent only drives Playwright at the deployed preview URL and never needs the repo source — but the action itself does.

Adds `actions/checkout@v4` pinned to the repo's default branch (`github.event.repository.default_branch`) before the agent step. We deliberately don't check out the PR head ref: this workflow runs under `pull_request_target`, and we'd rather not execute fork-supplied code in the runner. The base branch is sufficient to satisfy the action.

`persist-credentials: false` since the agent has its own `github_token` already.

## How to test on Vercel preview

N/A — CI workflow change.

## References

- Introduced in #2238