### PR TITLE
feat(mcp): add hyperdx_event_deltas tool

### DIFF
--- a/.changeset/event-deltas-mcp-tool.md
+++ b/.changeset/event-deltas-mcp-tool.md
@@ -1,0 +1,14 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/common-utils': patch
+---
+
+feat(mcp): add hyperdx_event_deltas tool
+
+Add `hyperdx_event_deltas` MCP tool that compares two row groups (target
+vs baseline) and ranks properties by how much their value distributions
+differ. Same algorithm as the in-app Event Deltas view.
+
+Extract shared event-deltas algorithm from the UI into
+`@hyperdx/common-utils/src/core/eventDeltas.ts` so it can be used by
+both the frontend and the MCP server.

--- a/MCP.md
+++ b/MCP.md
@@ -114,6 +114,7 @@ with:
 | `hyperdx_table`               | Compute aggregated metrics as a table, single number, or pie chart                           |
 | `hyperdx_search`              | Browse individual log, event, or trace rows                                                  |
 | `hyperdx_event_patterns`      | Discover the most common log messages and event patterns using Drain clustering               |
+| `hyperdx_event_deltas`        | Compare two row groups and rank properties by how their value distributions differ            |
 | `hyperdx_sql`                 | Execute raw ClickHouse SQL for advanced queries (JOINs, CTEs, sub-queries)                   |
 | `hyperdx_get_dashboard`       | List all dashboards or get full detail for a specific dashboard                              |
 | `hyperdx_save_dashboard`      | Create or update a dashboard with tiles (charts, tables, numbers, search, markdown)          |

