### PR TITLE
fix: Ensure search histogram count matches result table count

### DIFF
--- a/.changeset/smooth-goats-applaud.md
+++ b/.changeset/smooth-goats-applaud.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Ensure search histogram count matches result table count

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -116,17 +116,26 @@ export function convertToTimeChartConfig(
     granularity,
   );
 
+  // When the range is bucket-aligned, the end is the start of the next bucket,
+  // so end-exclusive is required to avoid double-counting boundary events.
+  // When alignment is off the end is the user's exact selection — fall back to
+  // the caller's setting, if there is one.
+  const isAligned = config.alignDateRangeToGranularity !== false;
+  const dateRangeEndInclusive = isAligned
+    ? false
+    : (config.dateRangeEndInclusive ?? false);
+
   return isBuilderChartConfig(config)
     ? {
         ...config,
         dateRange,
-        dateRangeEndInclusive: false,
+        dateRangeEndInclusive,
         granularity,
         limit: { limit: 100000 },
       }
     : {
         ...config,
-        dateRangeEndInclusive: false,
+        dateRangeEndInclusive,
         dateRange,
         granularity,
       };

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1483,9 +1483,15 @@ export function DBSearchPage() {
       with: aliasWith,
       // Preserve the original table select string for "View Events" links
       eventTableSelect: searchedConfig.select,
-      // In live mode, when the end date is aligned to the granularity, the end date does
-      // not change on every query, resulting in cached data being re-used.
-      alignDateRangeToGranularity: !isLive,
+      // Never align to granularity boundaries on the search page: the histogram
+      // and total count must reflect the user's exact selected range so they
+      // match the rows shown in the results table. Aligning to bucket
+      // boundaries (e.g. expanding a 2s selection to a 15s bucket) inflates
+      // the count beyond what the table shows. In live mode this also avoids
+      // stale cached data from an unchanging aligned end date.
+      alignDateRangeToGranularity: false,
+      // Make sure the end date is inclusive so that the histogram and table counts match
+      dateRangeEndInclusive: true,
       ...variableConfig,
     };
   }, [
@@ -1494,7 +1500,6 @@ export function DBSearchPage() {
     aliasWith,
     searchedTimeRange,
     searchedConfig.select,
-    isLive,
   ]);
 
   const onFormSubmit = useCallback<FormEventHandler<HTMLFormElement>>(

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1457,7 +1457,9 @@ export function DBSearchPage() {
       return undefined;
     }
 
-    const variableConfig: any = {};
+    const variableConfig: Partial<
+      Pick<BuilderChartConfigWithDateRange, 'groupBy'>
+    > = {};
     switch (searchedSource?.kind) {
       case SourceKind.Log:
         variableConfig.groupBy = searchedSource?.severityTextExpression;
@@ -1482,7 +1484,7 @@ export function DBSearchPage() {
       displayType: DisplayType.StackedBar,
       with: aliasWith,
       // Preserve the original table select string for "View Events" links
-      eventTableSelect: searchedConfig.select,
+      eventTableSelect: searchedConfig.select ?? undefined,
       // Never align to granularity boundaries on the search page: the histogram
       // and total count must reflect the user's exact selected range so they
       // match the rows shown in the results table. Aligning to bucket
@@ -1493,7 +1495,7 @@ export function DBSearchPage() {
       // Make sure the end date is inclusive so that the histogram and table counts match
       dateRangeEndInclusive: true,
       ...variableConfig,
-    };
+    } satisfies BuilderChartConfigWithDateRange;
   }, [
     chartConfig,
     searchedSource,

--- a/packages/app/src/components/SearchTotalCountChart.tsx
+++ b/packages/app/src/components/SearchTotalCountChart.tsx
@@ -105,7 +105,7 @@ export default function SearchTotalCountChart({
   );
 
   return (
-    <Text size="xs" lh="normal">
+    <Text data-testid="search-total-count" size="xs" lh="normal">
       {isLoading ? (
         <span className="effect-pulse">&middot;&middot;&middot; Results</span>
       ) : totalCount !== null && !isError ? (

--- a/packages/app/tests/e2e/features/search/total-count-matches-table.spec.ts
+++ b/packages/app/tests/e2e/features/search/total-count-matches-table.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression guard for: histogram "X Results" count must reflect the user's
+ * exact selected time range, not a granularity-bucket-aligned expansion of it.
+ *
+ * To get a deterministic assertion we seed our own logs directly into
+ * ClickHouse: 10 events spaced 1 s apart on fractional-second offsets, anchored
+ * to a 15-second-aligned reference time. A 5-second search range that starts
+ * 2 s into the bucket isolates exactly 5 of those events; the buggy
+ * bucket-aligned histogram query would see all 10.
+ */
+import { SearchPage } from '../../page-objects/SearchPage';
+import { expect, test } from '../../utils/base-test';
+import { E2E_CLICKHOUSE_DATABASE, E2E_LOGS_TABLE } from '../../utils/constants';
+
+const CLICKHOUSE_HOST =
+  process.env.CLICKHOUSE_HOST ||
+  `http://localhost:${process.env.HDX_E2E_CH_PORT || '20500'}`;
+const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER || 'default';
+const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD || '';
+
+async function clickhouseQuery(sql: string): Promise<void> {
+  const url = new URL(CLICKHOUSE_HOST);
+  url.searchParams.set('user', CLICKHOUSE_USER);
+  if (CLICKHOUSE_PASSWORD) {
+    url.searchParams.set('password', CLICKHOUSE_PASSWORD);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    body: sql,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `ClickHouse query failed (${response.status}): ${errorText}`,
+    );
+  }
+}
+
+/**
+ * Insert 10 log rows into e2e_otel_logs at fixed timestamps, all sharing a
+ * unique ServiceName so the test can filter to its own data (preventing
+ * collisions with other parallel tests or the global seed).
+ *
+ * Returns the bucket-aligned reference timestamp and the marker service name.
+ */
+async function seedCountMismatchLogs(): Promise<{
+  refMs: number;
+  markerService: string;
+}> {
+  // Unique marker per run; Lucene matches it exactly inside quotes.
+  const markerService = `count_mismatch_${Date.now()}_${Math.floor(
+    Math.random() * 1_000_000,
+  )}`;
+
+  // Anchor 5 minutes in the past (well within the 1h-past seed window) and
+  // snap down to a 15-second boundary so a sub-bucket search range will be
+  // fully contained in a single granularity bucket.
+  const fiveMinAgo = Date.now() - 5 * 60 * 1000;
+  const refMs = Math.floor(fiveMinAgo / 15_000) * 15_000;
+
+  // Events at offsets 0.5 s, 1.5 s, ..., 9.5 s. Placing them on the half-second
+  // means our 5 s search range [ref+2 s, ref+7 s] contains exactly the five
+  // events at offsets 2.5, 3.5, 4.5, 5.5, 6.5 — regardless of whether the
+  // range upper bound is treated as inclusive or exclusive.
+  const rows: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const tsMs = refMs + i * 1000 + 500;
+    const tsNs = tsMs * 1_000_000;
+    rows.push(
+      `('${tsNs}', '', '', 0, 'info', 0, '${markerService}', 'count test ${i}', '', {}, '', '', '', {}, {})`,
+    );
+  }
+
+  await clickhouseQuery(`
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_LOGS_TABLE} (
+      Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber,
+      ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl,
+      ScopeName, ScopeVersion, ScopeAttributes, LogAttributes
+    ) VALUES ${rows.join(',\n')}
+  `);
+
+  return { refMs, markerService };
+}
+
+function toPickerFormat(tsMs: number): string {
+  const d = new Date(tsMs);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+test.describe(
+  'Search histogram count matches table for sub-bucket time ranges',
+  { tag: ['@full-stack', '@search'] },
+  () => {
+    test('count is 5 (user range) not 10 (bucket-aligned range)', async ({
+      page,
+    }) => {
+      const { refMs, markerService } = await seedCountMismatchLogs();
+
+      const searchPage = new SearchPage(page);
+      await searchPage.goto();
+      await expect(searchPage.form).toBeVisible();
+
+      // 5-second range inside the 15-second bucket that contains all 10 events.
+      // Expected events in [ref+2 s, ref+7 s]: those at offsets 2.5–6.5 ⇒ 5.
+      const startMs = refMs + 2_000;
+      const endMs = refMs + 7_000;
+
+      await searchPage.timePicker.open();
+      await searchPage.timePicker.disableRelativeTime();
+      await searchPage.timePicker.selectRangeMode();
+      await searchPage.timePicker.setCustomTimeRange(
+        toPickerFormat(startMs),
+        toPickerFormat(endMs),
+      );
+
+      await searchPage.page.waitForURL(
+        u => new URL(u).searchParams.get('from') === String(startMs),
+      );
+
+      // Filter to ONLY the seeded events so the assertion is scoped.
+      await searchPage.performSearch(`ServiceName:"${markerService}"`);
+
+      await searchPage.waitForTotalCountLoaded();
+
+      await expect(searchPage.table.getRows()).toHaveCount(5);
+      await expect(searchPage.totalCountText).toHaveText('5 Results');
+    });
+  },
+);

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -2,7 +2,7 @@
  * SearchPage - Page object for the /search page
  * Encapsulates all interactions with the search interface
  */
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 
 import { FilterComponent } from '../components/FilterComponent';
 import { InfrastructurePanelComponent } from '../components/InfrastructurePanelComponent';
@@ -331,5 +331,14 @@ export class SearchPage {
 
   get otherSources() {
     return this.page.getByRole('option', { selected: false });
+  }
+
+  get totalCountText() {
+    return this.page.getByTestId('search-total-count');
+  }
+
+  async waitForTotalCountLoaded(timeout = 15_000) {
+    await expect(this.totalCountText).toBeVisible({ timeout });
+    await expect(this.totalCountText).not.toContainText('···', { timeout });
   }
 }

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -9,6 +9,15 @@
  * to tune the future buffer.
  */
 
+import {
+  E2E_CLICKHOUSE_DATABASE,
+  E2E_LOGS_TABLE,
+  E2E_METRICS_GAUGE_TABLE,
+  E2E_METRICS_SUM_TABLE,
+  E2E_SESSIONS_TABLE,
+  E2E_TRACES_TABLE,
+} from './utils/constants';
+
 interface ClickHouseConfig {
   host: string;
   user: string;
@@ -628,11 +637,21 @@ async function clearTestData(
   client: ReturnType<typeof createClickHouseClient>,
 ): Promise<void> {
   console.log('  Clearing existing test data...');
-  await client.query('TRUNCATE TABLE IF EXISTS default.e2e_otel_logs');
-  await client.query('TRUNCATE TABLE IF EXISTS default.e2e_otel_traces');
-  await client.query('TRUNCATE TABLE IF EXISTS default.e2e_hyperdx_sessions');
-  await client.query('TRUNCATE TABLE IF EXISTS default.e2e_otel_metrics_gauge');
-  await client.query('TRUNCATE TABLE IF EXISTS default.e2e_otel_metrics_sum');
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_LOGS_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_TRACES_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_SESSIONS_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METRICS_GAUGE_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METRICS_SUM_TABLE}`,
+  );
   console.log('  Existing data cleared');
 }
 
@@ -651,7 +670,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert log data
   console.log('  Inserting log data...');
   await client.query(`
-    INSERT INTO default.e2e_otel_logs (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_LOGS_TABLE} (
       Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber,
       ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl,
       ScopeName, ScopeVersion, ScopeAttributes, LogAttributes
@@ -662,7 +681,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert K8s-aware log data (logs with k8s resource attributes for infrastructure correlation)
   console.log('  Inserting K8s log data...');
   await client.query(`
-    INSERT INTO default.e2e_otel_logs (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_LOGS_TABLE} (
       Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber,
       ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl,
       ScopeName, ScopeVersion, ScopeAttributes, LogAttributes
@@ -673,7 +692,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert trace data
   console.log('  Inserting trace data...');
   await client.query(`
-    INSERT INTO default.e2e_otel_traces (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_TRACES_TABLE} (
       Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind,
       ServiceName, ResourceAttributes, ScopeName, ScopeVersion, SpanAttributes,
       Duration, StatusCode, StatusMessage, \`Events.Timestamp\`, \`Events.Name\`,
@@ -686,7 +705,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert session trace data (spans with rum.sessionId for session tracking)
   console.log('  Inserting session trace data...');
   await client.query(`
-    INSERT INTO default.e2e_otel_traces (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_TRACES_TABLE} (
       Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind,
       ServiceName, ResourceAttributes, ScopeName, ScopeVersion, SpanAttributes,
       Duration, StatusCode, StatusMessage, \`Events.Timestamp\`, \`Events.Name\`,
@@ -699,7 +718,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert session data
   console.log('  Inserting session data...');
   await client.query(`
-    INSERT INTO default.e2e_hyperdx_sessions (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_SESSIONS_TABLE} (
       Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber,
       ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl,
       ScopeName, ScopeVersion, ScopeAttributes, LogAttributes
@@ -710,7 +729,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert Kubernetes gauge metrics (pods and nodes)
   console.log('  Inserting Kubernetes gauge metrics...');
   await client.query(`
-    INSERT INTO default.e2e_otel_metrics_gauge (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_METRICS_GAUGE_TABLE} (
       ResourceAttributes, ResourceSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes,
       ScopeDroppedAttrCount, ScopeSchemaUrl, ServiceName, MetricName, MetricDescription,
       MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags,
@@ -725,7 +744,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert Kubernetes sum metrics (uptime)
   console.log('  Inserting Kubernetes sum metrics...');
   await client.query(`
-    INSERT INTO default.e2e_otel_metrics_sum (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_METRICS_SUM_TABLE} (
       ResourceAttributes, ResourceSchemaUrl, ScopeName, ScopeVersion, ScopeAttributes,
       ScopeDroppedAttrCount, ScopeSchemaUrl, ServiceName, MetricName, MetricDescription,
       MetricUnit, Attributes, StartTimeUnix, TimeUnix, Value, Flags,
@@ -739,7 +758,7 @@ export async function seedClickHouse(): Promise<void> {
   // Insert Kubernetes event logs
   console.log('  Inserting Kubernetes event logs...');
   await client.query(`
-    INSERT INTO default.e2e_otel_logs (
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_LOGS_TABLE} (
       Timestamp, TraceId, SpanId, TraceFlags, SeverityText, SeverityNumber,
       ServiceName, Body, ResourceSchemaUrl, ResourceAttributes, ScopeSchemaUrl,
       ScopeName, ScopeVersion, ScopeAttributes, LogAttributes

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -2,3 +2,13 @@ export const DEFAULT_SESSIONS_SOURCE_NAME = 'E2E Sessions';
 export const DEFAULT_TRACES_SOURCE_NAME = 'E2E Traces';
 export const DEFAULT_METRICS_SOURCE_NAME = 'E2E Metrics';
 export const DEFAULT_LOGS_SOURCE_NAME = 'E2E Logs';
+
+// ClickHouse database/table names backing the default E2E sources. Must stay
+// in sync with `tests/e2e/fixtures/e2e-fixtures.json` and the CREATE TABLE
+// statements in `docker/clickhouse/local/init-db-e2e.sh`.
+export const E2E_CLICKHOUSE_DATABASE = 'default';
+export const E2E_LOGS_TABLE = 'e2e_otel_logs';
+export const E2E_TRACES_TABLE = 'e2e_otel_traces';
+export const E2E_SESSIONS_TABLE = 'e2e_hyperdx_sessions';
+export const E2E_METRICS_GAUGE_TABLE = 'e2e_otel_metrics_gauge';
+export const E2E_METRICS_SUM_TABLE = 'e2e_otel_metrics_sum';


### PR DESCRIPTION
## Summary

This PR updates the ChartConfig used for the search page histogram and total result count, so that the count always matches what is shown in the results table.

Previously, there were two reasons the count might not match:

1. When not in live mode, the chart (and count) were aligned to the granularity, whereas the results table was not. This could cause the total count and histogram to over count the number of results
2. The histogram was end-exclusive, now it is end inclusive to match the search results table config.

### Screenshots or video

Before: alignment resulted in a count that was greater than the number of results in the table

<img width="2273" height="498" alt="Screenshot 2026-05-11 at 9 08 49 AM" src="https://github.com/user-attachments/assets/e8b6960a-49e3-4276-90d9-46d3a6552068" />

After: Count is correct even when date range is not aligned or exactly matches the queried result's timestamp (due to end inclusivity)

<img width="2274" height="452" alt="Screenshot 2026-05-11 at 9 08 33 AM" src="https://github.com/user-attachments/assets/3f32fc36-808f-461d-ac01-f4e70a44a020" />
<img width="2277" height="323" alt="Screenshot 2026-05-11 at 9 08 20 AM" src="https://github.com/user-attachments/assets/5e69b1f5-2e54-4f89-bb22-557bbbd13f5b" />

### How to test on Vercel preview

This can be tested in the preview environment by playing around with the filters and time ranges to get a small (countable) number of results. Or locally by seeding clickhouse with some data at particular timestamps (which is what the new E2E test does)

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4194 Closes #2255 
- Related PRs:
