### PR TITLE
Migrate Sessions page to PageLayout

### DIFF
--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -16,7 +16,6 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import {
   Anchor,
-  Box,
   Button,
   Code,
   Flex,
@@ -32,6 +31,8 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import EmptyState from '@/components/EmptyState';
+import { PageHeader } from '@/components/PageHeader';
+import { PageLayout } from '@/components/PageLayout';
 import { SourceSelectControlled } from '@/components/SourceSelect';
 import { TimePicker } from '@/components/TimePicker';
 import { parseTimeQuery, useNewTimeQuery } from '@/timeQuery';
@@ -352,11 +353,7 @@ export default function SessionsPage() {
   const targetSession = sessions.find(s => s.sessionId === selectedSession?.id);
 
   return (
-    <div
-      className="SessionsPage"
-      data-testid="sessions-page"
-      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
-    >
+    <>
       <Head>
         <title>Client Sessions - {brandName}</title>
       </Head>
@@ -382,80 +379,96 @@ export default function SessionsPage() {
             }
           />
         )}
-      <Box p="sm" style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-        <form
-          data-testid="sessions-search-form"
-          onSubmit={e => {
-            e.preventDefault();
-            onSubmit();
-            return false;
-          }}
-        >
-          <Flex gap="xs" direction="column" wrap="nowrap">
-            <Group justify="space-between" gap="xs" wrap="nowrap" flex={1}>
-              <SourceSelectControlled
-                control={control}
-                name="source"
-                allowedSourceKinds={[SourceKind.Session]}
-              />
-              <SearchWhereInput
-                tableConnection={tcFromSource(traceTrace)}
-                control={control}
-                name="where"
-                onSubmit={onSubmit}
-                enableHotkey
-                width="50%"
-              />
-              <TimePicker
-                inputValue={displayedTimeInputValue}
-                setInputValue={setDisplayedTimeInputValue}
-                onSearch={range => {
-                  onSearch(range);
-                }}
-              />
-              <Button
-                variant="primary"
-                type="submit"
-                px="sm"
-                leftSection={<IconPlayerPlay size={16} />}
-                style={{ flexShrink: 0 }}
+      <form
+        className={`SessionsPage ${styles.pageForm}`}
+        data-testid="sessions-search-form"
+        onSubmit={e => {
+          e.preventDefault();
+          onSubmit();
+          return false;
+        }}
+      >
+        <PageLayout
+          data-testid="sessions-page"
+          header={
+            <PageHeader>
+              <Group
+                justify="space-between"
+                gap="xs"
+                wrap="nowrap"
+                w="100%"
+                className={styles.toolbar}
               >
-                Run
-              </Button>
-            </Group>
-          </Flex>
-        </form>
-
-        {isSessionsLoading || isSessionSourceLoading ? (
-          <Group mt="md" align="center" justify="center" gap="xs">
-            <IconRefresh className="spin-animate" size={14} />
-            {isSessionSourceLoading ? 'Loading...' : 'Searching sessions...'}
-          </Group>
-        ) : (
-          <>
-            {!sessions.length ? (
-              <Flex
-                align="center"
-                justify="center"
-                style={{ flex: 1, minHeight: 0 }}
-              >
-                <SessionSetupInstructions />
-              </Flex>
-            ) : (
-              <div style={{ minHeight: 0 }} className="mt-4">
-                <SessionCardList
-                  onClick={session => {
-                    setSelectedSession(session);
-                  }}
-                  sessions={sessions}
-                  isSessionLoading={isSessionsLoading}
+                <SourceSelectControlled
+                  control={control}
+                  name="source"
+                  allowedSourceKinds={[SourceKind.Session]}
                 />
-              </div>
-            )}
-          </>
-        )}
-      </Box>
-    </div>
+                <SearchWhereInput
+                  tableConnection={tcFromSource(traceTrace)}
+                  control={control}
+                  name="where"
+                  onSubmit={onSubmit}
+                  enableHotkey
+                  width="50%"
+                />
+                <TimePicker
+                  inputValue={displayedTimeInputValue}
+                  setInputValue={setDisplayedTimeInputValue}
+                  onSearch={range => {
+                    onSearch(range);
+                  }}
+                />
+                <Button
+                  variant="primary"
+                  type="submit"
+                  px="sm"
+                  leftSection={<IconPlayerPlay size={16} />}
+                  style={{ flexShrink: 0 }}
+                >
+                  Run
+                </Button>
+              </Group>
+            </PageHeader>
+          }
+          padded
+          content={
+            <>
+              {isSessionsLoading || isSessionSourceLoading ? (
+                <Group mt="md" align="center" justify="center" gap="xs">
+                  <IconRefresh className="spin-animate" size={14} />
+                  {isSessionSourceLoading
+                    ? 'Loading...'
+                    : 'Searching sessions...'}
+                </Group>
+              ) : (
+                <>
+                  {!sessions.length ? (
+                    <Flex
+                      align="center"
+                      justify="center"
+                      style={{ flex: 1, minHeight: 0 }}
+                    >
+                      <SessionSetupInstructions />
+                    </Flex>
+                  ) : (
+                    <div style={{ minHeight: 0 }} className="mt-4">
+                      <SessionCardList
+                        onClick={session => {
+                          setSelectedSession(session);
+                        }}
+                        sessions={sessions}
+                        isSessionLoading={isSessionsLoading}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          }
+        />
+      </form>
+    </>
   );
 }
 

--- a/packages/app/styles/SessionsPage.module.scss
+++ b/packages/app/styles/SessionsPage.module.scss
@@ -1,3 +1,14 @@
+.pageForm {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.toolbar {
+  flex: 1;
+  min-width: 0;
+}
+
 .sessionCard {
   &:hover {
     .emailText {


### PR DESCRIPTION
## Summary
- Uses `PageLayout` with a custom `PageHeader` so the Sessions query toolbar stays a single row (source, where, time, Run).

## Test plan
- [ ] `/sessions` loads; Run and filters behave as before
- [ ] Session list and side panel flows unchanged

Made with [Cursor](https://cursor.com)