### PR TITLE
[HDX-4236] chore: deprecate miner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,6 @@ services:
       HYPERDX_APP_PORT: ${HYPERDX_APP_PORT}
       HYPERDX_APP_URL: ${HYPERDX_APP_URL}
       HYPERDX_LOG_LEVEL: ${HYPERDX_LOG_LEVEL}
-      MINER_API_URL: 'http://miner:5123'
       MONGO_URI: 'mongodb://db:27017/hyperdx'
       SERVER_URL: http://127.0.0.1:${HYPERDX_API_PORT}
       OPAMP_PORT: ${HYPERDX_OPAMP_PORT}

--- a/packages/api/.env.development
+++ b/packages/api/.env.development
@@ -5,7 +5,6 @@ FRONTEND_URL="http://localhost:${HYPERDX_APP_PORT}"
 HDX_NODE_ADVANCED_NETWORK_CAPTURE=1
 HDX_NODE_BETA_MODE=1
 HDX_NODE_CONSOLE_CAPTURE=1
-MINER_API_URL="http://localhost:5123"
 MONGO_URI="mongodb://localhost:${HDX_DEV_MONGO_PORT}/hyperdx"
 NODE_ENV=development
 OTEL_SERVICE_NAME="hdx-oss-dev-api"

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -33,7 +33,6 @@ export const HYPERDX_LOG_LEVEL = env.HYPERDX_LOG_LEVEL as string;
 export const IS_CI = NODE_ENV === 'test';
 export const IS_DEV = NODE_ENV === 'development';
 export const IS_PROD = NODE_ENV === 'production';
-export const MINER_API_URL = env.MINER_API_URL as string;
 export const MONGO_URI = env.MONGO_URI;
 export const OTEL_SERVICE_NAME = env.OTEL_SERVICE_NAME as string;
 export const PORT = Number.parseInt(env.PORT as string);


### PR DESCRIPTION
## Summary

The Python `miner` service has been deprecated. It is dead code — nothing in the repo calls it at runtime:

- `packages/app` mines patterns client-side using Pyodide-loaded `drain3` (`src/hooks/usePatterns.tsx`)
- `packages/cli` uses the TypeScript drain port in `packages/common-utils/src/drain/`
- `packages/api/src/config.ts` exported `MINER_API_URL` but no code path imported it

## Changes

Removed `MINER_API_URL` from:
- `packages/api/src/config.ts`
- `packages/api/.env.development`
- `docker-compose.yml`

## Verification

- `rg MINER_API_URL` → 0 hits
- `yarn lint:fix` → 0 errors

## Linear

[HDX-4236](https://linear.app/clickhouse/issue/HDX-4236/deprecate-miner-service)

## Related

Companion EE PR: DeploySentinel/hyperdx-ee#2069