### PR TITLE
feat: Add Lucene/SQL search filter to Service Map page

### DIFF
--- a/packages/app/src/DBServiceMapPage.tsx
+++ b/packages/app/src/DBServiceMapPage.tsx
@@ -1,15 +1,25 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import { parseAsInteger, useQueryState } from 'nuqs';
+import {
+  parseAsInteger,
+  parseAsStringEnum,
+  useQueryState,
+  useQueryStates,
+} from 'nuqs';
 import { useForm, useWatch } from 'react-hook-form';
+import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { SourceKind, TTraceSource } from '@hyperdx/common-utils/dist/types';
 import { Box, Button, Group, Modal, Slider, Text } from '@mantine/core';
 import { IconConnection } from '@tabler/icons-react';
 
 import EmptyState from '@/components/EmptyState';
+import SearchWhereInput, {
+  getStoredLanguage,
+} from '@/components/SearchInput/SearchWhereInput';
 import { IS_LOCAL_MODE } from '@/config';
 import { withAppNav } from '@/layout';
+import { parseAsStringEncoded } from '@/utils/queryParsers';
 
 import OnboardingModal from './components/OnboardingModal';
 import ServiceMap from './components/ServiceMap/ServiceMap';
@@ -51,12 +61,20 @@ const defaultTimeRange = parseTimeQuery(DEFAULT_INTERVAL, false) as [
   Date,
 ];
 
+const searchQueryStateMap = {
+  where: parseAsStringEncoded,
+  whereLanguage: parseAsStringEnum<'sql' | 'lucene'>(['sql', 'lucene']),
+};
+
 function DBServiceMapPage() {
   const brandName = useBrandDisplayName();
 
   const { data: sources } = useSources();
   const [sourceId, setSourceId] = useQueryState('source');
   const [isCreateSourceModalOpen, setIsCreateSourceModalOpen] = useState(false);
+
+  const [searchedConfig, setSearchedConfig] =
+    useQueryStates(searchQueryStateMap);
 
   const [displayedTimeInputValue, setDisplayedTimeInputValue] =
     useState(DEFAULT_INTERVAL);
@@ -78,9 +96,12 @@ function DBServiceMapPage() {
         ) ?? defaultSource)
       : defaultSource;
 
-  const { control } = useForm({
+  const { control, handleSubmit, setValue } = useForm({
     values: {
       source: source?.id,
+      where: searchedConfig.where ?? '',
+      whereLanguage:
+        searchedConfig.whereLanguage ?? getStoredLanguage() ?? 'lucene',
     },
   });
 
@@ -91,6 +112,15 @@ function DBServiceMapPage() {
       setSourceId(watchedSource ?? null);
     }
   }, [watchedSource, sourceId, setSourceId]);
