### PR TITLE
fix(common-utils): wrap Date partition columns in toDate() inside CTE-using queries (HDX-4247)

### DIFF
--- a/.changeset/fix-pattern-date-pk.md
+++ b/.changeset/fix-pattern-date-pk.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: Event Patterns and other CTE-using queries now correctly detect Date-typed partition columns and wrap them in toDate(), fixing "No results found" against sources with a Date partition key (e.g. event_date / EventDate).

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -1736,6 +1736,45 @@ describe('renderChartConfig', () => {
         `(date >= toDate(fromUnixTimestamp64Milli(${dateRange[0].getTime()})) AND date <= toDate(fromUnixTimestamp64Milli(${dateRange[1].getTime()})))`,
       );
     });
+
+    it('wraps Date-type column in toDate() when a subquery CTE is present and FROM is a base table', async () => {
+      // Repro for HDX-4247: when a subquery CTE is added to the outer chart
+      // config (e.g. sampling CTE in the Event Patterns panel) but the outer
+      // query still selects from a real base table, the time-filter must still
+      // detect that the partition column is Date-typed and wrap the bounds in
+      // toDate(). Otherwise ClickHouse promotes Date -> DateTime at midnight
+      // and the entire day's rows are excluded.
+      const dateRange: [Date, Date] = [
+        new Date('2025-02-12 03:53:38Z'),
+        new Date('2025-02-12 04:08:38Z'),
+      ];
+
+      const actual = await timeFilterExpr({
+        timestampValueExpression: 'date',
+        dateRangeEndInclusive: true,
+        dateRangeStartInclusive: true,
+        dateRange,
+        connectionId: 'test-connection',
+        databaseName: 'default',
+        tableName: 'target_table',
+        metadata: mockMetadata,
+        with: [
+          {
+            name: 'tableStats',
+            sql: {
+              sql: 'SELECT count() as total FROM target_table',
+              params: {},
+            },
+            // isSubquery defaults to true -> exercises the subquery-CTE path
+          },
+        ],
+      });
+
+      const actualSql = parameterizedQueryToSql(actual);
+      expect(actualSql).toBe(
+        `(date >= toDate(fromUnixTimestamp64Milli(${dateRange[0].getTime()})) AND date <= toDate(fromUnixTimestamp64Milli(${dateRange[1].getTime()})))`,
+      );
+    });
   });
 
   it('should not generate invalid SQL when primary key wraps toStartOfInterval', async () => {

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -700,26 +700,31 @@ export async function timeFilterExpr({
       // Detect toDate(...) wrapper expressions
       const isToDateExpr = /^toDate\s*\(/.test(col);
 
-      const columnMeta =
-        hasSubqueryCte(withClauses) || toStartOf || isToDateExpr
-          ? null
-          : await metadata.getColumn({
-              databaseName,
-              tableName,
-              column: col,
-              connectionId,
-            });
+      // Skip the column-metadata lookup when:
+      //   - the FROM references a CTE alias (no real base table to DESCRIBE), or
+      //   - the expression isn't a bare column name (wrapped in toStartOf/toDate).
+      // A subquery CTE alone is not enough — when `databaseName` is set, `col` still
+      // references a real base-table column whose type (e.g. Date) we need to know
+      // to generate a correct time filter.
+      const skipColumnLookup =
+        (hasSubqueryCte(withClauses) && !databaseName) ||
+        !!toStartOf ||
+        isToDateExpr;
+
+      const columnMeta = skipColumnLookup
+        ? null
+        : await metadata.getColumn({
+            databaseName,
+            tableName,
+            column: col,
+            connectionId,
+          });
 
       const unsafeTimestampValueExpression = {
         UNSAFE_RAW_SQL: col,
       };
 
-      if (
-        columnMeta == null &&
-        hasSubqueryCte(withClauses) &&
-        !toStartOf &&
-        !isToDateExpr
-      ) {
+      if (columnMeta == null && !skipColumnLookup) {
         console.warn(
           `Column ${col} not found in ${databaseName}.${tableName} while inferring type for time filter`,
         );


### PR DESCRIPTION
## Summary

Event Patterns (and several other CTE-using panels) silently return **No results found** against any source whose partition/primary key is a `Date` column, when the query window does not cross midnight UTC. This happens for the entire class of sources that follow the OpenTelemetry ClickHouse exporter default of partitioning by `event_date` / `EventDate`.

### Root cause

In `timeFilterExpr`, the column-metadata lookup is skipped whenever the chart config contains a subquery CTE:

```ts
const columnMeta =
  hasSubqueryCte(withClauses) || toStartOf || isToDateExpr
    ? null
    : await metadata.getColumn({...});
```

The skip is too aggressive. A subquery CTE in `WITH` does **not** imply that `FROM` references the CTE — chart configs routinely inject a subquery CTE (e.g. pattern sampling) while the outer `FROM` still hits a real base table. When that base-table column is `Date`-typed, the lookup is the only signal that tells the filter to wrap bounds in `toDate(...)`. Without it, ClickHouse promotes `Date -> DateTime` at midnight and any window not crossing midnight UTC returns zero rows.

### Fix

Tighten the skip to `(hasSubqueryCte(withClauses) && !databaseName)`, matching the established guard pattern already used twice in the same file ([line 524](https://github.com/hyperdxio/hyperdx/blob/main/packages/common-utils/src/core/renderChartConfig.ts#L524) and [line 842](https://github.com/hyperdxio/hyperdx/blob/main/packages/common-utils/src/core/renderChartConfig.ts#L842)) — `databaseName` is the existing signal that `FROM` is a CTE alias rather than a real table. Also consolidate the lookup-skip and warning-suppression into one `skipColumnLookup` boolean so they cannot desync.

Behavioral diff:

| `withClauses` | `databaseName` | Before | After |
|---|---|---|---|
| subquery CTE | unset (FROM is CTE) | skip lookup | skip lookup *(unchanged)* |
| subquery CTE | set (FROM is real table) | **skip lookup (bug)** | **do lookup (fixed)** |
| no CTE / alias only | set | do lookup | do lookup *(unchanged)* |

### Impact

- **Event Patterns** panel now returns rows on Date-PK sources (primary motivation).
- Silently improves any other path that calls `timeFilterExpr` with a subquery CTE against a base table — heatmap tile, value-distribution autocomplete, services dashboard.
- No behavior change for sources whose primary key is `DateTime` / `DateTime64`.

### Test

Added a regression test inside `describe('timeFilterExpr', …)` that pins the fix:

- `timestampValueExpression: 'date'` (mocked as `Date`-typed)
- `databaseName: 'default'`, `tableName: 'target_table'` (real base table)
- A subquery CTE in `with: [{ name: 'tableStats', sql: ... }]`
- Asserts the generated SQL wraps both bounds in `toDate(fromUnixTimestamp64Milli(...))`.

The test fails on `main` and passes with this change.

### Screenshots or video

N/A — non-UI change in `@hyperdx/common-utils`. The user-visible effect (Event Patterns rendering rows instead of "No results found") is downstream of this SQL generation.

### How to test on Vercel preview

N/A — non-UI change. To exercise manually:

1. Point HyperDX at a source whose partition key is a `Date` column (e.g. an OTel ClickHouse exporter table with `event_date Date`).
2. Open the Event Patterns panel with a time range narrower than a full UTC day (e.g. last 15 minutes).
3. Confirm patterns now render. Without the fix the panel shows "No results found".

### References

- Linear Issue: HDX-4247
- Downstream PR (hyperdx-ee): https://github.com/DeploySentinel/hyperdx-ee/pull/2091
- Established guard pattern: `packages/common-utils/src/core/renderChartConfig.ts:524`, `:842`
