### PR TITLE
fix: scope ClickHouse settings cache key by connectionId in NodeClickhouseClient

### DIFF
--- a/.changeset/forty-beers-applaud.md
+++ b/.changeset/forty-beers-applaud.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+Fix issue with incorrect cache key being set in settings queries in nodejs

--- a/packages/common-utils/src/__tests__/clickhouse.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouse.test.ts
@@ -472,6 +472,7 @@ describe('processClickhouseSettings - optimization settings', () => {
     await client.query({
       query: 'SELECT 1',
       format: 'JSON',
+      connectionId: 'test-conn',
     });
 
     const actualQueryCall = mockQueryMethod.mock.calls.find(
@@ -504,6 +505,7 @@ describe('processClickhouseSettings - optimization settings', () => {
     await client.query({
       query: 'SELECT 1',
       format: 'JSON',
+      connectionId: 'test-conn',
     });
 
     const actualQueryCall = mockQueryMethod.mock.calls.find(
@@ -531,6 +533,7 @@ describe('processClickhouseSettings - optimization settings', () => {
     await client.query({
       query: 'SELECT 1',
       format: 'JSON',
+      connectionId: 'test-conn',
       clickhouse_settings: {
         max_rows_to_read: '1000000',
       },
@@ -582,6 +585,7 @@ describe('processClickhouseSettings - optimization settings', () => {
     await client.query({
       query: 'SELECT 1',
       format: 'JSON',
+      connectionId: 'test-conn',
     });
 
     const actualQueryCall = mockQueryMethod.mock.calls.find(
@@ -602,8 +606,16 @@ describe('processClickhouseSettings - optimization settings', () => {
     setupMockQuery([{ name: 'use_skip_indexes_for_top_k', value: '1' }]);
 
     // Run two queries
-    await client.query({ query: 'SELECT 1', format: 'JSON' });
-    await client.query({ query: 'SELECT 2', format: 'JSON' });
+    await client.query({
+      query: 'SELECT 1',
+      format: 'JSON',
+      connectionId: 'test-conn',
+    });
+    await client.query({
+      query: 'SELECT 2',
+      format: 'JSON',
+      connectionId: 'test-conn',
+    });
 
     // Should only fetch settings once
     const settingsCalls = mockQueryMethod.mock.calls.filter(

--- a/packages/common-utils/src/clickhouse/browser.ts
+++ b/packages/common-utils/src/clickhouse/browser.ts
@@ -124,7 +124,7 @@ export class ClickhouseClient extends BaseClickhouseClient {
 
     let clickhouseSettings: ClickHouseSettings | undefined;
     // If this is the settings query, we must not process the clickhouse settings, or else we will infinitely recurse
-    if (!shouldSkipApplySettings) {
+    if (!shouldSkipApplySettings && connectionId) {
       clickhouseSettings = await this.processClickhouseSettings({
         connectionId,
         externalClickhouseSettings,

--- a/packages/common-utils/src/clickhouse/browser.ts
+++ b/packages/common-utils/src/clickhouse/browser.ts
@@ -124,7 +124,7 @@ export class ClickhouseClient extends BaseClickhouseClient {
 
     let clickhouseSettings: ClickHouseSettings | undefined;
     // If this is the settings query, we must not process the clickhouse settings, or else we will infinitely recurse
-    if (!shouldSkipApplySettings && connectionId) {
+    if (!shouldSkipApplySettings) {
       clickhouseSettings = await this.processClickhouseSettings({
         connectionId,
         externalClickhouseSettings,

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -508,7 +508,7 @@ export abstract class BaseClickhouseClient {
     connectionId,
     externalClickhouseSettings,
   }: {
-    connectionId: string;
+    connectionId?: string;
     externalClickhouseSettings?: ClickHouseSettings;
   }): Promise<ClickHouseSettings> {
     const clickhouse_settings = structuredClone(
@@ -532,8 +532,13 @@ export abstract class BaseClickhouseClient {
       output_format_json_quote_64bit_integers: 1, // In 25.8, the default value for this was changed from 1 to 0. Due to JavaScript's poor precision for big integers, we should enable this https://github.com/ClickHouse/ClickHouse/pull/74079
     };
 
-    const metadata = getMetadata(this);
-    const serverSettings = await metadata.getSettings({ connectionId });
+    // Only look up server-specific optimization settings when we have a
+    // connectionId to scope the cache key. Without one the cache key would
+    // be "undefined.availableSettings", which can collide across different
+    // ClickHouse instances sharing the same MetadataCache singleton.
+    const serverSettings = connectionId
+      ? await getMetadata(this).getSettings({ connectionId })
+      : undefined;
 
     const applySettingIfAvailable = (name: string, value: string) => {
       if (!serverSettings || !serverSettings.has(name)) return;

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -508,7 +508,7 @@ export abstract class BaseClickhouseClient {
     connectionId,
     externalClickhouseSettings,
   }: {
-    connectionId?: string;
+    connectionId: string;
     externalClickhouseSettings?: ClickHouseSettings;
   }): Promise<ClickHouseSettings> {
     const clickhouse_settings = structuredClone(

--- a/packages/common-utils/src/clickhouse/node.ts
+++ b/packages/common-utils/src/clickhouse/node.ts
@@ -42,7 +42,7 @@ export class ClickhouseClient extends BaseClickhouseClient {
 
     let clickhouseSettings: ClickHouseSettings | undefined;
     // If this is the settings query, we must not process the clickhouse settings, or else we will infinitely recurse
-    if (!shouldSkipApplySettings && connectionId) {
+    if (!shouldSkipApplySettings) {
       clickhouseSettings = await this.processClickhouseSettings({
         externalClickhouseSettings,
         connectionId,

--- a/packages/common-utils/src/clickhouse/node.ts
+++ b/packages/common-utils/src/clickhouse/node.ts
@@ -34,6 +34,7 @@ export class ClickhouseClient extends BaseClickhouseClient {
     query_params = {},
     abort_signal,
     clickhouse_settings: externalClickhouseSettings,
+    connectionId,
     queryId,
     shouldSkipApplySettings,
   }: QueryInputs<Format>): Promise<BaseResultSet<ReadableStream, Format>> {
@@ -41,9 +42,10 @@ export class ClickhouseClient extends BaseClickhouseClient {
 
     let clickhouseSettings: ClickHouseSettings | undefined;
     // If this is the settings query, we must not process the clickhouse settings, or else we will infinitely recurse
-    if (!shouldSkipApplySettings) {
+    if (!shouldSkipApplySettings && connectionId) {
       clickhouseSettings = await this.processClickhouseSettings({
         externalClickhouseSettings,
+        connectionId,
       });
     }
 

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -845,7 +845,7 @@ export class Metadata {
     });
   }
 
-  async getSettings({ connectionId }: { connectionId?: string }) {
+  async getSettings({ connectionId }: { connectionId: string }) {
     return this.cache.getOrFetch(
       `${connectionId}.availableSettings`,
       async () => {


### PR DESCRIPTION
## Summary

- Fix MCP server queries failing with `Setting query_plan_optimize_lazy_materialization is neither a builtin setting` when querying ClickHouse instances that don't support that setting
- Forward `connectionId` in `NodeClickhouseClient.__query()` to `processClickhouseSettings()`, matching the browser client's behavior
- Guard the `metadata.getSettings()` lookup on `connectionId` presence inside `processClickhouseSettings()`, so default settings and externally-provided settings always apply even when `connectionId` is absent

## Problem

`NodeClickhouseClient.__query()` did not destructure or forward `connectionId` to `processClickhouseSettings()`. This caused `metadata.getSettings()` to always use the cache key `"undefined.availableSettings"`.

All `NodeClickhouseClient` instances on the API server (MCP tools, alert checkers, external API charts, etc.) share a single global `MetadataCache` with no TTL. When the first Node-side query hit a ClickHouse that **has** `query_plan_optimize_lazy_materialization` in `system.settings`, that Map was cached under `"undefined.availableSettings"`. Subsequent queries to a **different** ClickHouse (e.g. an older version) reused the stale cache, `applySettingIfAvailable` saw the setting as available, and ClickHouse rejected it.

The browser client was unaffected because `BrowserClickhouseClient.__query()` already passes `connectionId`, scoping the cache key correctly as `"<connectionId>.availableSettings"`.

## Approach

The `connectionId` guard is placed **inside** `processClickhouseSettings()` around only the `metadata.getSettings()` call, rather than wrapping the entire function at the call site. This ensures:

- **Default settings** (`allow_experimental_analyzer`, `max_execution_time`, `output_format_json_quote_64bit_integers`, etc.) always apply
- **Externally-provided** `clickhouse_settings` always flow through
- **Server-specific optimization settings** (lazy materialization, skip indexes, etc.) are only looked up when `connectionId` is present, preventing the `"undefined.availableSettings"` cache key collision

## Changes

| File | Change |
|------|--------|
| `packages/common-utils/src/clickhouse/node.ts` | Destructure `connectionId` from `QueryInputs` and forward it to `processClickhouseSettings()` |
| `packages/common-utils/src/clickhouse/index.ts` | Guard `metadata.getSettings()` on `connectionId` presence inside `processClickhouseSettings()` — returns `undefined` serverSettings when missing, so defaults still apply |
| `packages/common-utils/src/core/metadata.ts` | Make `connectionId` required (`string`, was `string?`) in `getSettings()` to prevent future callers from passing `undefined` |
| `packages/common-utils/src/__tests__/clickhouse.test.ts` | Add `connectionId: 'test-conn'` to tests exercising the server settings lookup path |