### PR TITLE
fix(app): prevent crash when a source's database/table doesn't exist

### DIFF
--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -2079,7 +2079,10 @@ const DBSearchPageFiltersComponent = ({
   );
 };
 
-function isFieldPrimary(tableMetadata: TableMetadata | undefined, key: string) {
+function isFieldPrimary(
+  tableMetadata: TableMetadata | null | undefined,
+  key: string,
+) {
   return tableMetadata?.primary_key?.includes(key);
 }
 export const DBSearchPageFilters = memo(DBSearchPageFiltersComponent);

--- a/packages/app/src/components/SearchInput/SearchInputV2.tsx
+++ b/packages/app/src/components/SearchInput/SearchInputV2.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useController, UseControllerProps } from 'react-hook-form';
 import { useHotkeys } from 'react-hotkeys-hook';
 import {
   Field,
+  TableConnection,
   TableConnectionChoice,
 } from '@hyperdx/common-utils/dist/core/metadata';
 import { genEnglishExplanation } from '@hyperdx/common-utils/dist/queryParser';
@@ -32,6 +33,12 @@ export class LuceneLanguageFormatter implements ILanguageFormatter {
 }
 
 const luceneLanguageFormatter = new LuceneLanguageFormatter();
+
+function stableTableConnectionToKey(tc: TableConnection | undefined): string {
+  if (!tc) return '';
+  return `${tc.connectionId}|${tc.databaseName}|${tc.tableName}`;
+}
+
 export default function SearchInputV2({
   tableConnection,
   tableConnections,
@@ -87,17 +94,40 @@ export default function SearchInputV2({
     },
   );
 
+  // Callers commonly pass an inline `tcFromSource(source)` for `tableConnection`,
+  // which produces a fresh object reference on every parent render. Without
+  // stabilizing here, the explanation effect below would re-run continuously,
+  // re-triggering schema queries and (when the underlying ClickHouse database
+  // doesn't exist) setting the same string state in a tight loop, eventually
+  // tripping React's "Maximum update depth exceeded" guard.
+  const stableTableConnectionKey = stableTableConnectionToKey(tableConnection);
+  const stableTableConnection = useMemo<TableConnection | undefined>(
+    () => tableConnection,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stableTableConnectionKey],
+  );
+
   useEffect(() => {
-    if (tableConnection) {
-      genEnglishExplanation({
-        query: value,
-        tableConnection,
-        metadata,
-      }).then(q => {
-        setParsedEnglishQuery(q);
+    if (!stableTableConnection) return;
+    let cancelled = false;
+    genEnglishExplanation({
+      query: value,
+      tableConnection: stableTableConnection,
+      metadata,
+    })
+      .then(q => {
+        if (!cancelled) setParsedEnglishQuery(q);
+      })
+      .catch(err => {
+        // Schema lookups can fail for sources whose database/table no longer
+        // exists. Swallow these so a stale source doesn't surface as an
+        // unhandled rejection that contributes to render-loop crashes.
+        console.warn('Failed to compute lucene query explanation:', err);
       });
-    }
-  }, [value, tableConnection, metadata]);
+    return () => {
+      cancelled = true;
+    };
+  }, [value, stableTableConnection, metadata]);
 
   useHotkeys(
     ['/', 's'],

--- a/packages/app/src/hooks/useFieldExpressionGenerator.tsx
+++ b/packages/app/src/hooks/useFieldExpressionGenerator.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import SqlString from 'sqlstring';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { TSource } from '@hyperdx/common-utils/dist/types';
@@ -24,24 +25,26 @@ export default function useFieldExpressionGenerator(
     tcFromSource(source),
   );
 
-  if (source && !isLoadingJsonColumns) {
-    return {
-      isLoading: false,
-      getFieldExpression: (
-        column: string,
-        key: string,
-        convertFn: string = 'toString',
-      ) => {
-        const isJson = jsonColumns?.includes(column);
-        return isJson
-          ? SqlString.format(`${convertFn}(??.??)`, [column, key])
-          : SqlString.format('??[?]', [column, key]);
-      },
-    };
-  } else {
-    return {
-      isLoading: isLoadingJsonColumns,
-      getFieldExpression: undefined,
-    };
-  }
+  // Memoize the generator so it has a stable reference across renders when
+  // its inputs haven't changed. Several call sites pass the returned function
+  // into `useMemo` / `useEffect` dependency arrays, and a fresh closure on
+  // every render previously caused expensive recomputation cascades that
+  // amplified render-loop bugs when the underlying schema query failed.
+  const getFieldExpression = useCallback<FieldExpressionGenerator>(
+    (column, key, convertFn = 'toString') => {
+      const isJson = jsonColumns?.includes(column);
+      return isJson
+        ? SqlString.format(`${convertFn}(??.??)`, [column, key])
+        : SqlString.format('??[?]', [column, key]);
+    },
+    [jsonColumns],
+  );
+
+  return useMemo(
+    () =>
+      source && !isLoadingJsonColumns
+        ? { isLoading: false, getFieldExpression }
+        : { isLoading: isLoadingJsonColumns, getFieldExpression: undefined },
+    [source, isLoadingJsonColumns, getFieldExpression],
+  );
 }

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -74,6 +74,13 @@ export function useMetadataWithSettings() {
   return metadata;
 }
 
+// Schema-discovery queries (DESCRIBE / system.tables) deterministically fail
+// when the source's database or table doesn't exist on the current ClickHouse
+// server. There's nothing useful to gain from retrying those failures, and the
+// retries amplify spurious re-renders that have caused render-loop crashes
+// (e.g. "Maximum update depth exceeded") in pages that observe these hooks.
+const SCHEMA_QUERY_RETRY = 0;
+
 export function useColumns(
   {
     databaseName,
@@ -96,6 +103,7 @@ export function useColumns(
         connectionId,
       });
     },
+    retry: SCHEMA_QUERY_RETRY,
     enabled: !!databaseName && !!tableName && !!connectionId,
     ...options,
   });
