### PR TITLE
feat(mcp): improve MCP docs and increase rate limit to 600 req/min

### DIFF
--- a/.changeset/proud-hounds-draw.md
+++ b/.changeset/proud-hounds-draw.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+Increase MCP rate limit to 10 req/s

--- a/MCP.md
+++ b/MCP.md
@@ -1,28 +1,42 @@
 # HyperDX MCP Server
 
-HyperDX exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that lets AI assistants query your observability
-data, manage dashboards, and explore data sources directly.
+HyperDX exposes a
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that
+lets AI assistants query your observability data, manage dashboards, and explore
+data sources directly.
 
 ## Prerequisites
 
-- A running HyperDX instance (see [CONTRIBUTING.md](/CONTRIBUTING.md) for local development setup, or [DEPLOY.md](/DEPLOY.md) for
-  self-hosted deployment)
-- A **Personal API Access Key** — find yours in the HyperDX UI under **Team Settings > API Keys > Personal API Access Key**
+- A running HyperDX instance (see [CONTRIBUTING.md](/CONTRIBUTING.md) for local
+  development setup, or [DEPLOY.md](/DEPLOY.md) for self-hosted deployment)
+- A **Personal API Access Key** — find yours in the HyperDX UI under **Team
+  Settings > API Keys > Personal API Access Key**
+
+> **Note:** HyperDX v1 ([hyperdx.io](https://hyperdx.io)) does not yet support
+> the MCP server. The documentation below applies to self-hosted HyperDX v2
+> (Free and Enterprise).
 
 ## Endpoint
 
-The MCP server is available at the `/api/mcp` path on your HyperDX instance. For local development this is:
+The MCP server is available at the `/api/mcp` path on your HyperDX instance. For
+local development this is:
 
 ```
 http://localhost:8080/api/mcp
 ```
 
-Replace `localhost:8080` with your instance's host and port if you've customized the defaults.
+Replace `localhost:8080` with your instance's host and port if you've customized
+the defaults.
+
+> **Note:** The examples below use `localhost:8080` (the frontend app). You can
+> also reach the MCP server directly at `<backend_url>/mcp`, but not all
+> deployments expose the backend, so these docs use frontend paths.
 
 ## Connecting an MCP Client
 
-The MCP server uses the **Streamable HTTP** transport with Bearer token authentication. In the examples below, replace `<your-hyperdx-url>`
-with your instance URL (e.g. `http://localhost:8080`).
+The MCP server uses the **Streamable HTTP** transport with Bearer token
+authentication. In the examples below, replace `<your-hyperdx-url>` with your
+instance URL (e.g. `http://localhost:8080`).
 
 ### Claude Code
 
@@ -33,14 +47,25 @@ claude mcp add --transport http hyperdx <your-hyperdx-url>/api/mcp \
 
 ### OpenCode
 
-```bash
-opencode mcp add --transport http hyperdx <your-hyperdx-url>/api/mcp \
-  --header "Authorization: Bearer <your-personal-access-key>"
+Add the following to your [OpenCode config](https://opencode.ai/docs/config):
+
+```json
+"mcp": {
+  "hyperdx": {
+    "enabled": true,
+    "type": "remote",
+    "url": "<your-hyperdx-url>/api/mcp",
+    "headers": {
+      "Authorization": "Bearer <your-personal-access-key>"
+    }
+  }
+}
 ```
 
 ### Cursor
 
-Add the following to `.cursor/mcp.json` in your project (or your global Cursor settings):
+Add the following to `.cursor/mcp.json` in your project (or your global Cursor
+settings):
 
 ```json
 {
@@ -67,12 +92,14 @@ Then configure the inspector:
 
 1. **Transport Type:** Streamable HTTP
 2. **URL:** `<your-hyperdx-url>/api/mcp`
-3. **Authentication:** Header `Authorization` with value `Bearer <your-personal-access-key>`
+3. **Authentication:** Header `Authorization` with value
+   `Bearer <your-personal-access-key>`
 4. Click **Connect**
 
 ### Other Clients
 
-Any MCP client that supports Streamable HTTP transport can connect. Configure it with:
+Any MCP client that supports Streamable HTTP transport can connect. Configure it
+with:
 
 - **URL:** `<your-hyperdx-url>/api/mcp`
 - **Header:** `Authorization: Bearer <your-personal-access-key>`

--- a/packages/api/src/mcp/app.ts
+++ b/packages/api/src/mcp/app.ts
@@ -12,7 +12,7 @@ const app = createMcpExpressApp();
 
 const mcpRateLimiter = rateLimiter({
   windowMs: 60 * 1000, // 1 minute
-  max: 100,
+  max: 600, // 10 req/s
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: rateLimiterKeyGenerator,


### PR DESCRIPTION
## Summary

- **MCP docs (MCP.md):** Added v1/v2 compatibility note, clarified frontend vs backend endpoint paths, replaced outdated OpenCode CLI command with JSON config block, fixed code fence language, and improved wording throughout.
- **MCP rate limit:** Increased from 100 to 600 requests/min (~10 req/s) per API key to support parallel agent workloads and power users without throttling during traffic spikes.