### PR TITLE
[HDX] fix(cli): add repository field to fix npm publish provenance error

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,11 +3,20 @@
   "version": "0.4.1",
   "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyperdxio/hyperdx.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/hyperdxio/hyperdx/tree/main/packages/cli#readme",
+  "bugs": {
+    "url": "https://github.com/hyperdxio/hyperdx/issues"
+  },
   "publishConfig": {
     "access": "public"
   },
   "bin": {
-    "hdx": "./dist/cli.js"
+    "hdx": "dist/cli.js"
   },
   "files": [
     "dist/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,7 +4571,7 @@ __metadata:
     tsx: "npm:^4.19.0"
     typescript: "npm:^5.9.3"
   bin:
-    hdx: ./dist/cli.js
+    hdx: dist/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Problem

The release workflow has been failing to publish `@hyperdx/cli` to npm with:

```
E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@hyperdx%2fcli
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/hyperdxio/hyperdx" from provenance
```

When `NPM_CONFIG_PROVENANCE=true` is set in CI (which we do in `.github/workflows/release.yml`), GitHub Actions signs a sigstore provenance bundle that embeds the source repo URL (`https://github.com/hyperdxio/hyperdx`). npm's registry then validates that the package.json's `repository.url` field matches that URL. Since `packages/cli/package.json` had **no `repository` field at all**, npm saw `""` and rejected the publish.

There was also a secondary warning in the log:

```
npm warn publish "bin[hdx]" script name dist/cli.js was invalid and removed
```

This came from `npm pkg fix` auto-stripping the leading `./` from `./dist/cli.js` before validating the bin map, and then concluding the corrected path didn't exist at that moment.

## Fix

`packages/cli/package.json`:

1. Add a `repository` field pointing at `git+https://github.com/hyperdxio/hyperdx.git` with `directory: packages/cli` — matches what GitHub Actions writes into the provenance bundle, so the registry check passes.
2. Normalize the `bin.hdx` path from `./dist/cli.js` to `dist/cli.js` — matches the form npm canonicalizes to, silencing the warning.
3. Add `homepage` and `bugs` fields — standard hygiene that `npm pkg fix` would otherwise add.

No workflow changes are needed; `release.yml`'s OIDC trusted-publishing setup is correct.

## Verification

- `yarn build` in `packages/cli` still succeeds and produces `dist/cli.js`.
- `npm pkg fix` reports no further auto-corrections, so the publish log should be clean.
- Next release with a changeset for `@hyperdx/cli` should publish to npm successfully with provenance attached.