### PR TITLE
refactor: Use new VirtualMultiSelect for dashboard filter inputs

### DIFF
--- a/.changeset/perfect-ladybugs-scream.md
+++ b/.changeset/perfect-ladybugs-scream.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+refactor: Use new VirtualMultiSelect for dashboard filter inputs

--- a/packages/app/src/DashboardFilters.tsx
+++ b/packages/app/src/DashboardFilters.tsx
@@ -1,8 +1,9 @@
 import { FilterState } from '@hyperdx/common-utils/dist/filters';
 import { DashboardFilter } from '@hyperdx/common-utils/dist/types';
-import { Group, MultiSelect, Stack, Text, Tooltip } from '@mantine/core';
+import { Group, Stack, Text, Tooltip } from '@mantine/core';
 import { IconHelp, IconRefresh } from '@tabler/icons-react';
 
+import { VirtualMultiSelect } from './components/VirtualMultiSelect/VirtualMultiSelect';
 import { useDashboardFilterValues } from './hooks/useDashboardFilterValues';
 
 interface DashboardFilterSelectProps {
@@ -26,11 +27,7 @@ const DashboardFilterSelect = ({
   values,
   isLoading,
 }: DashboardFilterSelectProps) => {
-  const selectValues = values?.toSorted().map(value => ({
-    value,
-    label: value,
-  }));
-
+  const sortedValues = values?.toSorted() || [];
   const tooltipText = getAppliesToTooltip(filter);
 
   return (
@@ -47,21 +44,16 @@ const DashboardFilterSelect = ({
           />
         </Tooltip>
       </Group>
-      <MultiSelect
-        placeholder={value.length === 0 ? filter.name : undefined}
-        value={value}
-        data={selectValues || []}
-        searchable
-        clearable
-        size="xs"
-        maxDropdownHeight={280}
-        disabled={isLoading}
-        variant="filled"
-        w={250}
-        limit={20}
-        onChange={onChange}
-        data-testid={`dashboard-filter-select-${filter.name}`}
-      />
+      <div style={{ width: 250 }}>
+        <VirtualMultiSelect
+          placeholder={value.length === 0 ? filter.name : undefined}
+          values={value}
+          data={sortedValues}
+          disabled={isLoading}
+          onChange={onChange}
+          data-testid={`dashboard-filter-select-${filter.name}`}
+        />
+      </div>
     </Stack>
   );
 };

--- a/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.stories.tsx
+++ b/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.stories.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { sample, times } from 'lodash';
+import { Box } from '@mantine/core';
+import { Meta, StoryObj } from '@storybook/nextjs';
+
+import { VirtualMultiSelect } from './VirtualMultiSelect';
+
+const regions = [
+  'eu-central',
+  'eu-central-eu-central',
+  'eu-north',
+  'eu-west',
+  'eu-west',
+];
+const data = times(10_000, i => `${sample(regions)}-${i}`);
+
+const meta: Meta<typeof VirtualMultiSelect> = {
+  title: 'Components/VirtualMultiSelect',
+
+  component: VirtualMultiSelect,
+
+  parameters: {
+    layout: 'centered',
+  },
+
+  args: {
+    placeholder: 'regions',
+    disabled: false,
+  },
+
+  argTypes: {
+    data: { table: { disable: true } },
+    values: { table: { disable: true } },
+    onChange: { table: { disable: true } },
+  },
+
+  decorators: [
+    (Story, ctx) => {
+      const [values, onChange] = useState<string[]>([]);
+      return (
+        <Box maw={128}>
+          <Story args={{ ...ctx.args, data, values, onChange }} />
+        </Box>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof VirtualMultiSelect>;
+
+export const Primary: Story = {};

--- a/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.tsx
+++ b/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.tsx
@@ -1,0 +1,197 @@
+import {
+  ChangeEventHandler,
+  KeyboardEventHandler,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  CheckIcon,
+  CloseButton,
+  Combobox,
+  Group,
+  Pill,
+  PillsInput,
+  ScrollArea,
+  Text,
+  useCombobox,
+} from '@mantine/core';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+type VirtualMultiSelectProps = {
+  data: string[];
+  disabled?: boolean;
+  placeholder?: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+  'data-testid'?: string;
+};
+
+export function VirtualMultiSelect({
+  data,
+  disabled,
+  placeholder,
+  values,
+  onChange,
+  'data-testid': dataTestId,
+}: VirtualMultiSelectProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  const [search, setSearch] = useState('');
+
+  const options = useMemo(() => {
+    const searchLowerCase = search.trim().toLowerCase();
+    return data.filter(item => item.toLowerCase().includes(searchLowerCase));
+  }, [data, search]);
+
+  const virtualizer = useVirtualizer({
+    count: options.length,
+    getScrollElement: () => viewportRef.current,
+    estimateSize: () => 36,
+    overscan: 5,
+  });
+
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+    onDropdownOpen: () => {
+      combobox.updateSelectedOptionIndex('active');
+      virtualizer.measure();
+    },
+  });
+
+  const handleSelectValue = (val: string) =>
+    onChange(
+      values.includes(val) ? values.filter(v => v !== val) : [...values, val],
+    );
+
+  const handleRemoveValue = (val: string) =>
+    onChange(values.filter(v => v !== val));
+
+  const handleRemoveAllValues = () => onChange([]);
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = event => {
+    if (event.key === 'Backspace' && search.length === 0 && values.length > 0) {
+      event.preventDefault();
+      handleRemoveValue(values[values.length - 1]);
+    }
+  };
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = event => {
+    combobox.updateSelectedOptionIndex();
+    setSearch(event.currentTarget.value);
+  };
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+
+  return (
+    <Combobox
+      store={combobox}
+      onOptionSubmit={handleSelectValue}
+      disabled={disabled}
+    >
+      <Combobox.DropdownTarget>
+        <PillsInput
+          onClick={() => combobox.openDropdown()}
+          disabled={disabled}
+          size="xs"
+          data-testid={dataTestId}
+          {...(values.length
+            ? {
+                rightSection: (
+                  <CloseButton
+                    disabled={disabled}
+                    size="xs"
+                    variant="transparent"
+                    onClick={handleRemoveAllValues}
+                  />
+                ),
+                rightSectionPointerEvents: disabled ? 'none' : 'auto',
+              }
+            : {
+                rightSection: <Combobox.Chevron />,
+                rightSectionPointerEvents: 'none',
+              })}
+        >
+          <Pill.Group>
+            {values.map(item => (
+              <Pill
+                key={item}
+                withRemoveButton
+                onRemove={() => handleRemoveValue(item)}
+                // manually disabling instead of using `disabled` prop
+                // `disabled` prop hides remove button which can cause layout to jump
+                aria-disabled={disabled}
+                styles={{ root: { pointerEvents: disabled ? 'none' : 'auto' } }}
+              >
+                {item}
+              </Pill>
+            ))}
+
+            <Combobox.EventsTarget>
+              <PillsInput.Field
+                onFocus={() => combobox.openDropdown()}
+                onBlur={() => combobox.closeDropdown()}
+                value={search}
+                placeholder={placeholder}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+              />
+            </Combobox.EventsTarget>
+          </Pill.Group>
+        </PillsInput>
+      </Combobox.DropdownTarget>
+
+      <Combobox.Dropdown>
+        <Combobox.Options>
+          {options.length > 0 ? (
+            <ScrollArea.Autosize
+              type="scroll"
+              mah={300}
+              viewportRef={viewportRef}
+            >
+              <div
+                style={{
+                  height: `${totalSize}px`,
+                  width: '100%',
+                  position: 'relative',
+                }}
+              >
+                {virtualItems.map(virtualItem => {
+                  const item = options[virtualItem.index];
+
+                  return (
+                    <div
+                      key={virtualItem.key}
+                      data-index={virtualItem.index}
+                      ref={virtualizer.measureElement}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      <Combobox.Option
+                        value={item}
+                        active={values.includes(item)}
+                      >
+                        <Group gap="xs">
+                          {values.includes(item) && <CheckIcon size={10} />}
+                          <Text size="xs">{item}</Text>
+                        </Group>
+                      </Combobox.Option>
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea.Autosize>
+          ) : (
+            <Combobox.Empty>Nothing found...</Combobox.Empty>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}


### PR DESCRIPTION
## Summary

This PR backports the VirtualMultiSelect component from the EE repo, and makes use of it in the dashboard filters.

This ensures we can use a consistent component for dashboard filter dropdowns between the current dashboard filters and upcoming source filters on dashboards.

### Screenshots or video

<img width="1296" height="839" alt="Screenshot 2026-05-26 at 6 45 59 AM" src="https://github.com/user-attachments/assets/28f64b43-c8c8-4b65-bc20-22db3ee67596" />

### How to test on Vercel preview

This can be tested by adding a filter to a dashboard in the preview environment and testing the dropdown functionality.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4333
- Related PRs:
