### PR TITLE
chore: Remove the 'saved searches and dashboards have moved' callout

### DIFF
--- a/.changeset/strong-owls-peel.md
+++ b/.changeset/strong-owls-peel.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+chore: Remove the 'saved searches and dashboards have moved' callout

--- a/packages/app/src/components/AppNav/AppNav.tsx
+++ b/packages/app/src/components/AppNav/AppNav.tsx
@@ -460,20 +460,6 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
               </Collapse>
             )}
 
-            {!isCollapsed && (
-              <Text size="xs" px="lg" py="xs" fw="lighter" fs="italic">
-                Saved searches and dashboards have moved! Try the{' '}
-                <Anchor component={Link} href="/search/list">
-                  Saved Searches
-                </Anchor>{' '}
-                or{' '}
-                <Anchor component={Link} href="/dashboards/list">
-                  Dashboards
-                </Anchor>{' '}
-                page.
-              </Text>
-            )}
-
             {/* Help */}
             <AppNavHelpMenu version={APP_VERSION} />
 


### PR DESCRIPTION
## Summary

This PR removes the 'saved searches and dashboards have moved' message, since its been around for long enough that users have probably found their dashboards and searches.

### Screenshots or video

before

<img width="260" height="631" alt="Screenshot 2026-05-18 at 3 32 21 PM" src="https://github.com/user-attachments/assets/d2516081-6a70-4be4-9fc3-d76543c23a1f" />

after

<img width="274" height="820" alt="Screenshot 2026-05-18 at 3 32 32 PM" src="https://github.com/user-attachments/assets/0ca985ac-22b5-49a4-a015-de34ad73a710" />


Closes HDX-3827