### PR TITLE
Add descriptions to dashboards

### DIFF
--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -2011,6 +2011,12 @@
             "maxLength": 1024,
             "example": "Service Overview"
           },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the dashboard",
+            "maxLength": 40000,
+            "example": "Monitors key service health metrics including latency and error rates"
+          },
           "tiles": {
             "type": "array",
             "description": "List of tiles/charts in the dashboard",
@@ -2073,6 +2079,12 @@
             "description": "Dashboard name.",
             "example": "New Dashboard"
           },
+          "description": {
+            "type": "string",
+            "maxLength": 40000,
+            "description": "Optional description of the dashboard.",
+            "example": "Monitors key service health metrics"
+          },
           "tiles": {
             "type": "array",
             "description": "List of tiles/charts to include in the dashboard.",
@@ -2133,6 +2145,12 @@
             "maxLength": 1024,
             "description": "Dashboard name.",
             "example": "Updated Dashboard Name"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 40000,
+            "description": "Optional description of the dashboard.",
+            "example": "Updated description for this dashboard"
           },
           "tiles": {
             "type": "array",

--- a/packages/api/src/mcp/tools/dashboards/getDashboard.ts
+++ b/packages/api/src/mcp/tools/dashboards/getDashboard.ts
@@ -41,6 +41,7 @@ export function registerGetDashboard(
         const output = dashboards.map(d => ({
           id: d._id.toString(),
           name: d.name,
+          ...(d.description ? { description: d.description } : {}),
           tags: d.tags,
           ...(frontendUrl ? { url: `${frontendUrl}/dashboards/${d._id}` } : {}),
         }));

--- a/packages/api/src/mcp/tools/dashboards/saveDashboard.ts
+++ b/packages/api/src/mcp/tools/dashboards/saveDashboard.ts
@@ -47,6 +47,11 @@ export function registerSaveDashboard(
             'Dashboard ID. Omit to create a new dashboard, provide to update an existing one.',
           ),
         name: z.string().describe('Dashboard name'),
+        description: z
+          .string()
+          .max(40000)
+          .optional()
+          .describe('Optional description of the dashboard'),
         tiles: mcpTilesParam,
         tags: z.array(z.string()).optional().describe('Dashboard tags'),
       }),
@@ -54,12 +59,19 @@ export function registerSaveDashboard(
     withToolTracing(
       'hyperdx_save_dashboard',
       context,
-      async ({ id: dashboardId, name, tiles: inputTiles, tags }) => {
+      async ({
+        id: dashboardId,
+        name,
+        description,
+        tiles: inputTiles,
+        tags,
+      }) => {
         if (!dashboardId) {
           return createDashboard({
             teamId,
             frontendUrl,
             name,
+            description,
             inputTiles,
             tags,
           });
@@ -69,6 +81,7 @@ export function registerSaveDashboard(
           frontendUrl,
           dashboardId,
           name,
+          description,
           inputTiles,
           tags,
         });
@@ -83,17 +96,20 @@ async function createDashboard({
   teamId,
   frontendUrl,
   name,
+  description,
   inputTiles,
   tags,
 }: {
   teamId: string;
   frontendUrl: string | undefined;
   name: string;
+  description: string | undefined;
   inputTiles: unknown[];
   tags: string[] | undefined;
 }) {
   const parsed = createDashboardBodySchema.safeParse({
     name,
+    description,
     tiles: inputTiles,
     tags,
   });
@@ -149,6 +165,9 @@ async function createDashboard({
 
   const newDashboard = await new Dashboard({
     name: parsed.data.name,
+    ...(parsed.data.description !== undefined
+      ? { description: parsed.data.description }
+      : {}),
     tiles: internalTiles,
     tags: tags && uniq(tags),
     filters: filtersWithIds,
@@ -184,6 +203,7 @@ async function updateDashboard({
   frontendUrl,
   dashboardId,
   name,
+  description,
   inputTiles,
   tags,
 }: {
@@ -191,6 +211,7 @@ async function updateDashboard({
   frontendUrl: string | undefined;
   dashboardId: string;
   name: string;
+  description: string | undefined;
   inputTiles: unknown[];
   tags: string[] | undefined;
 }) {
@@ -203,6 +224,7 @@ async function updateDashboard({
 
   const parsed = updateDashboardBodySchema.safeParse({
     name,
+    description,
     tiles: inputTiles,
     tags,
   });
@@ -277,6 +299,10 @@ async function updateDashboard({
     tiles: internalTiles,
     tags: tags && uniq(tags),
   };
+
+  if (description !== undefined) {
+    setPayload.description = description;
+  }
 
   if (filters !== undefined) {
     setPayload.filters = convertExternalFiltersToInternal(

--- a/packages/api/src/models/dashboard.ts
+++ b/packages/api/src/models/dashboard.ts
@@ -23,6 +23,7 @@ export default mongoose.model<IDashboard>(
         type: String,
         required: true,
       },
+      description: { type: String, required: false },
       tiles: { type: mongoose.Schema.Types.Mixed, required: true },
       team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team' },
       tags: {

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1073,6 +1073,11 @@ async function getSourceConnectionMismatches(
  *           description: Dashboard name
  *           maxLength: 1024
  *           example: "Service Overview"
+ *         description:
+ *           type: string
+ *           description: Optional description of the dashboard
+ *           maxLength: 40000
+ *           example: "Monitors key service health metrics including latency and error rates"
  *         tiles:
  *           type: array
  *           description: List of tiles/charts in the dashboard
@@ -1119,6 +1124,11 @@ async function getSourceConnectionMismatches(
  *           maxLength: 1024
  *           description: Dashboard name.
  *           example: "New Dashboard"
+ *         description:
+ *           type: string
+ *           maxLength: 40000
+ *           description: Optional description of the dashboard.
+ *           example: "Monitors key service health metrics"
  *         tiles:
  *           type: array
  *           description: List of tiles/charts to include in the dashboard.
@@ -1165,6 +1175,11 @@ async function getSourceConnectionMismatches(
  *           maxLength: 1024
  *           description: Dashboard name.
  *           example: "Updated Dashboard Name"
+ *         description:
+ *           type: string
+ *           maxLength: 40000
+ *           description: Optional description of the dashboard.
+ *           example: "Updated description for this dashboard"
  *         tiles:
  *           type: array
  *           items:
@@ -1305,6 +1320,7 @@ router.get('/', async (req, res, next) => {
       {
         _id: 1,
         name: 1,
+        description: 1,
         tiles: 1,
         tags: 1,
         filters: 1,
@@ -1422,6 +1438,7 @@ router.get(
         {
           _id: 1,
           name: 1,
+          description: 1,
           tiles: 1,
           tags: 1,
           filters: 1,
@@ -1589,6 +1606,7 @@ router.post(
 
       const {
         name,
+        description,
         tiles,
         tags,
         filters,
@@ -1635,6 +1653,7 @@ router.post(
 
       const newDashboard = await new Dashboard({
         name,
+        ...(description !== undefined ? { description } : {}),
         tiles: internalTiles,
         tags: tags && uniq(tags),
         filters: filtersWithIds,
@@ -1812,6 +1831,7 @@ router.put(
 
       const {
         name,
+        description,
         tiles,
         tags,
         filters,
@@ -1869,6 +1889,9 @@ router.put(
         tiles: internalTiles,
         tags: tags && uniq(tags),
       };
+      if (description !== undefined) {
+        setPayload.description = description;
+      }
       if (filters !== undefined) {
         setPayload.filters = convertExternalFiltersToInternal(
           filters,

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -71,6 +71,7 @@ export function isConfigTile(
 export type ExternalDashboard = {
   id: string;
   name: string;
+  description?: string;
   tiles: ExternalDashboardTileWithId[];
   tags?: string[];
   filters?: ExternalDashboardFilterWithId[];
@@ -310,6 +311,7 @@ export function convertToExternalDashboard(
   return {
     id: dashboard._id.toString(),
     name: dashboard.name,
+    ...(dashboard.description ? { description: dashboard.description } : {}),
     tiles: dashboard.tiles
       .map(convertTileToExternalChart)
       .filter(t => t !== undefined),
@@ -576,6 +578,7 @@ export function resolveSavedQueryLanguage(params: {
 
 const dashboardBodyBaseShape = {
   name: z.string().max(1024),
+  description: z.string().max(40000).optional(),
   tiles: externalDashboardTileListSchema,
   tags: tagsSchema,
   savedQuery: z.string().nullable().optional(),

--- a/packages/app/src/DBDashboardImportPage.tsx
+++ b/packages/app/src/DBDashboardImportPage.tsx
@@ -201,6 +201,7 @@ function FileSelection({
 
 const MappingForm = z.object({
   dashboardName: z.string().min(1),
+  dashboardDescription: z.string().max(40000).optional().default(''),
   tags: z.array(z.string()),
   sourceMappings: z.array(z.string()),
   connectionMappings: z.array(z.string()),
@@ -221,6 +222,7 @@ function Mapping({ input }: { input: DashboardTemplate }) {
       resolver: zodResolver(MappingForm),
       defaultValues: {
         dashboardName: input.name,
+        dashboardDescription: input.description ?? '',
         tags: input.tags ?? [],
         sourceMappings: input.tiles.map(() => ''),
         connectionMappings: input.tiles.map(() => ''),
@@ -397,6 +399,7 @@ function Mapping({ input }: { input: DashboardTemplate }) {
         tiles: zippedTiles,
         filters: zippedFilters,
         name: data.dashboardName,
+        description: data.dashboardDescription || undefined,
         tags: data.tags,
       });
       let _dashboardId = dashboardId;
@@ -437,6 +440,17 @@ function Mapping({ input }: { input: DashboardTemplate }) {
               label="Dashboard Name"
               {...field}
               error={formState.errors.dashboardName?.message}
+            />
+          )}
+        />
+        <Controller
+          name="dashboardDescription"
+          control={control}
+          render={({ field }) => (
+            <TextInput
+              label="Description"
+              placeholder="Optional description"
+              {...field}
             />
           )}
         />

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -64,9 +64,10 @@ import {
   Portal,
   Stack,
   Text,
+  Textarea,
   Tooltip,
 } from '@mantine/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys, useHover } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import {
   IconArrowsMaximize,
@@ -1172,6 +1173,95 @@ function DashboardContainerRow({
   );
 }
 
+function EditableDashboardDescription({
+  description,
+  onSave,
+}: {
+  description: string;
+  onSave: (description: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editedDescription, setEditedDescription] = useState(description);
+  const { hovered, ref } = useHover();
+
+  const cancelEditing = () => {
+    setEditedDescription(description);
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <Box ps="md" pe="md" mt={4}>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            onSave(editedDescription.trim());
+            setEditing(false);
+          }}
+          onKeyDown={e => {
+            if (e.key === 'Escape') {
+              cancelEditing();
+            }
+          }}
+          onBlur={e => {
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+              cancelEditing();
+            }
+          }}
+        >
+          <Textarea
+            value={editedDescription}
+            onChange={e => setEditedDescription(e.currentTarget.value)}
+            placeholder="Add a description..."
+            autoFocus
+            autosize
+            minRows={1}
+            maxRows={4}
+            size="sm"
+          />
+          <Group gap="xs" mt="xs">
+            <Button variant="primary" type="submit" size="xs">
+              Save
+            </Button>
+            <Button variant="secondary" size="xs" onClick={cancelEditing}>
+              Cancel
+            </Button>
+          </Group>
+        </form>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      ref={ref}
+      ps="md"
+      pe="md"
+      mt={2}
+      onClick={() => setEditing(true)}
+      className="cursor-pointer"
+      title="Click to edit description"
+    >
+      {description ? (
+        <Group gap={4} align="center">
+          <Text size="sm" c="dimmed" lineClamp={2}>
+            {description}
+          </Text>
+          {hovered && (
+            <IconPencil size={12} color="var(--mantine-color-dimmed)" />
+          )}
+        </Group>
+      ) : (
+        hovered && (
+          <Text size="sm" c="dimmed" fs="italic">
+            Add a description...
+          </Text>
+        )
+      )}
+    </Box>
+  );
+}
+
 function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const brandName = useBrandDisplayName();
   const confirm = useConfirm();
@@ -2079,18 +2169,32 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
         </Group>
       )}
       <Flex mt="xs" mb="md" justify="space-between" align="flex-start">
-        <EditablePageName
-          key={`${dashboardHash}`}
-          name={dashboard?.name ?? ''}
-          onSave={editedName => {
-            if (dashboard != null) {
-              setDashboard({
-                ...dashboard,
-                name: editedName,
-              });
-            }
-          }}
-        />
+        <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+          <EditablePageName
+            key={`${dashboardHash}`}
+            name={dashboard?.name ?? ''}
+            onSave={editedName => {
+              if (dashboard != null) {
+                setDashboard({
+                  ...dashboard,
+                  name: editedName,
+                });
+              }
+            }}
+          />
+          <EditableDashboardDescription
+            key={`desc-${dashboardHash}`}
+            description={dashboard?.description ?? ''}
+            onSave={desc => {
+              if (dashboard != null) {
+                setDashboard({
+                  ...dashboard,
+                  description: desc || undefined,
+                });
+              }
+            }}
+          />
+        </Stack>
         <Group gap="xs">
           {!isLocalDashboard && dashboard?.id && (
             <FavoriteButton

--- a/packages/app/src/components/Dashboards/DashboardsListPage.tsx
+++ b/packages/app/src/components/Dashboards/DashboardsListPage.tsx
@@ -122,7 +122,8 @@ export default function DashboardsListPage() {
       result = result.filter(
         d =>
           d.name.toLowerCase().includes(q) ||
-          d.tags.some(t => t.toLowerCase().includes(q)),
+          d.tags.some(t => t.toLowerCase().includes(q)) ||
+          d.description?.toLowerCase().includes(q),
       );
     }
     return result.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -222,7 +223,10 @@ export default function DashboardsListPage() {
                   name={d.name}
                   href={`/dashboards/${d.id}`}
                   tags={d.tags}
-                  description={`${d.tiles.length} ${d.tiles.length === 1 ? 'tile' : 'tiles'}`}
+                  description={
+                    d.description ||
+                    `${d.tiles.length} ${d.tiles.length === 1 ? 'tile' : 'tiles'}`
+                  }
                   onDelete={() => handleDelete(d.id)}
                   statusIcon={
                     <AlertStatusIcon alerts={getDashboardAlerts(d.tiles)} />
@@ -426,7 +430,10 @@ export default function DashboardsListPage() {
                       name={d.name}
                       href={`/dashboards/${d.id}`}
                       tags={d.tags}
-                      description={`${d.tiles.length} ${d.tiles.length === 1 ? 'tile' : 'tiles'}`}
+                      description={
+                        d.description ||
+                        `${d.tiles.length} ${d.tiles.length === 1 ? 'tile' : 'tiles'}`
+                      }
                       onDelete={() => handleDelete(d.id)}
                       statusIcon={
                         <AlertStatusIcon alerts={getDashboardAlerts(d.tiles)} />

--- a/packages/app/src/dashboard.ts
+++ b/packages/app/src/dashboard.ts
@@ -31,6 +31,7 @@ export type Tile = {
 export type Dashboard = {
   id: string;
   name: string;
+  description?: string;
   tiles: Tile[];
   tags: string[];
   filters?: DashboardFilter[];

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -470,6 +470,7 @@ export function convertToDashboardTemplate(
   const output: DashboardTemplate = {
     version: '0.1.0',
     name: input.name,
+    ...(input.description ? { description: input.description } : {}),
     tags: input.tags.length > 0 ? input.tags : undefined,
     tiles: [],
   };
@@ -534,6 +535,7 @@ export function convertToDashboardDocument(
 ): DashboardWithoutId {
   const output: DashboardWithoutId = {
     name: input.name,
+    ...(input.description ? { description: input.description } : {}),
     tiles: [],
     tags: input.tags ?? [],
   };

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -979,6 +979,7 @@ export function addDuplicateTileIdIssues(
 export const DashboardSchema = z.object({
   id: z.string(),
   name: z.string().min(1),
+  description: z.string().max(40000).optional(),
   tiles: z.array(TileSchema),
   tags: z.array(z.string()),
   filters: z.array(DashboardFilterSchema).optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional `description` field to dashboards that can be set, viewed, and edited across the platform. This enables users and agents to document what a dashboard is for, making it easier to find relevant dashboards in listings and programmatic access.

**Changes:**

- **Schema (common-utils):** Added optional `description` (max 40,000 chars) to `DashboardSchema`; already existed on `DashboardTemplateSchema` for import/export
- **MongoDB model:** Added `description` field to Mongoose dashboard schema
- **Internal API:** Description flows through create/update/get via existing `DashboardSchema.partial()` validation
- **External API v2:** Added `description` to body schemas, route handlers, response type, and OpenAPI docs
- **MCP tools:** `hyperdx_get_dashboard` includes description in listings; `hyperdx_save_dashboard` accepts a `description` parameter
- **Dashboard detail page:** Inline-editable description below the dashboard name (click to edit, with save/cancel)
- **Dashboard listing page:** Shows description on cards (falls back to tile count if no description)
- **Import flow:** Description field editable in the mapping form; preserved through export/import cycle
- **Search:** Dashboard list search also matches against description text

### Screenshots or video

| Before | After |
| :----- | :---- |
| (no description field) | [Dashboard listing with description](https://cursor.com/agents/bc-2ef52843-149e-4bde-9998-1d95a4e1fb91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_list_with_description.webp) |
|  | [Dashboard detail with editable description](https://cursor.com/agents/bc-2ef52843-149e-4bde-9998-1d95a4e1fb91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_detail_description.webp) |
|  | [Editing description inline](https://cursor.com/agents/bc-2ef52843-149e-4bde-9998-1d95a4e1fb91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_description_edited.webp) |

[dashboard_description_demo.mp4](https://cursor.com/agents/bc-2ef52843-149e-4bde-9998-1d95a4e1fb91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_description_demo.mp4)

### How to test on Vercel preview

**Preview routes:** /dashboards/list, /dashboards/[id], /dashboards/import

**Steps:**

1. Navigate to /dashboards/list and create a new "Saved Dashboard"
2. On the dashboard detail page, hover below the title - verify "Add a description..." appears
3. Click to open the description editor, type a description, click Save
4. Navigate back to /dashboards/list - verify the description appears on the card
5. Open the dashboard again - verify the description persists

### References

- Linear Issue: HDX-3813

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-3813](https://linear.app/clickhouse/issue/HDX-3813/add-descriptions-to-dashboards)

<div><a href="https://cursor.com/agents/bc-2ef52843-149e-4bde-9998-1d95a4e1fb91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ef52843-149e-4bde-9998-1d95a4e1fb91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

