### PR TITLE
fix: prevent jest & playwright test runners from hanging

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -92,7 +92,7 @@
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit && yarn lint:openapi",
     "ci:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --ci --forceExit",
-    "dev:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --coverage --detectOpenHandles --forceExit",
+    "dev:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --coverage --forceExit",
     "dev:migrate-db-create": "ts-node node_modules/.bin/migrate-mongo create -f migrate-mongo-config.ts",
     "dev:migrate-db": "ts-node node_modules/.bin/migrate-mongo up -f migrate-mongo-config.ts",
     "dev:migrate-ch-create": "migrate create -ext sql -dir ./migrations/ch -seq",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -92,7 +92,7 @@
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit && yarn lint:openapi",
     "ci:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --ci --forceExit",
-    "dev:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --coverage",
+    "dev:int": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_OVERRIDE=true jest --runInBand --coverage --detectOpenHandles --forceExit",
     "dev:migrate-db-create": "ts-node node_modules/.bin/migrate-mongo create -f migrate-mongo-config.ts",
     "dev:migrate-db": "ts-node node_modules/.bin/migrate-mongo up -f migrate-mongo-config.ts",
     "dev:migrate-ch-create": "migrate create -ext sql -dir ./migrations/ch -seq",

--- a/packages/api/src/tasks/usageStats.ts
+++ b/packages/api/src/tasks/usageStats.ts
@@ -21,10 +21,10 @@ import User from '@/models/user';
 // would otherwise create a worker thread that keeps Jest from exiting cleanly.
 // The logger is only instantiated when usage stats are actually reported,
 // which is gated by USAGE_STATS_ENABLED && !IS_CI in api-app.ts.
