### PR TITLE
feat(app): dashboard section navigation aids (TOC, view options, deep links)

### DIFF
--- a/.changeset/easy-snakes-go.md
+++ b/.changeset/easy-snakes-go.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat(app): dashboard section navigation aids (TOC, view options, deep links)

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -2530,12 +2530,14 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             <IconFilterEdit size={18} />
           </ActionIcon>
         </Tooltip>
-        <DashboardViewOptions
-          onCollapseAll={collapseAll}
-          onExpandAll={expandAll}
-          tocVisible={tocVisible}
-          onToggleToc={toggleToc}
-        />
+        {containers.length > 0 && (
+          <DashboardViewOptions
+            onCollapseAll={collapseAll}
+            onExpandAll={expandAll}
+            tocVisible={tocVisible}
+            onToggleToc={toggleToc}
+          />
+        )}
         <Button
           data-testid="search-submit-button"
           variant="primary"

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -2557,92 +2557,96 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           </Flex>
         </Paper>
       )}
-      <Box mt="sm">
-        {dashboard != null && dashboard.tiles != null ? (
-          <ErrorBoundary
-            onError={console.error}
-            fallback={
-              <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
-                An error occurred while rendering the dashboard.
-              </div>
-            }
-          >
-            <DashboardDndProvider
-              containers={containers}
-              onReorderContainers={handleReorderContainers}
+      {/* DEBUG: bisect step 3 — Flex wrap around the dashboard content (no
+          TOC sibling, just the wrap itself to isolate CSS structure change). */}
+      <Flex gap="md" align="flex-start" mt="sm">
+        <Box flex={1} miw={0}>
+          {dashboard != null && dashboard.tiles != null ? (
+            <ErrorBoundary
+              onError={console.error}
+              fallback={
+                <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
+                  An error occurred while rendering the dashboard.
+                </div>
+              }
             >
-              {ungroupedTiles.length > 0 && (
-                <ReactGridLayout
-                  layout={ungroupedTiles.map(tileToLayoutItem)}
-                  containerPadding={[0, 0]}
-                  onLayoutChange={onUngroupedLayoutChange}
-                  cols={24}
-                  rowHeight={32}
-                >
-                  {ungroupedTiles.map(renderTileComponent)}
-                </ReactGridLayout>
-              )}
-              {containers.map(container => (
-                <SortableContainerWrapper
-                  key={container.id}
-                  containerId={container.id}
-                  containerTitle={container.title}
-                >
-                  {(dragHandleProps: DragHandleProps) => (
-                    <DashboardContainerRow
-                      container={container}
-                      containerTiles={
-                        tilesByContainerId.get(container.id) ?? []
-                      }
-                      isCollapsed={isContainerCollapsed(container)}
-                      activeTabId={getActiveTabId(container)}
-                      alertingTabIds={alertingTabIdsByContainer.get(
-                        container.id,
-                      )}
-                      onToggleCollapse={() =>
-                        handleToggleCollapse(container.id)
-                      }
-                      onToggleDefaultCollapsed={() =>
-                        handleToggleDefaultCollapsed(container.id)
-                      }
-                      onToggleCollapsible={() =>
-                        handleToggleCollapsible(container.id)
-                      }
-                      onToggleBordered={() =>
-                        handleToggleBordered(container.id)
-                      }
-                      onDeleteContainer={action =>
-                        handleDeleteContainer(container.id, action)
-                      }
-                      onAddTile={onAddTile}
-                      onAddTab={() => {
-                        const newTabId = handleAddTab(container.id);
-                        if (newTabId) handleTabChange(container.id, newTabId);
-                      }}
-                      onRenameTab={(tabId, title) =>
-                        handleRenameTab(container.id, tabId, title)
-                      }
-                      onDeleteTab={(tabId, action) =>
-                        handleDeleteTab(container.id, tabId, action)
-                      }
-                      onRenameContainer={title =>
-                        handleRenameContainer(container.id, title)
-                      }
-                      onTabChange={tabId =>
-                        handleTabChange(container.id, tabId)
-                      }
-                      dragHandleProps={dragHandleProps}
-                      makeLayoutChangeHandler={makeOnLayoutChange}
-                      tileToLayoutItem={tileToLayoutItem}
-                      renderTileComponent={renderTileComponent}
-                    />
-                  )}
-                </SortableContainerWrapper>
-              ))}
-            </DashboardDndProvider>
-          </ErrorBoundary>
-        ) : null}
-      </Box>
+              <DashboardDndProvider
+                containers={containers}
+                onReorderContainers={handleReorderContainers}
+              >
+                {ungroupedTiles.length > 0 && (
+                  <ReactGridLayout
+                    layout={ungroupedTiles.map(tileToLayoutItem)}
+                    containerPadding={[0, 0]}
+                    onLayoutChange={onUngroupedLayoutChange}
+                    cols={24}
+                    rowHeight={32}
+                  >
+                    {ungroupedTiles.map(renderTileComponent)}
+                  </ReactGridLayout>
+                )}
+                {containers.map(container => (
+                  <SortableContainerWrapper
+                    key={container.id}
+                    containerId={container.id}
+                    containerTitle={container.title}
+                  >
+                    {(dragHandleProps: DragHandleProps) => (
+                      <DashboardContainerRow
+                        container={container}
+                        containerTiles={
+                          tilesByContainerId.get(container.id) ?? []
+                        }
+                        isCollapsed={isContainerCollapsed(container)}
+                        activeTabId={getActiveTabId(container)}
+                        alertingTabIds={alertingTabIdsByContainer.get(
+                          container.id,
+                        )}
+                        onToggleCollapse={() =>
+                          handleToggleCollapse(container.id)
+                        }
+                        onToggleDefaultCollapsed={() =>
+                          handleToggleDefaultCollapsed(container.id)
+                        }
+                        onToggleCollapsible={() =>
+                          handleToggleCollapsible(container.id)
+                        }
+                        onToggleBordered={() =>
+                          handleToggleBordered(container.id)
+                        }
+                        onDeleteContainer={action =>
+                          handleDeleteContainer(container.id, action)
+                        }
+                        onAddTile={onAddTile}
+                        onAddTab={() => {
+                          const newTabId = handleAddTab(container.id);
+                          if (newTabId) handleTabChange(container.id, newTabId);
+                        }}
+                        onRenameTab={(tabId, title) =>
+                          handleRenameTab(container.id, tabId, title)
+                        }
+                        onDeleteTab={(tabId, action) =>
+                          handleDeleteTab(container.id, tabId, action)
+                        }
+                        onRenameContainer={title =>
+                          handleRenameContainer(container.id, title)
+                        }
+                        onTabChange={tabId =>
+                          handleTabChange(container.id, tabId)
+                        }
+                        dragHandleProps={dragHandleProps}
+                        makeLayoutChangeHandler={makeOnLayoutChange}
+                        tileToLayoutItem={tileToLayoutItem}
+                        renderTileComponent={renderTileComponent}
+                      />
+                    )}
+                  </SortableContainerWrapper>
+                ))}
+              </DashboardDndProvider>
+            </ErrorBoundary>
+          ) : null}
+        </Box>
+      </Flex>
       <Menu position="top" width={200}>
         <Menu.Target>
           <Button

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1652,6 +1652,17 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     [tocVisible, setUserPreference],
   );
 
+  // When the TOC mounts/unmounts the flex child holding the tile grid
+  // changes width. ReactGridLayout's WidthProvider listens for window
+  // resize events to re-measure, so dispatch one whenever `tocVisible`
+  // flips. Without this the RGL columns keep their old pixel widths and
+  // tiles either overflow under the TOC (when toggling on) or leave a
+  // gap (when toggling off) until the next page refresh.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new Event('resize'));
+  }, [tocVisible]);
+
   // Lightweight projection of containers (id + label) for the TOC rail.
   // The label mirrors what the user perceives as the section name:
   //   - 1-tab container: the visible header is the first tab's title (the

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1284,6 +1284,13 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const brandName = useBrandDisplayName();
   const confirm = useConfirm();
 
+  // DEBUG: bisect — re-introducing only the top-level useUserPreferences()
+  // subscription. If the saved-dashboard refresh bug returns with this single
+  // addition, the cause is this hook's Jotai/atomWithStorage subscription
+  // racing the post-hydration router state transition.
+  const { userPreferences: _bisectUserPreferences } = useUserPreferences();
+  void _bisectUserPreferences;
+
   const router = useRouter();
   const dashboardId = router.query.dashboardId as string | undefined;
 

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -122,6 +122,7 @@ import {
 import useDashboardContainers, {
   TabDeleteAction,
 } from '@/hooks/useDashboardContainers';
+import { useDashboardSectionNav } from '@/hooks/useDashboardSectionNav';
 import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer from './components/charts/ChartContainer';
@@ -1627,6 +1628,19 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     'expanded',
     parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
   );
