### PR TITLE
Use PageHeader title on list pages

### DIFF
--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -358,7 +358,7 @@ export default function AlertsPage() {
       <Head>
         <title>Alerts - {brandName}</title>
       </Head>
-      <PageHeader>Alerts</PageHeader>
+      <PageHeader title="Alerts" />
       <div className="my-4" style={{ flex: 1 }}>
         {isLoading ? (
           <div className="text-center my-4 fs-8">Loading...</div>

--- a/packages/app/src/components/Dashboards/DashboardsListPage.tsx
+++ b/packages/app/src/components/Dashboards/DashboardsListPage.tsx
@@ -184,7 +184,7 @@ export default function DashboardsListPage() {
       <Head>
         <title>Dashboards - {brandName}</title>
       </Head>
-      <PageHeader>Dashboards</PageHeader>
+      <PageHeader title="Dashboards" />
       <Container
         maw={1200}
         py="lg"

--- a/packages/app/src/components/SavedSearches/SavedSearchesListPage.tsx
+++ b/packages/app/src/components/SavedSearches/SavedSearchesListPage.tsx
@@ -129,7 +129,7 @@ export default function SavedSearchesListPage() {
       <Head>
         <title>Saved Searches - {brandName}</title>
       </Head>
-      <PageHeader>Saved Searches</PageHeader>
+      <PageHeader title="Saved Searches" />
       <Container
         maw={1200}
         py="lg"


### PR DESCRIPTION
## Summary
- Switches Alerts, Dashboards, and Saved Searches to the explicit `PageHeader` `title` prop for consistency with the shared header API.

## Test plan
- [ ] Open Alerts, Dashboards list, and Saved Searches; confirm titles and layout unchanged aside from header implementation

Made with [Cursor](https://cursor.com)