@@ -117,8 +125,9 @@ export function useJsonColumns(
         ) ?? []
       );
     },
+    retry: SCHEMA_QUERY_RETRY,
     enabled:
-      tableConnection &&
+      !!tableConnection &&
       !!tableConnection.databaseName &&
       !!tableConnection.tableName &&
       !!tableConnection.connectionId,
@@ -208,15 +217,24 @@ export function useTableMetadata(
   options?: Omit<UseQueryOptions<any, Error>, 'queryKey'>,
 ) {
   const metadata = useMetadataWithSettings();
-  return useQuery<TableMetadata | undefined>({
+  return useQuery<TableMetadata | null>({
     queryKey: ['useMetadata.useTableMetadata', { databaseName, tableName }],
     queryFn: async () => {
-      return await metadata.getTableMetadata({
+      // `getTableMetadata` resolves to `undefined` when the table doesn't
+      // exist (e.g. the source points at a database that's missing on the
+      // current ClickHouse server). React Query v5 forbids `undefined` query
+      // results and throws "Query data cannot be undefined", which previously
+      // surfaced as a hard render-loop crash from consumers of this hook.
+      // Normalize the missing case to `null` so the absence is still
+      // observable but the query resolves cleanly.
+      const tableMetadata = await metadata.getTableMetadata({
         databaseName,
         tableName,
         connectionId,
       });
+      return tableMetadata ?? null;
     },
+    retry: SCHEMA_QUERY_RETRY,
     staleTime: 1000 * 60 * 5, // Cache every 5 min
     enabled: !!databaseName && !!tableName && !!connectionId,
     ...options,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When a Source is configured against a ClickHouse database or table that doesn't exist on the current server (e.g. a stale source carried over from another deployment, or a freshly imported config before the data lands), navigating around the app crashed the page with `Maximum update depth exceeded` originating from a Mantine `<input>`. The console showed:

```
ClickHouseQueryError: Database otel_v2 does not exist.
    at t.aP.query (...)
    at async ... useMetadata.useJsonColumns
```

The crash was reproducible by creating a Trace source pointing at a database that doesn't exist (e.g. `otel_v2`), selecting it on the Search page, and navigating to/from Service Map (or other pages that observe the same source). See `before_fix_crash_screen.png` below.

## Why

Three intertwined issues combined to surface as a hard render-loop crash:

1. **`useTableMetadata`'s `queryFn` could resolve to `undefined`** when the underlying table is missing in `system.tables`. React Query v5 treats `undefined` as an invalid result and throws `Query data cannot be undefined`. That synthetic error propagated through consumers that render schema-derived UI (filter sidebar, default order-by, etc.) and contributed to render loops.

2. **Schema-discovery hooks used the default 3-retry policy.** "Database does not exist" is deterministic — retrying just amplifies the spurious re-renders that triggered the crash, and hammers ClickHouse with useless `DESCRIBE` requests.

3. **`SearchInputV2`'s English-explanation effect re-ran every render.** Many callers pass an inline `tcFromSource(source)` for `tableConnection`, which produces a fresh object reference each parent render. The effect depended on that reference, called `genEnglishExplanation` (which performs schema lookups), and updated state in a tight loop. When the underlying schema lookup rejected, the `.then` had no error handler, so the rejection bubbled as an unhandled promise rejection during a render storm. `useFieldExpressionGenerator` had a similar instability — it returned a fresh `getFieldExpression` closure on every render, destabilizing `useMemo` deps in callers.

## What changed

- `useTableMetadata` now normalizes the missing-table case to `null` (instead of `undefined`), so React Query no longer throws. Consumers already use `tableMetadata?.…`, so they see absence either way.
- `useColumns`, `useJsonColumns`, and `useTableMetadata` now use `retry: 0`. These are deterministic schema queries — retrying is never useful.
- `useFieldExpressionGenerator` memoizes its `getFieldExpression` closure with `useCallback` keyed on `jsonColumns`, so consumers' `useMemo`s only recompute when the JSON-column set actually changes.
- `SearchInputV2` stabilizes the `tableConnection` dep via a content-derived key, swallows schema-lookup rejections to a `console.warn`, and adds a cancel flag so a stale resolution can't update state after the connection changed.

## Walkthrough

Before — `Search → Service Map` with a source pointing at a non-existent database hard-crashed the page with `Maximum update depth exceeded` (image captured prior to the fix):

[Before fix: Runtime Error overlay - Maximum update depth exceeded](https://cursor.com/agents/bc-7db2efd5-f552-49cd-85ab-7a4c5d713e7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_crash_screen.png)

After — same path now resolves cleanly: the Service Map page renders with a graceful inline error explaining that the database doesn't exist, and the rest of the navigation continues to work.

[after_fix_search_to_service_map_no_crash.mp4](https://cursor.com/agents/bc-7db2efd5-f552-49cd-85ab-7a4c5d713e7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_search_to_service_map_no_crash.mp4)
[After fix: Service Map shows ](https://cursor.com/agents/bc-7db2efd5-f552-49cd-85ab-7a4c5d713e7e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_after_fix_no_crash.png)

## Testing

- ✅ `make ci-lint` (lint + TypeScript across all packages)
- ✅ `yarn nx run @hyperdx/app:ci:unit` — 1679 tests passed, 0 failed
- ✅ Manually reproduced the original crash on `main`, then verified the same path no longer crashes after these changes (see walkthrough above).

## Notes / known follow-ups

- One specific navigation order — `Service Map → Search` while `lastSelectedSourceId` in localStorage points at a "bad" source — still surfaces the dev-mode error overlay in some manual sessions. The original user-reported error chain (`useMetadata.useJsonColumns` → React Query throwing `data is undefined` → cascade) is fixed; the remaining edge case looks like a separate render-loop interaction inside the Search page's form/source-resolution effects and was not consistently reproducible from a headless harness in this task. Investigating it further may require additional instrumentation around `useForm({ values })` syncing on the Search page.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7db2efd5-f552-49cd-85ab-7a4c5d713e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7db2efd5-f552-49cd-85ab-7a4c5d713e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

