### PR TITLE
feat(mcp): add trace waterfall and breakdown tools

### DIFF
--- a/.changeset/mcp-trace-tools.md
+++ b/.changeset/mcp-trace-tools.md
@@ -1,0 +1,14 @@
+---
+'@hyperdx/api': patch
+---
+
+feat(mcp): add trace waterfall and breakdown tools
+
+Add `hyperdx_trace_waterfall` — fetch all spans in a single trace as a
+parent/child waterfall tree with optional correlated logs. Supports
+auto-pick by slowest, first error, or most recent trace.
+
+Add `hyperdx_trace_top_time_consuming_operations` — aggregate breakdown
+of child operations consuming the most cumulative time across traces
+matching a parent-span filter. Same algorithm as the in-app "Top Most
+Time Consuming Operations" chart.

--- a/MCP.md
+++ b/MCP.md
@@ -123,4 +123,6 @@ with:
 | `hyperdx_save_saved_search`   | Create or update a saved search (reusable query against a data source)                       |
 | `hyperdx_get_alert`           | List alerts (summary) or get full detail with evaluation history; filter by state             |
 | `hyperdx_save_alert`          | Create a new alert or update an existing one                                                 |
+| `hyperdx_trace_waterfall`     | Fetch all spans in a single trace as a parent/child waterfall tree with optional correlated logs |
+| `hyperdx_trace_top_time_consuming_operations` | Aggregate breakdown of child operations by cumulative time across matching parent traces |
 | `hyperdx_get_webhook`         | List available webhook destinations for use as alert notification channels                    |

