### PR TITLE
ci(release): fix OIDC trusted publishing, add Slack alert, allow manual re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
           cache: 'yarn'
           # Note: Do NOT set registry-url here — it creates a NODE_AUTH_TOKEN
           # that conflicts with npm OIDC trusted publishing
+      # npm OIDC trusted publishing requires npm >= 11.5.1 client-side. Node 22
+      # LTS ships npm 10.x, which has no OIDC code path and falls back to
+      # NODE_AUTH_TOKEN, failing ENEEDAUTH.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: Configure npm registry
         run: npm config set registry https://registry.npmjs.org/
       - name: Install root dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -692,6 +692,79 @@ jobs:
               }
             });
 
+  # ---------------------------------------------------------------------------
+  # Failure notification
+  # ---------------------------------------------------------------------------
+  slack-notify-failure:
+    name: Notify Slack on Failure
+    needs:
+      [
+        check_changesets,
+        publish-app,
+        publish-otel-collector,
+        publish-local,
+        publish-all-in-one,
+        release-cli,
+        notify_helm_charts,
+        notify_ch,
+        notify_clickhouse_clickstack,
+      ]
+    runs-on: ubuntu-24.04
+    if: failure() && always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get failed jobs
+        id: get_failed_jobs
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const response = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+
+            const failedJobs = response.data.jobs
+              .filter(job => job.status === 'completed' && job.conclusion === 'failure')
+              .map(job => job.name)
+              .join(', ');
+
+            core.setOutput('failed_jobs', failedJobs);
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: repo,workflow,commit,author
+          custom_payload: |
+            {
+              "text": "Release Failed",
+              "attachments": [{
+                "color": "danger",
+                "fields": [
+                  {
+                    "title": "Failed Build",
+                    "value": "${{ steps.get_failed_jobs.outputs.failed_jobs }}",
+                    "short": false
+                  },
+                  {
+                    "title": "Commit",
+                    "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
+                    "short": false
+                  },
+                  {
+                    "title": "Author",
+                    "value": "${{ github.actor }}",
+                    "short": true
+                  }
+                ]
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_ENG_NOTIFS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   otel-cicd-action:
     if: always()
     name: OpenTelemetry Export Trace
@@ -707,6 +780,7 @@ jobs:
         notify_helm_charts,
         notify_ch,
         notify_clickhouse_clickstack,
+        slack-notify-failure,
       ]
     steps:
       - name: Export workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -711,6 +711,29 @@ jobs:
     runs-on: ubuntu-24.04
     if: failure()
     steps:
+      - name: Get failed steps
+        id: get_failed_steps
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
+            const failedSteps = data.jobs
+              .filter(job => job.conclusion === 'failure')
+              .flatMap(job => {
+                const stepNames = (job.steps ?? [])
+                  .filter(step => step.conclusion === 'failure')
+                  .map(step => `${job.name} → ${step.name}`);
+                return stepNames.length > 0 ? stepNames : [`${job.name} → (unknown step)`];
+              })
+              .join(', ');
+
+            core.setOutput('failed_steps', failedSteps || 'unknown');
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         with:
@@ -722,6 +745,11 @@ jobs:
               "attachments": [{
                 "color": "danger",
                 "fields": [
+                  {
+                    "title": "Failed step(s)",
+                    "value": "${{ steps.get_failed_steps.outputs.failed_steps }}",
+                    "short": false
+                  },
                   {
                     "title": "Commit",
                     "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         run: make ci-build
       - name: Create Release Pull Request or Publish to npm
         if: always()
-        continue-on-error: true
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,7 +696,6 @@ jobs:
   # Failure notification
   # ---------------------------------------------------------------------------
   slack-notify-failure:
-    name: Notify Slack on Failure
     needs:
       [
         check_changesets,
@@ -710,52 +709,32 @@ jobs:
         notify_clickhouse_clickstack,
       ]
     runs-on: ubuntu-24.04
-    if: failure() && always()
+    if: failure()
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Get failed jobs
-        id: get_failed_jobs
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const response = await github.rest.actions.listJobsForWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            });
-
-            const failedJobs = response.data.jobs
-              .filter(job => job.status === 'completed' && job.conclusion === 'failure')
-              .map(job => job.name)
-              .join(', ');
-
-            core.setOutput('failed_jobs', failedJobs);
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
         with:
           status: custom
-          fields: repo,workflow,commit,author
+          fields: repo,workflow
           custom_payload: |
             {
-              "text": "Release Failed",
+              "text": "Release workflow failed!",
               "attachments": [{
                 "color": "danger",
                 "fields": [
-                  {
-                    "title": "Failed Build",
-                    "value": "${{ steps.get_failed_jobs.outputs.failed_jobs }}",
-                    "short": false
-                  },
                   {
                     "title": "Commit",
                     "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>",
                     "short": false
                   },
                   {
-                    "title": "Author",
+                    "title": "Actor",
                     "value": "${{ github.actor }}",
+                    "short": true
+                  },
+                  {
+                    "title": "Run",
+                    "value": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>",
                     "short": true
                   }
                 ]


### PR DESCRIPTION
## Summary

Four ci-only changes to `release.yml` that together unblock npm OIDC trusted publishing, route future failures to Slack, and give us a manual retry path:

1. **Upgrade npm to `latest` in `check_changesets`** so `npm publish` can perform the OIDC handshake. Runner ships Node 22 + npm 10.9.4 by default, but client-side OIDC trusted publishing landed in **npm 11.5.1** (July 2025). Without this upgrade `npm publish` has no OIDC code path, falls back to looking for a `NODE_AUTH_TOKEN` (deliberately not set, to avoid conflicting with OIDC), and exits `ENEEDAUTH`.
2. **Drop `continue-on-error: true`** from the `Create Release Pull Request or Publish to npm` step so a future publish failure fails the workflow run instead of leaving it green with no releases shipped.
3. **Add `slack-notify-failure` job** mirroring the pattern in `release-nightly.yml`: gated on `if: failure() && always()`, waits on every major job, lists the failed ones via `listJobsForWorkflowRun`, and posts a danger-colored Slack message to `SLACK_WEBHOOK_URL_ENG_NOTIFS` with the commit SHA + author. Combined with (2), the next release.yml failure surfaces on Slack instead of going silent.
4. **Add `workflow_dispatch:` trigger** so we can manually re-run the workflow against an arbitrary `main` SHA (`gh workflow run release.yml --ref main` or the UI "Run workflow" button). Needed for the recovery path below — `gh run rerun <run-id>` re-uses the original commit's workflow file, so it can't test fixes added in later commits.

## Why we didn't catch this on the April-23 OIDC switch

The April-23 release that introduced OIDC ([commit 3ae1b85d8](https://github.com/hyperdxio/hyperdx/commit/3ae1b85d8)) only **appeared** to work — OIDC never actually fired. Sequence:

1. [Run 24862921978](https://github.com/hyperdxio/hyperdx/actions/runs/24862921978) (2026-04-23, on the release-PR commit before the OIDC switch) tried to publish `@hyperdx/cli@0.4.0` and failed with `E404 Not Found - PUT /@hyperdx%2fcli` — same `continue-on-error: true` mask, workflow green, no GH Releases created.
2. Between 22:55 and 23:30 UTC, `@hyperdx/cli@0.4.0` was published out of band (manual `npm publish`).
3. [Run 24864061403](https://github.com/hyperdxio/hyperdx/actions/runs/24864061403), kicked off by the OIDC commit itself, re-ran `changeset publish` which saw the package was already on npm and emitted:
   ```
   🦋  warn @hyperdx/cli is not being published because version 0.4.0 is already published on npm
   🦋  warn No unpublished projects to publish
   ```
   `changeset publish` then exited zero, `changesets/action` proceeded with its `createRelease` loop, and the five `@hyperdx/{api,app,cli,common-utils,otel-collector}` GH Releases got created. OIDC was never exercised — the publish was a no-op.

Today's 2.25.0 release ([run 25827737203](https://github.com/hyperdxio/hyperdx/actions/runs/25827737203)) had no out-of-band publish to fall back on, so the underlying `ENEEDAUTH` surfaced as a real failure for `@hyperdx/cli@0.4.1`. `changesets/action` aborts inside `runPublish` (the `execWithOutput` call sits above the `createGithubReleases` loop, and it re-throws on non-zero exit), so neither the cli nor the four private-package GH Releases (`@hyperdx/api@2.25.0`, `@hyperdx/app@2.25.0`, `@hyperdx/common-utils@0.19.0`, `@hyperdx/otel-collector@2.25.0`) ever got created. The lone `cli-v0.4.1` entry on the Releases page came from the separate `release-cli` job using `softprops/action-gh-release` — not from changesets.

The npm trusted-publisher config also had a `release.yaml` → `release.yml` filename typo (fixed in the npm UI). Real bug, but **independent** — when the npm client never sends an OIDC token in the first place, registry-side trusted-publisher matching is moot.

## Recovery for the stuck 2.25.0 / cli@0.4.1 cycle

After merging this PR:

```bash
gh workflow run release.yml --ref main
```

The run will:

- `check_changesets`: install npm `latest`, see no changesets, `yarn release` → genuine OIDC `npm publish` of `@hyperdx/cli@0.4.1` (with provenance) → push the five 2.25.0 / 0.19.0 git tags → `changesets/action` creates all five GH Releases.
- `check_version`: `manifest inspect` finds the existing 2.25.0 image tag → `should_release=false` → all Docker build / publish / downstream-notify jobs short-circuit.
- `release-cli`: `gh release view cli-v0.4.1` succeeds → `exists=true` → compile + create-release steps are skipped.
- `slack-notify-failure`: only runs if any of the above fail — silent on success.