+
+  const sourceTableConnection = useMemo(() => tcFromSource(source), [source]);
+
+  const onSubmit = useCallback(() => {
+    onSearch(displayedTimeInputValue);
+    handleSubmit(({ where, whereLanguage }) => {
+      setSearchedConfig({ where, whereLanguage });
+    })();
+  }, [handleSubmit, setSearchedConfig, displayedTimeInputValue, onSearch]);
 
   const [samplingFactor, setSamplingFactor] = useQueryState(
     'samplingFactor',
@@ -179,7 +209,7 @@ function DBServiceMapPage() {
       style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}
     >
       {head}
-      <Group mb="md" justify="space-between">
+      <Group mb="xs" justify="space-between">
         <Group>
           <Text size="xl">Service Map</Text>
           <SourceSelectControlled
@@ -215,10 +245,30 @@ function DBServiceMapPage() {
           />
         </Group>
       </Group>
+      <Box mb="sm">
+        <SearchWhereInput
+          tableConnection={sourceTableConnection}
+          control={control}
+          name="where"
+          onSubmit={onSubmit}
+          onLanguageChange={lang =>
+            setValue('whereLanguage', lang, { shouldDirty: true })
+          }
+          enableHotkey
+          size="xs"
+          data-testid="service-map-search-input"
+          dateRange={searchedTimeRange}
+          sourceId={source?.id}
+          lucenePlaceholder="Filter spans w/ Lucene (ex. ServiceName:my-service)"
+          sqlPlaceholder="SQL WHERE to filter spans (ex. ServiceName = 'my-service')"
+        />
+      </Box>
       <ServiceMap
         traceTableSource={source}
         dateRange={searchedTimeRange}
         samplingFactor={samplingFactor}
+        where={searchedConfig.where ?? undefined}
+        whereLanguage={searchedConfig.whereLanguage ?? undefined}
       />
     </Box>
   ) : null;

--- a/packages/app/src/DBServiceMapPage.tsx
+++ b/packages/app/src/DBServiceMapPage.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import {
+  parseAsArrayOf,
   parseAsInteger,
+  parseAsString,
   parseAsStringEnum,
   useQueryState,
   useQueryStates,
@@ -10,7 +12,16 @@ import {
 import { useForm, useWatch } from 'react-hook-form';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { SourceKind, TTraceSource } from '@hyperdx/common-utils/dist/types';
-import { Box, Button, Group, Modal, Slider, Text } from '@mantine/core';
+import {
+  Box,
+  Button,
+  Flex,
+  Group,
+  Modal,
+  MultiSelect,
+  Slider,
+  Text,
+} from '@mantine/core';
 import { IconConnection } from '@tabler/icons-react';
 
 import EmptyState from '@/components/EmptyState';
@@ -18,6 +29,7 @@ import SearchWhereInput, {
   getStoredLanguage,
 } from '@/components/SearchInput/SearchWhereInput';
 import { IS_LOCAL_MODE } from '@/config';
+import { useGetKeyValues } from '@/hooks/useMetadata';
 import { withAppNav } from '@/layout';
 import { parseAsStringEncoded } from '@/utils/queryParsers';
 
@@ -64,6 +76,7 @@ const defaultTimeRange = parseTimeQuery(DEFAULT_INTERVAL, false) as [
 const searchQueryStateMap = {
   where: parseAsStringEncoded,
   whereLanguage: parseAsStringEnum<'sql' | 'lucene'>(['sql', 'lucene']),
+  services: parseAsArrayOf(parseAsString),
 };
 
 function DBServiceMapPage() {
@@ -115,10 +128,54 @@ function DBServiceMapPage() {
 
   const sourceTableConnection = useMemo(() => tcFromSource(source), [source]);
 
+  const serviceNameKey = source?.serviceNameExpression ?? 'ServiceName';
+  const serviceNamesChartConfig = useMemo(
+    () =>
+      source
+        ? {
+            from: source.from,
+            connection: source.connection,
+            timestampValueExpression: source.timestampValueExpression,
+            where: '',
+            select: '',
+            dateRange: searchedTimeRange,
+          }
+        : undefined,
+    [source, searchedTimeRange],
+  );
+  const { data: serviceNameValues, isLoading: isServiceNamesLoading } =
+    useGetKeyValues(
+      {
+        chartConfig: serviceNamesChartConfig,
+        keys: [serviceNameKey],
+        disableRowLimit: true,
+        limit: 10000,
+      },
+      { enabled: !!source },
+    );
+  const serviceNameOptions = useMemo(
+    () =>
+      (serviceNameValues?.[0]?.value ?? [])
+        .map(v => String(v))
+        .sort((a, b) => a.localeCompare(b)),
+    [serviceNameValues],
+  );
+
+  const selectedServices = searchedConfig.services ?? [];
+  const setSelectedServices = useCallback(
+    (values: string[]) => {
+      setSearchedConfig(prev => ({
+        ...prev,
+        services: values.length > 0 ? values : null,
+      }));
+    },
+    [setSearchedConfig],
+  );
+
   const onSubmit = useCallback(() => {
     onSearch(displayedTimeInputValue);
     handleSubmit(({ where, whereLanguage }) => {
-      setSearchedConfig({ where, whereLanguage });
+      setSearchedConfig(prev => ({ ...prev, where, whereLanguage }));
     })();
   }, [handleSubmit, setSearchedConfig, displayedTimeInputValue, onSearch]);
 
@@ -245,7 +302,24 @@ function DBServiceMapPage() {
           />
         </Group>
       </Group>
-      <Box mb="sm">
+      <Flex mb="sm" gap="sm" align="flex-start" wrap="wrap">
+        <MultiSelect
+          placeholder={
+            selectedServices.length === 0 ? 'All Services' : undefined
+          }
+          value={selectedServices}
+          data={serviceNameOptions}
+          onChange={setSelectedServices}
+          searchable
+          clearable
+          size="xs"
+          maxDropdownHeight={280}
+          disabled={isServiceNamesLoading}
+          variant="filled"
+          w={250}
+          limit={100}
+          data-testid="service-map-service-filter"
+        />
         <SearchWhereInput
           tableConnection={sourceTableConnection}
           control={control}
@@ -259,16 +333,20 @@ function DBServiceMapPage() {
           data-testid="service-map-search-input"
           dateRange={searchedTimeRange}
           sourceId={source?.id}
-          lucenePlaceholder="Filter spans w/ Lucene (ex. ServiceName:my-service)"
-          sqlPlaceholder="SQL WHERE to filter spans (ex. ServiceName = 'my-service')"
+          lucenePlaceholder="Filter spans w/ Lucene (ex. http.method:GET)"
+          sqlPlaceholder="SQL WHERE to filter spans (ex. Duration > 1000000)"
+          minWidth="min(500px, 100%)"
         />
-      </Box>
+      </Flex>
       <ServiceMap
         traceTableSource={source}
         dateRange={searchedTimeRange}
         samplingFactor={samplingFactor}
         where={searchedConfig.where ?? undefined}
         whereLanguage={searchedConfig.whereLanguage ?? undefined}
+        serviceNames={
+          selectedServices.length > 0 ? selectedServices : undefined
+        }
       />
     </Box>
   ) : null;

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -248,6 +248,7 @@ interface ServiceMapProps {
   isSingleTrace?: boolean;
   where?: string;
   whereLanguage?: 'sql' | 'lucene';
+  serviceNames?: string[];
 }
 
 export default function ServiceMap({
@@ -258,6 +259,7 @@ export default function ServiceMap({
   isSingleTrace,
   where,
   whereLanguage,
+  serviceNames,
 }: ServiceMapProps) {
   const {
     isLoading,
@@ -270,6 +272,7 @@ export default function ServiceMap({
     samplingFactor,
     where,
     whereLanguage,
+    serviceNames,
   });
 
   useEffect(() => {

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -246,6 +246,8 @@ interface ServiceMapProps {
   dateRange: [Date, Date];
   samplingFactor?: number;
   isSingleTrace?: boolean;
+  where?: string;
+  whereLanguage?: 'sql' | 'lucene';
 }
 
 export default function ServiceMap({
@@ -254,6 +256,8 @@ export default function ServiceMap({
   dateRange,
   samplingFactor = 1,
   isSingleTrace,
+  where,
+  whereLanguage,
 }: ServiceMapProps) {
   const {
     isLoading,
@@ -264,6 +268,8 @@ export default function ServiceMap({
     source: traceTableSource,
     dateRange,
     samplingFactor,
+    where,
+    whereLanguage,
   });
 
   useEffect(() => {

--- a/packages/app/src/hooks/useServiceMap.tsx
+++ b/packages/app/src/hooks/useServiceMap.tsx
@@ -66,18 +66,6 @@ async function getServiceMapQuery({
             },
           ]
         : []),
-      // Optionally filter by selected service names
-      ...(serviceNames && serviceNames.length > 0
-        ? [
-            {
-              type: 'sql' as const,
-              condition: SqlString.format('? IN (?)', [
-                SqlString.raw(source.serviceNameExpression ?? 'ServiceName'),
-                serviceNames,
-              ]),
-            },
-          ]
-        : []),
     ],
     select: [
       {
@@ -134,6 +122,16 @@ async function getServiceMapQuery({
     ),
   ]);
 
+  const serviceNameInList = serviceNames?.length
+    ? { UNSAFE_RAW_SQL: serviceNames.map(s => SqlString.escape(s)).join(', ') }
+    : null;
+  const serviceNameFilter = serviceNameInList
+    ? chSql`AND (
+        ServerSpans.serviceName IN (${serviceNameInList})
+        OR ClientSpans.serviceName IN (${serviceNameInList})
+      )`
+    : chSql``;
+
   // Left join to support services which receive requests from clients that are not instrumented.
   // Ordering helps ensure stable graph layout.
   return chSql`
@@ -150,6 +148,7 @@ async function getServiceMapQuery({
         ON ServerSpans.traceId = ClientSpans.traceId
         AND ServerSpans.parentSpanId = ClientSpans.spanId
     WHERE (ClientSpans.serviceName IS NULL OR ServerSpans.serviceName != ClientSpans.serviceName)
+      ${serviceNameFilter}
     GROUP BY serverServiceName, serverStatusCode, clientServiceName
     ORDER BY serverServiceName, serverStatusCode, clientServiceName
   `;

--- a/packages/app/src/hooks/useServiceMap.tsx
+++ b/packages/app/src/hooks/useServiceMap.tsx
@@ -22,12 +22,16 @@ async function getServiceMapQuery({
   traceId,
   metadata,
   samplingFactor,
+  where,
+  whereLanguage,
 }: {
   source: TTraceSource;
   dateRange: [Date, Date];
   traceId?: string;
   metadata: Metadata;
   samplingFactor: number;
+  where?: string;
+  whereLanguage?: 'sql' | 'lucene';
 }) {
   // Don't sample if we're looking for a specific trace
   const effectiveSamplingLevel = traceId ? 1 : samplingFactor;
@@ -37,6 +41,11 @@ async function getServiceMapQuery({
     connection: source.connection,
     dateRange,
     timestampValueExpression: source.timestampValueExpression,
+    ...(source.implicitColumnExpression != null
+      ? { implicitColumnExpression: source.implicitColumnExpression }
+      : {}),
+    where: where || '',
+    whereLanguage: (whereLanguage ?? 'lucene') as 'sql' | 'lucene',
     filters: [
       // Sample a subset of traces, for performance in the following join
       {
@@ -91,7 +100,6 @@ async function getServiceMapQuery({
             condition: `${source.spanKindExpression} IN ('Server', 'Consumer', 'SPAN_KIND_SERVER', 'SPAN_KIND_CONSUMER')`,
           },
         ],
-        where: '',
       },
       metadata,
       source.querySettings,
@@ -106,7 +114,6 @@ async function getServiceMapQuery({
             condition: `${source.spanKindExpression} IN ('Client', 'Producer', 'SPAN_KIND_CLIENT', 'SPAN_KIND_PRODUCER')`,
           },
         ],
-        where: '',
       },
       metadata,
       source.querySettings,
@@ -246,17 +253,29 @@ export default function useServiceMap({
   dateRange,
   traceId,
   samplingFactor,
+  where,
+  whereLanguage,
 }: {
   source: TTraceSource;
   dateRange: [Date, Date];
   traceId?: string;
   samplingFactor: number;
+  where?: string;
+  whereLanguage?: 'sql' | 'lucene';
 }) {
   const client = useClickhouseClient();
   const metadata = useMetadataWithSettings();
 
   return useQuery({
-    queryKey: ['serviceMapData', traceId, source, dateRange, samplingFactor],
+    queryKey: [
+      'serviceMapData',
+      traceId,
+      source,
+      dateRange,
+      samplingFactor,
+      where,
+      whereLanguage,
+    ],
     queryFn: async ({ signal }) => {
       const query = await getServiceMapQuery({
         source,
@@ -264,6 +283,8 @@ export default function useServiceMap({
         traceId,
         metadata,
         samplingFactor,
+        where,
+        whereLanguage,
       });
 
       const data = await client

--- a/packages/app/src/hooks/useServiceMap.tsx
+++ b/packages/app/src/hooks/useServiceMap.tsx
@@ -71,7 +71,7 @@ async function getServiceMapQuery({
         ? [
             {
               type: 'sql' as const,
-              condition: SqlString.format('?? IN (?)', [
+              condition: SqlString.format('? IN (?)', [
                 SqlString.raw(source.serviceNameExpression ?? 'ServiceName'),
                 serviceNames,
               ]),

--- a/packages/app/src/hooks/useServiceMap.tsx
+++ b/packages/app/src/hooks/useServiceMap.tsx
@@ -24,6 +24,7 @@ async function getServiceMapQuery({
   samplingFactor,
   where,
   whereLanguage,
+  serviceNames,
 }: {
   source: TTraceSource;
   dateRange: [Date, Date];
@@ -32,6 +33,7 @@ async function getServiceMapQuery({
   samplingFactor: number;
   where?: string;
   whereLanguage?: 'sql' | 'lucene';
+  serviceNames?: string[];
 }) {
   // Don't sample if we're looking for a specific trace
   const effectiveSamplingLevel = traceId ? 1 : samplingFactor;
@@ -60,6 +62,18 @@ async function getServiceMapQuery({
               condition: SqlString.format('?? = ?', [
                 source.traceIdExpression,
                 traceId,
+              ]),
+            },
+          ]
+        : []),
+      // Optionally filter by selected service names
+      ...(serviceNames && serviceNames.length > 0
+        ? [
+            {
+              type: 'sql' as const,
+              condition: SqlString.format('?? IN (?)', [
+                SqlString.raw(source.serviceNameExpression ?? 'ServiceName'),
+                serviceNames,
               ]),
             },
           ]
@@ -255,6 +269,7 @@ export default function useServiceMap({
   samplingFactor,
   where,
   whereLanguage,
+  serviceNames,
 }: {
   source: TTraceSource;
   dateRange: [Date, Date];
@@ -262,6 +277,7 @@ export default function useServiceMap({
   samplingFactor: number;
   where?: string;
   whereLanguage?: 'sql' | 'lucene';
+  serviceNames?: string[];
 }) {
   const client = useClickhouseClient();
   const metadata = useMetadataWithSettings();
@@ -275,6 +291,7 @@ export default function useServiceMap({
       samplingFactor,
       where,
       whereLanguage,
+      serviceNames,
     ],
     queryFn: async ({ signal }) => {
       const query = await getServiceMapQuery({
@@ -285,6 +302,7 @@ export default function useServiceMap({
         samplingFactor,
         where,
         whereLanguage,
+        serviceNames,
       });
 
       const data = await client


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add support for filtering on Service Maps (HDX-3025). Two complementary filter mechanisms:

1. **Service name MultiSelect** — A searchable, clearable dropdown populated with distinct service names from ClickHouse. Selecting services shows that service **plus all its inbound callers and outbound callees** — so you see the full neighborhood of the selected service(s) in the graph. The filter is applied post-JOIN on the outer query (`WHERE serverServiceName IN (...) OR clientServiceName IN (...)`), preserving the span linkage that builds edges.

2. **Lucene/SQL search bar** — A free-form search input (same `SearchWhereInput` used on the Search page) for filtering on any span attribute. Supports both Lucene syntax and raw SQL WHERE clauses. This enables deeper filtering beyond service names (e.g. `http.method:GET`, `Duration > 1000000`, `SpanAttributes['db.system'] = 'postgresql'`).

Both filters persist in URL params for shareable filtered views.

**Key changes:**
- `DBServiceMapPage.tsx` — Added MultiSelect (service names via `useGetKeyValues`) and `SearchWhereInput` with URL state persistence via `nuqs`
- `ServiceMap.tsx` — Thread `where`, `whereLanguage`, and `serviceNames` props through
- `useServiceMap.tsx` — Apply service name filter on the outer query (post-JOIN) so both inbound and outbound neighbors are shown; apply free-text WHERE/filters via `renderChartConfig` in the CTEs

### Screenshots or video

**Full service map (no filter)** — all 6 services visible:

[Full service map](https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneighbor_no_filter.png)

**api-gateway selected** — shows api-gateway + all neighbors (web-frontend, user-service, order-service, payment-service):

[api-gateway with neighbors](https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneighbor_api_gateway.png)

**order-service selected** — shows order-service + api-gateway (inbound) + inventory-service (outbound):

[order-service with neighbors](https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneighbor_order_service.png)

**payment-service selected** — shows payment-service + api-gateway (its caller):

[payment-service with caller](https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneighbor_payment_service.png)

**Neighbor-inclusive filtering demo** — selecting services and seeing their neighborhoods:

[demo_neighbor_filtering.webm](https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_neighbor_filtering.webm)

### Test results

| Scenario | Expected | Actual |
|----------|----------|--------|
| No filter | 6 services | 6 nodes |
| api-gateway | api-gateway + 4 neighbors | 5 nodes: api-gateway, web-frontend, user-service, order-service, payment-service |
| order-service | order-service + 2 neighbors | 3 nodes: order-service, api-gateway, inventory-service |
| payment-service | payment-service + 1 neighbor | 2 nodes: payment-service, api-gateway |
| user-service | user-service + 1 neighbor | 2 nodes: user-service, api-gateway |
| Lint + type check (`make ci-lint`) | Pass | Pass |
| Unit tests (`make ci-unit`) | Pass | Pass |

### How to test on Vercel preview

**Preview routes:** /service-map

**Steps:**

1. Navigate to /service-map
2. Verify a "All Services" MultiSelect dropdown and a Lucene/SQL search bar appear in the filter row
3. Click the MultiSelect and select a service (e.g. "api-gateway")
4. Verify the map shows the selected service AND its direct inbound/outbound neighbors with edges
5. Add another service to the selection — verify the map expands to include that service's neighbors too
6. Clear the selection — verify the map returns to showing all services
7. Verify URL updates with `services` param for shareable links

### References

- Linear Issue: HDX-3025
- Related PRs: None

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-3025](https://linear.app/clickhouse/issue/HDX-3025/service-maps-add-ability-to-filter)

<div><a href="https://cursor.com/agents/bc-48ead66c-c7db-43dd-a5f3-91571077fc03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ead66c-c7db-43dd-a5f3-91571077fc03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