-let _logger: pino.Logger | null = null;
-function getLogger(): pino.Logger {
-  if (!_logger) {
-    _logger = pino({
+let usageStatsLogger: pino.Logger | null = null;
+function getUsageStatsLogger(): pino.Logger {
+  if (!usageStatsLogger) {
+    usageStatsLogger = pino({
       level: 'info',
       transport: {
         targets: [
@@ -39,7 +39,7 @@ function getLogger(): pino.Logger {
       },
     });
   }
-  return _logger;
+  return usageStatsLogger;
 }
 
 function extractTableNames(source: SourceDocument): string[] {
@@ -145,7 +145,7 @@ async function getUsageStats() {
       getClickhouseTableSize(),
     ]);
     const clusterId = team[0]?._id.toString();
-    getLogger().info(
+    getUsageStatsLogger().info(
       {
         clusterId,
         version: config.CODE_VERSION,

--- a/packages/api/src/tasks/usageStats.ts
+++ b/packages/api/src/tasks/usageStats.ts
@@ -16,20 +16,31 @@ import { Source, SourceDocument } from '@/models/source';
 import Team from '@/models/team';
 import User from '@/models/user';
 
-const logger = pino({
-  level: 'info',
-  transport: {
-    targets: [
-      HyperDX.getPinoTransport('info', {
-        headers: {
-          Authorization: '3f26ffad-14cf-4fb7-9dc9-e64fa0b84ee0', // hyperdx usage stats service api key
-        },
-        baseUrl: 'https://in-otel.hyperdx.io/v1/logs',
-        service: 'hyperdx-oss-usage-stats',
-      }),
-    ],
-  },
-});
+// Lazily construct the pino logger so the thread-stream worker isn't spawned
+// at module-load time. Importing this file (e.g. via api-app.ts during tests)
+// would otherwise create a worker thread that keeps Jest from exiting cleanly.
+// The logger is only instantiated when usage stats are actually reported,
+// which is gated by USAGE_STATS_ENABLED && !IS_CI in api-app.ts.
+let _logger: pino.Logger | null = null;
+function getLogger(): pino.Logger {
+  if (!_logger) {
+    _logger = pino({
+      level: 'info',
+      transport: {
+        targets: [
+          HyperDX.getPinoTransport('info', {
+            headers: {
+              Authorization: '3f26ffad-14cf-4fb7-9dc9-e64fa0b84ee0', // hyperdx usage stats service api key
+            },
+            baseUrl: 'https://in-otel.hyperdx.io/v1/logs',
+            service: 'hyperdx-oss-usage-stats',
+          }),
+        ],
+      },
+    });
+  }
+  return _logger;
+}
 
 function extractTableNames(source: SourceDocument): string[] {
   const tables: string[] = [];
@@ -134,7 +145,7 @@ async function getUsageStats() {
       getClickhouseTableSize(),
     ]);
     const clusterId = team[0]?._id.toString();
-    logger.info(
+    getLogger().info(
       {
         clusterId,
         version: config.CODE_VERSION,

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -60,6 +60,15 @@ export HDX_E2E_APP_PORT="${HDX_E2E_APP_PORT:-$((21300 + HDX_E2E_SLOT))}"
 
 export E2E_PROJECT="e2e-${HDX_E2E_SLOT}"
 
+# Prevent Playwright's html reporter from spawning a blocking server on port
+# 9323 ("Serving HTML report... Press Ctrl+C to quit.") after a failed/flaky
+# run. Without this, the test process never exits in interactive terminals,
+# which breaks non-interactive (agent) invocations of `make dev-e2e`.
+# The Makefile's `REPORT=1` flag still works because it invokes
+# `npx playwright show-report` separately after the test process exits.
+# CI is already unaffected (Playwright skips auto-open when process.env.CI is set).
+export PLAYWRIGHT_HTML_OPEN=never
+
 # --- Log capture for dev-portal visibility ---
 HDX_E2E_SLOTS_DIR="${HOME}/.config/hyperdx/dev-slots"
 HDX_E2E_LOGS_DIR="${HDX_E2E_SLOTS_DIR}/${HDX_E2E_SLOT}/logs-e2e"


### PR DESCRIPTION
## Problem

These fixes make it possible for an agent to run the integration and E2E tests non-interactively via `make dev-int ...` and `make dev-e2e ...`. Today both commands hang instead of exiting cleanly, which blocks agent workflows that depend on the test process terminating on its own.

### 1. `make dev-int` — Jest open handle

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  WORKER,MESSAGEPORT
      19 | const logger = pino({
         |                    ^
      at createWorker (../../../node_modules/thread-stream/index.js:55:18)
      ...
      at Object.<anonymous> (tasks/usageStats.ts:19:20)
      at Object.require (api-app.ts:20:1)
      at Object.require (server.ts:5:1)
      at Object.require (fixtures.ts:20:1)
      at Object.<anonymous> (routers/api/__tests__/savedSearch.test.ts:1:1)
```

Without `--forceExit`, this open handle causes the integration test suite to **hang** instead of exiting after the tests complete.

### 2. `make dev-e2e` — Playwright HTML reporter

```
Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.
```

Playwright's `html` reporter defaults to `open: 'on-failure'`. Whenever a test fails or flakes in an interactive terminal, the reporter spawns a blocking HTTP server on port 9323 and awaits `new Promise(() => {})` forever. `scripts/test-e2e.sh` only runs `docker compose down -v` after Playwright exits, so the whole stack stays up.

## Root Causes

### Jest open handle

`packages/api/src/tasks/usageStats.ts` constructed a pino logger with a `HyperDX.getPinoTransport` target at **module-load time**. The transport spawns a `thread-stream` worker thread (MESSAGEPORT) as soon as the file is imported, regardless of whether usage stats are enabled.

The `USAGE_STATS_ENABLED && !IS_CI` gate in `api-app.ts:84` only guards the **invocation** of `usageStats()`, not the import side effect. Any test that imports `server.ts` (via `fixtures.ts`) transitively pulled in this module and spawned the worker, which kept Jest from exiting.

This is why https://github.com/hyperdxio/hyperdx/commit/7335a23acdd4943367cbd49c9065db210ee646df previously had to remove `--forceExit` from `dev:int` — but without `--forceExit`, the suite hangs on this open handle.

### Playwright report server

In `node_modules/playwright/lib/reporters/html.js`:
- Line 94: `open` defaults to `'on-failure'` when not set in config.
- Line 130: auto-open is skipped only when `process.env.CI` is truthy.
- Line 133: when running under a TTY and any test failed, `shouldOpen` becomes true.
- Lines 176, 185: starts an HTTP server on port 9323 and `await new Promise(() => {})` forever.

`packages/app/playwright.config.ts:38` registers `['html']` with no options, so the default `on-failure` applies. `scripts/test-e2e.sh` runs Playwright from a TTY, so the auto-open kicks in on any failure/flake — `make dev-e2e` blocks until you hit Ctrl+C.

## Fix

1. **Make the pino logger lazy** in `tasks/usageStats.ts` so the thread-stream worker is only spawned when usage stats are actually reported. Since the default export is gated by `USAGE_STATS_ENABLED && !IS_CI` in `api-app.ts`, the lazy logger never initializes during tests.
2. **Restore `--forceExit`** on the `dev:int` jest script as a belt-and-braces safeguard. Without `--forceExit`, any future stray open handle would cause the integration test suite to hang indefinitely instead of exiting cleanly after the tests complete.
3. **Remove `--detectOpenHandles`** from `dev:int` — it was diagnostic-only and no longer needed.
4. **Set `PLAYWRIGHT_HTML_OPEN=never` in `scripts/test-e2e.sh`** so the html reporter never spawns the blocking port 9323 server. The Makefile's existing `REPORT=1` flag still works because it invokes `npx playwright show-report` separately *after* the test process exits. CI is unaffected — Playwright already skips auto-open when `process.env.CI` is set.

## Verification

- `yarn lint:fix` — 0 errors
- `npx tsc --noEmit` — clean
- `make dev-int FILE=savedSearch` — no more `WORKER,MESSAGEPORT` warning, Jest exits cleanly
- `make dev-e2e FILE=<anything>` — exits cleanly even when tests fail/flake; `REPORT=1` continues to work as the explicit opt-in for the report UI