--- a/packages/api/src/mcp/__tests__/deltasTool.test.ts
+++ b/packages/api/src/mcp/__tests__/deltasTool.test.ts
@@ -1,0 +1,231 @@
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+import * as config from '@/config';
+import {
+  bulkInsertLogs,
+  DEFAULT_DATABASE,
+  DEFAULT_LOGS_TABLE,
+  getLoggedInAgent,
+  getServer,
+} from '@/fixtures';
+import Connection from '@/models/connection';
+import { Source } from '@/models/source';
+
+import { McpContext } from '../tools/types';
+import { callTool, createTestClient, getFirstText } from './mcpTestUtils';
+
+describe('MCP Event Deltas Tool', () => {
+  const server = getServer();
+  let team: any;
+  let user: any;
+  let logSource: any;
+  let connection: any;
+  let client: Client;
+
+  beforeAll(async () => {
+    await server.start();
+  });
+
+  beforeEach(async () => {
+    const result = await getLoggedInAgent(server);
+    team = result.team;
+    user = result.user;
+
+    connection = await Connection.create({
+      team: team._id,
+      name: 'Default',
+      host: config.CLICKHOUSE_HOST,
+      username: config.CLICKHOUSE_USER,
+      password: config.CLICKHOUSE_PASSWORD,
+    });
+
+    logSource = await Source.create({
+      kind: SourceKind.Log,
+      team: team._id,
+      from: { databaseName: DEFAULT_DATABASE, tableName: DEFAULT_LOGS_TABLE },
+      timestampValueExpression: 'Timestamp',
+      connection: connection._id,
+      name: 'Logs',
+      serviceNameExpression: 'ServiceName',
+      severityTextExpression: 'SeverityText',
+      bodyExpression: 'Body',
+      defaultTableSelectExpression:
+        'Timestamp, ServiceName, SeverityText, Body',
+    });
+
+    const context: McpContext = {
+      teamId: team._id.toString(),
+      userId: user._id.toString(),
+    };
+    client = await createTestClient(context);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.clearDBs();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  describe('schema serialization', () => {
+    it('exposes hyperdx_event_deltas via tools/list with target + baseline groups', async () => {
+      const { tools } = await client.listTools();
+      const t = tools.find(t => t.name === 'hyperdx_event_deltas');
+      expect(t).toBeDefined();
+      const schema = t!.inputSchema;
+      const props = Object.keys(schema.properties ?? {});
+      expect(props).toContain('sourceId');
+      expect(props).toContain('target');
+      expect(props).toContain('baseline');
+      expect(props).toContain('topN');
+      expect(props).toContain('includeHidden');
+      expect(schema.required).toContain('sourceId');
+      expect(schema.required).toContain('target');
+      expect(schema.required).toContain('baseline');
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects target where endTime <= startTime', async () => {
+      const result = await callTool(client, 'hyperdx_event_deltas', {
+        sourceId: logSource._id.toString(),
+        target: {
+          startTime: '2026-05-10T01:00:00Z',
+          endTime: '2026-05-10T01:00:00Z',
+        },
+        baseline: {
+          startTime: '2026-05-10T00:00:00Z',
+          endTime: '2026-05-10T00:30:00Z',
+        },
+      });
+      expect(result.isError).toBeTruthy();
+      expect(getFirstText(result)).toMatch(/endTime must be greater/);
+    });
+  });
+
+  describe('algorithm against ClickHouse', () => {
+    beforeEach(async () => {
+      const now = Date.now();
+      const events: Array<{
+        Body: string;
+        ServiceName: string;
+        SeverityText: string;
+        Timestamp: Date;
+      }> = [];
+
+      // Baseline window (5–10 min ago): healthy mix — mostly INFO from
+      // service-a, a few from service-b. NO ERROR severity, NO failing rows.
+      for (let i = 0; i < 200; i++) {
+        events.push({
+          Body: `request handled ok id=${i}`,
+          ServiceName: i % 5 === 0 ? 'service-b' : 'service-a',
+          SeverityText: 'INFO',
+          Timestamp: new Date(now - 9 * 60_000 + i * 100),
+        });
+      }
+
+      // Target window (last 5 min): mostly ERROR from service-b.
+      // The DELTA between target and baseline should expose:
+      //   - SeverityText shifts to ERROR
+      //   - ServiceName shifts toward service-b
+      for (let i = 0; i < 200; i++) {
+        events.push({
+          Body: `request failed id=${i}`,
+          ServiceName: i % 5 === 0 ? 'service-a' : 'service-b',
+          SeverityText: 'ERROR',
+          Timestamp: new Date(now - 4 * 60_000 + i * 100),
+        });
+      }
+
+      await bulkInsertLogs(events);
+    });
+
+    it('ranks SeverityText and ServiceName as top differentiating properties', async () => {
+      const now = Date.now();
+      const result = await callTool(client, 'hyperdx_event_deltas', {
+        sourceId: logSource._id.toString(),
+        target: {
+          startTime: new Date(now - 5 * 60_000).toISOString(),
+          endTime: new Date(now).toISOString(),
+        },
+        baseline: {
+          startTime: new Date(now - 10 * 60_000).toISOString(),
+          endTime: new Date(now - 5 * 60_000).toISOString(),
+        },
+        sampleSize: 500,
+        topN: 10,
+      });
+
+      expect(result.isError).toBeFalsy();
+      const output = JSON.parse(getFirstText(result));
+      expect(output.summary.targetSampleCount).toBeGreaterThan(0);
+      expect(output.summary.baselineSampleCount).toBeGreaterThan(0);
+      expect(output.properties.length).toBeGreaterThan(0);
+
+      const topKeys = output.properties.map((p: { key: string }) => p.key);
+      // The two columns we deliberately shifted between groups must appear
+      // near the top of the ranking.
+      expect(topKeys).toEqual(
+        expect.arrayContaining(['SeverityText', 'ServiceName']),
+      );
+
+      const severity = output.properties.find(
+        (p: { key: string }) => p.key === 'SeverityText',
+      );
+      expect(severity).toBeDefined();
+      expect(severity.score).toBeGreaterThan(50);
+      // The response intentionally omits separate target.topValues /
+      // baseline.topValues — topDeltas covers the same data with per-value
+      // target%/baseline%/diff%. Confirm the data is still discoverable.
+      expect(severity.target).toBeUndefined();
+      expect(severity.baseline).toBeUndefined();
+      expect(severity.targetCount).toBeGreaterThan(0);
+      expect(severity.baselineCount).toBeGreaterThan(0);
+      const errorDelta = (
+        severity.topDeltas as Array<{
+          value: string;
+          targetPct: number;
+          baselinePct: number;
+        }>
+      ).find(v => v.value === 'ERROR');
+      expect(errorDelta).toBeDefined();
+      // Target window planted ERROR, baseline window planted INFO.
+      expect(errorDelta!.targetPct).toBeGreaterThan(errorDelta!.baselinePct);
+      const infoDelta = (
+        severity.topDeltas as Array<{
+          value: string;
+          targetPct: number;
+          baselinePct: number;
+        }>
+      ).find(v => v.value === 'INFO');
+      expect(infoDelta).toBeDefined();
+      expect(infoDelta!.baselinePct).toBeGreaterThan(infoDelta!.targetPct);
+    });
+
+    it('returns includeHidden:true with a hidden array containing high-cardinality / id fields', async () => {
+      const now = Date.now();
+      const result = await callTool(client, 'hyperdx_event_deltas', {
+        sourceId: logSource._id.toString(),
+        target: {
+          startTime: new Date(now - 5 * 60_000).toISOString(),
+          endTime: new Date(now).toISOString(),
+        },
+        baseline: {
+          startTime: new Date(now - 10 * 60_000).toISOString(),
+          endTime: new Date(now - 5 * 60_000).toISOString(),
+        },
+        sampleSize: 500,
+        topN: 5,
+        includeHidden: true,
+      });
+      expect(result.isError).toBeFalsy();
+      const output = JSON.parse(getFirstText(result));
+      // The Body column has unique strings per row → high cardinality → hidden.
+      // (Or empty if drain-ish dedup pushed cardinality below the threshold.)
+      expect(output).toHaveProperty('hidden');
+    });
+  });
+});

--- a/packages/api/src/mcp/__tests__/deltasTool.test.ts
+++ b/packages/api/src/mcp/__tests__/deltasTool.test.ts
@@ -107,8 +107,11 @@ describe('MCP Event Deltas Tool', () => {
   });
 
   describe('algorithm against ClickHouse', () => {
+    // Capture once so insert timestamps and query windows are consistent.
+    let now: number;
+
     beforeEach(async () => {
-      const now = Date.now();
+      now = Date.now();
       const events: Array<{
         Body: string;
         ServiceName: string;
@@ -144,7 +147,6 @@ describe('MCP Event Deltas Tool', () => {
     });
 
     it('ranks SeverityText and ServiceName as top differentiating properties', async () => {
-      const now = Date.now();
       const result = await callTool(client, 'hyperdx_event_deltas', {
         sourceId: logSource._id.toString(),
         target: {
@@ -206,7 +208,6 @@ describe('MCP Event Deltas Tool', () => {
     });
 
     it('returns includeHidden:true with a hidden array containing high-cardinality / id fields', async () => {
-      const now = Date.now();
       const result = await callTool(client, 'hyperdx_event_deltas', {
         sourceId: logSource._id.toString(),
         target: {
@@ -224,8 +225,13 @@ describe('MCP Event Deltas Tool', () => {
       expect(result.isError).toBeFalsy();
       const output = JSON.parse(getFirstText(result));
       // The Body column has unique strings per row → high cardinality → hidden.
-      // (Or empty if drain-ish dedup pushed cardinality below the threshold.)
       expect(output).toHaveProperty('hidden');
+      expect(output.hidden.length).toBeGreaterThan(0);
+      const bodyEntry = output.hidden.find(
+        (p: { key: string }) => p.key === 'Body',
+      );
+      expect(bodyEntry).toBeDefined();
+      expect(bodyEntry.hiddenReason).toBe('high_cardinality');
     });
   });
 });

--- a/packages/api/src/mcp/tools/query/eventDeltas.ts
+++ b/packages/api/src/mcp/tools/query/eventDeltas.ts
@@ -1,0 +1,527 @@
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
+import {
+  computeEffectiveSampleSize,
+  getStableSampleExpression,
+  rankProperties,
+  SAMPLE_SIZE,
+} from '@hyperdx/common-utils/dist/core/eventDeltas';
+import { getMetadata } from '@hyperdx/common-utils/dist/core/metadata';
+import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
+import {
+  type BuilderChartConfigWithDateRange,
+  DisplayType,
+  SourceKind,
+} from '@hyperdx/common-utils/dist/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { getConnectionById } from '@/controllers/connection';
+import { getSource } from '@/controllers/sources';
+
+import { asMcpText } from '../../utils/toon';
+import { withToolTracing } from '../../utils/tracing';
+import type { McpContext } from '../types';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const groupSchema = z.object({
+  startTime: z.string().describe('Start of the group window as ISO 8601.'),
+  endTime: z.string().describe('End of the group window as ISO 8601.'),
+  where: z
+    .string()
+    .optional()
+    .default('')
+    .describe(
+      'Optional row filter (Lucene by default, SQL via whereLanguage). ' +
+        'Combined with the time window via AND. Useful for restricting the ' +
+        'group to a service, endpoint, or other dimension.',
+    ),
+  whereLanguage: z
+    .enum(['lucene', 'sql'])
+    .optional()
+    .default('lucene')
+    .describe('Query language for where. Default: lucene.'),
+});
+
+const deltasSchema = z.object({
+  sourceId: z
+    .string()
+    .describe(
+      'Source ID. Works for trace and log sources. ' +
+        'Call hyperdx_list_sources for available sources.',
+    ),
+  target: groupSchema.describe(
+    'Target ("outlier") group — the rows you suspect are different (e.g. the ' +
+      'recent slow window, the failing requests, the affected segment).',
+  ),
+  baseline: groupSchema.describe(
+    'Baseline ("inlier") group — the rows considered normal (e.g. an earlier ' +
+      'healthy window, the successful requests, the unaffected segment).',
+  ),
+  sampleSize: z
+    .number()
+    .min(100)
+    .max(5000)
+    .optional()
+    .describe(
+      'Rows to sample from each group. Default: adaptive 500–5000 based on ' +
+        'group sizes. Larger samples give more stable rankings at the cost ' +
+        'of latency.',
+    ),
+  topN: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe(
+      'Number of top-ranked properties to return in `properties`. Default: 20.',
+    ),
+  includeHidden: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, include denylisted/high-cardinality properties in a separate ' +
+        '`hidden` array. Default: false (mirrors UI behavior — these are noisy).',
+    ),
+  topValuesPerProperty: z
+    .number()
+    .min(2)
+    .max(20)
+    .optional()
+    .default(6)
+    .describe(
+      'How many top values per property to include in the response. Default: 6.',
+    ),
+});
+
+type DeltasInput = z.infer<typeof deltasSchema>;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function parseGroupTimeRange(group: {
+  startTime: string;
+  endTime: string;
+}): { error: string } | { startDate: Date; endDate: Date } {
+  const startDate = new Date(group.startTime);
+  const endDate = new Date(group.endTime);
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    return {
+      error: `Invalid startTime/endTime — must be valid ISO 8601 strings.`,
+    };
+  }
+  if (endDate.getTime() <= startDate.getTime()) {
+    return { error: `endTime must be greater than startTime.` };
+  }
+  return { startDate, endDate };
+}
+
+function topDeltasForProperty(
+  key: string,
+  targetValues: Map<string, number>,
+  baselineValues: Map<string, number>,
+  targetTotal: number,
+  baselineTotal: number,
+  n: number,
+): Array<{
+  value: string;
+  targetPct: number;
+  baselinePct: number;
+  diffPct: number;
+}> {
+  const allValues = new Set([...targetValues.keys(), ...baselineValues.keys()]);
+  const out: Array<{
+    value: string;
+    targetPct: number;
+    baselinePct: number;
+    diffPct: number;
+  }> = [];
+  for (const value of allValues) {
+    const tCount = targetValues.get(value) ?? 0;
+    const bCount = baselineValues.get(value) ?? 0;
+    const tPct = targetTotal > 0 ? (tCount / targetTotal) * 100 : 0;
+    const bPct = baselineTotal > 0 ? (bCount / baselineTotal) * 100 : 0;
+    out.push({
+      value,
+      targetPct: tPct,
+      baselinePct: bPct,
+      diffPct: tPct - bPct,
+    });
+    void key;
+  }
+  out.sort((a, b) => Math.abs(b.diffPct) - Math.abs(a.diffPct));
+  return out.slice(0, n);
+}
+
+// ─── Tool definition ─────────────────────────────────────────────────────────
+
+export function registerEventDeltas(server: McpServer, context: McpContext) {
+  const { teamId } = context;
+
+  server.registerTool(
+    'hyperdx_event_deltas',
+    {
+      title: 'Compare Events: Target vs Baseline',
+      description:
+        'Rank the properties of two row groups (logs or trace spans) by ' +
+        'how much their value distributions differ. Same algorithm as the ' +
+        'in-app Event Deltas view (DBDeltaChart). High-cardinality fields ' +
+        '(IDs, request IDs, timestamps) are filtered out by default so the ' +
+        'ranking surfaces the categorical attributes that actually separate ' +
+        'the two groups. Score is computed after normalizing each group to ' +
+        "100% so it's robust to different group sizes.\n\n" +
+        'USE THIS INSTEAD OF MANUAL PIVOTS. When two row sets visibly differ ' +
+        "and you don't know which attribute(s) separate them, the standard " +
+        'agentic move is to run a GROUP BY for each candidate attribute and ' +
+        'compare. event_deltas does this for ALL attributes in one call, ' +
+        'ranked by signal strength — usually 1 call instead of 5–20.\n\n' +
+        'NARROW the target to the specific outlier rows. A broad target ' +
+        'mostly contains healthy rows, so the ranking comes back noisy. ' +
+        'The narrower target — the sharper the ranking.\n\n' +
+        'TYPICAL USES (any source — logs or traces):\n' +
+        '  - Slow vs fast spans (MOST COMMON for latency triage):\n' +
+        '      target = {where: <op-filter> AND Duration > <threshold>},\n' +
+        '      baseline = {where: <op-filter> AND Duration <= <threshold>}\n' +
+        '      Scope BOTH to the same operation/endpoint via `<op-filter>`; ' +
+        'the ranked attribute(s) are then what discriminates the slow ' +
+        'invocations of THAT operation from the fast ones. Skipping the ' +
+        'op-filter gives a noisy "which operation is slow" answer instead ' +
+        'of "which sub-set of one operation is slow".\n' +
+        '  - Before vs after a deploy / incident onset:\n' +
+        '      target = {window: after onset}, baseline = {window: before onset}\n' +
+        '  - Failing vs succeeding rows:\n' +
+        '      target = {where: <failing filter>}, baseline = {where: <succeeding filter>}\n' +
+        '  - One service / endpoint vs the rest:\n' +
+        '      target = {where: ServiceName=X}, baseline = {where: ServiceName != X}\n' +
+        '  Any pair of row sets over the same source works — the tool just ' +
+        '  asks "what is statistically different about target vs baseline".\n\n' +
+        'WHEN NOT TO USE: when the question is already known to be about a ' +
+        'specific attribute (use hyperdx_table groupBy), when you want raw ' +
+        'rows (use hyperdx_search), or when you need a time-series shape ' +
+        '(use hyperdx_timeseries).\n\n' +
+        'OUTPUT SHAPE: an array of properties, each with rank, key, score, ' +
+        'semanticBoost (true for well-known OTel attrs like service.name / ' +
+        'http.method / error.type / status), targetCount and baselineCount ' +
+        '(sample sizes), and topDeltas — the values whose share shifted ' +
+        'most, each with `value`, `targetPct`, `baselinePct`, and `diffPct`. ' +
+        'topDeltas already contains the full per-value comparison for that ' +
+        'attribute, so there is no separate target/baseline distribution to ' +
+        'consult.\n\n' +
+        'IMPORTANT — DO NOT STOP AT RANK 1. The top ~5 ranked properties ' +
+        'are often INDEPENDENT axes that together explain the population ' +
+        'shift (e.g. a regression localized on the intersection of two ' +
+        'attributes). Scan down the list until the score visibly drops to ' +
+        'noise level; any property well above that floor is a candidate axis ' +
+        'to combine with the others.',
+      inputSchema: deltasSchema,
+    },
+    withToolTracing(
+      'hyperdx_event_deltas',
+      context,
+      async (rawInput: DeltasInput) => {
+        const input = deltasSchema.parse(rawInput);
+
+        const targetRange = parseGroupTimeRange(input.target);
+        if ('error' in targetRange) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `target: ${targetRange.error}`,
+              },
+            ],
+          };
+        }
+        const baselineRange = parseGroupTimeRange(input.baseline);
+        if ('error' in baselineRange) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `baseline: ${baselineRange.error}`,
+              },
+            ],
+          };
+        }
+
+        // Refuse calls where target and baseline can't possibly produce a
+        // meaningful comparison. The agent presumably wanted to write
+        // something different on one side and didn't — flag it so the
+        // round-trip is short instead of returning empty deltas.
+        const targetWhere = (input.target.where ?? '').trim();
+        const baselineWhere = (input.baseline.where ?? '').trim();
+        const targetLang = input.target.whereLanguage ?? 'lucene';
+        const baselineLang = input.baseline.whereLanguage ?? 'lucene';
+        const sameWhere =
+          targetWhere === baselineWhere && targetLang === baselineLang;
+        const sameWindow =
+          targetRange.startDate.getTime() ===
+            baselineRange.startDate.getTime() &&
+          targetRange.endDate.getTime() === baselineRange.endDate.getTime();
+        if (sameWhere && sameWindow) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text:
+                  'target and baseline are identical (same where + same time ' +
+                  'window) — that yields nothing to compare. Pick distinct ' +
+                  'groups: e.g. (a) before vs after a step change in time, ' +
+                  '(b) failing rows vs succeeding rows, (c) slow spans ' +
+                  '(Duration > X) vs fast spans (Duration <= X) in the same ' +
+                  'window, or (d) one cohort vs the rest. At least one of ' +
+                  '`where` or the time window must differ between the two ' +
+                  'groups.',
+              },
+            ],
+          };
+        }
+
+        const source = await getSource(teamId.toString(), input.sourceId);
+        if (!source) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source not found: ${input.sourceId}. Call hyperdx_list_sources to find available source IDs.`,
+              },
+            ],
+          };
+        }
+        if (
+          source.kind !== SourceKind.Trace &&
+          source.kind !== SourceKind.Log
+        ) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source ${input.sourceId} is kind="${source.kind}". hyperdx_event_deltas requires a trace or log source.`,
+              },
+            ],
+          };
+        }
+
+        const connection = await getConnectionById(
+          teamId.toString(),
+          source.connection.toString(),
+          true,
+        );
+        if (!connection) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Connection not found for source: ${input.sourceId}`,
+              },
+            ],
+          };
+        }
+
+        const clickhouseClient = new ClickhouseClient({
+          host: connection.host,
+          username: connection.username,
+          password: connection.password,
+        });
+        const metadata = getMetadata(clickhouseClient);
+
+        // Build a stable per-source ORDER BY for sampling (matches what the
+        // app does — uses spanIdExpression on traces, falls back to rand()).
+        const stableSampleExpr =
+          'spanIdExpression' in source
+            ? getStableSampleExpression(source.spanIdExpression)
+            : 'rand()';
+
+        // Adaptive sample size — prefer caller's value, otherwise fall back to
+        // the algorithm's default. The sampling target rows should be similar
+        // in count to the baseline so neither group dominates the percentages.
+        const sampleSize =
+          input.sampleSize ?? computeEffectiveSampleSize(SAMPLE_SIZE * 10);
+
+        const buildSampleConfig = (
+          group: { where: string; whereLanguage: 'lucene' | 'sql' },
+          startDate: Date,
+          endDate: Date,
+        ): BuilderChartConfigWithDateRange => ({
+          displayType: DisplayType.Search,
+          // SELECT * so the algorithm sees all columns (it flattens nested
+          // Maps/Arrays internally).
+          select: '*',
+          from: source.from,
+          where: group.where,
+          whereLanguage: group.where ? group.whereLanguage : 'sql',
+          connection: source.connection.toString(),
+          timestampValueExpression: source.timestampValueExpression,
+          implicitColumnExpression: source.implicitColumnExpression,
+          orderBy: stableSampleExpr,
+          limit: { limit: sampleSize },
+          dateRange: [startDate, endDate],
+        });
+
+        const targetConfig = buildSampleConfig(
+          input.target,
+          targetRange.startDate,
+          targetRange.endDate,
+        );
+        const baselineConfig = buildSampleConfig(
+          input.baseline,
+          baselineRange.startDate,
+          baselineRange.endDate,
+        );
+
+        let targetSql, baselineSql;
+        try {
+          [targetSql, baselineSql] = await Promise.all([
+            renderChartConfig(targetConfig, metadata, source.querySettings),
+            renderChartConfig(baselineConfig, metadata, source.querySettings),
+          ]);
+        } catch (e) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Failed to build sample queries: ${e instanceof Error ? e.message : String(e)}`,
+              },
+            ],
+          };
+        }
+
+        // ClickHouse columns metadata for denylist + cardinality classification.
+        let columnMeta: { name: string; type: string }[] = [];
+        try {
+          const cols = await metadata.getColumns({
+            databaseName: source.from.databaseName,
+            tableName: source.from.tableName,
+            connectionId: source.connection.toString(),
+          });
+          columnMeta = cols.map(c => ({ name: c.name, type: c.type }));
+        } catch {
+          // Without column meta the algorithm just won't denylist anything —
+          // not fatal.
+        }
+
+        let targetRows: Record<string, any>[];
+        let baselineRows: Record<string, any>[];
+        try {
+          const [targetRes, baselineRes] = await Promise.all([
+            clickhouseClient.query({
+              query: targetSql.sql,
+              query_params: targetSql.params,
+              format: 'JSON',
+              connectionId: source.connection.toString(),
+            }),
+            clickhouseClient.query({
+              query: baselineSql.sql,
+              query_params: baselineSql.params,
+              format: 'JSON',
+              connectionId: source.connection.toString(),
+            }),
+          ]);
+          const targetJson = (await (
+            targetRes as { json: () => Promise<{ data: any[] }> }
+          ).json()) ?? { data: [] };
+          const baselineJson = (await (
+            baselineRes as { json: () => Promise<{ data: any[] }> }
+          ).json()) ?? { data: [] };
+          targetRows = targetJson.data ?? [];
+          baselineRows = baselineJson.data ?? [];
+        } catch (e) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Failed to sample rows: ${e instanceof Error ? e.message : String(e)}`,
+              },
+            ],
+          };
+        }
+
+        const ranked = rankProperties({
+          targetRows,
+          baselineRows,
+          columnMeta,
+        });
+
+        const visible = ranked.ranked.filter(p => !p.hidden);
+        const hidden = ranked.ranked.filter(p => p.hidden);
+
+        const renderEntry = (
+          rank: number,
+          p: (typeof ranked.ranked)[number],
+        ) => {
+          const tValues =
+            ranked.targetStats.valueOccurences.get(p.key) ??
+            new Map<string, number>();
+          const bValues =
+            ranked.baselineStats.valueOccurences.get(p.key) ??
+            new Map<string, number>();
+          const tTotal = ranked.targetStats.propertyOccurences.get(p.key) ?? 0;
+          const bTotal =
+            ranked.baselineStats.propertyOccurences.get(p.key) ?? 0;
+          // Compact entry: topDeltas already contains every value's
+          // target%/baseline%/diff%, so the previously-emitted nested
+          // `target.topValues` / `baseline.topValues` were redundant
+          // (~60% of the response payload). Keep the flat sample counts
+          // so the agent can size-check the comparison.
+          return {
+            rank,
+            key: p.key,
+            score: p.score,
+            semanticBoost: p.semanticBoost > 0,
+            targetCount: tTotal,
+            baselineCount: bTotal,
+            ...(p.hidden ? { hiddenReason: p.hiddenReason } : {}),
+            topDeltas: topDeltasForProperty(
+              p.key,
+              tValues,
+              bValues,
+              tTotal,
+              bTotal,
+              input.topValuesPerProperty,
+            ),
+          };
+        };
+
+        const properties = visible
+          .slice(0, input.topN)
+          .map((p, i) => renderEntry(i + 1, p));
+        const hiddenEntries = input.includeHidden
+          ? hidden.slice(0, input.topN).map((p, i) => renderEntry(i + 1, p))
+          : undefined;
+
+        const output = {
+          summary: {
+            sampleSize,
+            targetSampleCount: targetRows.length,
+            baselineSampleCount: baselineRows.length,
+            propertiesScored: ranked.ranked.length,
+            propertiesVisible: visible.length,
+            propertiesHidden: hidden.length,
+          },
+          properties,
+          ...(hiddenEntries ? { hidden: hiddenEntries } : {}),
+          usage:
+            'score is the maximum %-share difference of any value between target ' +
+            'and baseline (after normalizing each group to 100%), plus a 0.1 ' +
+            'tiebreaker boost for well-known OTel attributes. ' +
+            'Properties with `semanticBoost: true` are well-known OTel attrs. ' +
+            'Hidden properties (ID/timestamp arrays + high-cardinality fields) ' +
+            'are dropped by default — set includeHidden:true to inspect them.',
+        };
+
+        return {
+          content: [asMcpText(output)],
+        };
+      },
+    ),
+  );
+}

--- a/packages/api/src/mcp/tools/query/eventDeltas.ts
+++ b/packages/api/src/mcp/tools/query/eventDeltas.ts
@@ -1,7 +1,6 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import {
   getStableSampleExpression,
-  MIN_SAMPLE_SIZE,
   rankProperties,
 } from '@hyperdx/common-utils/dist/core/eventDeltas';
 import { getMetadata } from '@hyperdx/common-utils/dist/core/metadata';
@@ -61,6 +60,7 @@ const deltasSchema = z.object({
     .min(100)
     .max(5000)
     .optional()
+    .default(500)
     .describe(
       'Rows to sample from each group. Default: 500. Larger samples give ' +
         'more stable rankings at the cost of latency.',
@@ -214,9 +214,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
     withToolTracing(
       'hyperdx_event_deltas',
       context,
-      async (rawInput: DeltasInput) => {
-        const input = deltasSchema.parse(rawInput);
-
+      async (input: DeltasInput) => {
         const targetRange = parseGroupTimeRange(input.target);
         if ('error' in targetRange) {
           return {
@@ -330,11 +328,11 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
         // Build a stable per-source ORDER BY for sampling (matches what the
         // app does — uses spanIdExpression on traces, falls back to rand()).
         const stableSampleExpr =
-          'spanIdExpression' in source
+          source.kind === SourceKind.Trace
             ? getStableSampleExpression(source.spanIdExpression)
             : 'rand()';
 
-        const sampleSize = input.sampleSize ?? MIN_SAMPLE_SIZE;
+        const sampleSize = input.sampleSize;
 
         const buildSampleConfig = (
           group: { where: string; whereLanguage: 'lucene' | 'sql' },
@@ -414,6 +412,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
 
         let targetRows: Record<string, any>[];
         let baselineRows: Record<string, any>[];
+        const abortController = new AbortController();
         try {
           const [targetRes, baselineRes] = await Promise.all([
             clickhouseClient.query({
@@ -422,6 +421,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
               format: 'JSON',
               connectionId: source.connection.toString(),
               clickhouse_settings: { max_execution_time: 30 },
+              abort_signal: abortController.signal,
             }),
             clickhouseClient.query({
               query: baselineSql.sql,
@@ -429,6 +429,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
               format: 'JSON',
               connectionId: source.connection.toString(),
               clickhouse_settings: { max_execution_time: 30 },
+              abort_signal: abortController.signal,
             }),
           ]);
           const targetJson = (await (
@@ -440,6 +441,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
           targetRows = targetJson.data ?? [];
           baselineRows = baselineJson.data ?? [];
         } catch (e) {
+          abortController.abort();
           return {
             isError: true as const,
             content: [
@@ -500,7 +502,9 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
           .slice(0, input.topN)
           .map((p, i) => renderEntry(i + 1, p));
         const hiddenEntries = input.includeHidden
-          ? hidden.slice(0, input.topN).map((p, i) => renderEntry(i + 1, p))
+          ? hidden
+              .slice(0, input.topN)
+              .map((p, i) => renderEntry(properties.length + i + 1, p))
           : undefined;
 
         const output = {
@@ -512,6 +516,13 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             propertiesVisible: visible.length,
             propertiesHidden: hidden.length,
             ...(columnMetaUnavailable ? { columnMetaUnavailable: true } : {}),
+            ...(targetRows.length === 0 || baselineRows.length === 0
+              ? {
+                  warning:
+                    'One or both groups returned 0 rows — verify the time ' +
+                    'window and where filter via hyperdx_search.',
+                }
+              : {}),
           },
           properties,
           ...(hiddenEntries ? { hidden: hiddenEntries } : {}),
@@ -525,9 +536,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
         };
 
         return {
-          content: [
-            { type: 'text' as const, text: JSON.stringify(output, null, 2) },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify(output) }],
         };
       },
     ),

--- a/packages/api/src/mcp/tools/query/eventDeltas.ts
+++ b/packages/api/src/mcp/tools/query/eventDeltas.ts
@@ -18,7 +18,6 @@ import { z } from 'zod';
 import { getConnectionById } from '@/controllers/connection';
 import { getSource } from '@/controllers/sources';
 
-import { asMcpText } from '../../utils/toon';
 import { withToolTracing } from '../../utils/tracing';
 import type { McpContext } from '../types';
 
@@ -519,7 +518,9 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
         };
 
         return {
-          content: [asMcpText(output)],
+          content: [
+            { type: 'text' as const, text: JSON.stringify(output, null, 2) },
+          ],
         };
       },
     ),

--- a/packages/api/src/mcp/tools/query/eventDeltas.ts
+++ b/packages/api/src/mcp/tools/query/eventDeltas.ts
@@ -15,9 +15,11 @@ import { z } from 'zod';
 
 import { getConnectionById } from '@/controllers/connection';
 import { getSource } from '@/controllers/sources';
+import { trimToolResponse } from '@/utils/trimToolResponse';
 
 import { withToolTracing } from '../../utils/tracing';
 import type { McpContext } from '../types';
+import { parseTimeRange } from './helpers';
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 
@@ -96,23 +98,6 @@ const deltasSchema = z.object({
 type DeltasInput = z.infer<typeof deltasSchema>;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function parseGroupTimeRange(group: {
-  startTime: string;
-  endTime: string;
-}): { error: string } | { startDate: Date; endDate: Date } {
-  const startDate = new Date(group.startTime);
-  const endDate = new Date(group.endTime);
-  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-    return {
-      error: `Invalid startTime/endTime — must be valid ISO 8601 strings.`,
-    };
-  }
-  if (endDate.getTime() <= startDate.getTime()) {
-    return { error: `endTime must be greater than startTime.` };
-  }
-  return { startDate, endDate };
-}
 
 function topDeltasForProperty(
   targetValues: Map<string, number>,
@@ -215,7 +200,10 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
       'hyperdx_event_deltas',
       context,
       async (input: DeltasInput) => {
-        const targetRange = parseGroupTimeRange(input.target);
+        const targetRange = parseTimeRange(
+          input.target.startTime,
+          input.target.endTime,
+        );
         if ('error' in targetRange) {
           return {
             isError: true as const,
@@ -227,7 +215,10 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             ],
           };
         }
-        const baselineRange = parseGroupTimeRange(input.baseline);
+        const baselineRange = parseTimeRange(
+          input.baseline.startTime,
+          input.baseline.endTime,
+        );
         if ('error' in baselineRange) {
           return {
             isError: true as const,
@@ -535,8 +526,15 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             'are dropped by default — set includeHidden:true to inspect them.',
         };
 
+        const trimmedOutput = trimToolResponse(output);
+
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(output) }],
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(trimmedOutput, null, 2),
+            },
+          ],
         };
       },
     ),

--- a/packages/api/src/mcp/tools/query/eventDeltas.ts
+++ b/packages/api/src/mcp/tools/query/eventDeltas.ts
@@ -1,9 +1,8 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import {
-  computeEffectiveSampleSize,
   getStableSampleExpression,
+  MIN_SAMPLE_SIZE,
   rankProperties,
-  SAMPLE_SIZE,
 } from '@hyperdx/common-utils/dist/core/eventDeltas';
 import { getMetadata } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
@@ -63,9 +62,8 @@ const deltasSchema = z.object({
     .max(5000)
     .optional()
     .describe(
-      'Rows to sample from each group. Default: adaptive 500–5000 based on ' +
-        'group sizes. Larger samples give more stable rankings at the cost ' +
-        'of latency.',
+      'Rows to sample from each group. Default: 500. Larger samples give ' +
+        'more stable rankings at the cost of latency.',
     ),
   topN: z
     .number()
@@ -117,7 +115,6 @@ function parseGroupTimeRange(group: {
 }
 
 function topDeltasForProperty(
-  key: string,
   targetValues: Map<string, number>,
   baselineValues: Map<string, number>,
   targetTotal: number,
@@ -147,7 +144,6 @@ function topDeltasForProperty(
       baselinePct: bPct,
       diffPct: tPct - bPct,
     });
-    void key;
   }
   out.sort((a, b) => Math.abs(b.diffPct) - Math.abs(a.diffPct));
   return out.slice(0, n);
@@ -338,11 +334,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             ? getStableSampleExpression(source.spanIdExpression)
             : 'rand()';
 
-        // Adaptive sample size — prefer caller's value, otherwise fall back to
-        // the algorithm's default. The sampling target rows should be similar
-        // in count to the baseline so neither group dominates the percentages.
-        const sampleSize =
-          input.sampleSize ?? computeEffectiveSampleSize(SAMPLE_SIZE * 10);
+        const sampleSize = input.sampleSize ?? MIN_SAMPLE_SIZE;
 
         const buildSampleConfig = (
           group: { where: string; whereLanguage: 'lucene' | 'sql' },
@@ -358,7 +350,10 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
           whereLanguage: group.where ? group.whereLanguage : 'sql',
           connection: source.connection.toString(),
           timestampValueExpression: source.timestampValueExpression,
-          implicitColumnExpression: source.implicitColumnExpression,
+          implicitColumnExpression:
+            'implicitColumnExpression' in source
+              ? source.implicitColumnExpression
+              : undefined,
           orderBy: stableSampleExpr,
           limit: { limit: sampleSize },
           dateRange: [startDate, endDate],
@@ -375,12 +370,36 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
           baselineRange.endDate,
         );
 
+        // Run renderChartConfig for both groups and getColumns in parallel —
+        // they're independent and each hits ClickHouse metadata.
         let targetSql, baselineSql;
+        let columnMeta: { name: string; type: string }[] = [];
+        let columnMetaUnavailable = false;
         try {
-          [targetSql, baselineSql] = await Promise.all([
+          const [targetResult, baselineResult, colsResult] = await Promise.all([
             renderChartConfig(targetConfig, metadata, source.querySettings),
             renderChartConfig(baselineConfig, metadata, source.querySettings),
+            metadata
+              .getColumns({
+                databaseName: source.from.databaseName,
+                tableName: source.from.tableName,
+                connectionId: source.connection.toString(),
+              })
+              .catch(() => null),
           ]);
+          targetSql = targetResult;
+          baselineSql = baselineResult;
+          if (colsResult) {
+            columnMeta = colsResult.map(c => ({
+              name: c.name,
+              type: c.type,
+            }));
+          } else {
+            // Without column meta the algorithm just won't denylist anything —
+            // not fatal, but signal it in the response so the agent knows
+            // high-cardinality / ID fields may appear in the ranking.
+            columnMetaUnavailable = true;
+          }
         } catch (e) {
           return {
             isError: true as const,
@@ -393,20 +412,6 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
           };
         }
 
-        // ClickHouse columns metadata for denylist + cardinality classification.
-        let columnMeta: { name: string; type: string }[] = [];
-        try {
-          const cols = await metadata.getColumns({
-            databaseName: source.from.databaseName,
-            tableName: source.from.tableName,
-            connectionId: source.connection.toString(),
-          });
-          columnMeta = cols.map(c => ({ name: c.name, type: c.type }));
-        } catch {
-          // Without column meta the algorithm just won't denylist anything —
-          // not fatal.
-        }
-
         let targetRows: Record<string, any>[];
         let baselineRows: Record<string, any>[];
         try {
@@ -416,12 +421,14 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
               query_params: targetSql.params,
               format: 'JSON',
               connectionId: source.connection.toString(),
+              clickhouse_settings: { max_execution_time: 30 },
             }),
             clickhouseClient.query({
               query: baselineSql.sql,
               query_params: baselineSql.params,
               format: 'JSON',
               connectionId: source.connection.toString(),
+              clickhouse_settings: { max_execution_time: 30 },
             }),
           ]);
           const targetJson = (await (
@@ -480,7 +487,6 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             baselineCount: bTotal,
             ...(p.hidden ? { hiddenReason: p.hiddenReason } : {}),
             topDeltas: topDeltasForProperty(
-              p.key,
               tValues,
               bValues,
               tTotal,
@@ -505,6 +511,7 @@ export function registerEventDeltas(server: McpServer, context: McpContext) {
             propertiesScored: ranked.ranked.length,
             propertiesVisible: visible.length,
             propertiesHidden: hidden.length,
+            ...(columnMetaUnavailable ? { columnMetaUnavailable: true } : {}),
           },
           properties,
           ...(hiddenEntries ? { hidden: hiddenEntries } : {}),

--- a/packages/api/src/mcp/tools/query/helpers.ts
+++ b/packages/api/src/mcp/tools/query/helpers.ts
@@ -62,8 +62,8 @@ export function parseTimeRange(
       error: 'Invalid startTime or endTime: must be valid ISO 8601 strings',
     };
   }
-  if (startDate > endDate) {
-    return { error: 'startTime must not be after endTime' };
+  if (startDate >= endDate) {
+    return { error: 'endTime must be greater than startTime' };
   }
   return { startDate, endDate };
 }

--- a/packages/api/src/mcp/tools/query/index.ts
+++ b/packages/api/src/mcp/tools/query/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import type { McpContext, ToolDefinition } from '../types';
+import { registerEventDeltas } from './eventDeltas';
 import { registerEventPatterns } from './eventPatterns';
 import { registerSearch } from './search';
 import { registerSql } from './sql';
@@ -12,6 +13,7 @@ const queryTools: ToolDefinition = (server: McpServer, context: McpContext) => {
   registerTable(server, context);
   registerSearch(server, context);
   registerEventPatterns(server, context);
+  registerEventDeltas(server, context);
   registerSql(server, context);
 };
 

--- a/packages/app/src/components/deltaChartUtils.ts
+++ b/packages/app/src/components/deltaChartUtils.ts
@@ -13,7 +13,6 @@
 export {
   computeComparisonScore,
   computeEffectiveSampleSize,
-  flattenData,
   getBaseColumnName,
   getPropertyStatistics,
   getStableSampleExpression,
@@ -22,9 +21,7 @@ export {
   isIdField,
   isTimestampArrayField,
   MAX_SAMPLE_SIZE,
-  MIN_PROPERTY_OCCURENCES,
   MIN_SAMPLE_SIZE,
-  rankProperties,
   SAMPLE_RATIO,
   SAMPLE_SIZE,
   semanticBoost,

--- a/packages/app/src/components/deltaChartUtils.ts
+++ b/packages/app/src/components/deltaChartUtils.ts
@@ -1,87 +1,39 @@
 /**
- * Utility functions for DBDeltaChart.
- * Pure helpers with no React dependencies — safe to import from tests.
+ * UI helpers for DBDeltaChart.
+ *
+ * Pure algorithm functions (flattenData, getPropertyStatistics,
+ * computeComparisonScore, semanticBoost, isDenylisted, isHighCardinality,
+ * sample-size helpers, rankProperties) live in
+ * @hyperdx/common-utils/dist/core/eventDeltas so the MCP server can run the
+ * same algorithm. This file re-exports them for backwards compatibility plus
+ * the bits that are React/UI-specific (constants, AddFilterFn type, the
+ * SQL/filter key conversion helpers that depend on UI semantics).
  */
 
-// Recursively flattens nested objects/arrays into dot-notation keys.
-// Empty objects produce an empty {} entry; empty arrays produce an empty [] entry.
-// Based on https://stackoverflow.com/a/19101235
-function flattenData(data: Record<string, any>) {
-  const result: Record<string, any> = {};
-  function recurse(cur: Record<string, any>, prop: string) {
-    if (Object(cur) !== cur) {
-      result[prop] = cur;
-    } else if (Array.isArray(cur)) {
-      let l;
-      for (let i = 0, l = cur.length; i < l; i++)
-        recurse(cur[i], prop + '[' + i + ']');
-      if (l == 0) result[prop] = [];
-    } else {
-      let isEmpty = true;
-      for (const p in cur) {
-        isEmpty = false;
-        recurse(cur[p], prop ? prop + '.' + p : p);
-      }
-      if (isEmpty && prop) result[prop] = {};
-    }
-  }
-  recurse(data, '');
-  return result;
-}
+export {
+  computeComparisonScore,
+  computeEffectiveSampleSize,
+  flattenData,
+  getBaseColumnName,
+  getPropertyStatistics,
+  getStableSampleExpression,
+  isDenylisted,
+  isHighCardinality,
+  isIdField,
+  isTimestampArrayField,
+  MAX_SAMPLE_SIZE,
+  MIN_PROPERTY_OCCURENCES,
+  MIN_SAMPLE_SIZE,
+  rankProperties,
+  SAMPLE_RATIO,
+  SAMPLE_SIZE,
+  semanticBoost,
+  stripTypeWrappers,
+} from '@hyperdx/common-utils/dist/core/eventDeltas';
 
-export function getPropertyStatistics(data: Record<string, any>[]) {
-  const flattened = data.map(flattenData);
-  const propertyOccurences = new Map<string, number>();
-
-  const MIN_PROPERTY_OCCURENCES = 5;
-  const commonProperties = new Set<string>();
-
-  flattened.forEach(item => {
-    Object.entries(item).forEach(([key]) => {
-      const count = propertyOccurences.get(key) || 0;
-      propertyOccurences.set(key, count + 1);
-
-      if (count + 1 >= MIN_PROPERTY_OCCURENCES) {
-        commonProperties.add(key);
-      }
-    });
-  });
-
-  // property -> (value -> count)
-  const valueOccurences = new Map<string, Map<string, number>>();
-  flattened.forEach(item => {
-    Object.entries(item).forEach(([key, value]) => {
-      if (commonProperties.has(key)) {
-        let valuesMap = valueOccurences.get(key);
-        if (!valuesMap) {
-          valuesMap = new Map<string, number>();
-          valueOccurences.set(key, valuesMap);
-        }
-
-        const valueCount = valuesMap.get(value) || 0;
-        valuesMap.set(value, valueCount + 1);
-      }
-    });
-  });
-
-  const percentageOccurences = new Map<string, Map<string, number>>();
-  valueOccurences.forEach((valuesMap, property) => {
-    const percentageMap = new Map<string, number>();
-    valuesMap.forEach((valueCount, value) => {
-      percentageMap.set(
-        value,
-        (valueCount / (propertyOccurences.get(property) ?? 0)) * 100,
-      );
-    });
-    percentageOccurences.set(property, percentageMap);
-  });
-
-  return {
-    percentageOccurences,
-    propertyOccurences,
-    valueOccurences,
-  };
-}
+// ---------------------------------------------------------------------------
+// UI-only helpers
+// ---------------------------------------------------------------------------
 
 // Maximum number of distinct values to show in a chart before collapsing
 // the rest into an "Other (N)" bucket. The effective limit adapts: when the
@@ -167,8 +119,11 @@ export function applyTopNAggregation(
 }
 
 // ---------------------------------------------------------------------------
-// Filter key conversion helpers
+// Filter key conversion helpers (UI-specific — produce ClickHouse SQL
+// expressions / filter keys for the search bar).
 // ---------------------------------------------------------------------------
+
+import { stripTypeWrappers } from '@hyperdx/common-utils/dist/core/eventDeltas';
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -230,10 +185,6 @@ export function flattenedKeyToFilterKey(
   key: string,
   columnMeta: { name: string; type: string }[],
 ): string {
-  // Delegates to flattenedKeyToSqlExpression for now — both produce bracket
-  // notation for Map columns. Kept as a separate entry point so filter keys
-  // can diverge from SQL expressions in the future (e.g., different format
-  // for sidebar facets vs WHERE clause for Array(Map) columns).
   return flattenedKeyToSqlExpression(key, columnMeta);
 }
 
@@ -244,215 +195,8 @@ export type AddFilterFn = (
 ) => void;
 
 // ---------------------------------------------------------------------------
-// Field classification helpers
+// Entropy scoring (UI-only — used for distribution mode sorting, not by MCP)
 // ---------------------------------------------------------------------------
-
-/**
- * Extracts the base column name from a flattened key.
- * Strips array indices (e.g., "Events.Name[0]" → "Events.Name").
- * Returns null for keys with sub-keys after array indices (e.g., "Events.Attributes[0].spanId").
- */
-export function getBaseColumnName(key: string): string | null {
-  const arrMatch = key.match(/^([^[]+)\[(\d+)\]$/);
-  return arrMatch ? arrMatch[1] : key.includes('[') ? null : key;
-}
-
-/** Removes `LowCardinality(...)` and `Nullable(...)` wrappers from ClickHouse type strings. */
-export function stripTypeWrappers(type: string): string {
-  let t = type.trim();
-  let changed = true;
-  while (changed) {
-    changed = false;
-    if (t.startsWith('LowCardinality(') && t.endsWith(')')) {
-      t = t.slice('LowCardinality('.length, -1).trim();
-      changed = true;
-    } else if (t.startsWith('Nullable(') && t.endsWith(')')) {
-      t = t.slice('Nullable('.length, -1).trim();
-      changed = true;
-    }
-  }
-  return t;
-}
-
-/**
- * Returns true if the field is a structural ID field that should always be hidden.
- * Matches top-level String columns or Array(String) elements ending in "Id"/"ID".
- */
-export function isIdField(
-  key: string,
-  columnMeta: { name: string; type: string }[],
-): boolean {
-  const colName = getBaseColumnName(key);
-  if (!colName) return false;
-  if (!/(Id|ID)$/.test(colName)) return false;
-
-  const col = columnMeta.find(c => c.name === colName);
-  if (!col) return false;
-  const baseType = stripTypeWrappers(col.type);
-  if (baseType === 'String') return true;
-  if (baseType.startsWith('Array(')) {
-    const innerType = stripTypeWrappers(baseType.slice('Array('.length, -1));
-    return innerType === 'String';
-  }
-  return false;
-}
-
-/**
- * Returns true if the field is a per-index timestamp array element
- * (e.g., Events.Timestamp[0]) from a column of type Array(DateTime64(...)).
- */
-export function isTimestampArrayField(
-  key: string,
-  columnMeta: { name: string; type: string }[],
-): boolean {
-  const colName = getBaseColumnName(key);
-  if (!colName) return false;
-
-  const col = columnMeta.find(c => c.name === colName);
-  if (!col) return false;
-  const baseType = stripTypeWrappers(col.type);
-  if (!baseType.startsWith('Array(')) return false;
-  const innerType = stripTypeWrappers(baseType.slice('Array('.length, -1));
-  return innerType.startsWith('DateTime64(');
-}
-
-/**
- * Returns true if the field should always be hidden (ID fields + timestamp arrays).
- */
-export function isDenylisted(
-  key: string,
-  columnMeta: { name: string; type: string }[],
-): boolean {
-  return isIdField(key, columnMeta) || isTimestampArrayField(key, columnMeta);
-}
-
-/**
- * Returns true if the field has high cardinality (most values unique).
- * Uses min(outlierUniqueness, inlierUniqueness) > 0.9 with combined sample > 20.
- */
-export function isHighCardinality(
-  key: string,
-  outlierValueOccurences: Map<string, Map<string, number>>,
-  inlierValueOccurences: Map<string, Map<string, number>>,
-  outlierPropertyOccurences: Map<string, number>,
-  inlierPropertyOccurences: Map<string, number>,
-): boolean {
-  const outlierTotal = outlierPropertyOccurences.get(key) ?? 0;
-  const inlierTotal = inlierPropertyOccurences.get(key) ?? 0;
-  const combinedSampleSize = outlierTotal + inlierTotal;
-  if (combinedSampleSize <= 20) return false;
-
-  const outlierUniqueValues = outlierValueOccurences.get(key)?.size ?? 0;
-  const inlierUniqueValues = inlierValueOccurences.get(key)?.size ?? 0;
-
-  const outlierUniqueness =
-    outlierTotal > 0 ? outlierUniqueValues / outlierTotal : null;
-  const inlierUniqueness =
-    inlierTotal > 0 ? inlierUniqueValues / inlierTotal : null;
-
-  let effectiveUniqueness: number;
-  if (outlierUniqueness !== null && inlierUniqueness !== null) {
-    effectiveUniqueness = Math.min(outlierUniqueness, inlierUniqueness);
-  } else if (outlierUniqueness !== null) {
-    effectiveUniqueness = outlierUniqueness;
-  } else if (inlierUniqueness !== null) {
-    effectiveUniqueness = inlierUniqueness;
-  } else {
-    return false;
-  }
-
-  return effectiveUniqueness > 0.9;
-}
-
-// ---------------------------------------------------------------------------
-// Sampling configuration
-// ---------------------------------------------------------------------------
-
-/** Default number of rows sampled when the total count is unknown */
-export const SAMPLE_SIZE = 1000;
-
-/** Minimum number of rows to sample */
-export const MIN_SAMPLE_SIZE = 500;
-
-/** Maximum number of rows to sample */
-export const MAX_SAMPLE_SIZE = 5000;
-
-/** Fraction of total rows to sample (e.g., 0.01 = 1%) */
-export const SAMPLE_RATIO = 0.01;
-
-/**
- * Builds a deterministic ORDER BY expression for stable sampling.
- * Uses the source's spanIdExpression when available, falls back to rand().
- */
-export function getStableSampleExpression(spanIdExpression?: string): string {
-  if (spanIdExpression) {
-    return `cityHash64(${spanIdExpression})`;
-  }
-  return 'rand()';
-}
-
-/**
- * Computes the effective sample size based on total row count.
- * Adaptive formula: clamp(MIN_SAMPLE_SIZE, ceil(totalCount * SAMPLE_RATIO), MAX_SAMPLE_SIZE).
- * Returns SAMPLE_SIZE as fallback when totalCount is 0 or unavailable.
- */
-export function computeEffectiveSampleSize(totalCount: number): number {
-  if (totalCount <= 0) return SAMPLE_SIZE;
-  return Math.min(
-    MAX_SAMPLE_SIZE,
-    Math.max(MIN_SAMPLE_SIZE, Math.ceil(totalCount * SAMPLE_RATIO)),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Attribute sorting and scoring
-// ---------------------------------------------------------------------------
-
-/**
- * Comparison mode scoring: normalizes each group's percentages to sum to 100%
- * before computing max delta. Fields with identical proportional distributions
- * score 0 regardless of coverage rate differences.
- */
-export function computeComparisonScore(
-  outlierValues: Map<string, number>,
-  inlierValues: Map<string, number>,
-): number {
-  const allValues = new Set([...outlierValues.keys(), ...inlierValues.keys()]);
-  if (allValues.size === 0) return 0;
-
-  let outlierSum = 0;
-  let inlierSum = 0;
-  outlierValues.forEach(v => (outlierSum += v));
-  inlierValues.forEach(v => (inlierSum += v));
-
-  if (outlierSum === 0 && inlierSum === 0) return 0;
-  if (outlierSum === 0 || inlierSum === 0) {
-    // One group has data, the other doesn't.
-    const presentValues = outlierSum > 0 ? outlierValues : inlierValues;
-    // Single value with no comparison group is uninformative — score 0.
-    // (e.g., Events.Name[N] = "message" at 100% with no inlier data)
-    // Multi-value fields with no comparison group ARE informative — they show
-    // that the present group has a distinctive distribution.
-    if (presentValues.size <= 1) return 0;
-    // Normalize to [0, 100] so the score is scale-consistent with the two-group case.
-    const presentSum = outlierSum > 0 ? outlierSum : inlierSum;
-    let maxNormPct = 0;
-    presentValues.forEach(v => {
-      const pct = (v / presentSum) * 100;
-      if (pct > maxNormPct) maxNormPct = pct;
-    });
-    return maxNormPct;
-  }
-
-  let maxDelta = 0;
-  allValues.forEach(value => {
-    const outlierNorm = ((outlierValues.get(value) ?? 0) / outlierSum) * 100;
-    const inlierNorm = ((inlierValues.get(value) ?? 0) / inlierSum) * 100;
-    const delta = Math.abs(outlierNorm - inlierNorm);
-    if (delta > maxDelta) maxDelta = delta;
-  });
-  return maxDelta;
-}
 
 /**
  * Shannon entropy-based distribution score for sorting properties.
@@ -483,37 +227,4 @@ export function computeEntropyScore(
   if (maxEntropy === 0) return 0;
 
   return 1 - entropy / maxEntropy;
-}
-
-/** Well-known OTel attribute suffixes that get a score boost */
-const BOOSTED_ATTRIBUTE_SUFFIXES = [
-  'service.name',
-  'http.method',
-  'http.request.method',
-  'http.status_code',
-  'http.response.status_code',
-  'error',
-  'error.type',
-  'deployment.environment',
-  'deployment.environment.name',
-  'rpc.method',
-  'rpc.service',
-  'db.system',
-  'db.operation',
-  'messaging.system',
-  'messaging.operation',
-];
-
-/**
- * Returns 1 for well-known OTel attributes, 0 otherwise.
- * Uses dot-segment boundary matching to avoid false positives
- * (e.g., 'SpanAttributes.myerror' won't match the 'error' entry).
- * Callers scale this as a tiebreaker (e.g., * 0.1) and only apply when baseScore > 0.
- */
-export function semanticBoost(key: string): number {
-  const lowerKey = key.toLowerCase();
-  for (const suffix of BOOSTED_ATTRIBUTE_SUFFIXES) {
-    if (lowerKey.endsWith('.' + suffix) || lowerKey === suffix) return 1;
-  }
-  return 0;
 }

--- a/packages/app/src/components/deltaChartUtils.ts
+++ b/packages/app/src/components/deltaChartUtils.ts
@@ -28,6 +28,10 @@ export {
   stripTypeWrappers,
 } from '@hyperdx/common-utils/dist/core/eventDeltas';
 
+// Local binding for use in filter key helpers below (the re-export above
+// only makes it available to consumers, not to this file's own functions).
+import { stripTypeWrappers } from '@hyperdx/common-utils/dist/core/eventDeltas';
+
 // ---------------------------------------------------------------------------
 // UI-only helpers
 // ---------------------------------------------------------------------------
@@ -119,8 +123,6 @@ export function applyTopNAggregation(
 // Filter key conversion helpers (UI-specific — produce ClickHouse SQL
 // expressions / filter keys for the search bar).
 // ---------------------------------------------------------------------------
-
-import { stripTypeWrappers } from '@hyperdx/common-utils/dist/core/eventDeltas';
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/common-utils/src/__tests__/eventDeltas.test.ts
+++ b/packages/common-utils/src/__tests__/eventDeltas.test.ts
@@ -1,0 +1,210 @@
+import {
+  computeComparisonScore,
+  flattenData,
+  getPropertyStatistics,
+  isDenylisted,
+  isHighCardinality,
+  rankProperties,
+  semanticBoost,
+} from '../core/eventDeltas';
+
+describe('eventDeltas', () => {
+  describe('flattenData', () => {
+    it('flattens nested objects with dot notation', () => {
+      expect(flattenData({ a: { b: { c: 1 } } })).toEqual({ 'a.b.c': 1 });
+    });
+
+    it('flattens arrays with bracket notation', () => {
+      expect(flattenData({ arr: ['x', 'y'] })).toEqual({
+        'arr[0]': 'x',
+        'arr[1]': 'y',
+      });
+    });
+
+    it('preserves empty objects as sentinel entries', () => {
+      const out = flattenData({ empty: {} });
+      expect(out['empty']).toEqual({});
+    });
+  });
+
+  describe('getPropertyStatistics', () => {
+    it('only counts properties that meet MIN_PROPERTY_OCCURENCES (5)', () => {
+      const data = Array.from({ length: 10 }, (_, i) =>
+        i < 4 ? { always: 'yes', sometimes: 'present' } : { always: 'yes' },
+      );
+      const stats = getPropertyStatistics(data);
+      expect(stats.valueOccurences.has('always')).toBe(true);
+      expect(stats.valueOccurences.has('sometimes')).toBe(false);
+    });
+
+    it('computes per-value counts correctly', () => {
+      const data = Array.from({ length: 10 }, (_, i) => ({
+        kind: i < 6 ? 'A' : 'B',
+      }));
+      const stats = getPropertyStatistics(data);
+      const kindValues = stats.valueOccurences.get('kind')!;
+      expect(kindValues.get('A')).toBe(6);
+      expect(kindValues.get('B')).toBe(4);
+    });
+  });
+
+  describe('computeComparisonScore', () => {
+    it('returns 0 for identical proportional distributions', () => {
+      const target = new Map([
+        ['A', 50],
+        ['B', 50],
+      ]);
+      const baseline = new Map([
+        ['A', 200],
+        ['B', 200],
+      ]);
+      expect(computeComparisonScore(target, baseline)).toBe(0);
+    });
+
+    it('returns the max % delta when distributions differ', () => {
+      // target: 100% A, baseline: 100% B → 100 delta on each value
+      const target = new Map([['A', 10]]);
+      const baseline = new Map([['B', 10]]);
+      expect(computeComparisonScore(target, baseline)).toBe(100);
+    });
+
+    it('returns 0 for empty groups', () => {
+      expect(computeComparisonScore(new Map(), new Map())).toBe(0);
+    });
+  });
+
+  describe('semanticBoost', () => {
+    it('boosts well-known OTel attributes', () => {
+      expect(semanticBoost('SpanAttributes.service.name')).toBe(1);
+      expect(semanticBoost('ResourceAttributes.http.status_code')).toBe(1);
+      expect(semanticBoost('error.type')).toBe(1);
+    });
+
+    it('does not boost unrelated keys (segment-aware match)', () => {
+      expect(semanticBoost('SpanAttributes.myerror')).toBe(0);
+      expect(semanticBoost('SpanAttributes.error_message')).toBe(0);
+    });
+  });
+
+  describe('isDenylisted', () => {
+    const cols = [
+      { name: 'TraceId', type: 'String' },
+      { name: 'Body', type: 'String' },
+      { name: 'Events.Timestamp', type: 'Array(DateTime64(9))' },
+    ];
+    it('flags top-level Id columns', () => {
+      expect(isDenylisted('TraceId', cols)).toBe(true);
+    });
+    it('does not flag non-Id String columns', () => {
+      expect(isDenylisted('Body', cols)).toBe(false);
+    });
+    it('flags per-index timestamp arrays', () => {
+      expect(isDenylisted('Events.Timestamp[0]', cols)).toBe(true);
+    });
+  });
+
+  describe('isHighCardinality', () => {
+    it('flags fields with >0.9 unique ratio and >20 samples', () => {
+      const targetValues = new Map<string, Map<string, number>>();
+      const targetMap = new Map<string, number>();
+      // 30 samples, 30 unique values → 100% unique
+      for (let i = 0; i < 30; i++) targetMap.set(`v${i}`, 1);
+      targetValues.set('Body', targetMap);
+
+      const baselineValues = new Map<string, Map<string, number>>();
+      const baselineMap = new Map<string, number>();
+      for (let i = 0; i < 30; i++) baselineMap.set(`v${i + 100}`, 1);
+      baselineValues.set('Body', baselineMap);
+
+      const targetProperty = new Map<string, number>([['Body', 30]]);
+      const baselineProperty = new Map<string, number>([['Body', 30]]);
+
+      expect(
+        isHighCardinality(
+          'Body',
+          targetValues,
+          baselineValues,
+          targetProperty,
+          baselineProperty,
+        ),
+      ).toBe(true);
+    });
+
+    it('does not flag fields with low cardinality', () => {
+      const targetValues = new Map<string, Map<string, number>>();
+      targetValues.set(
+        'ServiceName',
+        new Map([
+          ['svc-a', 30],
+          ['svc-b', 20],
+        ]),
+      );
+      const baselineValues = new Map<string, Map<string, number>>();
+      baselineValues.set(
+        'ServiceName',
+        new Map([
+          ['svc-a', 25],
+          ['svc-b', 25],
+        ]),
+      );
+      const targetProperty = new Map<string, number>([['ServiceName', 50]]);
+      const baselineProperty = new Map<string, number>([['ServiceName', 50]]);
+      expect(
+        isHighCardinality(
+          'ServiceName',
+          targetValues,
+          baselineValues,
+          targetProperty,
+          baselineProperty,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('rankProperties', () => {
+    it('ranks the most differentiating property first', () => {
+      // Target: 100% ERROR. Baseline: 100% INFO. Severity should rank above
+      // a uniformly-distributed Region property.
+      const targetRows = Array.from({ length: 50 }, (_, i) => ({
+        Severity: 'ERROR',
+        Region: i % 3 === 0 ? 'us' : i % 3 === 1 ? 'eu' : 'ap',
+      }));
+      const baselineRows = Array.from({ length: 50 }, (_, i) => ({
+        Severity: 'INFO',
+        Region: i % 3 === 0 ? 'us' : i % 3 === 1 ? 'eu' : 'ap',
+      }));
+      const result = rankProperties({
+        targetRows,
+        baselineRows,
+        columnMeta: [
+          { name: 'Severity', type: 'String' },
+          { name: 'Region', type: 'String' },
+        ],
+      });
+      expect(result.ranked[0].key).toBe('Severity');
+      expect(result.ranked[0].score).toBeGreaterThan(50);
+    });
+
+    it('marks Id columns hidden via denylist', () => {
+      const targetRows = Array.from({ length: 30 }, (_, i) => ({
+        TraceId: `t${i}`,
+        Service: i % 2 === 0 ? 'a' : 'b',
+      }));
+      const baselineRows = Array.from({ length: 30 }, (_, i) => ({
+        TraceId: `t${100 + i}`,
+        Service: i % 4 === 0 ? 'a' : 'b',
+      }));
+      const result = rankProperties({
+        targetRows,
+        baselineRows,
+        columnMeta: [
+          { name: 'TraceId', type: 'String' },
+          { name: 'Service', type: 'String' },
+        ],
+      });
+      const traceIdEntry = result.ranked.find(p => p.key === 'TraceId');
+      expect(traceIdEntry?.hidden).toBe(true);
+      expect(traceIdEntry?.hiddenReason).toBe('denylist');
+    });
+  });
+});

--- a/packages/common-utils/src/core/eventDeltas.ts
+++ b/packages/common-utils/src/core/eventDeltas.ts
@@ -1,0 +1,409 @@
+/**
+ * Event-deltas algorithm — pure functions used by both the HyperDX UI
+ * (DBDeltaChart) and the MCP server (hyperdx_event_deltas tool).
+ *
+ * Given two row sets — a target group and a baseline group — the algorithm
+ * ranks each property by how differently its values are distributed between
+ * the two groups. Output is a sorted list of property keys, with optional
+ * filtering for ID/timestamp fields and high-cardinality columns.
+ *
+ * No React or environment-specific dependencies — safe to import from a Node
+ * server, a browser app, or a test runner.
+ */
+
+// ---------------------------------------------------------------------------
+// Row flattening
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively flattens nested objects/arrays into dot-notation keys.
+ * Empty objects → "{}" entry; empty arrays → "[]" entry.
+ * Based on https://stackoverflow.com/a/19101235
+ */
+export function flattenData(data: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+  // eslint-disable-next-line security/detect-object-injection -- prop is built from known object keys via recursion, not user input
+  function recurse(cur: Record<string, any>, prop: string) {
+    if (Object(cur) !== cur) {
+      result[prop] = cur; // eslint-disable-line security/detect-object-injection
+    } else if (Array.isArray(cur)) {
+      for (let i = 0; i < cur.length; i++)
+        recurse(cur[i], prop + '[' + i + ']');
+      if (cur.length === 0) result[prop] = []; // eslint-disable-line security/detect-object-injection
+    } else {
+      let isEmpty = true;
+      for (const p in cur) {
+        isEmpty = false;
+        recurse(cur[p], prop ? prop + '.' + p : p);
+      }
+      if (isEmpty && prop) result[prop] = {}; // eslint-disable-line security/detect-object-injection
+    }
+  }
+  recurse(data, '');
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Property statistics
+// ---------------------------------------------------------------------------
+
+export interface PropertyStatistics {
+  /** Property key → (value → percentage of rows where this property has this value) */
+  percentageOccurences: Map<string, Map<string, number>>;
+  /** Property key → number of rows where the key was present */
+  propertyOccurences: Map<string, number>;
+  /** Property key → (value → count) */
+  valueOccurences: Map<string, Map<string, number>>;
+}
+
+/** Minimum row count for a property to qualify as "common" enough to score. */
+export const MIN_PROPERTY_OCCURENCES = 5;
+
+export function getPropertyStatistics(
+  data: Record<string, any>[],
+): PropertyStatistics {
+  const flattened = data.map(flattenData);
+  const propertyOccurences = new Map<string, number>();
+  const commonProperties = new Set<string>();
+
+  flattened.forEach(item => {
+    Object.entries(item).forEach(([key]) => {
+      const count = propertyOccurences.get(key) || 0;
+      propertyOccurences.set(key, count + 1);
+      if (count + 1 >= MIN_PROPERTY_OCCURENCES) {
+        commonProperties.add(key);
+      }
+    });
+  });
+
+  const valueOccurences = new Map<string, Map<string, number>>();
+  flattened.forEach(item => {
+    Object.entries(item).forEach(([key, value]) => {
+      if (commonProperties.has(key)) {
+        let valuesMap = valueOccurences.get(key);
+        if (!valuesMap) {
+          valuesMap = new Map<string, number>();
+          valueOccurences.set(key, valuesMap);
+        }
+        const valueStr =
+          value === null || value === undefined ? '' : String(value);
+        const valueCount = valuesMap.get(valueStr) || 0;
+        valuesMap.set(valueStr, valueCount + 1);
+      }
+    });
+  });
+
+  const percentageOccurences = new Map<string, Map<string, number>>();
+  valueOccurences.forEach((valuesMap, property) => {
+    const percentageMap = new Map<string, number>();
+    valuesMap.forEach((valueCount, value) => {
+      percentageMap.set(
+        value,
+        (valueCount / (propertyOccurences.get(property) ?? 1)) * 100,
+      );
+    });
+    percentageOccurences.set(property, percentageMap);
+  });
+
+  return { percentageOccurences, propertyOccurences, valueOccurences };
+}
+
+// ---------------------------------------------------------------------------
+// Field classification
+// ---------------------------------------------------------------------------
+
+/** Strips LowCardinality(...)/Nullable(...) wrappers from a ClickHouse type. */
+export function stripTypeWrappers(type: string): string {
+  let t = type.trim();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    if (t.startsWith('LowCardinality(') && t.endsWith(')')) {
+      t = t.slice('LowCardinality('.length, -1).trim();
+      changed = true;
+    } else if (t.startsWith('Nullable(') && t.endsWith(')')) {
+      t = t.slice('Nullable('.length, -1).trim();
+      changed = true;
+    }
+  }
+  return t;
+}
+
+/**
+ * Extracts the base column name from a flattened key (strips array indices).
+ * "Events.Name[0]" → "Events.Name"; returns null for keys with sub-keys
+ * after array indices ("Events.Attributes[0].spanId").
+ */
+export function getBaseColumnName(key: string): string | null {
+  const arrMatch = key.match(/^([^[]+)\[(\d+)\]$/);
+  return arrMatch ? arrMatch[1] : key.includes('[') ? null : key;
+}
+
+/** Top-level String columns or Array(String) elements ending in Id/ID. */
+export function isIdField(
+  key: string,
+  columnMeta: { name: string; type: string }[],
+): boolean {
+  const colName = getBaseColumnName(key);
+  if (!colName) return false;
+  if (!/(Id|ID)$/.test(colName)) return false;
+  const col = columnMeta.find(c => c.name === colName);
+  if (!col) return false;
+  const baseType = stripTypeWrappers(col.type);
+  if (baseType === 'String') return true;
+  if (baseType.startsWith('Array(')) {
+    const innerType = stripTypeWrappers(baseType.slice('Array('.length, -1));
+    return innerType === 'String';
+  }
+  return false;
+}
+
+/** Per-index timestamp array elements (Events.Timestamp[N] of Array(DateTime64)). */
+export function isTimestampArrayField(
+  key: string,
+  columnMeta: { name: string; type: string }[],
+): boolean {
+  const colName = getBaseColumnName(key);
+  if (!colName) return false;
+  const col = columnMeta.find(c => c.name === colName);
+  if (!col) return false;
+  const baseType = stripTypeWrappers(col.type);
+  if (!baseType.startsWith('Array(')) return false;
+  const innerType = stripTypeWrappers(baseType.slice('Array('.length, -1));
+  return innerType.startsWith('DateTime64(');
+}
+
+/** Hide-by-default fields (IDs + per-index timestamps). */
+export function isDenylisted(
+  key: string,
+  columnMeta: { name: string; type: string }[],
+): boolean {
+  return isIdField(key, columnMeta) || isTimestampArrayField(key, columnMeta);
+}
+
+/**
+ * High cardinality: most values are unique (uniqueness > 0.9 with > 20
+ * combined samples). Such columns produce noisy/distracting deltas and are
+ * hidden by default.
+ */
+export function isHighCardinality(
+  key: string,
+  outlierValueOccurences: Map<string, Map<string, number>>,
+  inlierValueOccurences: Map<string, Map<string, number>>,
+  outlierPropertyOccurences: Map<string, number>,
+  inlierPropertyOccurences: Map<string, number>,
+): boolean {
+  const outlierTotal = outlierPropertyOccurences.get(key) ?? 0;
+  const inlierTotal = inlierPropertyOccurences.get(key) ?? 0;
+  const combinedSampleSize = outlierTotal + inlierTotal;
+  if (combinedSampleSize <= 20) return false;
+
+  const outlierUniqueValues = outlierValueOccurences.get(key)?.size ?? 0;
+  const inlierUniqueValues = inlierValueOccurences.get(key)?.size ?? 0;
+
+  const outlierUniqueness =
+    outlierTotal > 0 ? outlierUniqueValues / outlierTotal : null;
+  const inlierUniqueness =
+    inlierTotal > 0 ? inlierUniqueValues / inlierTotal : null;
+
+  let effectiveUniqueness: number;
+  if (outlierUniqueness !== null && inlierUniqueness !== null) {
+    effectiveUniqueness = Math.min(outlierUniqueness, inlierUniqueness);
+  } else if (outlierUniqueness !== null) {
+    effectiveUniqueness = outlierUniqueness;
+  } else if (inlierUniqueness !== null) {
+    effectiveUniqueness = inlierUniqueness;
+  } else {
+    return false;
+  }
+
+  return effectiveUniqueness > 0.9;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Comparison-mode scoring: normalizes each group's percentages to sum to 100%
+ * before computing the max delta. Fields with identical proportional
+ * distributions score 0 regardless of coverage rate differences.
+ */
+export function computeComparisonScore(
+  outlierValues: Map<string, number>,
+  inlierValues: Map<string, number>,
+): number {
+  const allValues = new Set([...outlierValues.keys(), ...inlierValues.keys()]);
+  if (allValues.size === 0) return 0;
+
+  let outlierSum = 0;
+  let inlierSum = 0;
+  outlierValues.forEach(v => (outlierSum += v));
+  inlierValues.forEach(v => (inlierSum += v));
+
+  if (outlierSum === 0 && inlierSum === 0) return 0;
+  if (outlierSum === 0 || inlierSum === 0) {
+    const presentValues = outlierSum > 0 ? outlierValues : inlierValues;
+    if (presentValues.size <= 1) return 0;
+    const presentSum = outlierSum > 0 ? outlierSum : inlierSum;
+    let maxNormPct = 0;
+    presentValues.forEach(v => {
+      const pct = (v / presentSum) * 100;
+      if (pct > maxNormPct) maxNormPct = pct;
+    });
+    return maxNormPct;
+  }
+
+  let maxDelta = 0;
+  allValues.forEach(value => {
+    const outlierNorm = ((outlierValues.get(value) ?? 0) / outlierSum) * 100;
+    const inlierNorm = ((inlierValues.get(value) ?? 0) / inlierSum) * 100;
+    const delta = Math.abs(outlierNorm - inlierNorm);
+    if (delta > maxDelta) maxDelta = delta;
+  });
+  return maxDelta;
+}
+
+/** Well-known OTel attribute suffixes that get a tiebreaker score boost. */
+const BOOSTED_ATTRIBUTE_SUFFIXES = [
+  'service.name',
+  'http.method',
+  'http.request.method',
+  'http.status_code',
+  'http.response.status_code',
+  'error',
+  'error.type',
+  'deployment.environment',
+  'deployment.environment.name',
+  'rpc.method',
+  'rpc.service',
+  'db.system',
+  'db.operation',
+  'messaging.system',
+  'messaging.operation',
+];
+
+/** 1 for well-known OTel attributes (dot-segment match), 0 otherwise. */
+export function semanticBoost(key: string): number {
+  const lowerKey = key.toLowerCase();
+  for (const suffix of BOOSTED_ATTRIBUTE_SUFFIXES) {
+    if (lowerKey.endsWith('.' + suffix) || lowerKey === suffix) return 1;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Sampling configuration (used by callers that build their own queries)
+// ---------------------------------------------------------------------------
+
+export const SAMPLE_SIZE = 1000;
+export const MIN_SAMPLE_SIZE = 500;
+export const MAX_SAMPLE_SIZE = 5000;
+export const SAMPLE_RATIO = 0.01;
+
+export function getStableSampleExpression(spanIdExpression?: string): string {
+  if (spanIdExpression) {
+    return `cityHash64(${spanIdExpression})`;
+  }
+  return 'rand()';
+}
+
+export function computeEffectiveSampleSize(totalCount: number): number {
+  if (totalCount <= 0) return SAMPLE_SIZE;
+  return Math.min(
+    MAX_SAMPLE_SIZE,
+    Math.max(MIN_SAMPLE_SIZE, Math.ceil(totalCount * SAMPLE_RATIO)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Composed: rank properties by their group-to-group delta
+// ---------------------------------------------------------------------------
+
+export interface RankedProperty {
+  key: string;
+  /** computeComparisonScore + semanticBoost*0.1 (boost only applied when score > 0) */
+  score: number;
+  baseScore: number;
+  semanticBoost: number;
+  hidden: boolean;
+  hiddenReason?: 'denylist' | 'high_cardinality';
+}
+
+export interface RankPropertiesOptions {
+  /** Rows in the target / outlier group. */
+  targetRows: Record<string, any>[];
+  /** Rows in the baseline / inlier group. */
+  baselineRows: Record<string, any>[];
+  /** Column metadata (name + ClickHouse type) for denylist + cardinality checks. */
+  columnMeta: { name: string; type: string }[];
+}
+
+export interface RankPropertiesResult {
+  ranked: RankedProperty[];
+  targetStats: PropertyStatistics;
+  baselineStats: PropertyStatistics;
+}
+
+/**
+ * Run getPropertyStatistics on both groups, then rank every property by
+ * computeComparisonScore + semanticBoost. Annotates each entry with whether
+ * it would be hidden in the UI (denylisted ID / timestamp arrays, or high
+ * cardinality). Pure function — does not query ClickHouse.
+ */
+export function rankProperties(
+  opts: RankPropertiesOptions,
+): RankPropertiesResult {
+  const targetStats = getPropertyStatistics(opts.targetRows);
+  const baselineStats = getPropertyStatistics(opts.baselineRows);
+
+  const uniqueKeys = new Set<string>([
+    ...targetStats.valueOccurences.keys(),
+    ...baselineStats.valueOccurences.keys(),
+  ]);
+
+  const ranked: RankedProperty[] = [];
+  for (const key of uniqueKeys) {
+    const targetValueCounts =
+      targetStats.valueOccurences.get(key) ?? new Map<string, number>();
+    const baselineValueCounts =
+      baselineStats.valueOccurences.get(key) ?? new Map<string, number>();
+
+    const baseScore = computeComparisonScore(
+      targetValueCounts,
+      baselineValueCounts,
+    );
+    const boost = baseScore > 0 ? semanticBoost(key) : 0;
+    const score = baseScore + boost * 0.1;
+
+    let hidden = false;
+    let hiddenReason: 'denylist' | 'high_cardinality' | undefined;
+    if (isDenylisted(key, opts.columnMeta)) {
+      hidden = true;
+      hiddenReason = 'denylist';
+    } else if (
+      isHighCardinality(
+        key,
+        targetStats.valueOccurences,
+        baselineStats.valueOccurences,
+        targetStats.propertyOccurences,
+        baselineStats.propertyOccurences,
+      )
+    ) {
+      hidden = true;
+      hiddenReason = 'high_cardinality';
+    }
+
+    ranked.push({
+      key,
+      score,
+      baseScore,
+      semanticBoost: boost,
+      hidden,
+      hiddenReason,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return { ranked, targetStats, baselineStats };
+}


### PR DESCRIPTION
## Summary

Add the `hyperdx_event_deltas` MCP tool that compares two row groups (target vs baseline) and ranks properties by how much their value distributions differ. Uses the same algorithm as the in-app Event Deltas view (DBDeltaChart).

## What changed

### New files
- **`packages/common-utils/src/core/eventDeltas.ts`** — Pure algorithm functions extracted from the UI: `flattenData`, `getPropertyStatistics`, `computeComparisonScore`, `semanticBoost`, field classification helpers, sampling config, and `rankProperties`. Shared by both the UI and MCP server.
- **`packages/api/src/mcp/tools/query/eventDeltas.ts`** — The `hyperdx_event_deltas` MCP tool. Validates input, queries ClickHouse for target/baseline row samples, runs `rankProperties`, and returns ranked property deltas.
- **`packages/common-utils/src/__tests__/eventDeltas.test.ts`** — Unit tests for the shared algorithm.
- **`packages/api/src/mcp/__tests__/deltasTool.test.ts`** — Integration tests for the MCP tool (schema validation, time range rejection, algorithm ranking against ClickHouse data).

### Modified files
- **`packages/api/src/mcp/tools/query/index.ts`** — Register `eventDeltas` tool.
- **`packages/app/src/components/deltaChartUtils.ts`** — Replaced inline algorithm definitions with re-exports from `@hyperdx/common-utils/dist/core/eventDeltas`. UI-only helpers (`mergeValueStatisticsMaps`, `applyTopNAggregation`, `computeEntropyScore`, filter key converters, constants) remain in place.

## How the tool works

Given a source ID, a target group (time window + optional filter), and a baseline group, the tool:
1. Samples rows from each group via `renderChartConfig`
2. Runs the shared `rankProperties` algorithm to score every property by distribution delta
3. Returns a ranked list of properties with per-value target%/baseline%/diff% breakdowns

Typical uses: slow vs fast spans, before vs after a deploy, failing vs succeeding requests.