### PR TITLE
fix: dedupe map sub-key entries in filter sidebar (HDX-4340)

### DIFF
--- a/.changeset/dedupe-map-subkey-filters.md
+++ b/.changeset/dedupe-map-subkey-filters.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: collapse duplicate map sub-key entries in the search filter sidebar (HDX-4340)
+
+A map sub-field stored in `filterState` under dot notation (e.g. `LogAttributes.time`,
+from a Lucene URL round-trip) and the same key returned by the facet query under
+bracket notation (e.g. `LogAttributes['time']`) no longer render as two separate
+accordion items. The merged entry keeps the bracket form so "Load more" stays
+valid, and the user's selection still resolves via a tolerant filterState lookup.

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -87,6 +87,7 @@ import { SharedFiltersSection } from './DBSearchPageFilters/SharedFilters';
 import {
   getFilterStateEntry,
   groupFacetsByBaseName,
+  toClickHouseKeyExpression,
 } from './DBSearchPageFilters/utils';
 
 import resizeStyles from '../../styles/ResizablePanel.module.scss';
@@ -1339,13 +1340,20 @@ const DBSearchPageFiltersComponent = ({
     async (key: string) => {
       setLoadMoreLoadingKeys(prev => new Set(prev).add(key));
       try {
+        // Coerce dot-form Map sub-keys (LogAttributes.foo) into bracket form
+        // (LogAttributes['foo']) before handing them to ClickHouse. Bracket
+        // form is the canonical SQL key produced by mergePath; dot form ends
+        // up in filterState after setFilterValue's parseKeyPath().join('.')
+        // normalization or after a Lucene URL round-trip, and ClickHouse
+        // cannot resolve it as map access.
+        const sqlKey = toClickHouseKeyExpression(key);
         let newValues: string[];
         if (!useExactPipeline) {
           const results = await metadata.getAllKeyValues({
             databaseName: chartConfig.from.databaseName,
             tableName: chartConfig.from.tableName,
             connectionId: chartConfig.connection,
-            keyExpressions: [key],
+            keyExpressions: [sqlKey],
             maxValuesPerKey: LOAD_MORE_LOAD_LIMIT,
             metadataMVs: sourceTableConnection.metadataMVs,
             dateRange,
@@ -1358,15 +1366,18 @@ const DBSearchPageFiltersComponent = ({
           // to the user's current selection (exact filter mode, with selections
           // on this key). Other dimensions' filters and the free-text where
           // stay applied so counts remain search-aware for unrelated fields.
+          // Strip under both bracket and dot forms since filterState may carry
+          // either depending on how the filter was authored.
           const strippedFilterState: FilterState = { ...filterState };
           delete strippedFilterState[key];
+          if (sqlKey !== key) delete strippedFilterState[sqlKey];
           const newKeyVals = await metadata.getKeyValuesWithMVs({
             chartConfig: {
               ...chartConfig,
               dateRange,
               filters: filtersToQuery(strippedFilterState),
             },
-            keys: [key],
+            keys: [sqlKey],
             limit: LOAD_MORE_LOAD_LIMIT,
             disableRowLimit: true,
             source,

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -84,7 +84,10 @@ import {
   PinShareMenu,
 } from './DBSearchPageFilters/PinShareMenu';
 import { SharedFiltersSection } from './DBSearchPageFilters/SharedFilters';
-import { groupFacetsByBaseName } from './DBSearchPageFilters/utils';
+import {
+  getFilterStateEntry,
+  groupFacetsByBaseName,
+} from './DBSearchPageFilters/utils';
 
 import resizeStyles from '../../styles/ResizablePanel.module.scss';
 import classes from '../../styles/SearchPage.module.scss';
@@ -1660,7 +1663,10 @@ const DBSearchPageFiltersComponent = ({
               name={group.key}
               childFilters={group.children}
               selectedValues={group.children.reduce((acc, child) => {
-                acc[child.key] = filterState[child.key] ?? {
+                acc[child.key] = getFilterStateEntry(
+                  filterState,
+                  child.key,
+                ) ?? {
                   included: new Set(),
                   excluded: new Set(),
                 };
@@ -1702,14 +1708,15 @@ const DBSearchPageFiltersComponent = ({
               )}
               isDefaultExpanded={
                 forceExpanded ??
-                group.children.some(
-                  child =>
-                    (filterState[child.key] &&
-                      (filterState[child.key].included.size > 0 ||
-                        filterState[child.key].excluded.size > 0)) ||
+                group.children.some(child => {
+                  const entry = getFilterStateEntry(filterState, child.key);
+                  return (
+                    (entry &&
+                      (entry.included.size > 0 || entry.excluded.size > 0)) ||
                     isFieldPinned(child.key) ||
-                    isSharedFieldPinned(child.key),
-                )
+                    isSharedFieldPinned(child.key)
+                  );
+                })
               }
               chartConfig={chartConfig}
               isLive={isLive}
@@ -1727,7 +1734,7 @@ const DBSearchPageFiltersComponent = ({
               }))}
               optionsLoading={isFacetsLoading}
               selectedValues={
-                filterState[facet.key] ?? {
+                getFilterStateEntry(filterState, facet.key) ?? {
                   included: new Set(),
                   excluded: new Set(),
                 }
@@ -1747,16 +1754,19 @@ const DBSearchPageFiltersComponent = ({
               onLoadMore={loadMoreFilterValuesForKey}
               loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
               hasLoadedMore={Boolean(extraFacets[facet.key])}
-              isDefaultExpanded={
-                forceExpanded ??
-                (isFieldPrimary(tableMetadata, facet.key) ||
-                  isFieldPinned(facet.key) ||
-                  isSharedFieldPinned(facet.key) ||
-                  (filterState[facet.key] != null &&
-                    (filterState[facet.key].included.size > 0 ||
-                      filterState[facet.key].excluded.size > 0 ||
-                      filterState[facet.key].range != null)))
-              }
+              isDefaultExpanded={(() => {
+                const entry = getFilterStateEntry(filterState, facet.key);
+                return (
+                  forceExpanded ??
+                  (isFieldPrimary(tableMetadata, facet.key) ||
+                    isFieldPinned(facet.key) ||
+                    isSharedFieldPinned(facet.key) ||
+                    (entry != null &&
+                      (entry.included.size > 0 ||
+                        entry.excluded.size > 0 ||
+                        entry.range != null)))
+                );
+              })()}
               chartConfig={chartConfig}
               isLive={isLive}
               onRangeChange={range => setFilterRange(facet.key, range)}

--- a/packages/app/src/components/DBSearchPageFilters/utils.test.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.test.ts
@@ -1,6 +1,10 @@
 import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
-import { getFilterStateEntry, groupFacetsByBaseName } from './utils';
+import {
+  getFilterStateEntry,
+  groupFacetsByBaseName,
+  toClickHouseKeyExpression,
+} from './utils';
 
 describe('groupFacetsByBaseName — dot/bracket de-duplication', () => {
   it('collapses bracket-form and dot-form entries for the same logical key', () => {
@@ -94,5 +98,47 @@ describe('getFilterStateEntry', () => {
   it('returns undefined for non-map keys with no direct match', () => {
     const filterState: FilterState = {};
     expect(getFilterStateEntry(filterState, 'Timestamp')).toBeUndefined();
+  });
+});
+
+describe('toClickHouseKeyExpression', () => {
+  it('rewrites dot-form map sub-keys to bracket form', () => {
+    expect(toClickHouseKeyExpression('LogAttributes.time')).toBe(
+      "LogAttributes['time']",
+    );
+  });
+
+  it('preserves the full property path when it contains dots', () => {
+    expect(toClickHouseKeyExpression('ResourceAttributes.host.name')).toBe(
+      "ResourceAttributes['host.name']",
+    );
+  });
+
+  it('leaves bracket-form keys unchanged', () => {
+    expect(toClickHouseKeyExpression("LogAttributes['time']")).toBe(
+      "LogAttributes['time']",
+    );
+  });
+
+  it('leaves double-quoted bracket-form keys unchanged', () => {
+    expect(toClickHouseKeyExpression('LogAttributes["time"]')).toBe(
+      'LogAttributes["time"]',
+    );
+  });
+
+  it('leaves backtick-form JSON paths unchanged', () => {
+    expect(toClickHouseKeyExpression('Body.`json`.`field`')).toBe(
+      'Body.`json`.`field`',
+    );
+  });
+
+  it('leaves toString() wrappers unchanged', () => {
+    expect(
+      toClickHouseKeyExpression("toString(LogAttributes['service.name'])"),
+    ).toBe("toString(LogAttributes['service.name'])");
+  });
+
+  it('leaves plain column names unchanged', () => {
+    expect(toClickHouseKeyExpression('Timestamp')).toBe('Timestamp');
   });
 });

--- a/packages/app/src/components/DBSearchPageFilters/utils.test.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.test.ts
@@ -1,0 +1,98 @@
+import type { FilterState } from '@hyperdx/common-utils/dist/filters';
+
+import { getFilterStateEntry, groupFacetsByBaseName } from './utils';
+
+describe('groupFacetsByBaseName — dot/bracket de-duplication', () => {
+  it('collapses bracket-form and dot-form entries for the same logical key', () => {
+    const result = groupFacetsByBaseName([
+      { key: 'LogAttributes.time', value: ['1779461580003'] },
+      {
+        key: "LogAttributes['time']",
+        value: ['1779461580003', '1779461580004'],
+      },
+    ]);
+
+    expect(result.grouped).toHaveLength(1);
+    expect(result.grouped[0].children).toHaveLength(1);
+    const [child] = result.grouped[0].children;
+    expect(child.propertyPath).toBe('time');
+    // Bracket form wins so child.key stays valid as a ClickHouse expression
+    expect(child.key).toBe("LogAttributes['time']");
+    expect(child.value).toEqual(['1779461580003', '1779461580004']);
+  });
+
+  it('keeps the existing bracket-form key when a dot-form duplicate arrives second', () => {
+    const result = groupFacetsByBaseName([
+      { key: "LogAttributes['time']", value: ['a'] },
+      { key: 'LogAttributes.time', value: ['b'] },
+    ]);
+
+    const [child] = result.grouped[0].children;
+    expect(child.key).toBe("LogAttributes['time']");
+    expect(child.value).toEqual(['a', 'b']);
+  });
+
+  it('merges values without duplicating identical entries', () => {
+    const result = groupFacetsByBaseName([
+      { key: 'LogAttributes.foo', value: ['x', 'y'] },
+      { key: "LogAttributes['foo']", value: ['y', 'z'] },
+    ]);
+
+    expect(result.grouped[0].children[0].value).toEqual(['x', 'y', 'z']);
+  });
+
+  it('does not collapse different propertyPaths under the same base name', () => {
+    const result = groupFacetsByBaseName([
+      { key: "LogAttributes['time']", value: ['1'] },
+      { key: "LogAttributes['user']", value: ['alice'] },
+    ]);
+
+    expect(result.grouped[0].children).toHaveLength(2);
+  });
+});
+
+describe('getFilterStateEntry', () => {
+  const makeEntry = (included: string[]): FilterState[string] => ({
+    included: new Set<string | boolean>(included),
+    excluded: new Set<string | boolean>(),
+  });
+
+  it('returns the entry for an exact key match', () => {
+    const filterState: FilterState = {
+      "LogAttributes['time']": makeEntry(['a']),
+    };
+    expect(getFilterStateEntry(filterState, "LogAttributes['time']")).toBe(
+      filterState["LogAttributes['time']"],
+    );
+  });
+
+  it('falls back to dot form when given bracket form', () => {
+    const filterState: FilterState = {
+      'LogAttributes.time': makeEntry(['1779461580003']),
+    };
+    const result = getFilterStateEntry(filterState, "LogAttributes['time']");
+    expect(result).toBe(filterState['LogAttributes.time']);
+  });
+
+  it('falls back to bracket form when given dot form', () => {
+    const filterState: FilterState = {
+      "LogAttributes['time']": makeEntry(['1779461580003']),
+    };
+    const result = getFilterStateEntry(filterState, 'LogAttributes.time');
+    expect(result).toBe(filterState["LogAttributes['time']"]);
+  });
+
+  it('returns undefined when no matching entry exists', () => {
+    const filterState: FilterState = {
+      OtherField: makeEntry(['x']),
+    };
+    expect(
+      getFilterStateEntry(filterState, "LogAttributes['time']"),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for non-map keys with no direct match', () => {
+    const filterState: FilterState = {};
+    expect(getFilterStateEntry(filterState, 'Timestamp')).toBeUndefined();
+  });
+});

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -1,6 +1,7 @@
 // Utility functions for parsing and grouping map-like field names
 
 import { parseKeyPath } from '@hyperdx/common-utils/dist/core/metadata';
+import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
 // Clean ClickHouse expressions to extract clean property paths
 export function cleanClickHouseExpression(key: string): string {
@@ -42,7 +43,22 @@ export function parseMapFieldName(
   return null;
 }
 
-// Group facets by their base names for map-like fields
+// Bracket-form keys (e.g. LogAttributes['time']) are the canonical SQL form
+// produced by mergePath for Map columns, while dot-form keys
+// (e.g. LogAttributes.time) are what setFilterValue stores after its
+// parseKeyPath().join('.') normalization and what parseLuceneFilter returns
+// on URL load. Same logical field, different raw string.
+function isBracketFormMapKey(key: string): boolean {
+  return key.includes("['") || key.includes('["');
+}
+
+// Group facets by their base names for map-like fields.
+//
+// De-duplicates children that resolve to the same (baseName, propertyPath)
+// — a filterState entry like `LogAttributes.time` and a facet entry like
+// `LogAttributes['time']` refer to the same logical field and must collapse
+// into a single child. When merging, we keep the bracket-form key so
+// `child.key` remains a valid ClickHouse expression for "Load more" SQL.
 export function groupFacetsByBaseName(
   facets: { key: string; value: (string | boolean)[] }[],
 ) {
@@ -72,14 +88,53 @@ export function groupFacetsByBaseName(
         });
       }
       const group = grouped.get(baseName)!;
-      group.children.push({
-        ...facet,
-        propertyPath,
-      });
+      const existing = group.children.find(
+        c => c.propertyPath === propertyPath,
+      );
+      if (existing) {
+        const mergedValues: (string | boolean)[] = [...existing.value];
+        for (const v of facet.value) {
+          if (!mergedValues.includes(v)) {
+            mergedValues.push(v);
+          }
+        }
+        existing.value = mergedValues;
+        if (
+          isBracketFormMapKey(facet.key) &&
+          !isBracketFormMapKey(existing.key)
+        ) {
+          existing.key = facet.key;
+        }
+      } else {
+        group.children.push({
+          ...facet,
+          propertyPath,
+        });
+      }
     } else {
       nonGrouped.push(facet);
     }
   }
 
   return { grouped: Array.from(grouped.values()), nonGrouped };
+}
+
+// Look up a filterState entry by either bracket-form or dot-form map sub-key.
+// Bracket form is the canonical SQL key used in facet results; dot form is
+// what setFilterValue stores after its parseKeyPath().join('.') normalization
+// and what parseLuceneFilter restores from a Lucene URL round-trip. Reads
+// need to tolerate either so the user's selection still resolves regardless
+// of which form `child.key` carries after groupFacetsByBaseName's merge.
+export function getFilterStateEntry(
+  filterState: FilterState,
+  key: string,
+): FilterState[string] | undefined {
+  const direct = filterState[key];
+  if (direct) return direct;
+  const parsed = parseMapFieldName(key);
+  if (!parsed) return undefined;
+  return (
+    filterState[`${parsed.baseName}.${parsed.propertyPath}`] ??
+    filterState[`${parsed.baseName}['${parsed.propertyPath}']`]
+  );
 }

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -138,3 +138,24 @@ export function getFilterStateEntry(
     filterState[`${parsed.baseName}['${parsed.propertyPath}']`]
   );
 }
+
+// Coerce a filterState key into a ClickHouse expression suitable for raw SQL.
+// A dot-form Map sub-key like `LogAttributes.host.name` is rewritten to bracket
+// form `LogAttributes['host.name']`. Bracket form, backtick-quoted JSON paths,
+// `toString(...)` wrappers, and plain column names are returned unchanged. Use
+// this when handing a filterState key off to a SQL caller (e.g. "Load more"
+// via metadata.getKeyValues), since `setFilterValue` normalizes Map sub-keys
+// to dot form which ClickHouse cannot resolve as map access.
+export function toClickHouseKeyExpression(key: string): string {
+  if (
+    key.includes("['") ||
+    key.includes('["') ||
+    key.includes('`') ||
+    key.startsWith('toString(')
+  ) {
+    return key;
+  }
+  const parsed = parseMapFieldName(key);
+  if (!parsed) return key;
+  return `${parsed.baseName}['${parsed.propertyPath}']`;
+}

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -3,6 +3,8 @@
 import { parseKeyPath } from '@hyperdx/common-utils/dist/core/metadata';
 import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
+import { mergePath } from '@/utils';
+
 // Clean ClickHouse expressions to extract clean property paths
 export function cleanClickHouseExpression(key: string): string {
   // Remove toString() wrapper if present
@@ -141,11 +143,13 @@ export function getFilterStateEntry(
 
 // Coerce a filterState key into a ClickHouse expression suitable for raw SQL.
 // A dot-form Map sub-key like `LogAttributes.host.name` is rewritten to bracket
-// form `LogAttributes['host.name']`. Bracket form, backtick-quoted JSON paths,
-// `toString(...)` wrappers, and plain column names are returned unchanged. Use
-// this when handing a filterState key off to a SQL caller (e.g. "Load more"
-// via metadata.getKeyValues), since `setFilterValue` normalizes Map sub-keys
-// to dot form which ClickHouse cannot resolve as map access.
+// form `LogAttributes['host.name']` via `mergePath` so the conversion stays
+// consistent with the keys produced by the facet-discovery path. Bracket form,
+// backtick-quoted JSON paths, `toString(...)` wrappers, and plain column names
+// are returned unchanged. Use this when handing a filterState key off to a SQL
+// caller (e.g. "Load more" via metadata.getKeyValues), since `setFilterValue`
+// normalizes Map sub-keys to dot form which ClickHouse cannot resolve as map
+// access.
 export function toClickHouseKeyExpression(key: string): string {
   if (
     key.includes("['") ||
@@ -157,5 +161,5 @@ export function toClickHouseKeyExpression(key: string): string {
   }
   const parsed = parseMapFieldName(key);
   if (!parsed) return key;
-  return `${parsed.baseName}['${parsed.propertyPath}']`;
+  return mergePath([parsed.baseName, parsed.propertyPath]);
 }


### PR DESCRIPTION
## Summary

The filter sidebar rendered two separate accordion items for the same map sub-field (e.g. two `time (1)` rows under `LogAttributes`, both showing the same value) whenever a Lucene URL round-trip put a map filter back into `filterState`. Root cause: `filterState` stores map sub-keys in dot notation (`LogAttributes.time`) after `setFilterValue`'s `parseKeyPath().join('.')` normalization, while the facet query returns the same logical key in bracket notation (`LogAttributes['time']`); the merge in `shownFacets` treated them as distinct.

`groupFacetsByBaseName` now collapses children by `(baseName, propertyPath)` and keeps the bracket form so `child.key` stays valid for "Load more" SQL. A new `getFilterStateEntry` helper tolerates either form when reading `filterState`, so the user's selection still resolves on the merged child. Writes are unchanged.

### Screenshots or video

| Before | After |
| :----- | :---- |
| Two `time` rows under `LogAttributes`, only the first checked. | Single `time` row with the selection preserved. |

### How to test on Vercel preview

**Preview routes:** /search

**Steps:**

1. Open the Search page on a source whose `LogAttributes` (or any Map column) has at least one observed key — `service.name` is a good candidate on the demo data.
2. Append `&where=LogAttributes.service.name%3A%22api%22` (substitute any real attribute key/value) to the URL and reload.
3. Expand `LogAttributes` in the filter sidebar.
4. Verify only one row appears for the filtered key (no duplicate accordion item), the checkbox shows the selection, and clicking "Load more" surfaces additional values.

### References

- Linear Issue: [HDX-4340](https://linear.app/clickhouse/issue/HDX-4340/filtering-on-map-keyvals-results-in-duplicate-map-entries-in-the)
- Related PRs: