### PR TITLE
feat: Minor dashboard improvements

### DIFF
--- a/.changeset/calm-ghosts-switch.md
+++ b/.changeset/calm-ghosts-switch.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: Minor dashboard improvements

--- a/packages/app/src/ClickhousePage.tsx
+++ b/packages/app/src/ClickhousePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import Link from 'next/link';
 import {
   parseAsFloat,
@@ -43,6 +44,7 @@ import { DBSqlRowTable } from './components/DBRowTable';
 import DBTableChart from './components/DBTableChart';
 import OnboardingModal from './components/OnboardingModal';
 import { useDashboardRefresh } from './hooks/useDashboardRefresh';
+import { useBrandDisplayName } from './theme/ThemeProvider';
 import { clickhouseSql } from './utils/codeMirror';
 import { useConnections } from './connection';
 import { parseTimeQuery, useNewTimeQuery } from './timeQuery';
@@ -489,6 +491,7 @@ function InsertsTab({
 }
 
 function ClickhousePage() {
+  const brandName = useBrandDisplayName();
   const { colorScheme } = useMantineColorScheme();
   const { data: connections } = useConnections();
   const [_connection, setConnection] = useQueryState('connection');
@@ -586,6 +589,9 @@ function ClickhousePage() {
 
   return (
     <Box p="sm" data-testid="clickhouse-dashboard-page">
+      <Head>
+        <title>ClickHouse Dashboard – {brandName}</title>
+      </Head>
       <Breadcrumbs mb="xs" mt="xs" fz="sm">
         <Anchor component={Link} href="/dashboards/list" fz="sm" c="dimmed">
           Dashboards

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -2044,7 +2044,9 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   return (
     <Box p="sm" data-testid="dashboard-page">
       <Head>
-        <title>Dashboard – {brandName}</title>
+        <title>
+          {dashboard?.name ? `${dashboard.name}` : 'Dashboard'} – {brandName}
+        </title>
       </Head>
       <OnboardingModal />
       <EditTileModal

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -23,6 +23,7 @@ import {
   convertToDashboardTemplate,
   displayTypeSupportsBuilderAlerts,
   displayTypeSupportsRawSqlAlerts,
+  Granularity,
 } from '@hyperdx/common-utils/dist/core/utils';
 import {
   displayTypeRequiresSource,
@@ -110,6 +111,7 @@ import { DBTimeChart } from '@/components/DBTimeChart';
 import { FavoriteButton } from '@/components/FavoriteButton';
 import FullscreenPanelModal from '@/components/FullscreenPanelModal';
 import { TimePicker } from '@/components/TimePicker';
+import { parseTimeRangeInput } from '@/components/TimePicker/utils';
 import {
   Dashboard,
   type Tile,
@@ -148,7 +150,10 @@ import { useDashboard } from './dashboard';
 import DashboardFilters from './DashboardFilters';
 import DashboardFiltersModal from './DashboardFiltersModal';
 import { EditablePageName } from './EditablePageName';
-import { GranularityPickerControlled } from './GranularityPicker';
+import {
+  GranularityPicker,
+  GranularityPickerControlled,
+} from './GranularityPicker';
 import HDXMarkdownChart from './HDXMarkdownChart';
 import { withAppNav } from './layout';
 import {
@@ -156,9 +161,14 @@ import {
   useSource,
   useSources,
 } from './source';
-import { parseTimeQuery, useNewTimeQuery } from './timeQuery';
+import {
+  dateRangeToString,
+  parseTimeQuery,
+  useNewTimeQuery,
+} from './timeQuery';
 import { useConfirm } from './useConfirm';
 import { FormatTime } from './useFormatTime';
+import { useUserPreferences } from './useUserPreferences';
 import { getMetricTableName } from './utils';
 import { useZIndex, ZIndexContext } from './zIndex';
 
@@ -377,6 +387,42 @@ const Tile = forwardRef(
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
 
+    const {
+      userPreferences: { isUTC },
+    } = useUserPreferences();
+
+    // Date range and granularity state local to the fullscreen view so that
+    // changing them does not propagate up to the dashboard.
+    const [fullscreenDateRange, setFullscreenDateRange] =
+      useState<[Date, Date]>(dateRange);
+    const [fullscreenInputValue, setFullscreenInputValue] = useState<string>(
+      () => dateRangeToString(dateRange, isUTC),
+    );
+    const [fullscreenGranularity, setFullscreenGranularity] = useState<
+      Granularity | 'auto' | undefined
+    >(() => (granularity as Granularity | undefined) ?? 'auto');
+
+    const openFullscreen = useCallback(() => {
+      // Reinitialize to the dashboard's current date range and granularity
+      // each time the fullscreen view is opened.
+      setFullscreenDateRange(dateRange);
+      setFullscreenInputValue(dateRangeToString(dateRange, isUTC));
+      setFullscreenGranularity(
+        (granularity as Granularity | undefined) ?? 'auto',
+      );
+      setIsFullscreen(true);
+    }, [dateRange, granularity, isUTC]);
+
+    const handleFullscreenSearch = useCallback(
+      (value: string) => {
+        const [start, end] = parseTimeRangeInput(value, isUTC);
+        if (start != null && end != null) {
+          setFullscreenDateRange([start, end]);
+        }
+      },
+      [isUTC],
+    );
+
     useEffect(() => {
       if (isHighlighted) {
         document
@@ -386,7 +432,19 @@ const Tile = forwardRef(
     }, [chart.id, isHighlighted]);
 
     // YouTube-style 'f' key shortcut for fullscreen toggle
-    useHotkeys([['f', () => isFocused && setIsFullscreen(prev => !prev)]]);
+    useHotkeys([
+      [
+        'f',
+        () => {
+          if (!isFocused) return;
+          if (isFullscreen) {
+            setIsFullscreen(false);
+          } else {
+            openFullscreen();
+          }
+        },
+      ],
+    ]);
 
     const [queriedConfig, setQueriedConfig] = useState<
       ChartConfigWithDateRange | undefined
@@ -586,7 +644,7 @@ const Tile = forwardRef(
             size="sm"
             onClick={e => {
               e.stopPropagation();
-              setIsFullscreen(true);
+              openFullscreen();
             }}
             title="View Fullscreen (f)"
           >
@@ -694,6 +752,7 @@ const Tile = forwardRef(
       onDuplicateClick,
       onEditClick,
       onMoveToGroup,
+      openFullscreen,
     ]);
 
     const title = useMemo(
@@ -713,8 +772,25 @@ const Tile = forwardRef(
           : [hoverToolbar, filterWarning];
         const keyPrefix = isFullscreenView ? 'fullscreen' : 'tile';
 
+        // Use the fullscreen-local date range and granularity when rendering
+        // inside the fullscreen modal so that changing them does not affect
+        // the dashboard.
+        const effectiveDateRange = isFullscreenView
+          ? fullscreenDateRange
+          : dateRange;
+        const effectiveGranularity = isFullscreenView
+          ? fullscreenGranularity
+          : queriedConfig?.granularity;
+        const effectiveQueriedConfig = queriedConfig
+          ? {
+              ...queriedConfig,
+              dateRange: effectiveDateRange,
+              granularity: effectiveGranularity,
+            }
+          : undefined;
+
         // Markdown charts may not have queriedConfig, if config.source is not set
-        const effectiveMarkdownConfig = queriedConfig ?? chart.config;
+        const effectiveMarkdownConfig = effectiveQueriedConfig ?? chart.config;
 
         return (
           <ErrorBoundary
@@ -745,16 +821,21 @@ const Tile = forwardRef(
               </ChartContainer>
             ) : (
               <>
-                {(queriedConfig?.displayType === DisplayType.Line ||
-                  queriedConfig?.displayType === DisplayType.StackedBar) && (
+                {(effectiveQueriedConfig?.displayType === DisplayType.Line ||
+                  effectiveQueriedConfig?.displayType ===
+                    DisplayType.StackedBar) && (
                   <DBTimeChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
                     toolbarPrefix={toolbar}
                     sourceId={chart.config.source}
                     showDisplaySwitcher={true}
-                    config={queriedConfig}
-                    onTimeRangeSelect={onTimeRangeSelect}
+                    config={effectiveQueriedConfig}
+                    onTimeRangeSelect={
+                      isFullscreenView
+                        ? (start, end) => setFullscreenDateRange([start, end])
+                        : onTimeRangeSelect
+                    }
                     setDisplayType={displayType => {
                       onUpdateChart?.({
                         ...chart,
@@ -766,54 +847,54 @@ const Tile = forwardRef(
                     }}
                   />
                 )}
-                {queriedConfig?.displayType === DisplayType.Table && (
+                {effectiveQueriedConfig?.displayType === DisplayType.Table && (
                   <Box p="xs" h="100%">
                     <DBTableChart
                       key={`${keyPrefix}-${chart.id}`}
                       title={title}
                       toolbarPrefix={toolbar}
-                      config={queriedConfig}
+                      config={effectiveQueriedConfig}
                       variant="muted"
                       getRowSearchLink={
-                        isBuilderChartConfig(queriedConfig)
+                        isBuilderChartConfig(effectiveQueriedConfig)
                           ? row =>
                               buildTableRowSearchUrl({
                                 row,
                                 source,
-                                config: queriedConfig,
-                                dateRange: dateRange,
+                                config: effectiveQueriedConfig,
+                                dateRange: effectiveDateRange,
                               })
                           : undefined
                       }
                     />
                   </Box>
                 )}
-                {queriedConfig?.displayType === DisplayType.Number && (
+                {effectiveQueriedConfig?.displayType === DisplayType.Number && (
                   <DBNumberChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
                     toolbarPrefix={toolbar}
-                    config={queriedConfig}
+                    config={effectiveQueriedConfig}
                   />
                 )}
-                {queriedConfig?.displayType === DisplayType.Pie && (
+                {effectiveQueriedConfig?.displayType === DisplayType.Pie && (
                   <DBPieChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
                     toolbarPrefix={toolbar}
-                    config={queriedConfig}
+                    config={effectiveQueriedConfig}
                   />
                 )}
-                {queriedConfig?.displayType === DisplayType.Heatmap &&
-                  isBuilderChartConfig(queriedConfig) && (
+                {effectiveQueriedConfig?.displayType === DisplayType.Heatmap &&
+                  isBuilderChartConfig(effectiveQueriedConfig) && (
                     <HeatmapTile
                       keyPrefix={keyPrefix}
                       chartId={chart.id}
                       title={title}
                       toolbar={toolbar}
-                      queriedConfig={queriedConfig}
+                      queriedConfig={effectiveQueriedConfig}
                       source={source}
-                      dateRange={dateRange}
+                      dateRange={effectiveDateRange}
                     />
                   )}
                 {effectiveMarkdownConfig?.displayType ===
@@ -826,8 +907,8 @@ const Tile = forwardRef(
                       config={effectiveMarkdownConfig}
                     />
                   )}
-                {queriedConfig?.displayType === DisplayType.Search &&
-                  isBuilderChartConfig(queriedConfig) &&
+                {effectiveQueriedConfig?.displayType === DisplayType.Search &&
+                  isBuilderChartConfig(effectiveQueriedConfig) &&
                   isBuilderSavedChartConfig(chart.config) && (
                     <ChartContainer
                       title={title}
@@ -839,18 +920,18 @@ const Tile = forwardRef(
                         enabled
                         sourceId={chart.config.source}
                         config={{
-                          ...queriedConfig,
+                          ...effectiveQueriedConfig,
                           orderBy: [
                             {
                               ordering: 'DESC',
                               valueExpression: getFirstTimestampValueExpression(
-                                queriedConfig.timestampValueExpression,
+                                effectiveQueriedConfig.timestampValueExpression,
                               ),
                             },
                           ],
-                          dateRange,
+                          dateRange: effectiveDateRange,
                           select:
-                            queriedConfig.select ||
+                            effectiveQueriedConfig.select ||
                             (source?.kind === SourceKind.Log ||
                             source?.kind === SourceKind.Trace
                               ? source.defaultTableSelectExpression
@@ -879,6 +960,8 @@ const Tile = forwardRef(
         onUpdateChart,
         source,
         dateRange,
+        fullscreenDateRange,
+        fullscreenGranularity,
         filterWarning,
         isSourceMissing,
         isSourceUnset,
@@ -952,7 +1035,24 @@ const Tile = forwardRef(
           opened={isFullscreen}
           onClose={() => setIsFullscreen(false)}
         >
-          {isFullscreen && renderChartContent(true, true)}
+          {isFullscreen && (
+            <Flex direction="column" gap="sm" h="100%" w="100%">
+              <Flex justify="flex-end" gap="sm">
+                <TimePicker
+                  inputValue={fullscreenInputValue}
+                  setInputValue={setFullscreenInputValue}
+                  onSearch={handleFullscreenSearch}
+                />
+                <GranularityPicker
+                  value={fullscreenGranularity}
+                  onChange={setFullscreenGranularity}
+                />
+              </Flex>
+              <Box style={{ flex: 1, minHeight: 0 }}>
+                {renderChartContent(true, true)}
+              </Box>
+            </Flex>
+          )}
         </FullscreenPanelModal>
       </>
     );

--- a/packages/app/src/GranularityPicker.tsx
+++ b/packages/app/src/GranularityPicker.tsx
@@ -3,7 +3,7 @@ import { useController, UseControllerProps } from 'react-hook-form';
 import { Granularity } from '@hyperdx/common-utils/dist/core/utils';
 import { Select } from '@mantine/core';
 
-function GranularityPicker({
+export function GranularityPicker({
   value,
   onChange,
   disabled,

--- a/packages/app/src/KubernetesDashboardPage.tsx
+++ b/packages/app/src/KubernetesDashboardPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import Link from 'next/link';
 import cx from 'classnames';
 import sub from 'date-fns/sub';
@@ -54,6 +55,7 @@ import { SourceSelectControlled } from './components/SourceSelect';
 import { useQueriedChartConfig } from './hooks/useChartConfig';
 import { useDashboardRefresh } from './hooks/useDashboardRefresh';
 import { useJsonColumns } from './hooks/useMetadata';
+import { useBrandDisplayName } from './theme/ThemeProvider';
 import {
   convertV1ChartConfigToV2,
   K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
@@ -1043,6 +1045,7 @@ export const resolveSourceIds = (
 };
 
 function KubernetesDashboardPage() {
+  const brandName = useBrandDisplayName();
   const { data: sources } = useSources();
 
   const [_logSourceId, setLogSourceId] = useQueryState('logSource');
@@ -1248,6 +1251,9 @@ function KubernetesDashboardPage() {
 
   return (
     <Box data-testid="kubernetes-dashboard-page" p="sm">
+      <Head>
+        <title>Kubernetes Dashboard – {brandName}</title>
+      </Head>
       <Breadcrumbs mb="xs" mt="xs" fz="sm">
         <Anchor component={Link} href="/dashboards/list" fz="sm" c="dimmed">
           Dashboards

--- a/packages/app/src/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import Link from 'next/link';
 import {
   parseAsString,
@@ -88,6 +89,7 @@ import {
   useServiceDashboardExpressions,
 } from '@/serviceDashboard';
 import { useSource, useSources } from '@/source';
+import { useBrandDisplayName } from '@/theme/ThemeProvider';
 import { parseTimeQuery, useNewTimeQuery } from '@/timeQuery';
 
 import DisplaySwitcher from './components/charts/DisplaySwitcher';
@@ -1434,6 +1436,7 @@ const appliedConfigMap = {
 };
 
 function ServicesDashboardPage() {
+  const brandName = useBrandDisplayName();
   const [tab, setTab] = useQueryState(
     'tab',
     parseAsStringEnum<string>(['http', 'database', 'errors']).withDefault(
@@ -1578,6 +1581,9 @@ function ServicesDashboardPage() {
 
   return (
     <Box p="sm" data-testid="services-dashboard-page">
+      <Head>
+        <title>Services Dashboard – {brandName}</title>
+      </Head>
       <Breadcrumbs mb="sm" mt="xs" fz="sm">
         <Anchor component={Link} href="/dashboards/list" fz="sm" c="dimmed">
           Dashboards

--- a/packages/app/src/Spotlights.tsx
+++ b/packages/app/src/Spotlights.tsx
@@ -16,6 +16,7 @@ import {
 
 import { useBrandDisplayName, useLogomark } from './theme/ThemeProvider';
 import api from './api';
+import { IS_K8S_DASHBOARD_ENABLED } from './config';
 import { useSavedSearches } from './savedSearch';
 
 import '@mantine/spotlight/styles.css';
@@ -58,6 +59,49 @@ export const useSpotlightActions = () => {
         keywords: ['dashboard'],
         onClick: () => {
           router.push(`/dashboards/${dashboard.id}`);
+        },
+      });
+    });
+
+    // Preset dashboards
+    const presetDashboards = [
+      {
+        id: 'preset-services',
+        label: 'Services',
+        description: 'Monitor HTTP endpoints, latency, and error rates',
+        href: '/services',
+        keywords: ['preset', 'dashboard', 'http', 'latency', 'errors'],
+      },
+      {
+        id: 'preset-clickhouse',
+        label: 'ClickHouse',
+        description: 'ClickHouse cluster health and query performance',
+        href: '/clickhouse',
+        keywords: ['preset', 'dashboard', 'database', 'queries'],
+      },
+      ...(IS_K8S_DASHBOARD_ENABLED
+        ? [
+            {
+              id: 'preset-kubernetes',
+              label: 'Kubernetes',
+              description: 'Kubernetes cluster monitoring and pod health',
+              href: '/kubernetes',
+              keywords: ['preset', 'dashboard', 'k8s', 'pods', 'cluster'],
+            },
+          ]
+        : []),
+    ];
+
+    presetDashboards.forEach(preset => {
+      logViewActions.push({
+        id: preset.id,
+        group: 'Preset Dashboards',
+        leftSection: <IconLayout size={16} />,
+        label: preset.label,
+        description: preset.description,
+        keywords: preset.keywords,
+        onClick: () => {
+          router.push(preset.href);
         },
       });
     });

--- a/packages/app/src/timeQuery.ts
+++ b/packages/app/src/timeQuery.ts
@@ -32,7 +32,7 @@ import { usePrevious } from './utils';
 const LIVE_TAIL_TIME_QUERY = 'Live Tail';
 const LIVE_TAIL_REFRESH_INTERVAL_MS = 1000;
 
-const dateRangeToString = (range: [Date, Date], isUTC: boolean) => {
+export const dateRangeToString = (range: [Date, Date], isUTC: boolean) => {
   return `${formatDate(range[0], {
     isUTC,
     format: 'normal',

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -1310,4 +1310,74 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       });
     },
   );
+
+  test(
+    'should isolate the fullscreen tile time picker from the dashboard time range',
+    { tag: ['@full-stack', '@dashboard'] },
+    async () => {
+      test.setTimeout(60000);
+      const ts = Date.now();
+      const chartName = `Fullscreen TP Test ${ts}`;
+
+      await test.step('Create a new dashboard', async () => {
+        await expect(dashboardPage.createButton).toBeVisible();
+        await dashboardPage.createNewDashboard();
+      });
+
+      await test.step('Add a basic chart tile', async () => {
+        await dashboardPage.addTile();
+        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+        await dashboardPage.chartEditor.createBasicChart(chartName);
+
+        const dashboardTiles = dashboardPage.getTiles();
+        await expect(dashboardTiles).toHaveCount(1, { timeout: 10000 });
+      });
+
+      let mainTimePickerValueBefore = '';
+      await test.step('Set the dashboard time range to "Last 1 hour"', async () => {
+        await dashboardPage.timePicker.selectRelativeTime('Last 1 hour');
+        mainTimePickerValueBefore =
+          await dashboardPage.timePicker.input.inputValue();
+        console.log(
+          'Main time picker value before opening fullscreen:',
+          mainTimePickerValueBefore,
+        );
+      });
+
+      await test.step('Open the tile in fullscreen and verify the modal appears', async () => {
+        await dashboardPage.openFullscreenForTile(0);
+        await expect(dashboardPage.fullscreenTimePickerInput).toBeVisible();
+      });
+
+      await test.step('Verify the fullscreen TimePicker is initialized with a non-empty value', async () => {
+        // The fullscreen picker is seeded with dateRangeToString — an absolute
+        // date-range string — not the "Last 1 hour" relative label.
+        const fullscreenValue =
+          await dashboardPage.fullscreenTimePickerInput.inputValue();
+        expect(fullscreenValue.length).toBeGreaterThan(0);
+      });
+
+      await test.step('Change the fullscreen time range to "Last 15 minutes"', async () => {
+        await dashboardPage.selectFullscreenRelativeTime('Last 15 minutes');
+        // Verify the chart inside the modal re-renders with the new range
+        await expect(
+          dashboardPage.fullscreenModalBody.locator(
+            '.recharts-responsive-container',
+          ),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step('Close the fullscreen modal', async () => {
+        await dashboardPage.closeFullscreen();
+      });
+
+      await test.step('Verify the dashboard main time picker is unchanged', async () => {
+        // The fullscreen time-range change must NOT have propagated to the
+        // dashboard-level time picker.
+        await expect(dashboardPage.timePicker.input).toHaveValue(
+          mainTimePickerValueBefore,
+        );
+      });
+    },
+  );
 });

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -776,4 +776,72 @@ export class DashboardPage {
   get unsavedChangesConfirmDiscardButton() {
     return this.confirmConfirmButton;
   }
+
+  // ---- Fullscreen tile helpers ----
+
+  /**
+   * The Mantine Modal body that hosts the fullscreen tile view.
+   * Scoped by the presence of a time-picker-input so it stays unambiguous
+   * even when other modals (e.g. the chart editor) are open simultaneously.
+   */
+  get fullscreenModalBody() {
+    return this.page
+      .locator('.mantine-Modal-body')
+      .filter({ has: this.page.getByTestId('time-picker-input') });
+  }
+
+  /**
+   * The time-picker-input inside the fullscreen modal.
+   * Scoped to fullscreenModalBody so it never matches the dashboard's
+   * main time picker when both exist in the DOM.
+   */
+  get fullscreenTimePickerInput() {
+    return this.fullscreenModalBody.getByTestId('time-picker-input');
+  }
+
+  /**
+   * Hover over the tile at `index` and click its fullscreen button
+   * (`data-testid="tile-fullscreen-button-<chartId>"`).
+   * Waits for the fullscreen modal's TimePicker to appear before returning.
+   */
+  async openFullscreenForTile(index: number) {
+    await this.hoverOverTile(index);
+    const fullscreenBtn = this.page
+      .locator('[data-testid^="tile-fullscreen-button-"]')
+      .first();
+    await fullscreenBtn.click();
+    await this.fullscreenTimePickerInput.waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * Select a relative time interval from the TimePicker inside the fullscreen
+   * modal (e.g. "Last 15 minutes").
+   * Opens the picker popover first if it is not already visible.
+   */
+  async selectFullscreenRelativeTime(label: string) {
+    const input = this.fullscreenTimePickerInput;
+    const popover = this.page.getByTestId('time-picker-popover');
+    const isOpen = await popover.isVisible();
+    if (!isOpen) {
+      await input.click();
+      await popover.waitFor({ state: 'visible', timeout: 5000 });
+    }
+    const intervalButton = popover.getByRole('button', { name: label });
+    await intervalButton.waitFor({ state: 'visible', timeout: 5000 });
+    await intervalButton.click({ timeout: 10000 });
+  }
+
+  /**
+   * Close the fullscreen modal by pressing Escape and wait for it to disappear.
+   */
+  async closeFullscreen() {
+    await this.page.keyboard.press('Escape');
+    await this.fullscreenTimePickerInput.waitFor({
+      state: 'hidden',
+      timeout: 5000,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

This PR makes a few minor improvements to dashboards.
- Full-screened Dashboard Tiles now have their own time + granularity picker
- Dashboard names are now in browser tab titles
- Preset dashboards now appear in the CMD+K Spotlight Menu

### Full-screened Dashboard Tiles now have their own time + granularity picker

These inputs are isolated from the main dashboard's time picker and granularity, allowing you to view a very long time range for a single tile without refreshing the entire dashboard.

https://github.com/user-attachments/assets/a5f11eb8-985c-4feb-948a-84d11f9be44e

### Dashboard names are now in browser tab titles

<img width="1791" height="1412" alt="Screenshot 2026-05-19 at 8 48 48 AM" src="https://github.com/user-attachments/assets/68961c89-4adc-4f13-a68b-5ff42a60c1d5" />

### Preset dashboards now appear in the CMD+K Spotlight Menu

https://github.com/user-attachments/assets/62576a66-6657-487c-8f73-e89f6c56c025

### How to test on Vercel preview

All of these can be tested in the preview environment

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4261 Closes HDX-4266 Closes HDX-4263
- Related PRs:
