### PR TITLE
fix(theme): red Menu.Item label contrast in portaled menus

### DIFF
--- a/.changeset/fix-menu-red-item-label.md
+++ b/.changeset/fix-menu-red-item-label.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix label color for red `Menu.Item` rows (for example Logout) by overriding `--menu-item-color` in global CSS. `Menu.extend` item styles do not apply when the menu dropdown is portaled outside the Menu root.

--- a/packages/app/src/theme/themes/_base-tokens.scss
+++ b/packages/app/src/theme/themes/_base-tokens.scss
@@ -20,3 +20,14 @@
 [data-mantine-color-scheme='light'] {
   @include hyperdx-tokens.light-mode-tokens;
 }
+
+/*
+ * Menu.Item + color="red": Mantine inlines --menu-item-color as red-6 while
+ * --menu-item-hover uses red-light-hover. `Menu.extend` styles do not reach items
+ * because Popover defaults to withinPortal — the dropdown is outside the Menu
+ * root, so component-scoped theme CSS never matches. Global rule + !important
+ * beats inline vars; substring matches Mantine red light hover token.
+ */
+[data-menu-item][style*='red-light-hover'] {
+  --menu-item-color: var(--mantine-color-red-light-color) !important;
+}


### PR DESCRIPTION
## Summary

- Add a global CSS override in `_base-tokens.scss` so `Menu.Item` with `color="red"` uses `--mantine-color-red-light-color` for `--menu-item-color`, matching danger controls and fixing low contrast from Mantine default `red-6`.
- `Menu.extend` item styles cannot target these rows because Popover defaults to `withinPortal`, so the dropdown DOM is outside the `Menu` root.

<img width="832" height="612" alt="image" src="https://github.com/user-attachments/assets/436e143b-813c-4460-98e0-263c3a16e346" />



## Test plan

- [ ] Open user menu, confirm Logout (red row) label reads clearly in light and dark mode.
- [ ] Smoke another menu with a red item if applicable.

Made with [Cursor](https://cursor.com)