+
+  // DEBUG: bisect step 4 — last suspect. useDashboardSectionNav is just
+  // five useCallback wrappers, no useState / useEffect, but it's the only
+  // remaining piece of my changes still pending. If the bug returns with
+  // this addition, the cause is something subtle about the hook itself
+  // (probably useCallback identity churn cascading into other effects).
+  const _bisectSectionNav = useDashboardSectionNav({
+    containers,
+    setUrlCollapsedIds,
+    setUrlExpandedIds,
+  });
+  void _bisectSectionNav;
+
   // Per-viewer active tab selection: `{ [containerId]: tabId }`.
   // Falls back to the first tab for any container not in the map.
   const [urlActiveTabs, setUrlActiveTabs] = useQueryState(

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -104,8 +104,6 @@ import {
   DashboardDndProvider,
   type DragHandleProps,
 } from '@/components/DashboardDndContext';
-import { DashboardTOC } from '@/components/DashboardTOC';
-import { DashboardViewOptions } from '@/components/DashboardViewOptions';
 import EditTimeChartForm from '@/components/DBEditTimeChartForm';
 import DBNumberChart from '@/components/DBNumberChart';
 import DBTableChart from '@/components/DBTableChart';
@@ -124,7 +122,6 @@ import {
 import useDashboardContainers, {
   TabDeleteAction,
 } from '@/hooks/useDashboardContainers';
-import { useDashboardSectionNav } from '@/hooks/useDashboardSectionNav';
 import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer from './components/charts/ChartContainer';
@@ -1191,7 +1188,6 @@ function DashboardContainerRow({
   onDeleteTab,
   onRenameContainer,
   onTabChange,
-  onCopyLink,
   dragHandleProps,
   makeLayoutChangeHandler,
   tileToLayoutItem,
@@ -1213,7 +1209,6 @@ function DashboardContainerRow({
   onDeleteTab: (tabId: string, action: TabDeleteAction) => void;
   onRenameContainer: (newTitle: string) => void;
   onTabChange: (tabId: string) => void;
-  onCopyLink: () => void;
   dragHandleProps: DragHandleProps;
   makeLayoutChangeHandler: (tiles: Tile[]) => (newLayout: RGL.Layout[]) => void;
   tileToLayoutItem: (tile: Tile) => RGL.Layout;
@@ -1253,7 +1248,6 @@ function DashboardContainerRow({
       onRenameTab={onRenameTab}
       onDeleteTab={onDeleteTab}
       onRename={onRenameContainer}
-      onCopyLink={onCopyLink}
       dragHandleProps={dragHandleProps}
       alertingTabIds={alertingTabIds}
     >
@@ -1617,7 +1611,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     () => dashboard?.containers ?? [],
     [dashboard?.containers],
   );
-
   // URL-based collapse state: tracks which containers the current viewer has
   // explicitly collapsed/expanded. Falls back to the DB-stored default.
   const [urlCollapsedIds, setUrlCollapsedIds] = useQueryState(
@@ -1627,47 +1620,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const [urlExpandedIds, setUrlExpandedIds] = useQueryState(
     'expanded',
     parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
-  );
-
-  // Section-level navigation helpers: scroll-to-section, deep-link copy, and
-  // batch collapse/expand. Consumed by the view-options menu (collapseAll /
-  // expandAll), the per-container header (copySectionLink), the TOC rail
-  // (scrollToContainer), and the hash-on-load effect (scrollToContainer).
-  // The hook takes the URL setters from above so there is only ever one
-  // useQueryState subscriber per `collapsed`/`expanded` key in this tree.
-  const { scrollToContainer, copySectionLink, collapseAll, expandAll } =
-    useDashboardSectionNav({
-      containers,
-      setUrlCollapsedIds,
-      setUrlExpandedIds,
-    });
-
-  // Per-user preference for whether the sticky table-of-contents rail is shown.
-  // Defaults to false (off) so dashboard behavior is unchanged for users who
-  // never opt in via the view-options menu.
-  const { userPreferences, setUserPreference } = useUserPreferences();
-  const tocVisible = userPreferences.tocVisible ?? false;
-  const toggleToc = useCallback(
-    () => setUserPreference({ tocVisible: !tocVisible }),
-    [tocVisible, setUserPreference],
-  );
-
-  // Lightweight projection of containers (id + label) for the TOC rail.
-  // The label mirrors what the user perceives as the section name:
-  //   - 1-tab container: the visible header is the first tab's title (the
-  //     header rename flow in DashboardContainer redirects to the first tab),
-  //     so use that.
-  //   - Multi-tab container: the visible header is the tab bar showing every
-  //     tab; `container.title` is the section-level name that doesn't move
-  //     when the active tab changes, so use that as the TOC label.
-  const tocContainers = useMemo(
-    () =>
-      containers.map(c => {
-        const tabs = c.tabs ?? [];
-        const label = tabs.length >= 2 ? c.title : (tabs[0]?.title ?? c.title);
-        return { id: c.id, title: label };
-      }),
-    [containers],
   );
   // Per-viewer active tab selection: `{ [containerId]: tabId }`.
   // Falls back to the first tab for any container not in the map.
@@ -1739,37 +1691,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     getActiveTabId,
     setUrlActiveTabs,
   ]);
-
-  // Hash-based deep links to dashboard sections (e.g. `#container-abc123`).
-  // Runs an initial scroll once per dashboard load (re-armed when the user
-  // navigates between dashboards in the SPA), then keeps a hashchange listener
-  // attached so in-page hash navigation also scrolls. Unknown containers
-  // (deleted sections, stale links) are silently ignored.
-  const initialHashScrolledForDashboardRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (typeof window === 'undefined' || !dashboard) return;
-    // Wait until containers are available so the existence check below can
-    // distinguish "unknown container" from "containers still loading".
-    if (!dashboard.containers || dashboard.containers.length === 0) return;
-
-    const handleHash = () => {
-      const match = window.location.hash.match(/^#container-(.+)$/);
-      if (!match) return;
-      const containerId = match[1];
-      const exists = dashboard.containers?.some(c => c.id === containerId);
-      if (!exists) return;
-      scrollToContainer(containerId);
-    };
-
-    // Fire the initial scroll once per dashboard.id so SPA navigation between
-    // dashboards (same component instance) re-arms the deep-link behavior.
-    if (initialHashScrolledForDashboardRef.current !== dashboard.id) {
-      initialHashScrolledForDashboardRef.current = dashboard.id;
-      handleHash();
-    }
-    window.addEventListener('hashchange', handleHash);
-    return () => window.removeEventListener('hashchange', handleHash);
-  }, [dashboard, scrollToContainer]);
 
   // Valid move targets: groups and individual tabs within groups
   const moveTargetContainers = useMemo<MoveTarget[]>(() => {
@@ -2545,14 +2466,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             <IconFilterEdit size={18} />
           </ActionIcon>
         </Tooltip>
-        {containers.length > 0 && (
-          <DashboardViewOptions
-            onCollapseAll={collapseAll}
-            onExpandAll={expandAll}
-            tocVisible={tocVisible}
-            onToggleToc={toggleToc}
-          />
-        )}
         <Button
           data-testid="search-submit-button"
           variant="primary"
@@ -2615,111 +2528,92 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           </Flex>
         </Paper>
       )}
-      <Flex gap="md" align="flex-start" mt="sm">
-        <Box flex={1} miw={0}>
-          {dashboard != null && dashboard.tiles != null ? (
-            <ErrorBoundary
-              onError={console.error}
-              fallback={
-                <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
-                  An error occurred while rendering the dashboard.
-                </div>
-              }
-            >
-              <DashboardDndProvider
-                containers={containers}
-                onReorderContainers={handleReorderContainers}
-              >
-                {ungroupedTiles.length > 0 && (
-                  <ReactGridLayout
-                    layout={ungroupedTiles.map(tileToLayoutItem)}
-                    containerPadding={[0, 0]}
-                    onLayoutChange={onUngroupedLayoutChange}
-                    cols={24}
-                    rowHeight={32}
-                  >
-                    {ungroupedTiles.map(renderTileComponent)}
-                  </ReactGridLayout>
-                )}
-                {containers.map(container => (
-                  <SortableContainerWrapper
-                    key={container.id}
-                    containerId={container.id}
-                    containerTitle={container.title}
-                  >
-                    {(dragHandleProps: DragHandleProps) => (
-                      <DashboardContainerRow
-                        container={container}
-                        containerTiles={
-                          tilesByContainerId.get(container.id) ?? []
-                        }
-                        isCollapsed={isContainerCollapsed(container)}
-                        activeTabId={getActiveTabId(container)}
-                        alertingTabIds={alertingTabIdsByContainer.get(
-                          container.id,
-                        )}
-                        onToggleCollapse={() =>
-                          handleToggleCollapse(container.id)
-                        }
-                        onToggleDefaultCollapsed={() =>
-                          handleToggleDefaultCollapsed(container.id)
-                        }
-                        onToggleCollapsible={() =>
-                          handleToggleCollapsible(container.id)
-                        }
-                        onToggleBordered={() =>
-                          handleToggleBordered(container.id)
-                        }
-                        onDeleteContainer={action =>
-                          handleDeleteContainer(container.id, action)
-                        }
-                        onAddTile={onAddTile}
-                        onAddTab={() => {
-                          const newTabId = handleAddTab(container.id);
-                          if (newTabId) handleTabChange(container.id, newTabId);
-                        }}
-                        onRenameTab={(tabId, title) =>
-                          handleRenameTab(container.id, tabId, title)
-                        }
-                        onDeleteTab={(tabId, action) =>
-                          handleDeleteTab(container.id, tabId, action)
-                        }
-                        onRenameContainer={title =>
-                          handleRenameContainer(container.id, title)
-                        }
-                        onTabChange={tabId =>
-                          handleTabChange(container.id, tabId)
-                        }
-                        onCopyLink={() => copySectionLink(container.id)}
-                        dragHandleProps={dragHandleProps}
-                        makeLayoutChangeHandler={makeOnLayoutChange}
-                        tileToLayoutItem={tileToLayoutItem}
-                        renderTileComponent={renderTileComponent}
-                      />
-                    )}
-                  </SortableContainerWrapper>
-                ))}
-              </DashboardDndProvider>
-            </ErrorBoundary>
-          ) : null}
-        </Box>
-        {tocVisible && (
-          <Box
-            w={180}
-            visibleFrom="md"
-            style={{
-              position: 'sticky',
-              top: 16,
-              alignSelf: 'flex-start',
-            }}
+      <Box mt="sm">
+        {dashboard != null && dashboard.tiles != null ? (
+          <ErrorBoundary
+            onError={console.error}
+            fallback={
+              <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
+                An error occurred while rendering the dashboard.
+              </div>
+            }
           >
-            <DashboardTOC
-              containers={tocContainers}
-              onJump={scrollToContainer}
-            />
-          </Box>
-        )}
-      </Flex>
+            <DashboardDndProvider
+              containers={containers}
+              onReorderContainers={handleReorderContainers}
+            >
+              {ungroupedTiles.length > 0 && (
+                <ReactGridLayout
+                  layout={ungroupedTiles.map(tileToLayoutItem)}
+                  containerPadding={[0, 0]}
+                  onLayoutChange={onUngroupedLayoutChange}
+                  cols={24}
+                  rowHeight={32}
+                >
+                  {ungroupedTiles.map(renderTileComponent)}
+                </ReactGridLayout>
+              )}
+              {containers.map(container => (
+                <SortableContainerWrapper
+                  key={container.id}
+                  containerId={container.id}
+                  containerTitle={container.title}
+                >
+                  {(dragHandleProps: DragHandleProps) => (
+                    <DashboardContainerRow
+                      container={container}
+                      containerTiles={
+                        tilesByContainerId.get(container.id) ?? []
+                      }
+                      isCollapsed={isContainerCollapsed(container)}
+                      activeTabId={getActiveTabId(container)}
+                      alertingTabIds={alertingTabIdsByContainer.get(
+                        container.id,
+                      )}
+                      onToggleCollapse={() =>
+                        handleToggleCollapse(container.id)
+                      }
+                      onToggleDefaultCollapsed={() =>
+                        handleToggleDefaultCollapsed(container.id)
+                      }
+                      onToggleCollapsible={() =>
+                        handleToggleCollapsible(container.id)
+                      }
+                      onToggleBordered={() =>
+                        handleToggleBordered(container.id)
+                      }
+                      onDeleteContainer={action =>
+                        handleDeleteContainer(container.id, action)
+                      }
+                      onAddTile={onAddTile}
+                      onAddTab={() => {
+                        const newTabId = handleAddTab(container.id);
+                        if (newTabId) handleTabChange(container.id, newTabId);
+                      }}
+                      onRenameTab={(tabId, title) =>
+                        handleRenameTab(container.id, tabId, title)
+                      }
+                      onDeleteTab={(tabId, action) =>
+                        handleDeleteTab(container.id, tabId, action)
+                      }
+                      onRenameContainer={title =>
+                        handleRenameContainer(container.id, title)
+                      }
+                      onTabChange={tabId =>
+                        handleTabChange(container.id, tabId)
+                      }
+                      dragHandleProps={dragHandleProps}
+                      makeLayoutChangeHandler={makeOnLayoutChange}
+                      tileToLayoutItem={tileToLayoutItem}
+                      renderTileComponent={renderTileComponent}
+                    />
+                  )}
+                </SortableContainerWrapper>
+              ))}
+            </DashboardDndProvider>
+          </ErrorBoundary>
+        ) : null}
+      </Box>
       <Menu position="top" width={200}>
         <Menu.Target>
           <Button

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1618,12 +1618,29 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     [dashboard?.containers],
   );
 
+  // URL-based collapse state: tracks which containers the current viewer has
+  // explicitly collapsed/expanded. Falls back to the DB-stored default.
+  const [urlCollapsedIds, setUrlCollapsedIds] = useQueryState(
+    'collapsed',
+    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
+  );
+  const [urlExpandedIds, setUrlExpandedIds] = useQueryState(
+    'expanded',
+    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
+  );
+
   // Section-level navigation helpers: scroll-to-section, deep-link copy, and
   // batch collapse/expand. Consumed by the view-options menu (collapseAll /
   // expandAll), the per-container header (copySectionLink), the TOC rail
   // (scrollToContainer), and the hash-on-load effect (scrollToContainer).
+  // The hook takes the URL setters from above so there is only ever one
+  // useQueryState subscriber per `collapsed`/`expanded` key in this tree.
   const { scrollToContainer, copySectionLink, collapseAll, expandAll } =
-    useDashboardSectionNav({ containers });
+    useDashboardSectionNav({
+      containers,
+      setUrlCollapsedIds,
+      setUrlExpandedIds,
+    });
 
   // Per-user preference for whether the sticky table-of-contents rail is shown.
   // Defaults to false (off) so dashboard behavior is unchanged for users who
@@ -1651,17 +1668,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
         return { id: c.id, title: label };
       }),
     [containers],
-  );
-
-  // URL-based collapse state: tracks which containers the current viewer has
-  // explicitly collapsed/expanded. Falls back to the DB-stored default.
-  const [urlCollapsedIds, setUrlCollapsedIds] = useQueryState(
-    'collapsed',
-    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
-  );
-  const [urlExpandedIds, setUrlExpandedIds] = useQueryState(
-    'expanded',
-    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
   );
   // Per-viewer active tab selection: `{ [containerId]: tabId }`.
   // Falls back to the first tab for any container not in the map.

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1284,10 +1284,9 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const brandName = useBrandDisplayName();
   const confirm = useConfirm();
 
-  // DEBUG: bisect — re-introducing only the top-level useUserPreferences()
-  // subscription. If the saved-dashboard refresh bug returns with this single
-  // addition, the cause is this hook's Jotai/atomWithStorage subscription
-  // racing the post-hydration router state transition.
+  // DEBUG: bisect step 2 — useUserPreferences was confirmed safe in step 1.
+  // Now adding the hash-on-load useEffect (the only top-level useEffect my
+  // changes introduced). If the bug returns, this effect is the cause.
   const { userPreferences: _bisectUserPreferences } = useUserPreferences();
   void _bisectUserPreferences;
 
@@ -1698,6 +1697,29 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     getActiveTabId,
     setUrlActiveTabs,
   ]);
+
+  // DEBUG: bisect step 2 — the hash-on-load useEffect.
+  // No `scrollToContainer` body so this is the pure effect-and-listener
+  // shape, isolated from any of my other code.
+  const initialHashScrolledForDashboardRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !dashboard) return;
+    if (!dashboard.containers || dashboard.containers.length === 0) return;
+
+    const handleHash = () => {
+      const match = window.location.hash.match(/^#container-(.+)$/);
+      if (!match) return;
+      // Bisect: no scroll, just confirm parse path exists.
+      void match[1];
+    };
+
+    if (initialHashScrolledForDashboardRef.current !== dashboard.id) {
+      initialHashScrolledForDashboardRef.current = dashboard.id;
+      handleHash();
+    }
+    window.addEventListener('hashchange', handleHash);
+    return () => window.removeEventListener('hashchange', handleHash);
+  }, [dashboard]);
 
   // Valid move targets: groups and individual tabs within groups
   const moveTargetContainers = useMemo<MoveTarget[]>(() => {

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1712,9 +1712,11 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setUrlActiveTabs,
   ]);
 
-  // DEBUG: bisect step 2 — the hash-on-load useEffect.
-  // No `scrollToContainer` body so this is the pure effect-and-listener
-  // shape, isolated from any of my other code.
+  // DEBUG: bisect step 5 — the FULL hash effect, now with scrollToContainer
+  // in the dependency array. If nuqs v1 setters change identity each render,
+  // expandContainer → scrollToContainer → this effect all re-run on every
+  // render, thrashing hashchange listener attach/detach. If the bug returns
+  // with this commit, the cause is the effect+identity-churn interaction.
   const initialHashScrolledForDashboardRef = useRef<string | null>(null);
   useEffect(() => {
     if (typeof window === 'undefined' || !dashboard) return;
@@ -1723,8 +1725,10 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     const handleHash = () => {
       const match = window.location.hash.match(/^#container-(.+)$/);
       if (!match) return;
-      // Bisect: no scroll, just confirm parse path exists.
-      void match[1];
+      const containerId = match[1];
+      const exists = dashboard.containers?.some(c => c.id === containerId);
+      if (!exists) return;
+      _bisectSectionNav.scrollToContainer(containerId);
     };
 
     if (initialHashScrolledForDashboardRef.current !== dashboard.id) {
@@ -1733,7 +1737,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     }
     window.addEventListener('hashchange', handleHash);
     return () => window.removeEventListener('hashchange', handleHash);
-  }, [dashboard]);
+  }, [dashboard, _bisectSectionNav]);
 
   // Valid move targets: groups and individual tabs within groups
   const moveTargetContainers = useMemo<MoveTarget[]>(() => {

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -104,6 +104,8 @@ import {
   DashboardDndProvider,
   type DragHandleProps,
 } from '@/components/DashboardDndContext';
+import { DashboardTOC } from '@/components/DashboardTOC';
+import { DashboardViewOptions } from '@/components/DashboardViewOptions';
 import EditTimeChartForm from '@/components/DBEditTimeChartForm';
 import DBNumberChart from '@/components/DBNumberChart';
 import DBTableChart from '@/components/DBTableChart';
@@ -1189,6 +1191,7 @@ function DashboardContainerRow({
   onDeleteTab,
   onRenameContainer,
   onTabChange,
+  onCopyLink,
   dragHandleProps,
   makeLayoutChangeHandler,
   tileToLayoutItem,
@@ -1210,6 +1213,7 @@ function DashboardContainerRow({
   onDeleteTab: (tabId: string, action: TabDeleteAction) => void;
   onRenameContainer: (newTitle: string) => void;
   onTabChange: (tabId: string) => void;
+  onCopyLink: () => void;
   dragHandleProps: DragHandleProps;
   makeLayoutChangeHandler: (tiles: Tile[]) => (newLayout: RGL.Layout[]) => void;
   tileToLayoutItem: (tile: Tile) => RGL.Layout;
@@ -1249,6 +1253,7 @@ function DashboardContainerRow({
       onRenameTab={onRenameTab}
       onDeleteTab={onDeleteTab}
       onRename={onRenameContainer}
+      onCopyLink={onCopyLink}
       dragHandleProps={dragHandleProps}
       alertingTabIds={alertingTabIds}
     >
@@ -1284,12 +1289,6 @@ function DashboardContainerRow({
 function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   const brandName = useBrandDisplayName();
   const confirm = useConfirm();
-
-  // DEBUG: bisect step 2 — useUserPreferences was confirmed safe in step 1.
-  // Now adding the hash-on-load useEffect (the only top-level useEffect my
-  // changes introduced). If the bug returns, this effect is the cause.
-  const { userPreferences: _bisectUserPreferences } = useUserPreferences();
-  void _bisectUserPreferences;
 
   const router = useRouter();
   const dashboardId = router.query.dashboardId as string | undefined;
@@ -1618,6 +1617,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     () => dashboard?.containers ?? [],
     [dashboard?.containers],
   );
+
   // URL-based collapse state: tracks which containers the current viewer has
   // explicitly collapsed/expanded. Falls back to the DB-stored default.
   const [urlCollapsedIds, setUrlCollapsedIds] = useQueryState(
@@ -1629,18 +1629,46 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
   );
 
-  // DEBUG: bisect step 4 — last suspect. useDashboardSectionNav is just
-  // five useCallback wrappers, no useState / useEffect, but it's the only
-  // remaining piece of my changes still pending. If the bug returns with
-  // this addition, the cause is something subtle about the hook itself
-  // (probably useCallback identity churn cascading into other effects).
-  const _bisectSectionNav = useDashboardSectionNav({
-    containers,
-    setUrlCollapsedIds,
-    setUrlExpandedIds,
-  });
-  void _bisectSectionNav;
+  // Section-level navigation helpers: scroll-to-section, deep-link copy, and
+  // batch collapse/expand. Consumed by the view-options menu (collapseAll /
+  // expandAll), the per-container header (copySectionLink), the TOC rail
+  // (scrollToContainer), and the hash-on-load effect (scrollToContainer).
+  // The hook takes the URL setters from above so there is only ever one
+  // useQueryState subscriber per `collapsed`/`expanded` key in this tree.
+  const { scrollToContainer, copySectionLink, collapseAll, expandAll } =
+    useDashboardSectionNav({
+      containers,
+      setUrlCollapsedIds,
+      setUrlExpandedIds,
+    });
 
+  // Per-user preference for whether the sticky table-of-contents rail is shown.
+  // Defaults to false (off) so dashboard behavior is unchanged for users who
+  // never opt in via the view-options menu.
+  const { userPreferences, setUserPreference } = useUserPreferences();
+  const tocVisible = userPreferences.tocVisible ?? false;
+  const toggleToc = useCallback(
+    () => setUserPreference({ tocVisible: !tocVisible }),
+    [tocVisible, setUserPreference],
+  );
+
+  // Lightweight projection of containers (id + label) for the TOC rail.
+  // The label mirrors what the user perceives as the section name:
+  //   - 1-tab container: the visible header is the first tab's title (the
+  //     header rename flow in DashboardContainer redirects to the first tab),
+  //     so use that.
+  //   - Multi-tab container: the visible header is the tab bar showing every
+  //     tab; `container.title` is the section-level name that doesn't move
+  //     when the active tab changes, so use that as the TOC label.
+  const tocContainers = useMemo(
+    () =>
+      containers.map(c => {
+        const tabs = c.tabs ?? [];
+        const label = tabs.length >= 2 ? c.title : (tabs[0]?.title ?? c.title);
+        return { id: c.id, title: label };
+      }),
+    [containers],
+  );
   // Per-viewer active tab selection: `{ [containerId]: tabId }`.
   // Falls back to the first tab for any container not in the map.
   const [urlActiveTabs, setUrlActiveTabs] = useQueryState(
@@ -1712,14 +1740,16 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setUrlActiveTabs,
   ]);
 
-  // DEBUG: bisect step 5 — the FULL hash effect, now with scrollToContainer
-  // in the dependency array. If nuqs v1 setters change identity each render,
-  // expandContainer → scrollToContainer → this effect all re-run on every
-  // render, thrashing hashchange listener attach/detach. If the bug returns
-  // with this commit, the cause is the effect+identity-churn interaction.
+  // Hash-based deep links to dashboard sections (e.g. `#container-abc123`).
+  // Runs an initial scroll once per dashboard load (re-armed when the user
+  // navigates between dashboards in the SPA), then keeps a hashchange listener
+  // attached so in-page hash navigation also scrolls. Unknown containers
+  // (deleted sections, stale links) are silently ignored.
   const initialHashScrolledForDashboardRef = useRef<string | null>(null);
   useEffect(() => {
     if (typeof window === 'undefined' || !dashboard) return;
+    // Wait until containers are available so the existence check below can
+    // distinguish "unknown container" from "containers still loading".
     if (!dashboard.containers || dashboard.containers.length === 0) return;
 
     const handleHash = () => {
@@ -1728,16 +1758,18 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       const containerId = match[1];
       const exists = dashboard.containers?.some(c => c.id === containerId);
       if (!exists) return;
-      _bisectSectionNav.scrollToContainer(containerId);
+      scrollToContainer(containerId);
     };
 
+    // Fire the initial scroll once per dashboard.id so SPA navigation between
+    // dashboards (same component instance) re-arms the deep-link behavior.
     if (initialHashScrolledForDashboardRef.current !== dashboard.id) {
       initialHashScrolledForDashboardRef.current = dashboard.id;
       handleHash();
     }
     window.addEventListener('hashchange', handleHash);
     return () => window.removeEventListener('hashchange', handleHash);
-  }, [dashboard, _bisectSectionNav]);
+  }, [dashboard, scrollToContainer]);
 
   // Valid move targets: groups and individual tabs within groups
   const moveTargetContainers = useMemo<MoveTarget[]>(() => {
@@ -2513,6 +2545,14 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             <IconFilterEdit size={18} />
           </ActionIcon>
         </Tooltip>
+        {containers.length > 0 && (
+          <DashboardViewOptions
+            onCollapseAll={collapseAll}
+            onExpandAll={expandAll}
+            tocVisible={tocVisible}
+            onToggleToc={toggleToc}
+          />
+        )}
         <Button
           data-testid="search-submit-button"
           variant="primary"
@@ -2575,8 +2615,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           </Flex>
         </Paper>
       )}
-      {/* DEBUG: bisect step 3 — Flex wrap around the dashboard content (no
-          TOC sibling, just the wrap itself to isolate CSS structure change). */}
       <Flex gap="md" align="flex-start" mt="sm">
         <Box flex={1} miw={0}>
           {dashboard != null && dashboard.tiles != null ? (
@@ -2652,6 +2690,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
                         onTabChange={tabId =>
                           handleTabChange(container.id, tabId)
                         }
+                        onCopyLink={() => copySectionLink(container.id)}
                         dragHandleProps={dragHandleProps}
                         makeLayoutChangeHandler={makeOnLayoutChange}
                         tileToLayoutItem={tileToLayoutItem}
@@ -2664,6 +2703,22 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             </ErrorBoundary>
           ) : null}
         </Box>
+        {tocVisible && (
+          <Box
+            w={180}
+            visibleFrom="md"
+            style={{
+              position: 'sticky',
+              top: 16,
+              alignSelf: 'flex-start',
+            }}
+          >
+            <DashboardTOC
+              containers={tocContainers}
+              onJump={scrollToContainer}
+            />
+          </Box>
+        )}
       </Flex>
       <Menu position="top" width={200}>
         <Menu.Target>

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -104,6 +104,8 @@ import {
   DashboardDndProvider,
   type DragHandleProps,
 } from '@/components/DashboardDndContext';
+import { DashboardTOC } from '@/components/DashboardTOC';
+import { DashboardViewOptions } from '@/components/DashboardViewOptions';
 import EditTimeChartForm from '@/components/DBEditTimeChartForm';
 import DBNumberChart from '@/components/DBNumberChart';
 import DBTableChart from '@/components/DBTableChart';
@@ -122,6 +124,7 @@ import {
 import useDashboardContainers, {
   TabDeleteAction,
 } from '@/hooks/useDashboardContainers';
+import { useDashboardSectionNav } from '@/hooks/useDashboardSectionNav';
 import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer from './components/charts/ChartContainer';
@@ -1188,6 +1191,7 @@ function DashboardContainerRow({
   onDeleteTab,
   onRenameContainer,
   onTabChange,
+  onCopyLink,
   dragHandleProps,
   makeLayoutChangeHandler,
   tileToLayoutItem,
@@ -1209,6 +1213,7 @@ function DashboardContainerRow({
   onDeleteTab: (tabId: string, action: TabDeleteAction) => void;
   onRenameContainer: (newTitle: string) => void;
   onTabChange: (tabId: string) => void;
+  onCopyLink: () => void;
   dragHandleProps: DragHandleProps;
   makeLayoutChangeHandler: (tiles: Tile[]) => (newLayout: RGL.Layout[]) => void;
   tileToLayoutItem: (tile: Tile) => RGL.Layout;
@@ -1248,6 +1253,7 @@ function DashboardContainerRow({
       onRenameTab={onRenameTab}
       onDeleteTab={onDeleteTab}
       onRename={onRenameContainer}
+      onCopyLink={onCopyLink}
       dragHandleProps={dragHandleProps}
       alertingTabIds={alertingTabIds}
     >
@@ -1611,6 +1617,42 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     () => dashboard?.containers ?? [],
     [dashboard?.containers],
   );
+
+  // Section-level navigation helpers: scroll-to-section, deep-link copy, and
+  // batch collapse/expand. Consumed by the view-options menu (collapseAll /
+  // expandAll), the per-container header (copySectionLink), the TOC rail
+  // (scrollToContainer), and the hash-on-load effect (scrollToContainer).
+  const { scrollToContainer, copySectionLink, collapseAll, expandAll } =
+    useDashboardSectionNav({ containers });
+
+  // Per-user preference for whether the sticky table-of-contents rail is shown.
+  // Defaults to false (off) so dashboard behavior is unchanged for users who
+  // never opt in via the view-options menu.
+  const { userPreferences, setUserPreference } = useUserPreferences();
+  const tocVisible = userPreferences.tocVisible ?? false;
+  const toggleToc = useCallback(
+    () => setUserPreference({ tocVisible: !tocVisible }),
+    [tocVisible, setUserPreference],
+  );
+
+  // Lightweight projection of containers (id + label) for the TOC rail.
+  // The label mirrors what the user perceives as the section name:
+  //   - 1-tab container: the visible header is the first tab's title (the
+  //     header rename flow in DashboardContainer redirects to the first tab),
+  //     so use that.
+  //   - Multi-tab container: the visible header is the tab bar showing every
+  //     tab; `container.title` is the section-level name that doesn't move
+  //     when the active tab changes, so use that as the TOC label.
+  const tocContainers = useMemo(
+    () =>
+      containers.map(c => {
+        const tabs = c.tabs ?? [];
+        const label = tabs.length >= 2 ? c.title : (tabs[0]?.title ?? c.title);
+        return { id: c.id, title: label };
+      }),
+    [containers],
+  );
+
   // URL-based collapse state: tracks which containers the current viewer has
   // explicitly collapsed/expanded. Falls back to the DB-stored default.
   const [urlCollapsedIds, setUrlCollapsedIds] = useQueryState(
@@ -1691,6 +1733,37 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     getActiveTabId,
     setUrlActiveTabs,
   ]);
+
+  // Hash-based deep links to dashboard sections (e.g. `#container-abc123`).
+  // Runs an initial scroll once per dashboard load (re-armed when the user
+  // navigates between dashboards in the SPA), then keeps a hashchange listener
+  // attached so in-page hash navigation also scrolls. Unknown containers
+  // (deleted sections, stale links) are silently ignored.
+  const initialHashScrolledForDashboardRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !dashboard) return;
+    // Wait until containers are available so the existence check below can
+    // distinguish "unknown container" from "containers still loading".
+    if (!dashboard.containers || dashboard.containers.length === 0) return;
+
+    const handleHash = () => {
+      const match = window.location.hash.match(/^#container-(.+)$/);
+      if (!match) return;
+      const containerId = match[1];
+      const exists = dashboard.containers?.some(c => c.id === containerId);
+      if (!exists) return;
+      scrollToContainer(containerId);
+    };
+
+    // Fire the initial scroll once per dashboard.id so SPA navigation between
+    // dashboards (same component instance) re-arms the deep-link behavior.
+    if (initialHashScrolledForDashboardRef.current !== dashboard.id) {
+      initialHashScrolledForDashboardRef.current = dashboard.id;
+      handleHash();
+    }
+    window.addEventListener('hashchange', handleHash);
+    return () => window.removeEventListener('hashchange', handleHash);
+  }, [dashboard, scrollToContainer]);
 
   // Valid move targets: groups and individual tabs within groups
   const moveTargetContainers = useMemo<MoveTarget[]>(() => {
@@ -2457,6 +2530,12 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             <IconFilterEdit size={18} />
           </ActionIcon>
         </Tooltip>
+        <DashboardViewOptions
+          onCollapseAll={collapseAll}
+          onExpandAll={expandAll}
+          tocVisible={tocVisible}
+          onToggleToc={toggleToc}
+        />
         <Button
           data-testid="search-submit-button"
           variant="primary"
@@ -2519,92 +2598,111 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           </Flex>
         </Paper>
       )}
-      <Box mt="sm">
-        {dashboard != null && dashboard.tiles != null ? (
-          <ErrorBoundary
-            onError={console.error}
-            fallback={
-              <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
-                An error occurred while rendering the dashboard.
-              </div>
-            }
-          >
-            <DashboardDndProvider
-              containers={containers}
-              onReorderContainers={handleReorderContainers}
+      <Flex gap="md" align="flex-start" mt="sm">
+        <Box flex={1} miw={0}>
+          {dashboard != null && dashboard.tiles != null ? (
+            <ErrorBoundary
+              onError={console.error}
+              fallback={
+                <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent">
+                  An error occurred while rendering the dashboard.
+                </div>
+              }
             >
-              {ungroupedTiles.length > 0 && (
-                <ReactGridLayout
-                  layout={ungroupedTiles.map(tileToLayoutItem)}
-                  containerPadding={[0, 0]}
-                  onLayoutChange={onUngroupedLayoutChange}
-                  cols={24}
-                  rowHeight={32}
-                >
-                  {ungroupedTiles.map(renderTileComponent)}
-                </ReactGridLayout>
-              )}
-              {containers.map(container => (
-                <SortableContainerWrapper
-                  key={container.id}
-                  containerId={container.id}
-                  containerTitle={container.title}
-                >
-                  {(dragHandleProps: DragHandleProps) => (
-                    <DashboardContainerRow
-                      container={container}
-                      containerTiles={
-                        tilesByContainerId.get(container.id) ?? []
-                      }
-                      isCollapsed={isContainerCollapsed(container)}
-                      activeTabId={getActiveTabId(container)}
-                      alertingTabIds={alertingTabIdsByContainer.get(
-                        container.id,
-                      )}
-                      onToggleCollapse={() =>
-                        handleToggleCollapse(container.id)
-                      }
-                      onToggleDefaultCollapsed={() =>
-                        handleToggleDefaultCollapsed(container.id)
-                      }
-                      onToggleCollapsible={() =>
-                        handleToggleCollapsible(container.id)
-                      }
-                      onToggleBordered={() =>
-                        handleToggleBordered(container.id)
-                      }
-                      onDeleteContainer={action =>
-                        handleDeleteContainer(container.id, action)
-                      }
-                      onAddTile={onAddTile}
-                      onAddTab={() => {
-                        const newTabId = handleAddTab(container.id);
-                        if (newTabId) handleTabChange(container.id, newTabId);
-                      }}
-                      onRenameTab={(tabId, title) =>
-                        handleRenameTab(container.id, tabId, title)
-                      }
-                      onDeleteTab={(tabId, action) =>
-                        handleDeleteTab(container.id, tabId, action)
-                      }
-                      onRenameContainer={title =>
-                        handleRenameContainer(container.id, title)
-                      }
-                      onTabChange={tabId =>
-                        handleTabChange(container.id, tabId)
-                      }
-                      dragHandleProps={dragHandleProps}
-                      makeLayoutChangeHandler={makeOnLayoutChange}
-                      tileToLayoutItem={tileToLayoutItem}
-                      renderTileComponent={renderTileComponent}
-                    />
-                  )}
-                </SortableContainerWrapper>
-              ))}
-            </DashboardDndProvider>
-          </ErrorBoundary>
-        ) : null}
-      </Box>
+              <DashboardDndProvider
+                containers={containers}
+                onReorderContainers={handleReorderContainers}
+              >
+                {ungroupedTiles.length > 0 && (
+                  <ReactGridLayout
+                    layout={ungroupedTiles.map(tileToLayoutItem)}
+                    containerPadding={[0, 0]}
+                    onLayoutChange={onUngroupedLayoutChange}
+                    cols={24}
+                    rowHeight={32}
+                  >
+                    {ungroupedTiles.map(renderTileComponent)}
+                  </ReactGridLayout>
+                )}
+                {containers.map(container => (
+                  <SortableContainerWrapper
+                    key={container.id}
+                    containerId={container.id}
+                    containerTitle={container.title}
+                  >
+                    {(dragHandleProps: DragHandleProps) => (
+                      <DashboardContainerRow
+                        container={container}
+                        containerTiles={
+                          tilesByContainerId.get(container.id) ?? []
+                        }
+                        isCollapsed={isContainerCollapsed(container)}
+                        activeTabId={getActiveTabId(container)}
+                        alertingTabIds={alertingTabIdsByContainer.get(
+                          container.id,
+                        )}
+                        onToggleCollapse={() =>
+                          handleToggleCollapse(container.id)
+                        }
+                        onToggleDefaultCollapsed={() =>
+                          handleToggleDefaultCollapsed(container.id)
+                        }
+                        onToggleCollapsible={() =>
+                          handleToggleCollapsible(container.id)
+                        }
+                        onToggleBordered={() =>
+                          handleToggleBordered(container.id)
+                        }
+                        onDeleteContainer={action =>
+                          handleDeleteContainer(container.id, action)
+                        }
+                        onAddTile={onAddTile}
+                        onAddTab={() => {
+                          const newTabId = handleAddTab(container.id);
+                          if (newTabId) handleTabChange(container.id, newTabId);
+                        }}
+                        onRenameTab={(tabId, title) =>
+                          handleRenameTab(container.id, tabId, title)
+                        }
+                        onDeleteTab={(tabId, action) =>
+                          handleDeleteTab(container.id, tabId, action)
+                        }
+                        onRenameContainer={title =>
+                          handleRenameContainer(container.id, title)
+                        }
+                        onTabChange={tabId =>
+                          handleTabChange(container.id, tabId)
+                        }
+                        onCopyLink={() => copySectionLink(container.id)}
+                        dragHandleProps={dragHandleProps}
+                        makeLayoutChangeHandler={makeOnLayoutChange}
+                        tileToLayoutItem={tileToLayoutItem}
+                        renderTileComponent={renderTileComponent}
+                      />
+                    )}
+                  </SortableContainerWrapper>
+                ))}
+              </DashboardDndProvider>
+            </ErrorBoundary>
+          ) : null}
+        </Box>
+        {tocVisible && (
+          <Box
+            w={180}
+            visibleFrom="md"
+            style={{
+              position: 'sticky',
+              top: 16,
+              alignSelf: 'flex-start',
+            }}
+          >
+            <DashboardTOC
+              containers={tocContainers}
+              onJump={scrollToContainer}
+            />
+          </Box>
+        )}
+      </Flex>
       <Menu position="top" width={200}>
         <Menu.Target>
           <Button

--- a/packages/app/src/__tests__/DashboardContainer.test.tsx
+++ b/packages/app/src/__tests__/DashboardContainer.test.tsx
@@ -451,4 +451,57 @@ describe('DashboardContainer', () => {
       ).toBeNull();
     });
   });
+
+  describe('section deep linking', () => {
+    it('renders the container root with a stable id usable as a scroll target', () => {
+      renderDashboardContainer();
+      const container = screen.getByTestId('group-container-g1');
+      expect(container.id).toBe('container-g1');
+    });
+
+    it('renders the copy-link button when onCopyLink is provided (plain header)', () => {
+      renderDashboardContainer({ onCopyLink: jest.fn() });
+      expect(screen.getByTestId('group-copy-link-g1')).toBeInTheDocument();
+    });
+
+    it('omits the copy-link button when onCopyLink is not provided', () => {
+      renderDashboardContainer();
+      expect(
+        screen.queryByTestId('group-copy-link-g1'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onCopyLink when the button is clicked', () => {
+      const onCopyLink = jest.fn();
+      renderDashboardContainer({ onCopyLink });
+      fireEvent.click(screen.getByTestId('group-copy-link-g1'));
+      expect(onCopyLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the copy-link button in the multi-tab header', () => {
+      renderDashboardContainer({
+        onCopyLink: jest.fn(),
+        container: {
+          id: 'g1',
+          title: 'Group',
+          collapsed: false,
+          tabs: [
+            { id: 'tab-1', title: 'First' },
+            { id: 'tab-2', title: 'Second' },
+          ],
+        },
+        activeTabId: 'tab-1',
+        onTabChange: jest.fn(),
+      });
+      expect(screen.getByTestId('group-copy-link-g1')).toBeInTheDocument();
+    });
+
+    it('still renders the copy-link button when the container is collapsed', () => {
+      // Sharing a link to a collapsed section is intentional — it lets users
+      // point at "this part of the dashboard" without forcing a re-layout for
+      // the recipient.
+      renderDashboardContainer({ onCopyLink: jest.fn(), collapsed: true });
+      expect(screen.getByTestId('group-copy-link-g1')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/app/src/components/DashboardContainer.tsx
+++ b/packages/app/src/components/DashboardContainer.tsx
@@ -18,6 +18,7 @@ import {
   IconChevronRight,
   IconDotsVertical,
   IconGripVertical,
+  IconLink,
   IconPlus,
   IconTrash,
 } from '@tabler/icons-react';
@@ -44,6 +45,9 @@ type DashboardContainerProps = {
   onRenameTab: (tabId: string, newTitle: string) => void;
   onDeleteTab: (tabId: string, action: TabDeleteAction) => void;
   onRename: (newTitle: string) => void;
+  /** When provided, renders a hover-revealed "copy link" icon that copies a
+   *  shareable deep link (`#container-<id>`) for this section. */
+  onCopyLink?: () => void;
   children: (activeTabId: string | undefined) => React.ReactNode;
   dragHandleProps: DragHandleProps;
   /** Tab IDs that contain tiles with active alerts, if any */
@@ -67,6 +71,7 @@ export default function DashboardContainer({
   onRenameTab,
   onDeleteTab,
   onRename,
+  onCopyLink,
   children,
   dragHandleProps,
   alertingTabIds,
@@ -147,6 +152,25 @@ export default function DashboardContainer({
       </ActionIcon>
     </Tooltip>
   );
+
+  // Hover-revealed deep-link copy button. Available in both expanded and
+  // collapsed states because deep-linking to a collapsed section is useful for
+  // sharing "look at this part of the dashboard" without forcing a re-layout.
+  const copyLinkButton = onCopyLink ? (
+    <Tooltip label="Copy link to section" position="top" withArrow>
+      <ActionIcon
+        variant="subtle"
+        size="sm"
+        tabIndex={showControls ? 0 : -1}
+        style={hoverControlStyle}
+        onClick={onCopyLink}
+        data-testid={`group-copy-link-${container.id}`}
+        aria-label="Copy link to section"
+      >
+        <IconLink size={14} />
+      </ActionIcon>
+    </Tooltip>
+  ) : null;
 
   const overflowMenu = (
     <Menu width={200} position="bottom-end" onChange={setMenuOpen}>
@@ -236,6 +260,7 @@ export default function DashboardContainer({
 
   return (
     <Box
+      id={`container-${container.id}`}
       data-testid={`group-container-${container.id}`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -271,6 +296,7 @@ export default function DashboardContainer({
               hoverControlStyle={hoverControlStyle}
             />
             {addTileButton}
+            {copyLinkButton}
             {overflowMenu}
           </Flex>
         </Tabs>
@@ -354,6 +380,7 @@ export default function DashboardContainer({
             </Flex>
           )}
           {addTileButton}
+          {copyLinkButton}
           {overflowMenu}
         </Flex>
       )}

--- a/packages/app/src/components/DashboardTOC.tsx
+++ b/packages/app/src/components/DashboardTOC.tsx
@@ -29,10 +29,20 @@ export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
   // `useScrollSpy` walks the DOM once at mount. Re-scan whenever the set of
   // containers changes so renames / additions / removals don't leave us
   // pointing at a stale index.
+  //
+  // `reinitialize` is deliberately NOT in the dep array: in Mantine v9 its
+  // identity changes every render. If it's a dep, the effect re-fires each
+  // render → reinitialize schedules a state update inside useScrollSpy →
+  // component re-renders → reinitialize has a new identity → effect fires
+  // again — infinite loop, "Maximum update depth exceeded", and React
+  // never reaches the post-hydration commit that would populate
+  // `router.query.dashboardId` on the dashboard page (manifesting as a
+  // stuck "Temporary Dashboard" banner on saved-dashboard URLs).
   const containerSignature = containers.map(c => c.id).join('|');
   useEffect(() => {
     reinitialize();
-  }, [containerSignature, reinitialize]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerSignature]);
 
   if (containers.length === 0) return null;
 

--- a/packages/app/src/components/DashboardTOC.tsx
+++ b/packages/app/src/components/DashboardTOC.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, ScrollArea, Stack, Text, UnstyledButton } from '@mantine/core';
 import { useScrollSpy } from '@mantine/hooks';
 
@@ -58,6 +58,54 @@ export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerSignature]);
 
+  // Click-overrides-spy. The spy reports the section whose top is closest to
+  // the viewport top — which is what you want most of the time, but it has a
+  // common dead zone: when the user clicks a section that is already visible
+  // but cannot be scroll-pinned at the top (e.g. the last section in a
+  // dashboard short enough that the bottom hits the scroll end before the
+  // section's top reaches the viewport top), the spy never updates and the
+  // highlight stays on whatever was previously active. Treating a click as
+  // explicit user intent fixes the dead zone: we override the spy's `active`
+  // with the clicked entry, then hand control back to the spy when the user
+  // next scrolls manually.
+  const [clickedId, setClickedId] = useState<string | null>(null);
+  const clickArmTimerRef = useRef<number | null>(null);
+
+  const handleEntryClick = useCallback(
+    (id: string) => {
+      setClickedId(id);
+      onJump(id);
+    },
+    [onJump],
+  );
+
+  // When a click override is set, wait long enough for the smooth scroll
+  // triggered by the click to settle (~700ms), then arm a one-time scroll
+  // listener that clears the override on the next user-initiated scroll.
+  useEffect(() => {
+    if (clickedId === null) return;
+    const host = scrollHost ?? window;
+    let cleanup: (() => void) | null = null;
+    clickArmTimerRef.current = window.setTimeout(() => {
+      const clear = () => setClickedId(null);
+      host.addEventListener('scroll', clear, { once: true });
+      cleanup = () => host.removeEventListener('scroll', clear);
+      clickArmTimerRef.current = null;
+    }, 700);
+    return () => {
+      if (clickArmTimerRef.current !== null) {
+        window.clearTimeout(clickArmTimerRef.current);
+        clickArmTimerRef.current = null;
+      }
+      if (cleanup) cleanup();
+    };
+  }, [clickedId, scrollHost]);
+
+  const clickedIndex = clickedId
+    ? containers.findIndex(c => c.id === clickedId)
+    : -1;
+  const activeIndex = clickedIndex >= 0 ? clickedIndex : active;
+
   if (containers.length === 0) return null;
 
   return (
@@ -76,11 +124,11 @@ export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
       <ScrollArea.Autosize mah="calc(100vh - 160px)" type="hover">
         <Stack gap={0}>
           {containers.map((c, i) => {
-            const isActive = i === active;
+            const isActive = i === activeIndex;
             return (
               <UnstyledButton
                 key={c.id}
-                onClick={() => onJump(c.id)}
+                onClick={() => handleEntryClick(c.id)}
                 data-testid={`toc-entry-${c.id}`}
                 data-active={isActive || undefined}
                 style={{

--- a/packages/app/src/components/DashboardTOC.tsx
+++ b/packages/app/src/components/DashboardTOC.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, ScrollArea, Stack, Text, UnstyledButton } from '@mantine/core';
-import { useScrollSpy } from '@mantine/hooks';
 
 type TOCContainer = { id: string; title: string };
 
@@ -9,102 +8,70 @@ type DashboardTOCProps = {
   onJump: (containerId: string) => void;
 };
 
+const SCROLL_HOST_ID = 'app-content-scroll-container';
+const CONTAINER_ID_PREFIX = 'container-';
+
 /**
- * In-flow table-of-contents rail listing dashboard sections (containers) for
- * quick navigation. Designed to be mounted inside a sticky sidebar slot in
- * `DBDashboardPage` so it sits next to the dashboard content rather than
- * overlaying it.
+ * In-flow table-of-contents rail listing dashboard sections (containers).
  *
- * Uses Mantine's `useScrollSpy` to highlight the section currently closest to
- * the top of the viewport. Mounted only when the user has opted in via the
- * "Show table of contents" view-option, so this UI is invisible by default.
+ * The active highlight follows whichever section has the highest viewport
+ * visibility — computed via an `IntersectionObserver` rooted at the actual
+ * scroll container (the app layout puts page content inside #app-content-
+ * scroll-container; the window does not scroll). That rule is what users
+ * naturally expect ("highlight what I'm looking at") and it handles two
+ * cases that the more common "closest-to-viewport-top" heuristic fails on:
+ *
+ *  - Clicking a section that already fits in the viewport but cannot be
+ *    scroll-pinned to the top (e.g. the last section when the dashboard's
+ *    bottom hits the scroll end first). After `scrollIntoView` settles
+ *    that section IS the most-visible one, so it ends up highlighted.
+ *  - Sections smaller than the viewport: whichever one occupies the most
+ *    pixels wins, which matches what the user sees.
  */
 export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
-  // The app layout puts page content inside #app-content-scroll-container,
-  // which is what actually scrolls (the window does not). useScrollSpy
-  // defaults to listening on `window`, so without this it never sees the
-  // scroll events the dashboard generates and `active` stays at 0 forever.
-  // Resolve the element after mount because it doesn't exist during SSR.
-  const [scrollHost, setScrollHost] = useState<HTMLElement | undefined>(
-    undefined,
-  );
-  useEffect(() => {
-    const el = document.getElementById('app-content-scroll-container');
-    if (el) setScrollHost(el);
-  }, []);
+  const [activeId, setActiveId] = useState<string | null>(null);
 
-  const { active, reinitialize } = useScrollSpy({
-    selector: '[id^="container-"]',
-    getDepth: () => 1,
-    getValue: el => el.id,
-    scrollHost,
-  });
+  // Containers' identity is used as the effect's dep. We also depend on the
+  // referenced id strings, not the array reference, so a parent re-render
+  // that produces a new array but the same ids doesn't churn the observer.
+  const containersKey = containers.map(c => c.id).join('|');
 
-  // `useScrollSpy` walks the DOM once at mount. Re-scan whenever the set of
-  // containers changes so renames / additions / removals don't leave us
-  // pointing at a stale index.
-  //
-  // `reinitialize` is deliberately NOT in the dep array: in Mantine v9 its
-  // identity changes every render. If it's a dep, the effect re-fires each
-  // render → reinitialize schedules a state update inside useScrollSpy →
-  // component re-renders → reinitialize has a new identity → effect fires
-  // again — infinite loop, "Maximum update depth exceeded", and React
-  // never reaches the post-hydration commit that would populate
-  // `router.query.dashboardId` on the dashboard page (manifesting as a
-  // stuck "Temporary Dashboard" banner on saved-dashboard URLs).
-  const containerSignature = containers.map(c => c.id).join('|');
   useEffect(() => {
-    reinitialize();
+    if (containers.length === 0) return;
+
+    const root = document.getElementById(SCROLL_HOST_ID);
+    const visibility = new Map<string, number>();
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          const id = entry.target.id.slice(CONTAINER_ID_PREFIX.length);
+          visibility.set(id, entry.intersectionRatio);
+        }
+        let bestId: string | null = null;
+        let bestRatio = -1;
+        for (const [id, ratio] of visibility) {
+          if (ratio > bestRatio) {
+            bestId = id;
+            bestRatio = ratio;
+          }
+        }
+        setActiveId(bestId);
+      },
+      { root, threshold: [0, 0.25, 0.5, 0.75, 1] },
+    );
+
+    for (const c of containers) {
+      const el = document.getElementById(`${CONTAINER_ID_PREFIX}${c.id}`);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+    // `containers` itself is fine to omit — `containersKey` captures the
+    // identity we care about and lets the effect re-run when the id list
+    // changes without churning on unrelated parent re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [containerSignature]);
-
-  // Click-overrides-spy. The spy reports the section whose top is closest to
-  // the viewport top — which is what you want most of the time, but it has a
-  // common dead zone: when the user clicks a section that is already visible
-  // but cannot be scroll-pinned at the top (e.g. the last section in a
-  // dashboard short enough that the bottom hits the scroll end before the
-  // section's top reaches the viewport top), the spy never updates and the
-  // highlight stays on whatever was previously active. Treating a click as
-  // explicit user intent fixes the dead zone: we override the spy's `active`
-  // with the clicked entry, then hand control back to the spy when the user
-  // next scrolls manually.
-  const [clickedId, setClickedId] = useState<string | null>(null);
-  const clickArmTimerRef = useRef<number | null>(null);
-
-  const handleEntryClick = useCallback(
-    (id: string) => {
-      setClickedId(id);
-      onJump(id);
-    },
-    [onJump],
-  );
-
-  // When a click override is set, wait long enough for the smooth scroll
-  // triggered by the click to settle (~700ms), then arm a one-time scroll
-  // listener that clears the override on the next user-initiated scroll.
-  useEffect(() => {
-    if (clickedId === null) return;
-    const host = scrollHost ?? window;
-    let cleanup: (() => void) | null = null;
-    clickArmTimerRef.current = window.setTimeout(() => {
-      const clear = () => setClickedId(null);
-      host.addEventListener('scroll', clear, { once: true });
-      cleanup = () => host.removeEventListener('scroll', clear);
-      clickArmTimerRef.current = null;
-    }, 700);
-    return () => {
-      if (clickArmTimerRef.current !== null) {
-        window.clearTimeout(clickArmTimerRef.current);
-        clickArmTimerRef.current = null;
-      }
-      if (cleanup) cleanup();
-    };
-  }, [clickedId, scrollHost]);
-
-  const clickedIndex = clickedId
-    ? containers.findIndex(c => c.id === clickedId)
-    : -1;
-  const activeIndex = clickedIndex >= 0 ? clickedIndex : active;
+  }, [containersKey]);
 
   if (containers.length === 0) return null;
 
@@ -123,12 +90,12 @@ export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
       </Text>
       <ScrollArea.Autosize mah="calc(100vh - 160px)" type="hover">
         <Stack gap={0}>
-          {containers.map((c, i) => {
-            const isActive = i === activeIndex;
+          {containers.map(c => {
+            const isActive = c.id === activeId;
             return (
               <UnstyledButton
                 key={c.id}
-                onClick={() => handleEntryClick(c.id)}
+                onClick={() => onJump(c.id)}
                 data-testid={`toc-entry-${c.id}`}
                 data-active={isActive || undefined}
                 style={{

--- a/packages/app/src/components/DashboardTOC.tsx
+++ b/packages/app/src/components/DashboardTOC.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { Box, ScrollArea, Stack, Text, UnstyledButton } from '@mantine/core';
+import { useScrollSpy } from '@mantine/hooks';
+
+type TOCContainer = { id: string; title: string };
+
+type DashboardTOCProps = {
+  containers: TOCContainer[];
+  onJump: (containerId: string) => void;
+};
+
+/**
+ * In-flow table-of-contents rail listing dashboard sections (containers) for
+ * quick navigation. Designed to be mounted inside a sticky sidebar slot in
+ * `DBDashboardPage` so it sits next to the dashboard content rather than
+ * overlaying it.
+ *
+ * Uses Mantine's `useScrollSpy` to highlight the section currently closest to
+ * the top of the viewport. Mounted only when the user has opted in via the
+ * "Show table of contents" view-option, so this UI is invisible by default.
+ */
+export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
+  const { active, reinitialize } = useScrollSpy({
+    selector: '[id^="container-"]',
+    getDepth: () => 1,
+    getValue: el => el.id,
+  });
+
+  // `useScrollSpy` walks the DOM once at mount. Re-scan whenever the set of
+  // containers changes so renames / additions / removals don't leave us
+  // pointing at a stale index.
+  const containerSignature = containers.map(c => c.id).join('|');
+  useEffect(() => {
+    reinitialize();
+  }, [containerSignature, reinitialize]);
+
+  if (containers.length === 0) return null;
+
+  return (
+    <Box data-testid="dashboard-toc" w="100%">
+      <Text
+        size="xs"
+        fw={600}
+        c="dimmed"
+        tt="uppercase"
+        mb={6}
+        ml={10}
+        style={{ letterSpacing: '0.04em' }}
+      >
+        Sections
+      </Text>
+      <ScrollArea.Autosize mah="calc(100vh - 160px)" type="hover">
+        <Stack gap={0}>
+          {containers.map((c, i) => {
+            const isActive = i === active;
+            return (
+              <UnstyledButton
+                key={c.id}
+                onClick={() => onJump(c.id)}
+                data-testid={`toc-entry-${c.id}`}
+                data-active={isActive || undefined}
+                style={{
+                  display: 'block',
+                  padding: '4px 10px',
+                  fontSize: 'var(--mantine-font-size-xs)',
+                  lineHeight: 1.5,
+                  color: isActive
+                    ? 'var(--mantine-color-text)'
+                    : 'var(--mantine-color-dimmed)',
+                  borderLeft: `2px solid ${
+                    isActive
+                      ? 'var(--mantine-primary-color-filled)'
+                      : 'var(--mantine-color-default-border)'
+                  }`,
+                  transition:
+                    'color 100ms ease, border-color 100ms ease, background-color 100ms ease',
+                  textAlign: 'left',
+                  width: '100%',
+                  borderRadius: 0,
+                }}
+                onMouseEnter={e => {
+                  if (!isActive) {
+                    e.currentTarget.style.color = 'var(--mantine-color-text)';
+                  }
+                }}
+                onMouseLeave={e => {
+                  if (!isActive) {
+                    e.currentTarget.style.color = 'var(--mantine-color-dimmed)';
+                  }
+                }}
+              >
+                {c.title || '(untitled)'}
+              </UnstyledButton>
+            );
+          })}
+        </Stack>
+      </ScrollArea.Autosize>
+    </Box>
+  );
+}

--- a/packages/app/src/components/DashboardTOC.tsx
+++ b/packages/app/src/components/DashboardTOC.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, ScrollArea, Stack, Text, UnstyledButton } from '@mantine/core';
 import { useScrollSpy } from '@mantine/hooks';
 
@@ -20,10 +20,24 @@ type DashboardTOCProps = {
  * "Show table of contents" view-option, so this UI is invisible by default.
  */
 export function DashboardTOC({ containers, onJump }: DashboardTOCProps) {
+  // The app layout puts page content inside #app-content-scroll-container,
+  // which is what actually scrolls (the window does not). useScrollSpy
+  // defaults to listening on `window`, so without this it never sees the
+  // scroll events the dashboard generates and `active` stays at 0 forever.
+  // Resolve the element after mount because it doesn't exist during SSR.
+  const [scrollHost, setScrollHost] = useState<HTMLElement | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    const el = document.getElementById('app-content-scroll-container');
+    if (el) setScrollHost(el);
+  }, []);
+
   const { active, reinitialize } = useScrollSpy({
     selector: '[id^="container-"]',
     getDepth: () => 1,
     getValue: el => el.id,
+    scrollHost,
   });
 
   // `useScrollSpy` walks the DOM once at mount. Re-scan whenever the set of

--- a/packages/app/src/components/DashboardViewOptions.tsx
+++ b/packages/app/src/components/DashboardViewOptions.tsx
@@ -1,0 +1,69 @@
+import { ActionIcon, Menu, Tooltip } from '@mantine/core';
+import {
+  IconAdjustmentsHorizontal,
+  IconChevronDown,
+  IconChevronUp,
+} from '@tabler/icons-react';
+
+type DashboardViewOptionsProps = {
+  /** Collapses every container on the dashboard to its header. */
+  onCollapseAll: () => void;
+  /** Expands every container on the dashboard. */
+  onExpandAll: () => void;
+  /** Current per-user preference for whether the sticky TOC rail is visible. */
+  tocVisible: boolean;
+  /** Toggles `tocVisible` in the user preferences atom. */
+  onToggleToc: () => void;
+};
+
+/**
+ * Toolbar control that opens a small "view options" menu for the current
+ * dashboard. Currently exposes batch collapse/expand of all sections and a
+ * toggle for the sticky table-of-contents rail. Lives next to the existing
+ * filter / refresh / run actions in the dashboard toolbar.
+ */
+export function DashboardViewOptions({
+  onCollapseAll,
+  onExpandAll,
+  tocVisible,
+  onToggleToc,
+}: DashboardViewOptionsProps) {
+  return (
+    <Menu position="bottom-end" width={220} withinPortal>
+      <Menu.Target>
+        <Tooltip withArrow label="View options" fz="xs" color="gray">
+          <ActionIcon
+            variant="secondary"
+            title="View options"
+            size="input-sm"
+            data-testid="dashboard-view-options"
+            aria-label="View options"
+          >
+            <IconAdjustmentsHorizontal size={18} />
+          </ActionIcon>
+        </Tooltip>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>Sections</Menu.Label>
+        <Menu.Item
+          leftSection={<IconChevronUp size={14} />}
+          onClick={onCollapseAll}
+          data-testid="dashboard-collapse-all"
+        >
+          Collapse all sections
+        </Menu.Item>
+        <Menu.Item
+          leftSection={<IconChevronDown size={14} />}
+          onClick={onExpandAll}
+          data-testid="dashboard-expand-all"
+        >
+          Expand all sections
+        </Menu.Item>
+        <Menu.Divider />
+        <Menu.Item onClick={onToggleToc} data-testid="dashboard-toggle-toc">
+          {tocVisible ? 'Hide table of contents' : 'Show table of contents'}
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/packages/app/src/components/__tests__/DashboardTOC.test.tsx
+++ b/packages/app/src/components/__tests__/DashboardTOC.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DashboardTOC } from '@/components/DashboardTOC';
+
+// `useScrollSpy` reaches into the DOM and attaches scroll listeners. None of
+// that is interesting at unit-test scope — what we care about is the list
+// renders correctly, click hands the right id back, and empty input renders
+// nothing. Mock it to a quiet stub.
+jest.mock('@mantine/hooks', () => {
+  const actual = jest.requireActual('@mantine/hooks');
+  return {
+    ...actual,
+    useScrollSpy: () => ({
+      active: 0,
+      data: [],
+      initialized: true,
+      reinitialize: jest.fn(),
+    }),
+  };
+});
+
+function renderTOC(
+  props: Partial<React.ComponentProps<typeof DashboardTOC>> = {},
+) {
+  const defaults: React.ComponentProps<typeof DashboardTOC> = {
+    containers: [
+      { id: 'a', title: 'Latency' },
+      { id: 'b', title: 'Errors' },
+      { id: 'c', title: 'Throughput' },
+    ],
+    onJump: jest.fn(),
+    ...props,
+  };
+  return render(
+    <MantineProvider>
+      <DashboardTOC {...defaults} />
+    </MantineProvider>,
+  );
+}
+
+describe('DashboardTOC', () => {
+  it('renders one entry per container', () => {
+    renderTOC();
+    expect(screen.getByTestId('toc-entry-a')).toBeInTheDocument();
+    expect(screen.getByTestId('toc-entry-b')).toBeInTheDocument();
+    expect(screen.getByTestId('toc-entry-c')).toBeInTheDocument();
+  });
+
+  it('shows container titles as the entry labels', () => {
+    renderTOC();
+    expect(screen.getByText('Latency')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Throughput')).toBeInTheDocument();
+  });
+
+  it('falls back to "(untitled)" for entries with an empty title', () => {
+    renderTOC({
+      containers: [{ id: 'x', title: '' }],
+    });
+    expect(screen.getByText('(untitled)')).toBeInTheDocument();
+  });
+
+  it('invokes onJump with the clicked container id', () => {
+    const onJump = jest.fn();
+    renderTOC({ onJump });
+    fireEvent.click(screen.getByTestId('toc-entry-b'));
+    expect(onJump).toHaveBeenCalledWith('b');
+  });
+
+  it('renders nothing when there are no containers', () => {
+    const { container } = renderTOC({ containers: [] });
+    expect(container.querySelector('[data-testid="dashboard-toc"]')).toBeNull();
+  });
+
+  it('marks only the scrollspy-active entry with data-active', () => {
+    // The mock fixes `active: 0`, so the first container ('a') should be the
+    // sole entry with `data-active`. This locks in the contract used by the
+    // visual styling (border + text color).
+    renderTOC();
+    expect(screen.getByTestId('toc-entry-a')).toHaveAttribute('data-active');
+    expect(screen.getByTestId('toc-entry-b')).not.toHaveAttribute(
+      'data-active',
+    );
+    expect(screen.getByTestId('toc-entry-c')).not.toHaveAttribute(
+      'data-active',
+    );
+  });
+});

--- a/packages/app/src/components/__tests__/DashboardTOC.test.tsx
+++ b/packages/app/src/components/__tests__/DashboardTOC.test.tsx
@@ -1,25 +1,86 @@
 import * as React from 'react';
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { DashboardTOC } from '@/components/DashboardTOC';
 
-// `useScrollSpy` reaches into the DOM and attaches scroll listeners. None of
-// that is interesting at unit-test scope — what we care about is the list
-// renders correctly, click hands the right id back, and empty input renders
-// nothing. Mock it to a quiet stub.
-jest.mock('@mantine/hooks', () => {
-  const actual = jest.requireActual('@mantine/hooks');
-  return {
-    ...actual,
-    useScrollSpy: () => ({
-      active: 0,
-      data: [],
-      initialized: true,
-      reinitialize: jest.fn(),
-    }),
-  };
+// jsdom does not ship an IntersectionObserver implementation. Provide a tiny
+// fake that records the most recent observer instance and exposes a manual
+// `trigger` so tests can simulate intersection-ratio updates and assert the
+// resulting active-state changes.
+type Entry = { id: string; intersectionRatio: number };
+type FakeObserver = {
+  callback: IntersectionObserverCallback;
+  observed: Set<Element>;
+  trigger: (entries: Entry[]) => void;
+};
+let lastObserver: FakeObserver | null = null;
+
+beforeEach(() => {
+  lastObserver = null;
+  class IO {
+    constructor(public callback: IntersectionObserverCallback) {
+      const observed = new Set<Element>();
+      const self: FakeObserver = {
+        callback,
+        observed,
+        trigger: entries => {
+          const ioEntries = entries.map(e => {
+            const target = document.getElementById(`container-${e.id}`)!;
+            return {
+              target,
+              intersectionRatio: e.intersectionRatio,
+              isIntersecting: e.intersectionRatio > 0,
+              boundingClientRect: target.getBoundingClientRect(),
+              intersectionRect: target.getBoundingClientRect(),
+              rootBounds: null,
+              time: 0,
+            } as unknown as IntersectionObserverEntry;
+          });
+          act(() => {
+            callback(ioEntries, this as unknown as IntersectionObserver);
+          });
+        },
+      };
+      Object.assign(this, self);
+      lastObserver = self;
+    }
+    observe(el: Element) {
+      (this as unknown as FakeObserver).observed.add(el);
+    }
+    unobserve(el: Element) {
+      (this as unknown as FakeObserver).observed.delete(el);
+    }
+    disconnect() {
+      (this as unknown as FakeObserver).observed.clear();
+    }
+    takeRecords() {
+      return [];
+    }
+  }
+  (
+    globalThis as unknown as {
+      IntersectionObserver: typeof IntersectionObserver;
+    }
+  ).IntersectionObserver = IO as unknown as typeof IntersectionObserver;
 });
+
+// The component scopes IntersectionObserver to #app-content-scroll-container.
+// We mount that element + a target element per container so observer.observe
+// has something to attach to.
+function mountDomFixtures(ids: string[]) {
+  const root = document.createElement('div');
+  root.id = 'app-content-scroll-container';
+  document.body.appendChild(root);
+  for (const id of ids) {
+    const el = document.createElement('div');
+    el.id = `container-${id}`;
+    root.appendChild(el);
+  }
+  return () => {
+    document.body.removeChild(root);
+  };
+}
 
 function renderTOC(
   props: Partial<React.ComponentProps<typeof DashboardTOC>> = {},
@@ -42,31 +103,37 @@ function renderTOC(
 
 describe('DashboardTOC', () => {
   it('renders one entry per container', () => {
+    const cleanup = mountDomFixtures(['a', 'b', 'c']);
     renderTOC();
     expect(screen.getByTestId('toc-entry-a')).toBeInTheDocument();
     expect(screen.getByTestId('toc-entry-b')).toBeInTheDocument();
     expect(screen.getByTestId('toc-entry-c')).toBeInTheDocument();
+    cleanup();
   });
 
   it('shows container titles as the entry labels', () => {
+    const cleanup = mountDomFixtures(['a', 'b', 'c']);
     renderTOC();
     expect(screen.getByText('Latency')).toBeInTheDocument();
     expect(screen.getByText('Errors')).toBeInTheDocument();
     expect(screen.getByText('Throughput')).toBeInTheDocument();
+    cleanup();
   });
 
   it('falls back to "(untitled)" for entries with an empty title', () => {
-    renderTOC({
-      containers: [{ id: 'x', title: '' }],
-    });
+    const cleanup = mountDomFixtures(['x']);
+    renderTOC({ containers: [{ id: 'x', title: '' }] });
     expect(screen.getByText('(untitled)')).toBeInTheDocument();
+    cleanup();
   });
 
   it('invokes onJump with the clicked container id', () => {
+    const cleanup = mountDomFixtures(['a', 'b', 'c']);
     const onJump = jest.fn();
     renderTOC({ onJump });
     fireEvent.click(screen.getByTestId('toc-entry-b'));
     expect(onJump).toHaveBeenCalledWith('b');
+    cleanup();
   });
 
   it('renders nothing when there are no containers', () => {
@@ -74,17 +141,40 @@ describe('DashboardTOC', () => {
     expect(container.querySelector('[data-testid="dashboard-toc"]')).toBeNull();
   });
 
-  it('marks only the scrollspy-active entry with data-active', () => {
-    // The mock fixes `active: 0`, so the first container ('a') should be the
-    // sole entry with `data-active`. This locks in the contract used by the
-    // visual styling (border + text color).
+  it('marks the most-visible entry as active', () => {
+    const cleanup = mountDomFixtures(['a', 'b', 'c']);
     renderTOC();
-    expect(screen.getByTestId('toc-entry-a')).toHaveAttribute('data-active');
-    expect(screen.getByTestId('toc-entry-b')).not.toHaveAttribute(
+    // Initially no observer reports → no entry is active.
+    expect(screen.getByTestId('toc-entry-a')).not.toHaveAttribute(
+      'data-active',
+    );
+
+    // Simulate scrolling so that container B has the highest intersection
+    // ratio. B should become the active entry; A and C should not be active.
+    lastObserver!.trigger([
+      { id: 'a', intersectionRatio: 0.2 },
+      { id: 'b', intersectionRatio: 0.9 },
+      { id: 'c', intersectionRatio: 0.1 },
+    ]);
+    expect(screen.getByTestId('toc-entry-b')).toHaveAttribute('data-active');
+    expect(screen.getByTestId('toc-entry-a')).not.toHaveAttribute(
       'data-active',
     );
     expect(screen.getByTestId('toc-entry-c')).not.toHaveAttribute(
       'data-active',
     );
+
+    // Now simulate scrolling so C is most visible — active moves to C.
+    lastObserver!.trigger([
+      { id: 'a', intersectionRatio: 0 },
+      { id: 'b', intersectionRatio: 0.3 },
+      { id: 'c', intersectionRatio: 0.8 },
+    ]);
+    expect(screen.getByTestId('toc-entry-c')).toHaveAttribute('data-active');
+    expect(screen.getByTestId('toc-entry-b')).not.toHaveAttribute(
+      'data-active',
+    );
+
+    cleanup();
   });
 });

--- a/packages/app/src/components/__tests__/DashboardViewOptions.test.tsx
+++ b/packages/app/src/components/__tests__/DashboardViewOptions.test.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DashboardViewOptions } from '@/components/DashboardViewOptions';
+
+function renderViewOptions(
+  props: Partial<React.ComponentProps<typeof DashboardViewOptions>> = {},
+) {
+  const defaults: React.ComponentProps<typeof DashboardViewOptions> = {
+    onCollapseAll: jest.fn(),
+    onExpandAll: jest.fn(),
+    tocVisible: false,
+    onToggleToc: jest.fn(),
+    ...props,
+  };
+  return render(
+    <MantineProvider>
+      <DashboardViewOptions {...defaults} />
+    </MantineProvider>,
+  );
+}
+
+describe('DashboardViewOptions', () => {
+  it('renders the toolbar trigger button', () => {
+    renderViewOptions();
+    expect(screen.getByTestId('dashboard-view-options')).toBeInTheDocument();
+  });
+
+  it('opens the menu with collapse/expand/toc items when the trigger is clicked', async () => {
+    renderViewOptions();
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+
+    expect(
+      await screen.findByTestId('dashboard-collapse-all'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-expand-all')).toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-toggle-toc')).toBeInTheDocument();
+  });
+
+  it('invokes onCollapseAll when "Collapse all sections" is clicked', async () => {
+    const onCollapseAll = jest.fn();
+    renderViewOptions({ onCollapseAll });
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+    fireEvent.click(await screen.findByTestId('dashboard-collapse-all'));
+    expect(onCollapseAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onExpandAll when "Expand all sections" is clicked', async () => {
+    const onExpandAll = jest.fn();
+    renderViewOptions({ onExpandAll });
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+    fireEvent.click(await screen.findByTestId('dashboard-expand-all'));
+    expect(onExpandAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Show table of contents" label when tocVisible is false', async () => {
+    renderViewOptions({ tocVisible: false });
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+    expect(
+      await screen.findByText('Show table of contents'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Hide table of contents" label when tocVisible is true', async () => {
+    renderViewOptions({ tocVisible: true });
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+    expect(
+      await screen.findByText('Hide table of contents'),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes onToggleToc when the toc menu item is clicked', async () => {
+    const onToggleToc = jest.fn();
+    renderViewOptions({ onToggleToc });
+    fireEvent.click(screen.getByTestId('dashboard-view-options'));
+    fireEvent.click(await screen.findByTestId('dashboard-toggle-toc'));
+    expect(onToggleToc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/hooks/__tests__/useDashboardSectionNav.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardSectionNav.test.tsx
@@ -2,34 +2,27 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useDashboardSectionNav } from '../useDashboardSectionNav';
 
-// Mock nuqs with a per-key state store so `collapsed` and `expanded` are
-// independent, mirroring how DBDashboardPage uses these two URL params.
-const mockState: Record<string, string[] | null> = {
-  collapsed: null,
-  expanded: null,
-};
-const mockSetters: Record<string, jest.Mock> = {};
-
-jest.mock('nuqs', () => ({
-  useQueryState: (key: string) => {
-    if (!mockSetters[key]) {
-      mockSetters[key] = jest.fn(
-        (
-          updater:
-            | string[]
-            | null
-            | ((prev: string[] | null) => string[] | null),
-        ) => {
-          mockState[key] =
-            typeof updater === 'function' ? updater(mockState[key]) : updater;
-        },
-      );
-    }
-    return [mockState[key], mockSetters[key]];
-  },
-  parseAsArrayOf: () => ({ withOptions: () => ({}) }),
-  parseAsString: {},
-}));
+// Stand-in for the URL setter the hook receives from its caller. Stores the
+// current value and supports both absolute writes and functional updates so
+// the hook's `produce(prev ?? [], ...)` and `(prev ?? []).filter(...)` paths
+// can be observed.
+function makeMockSetter() {
+  let current: string[] | null = null;
+  const setter = jest.fn(
+    (
+      updater: string[] | null | ((prev: string[] | null) => string[] | null),
+    ) => {
+      current = typeof updater === 'function' ? updater(current) : updater;
+    },
+  );
+  return Object.assign(setter, {
+    get: () => current,
+    reset: () => {
+      current = null;
+      setter.mockClear();
+    },
+  });
+}
 
 const mockNotificationsShow = jest.fn();
 jest.mock('@mantine/notifications', () => ({
@@ -46,11 +39,12 @@ jest.mock('@/utils/clipboard', () => ({
 
 describe('useDashboardSectionNav', () => {
   const containers = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  let setUrlCollapsedIds: ReturnType<typeof makeMockSetter>;
+  let setUrlExpandedIds: ReturnType<typeof makeMockSetter>;
 
   beforeEach(() => {
-    mockState.collapsed = null;
-    mockState.expanded = null;
-    Object.values(mockSetters).forEach(fn => fn.mockClear());
+    setUrlCollapsedIds = makeMockSetter();
+    setUrlExpandedIds = makeMockSetter();
     mockNotificationsShow.mockClear();
     mockCopyTextToClipboard.mockReset();
   });
@@ -58,38 +52,51 @@ describe('useDashboardSectionNav', () => {
   describe('collapseAll', () => {
     it('sets every container id as collapsed and clears the expanded set', () => {
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
       act(() => {
         result.current.collapseAll();
       });
-      expect(mockState.collapsed).toEqual(['a', 'b', 'c']);
-      expect(mockState.expanded).toBeNull();
+      expect(setUrlCollapsedIds.get()).toEqual(['a', 'b', 'c']);
+      expect(setUrlExpandedIds.get()).toBeNull();
     });
 
     it('clears both sets when there are no containers', () => {
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers: [] }),
+        useDashboardSectionNav({
+          containers: [],
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
       act(() => {
         result.current.collapseAll();
       });
-      expect(mockState.collapsed).toBeNull();
-      expect(mockState.expanded).toBeNull();
+      expect(setUrlCollapsedIds.get()).toBeNull();
+      expect(setUrlExpandedIds.get()).toBeNull();
     });
   });
 
   describe('expandAll', () => {
     it('sets every container id as expanded and clears the collapsed set', () => {
-      mockState.collapsed = ['a', 'b'];
+      setUrlCollapsedIds(['a', 'b']);
+      setUrlCollapsedIds.mockClear();
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
       act(() => {
         result.current.expandAll();
       });
-      expect(mockState.expanded).toEqual(['a', 'b', 'c']);
-      expect(mockState.collapsed).toBeNull();
+      expect(setUrlExpandedIds.get()).toEqual(['a', 'b', 'c']);
+      expect(setUrlCollapsedIds.get()).toBeNull();
     });
   });
 
@@ -104,7 +111,8 @@ describe('useDashboardSectionNav', () => {
       document.body.appendChild(target);
 
       // Drive requestAnimationFrame synchronously so we can assert the scroll
-      // call without juggling timers.
+      // call without juggling timers. The hook uses double-rAF, so the mock
+      // is invoked twice.
       const rafSpy = jest
         .spyOn(window, 'requestAnimationFrame')
         .mockImplementation((cb: FrameRequestCallback) => {
@@ -112,17 +120,22 @@ describe('useDashboardSectionNav', () => {
           return 0;
         });
 
-      mockState.collapsed = ['b'];
+      setUrlCollapsedIds(['b']);
+      setUrlCollapsedIds.mockClear();
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
 
       act(() => {
         result.current.scrollToContainer('b');
       });
 
-      expect(mockState.expanded).toContain('b');
-      expect(mockState.collapsed).toBeNull();
+      expect(setUrlExpandedIds.get()).toContain('b');
+      expect(setUrlCollapsedIds.get()).toBeNull();
       expect(scrollIntoView).toHaveBeenCalledWith({
         behavior: 'smooth',
         block: 'start',
@@ -141,7 +154,11 @@ describe('useDashboardSectionNav', () => {
         });
 
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
       expect(() => {
         act(() => {
@@ -172,7 +189,11 @@ describe('useDashboardSectionNav', () => {
       mockCopyTextToClipboard.mockResolvedValue(true);
 
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
 
       await act(async () => {
@@ -191,7 +212,11 @@ describe('useDashboardSectionNav', () => {
       mockCopyTextToClipboard.mockResolvedValue(false);
 
       const { result } = renderHook(() =>
-        useDashboardSectionNav({ containers }),
+        useDashboardSectionNav({
+          containers,
+          setUrlCollapsedIds,
+          setUrlExpandedIds,
+        }),
       );
 
       await act(async () => {

--- a/packages/app/src/hooks/__tests__/useDashboardSectionNav.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardSectionNav.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDashboardSectionNav } from '../useDashboardSectionNav';
+
+// Mock nuqs with a per-key state store so `collapsed` and `expanded` are
+// independent, mirroring how DBDashboardPage uses these two URL params.
+const mockState: Record<string, string[] | null> = {
+  collapsed: null,
+  expanded: null,
+};
+const mockSetters: Record<string, jest.Mock> = {};
+
+jest.mock('nuqs', () => ({
+  useQueryState: (key: string) => {
+    if (!mockSetters[key]) {
+      mockSetters[key] = jest.fn(
+        (
+          updater:
+            | string[]
+            | null
+            | ((prev: string[] | null) => string[] | null),
+        ) => {
+          mockState[key] =
+            typeof updater === 'function' ? updater(mockState[key]) : updater;
+        },
+      );
+    }
+    return [mockState[key], mockSetters[key]];
+  },
+  parseAsArrayOf: () => ({ withOptions: () => ({}) }),
+  parseAsString: {},
+}));
+
+const mockNotificationsShow = jest.fn();
+jest.mock('@mantine/notifications', () => ({
+  notifications: {
+    show: (...args: unknown[]) => mockNotificationsShow(...args),
+  },
+}));
+
+const mockCopyTextToClipboard = jest.fn();
+jest.mock('@/utils/clipboard', () => ({
+  CLIPBOARD_ERROR_MESSAGE: 'mock clipboard error',
+  copyTextToClipboard: (text: string) => mockCopyTextToClipboard(text),
+}));
+
+describe('useDashboardSectionNav', () => {
+  const containers = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  beforeEach(() => {
+    mockState.collapsed = null;
+    mockState.expanded = null;
+    Object.values(mockSetters).forEach(fn => fn.mockClear());
+    mockNotificationsShow.mockClear();
+    mockCopyTextToClipboard.mockReset();
+  });
+
+  describe('collapseAll', () => {
+    it('sets every container id as collapsed and clears the expanded set', () => {
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+      act(() => {
+        result.current.collapseAll();
+      });
+      expect(mockState.collapsed).toEqual(['a', 'b', 'c']);
+      expect(mockState.expanded).toBeNull();
+    });
+
+    it('clears both sets when there are no containers', () => {
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers: [] }),
+      );
+      act(() => {
+        result.current.collapseAll();
+      });
+      expect(mockState.collapsed).toBeNull();
+      expect(mockState.expanded).toBeNull();
+    });
+  });
+
+  describe('expandAll', () => {
+    it('sets every container id as expanded and clears the collapsed set', () => {
+      mockState.collapsed = ['a', 'b'];
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+      act(() => {
+        result.current.expandAll();
+      });
+      expect(mockState.expanded).toEqual(['a', 'b', 'c']);
+      expect(mockState.collapsed).toBeNull();
+    });
+  });
+
+  describe('scrollToContainer', () => {
+    it('expands the target container and scrolls its DOM node into view', () => {
+      const scrollIntoView = jest.fn();
+      const target = document.createElement('div');
+      target.id = 'container-b';
+      // Overwrite the native method with a spy. The native signature accepts
+      // boolean | ScrollIntoViewOptions; our hook only ever passes options.
+      Object.assign(target, { scrollIntoView });
+      document.body.appendChild(target);
+
+      // Drive requestAnimationFrame synchronously so we can assert the scroll
+      // call without juggling timers.
+      const rafSpy = jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+      mockState.collapsed = ['b'];
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+
+      act(() => {
+        result.current.scrollToContainer('b');
+      });
+
+      expect(mockState.expanded).toContain('b');
+      expect(mockState.collapsed).toBeNull();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+
+      rafSpy.mockRestore();
+      document.body.removeChild(target);
+    });
+
+    it('does not throw when the target node is missing', () => {
+      const rafSpy = jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          cb(0);
+          return 0;
+        });
+
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+      expect(() => {
+        act(() => {
+          result.current.scrollToContainer('does-not-exist');
+        });
+      }).not.toThrow();
+
+      rafSpy.mockRestore();
+    });
+  });
+
+  describe('copySectionLink', () => {
+    const originalUrl =
+      typeof window !== 'undefined' ? window.location.href : '';
+
+    beforeEach(() => {
+      // jsdom forbids reassigning `window.location`, but `history.replaceState`
+      // legitimately updates pathname/search via the platform — exactly what
+      // copySectionLink reads from window.location.
+      window.history.replaceState({}, '', '/dashboards/d-1?from=test');
+    });
+
+    afterEach(() => {
+      window.history.replaceState({}, '', originalUrl || '/');
+    });
+
+    it('delegates to copyTextToClipboard with the deep link and confirms via notification', async () => {
+      mockCopyTextToClipboard.mockResolvedValue(true);
+
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+
+      await act(async () => {
+        await result.current.copySectionLink('b');
+      });
+
+      expect(mockCopyTextToClipboard).toHaveBeenCalledWith(
+        `${window.location.origin}/dashboards/d-1?from=test#container-b`,
+      );
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'green', title: 'Link copied' }),
+      );
+    });
+
+    it('surfaces a failure notification when copyTextToClipboard returns false', async () => {
+      mockCopyTextToClipboard.mockResolvedValue(false);
+
+      const { result } = renderHook(() =>
+        useDashboardSectionNav({ containers }),
+      );
+
+      await act(async () => {
+        await result.current.copySectionLink('b');
+      });
+
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'red' }),
+      );
+    });
+  });
+});

--- a/packages/app/src/hooks/useDashboardSectionNav.ts
+++ b/packages/app/src/hooks/useDashboardSectionNav.ts
@@ -1,0 +1,115 @@
+import { useCallback } from 'react';
+import produce from 'immer';
+import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
+import { notifications } from '@mantine/notifications';
+
+import {
+  CLIPBOARD_ERROR_MESSAGE,
+  copyTextToClipboard,
+} from '@/utils/clipboard';
+
+type SectionNavContainer = { id: string };
+
+/**
+ * Navigation API for dashboard containers ("sections"):
+ * - `scrollToContainer` — ensures the container is expanded, then smooth-scrolls
+ *   the page so the container's header is visible.
+ * - `collapseAll` / `expandAll` — batch-set the URL-synced collapse state so the
+ *   user can toggle the entire dashboard into a compact menu or back.
+ * - `copySectionLink` — writes a shareable `#container-<id>` deep link to the
+ *   clipboard and surfaces a confirmation notification.
+ *
+ * State lives entirely in URL query params (`collapsed`, `expanded`) so any
+ * navigation taken here is shareable via the dashboard's URL like every other
+ * piece of dashboard state.
+ */
+export function useDashboardSectionNav({
+  containers,
+}: {
+  containers: SectionNavContainer[];
+}) {
+  const [, setUrlCollapsedIds] = useQueryState(
+    'collapsed',
+    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
+  );
+  const [, setUrlExpandedIds] = useQueryState(
+    'expanded',
+    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
+  );
+
+  const expandContainer = useCallback(
+    (containerId: string) => {
+      setUrlExpandedIds(prev =>
+        produce(prev ?? [], draft => {
+          if (!draft.includes(containerId)) draft.push(containerId);
+        }),
+      );
+      setUrlCollapsedIds(prev => {
+        const next = (prev ?? []).filter(id => id !== containerId);
+        return next.length > 0 ? next : null;
+      });
+    },
+    [setUrlCollapsedIds, setUrlExpandedIds],
+  );
+
+  const scrollToContainer = useCallback(
+    (containerId: string) => {
+      expandContainer(containerId);
+      // Double-rAF before scrolling: the first frame lets nuqs flush the URL
+      // setter and React commit the un-collapse; the second frame lets the
+      // newly-mounted tile grid lay out, so the container header position is
+      // stable when scrollIntoView measures it. A single rAF is too early when
+      // the section starts collapsed and the children have to mount.
+      if (typeof window === 'undefined') return;
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          document
+            .getElementById(`container-${containerId}`)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+      });
+    },
+    [expandContainer],
+  );
+
+  const collapseAll = useCallback(() => {
+    const ids = containers.map(c => c.id);
+    setUrlCollapsedIds(ids.length > 0 ? ids : null);
+    setUrlExpandedIds(null);
+  }, [containers, setUrlCollapsedIds, setUrlExpandedIds]);
+
+  const expandAll = useCallback(() => {
+    const ids = containers.map(c => c.id);
+    setUrlExpandedIds(ids.length > 0 ? ids : null);
+    setUrlCollapsedIds(null);
+  }, [containers, setUrlCollapsedIds, setUrlExpandedIds]);
+
+  const copySectionLink = useCallback(async (containerId: string) => {
+    if (typeof window === 'undefined') return;
+    const { origin, pathname, search } = window.location;
+    const url = `${origin}${pathname}${search}#container-${containerId}`;
+    const copied = await copyTextToClipboard(url);
+    if (!copied) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not copy link',
+        message: CLIPBOARD_ERROR_MESSAGE,
+        autoClose: 4000,
+      });
+      return;
+    }
+    notifications.show({
+      color: 'green',
+      title: 'Link copied',
+      message: 'Section link copied to clipboard.',
+      autoClose: 2000,
+    });
+  }, []);
+
+  return {
+    scrollToContainer,
+    collapseAll,
+    expandAll,
+    copySectionLink,
+  };
+}

--- a/packages/app/src/hooks/useDashboardSectionNav.ts
+++ b/packages/app/src/hooks/useDashboardSectionNav.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import produce from 'immer';
-import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
 import { notifications } from '@mantine/notifications';
 
 import {
@@ -9,6 +8,10 @@ import {
 } from '@/utils/clipboard';
 
 type SectionNavContainer = { id: string };
+
+type UrlIdsSetter = (
+  updater: string[] | null | ((prev: string[] | null) => string[] | null),
+) => void;
 
 /**
  * Navigation API for dashboard containers ("sections"):
@@ -19,24 +22,22 @@ type SectionNavContainer = { id: string };
  * - `copySectionLink` — writes a shareable `#container-<id>` deep link to the
  *   clipboard and surfaces a confirmation notification.
  *
- * State lives entirely in URL query params (`collapsed`, `expanded`) so any
- * navigation taken here is shareable via the dashboard's URL like every other
- * piece of dashboard state.
+ * The collapse-state setters are passed in from the caller rather than
+ * subscribed to internally so that there is exactly one `useQueryState`
+ * subscriber per URL param across the dashboard page (DBDashboardPage owns
+ * the canonical subscription). This avoids any subtle interaction between
+ * multiple subscribers that could affect router hydration on the saved
+ * dashboard page.
  */
 export function useDashboardSectionNav({
   containers,
+  setUrlCollapsedIds,
+  setUrlExpandedIds,
 }: {
   containers: SectionNavContainer[];
+  setUrlCollapsedIds: UrlIdsSetter;
+  setUrlExpandedIds: UrlIdsSetter;
 }) {
-  const [, setUrlCollapsedIds] = useQueryState(
-    'collapsed',
-    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
-  );
-  const [, setUrlExpandedIds] = useQueryState(
-    'expanded',
-    parseAsArrayOf(parseAsString).withOptions({ history: 'replace' }),
-  );
-
   const expandContainer = useCallback(
     (containerId: string) => {
       setUrlExpandedIds(prev =>

--- a/packages/app/src/useUserPreferences.tsx
+++ b/packages/app/src/useUserPreferences.tsx
@@ -12,6 +12,8 @@ export type UserPreferences = {
   colorMode: ColorModePreference;
   font: 'IBM Plex Mono' | 'Roboto Mono' | 'Inter' | 'Roboto';
   expandSidebarHeader?: boolean;
+  /** Show the sticky table-of-contents rail on dashboard pages. Off by default. */
+  tocVisible?: boolean;
 };
 
 // Legacy type for migration

--- a/packages/common-utils/src/core/eventDeltas.ts
+++ b/packages/common-utils/src/core/eventDeltas.ts
@@ -22,7 +22,7 @@
  */
 export function flattenData(data: Record<string, any>): Record<string, any> {
   const result: Record<string, any> = {};
-  // eslint-disable-next-line security/detect-object-injection -- prop is built from known object keys via recursion, not user input
+
   function recurse(cur: Record<string, any>, prop: string) {
     if (Object(cur) !== cur) {
       result[prop] = cur; // eslint-disable-line security/detect-object-injection


### PR DESCRIPTION
## Summary

Adds three opt-in dashboard navigation aids for dashboards that have grown past comfortable scroll length. All three are off by default — existing dashboards look unchanged for users who never open the new menu.

1. **Hash anchors per section.** Each `DashboardContainer` renders with `id="container-<id>"`, and hovering a section header reveals a "copy link" icon that writes `<current-url>#container-<id>` to the clipboard (via the shared `@/utils/clipboard` helper). Loading the page with such a hash auto-scrolls to that section, auto-expanding it first.
2. **View-options menu in the toolbar.** "Collapse all sections" / "Expand all sections" / "Show table of contents". Batch collapse/expand reuses the existing URL-synced collapse state (`?collapsed=…&expanded=…`), so a compact view is shareable like any other dashboard state.
3. **Sticky in-flow TOC rail.** When toggled on, a 180px column sits next to the dashboard content as a Flex sibling (no overlay, tiles reflow), with one entry per section, scrollspy-driven active highlighting, and click-to-jump that also auto-expands. Hidden below the `md` breakpoint. Visibility is a per-user preference in `useUserPreferences`.

Core logic lives in `src/hooks/useDashboardSectionNav.ts` (`scrollToContainer`, `copySectionLink`, `collapseAll`, `expandAll`). New components are `DashboardTOC` and `DashboardViewOptions`. `DashboardContainer` gained an optional `onCopyLink` prop and a stable `id` attribute on its root.

### Screenshots or video
Before
<img width="1484" height="1184" alt="image" src="https://github.com/user-attachments/assets/7f33c152-a3d9-429e-b5fe-bd5f103eeafe" />

After

https://github.com/user-attachments/assets/efe7e5b7-4f8f-454d-92cb-52eaefa59038


### How to test on Vercel preview

**Preview routes:** \`/dashboards/[id]\` (any existing dashboard with 4+ sections)

**Steps:**

1. Open a dashboard with at least four sections (group containers).
2. Click the view-options icon in the toolbar (between "Edit Filters" and "Run"); verify the menu shows "Collapse all sections", "Expand all sections", and "Show table of contents".
3. Click "Collapse all sections" — verify every section collapses to its header and the URL gains \`?collapsed=…\`.
4. Click "Show table of contents" — verify a sticky rail appears on the right with one entry per section.
5. Click any TOC entry — verify the page smooth-scrolls to that section and auto-expands it if collapsed.
6. Hover any section header — verify a small link icon appears. Click it — verify the "Link copied" notification, paste the URL in a new tab, and verify the page loads and scrolls to that section.

### References

- Linear Issue:  HDX-4339
- Related PRs: builds on #2292 (shared clipboard utility)

---

### Reviewer notes (pre-push fanout findings)

Ran \`ce-correctness\`, \`ce-maintainability\`, \`ce-adversarial\`, \`ce-kieran-typescript\`, and \`ce-testing\` reviewers in parallel before pushing. Triaged each finding as introduced/amplified/pre-existing.

**Fixed before push (P1 / P2):**
- Hash-on-load effect now keys on \`dashboard.id\` (not a binary ref), so SPA navigation between dashboards re-arms the deep-link scroll, and the initial scroll is gated on containers being loaded.
- \`scrollToContainer\` now uses double-rAF before measuring, so auto-expand-then-scroll on a collapsed section lands correctly after React commit + tile layout.
- TOC label uses \`container.title\` for multi-tab containers (the tab bar replaces a single-title header in that case) and falls back to the first tab's title for single-tab containers.

**Known follow-ups (P2, not fixed in this PR):**
- \`useDashboardSectionNav\` and \`DBDashboardPage\` both subscribe to \`useQueryState('collapsed' | 'expanded')\`. nuqs reads stay in sync, but consolidating the URL-collapse plumbing in one place would prevent future drift.
- TOC entry hover styling uses inline \`style\` + \`onMouseEnter/Leave\`. A CSS module keyed on \`data-active\` would be cleaner and matches the convention used elsewhere in the repo.
- \`copySectionLink\` includes the full current \`window.location.search\` in the copied URL — that intentionally captures the recipient's filter context, but means transient params (\`highlightedTileId\`, debug params) tag along. Worth a follow-up to filter.
- \`useScrollSpy\` uses a global \`[id^="container-"]\` selector. Tightening to a scoped ref would be more robust against future ID collisions or drag-overlay clones.