### PR TITLE
fix: guard granularity URL sync until router is ready

### DIFF
--- a/.changeset/fix-dashboard-granularity-url.md
+++ b/.changeset/fix-dashboard-granularity-url.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix `href interpolation failed` error when loading a dashboard page directly without query params by guarding the granularity URL sync until the router is ready.

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1329,10 +1329,14 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const watchedGranularity = useWatch({ control, name: 'granularity' });
 
   useEffect(() => {
-    if (watchedGranularity && watchedGranularity !== granularity) {
+    if (
+      router.isReady &&
+      watchedGranularity &&
+      watchedGranularity !== granularity
+    ) {
       setGranularity(watchedGranularity as SQLInterval);
     }
-  }, [watchedGranularity, granularity, setGranularity]);
+  }, [router.isReady, watchedGranularity, granularity, setGranularity]);
 
   const [displayedTimeInputValue, setDisplayedTimeInputValue] =
     useState('Past 1h');


### PR DESCRIPTION
## Summary

Fixes `href interpolation failed` error when loading a dashboard page directly (e.g. `/dashboards/<id>` without query params).

The granularity sync effect was calling `setGranularity` before `router.isReady`, causing nuqs to build a URL with an unresolved `[dashboardId]` segment. Added a `router.isReady` guard to match the pattern used by the existing dashboard initialization effect.

Before:
<img width="1614" height="649" alt="Screenshot 2026-05-15 at 2 36 52 PM" src="https://github.com/user-attachments/assets/d36a5e12-4524-4f55-9567-0905c1ed3841" />

Afte
<img width="1797" height="691" alt="Screenshot 2026-05-15 at 2 38 19 PM" src="https://github.com/user-attachments/assets/db4285ae-7ec2-44a1-9c2f-ab0c6e99d2bd" />
r:
