### PR TITLE
Tune HyperDX theme tokens and chart assistant button

### DIFF
--- a/.changeset/calm-lions-wave.md
+++ b/.changeset/calm-lions-wave.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Tune HyperDX theme tokens for sidenav active states, field backgrounds, borders, and hover grays; remove redundant color prop from chart assistant button

--- a/packages/app/src/DBChartPage.tsx
+++ b/packages/app/src/DBChartPage.tsx
@@ -149,12 +149,7 @@ function AIAssistant({
   return (
     <Box mb="sm">
       <Group gap="md" align="center" mb="sm">
-        <Button
-          onClick={() => setOpened(o => !o)}
-          size="xs"
-          variant="subtle"
-          color="gray"
-        >
+        <Button onClick={() => setOpened(o => !o)} size="xs" variant="subtle">
           <Group gap="xs">
             {opened ? (
               <IconChevronUp size={14} />

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -16,14 +16,14 @@
   --color-bg-muted: var(--mantine-color-dark-7);
   --color-bg-highlighted: rgb(55 58 64 / 70%);
   --color-bg-sidenav: var(--mantine-color-dark-9);
-  --color-bg-sidenav-link-active: var(--mantine-color-dark-6);
-  --color-bg-sidenav-link-active-hover: var(--mantine-color-dark-7);
+  --color-bg-sidenav-link-active: var(--mantine-color-dark-7);
+  --color-bg-sidenav-link-active-hover: var(--mantine-color-dark-6);
   --color-bg-header: var(--mantine-color-dark-9);
   --color-bg-hover: var(--mantine-color-dark-6);
   --color-bg-active: var(--mantine-color-dark-5);
-  --color-bg-field: var(--mantine-color-dark-6);
-  --color-bg-field-highlighted: var(--mantine-color-dark-5);
-  --color-bg-field-addon: var(--mantine-color-dark-5);
+  --color-bg-field: var(--mantine-color-dark-7);
+  --color-bg-field-highlighted: var(--mantine-color-dark-6);
+  --color-bg-field-addon: var(--mantine-color-dark-6);
   --color-bg-neutral: var(--mantine-color-dark-4);
   --color-bg-brand: var(--mantine-color-green-4);
   --color-bg-brand-hover: var(--mantine-color-green-3);
@@ -37,7 +37,7 @@
   --color-primary-button-text: var(--mantine-color-green-light-color);
 
   /* Borders & Dividers */
-  --color-border: var(--mantine-color-dark-5);
+  --color-border: var(--mantine-color-dark-6);
   --color-border-emphasis: var(--mantine-color-dark-4);
   --color-border-muted: rgb(255 255 255 / 8%);
 
@@ -129,11 +129,11 @@
   --color-bg-muted: #f6f6fa;
   --color-bg-highlighted: rgb(230 232 237 / 70%);
   --color-bg-sidenav: var(--mantine-color-white);
-  --color-bg-sidenav-link-active: #f6f6fa;
+  --color-bg-sidenav-link-active: #ebebef;
   --color-bg-sidenav-link-active-hover: var(--mantine-color-gray-2);
   --color-bg-header: var(--mantine-color-gray-1);
   --color-bg-modal: var(--mantine-color-white);
-  --color-bg-hover: var(--mantine-color-gray-3);
+  --color-bg-hover: var(--mantine-color-gray-1);
   --color-bg-active: var(--mantine-color-gray-4);
   --color-bg-field: #f9f9fc;
   --color-bg-field-highlighted: var(--mantine-color-white);


### PR DESCRIPTION
## Summary
- Adjusts HyperDX dark/light tokens for sidenav active states, field backgrounds, borders, and hover grays.
- Removes redundant `color` on a subtle `Button` in Chart Explorer assistant UI.

<img width="6946" height="1376" alt="image" src="https://github.com/user-attachments/assets/7692758c-e081-4748-a584-1c23b4bc909a" />


## Test plan
- [ ] Toggle light/dark and spot-check nav, inputs, and borders
- [ ] Open Chart Explorer and expand/collapse the AI assistant control

Made with [Cursor](https://cursor.com)