--- a/packages/api/src/mcp/__tests__/trace.test.ts
+++ b/packages/api/src/mcp/__tests__/trace.test.ts
@@ -224,10 +224,16 @@ describe('MCP Trace Tools', () => {
     });
 
     describe('with seeded trace data', () => {
+      // Use unique names to avoid collisions with other test suites —
+      // otel_traces is NOT truncated between tests (see clearClickhouseTables).
       const TRACE_ID = 'aaaabbbbccccddddeeeeffffgggghhhh';
       const ROOT_SPAN_ID = '1111111111111111';
       const CHILD_A_SPAN_ID = '2222222222222222';
       const CHILD_B_SPAN_ID = '3333333333333333';
+      const WF_SVC = 'wf-test-api-gateway';
+      const WF_ROOT_OP = 'GET /wf-test/users';
+      const WF_CHILD_A_OP = 'wf-test-SELECT-users';
+      const WF_CHILD_B_OP = 'wf-test-cache.get';
       const now = new Date();
       const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
 
@@ -238,9 +244,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID,
             SpanId: ROOT_SPAN_ID,
             ParentSpanId: '',
-            SpanName: 'GET /api/users',
+            SpanName: WF_ROOT_OP,
             SpanKind: 'SPAN_KIND_SERVER',
-            ServiceName: 'api-gateway',
+            ServiceName: WF_SVC,
             Duration: 500_000_000, // 500ms in ns
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -249,9 +255,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID,
             SpanId: CHILD_A_SPAN_ID,
             ParentSpanId: ROOT_SPAN_ID,
-            SpanName: 'SELECT users',
+            SpanName: WF_CHILD_A_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'api-gateway',
+            ServiceName: WF_SVC,
             Duration: 200_000_000, // 200ms in ns
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -260,9 +266,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID,
             SpanId: CHILD_B_SPAN_ID,
             ParentSpanId: ROOT_SPAN_ID,
-            SpanName: 'cache.get',
+            SpanName: WF_CHILD_B_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'cache-service',
+            ServiceName: 'wf-test-cache-service',
             Duration: 50_000_000, // 50ms in ns
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -286,8 +292,8 @@ describe('MCP Trace Tools', () => {
         // Root span should be first (depth 0)
         expect(output.spans[0].depth).toBe(0);
         expect(output.spans[0].spanId).toBe(ROOT_SPAN_ID);
-        expect(output.spans[0].serviceName).toBe('api-gateway');
-        expect(output.spans[0].spanName).toBe('GET /api/users');
+        expect(output.spans[0].serviceName).toBe(WF_SVC);
+        expect(output.spans[0].spanName).toBe(WF_ROOT_OP);
 
         // Children should follow (depth 1)
         const children = output.spans.filter((s: any) => s.depth === 1);
@@ -302,6 +308,7 @@ describe('MCP Trace Tools', () => {
       it('should auto-pick the slowest trace when traceId is omitted', async () => {
         const result = await callTool(client, 'hyperdx_trace_waterfall', {
           sourceId: traceSource._id.toString(),
+          pickFilter: `ServiceName:${WF_SVC}`,
           pickBy: 'slowest',
           startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
           endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
@@ -316,6 +323,7 @@ describe('MCP Trace Tools', () => {
       it('should auto-pick the most recent trace', async () => {
         const result = await callTool(client, 'hyperdx_trace_waterfall', {
           sourceId: traceSource._id.toString(),
+          pickFilter: `ServiceName:${WF_SVC}`,
           pickBy: 'most_recent',
           startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
           endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
@@ -349,16 +357,16 @@ describe('MCP Trace Tools', () => {
             Timestamp: fiveMinAgo,
             TraceId: TRACE_ID,
             SpanId: ROOT_SPAN_ID,
-            Body: 'Handling GET /api/users request',
-            ServiceName: 'api-gateway',
+            Body: 'Handling request',
+            ServiceName: WF_SVC,
             SeverityText: 'INFO',
           },
           {
             Timestamp: new Date(fiveMinAgo.getTime() + 15),
             TraceId: TRACE_ID,
             SpanId: CHILD_A_SPAN_ID,
-            Body: 'Executing SELECT query',
-            ServiceName: 'api-gateway',
+            Body: 'Executing query',
+            ServiceName: WF_SVC,
             SeverityText: 'DEBUG',
           },
         ]);
@@ -396,7 +404,7 @@ describe('MCP Trace Tools', () => {
       it('should apply pickFilter to narrow which trace is picked', async () => {
         const result = await callTool(client, 'hyperdx_trace_waterfall', {
           sourceId: traceSource._id.toString(),
-          pickFilter: 'ServiceName:api-gateway',
+          pickFilter: `ServiceName:${WF_SVC}`,
           pickBy: 'slowest',
           startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
           endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
@@ -475,8 +483,16 @@ describe('MCP Trace Tools', () => {
     });
 
     describe('with seeded trace data', () => {
+      // Use unique names to avoid collisions with other test suites —
+      // otel_traces is NOT truncated between tests (see clearClickhouseTables).
       const TRACE_ID_1 = 'aaaa1111bbbb2222cccc3333dddd4444';
       const TRACE_ID_2 = 'eeee5555ffff6666aaaa7777bbbb8888';
+      const PARENT_SVC = 'trc-test-api-gateway';
+      const PARENT_OP = 'GET /trc-test/users';
+      const CHILD_DB_SVC = 'trc-test-db-service';
+      const CHILD_DB_OP = 'trc-test-SELECT-users';
+      const CHILD_CACHE_SVC = 'trc-test-cache-service';
+      const CHILD_CACHE_OP = 'trc-test-cache.get';
       const now = new Date();
       const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
 
@@ -489,9 +505,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_1,
             SpanId: 'root_span_0001',
             ParentSpanId: '',
-            SpanName: 'GET /api/users',
+            SpanName: PARENT_OP,
             SpanKind: 'SPAN_KIND_SERVER',
-            ServiceName: 'api-gateway',
+            ServiceName: PARENT_SVC,
             Duration: 800_000_000, // 800ms in ns
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -501,9 +517,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_1,
             SpanId: 'child_db_0001',
             ParentSpanId: 'root_span_0001',
-            SpanName: 'SELECT users',
+            SpanName: CHILD_DB_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'db-service',
+            ServiceName: CHILD_DB_SVC,
             Duration: 600_000_000, // 600ms
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -513,9 +529,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_1,
             SpanId: 'child_cache_001',
             ParentSpanId: 'root_span_0001',
-            SpanName: 'cache.get',
+            SpanName: CHILD_CACHE_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'cache-service',
+            ServiceName: CHILD_CACHE_SVC,
             Duration: 10_000_000, // 10ms
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -525,9 +541,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_2,
             SpanId: 'root_span_0002',
             ParentSpanId: '',
-            SpanName: 'GET /api/users',
+            SpanName: PARENT_OP,
             SpanKind: 'SPAN_KIND_SERVER',
-            ServiceName: 'api-gateway',
+            ServiceName: PARENT_SVC,
             Duration: 900_000_000, // 900ms
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -536,9 +552,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_2,
             SpanId: 'child_db_0002',
             ParentSpanId: 'root_span_0002',
-            SpanName: 'SELECT users',
+            SpanName: CHILD_DB_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'db-service',
+            ServiceName: CHILD_DB_SVC,
             Duration: 700_000_000, // 700ms
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -547,9 +563,9 @@ describe('MCP Trace Tools', () => {
             TraceId: TRACE_ID_2,
             SpanId: 'child_cache_002',
             ParentSpanId: 'root_span_0002',
-            SpanName: 'cache.get',
+            SpanName: CHILD_CACHE_OP,
             SpanKind: 'SPAN_KIND_CLIENT',
-            ServiceName: 'cache-service',
+            ServiceName: CHILD_CACHE_SVC,
             Duration: 20_000_000, // 20ms
             StatusCode: 'STATUS_CODE_OK',
           },
@@ -562,8 +578,7 @@ describe('MCP Trace Tools', () => {
           'hyperdx_trace_top_time_consuming_operations',
           {
             sourceId: traceSource._id.toString(),
-            parentFilter:
-              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            parentFilter: `ServiceName = '${PARENT_SVC}' AND SpanName = '${PARENT_OP}'`,
             startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
             endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
           },
@@ -575,10 +590,10 @@ describe('MCP Trace Tools', () => {
 
         // DB operations should be ranked first (higher total time)
         const dbOp = output.operations.find(
-          (op: any) => op.operation === 'SELECT users',
+          (op: any) => op.operation === CHILD_DB_OP,
         );
         const cacheOp = output.operations.find(
-          (op: any) => op.operation === 'cache.get',
+          (op: any) => op.operation === CHILD_CACHE_OP,
         );
         expect(dbOp).toBeDefined();
         expect(cacheOp).toBeDefined();
@@ -600,8 +615,7 @@ describe('MCP Trace Tools', () => {
           'hyperdx_trace_top_time_consuming_operations',
           {
             sourceId: traceSource._id.toString(),
-            parentFilter:
-              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            parentFilter: `ServiceName = '${PARENT_SVC}' AND SpanName = '${PARENT_OP}'`,
             minParentDurationMs: 850, // 850ms threshold
             startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
             endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
@@ -614,7 +628,7 @@ describe('MCP Trace Tools', () => {
 
         // Only trace 2's children should be included (1 call each)
         const dbOp = output.operations.find(
-          (op: any) => op.operation === 'SELECT users',
+          (op: any) => op.operation === CHILD_DB_OP,
         );
         expect(dbOp).toBeDefined();
         expect(dbOp.inParents).toBe(1);
@@ -626,8 +640,7 @@ describe('MCP Trace Tools', () => {
           'hyperdx_trace_top_time_consuming_operations',
           {
             sourceId: traceSource._id.toString(),
-            parentFilter:
-              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            parentFilter: `ServiceName = '${PARENT_SVC}' AND SpanName = '${PARENT_OP}'`,
             topN: 1,
             startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
             endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
@@ -638,7 +651,7 @@ describe('MCP Trace Tools', () => {
         const output = JSON.parse(getFirstText(result));
         expect(output.operations).toHaveLength(1);
         // The top operation should be the DB call (highest total time)
-        expect(output.operations[0].operation).toBe('SELECT users');
+        expect(output.operations[0].operation).toBe(CHILD_DB_OP);
       });
 
       it('should include summary with parentFilter and time range', async () => {
@@ -652,8 +665,7 @@ describe('MCP Trace Tools', () => {
           'hyperdx_trace_top_time_consuming_operations',
           {
             sourceId: traceSource._id.toString(),
-            parentFilter:
-              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            parentFilter: `ServiceName = '${PARENT_SVC}' AND SpanName = '${PARENT_OP}'`,
             startTime,
             endTime,
           },
@@ -662,7 +674,7 @@ describe('MCP Trace Tools', () => {
         expect(result.isError).toBeFalsy();
         const output = JSON.parse(getFirstText(result));
         expect(output.summary).toBeDefined();
-        expect(output.summary.parentFilter).toContain('api-gateway');
+        expect(output.summary.parentFilter).toContain(PARENT_SVC);
         expect(output.summary.operationsReturned).toBeGreaterThan(0);
         expect(output.summary.grandTotalTimeMs).toBeGreaterThan(0);
       });

--- a/packages/api/src/mcp/__tests__/trace.test.ts
+++ b/packages/api/src/mcp/__tests__/trace.test.ts
@@ -414,6 +414,184 @@ describe('MCP Trace Tools', () => {
         const output = JSON.parse(getFirstText(result));
         expect(output.traceId).toBe(TRACE_ID);
       });
+
+      it('should apply pickFilter with sql language', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          pickFilter: `ServiceName = '${WF_SVC}'`,
+          pickFilterLanguage: 'sql',
+          pickBy: 'most_recent',
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(TRACE_ID);
+        expect(output.spanCount).toBeGreaterThan(0);
+      });
+    });
+
+    describe('first_error pick mode', () => {
+      const ERROR_TRACE_ID = 'ffff0000eeee1111dddd2222cccc3333';
+      const now = new Date();
+      const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
+
+      beforeEach(async () => {
+        await bulkInsertTraces([
+          {
+            Timestamp: fiveMinAgo,
+            TraceId: ERROR_TRACE_ID,
+            SpanId: 'err_root_span01',
+            ParentSpanId: '',
+            SpanName: 'GET /wf-test-err/fail',
+            SpanKind: 'SPAN_KIND_SERVER',
+            ServiceName: 'wf-test-err-svc',
+            Duration: 100_000_000,
+            StatusCode: 'STATUS_CODE_ERROR',
+            StatusMessage: 'Internal Server Error',
+          },
+        ]);
+      });
+
+      it('should auto-pick trace with an error span', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          pickFilter: 'ServiceName:wf-test-err-svc',
+          pickBy: 'first_error',
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(ERROR_TRACE_ID);
+        expect(output.spanCount).toBeGreaterThan(0);
+      });
+    });
+
+    describe('logSource edge cases', () => {
+      it('should handle missing logSourceId gracefully (no logs section)', async () => {
+        // Create a trace source WITHOUT logSourceId
+        const noLogTraceSource = await Source.create({
+          kind: SourceKind.Trace,
+          team: team._id,
+          from: {
+            databaseName: DEFAULT_DATABASE,
+            tableName: DEFAULT_TRACES_TABLE,
+          },
+          timestampValueExpression: 'Timestamp',
+          connection: connection._id,
+          name: 'Traces No Log Link',
+          traceIdExpression: 'TraceId',
+          spanIdExpression: 'SpanId',
+          parentSpanIdExpression: 'ParentSpanId',
+          spanNameExpression: 'SpanName',
+          spanKindExpression: 'SpanKind',
+          durationExpression: 'Duration',
+          durationPrecision: 9,
+          serviceNameExpression: 'ServiceName',
+          statusCodeExpression: 'StatusCode',
+          statusMessageExpression: 'StatusMessage',
+          eventAttributesExpression: 'SpanAttributes',
+          // logSourceId intentionally omitted
+        });
+
+        const TRACE_ID = 'aaaabbbbccccddddeeeeffffgggghhhh';
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: noLogTraceSource._id.toString(),
+          traceId: TRACE_ID,
+          includeLogs: true,
+          startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(Date.now() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        // Should succeed without a logs section
+        expect(output.logs).toBeUndefined();
+      });
+
+      it('should note when logSourceId points to a non-existent source', async () => {
+        const badLogTraceSource = await Source.create({
+          kind: SourceKind.Trace,
+          team: team._id,
+          from: {
+            databaseName: DEFAULT_DATABASE,
+            tableName: DEFAULT_TRACES_TABLE,
+          },
+          timestampValueExpression: 'Timestamp',
+          connection: connection._id,
+          name: 'Traces Bad Log Link',
+          traceIdExpression: 'TraceId',
+          spanIdExpression: 'SpanId',
+          parentSpanIdExpression: 'ParentSpanId',
+          spanNameExpression: 'SpanName',
+          spanKindExpression: 'SpanKind',
+          durationExpression: 'Duration',
+          durationPrecision: 9,
+          serviceNameExpression: 'ServiceName',
+          statusCodeExpression: 'StatusCode',
+          statusMessageExpression: 'StatusMessage',
+          eventAttributesExpression: 'SpanAttributes',
+          logSourceId: '000000000000000000000000',
+        });
+
+        const TRACE_ID = 'aaaabbbbccccddddeeeeffffgggghhhh';
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: badLogTraceSource._id.toString(),
+          traceId: TRACE_ID,
+          includeLogs: true,
+          startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(Date.now() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.logsNote).toBeDefined();
+        expect(output.logsNote).toContain('not found');
+      });
+
+      it('should note when logSourceId points to a non-log source', async () => {
+        // Point logSourceId at the trace source itself (wrong kind)
+        const wrongKindTraceSource = await Source.create({
+          kind: SourceKind.Trace,
+          team: team._id,
+          from: {
+            databaseName: DEFAULT_DATABASE,
+            tableName: DEFAULT_TRACES_TABLE,
+          },
+          timestampValueExpression: 'Timestamp',
+          connection: connection._id,
+          name: 'Traces Wrong Kind Log',
+          traceIdExpression: 'TraceId',
+          spanIdExpression: 'SpanId',
+          parentSpanIdExpression: 'ParentSpanId',
+          spanNameExpression: 'SpanName',
+          spanKindExpression: 'SpanKind',
+          durationExpression: 'Duration',
+          durationPrecision: 9,
+          serviceNameExpression: 'ServiceName',
+          statusCodeExpression: 'StatusCode',
+          statusMessageExpression: 'StatusMessage',
+          eventAttributesExpression: 'SpanAttributes',
+          logSourceId: traceSource._id.toString(), // points to a trace source, not log
+        });
+
+        const TRACE_ID = 'aaaabbbbccccddddeeeeffffgggghhhh';
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: wrongKindTraceSource._id.toString(),
+          traceId: TRACE_ID,
+          includeLogs: true,
+          startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(Date.now() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.logsNote).toBeDefined();
+        expect(output.logsNote).toContain('not "log"');
+      });
     });
   });
 

--- a/packages/api/src/mcp/__tests__/trace.test.ts
+++ b/packages/api/src/mcp/__tests__/trace.test.ts
@@ -1,0 +1,687 @@
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+import * as config from '@/config';
+import {
+  bulkInsertData,
+  DEFAULT_DATABASE,
+  DEFAULT_LOGS_TABLE,
+  DEFAULT_TRACES_TABLE,
+  getLoggedInAgent,
+  getServer,
+} from '@/fixtures';
+import Connection from '@/models/connection';
+import { Source, type SourceDocument } from '@/models/source';
+
+import { McpContext } from '../tools/types';
+import { callTool, createTestClient, getFirstText } from './mcpTestUtils';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Insert trace spans into the default otel_traces table. */
+async function bulkInsertTraces(
+  spans: {
+    Timestamp: Date;
+    TraceId: string;
+    SpanId: string;
+    ParentSpanId: string;
+    SpanName: string;
+    SpanKind: string;
+    ServiceName: string;
+    Duration: number; // nanoseconds
+    StatusCode: string;
+    StatusMessage?: string;
+    SpanAttributes?: Record<string, string>;
+  }[],
+) {
+  await bulkInsertData(
+    `${DEFAULT_DATABASE}.${DEFAULT_TRACES_TABLE}`,
+    spans.map(s => ({
+      ...s,
+      StatusMessage: s.StatusMessage ?? '',
+      SpanAttributes: s.SpanAttributes ?? {},
+      ResourceAttributes: {},
+    })),
+  );
+}
+
+/** Insert log rows into the default otel_logs table. */
+async function bulkInsertLogs(
+  logs: {
+    Timestamp: Date;
+    TraceId: string;
+    SpanId: string;
+    Body: string;
+    ServiceName: string;
+    SeverityText: string;
+  }[],
+) {
+  await bulkInsertData(`${DEFAULT_DATABASE}.${DEFAULT_LOGS_TABLE}`, logs);
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('MCP Trace Tools', () => {
+  const server = getServer();
+  let team: any;
+  let user: any;
+  let connection: any;
+  let traceSource: SourceDocument;
+  let logSource: SourceDocument;
+  let client: Client;
+
+  beforeAll(async () => {
+    await server.start();
+  });
+
+  beforeEach(async () => {
+    const result = await getLoggedInAgent(server);
+    team = result.team;
+    user = result.user;
+
+    connection = await Connection.create({
+      team: team._id,
+      name: 'Default',
+      host: config.CLICKHOUSE_HOST,
+      username: config.CLICKHOUSE_USER,
+      password: config.CLICKHOUSE_PASSWORD,
+    });
+
+    logSource = await Source.create({
+      kind: SourceKind.Log,
+      team: team._id,
+      from: {
+        databaseName: DEFAULT_DATABASE,
+        tableName: DEFAULT_LOGS_TABLE,
+      },
+      timestampValueExpression: 'Timestamp',
+      connection: connection._id,
+      name: 'Logs',
+      bodyExpression: 'Body',
+      severityTextExpression: 'SeverityText',
+      serviceNameExpression: 'ServiceName',
+      traceIdExpression: 'TraceId',
+      spanIdExpression: 'SpanId',
+    });
+
+    traceSource = await Source.create({
+      kind: SourceKind.Trace,
+      team: team._id,
+      from: {
+        databaseName: DEFAULT_DATABASE,
+        tableName: DEFAULT_TRACES_TABLE,
+      },
+      timestampValueExpression: 'Timestamp',
+      connection: connection._id,
+      name: 'Traces',
+      traceIdExpression: 'TraceId',
+      spanIdExpression: 'SpanId',
+      parentSpanIdExpression: 'ParentSpanId',
+      spanNameExpression: 'SpanName',
+      spanKindExpression: 'SpanKind',
+      durationExpression: 'Duration',
+      durationPrecision: 9,
+      serviceNameExpression: 'ServiceName',
+      statusCodeExpression: 'StatusCode',
+      statusMessageExpression: 'StatusMessage',
+      eventAttributesExpression: 'SpanAttributes',
+      logSourceId: logSource._id.toString(),
+    });
+
+    const context: McpContext = {
+      teamId: team._id.toString(),
+      userId: user._id.toString(),
+    };
+    client = await createTestClient(context);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.clearDBs();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  // ─── Schema serialization ──────────────────────────────────────────────────
+
+  describe('schema serialization', () => {
+    it('should expose hyperdx_trace_waterfall with expected properties', async () => {
+      const { tools } = await client.listTools();
+      const tool = tools.find(t => t.name === 'hyperdx_trace_waterfall');
+      expect(tool).toBeDefined();
+
+      const props = Object.keys(tool!.inputSchema.properties ?? {});
+      expect(props).toContain('sourceId');
+      expect(props).toContain('traceId');
+      expect(props).toContain('pickFilter');
+      expect(props).toContain('pickBy');
+      expect(props).toContain('maxSpans');
+      expect(props).toContain('includeLogs');
+      expect(tool!.inputSchema.required).toContain('sourceId');
+    });
+
+    it('should expose hyperdx_trace_top_time_consuming_operations with expected properties', async () => {
+      const { tools } = await client.listTools();
+      const tool = tools.find(
+        t => t.name === 'hyperdx_trace_top_time_consuming_operations',
+      );
+      expect(tool).toBeDefined();
+
+      const props = Object.keys(tool!.inputSchema.properties ?? {});
+      expect(props).toContain('sourceId');
+      expect(props).toContain('parentFilter');
+      expect(props).toContain('startTime');
+      expect(props).toContain('endTime');
+      expect(props).toContain('minParentDurationMs');
+      expect(props).toContain('topN');
+      expect(tool!.inputSchema.required).toContain('sourceId');
+      expect(tool!.inputSchema.required).toContain('parentFilter');
+      expect(tool!.inputSchema.required).toContain('startTime');
+      expect(tool!.inputSchema.required).toContain('endTime');
+    });
+  });
+
+  // ─── hyperdx_trace_waterfall ───────────────────────────────────────────────
+
+  describe('hyperdx_trace_waterfall', () => {
+    it('should return error for non-existent source', async () => {
+      const result = await callTool(client, 'hyperdx_trace_waterfall', {
+        sourceId: '000000000000000000000000',
+      });
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('Source not found');
+    });
+
+    it('should return error for non-trace source', async () => {
+      const result = await callTool(client, 'hyperdx_trace_waterfall', {
+        sourceId: logSource._id.toString(),
+      });
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('kind=');
+    });
+
+    it('should return error for invalid time range', async () => {
+      const result = await callTool(client, 'hyperdx_trace_waterfall', {
+        sourceId: traceSource._id.toString(),
+        startTime: 'not-a-date',
+      });
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('Invalid');
+    });
+
+    it('should return no-match hint when no traces exist', async () => {
+      const result = await callTool(client, 'hyperdx_trace_waterfall', {
+        sourceId: traceSource._id.toString(),
+        startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        endTime: new Date().toISOString(),
+      });
+      expect(result.isError).toBeFalsy();
+      const output = JSON.parse(getFirstText(result));
+      expect(output.result).toBeNull();
+      expect(output.hint).toBeDefined();
+    });
+
+    describe('with seeded trace data', () => {
+      const TRACE_ID = 'aaaabbbbccccddddeeeeffffgggghhhh';
+      const ROOT_SPAN_ID = '1111111111111111';
+      const CHILD_A_SPAN_ID = '2222222222222222';
+      const CHILD_B_SPAN_ID = '3333333333333333';
+      const now = new Date();
+      const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
+
+      beforeEach(async () => {
+        await bulkInsertTraces([
+          {
+            Timestamp: fiveMinAgo,
+            TraceId: TRACE_ID,
+            SpanId: ROOT_SPAN_ID,
+            ParentSpanId: '',
+            SpanName: 'GET /api/users',
+            SpanKind: 'SPAN_KIND_SERVER',
+            ServiceName: 'api-gateway',
+            Duration: 500_000_000, // 500ms in ns
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 10),
+            TraceId: TRACE_ID,
+            SpanId: CHILD_A_SPAN_ID,
+            ParentSpanId: ROOT_SPAN_ID,
+            SpanName: 'SELECT users',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'api-gateway',
+            Duration: 200_000_000, // 200ms in ns
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 20),
+            TraceId: TRACE_ID,
+            SpanId: CHILD_B_SPAN_ID,
+            ParentSpanId: ROOT_SPAN_ID,
+            SpanName: 'cache.get',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'cache-service',
+            Duration: 50_000_000, // 50ms in ns
+            StatusCode: 'STATUS_CODE_OK',
+          },
+        ]);
+      });
+
+      it('should fetch a trace by traceId and return a waterfall tree', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          traceId: TRACE_ID,
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(TRACE_ID);
+        expect(output.spanCount).toBe(3);
+        expect(output.spans).toHaveLength(3);
+
+        // Root span should be first (depth 0)
+        expect(output.spans[0].depth).toBe(0);
+        expect(output.spans[0].spanId).toBe(ROOT_SPAN_ID);
+        expect(output.spans[0].serviceName).toBe('api-gateway');
+        expect(output.spans[0].spanName).toBe('GET /api/users');
+
+        // Children should follow (depth 1)
+        const children = output.spans.filter((s: any) => s.depth === 1);
+        expect(children).toHaveLength(2);
+
+        // Summary fields
+        expect(output.rootSpan).toBeDefined();
+        expect(output.rootSpan.spanId).toBe(ROOT_SPAN_ID);
+        expect(output.totalDurationMs).toBeGreaterThan(0);
+      });
+
+      it('should auto-pick the slowest trace when traceId is omitted', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          pickBy: 'slowest',
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(TRACE_ID);
+        expect(output.spanCount).toBeGreaterThan(0);
+      });
+
+      it('should auto-pick the most recent trace', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          pickBy: 'most_recent',
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(TRACE_ID);
+      });
+
+      it('should respect maxSpans and note truncation', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          traceId: TRACE_ID,
+          maxSpans: 2,
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.spanCount).toBe(2);
+        expect(output.note).toBeDefined();
+        expect(output.note).toContain('truncated');
+      });
+
+      it('should include correlated logs when includeLogs is true and logSourceId is configured', async () => {
+        // Insert correlated log rows
+        await bulkInsertLogs([
+          {
+            Timestamp: fiveMinAgo,
+            TraceId: TRACE_ID,
+            SpanId: ROOT_SPAN_ID,
+            Body: 'Handling GET /api/users request',
+            ServiceName: 'api-gateway',
+            SeverityText: 'INFO',
+          },
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 15),
+            TraceId: TRACE_ID,
+            SpanId: CHILD_A_SPAN_ID,
+            Body: 'Executing SELECT query',
+            ServiceName: 'api-gateway',
+            SeverityText: 'DEBUG',
+          },
+        ]);
+
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          traceId: TRACE_ID,
+          includeLogs: true,
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.logs).toBeDefined();
+        expect(output.logsCount).toBe(2);
+        expect(output.logs[0]).toHaveProperty('spanId');
+        expect(output.logs[0]).toHaveProperty('body');
+      });
+
+      it('should omit logs when includeLogs is false', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          traceId: TRACE_ID,
+          includeLogs: false,
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.logs).toBeUndefined();
+      });
+
+      it('should apply pickFilter to narrow which trace is picked', async () => {
+        const result = await callTool(client, 'hyperdx_trace_waterfall', {
+          sourceId: traceSource._id.toString(),
+          pickFilter: 'ServiceName:api-gateway',
+          pickBy: 'slowest',
+          startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+          endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.traceId).toBe(TRACE_ID);
+      });
+    });
+  });
+
+  // ─── hyperdx_trace_top_time_consuming_operations ───────────────────────────
+
+  describe('hyperdx_trace_top_time_consuming_operations', () => {
+    it('should return error for non-existent source', async () => {
+      const result = await callTool(
+        client,
+        'hyperdx_trace_top_time_consuming_operations',
+        {
+          sourceId: '000000000000000000000000',
+          parentFilter: "ServiceName = 'api-gateway'",
+          startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+          endTime: new Date().toISOString(),
+        },
+      );
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('Source not found');
+    });
+
+    it('should return error for non-trace source', async () => {
+      const result = await callTool(
+        client,
+        'hyperdx_trace_top_time_consuming_operations',
+        {
+          sourceId: logSource._id.toString(),
+          parentFilter: "ServiceName = 'api-gateway'",
+          startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+          endTime: new Date().toISOString(),
+        },
+      );
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('kind=');
+    });
+
+    it('should return error for invalid time range', async () => {
+      const result = await callTool(
+        client,
+        'hyperdx_trace_top_time_consuming_operations',
+        {
+          sourceId: traceSource._id.toString(),
+          parentFilter: "ServiceName = 'api-gateway'",
+          startTime: 'not-a-date',
+          endTime: new Date().toISOString(),
+        },
+      );
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toContain('Invalid');
+    });
+
+    it('should return empty operations when no traces match', async () => {
+      const result = await callTool(
+        client,
+        'hyperdx_trace_top_time_consuming_operations',
+        {
+          sourceId: traceSource._id.toString(),
+          parentFilter: "ServiceName = 'nonexistent-service'",
+          startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+          endTime: new Date().toISOString(),
+        },
+      );
+      expect(result.isError).toBeFalsy();
+      const output = JSON.parse(getFirstText(result));
+      expect(output.operations).toHaveLength(0);
+      expect(output.summary.hint).toContain('No matching parent traces');
+    });
+
+    describe('with seeded trace data', () => {
+      const TRACE_ID_1 = 'aaaa1111bbbb2222cccc3333dddd4444';
+      const TRACE_ID_2 = 'eeee5555ffff6666aaaa7777bbbb8888';
+      const now = new Date();
+      const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
+
+      beforeEach(async () => {
+        // Trace 1: api-gateway -> db-service + cache-service
+        await bulkInsertTraces([
+          // Parent span in trace 1
+          {
+            Timestamp: fiveMinAgo,
+            TraceId: TRACE_ID_1,
+            SpanId: 'root_span_0001',
+            ParentSpanId: '',
+            SpanName: 'GET /api/users',
+            SpanKind: 'SPAN_KIND_SERVER',
+            ServiceName: 'api-gateway',
+            Duration: 800_000_000, // 800ms in ns
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          // Child: slow DB call
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 10),
+            TraceId: TRACE_ID_1,
+            SpanId: 'child_db_0001',
+            ParentSpanId: 'root_span_0001',
+            SpanName: 'SELECT users',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'db-service',
+            Duration: 600_000_000, // 600ms
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          // Child: fast cache call
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 20),
+            TraceId: TRACE_ID_1,
+            SpanId: 'child_cache_001',
+            ParentSpanId: 'root_span_0001',
+            SpanName: 'cache.get',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'cache-service',
+            Duration: 10_000_000, // 10ms
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          // Trace 2: same parent pattern, different child durations
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 1000),
+            TraceId: TRACE_ID_2,
+            SpanId: 'root_span_0002',
+            ParentSpanId: '',
+            SpanName: 'GET /api/users',
+            SpanKind: 'SPAN_KIND_SERVER',
+            ServiceName: 'api-gateway',
+            Duration: 900_000_000, // 900ms
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 1010),
+            TraceId: TRACE_ID_2,
+            SpanId: 'child_db_0002',
+            ParentSpanId: 'root_span_0002',
+            SpanName: 'SELECT users',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'db-service',
+            Duration: 700_000_000, // 700ms
+            StatusCode: 'STATUS_CODE_OK',
+          },
+          {
+            Timestamp: new Date(fiveMinAgo.getTime() + 1020),
+            TraceId: TRACE_ID_2,
+            SpanId: 'child_cache_002',
+            ParentSpanId: 'root_span_0002',
+            SpanName: 'cache.get',
+            SpanKind: 'SPAN_KIND_CLIENT',
+            ServiceName: 'cache-service',
+            Duration: 20_000_000, // 20ms
+            StatusCode: 'STATUS_CODE_OK',
+          },
+        ]);
+      });
+
+      it('should break down child operations ranked by total time', async () => {
+        const result = await callTool(
+          client,
+          'hyperdx_trace_top_time_consuming_operations',
+          {
+            sourceId: traceSource._id.toString(),
+            parentFilter:
+              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+            endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.operations.length).toBeGreaterThanOrEqual(2);
+
+        // DB operations should be ranked first (higher total time)
+        const dbOp = output.operations.find(
+          (op: any) => op.operation === 'SELECT users',
+        );
+        const cacheOp = output.operations.find(
+          (op: any) => op.operation === 'cache.get',
+        );
+        expect(dbOp).toBeDefined();
+        expect(cacheOp).toBeDefined();
+        expect(dbOp.totalTimeMs).toBeGreaterThan(cacheOp.totalTimeMs);
+
+        // DB op should appear in both parent traces
+        expect(dbOp.inParents).toBe(2);
+        expect(dbOp.calls).toBe(2);
+
+        // Each operation should have share of total time
+        expect(dbOp.shareOfTotalTime).toBeGreaterThan(0);
+        expect(dbOp.shareOfTotalTime).toBeLessThanOrEqual(1);
+      });
+
+      it('should filter by minParentDurationMs', async () => {
+        // Only trace 2 has a parent >= 850ms (900ms)
+        const result = await callTool(
+          client,
+          'hyperdx_trace_top_time_consuming_operations',
+          {
+            sourceId: traceSource._id.toString(),
+            parentFilter:
+              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            minParentDurationMs: 850, // 850ms threshold
+            startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+            endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.operations.length).toBeGreaterThanOrEqual(1);
+
+        // Only trace 2's children should be included (1 call each)
+        const dbOp = output.operations.find(
+          (op: any) => op.operation === 'SELECT users',
+        );
+        expect(dbOp).toBeDefined();
+        expect(dbOp.inParents).toBe(1);
+      });
+
+      it('should respect topN parameter', async () => {
+        const result = await callTool(
+          client,
+          'hyperdx_trace_top_time_consuming_operations',
+          {
+            sourceId: traceSource._id.toString(),
+            parentFilter:
+              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            topN: 1,
+            startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+            endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.operations).toHaveLength(1);
+        // The top operation should be the DB call (highest total time)
+        expect(output.operations[0].operation).toBe('SELECT users');
+      });
+
+      it('should include summary with parentFilter and time range', async () => {
+        const startTime = new Date(
+          now.getTime() - 10 * 60 * 1000,
+        ).toISOString();
+        const endTime = new Date(now.getTime() + 60 * 1000).toISOString();
+
+        const result = await callTool(
+          client,
+          'hyperdx_trace_top_time_consuming_operations',
+          {
+            sourceId: traceSource._id.toString(),
+            parentFilter:
+              "ServiceName = 'api-gateway' AND SpanName = 'GET /api/users'",
+            startTime,
+            endTime,
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.summary).toBeDefined();
+        expect(output.summary.parentFilter).toContain('api-gateway');
+        expect(output.summary.operationsReturned).toBeGreaterThan(0);
+        expect(output.summary.grandTotalTimeMs).toBeGreaterThan(0);
+      });
+
+      it('should return error for invalid parentFilter SQL', async () => {
+        const result = await callTool(
+          client,
+          'hyperdx_trace_top_time_consuming_operations',
+          {
+            sourceId: traceSource._id.toString(),
+            parentFilter: 'INVALID SQL @@@ SYNTAX',
+            startTime: new Date(now.getTime() - 10 * 60 * 1000).toISOString(),
+            endTime: new Date(now.getTime() + 60 * 1000).toISOString(),
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain('Failed to compute breakdown');
+      });
+    });
+  });
+});

--- a/packages/api/src/mcp/mcpServer.ts
+++ b/packages/api/src/mcp/mcpServer.ts
@@ -8,6 +8,7 @@ import dashboardsTools from './tools/dashboards/index';
 import queryTools from './tools/query/index';
 import savedSearchesTools from './tools/savedSearches/index';
 import sourcesTools from './tools/sources/index';
+import traceTools from './tools/trace/index';
 import { McpContext } from './tools/types';
 
 export function createServer(context: McpContext) {
@@ -21,6 +22,7 @@ export function createServer(context: McpContext) {
   dashboardsTools(server, context);
   queryTools(server, context);
   savedSearchesTools(server, context);
+  traceTools(server, context);
   dashboardPrompts(server, context);
 
   return server;

--- a/packages/api/src/mcp/tools/trace/breakdown.ts
+++ b/packages/api/src/mcp/tools/trace/breakdown.ts
@@ -38,6 +38,7 @@ const traceBreakdownSchema = z.object({
     ),
   parentFilter: z
     .string()
+    .max(4096)
     .describe(
       'SQL WHERE clause that selects the PARENT spans you want to break ' +
         'down. The tool finds the distinct TraceIds matching this filter, ' +
@@ -244,7 +245,7 @@ SELECT
   ${spanNameExpr} AS operation,
   sum(${durationExpr}) / {divisor:Float64} AS total_time_ms,
   count() AS calls,
-  count(DISTINCT ${traceIdExpr}) AS in_parents,
+  uniqExact(${traceIdExpr}) AS in_parents,
   quantile(0.5)(${durationExpr}) / {divisor:Float64} AS p50_ms,
   quantile(0.99)(${durationExpr}) / {divisor:Float64} AS p99_ms
 FROM \`${dbName}\`.\`${tableName}\`

--- a/packages/api/src/mcp/tools/trace/breakdown.ts
+++ b/packages/api/src/mcp/tools/trace/breakdown.ts
@@ -1,0 +1,372 @@
+/**
+ * hyperdx_trace_top_time_consuming_operations
+ *
+ * Aggregate counterpart to hyperdx_trace_waterfall. Given a parent-span
+ * filter (a service + operation, optionally constrained to slow durations),
+ * return the child operations consuming the most cumulative time across all
+ * traces matching the parent filter — ranked by total_time_ms DESC.
+ *
+ * Same SQL pattern the in-app `ServiceDashboardEndpointPerformanceChart`
+ * uses: subselect distinct TraceIds matching the parent, then aggregate
+ * all spans in those traces, excluding the matching root.
+ *
+ * Why this exists: incident-triage agents that anchor on the first slow
+ * endpoint they find need a way to ask "what's downstream of THIS slow
+ * endpoint" without dropping into raw SQL with self-JOINs. The builder
+ * tools (table / timeseries / search) can't express the TraceId subselect.
+ */
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { getConnectionById } from '@/controllers/connection';
+import { getSource } from '@/controllers/sources';
+
+import { withToolTracing } from '../../utils/tracing';
+import { parseTimeRange } from '../query/helpers';
+import type { McpContext } from '../types';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const traceBreakdownSchema = z.object({
+  sourceId: z
+    .string()
+    .describe(
+      'Trace source ID. Must be a source of kind="trace". ' +
+        'Call hyperdx_list_sources to find available sources.',
+    ),
+  parentFilter: z
+    .string()
+    .describe(
+      'SQL WHERE clause that selects the PARENT spans you want to break ' +
+        'down. The tool finds the distinct TraceIds matching this filter, ' +
+        'then aggregates all spans within those traces. ' +
+        'Use SQL syntax (not Lucene). Example: ' +
+        "\"ServiceName = '<your-service>' AND SpanName = '<your-operation>'\".\n\n" +
+        'SCOPE TO A SPECIFIC OPERATION, not just a service. A service-only ' +
+        'filter mixes every endpoint together and returns whatever has the ' +
+        "loudest child-time across all parents, which usually isn't what " +
+        'you want. Always include a SpanName (or another operation-level ' +
+        'discriminator). To compare two slow operations, call this tool ' +
+        'once per operation and diff the results — two operations with ' +
+        "similar p99 don't necessarily share a slow child.",
+    ),
+  startTime: z
+    .string()
+    .describe('Start of the parent-filter time window as ISO 8601. REQUIRED.'),
+  endTime: z
+    .string()
+    .describe('End of the parent-filter time window as ISO 8601. REQUIRED.'),
+  minParentDurationMs: z
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'When set, only break down parent spans whose Duration ≥ this value. ' +
+        'Use to focus the breakdown on slow parents (e.g. 1000 to only look ' +
+        'at parents that took ≥ 1 second).',
+    ),
+  topN: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe(
+      'Number of top operations to return, ranked by total_time_ms DESC. Default 20.',
+    ),
+  maxParentTraces: z
+    .number()
+    .min(100)
+    .max(1_000_000)
+    .optional()
+    .default(100_000)
+    .describe(
+      'Safety cap on the number of distinct parent TraceIds considered. ' +
+        'A breakdown over more than this many parent traces gets ' +
+        'truncated to the first N. Default 100000.',
+    ),
+});
+
+type TraceBreakdownInput = z.infer<typeof traceBreakdownSchema>;
+
+// ─── Tool ────────────────────────────────────────────────────────────────────
+
+function durationDivisor(precision: number): number {
+  return Math.pow(10, Math.max(0, precision - 3));
+}
+
+export function registerTraceBreakdown(server: McpServer, context: McpContext) {
+  const { teamId } = context;
+
+  server.registerTool(
+    'hyperdx_trace_top_time_consuming_operations',
+    {
+      title: 'Top Time-Consuming Operations Across Matching Traces',
+      description:
+        'Given a parent-span filter and a time window, return the child ' +
+        'operations contributing the most cumulative time across all traces ' +
+        'matching the parent filter. Same algorithm as the in-app ' +
+        '"Top Most Time Consuming Operations" chart on the service dashboard.\n\n' +
+        'WHAT IT DOES (two-stage, runs as one SQL):\n' +
+        '  1. Pick distinct TraceIds where the parent span matches ' +
+        '`parentFilter` in the window. Optionally restrict to ' +
+        '`minParentDurationMs` to focus on slow parents.\n' +
+        '  2. Aggregate ALL spans across those traces (excluding the ' +
+        'matching root span itself) by (ServiceName, SpanName), ranked by ' +
+        '`total_time_ms` DESC.\n\n' +
+        'USE WHEN: investigating "where is the time going" for a slow ' +
+        'operation. Filter to a specific (ServiceName, SpanName) pair and ' +
+        'set `minParentDurationMs` to the threshold above which a parent ' +
+        'span counts as "slow" for your investigation.\n\n' +
+        'MULTIPLE OPERATIONS SLOW: when more than one operation shows ' +
+        'elevated latency, call this tool ONCE PER (service, operation) ' +
+        'and compare the top child rows across the result sets. Operations ' +
+        'with the same top child likely share a cause; operations with ' +
+        'different top children are independent regressions that happen ' +
+        'to co-occur. DO NOT merge multiple operations into a single ' +
+        'parentFilter — the cumulative rank then conflates independent ' +
+        'investigations into one noisy answer.\n\n' +
+        'RANKING METRIC: `total_time_ms = sum(Duration)` across all matching ' +
+        'child spans. This captures the true contribution to elapsed time — ' +
+        'a fast-but-frequent child can dominate the latency even if its p99 ' +
+        'is unremarkable.\n\n' +
+        'RETURNS: array of rows, each with `service`, `operation`, ' +
+        '`total_time_ms`, `calls`, `in_parents` (how many parent traces ' +
+        'contained at least one such span), `p50_ms`, `p99_ms`. Plus a ' +
+        '`summary` block with the matched-parent count.\n\n' +
+        'NEXT STEP after this tool: once a dominant slow child operation is ' +
+        'identified, the canonical follow-up is hyperdx_event_deltas with ' +
+        'slow-vs-fast spans of THAT child operation as target/baseline ' +
+        "(target = {where: SpanName='<slow-child>' AND Duration > X}, " +
+        "baseline = {where: SpanName='<slow-child>' AND Duration <= Y}). " +
+        'The ranked attributes surface what distinguishes slow invocations ' +
+        'of the child operation from fast ones.\n\n' +
+        'CROSS-SERVICE BREAKDOWN: this tool does NOT scope children to the ' +
+        "parent's service. Slow cross-service calls (database, cache, " +
+        'upstream HTTP) surface naturally — useful for triage.\n\n' +
+        'PAIR TOOL: hyperdx_trace_waterfall returns ONE concrete trace as a ' +
+        "parent/child tree. Use it for an example after this tool's " +
+        'aggregate breakdown has pointed you at the slow downstream operation.',
+      inputSchema: traceBreakdownSchema,
+    },
+    withToolTracing(
+      'hyperdx_trace_top_time_consuming_operations',
+      context,
+      async (rawInput: TraceBreakdownInput) => {
+        const input = traceBreakdownSchema.parse(rawInput);
+
+        const timeRange = parseTimeRange(input.startTime, input.endTime);
+        if ('error' in timeRange) {
+          return {
+            isError: true as const,
+            content: [{ type: 'text' as const, text: timeRange.error }],
+          };
+        }
+        const { startDate, endDate } = timeRange;
+
+        const source = await getSource(teamId.toString(), input.sourceId);
+        if (!source) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source not found: ${input.sourceId}. Call hyperdx_list_sources to find available source IDs.`,
+              },
+            ],
+          };
+        }
+        if (source.kind !== SourceKind.Trace) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source ${input.sourceId} is kind="${source.kind}". hyperdx_trace_top_time_consuming_operations requires a source of kind="trace".`,
+              },
+            ],
+          };
+        }
+
+        const connection = await getConnectionById(
+          teamId.toString(),
+          source.connection.toString(),
+          true,
+        );
+        if (!connection) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Connection not found for source: ${input.sourceId}`,
+              },
+            ],
+          };
+        }
+
+        // Source-configured SQL expressions. These are trusted (set by the
+        // team admin in source config) and we substitute them into the
+        // generated SQL.
+        const tsExpr = source.timestampValueExpression;
+        const traceIdExpr = source.traceIdExpression;
+        const spanNameExpr = source.spanNameExpression ?? "''";
+        const serviceNameExpr = source.serviceNameExpression ?? "''";
+        const durationExpr = source.durationExpression;
+        const divisor = durationDivisor(source.durationPrecision);
+        const dbName = source.from.databaseName;
+        const tableName = source.from.tableName;
+
+        // Build the SQL. parentFilter is SQL only (documented); time bounds
+        // and topN/maxParentTraces are parameterized.
+        // The CTE selects distinct parent TraceIds. The outer query joins
+        // back, excludes the parent rows themselves (so we measure child
+        // contribution), and aggregates by service+operation.
+        const minDurationClause =
+          input.minParentDurationMs != null
+            ? `AND ${durationExpr} >= ({minParentDurationStored:Float64})`
+            : '';
+
+        const sql = `
+WITH parent_traces AS (
+  SELECT DISTINCT ${traceIdExpr} AS _trace_id
+  FROM \`${dbName}\`.\`${tableName}\`
+  WHERE ${tsExpr} >= fromUnixTimestamp64Milli({startMs:Int64})
+    AND ${tsExpr} <= fromUnixTimestamp64Milli({endMs:Int64})
+    AND (${input.parentFilter})
+    ${minDurationClause}
+  LIMIT {maxParentTraces:UInt32}
+)
+SELECT
+  ${serviceNameExpr} AS service,
+  ${spanNameExpr} AS operation,
+  sum(${durationExpr}) / {divisor:Float64} AS total_time_ms,
+  count() AS calls,
+  count(DISTINCT ${traceIdExpr}) AS in_parents,
+  quantile(0.5)(${durationExpr}) / {divisor:Float64} AS p50_ms,
+  quantile(0.99)(${durationExpr}) / {divisor:Float64} AS p99_ms
+FROM \`${dbName}\`.\`${tableName}\`
+WHERE ${traceIdExpr} IN (SELECT _trace_id FROM parent_traces)
+  AND ${tsExpr} >= fromUnixTimestamp64Milli({wideStartMs:Int64})
+  AND ${tsExpr} <= fromUnixTimestamp64Milli({wideEndMs:Int64})
+  AND NOT (${input.parentFilter})
+GROUP BY service, operation
+ORDER BY total_time_ms DESC
+LIMIT {topN:UInt32}
+        `;
+
+        const params: Record<string, unknown> = {
+          startMs: startDate.getTime(),
+          endMs: endDate.getTime(),
+          // Widen the child window by 60s on each side to catch children
+          // that started slightly before / ended slightly after the parent
+          // sampling window.
+          wideStartMs: startDate.getTime() - 60_000,
+          wideEndMs: endDate.getTime() + 60_000,
+          maxParentTraces: input.maxParentTraces,
+          topN: input.topN,
+          divisor,
+        };
+        if (input.minParentDurationMs != null) {
+          // Stored duration is divisor × ms.
+          params.minParentDurationStored = input.minParentDurationMs * divisor;
+        }
+
+        const clickhouseClient = new ClickhouseClient({
+          host: connection.host,
+          username: connection.username,
+          password: connection.password,
+        });
+
+        type Row = {
+          service: string;
+          operation: string;
+          total_time_ms: number | string;
+          calls: number | string;
+          in_parents: number | string;
+          p50_ms: number | string;
+          p99_ms: number | string;
+        };
+
+        let rows: Row[];
+        try {
+          const result = await clickhouseClient.query({
+            query: sql,
+            query_params: params,
+            format: 'JSON',
+            connectionId: source.connection.toString(),
+            clickhouse_settings: {
+              // Prevent DDL/DML injection via parentFilter — only SELECTs allowed.
+              readonly: 1,
+              ...(source.querySettings
+                ? Object.fromEntries(
+                    source.querySettings.map(s => [s.setting, s.value]),
+                  )
+                : {}),
+            },
+          });
+          const json = (await (
+            result as { json: () => Promise<{ data: Row[] }> }
+          ).json()) ?? { data: [] };
+          rows = json.data ?? [];
+        } catch (e) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Failed to compute breakdown: ${e instanceof Error ? e.message : String(e)}. The parentFilter must be valid ClickHouse SQL referencing columns on the trace table (e.g. ServiceName = 'X' AND SpanName = 'Y').`,
+              },
+            ],
+          };
+        }
+
+        // Normalise numerics — ClickHouse JSON sometimes returns strings for
+        // 64-bit integers. Cast everything to Number and compute share of
+        // total time at the same time.
+        const operations = rows.map(r => ({
+          service: r.service,
+          operation: r.operation,
+          totalTimeMs: Number(r.total_time_ms),
+          calls: Number(r.calls),
+          inParents: Number(r.in_parents),
+          p50Ms: Number(r.p50_ms),
+          p99Ms: Number(r.p99_ms),
+        }));
+        const grandTotalMs = operations.reduce(
+          (acc, r) => acc + r.totalTimeMs,
+          0,
+        );
+        const operationsWithShare = operations.map(r => ({
+          ...r,
+          shareOfTotalTime: grandTotalMs > 0 ? r.totalTimeMs / grandTotalMs : 0,
+        }));
+
+        const output = {
+          summary: {
+            parentFilter: input.parentFilter,
+            startTime: startDate.toISOString(),
+            endTime: endDate.toISOString(),
+            minParentDurationMs: input.minParentDurationMs ?? null,
+            operationsReturned: operationsWithShare.length,
+            topN: input.topN,
+            grandTotalTimeMs: grandTotalMs,
+            hint:
+              operationsWithShare.length === 0
+                ? 'No matching parent traces, or all matching traces had no other spans. Widen the time window, relax the parentFilter, or lower minParentDurationMs.'
+                : "Operations are sorted by total_time_ms (sum of child Duration). shareOfTotalTime is each row's share of the cumulative child time across all matching traces.",
+          },
+          operations: operationsWithShare,
+        };
+
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(output, null, 2) },
+          ],
+        };
+      },
+    ),
+  );
+}

--- a/packages/api/src/mcp/tools/trace/breakdown.ts
+++ b/packages/api/src/mcp/tools/trace/breakdown.ts
@@ -299,7 +299,7 @@ LIMIT {topN:UInt32}
             connectionId: source.connection.toString(),
             clickhouse_settings: {
               // Prevent DDL/DML injection via parentFilter — only SELECTs allowed.
-              readonly: 1,
+              readonly: '1',
               ...(source.querySettings
                 ? Object.fromEntries(
                     source.querySettings.map(s => [s.setting, s.value]),

--- a/packages/api/src/mcp/tools/trace/index.ts
+++ b/packages/api/src/mcp/tools/trace/index.ts
@@ -1,0 +1,12 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { McpContext, ToolDefinition } from '../types';
+import { registerTraceBreakdown } from './breakdown';
+import { registerTraceWaterfall } from './waterfall';
+
+const traceTools: ToolDefinition = (server: McpServer, context: McpContext) => {
+  registerTraceWaterfall(server, context);
+  registerTraceBreakdown(server, context);
+};
+
+export default traceTools;

--- a/packages/api/src/mcp/tools/trace/waterfall.ts
+++ b/packages/api/src/mcp/tools/trace/waterfall.ts
@@ -429,7 +429,7 @@ export function registerTraceWaterfall(server: McpServer, context: McpContext) {
             format: 'JSONEachRow',
             connectionId: source.connection.toString(),
             clickhouse_settings: {
-              readonly: 1,
+              readonly: '1',
               // Per-query timeout matches the rest of the MCP for consistency.
               ...(source.querySettings
                 ? Object.fromEntries(
@@ -552,7 +552,7 @@ export function registerTraceWaterfall(server: McpServer, context: McpContext) {
                   format: 'JSONEachRow',
                   connectionId: logSource.connection.toString(),
                   clickhouse_settings: {
-                    readonly: 1,
+                    readonly: '1',
                     ...(logSource.querySettings
                       ? Object.fromEntries(
                           logSource.querySettings.map(s => [

--- a/packages/api/src/mcp/tools/trace/waterfall.ts
+++ b/packages/api/src/mcp/tools/trace/waterfall.ts
@@ -1,0 +1,620 @@
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
+import { getMetadata } from '@hyperdx/common-utils/dist/core/metadata';
+import {
+  type BuilderChartConfigWithDateRange,
+  type ChartConfigWithDateRange,
+  DisplayType,
+  SourceKind,
+} from '@hyperdx/common-utils/dist/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { getConnectionById } from '@/controllers/connection';
+import { getSource } from '@/controllers/sources';
+
+import { withToolTracing } from '../../utils/tracing';
+import { parseTimeRange } from '../query/helpers';
+import type { McpContext } from '../types';
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const traceSchema = z.object({
+  sourceId: z
+    .string()
+    .describe(
+      'Trace source ID. Must be a source of kind "trace". ' +
+        'Call hyperdx_list_sources to find available sources.',
+    ),
+  traceId: z
+    .string()
+    .optional()
+    .describe(
+      'Specific TraceId to look up. When provided, the tool fetches every span ' +
+        'in this trace and returns them as a parent/child tree. ' +
+        'When omitted, the tool auto-picks one trace using pickFilter + pickBy.',
+    ),
+  pickFilter: z
+    .string()
+    .optional()
+    .default('')
+    .describe(
+      'Filter (Lucene by default, SQL via pickFilterLanguage) used to narrow which ' +
+        'trace to auto-pick when traceId is not provided. ' +
+        'Example shapes (Lucene): `ServiceName:<some-service>`, ' +
+        '`ServiceName:<svc> AND SpanName:"<some-operation>"`, ' +
+        '`StatusCode:<status-value>` (status values come from the source ' +
+        "schema's keyColumns). Ignored when traceId is provided.",
+    ),
+  pickFilterLanguage: z
+    .enum(['lucene', 'sql'])
+    .optional()
+    .default('lucene')
+    .describe('Query language for pickFilter. Default: lucene'),
+  pickBy: z
+    .enum(['slowest', 'first_error', 'most_recent'])
+    .optional()
+    .default('slowest')
+    .describe(
+      'How to choose which trace to return when traceId is not provided.\n' +
+        '  slowest – trace with the longest single span (use for latency investigations)\n' +
+        '  first_error – earliest trace whose root span has STATUS_CODE_ERROR\n' +
+        '  most_recent – the most recent trace matching pickFilter',
+    ),
+  startTime: z
+    .string()
+    .optional()
+    .describe(
+      'Start of the search window as ISO 8601. Default: 15 minutes ago.',
+    ),
+  endTime: z
+    .string()
+    .optional()
+    .describe('End of the search window as ISO 8601. Default: now.'),
+  maxSpans: z
+    .number()
+    .min(1)
+    .max(2000)
+    .optional()
+    .default(500)
+    .describe(
+      'Cap on spans returned in the tree (1–2000). Default 500. ' +
+        'A trace with more spans than this will be truncated; the response notes the truncation.',
+    ),
+  includeLogs: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'When true and the trace source has a linked logSourceId, also fetch ' +
+        'log rows that share the same TraceId and inline them in the response ' +
+        'as `logs[]`. Each log row carries its spanId so the agent can ' +
+        'attribute messages to specific spans. No-op if the trace source has ' +
+        'no logSourceId configured.',
+    ),
+  maxLogs: z
+    .number()
+    .min(1)
+    .max(1000)
+    .optional()
+    .default(100)
+    .describe(
+      'Cap on correlated log rows returned (1–1000). Default 100. Has no ' +
+        'effect when includeLogs is false or the trace source has no logSourceId.',
+    ),
+});
+
+type TraceInput = z.infer<typeof traceSchema>;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type SpanRow = {
+  spanId: string;
+  parentSpanId: string;
+  serviceName: string;
+  spanName: string;
+  spanKind: string;
+  durationMs: number;
+  statusCode: string;
+  statusMessage: string;
+  timestamp: string;
+  spanAttributes: Record<string, string>;
+};
+
+type TreeSpan = SpanRow & { depth: number };
+
+function buildPreOrderTree(spans: SpanRow[]): TreeSpan[] {
+  // Map child spans by their parentSpanId. A span with no matching parent in
+  // the result set is treated as a root (typical when the trace was truncated
+  // mid-tree, or for the actual root span which has parentSpanId = '').
+  const childrenByParent = new Map<string, SpanRow[]>();
+  const idsInResult = new Set(spans.map(s => s.spanId));
+  const roots: SpanRow[] = [];
+  for (const s of spans) {
+    const parentInResult = idsInResult.has(s.parentSpanId);
+    if (!parentInResult) {
+      roots.push(s);
+      continue;
+    }
+    const list = childrenByParent.get(s.parentSpanId) ?? [];
+    list.push(s);
+    childrenByParent.set(s.parentSpanId, list);
+  }
+
+  // Sort each level by timestamp so the tree reads in execution order.
+  const sortByTimestamp = (a: SpanRow, b: SpanRow) =>
+    a.timestamp.localeCompare(b.timestamp);
+  roots.sort(sortByTimestamp);
+  for (const list of childrenByParent.values()) list.sort(sortByTimestamp);
+
+  const ordered: TreeSpan[] = [];
+  const visit = (span: SpanRow, depth: number) => {
+    ordered.push({ ...span, depth });
+    const children = childrenByParent.get(span.spanId) ?? [];
+    for (const c of children) visit(c, depth + 1);
+  };
+  for (const r of roots) visit(r, 0);
+  return ordered;
+}
+
+function durationDivisor(precision: number): number {
+  // durationPrecision is the number of decimal digits in the stored value.
+  // precision=9 → ns (divide by 1e6 for ms), precision=6 → µs (divide by 1e3),
+  // precision=3 → already ms (divide by 1).
+  return Math.pow(10, Math.max(0, precision - 3));
+}
+
+// ─── Tool definition ─────────────────────────────────────────────────────────
+
+export function registerTraceWaterfall(server: McpServer, context: McpContext) {
+  const { teamId } = context;
+
+  server.registerTool(
+    'hyperdx_trace_waterfall',
+    {
+      title: 'Trace Waterfall (single trace)',
+      description:
+        'Fetch all spans in ONE trace and return them as a parent/child waterfall, ' +
+        'pre-ordered for human-readable display. Use this for "show me a concrete ' +
+        'example trace" or "what happened in trace X" investigations — the tool walks ' +
+        'the cascade for you instead of forcing the model to write self-JOINs in raw SQL.\n\n' +
+        'NOT THE RIGHT TOOL when the question is "where does the time go across MANY ' +
+        'slow traces of operation X" — that is the aggregate question, and the answer ' +
+        'is hyperdx_trace_top_time_consuming_operations (called per affected ' +
+        '(service, operation) with `minParentDurationMs`). Use this tool only when you ' +
+        'want a single concrete example to inspect, or after the aggregate breakdown ' +
+        'has already identified a suspicious operation.\n\n' +
+        'Two modes:\n' +
+        '  1. Specific trace: pass `traceId`. Returns every span in that trace.\n' +
+        '  2. Auto-pick: pass `pickFilter` + `pickBy`. The tool finds one matching trace ' +
+        '(slowest / first_error / most_recent) and returns its full tree.\n\n' +
+        'Each returned span has: depth (root=0), spanId, parentSpanId, serviceName, ' +
+        'spanName, spanKind, durationMs, statusCode, statusMessage, timestamp, and ' +
+        'spanAttributes. Spans are pre-order DFS — child spans follow their parent in ' +
+        'execution order. The tool also surfaces a `summary` section with the picked ' +
+        'TraceId, total span count, and root span info.\n\n' +
+        'When the trace source has a linked logSourceId (the standard config), the ' +
+        'response also includes a `logs[]` array of correlated log rows that share ' +
+        'the same TraceId — sorted by timestamp, each carrying its `spanId` so the ' +
+        'agent can attribute messages to specific spans. Disable with `includeLogs:false`.\n\n' +
+        "Prefer this over running raw SQL with JOINs on TraceId — it uses the source's " +
+        'configured traceIdExpression / parentSpanIdExpression / spanIdExpression so ' +
+        'attribute extraction stays consistent with the rest of the platform.\n\n' +
+        'PAIR TOOL: hyperdx_trace_top_time_consuming_operations is the aggregate ' +
+        'counterpart — given a parent-span filter, it ranks child operations by total ' +
+        'time across MANY matching traces. Use that when the question is "where does ' +
+        'time go in slow X" (aggregate), and use THIS tool when the question is "show ' +
+        'me one example of a slow X" (single trace).',
+      inputSchema: traceSchema,
+    },
+    withToolTracing(
+      'hyperdx_trace_waterfall',
+      context,
+      async (rawInput: TraceInput) => {
+        const input = traceSchema.parse(rawInput);
+        const timeRange = parseTimeRange(input.startTime, input.endTime);
+        if ('error' in timeRange) {
+          return {
+            isError: true as const,
+            content: [{ type: 'text' as const, text: timeRange.error }],
+          };
+        }
+        const { startDate, endDate } = timeRange;
+
+        const source = await getSource(teamId.toString(), input.sourceId);
+        if (!source) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source not found: ${input.sourceId}. Call hyperdx_list_sources to find available source IDs.`,
+              },
+            ],
+          };
+        }
+        if (source.kind !== SourceKind.Trace) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Source ${input.sourceId} is kind="${source.kind}". hyperdx_trace_waterfall requires a source of kind="trace".`,
+              },
+            ],
+          };
+        }
+
+        const connection = await getConnectionById(
+          teamId.toString(),
+          source.connection.toString(),
+          true,
+        );
+        if (!connection) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Connection not found for source: ${input.sourceId}`,
+              },
+            ],
+          };
+        }
+
+        const clickhouseClient = new ClickhouseClient({
+          host: connection.host,
+          username: connection.username,
+          password: connection.password,
+        });
+        const metadata = getMetadata(clickhouseClient);
+
+        const traceIdExpr = source.traceIdExpression;
+        const spanIdExpr = source.spanIdExpression;
+        const parentSpanIdExpr = source.parentSpanIdExpression;
+        const spanNameExpr = source.spanNameExpression;
+        const spanKindExpr = source.spanKindExpression;
+        const durationExpr = source.durationExpression;
+        const tsExpr = source.timestampValueExpression;
+        const serviceNameExpr = source.serviceNameExpression ?? "''";
+        const statusCodeExpr = source.statusCodeExpression ?? "''";
+        const statusMessageExpr = source.statusMessageExpression ?? "''";
+        const attrsExpr = source.eventAttributesExpression ?? 'map()';
+        const divisor = durationDivisor(source.durationPrecision);
+
+        // ── Step 1: pick a TraceId (unless one was provided) ──
+        let pickedTraceId = input.traceId;
+        if (!pickedTraceId) {
+          // Compose pickFilter with the pickBy-specific filter when needed.
+          let effectiveFilter = input.pickFilter;
+          let effectiveLanguage = input.pickFilterLanguage;
+          if (input.pickBy === 'first_error') {
+            // Statuses are typically stored as enum strings. Use SQL so we don't
+            // depend on lucene mapping the raw column name.
+            const errFilter = `${statusCodeExpr} = 'STATUS_CODE_ERROR'`;
+            if (effectiveFilter && effectiveLanguage === 'sql') {
+              effectiveFilter = `(${effectiveFilter}) AND (${errFilter})`;
+            } else if (effectiveFilter && effectiveLanguage === 'lucene') {
+              // Run lucene filter inside parens, AND with raw SQL.
+              // Easiest: convert to sql by AND-joining a fresh sql-only condition
+              // means we'd have to render lucene first. Compromise: tell user
+              // to express the error filter in pickFilter directly.
+              effectiveFilter = `(${effectiveFilter}) AND StatusCode:STATUS_CODE_ERROR`;
+              effectiveLanguage = 'lucene';
+            } else {
+              effectiveFilter = errFilter;
+              effectiveLanguage = 'sql';
+            }
+          }
+
+          const orderBy =
+            input.pickBy === 'slowest'
+              ? `max(${durationExpr}) DESC`
+              : input.pickBy === 'first_error'
+                ? `min(${tsExpr}) ASC`
+                : `max(${tsExpr}) DESC`;
+
+          const pickConfig: BuilderChartConfigWithDateRange = {
+            displayType: DisplayType.Table,
+            select: [
+              {
+                aggFn: 'count' as const,
+                valueExpression: '',
+                alias: 'span_count',
+                aggCondition: '',
+                aggConditionLanguage: 'sql' as const,
+              },
+            ],
+            from: source.from,
+            where: effectiveFilter,
+            whereLanguage: effectiveLanguage,
+            connection: source.connection.toString(),
+            timestampValueExpression: tsExpr,
+            implicitColumnExpression: source.implicitColumnExpression,
+            groupBy: traceIdExpr,
+            orderBy,
+            limit: { limit: 1 },
+            dateRange: [startDate, endDate],
+          };
+
+          let pickResult: { data?: Array<Record<string, unknown>> } = {};
+          try {
+            pickResult = (await clickhouseClient.queryChartConfig({
+              config: pickConfig as ChartConfigWithDateRange,
+              metadata,
+              querySettings: source.querySettings,
+            })) as { data?: Array<Record<string, unknown>> };
+          } catch (e) {
+            return {
+              isError: true as const,
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Failed to pick a trace: ${e instanceof Error ? e.message : String(e)}`,
+                },
+              ],
+            };
+          }
+
+          const firstRow = pickResult.data?.[0];
+          if (!firstRow) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify(
+                    {
+                      result: null,
+                      hint:
+                        'No traces matched. Widen the time range, relax pickFilter, or ' +
+                        'pass a specific traceId.',
+                      pickFilter: effectiveFilter,
+                      pickBy: input.pickBy,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          // The grouped traceId column is rendered into the result with the
+          // expression text as its alias. Locate it by stripping non-data keys.
+          const candidate = Object.entries(firstRow).find(
+            ([k]) => k !== 'span_count' && k !== '__hdx_time_bucket',
+          );
+          if (!candidate || candidate[1] == null) {
+            return {
+              isError: true as const,
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Picker returned a row but no TraceId column was found. Row keys: ${Object.keys(firstRow).join(', ')}`,
+                },
+              ],
+            };
+          }
+          pickedTraceId = String(candidate[1]);
+        }
+
+        // ── Step 2: fetch the full span tree ──
+        const treeQuery = `
+        SELECT
+          ${spanIdExpr} AS spanId,
+          ${parentSpanIdExpr} AS parentSpanId,
+          ${serviceNameExpr} AS serviceName,
+          ${spanNameExpr} AS spanName,
+          ${spanKindExpr} AS spanKind,
+          ${durationExpr} / {divisor:Float64} AS durationMs,
+          ${statusCodeExpr} AS statusCode,
+          ${statusMessageExpr} AS statusMessage,
+          ${tsExpr} AS timestamp,
+          ${attrsExpr} AS spanAttributes
+        FROM {db:Identifier}.{tbl:Identifier}
+        WHERE ${traceIdExpr} = {tid:String}
+        ORDER BY ${tsExpr} ASC
+        LIMIT {n:UInt32}
+      `;
+
+        let rows: SpanRow[];
+        try {
+          const result = await clickhouseClient.query({
+            query: treeQuery,
+            query_params: {
+              db: source.from.databaseName,
+              tbl: source.from.tableName,
+              tid: pickedTraceId,
+              n: input.maxSpans + 1, // +1 to detect truncation
+              divisor,
+            },
+            format: 'JSONEachRow',
+            connectionId: source.connection.toString(),
+            clickhouse_settings: {
+              readonly: 1,
+              // Per-query timeout matches the rest of the MCP for consistency.
+              ...(source.querySettings
+                ? Object.fromEntries(
+                    source.querySettings.map(s => [s.setting, s.value]),
+                  )
+                : {}),
+            },
+          });
+          rows =
+            (await (result as { json: () => Promise<SpanRow[]> }).json()) ?? [];
+        } catch (e) {
+          return {
+            isError: true as const,
+            content: [
+              {
+                type: 'text' as const,
+                text: `Failed to fetch trace ${pickedTraceId}: ${e instanceof Error ? e.message : String(e)}`,
+              },
+            ],
+          };
+        }
+
+        const truncated = rows.length > input.maxSpans;
+        const spans = truncated ? rows.slice(0, input.maxSpans) : rows;
+
+        if (spans.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  {
+                    result: null,
+                    traceId: pickedTraceId,
+                    hint: 'TraceId picked, but no spans exist in the time window. The trace may have spans outside startTime/endTime — widen the window.',
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+
+        const tree = buildPreOrderTree(spans);
+        const root = tree.find(s => s.depth === 0) ?? tree[0];
+        const totalDuration = Math.max(...spans.map(s => s.durationMs));
+
+        // ── Step 3: fetch correlated logs (when logSourceId is configured) ──
+        type LogRow = {
+          timestamp: string;
+          severityText: string;
+          body: string;
+          serviceName: string;
+          spanId: string;
+        };
+        let correlatedLogs: LogRow[] | undefined;
+        let logsTruncated = false;
+        let logsNote: string | undefined;
+        if (input.includeLogs && source.logSourceId) {
+          const logSource = await getSource(
+            teamId.toString(),
+            source.logSourceId,
+          );
+          if (!logSource) {
+            logsNote = `logSourceId ${source.logSourceId} configured but source not found`;
+          } else if (logSource.kind !== SourceKind.Log) {
+            logsNote = `logSourceId ${source.logSourceId} is kind="${logSource.kind}", not "log"`;
+          } else {
+            const logTraceIdExpr = logSource.traceIdExpression ?? 'TraceId';
+            const logSpanIdExpr = logSource.spanIdExpression ?? "''";
+            const logTsExpr = logSource.timestampValueExpression;
+            const logBodyExpr = logSource.bodyExpression ?? "''";
+            const logSevExpr = logSource.severityTextExpression ?? "''";
+            const logSvcExpr = logSource.serviceNameExpression ?? "''";
+
+            // Reuse the same connection only when the log source lives there.
+            let logClient = clickhouseClient;
+            if (
+              logSource.connection.toString() !== source.connection.toString()
+            ) {
+              const logConn = await getConnectionById(
+                teamId.toString(),
+                logSource.connection.toString(),
+                true,
+              );
+              if (!logConn) {
+                logsNote = `connection for log source ${source.logSourceId} not found`;
+              } else {
+                logClient = new ClickhouseClient({
+                  host: logConn.host,
+                  username: logConn.username,
+                  password: logConn.password,
+                });
+              }
+            }
+
+            if (!logsNote) {
+              const logsQuery = `
+              SELECT
+                ${logTsExpr} AS timestamp,
+                ${logSevExpr} AS severityText,
+                ${logBodyExpr} AS body,
+                ${logSvcExpr} AS serviceName,
+                ${logSpanIdExpr} AS spanId
+              FROM {db:Identifier}.{tbl:Identifier}
+              WHERE ${logTraceIdExpr} = {tid:String}
+              ORDER BY ${logTsExpr} ASC
+              LIMIT {n:UInt32}
+            `;
+              try {
+                const logResult = await logClient.query({
+                  query: logsQuery,
+                  query_params: {
+                    db: logSource.from.databaseName,
+                    tbl: logSource.from.tableName,
+                    tid: pickedTraceId,
+                    n: input.maxLogs + 1, // +1 to detect truncation
+                  },
+                  format: 'JSONEachRow',
+                  connectionId: logSource.connection.toString(),
+                  clickhouse_settings: {
+                    readonly: 1,
+                    ...(logSource.querySettings
+                      ? Object.fromEntries(
+                          logSource.querySettings.map(s => [
+                            s.setting,
+                            s.value,
+                          ]),
+                        )
+                      : {}),
+                  },
+                });
+                const allLogs =
+                  (await (
+                    logResult as { json: () => Promise<LogRow[]> }
+                  ).json()) ?? [];
+                logsTruncated = allLogs.length > input.maxLogs;
+                correlatedLogs = logsTruncated
+                  ? allLogs.slice(0, input.maxLogs)
+                  : allLogs;
+              } catch (e) {
+                logsNote = `Failed to fetch correlated logs: ${e instanceof Error ? e.message : String(e)}`;
+              }
+            }
+          }
+        }
+
+        const output = {
+          traceId: pickedTraceId,
+          spanCount: spans.length,
+          totalDurationMs: totalDuration,
+          rootSpan: {
+            spanId: root.spanId,
+            serviceName: root.serviceName,
+            spanName: root.spanName,
+            durationMs: root.durationMs,
+            statusCode: root.statusCode,
+          },
+          spans: tree,
+          ...(correlatedLogs
+            ? {
+                logs: correlatedLogs,
+                logsCount: correlatedLogs.length,
+                ...(logsTruncated
+                  ? {
+                      logsNote: `Logs truncated to ${input.maxLogs}. Increase maxLogs (max 1000) if needed.`,
+                    }
+                  : {}),
+              }
+            : {}),
+          ...(logsNote ? { logsNote } : {}),
+          ...(truncated
+            ? {
+                note: `Result truncated to ${input.maxSpans} spans. Increase maxSpans (max 2000) or narrow the trace if needed.`,
+              }
+            : {}),
+        };
+
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(output, null, 2) },
+          ],
+        };
+      },
+    ),
+  );
+}

--- a/packages/api/src/mcp/tools/trace/waterfall.ts
+++ b/packages/api/src/mcp/tools/trace/waterfall.ts
@@ -57,7 +57,7 @@ const traceSchema = z.object({
     .describe(
       'How to choose which trace to return when traceId is not provided.\n' +
         '  slowest – trace with the longest single span (use for latency investigations)\n' +
-        '  first_error – earliest trace whose root span has STATUS_CODE_ERROR\n' +
+        '  first_error – earliest trace containing a span with STATUS_CODE_ERROR\n' +
         '  most_recent – the most recent trace matching pickFilter',
     ),
   startTime: z


### PR DESCRIPTION
## What

Add two new MCP tools for trace investigation:

### `hyperdx_trace_waterfall`
Fetch all spans in a single trace as a parent/child waterfall tree, pre-ordered for human-readable display.

- **Specific trace mode**: pass `traceId` to fetch a known trace
- **Auto-pick mode**: pass `pickFilter` + `pickBy` (slowest / first_error / most_recent) to find one matching trace
- Includes correlated log rows when the trace source has a linked `logSourceId`
- Respects `maxSpans` / `maxLogs` caps with truncation notes

### `hyperdx_trace_top_time_consuming_operations`
Aggregate breakdown of child operations consuming the most cumulative time across traces matching a parent-span filter. Same algorithm as the in-app "Top Most Time Consuming Operations" chart.

- Two-stage SQL: find distinct TraceIds matching the parent filter, then aggregate child spans
- Supports `minParentDurationMs` to focus on slow parents
- Returns ranked operations with `totalTimeMs`, `calls`, `inParents`, `p50Ms`, `p99Ms`, and `shareOfTotalTime`

## Why

MCP agents investigating latency issues need a way to:
1. Inspect a single concrete trace tree without writing self-JOINs (`waterfall`)
2. Ask "where does the time go" across many slow traces of an operation (`breakdown`)

The existing builder tools (table/timeseries/search) can't express the TraceId subselect pattern needed for the breakdown.

## Testing

Integration tests in `packages/api/src/mcp/__tests__/trace.test.ts` cover:
- Schema serialization (expected input properties)
- Error paths: non-existent source, non-trace source, invalid time range, bad SQL
- Seeded data: waterfall tree structure, auto-pick modes, truncation, correlated logs, breakdown ranking, `minParentDurationMs` filtering, `topN`

Run with: `make dev-int FILE=trace`