### PR TITLE
feat: adds direct_read optimization by default for logs and traces

### DIFF
--- a/.changeset/direct-read-map-default.md
+++ b/.changeset/direct-read-map-default.md
@@ -22,15 +22,23 @@ unaffected (`CREATE TABLE IF NOT EXISTS` is a no-op).
 At query time, the app gates the `Map['key'] = 'value'` →
 `has(<MapItems>, concat('key', '=', 'value'))` rewrite on the connected
 ClickHouse server version (`SELECT version()`, cached per connection).
-The direct_read feature was backported into multiple stable 26.x release
-lines, so the gate uses a per-branch minimum:
+The gate only applies to **ALIAS** items columns, which are computed at
+query time and therefore depend on the server being able to perform a
+direct_read against the underlying Map's tuple storage. The direct_read
+feature was backported into multiple stable 26.x release lines, so the
+gate uses a per-branch minimum:
 
 - 26.2 line: >= 26.2.19.43
 - 26.3 line: >= 26.3.12.3
 - 26.4 line: >= 26.4.3.37
 - 26.5+ : always supported
 
-Servers below their branch's threshold continue to compile filters into
-the original Map-subscript form, since they cannot perform the direct_read
-against the Map's underlying tuple storage that makes the optimization
-profitable.
+ALIAS items columns on servers below their branch's threshold continue
+to compile filters into the original Map-subscript form.
+
+**MATERIALIZED items columns are always used when available**, regardless
+of ClickHouse version. MATERIALIZED columns are physically stored on
+disk, so `has(items, ...)` reads them directly and works on any
+ClickHouse version that supports the text index itself. Operators who
+want the optimization on servers below the backport cutoffs can
+`ALTER TABLE` to materialize the items columns.

--- a/.changeset/direct-read-map-default.md
+++ b/.changeset/direct-read-map-default.md
@@ -1,0 +1,36 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": patch
+---
+
+feat: default the direct_read map column optimization on supported ClickHouse versions
+
+The full-text-search logs schema (`00002_otel_logs.sql`) now ships with
+`ResourceAttributeItems`, `ScopeAttributeItems`, and `LogAttributeItems`
+ALIAS columns plus their `text(tokenizer='array')` skip indexes. The
+traces schema (`00005_otel_traces.sql`) similarly gains
+`ResourceAttributeItems` and `SpanAttributeItems` ALIAS columns with
+matching items indexes. New installs and freshly migrated tables get
+the optimization automatically — no manual `ALTER TABLE` required.
+
+Note: the traces table previously used only `bloom_filter` skip indexes
+and worked on any ClickHouse version. The added `text(tokenizer='array')`
+items indexes raise the minimum ClickHouse version required to **create**
+the traces table to **>= 26.2**. Existing tables on older clusters are
+unaffected (`CREATE TABLE IF NOT EXISTS` is a no-op).
+
+At query time, the app gates the `Map['key'] = 'value'` →
+`has(<MapItems>, concat('key', '=', 'value'))` rewrite on the connected
+ClickHouse server version (`SELECT version()`, cached per connection).
+The direct_read feature was backported into multiple stable 26.x release
+lines, so the gate uses a per-branch minimum:
+
+- 26.2 line: >= 26.2.19.43
+- 26.3 line: >= 26.3.12.3
+- 26.4 line: >= 26.4.3.37
+- 26.5+ : always supported
+
+Servers below their branch's threshold continue to compile filters into
+the original Map-subscript form, since they cannot perform the direct_read
+against the Map's underlying tuple storage that makes the optimization
+profitable.

--- a/docker/clickhouse/local/init-db-e2e.sh
+++ b/docker/clickhouse/local/init-db-e2e.sh
@@ -81,12 +81,16 @@ CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_otel_traces
     \`Links.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
     \`__hdx_materialized_rum.sessionId\` String MATERIALIZED ResourceAttributes['rum.sessionId'] CODEC(ZSTD(1)),
     \`SampleRate\` UInt64 MATERIALIZED greatest(toUInt64OrZero(SpanAttributes['SampleRate']), 1) CODEC(T64, ZSTD(1)),
+    \`ResourceAttributeItems\` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), ResourceAttributes::Array(Tuple(String, String))),
+    \`SpanAttributeItems\` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), SpanAttributes::Array(Tuple(String, String))),
     INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_rum_session_id __hdx_materialized_rum.sessionId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_items ResourceAttributeItems TYPE text(tokenizer = 'array'),
     INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_items SpanAttributeItems TYPE text(tokenizer = 'array'),
     INDEX idx_duration Duration TYPE minmax GRANULARITY 1,
     INDEX idx_lower_span_name lower(SpanName) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
 )

--- a/docker/otel-collector/schema/seed/00002_otel_logs.sql
+++ b/docker/otel-collector/schema/seed/00002_otel_logs.sql
@@ -25,13 +25,16 @@ CREATE TABLE IF NOT EXISTS ${DATABASE}.otel_logs
   `__hdx_materialized_k8s.pod.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.name'] CODEC(ZSTD(1)),
   `__hdx_materialized_k8s.pod.uid` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.uid'] CODEC(ZSTD(1)),
   `__hdx_materialized_deployment.environment.name` LowCardinality(String) MATERIALIZED ResourceAttributes['deployment.environment.name'] CODEC(ZSTD(1)),
+  `ResourceAttributeItems` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), ResourceAttributes::Array(Tuple(String, String))),
+  `ScopeAttributeItems` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), ScopeAttributes::Array(Tuple(String, String))),
+  `LogAttributeItems` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), LogAttributes::Array(Tuple(String, String))),
   INDEX idx_trace_id TraceId TYPE text(tokenizer = 'array'),
   INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE text(tokenizer = 'array'),
-  INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE text(tokenizer = 'array'),
+  INDEX idx_res_attr_items ResourceAttributeItems TYPE text(tokenizer = 'array'),
   INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE text(tokenizer = 'array'),
-  INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE text(tokenizer = 'array'),
+  INDEX idx_scope_attr_items ScopeAttributeItems TYPE text(tokenizer = 'array'),
   INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE text(tokenizer = 'array'),
-  INDEX idx_log_attr_value mapValues(LogAttributes) TYPE text(tokenizer = 'array'),
+  INDEX idx_log_attr_items LogAttributeItems TYPE text(tokenizer = 'array'),
   INDEX idx_lower_body lower(Body) TYPE text(tokenizer = 'splitByNonAlpha')
 )
 ENGINE = MergeTree

--- a/docker/otel-collector/schema/seed/00005_otel_traces.sql
+++ b/docker/otel-collector/schema/seed/00005_otel_traces.sql
@@ -25,12 +25,14 @@ CREATE TABLE IF NOT EXISTS ${DATABASE}.otel_traces
     `Links.Attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
     `__hdx_materialized_rum.sessionId` String MATERIALIZED ResourceAttributes['rum.sessionId'] CODEC(ZSTD(1)),
     `SampleRate` UInt64 MATERIALIZED greatest(toUInt64OrZero(SpanAttributes['SampleRate']), 1) CODEC(T64, ZSTD(1)),
+    `ResourceAttributeItems` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), ResourceAttributes::Array(Tuple(String, String))),
+    `SpanAttributeItems` Array(String) ALIAS arrayMap((arr) -> concat(arr.1, '=', arr.2), SpanAttributes::Array(Tuple(String, String))),
     INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_rum_session_id __hdx_materialized_rum.sessionId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_items ResourceAttributeItems TYPE text(tokenizer = 'array'),
     INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_items SpanAttributeItems TYPE text(tokenizer = 'array'),
     INDEX idx_duration Duration TYPE minmax GRANULARITY 1,
     INDEX idx_lower_span_name lower(SpanName) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
 )

--- a/docker/otel-collector/schema/seed/00005_otel_traces_compat.sql
+++ b/docker/otel-collector/schema/seed/00005_otel_traces_compat.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+-- Compatibility schema for ClickHouse < 26.2 (no full text search indexes).
+-- The main schema (00005_otel_traces.sql) adds text(tokenizer='array') items
+-- indexes that older ClickHouse cannot create; this file preserves the prior
+-- bloom_filter-only schema so traces still works on those servers.
+CREATE TABLE IF NOT EXISTS ${DATABASE}.otel_traces
+(
+    `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `TraceId` String CODEC(ZSTD(1)),
+    `SpanId` String CODEC(ZSTD(1)),
+    `ParentSpanId` String CODEC(ZSTD(1)),
+    `TraceState` String CODEC(ZSTD(1)),
+    `SpanName` LowCardinality(String) CODEC(ZSTD(1)),
+    `SpanKind` LowCardinality(String) CODEC(ZSTD(1)),
+    `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
+    `ResourceAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `ScopeName` String CODEC(ZSTD(1)),
+    `ScopeVersion` String CODEC(ZSTD(1)),
+    `SpanAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `Duration` UInt64 CODEC(ZSTD(1)),
+    `StatusCode` LowCardinality(String) CODEC(ZSTD(1)),
+    `StatusMessage` String CODEC(ZSTD(1)),
+    `Events.Timestamp` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    `Events.Name` Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    `Links.TraceId` Array(String) CODEC(ZSTD(1)),
+    `Links.SpanId` Array(String) CODEC(ZSTD(1)),
+    `Links.TraceState` Array(String) CODEC(ZSTD(1)),
+    `Links.Attributes` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    `__hdx_materialized_rum.sessionId` String MATERIALIZED ResourceAttributes['rum.sessionId'] CODEC(ZSTD(1)),
+    `SampleRate` UInt64 MATERIALIZED greatest(toUInt64OrZero(SpanAttributes['SampleRate']), 1) CODEC(T64, ZSTD(1)),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_rum_session_id __hdx_materialized_rum.sessionId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_duration Duration TYPE minmax GRANULARITY 1,
+    INDEX idx_lower_span_name lower(SpanName) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+TTL toDate(Timestamp) + ${TABLES_TTL}
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -1043,6 +1043,9 @@ describe('searchFilters', () => {
       },
     ]);
     metadata.getSetting = jest.fn().mockResolvedValue('0');
+    metadata.getServerVersion = jest
+      .fn()
+      .mockResolvedValue([26, 5, 0, 0] as const);
 
     const serializer = new CustomSchemaSQLSerializerV2({
       metadata,

--- a/packages/common-utils/src/__tests__/clickhouseVersion.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouseVersion.test.ts
@@ -1,0 +1,176 @@
+import {
+  compareClickHouseVersion,
+  isClickHouseVersionAtLeast,
+  parseClickHouseVersion,
+  supportsDirectReadMap,
+} from '@/core/clickhouseVersion';
+
+type ClickHouseVersionTuple = readonly [number, number, number, number];
+
+describe('parseClickHouseVersion', () => {
+  it('parses a full 4-part version string', () => {
+    expect(parseClickHouseVersion('26.4.1.3')).toEqual([26, 4, 1, 3]);
+  });
+
+  it('parses a version with multi-digit components', () => {
+    expect(parseClickHouseVersion('25.12.0.123')).toEqual([25, 12, 0, 123]);
+  });
+
+  it('defaults missing trailing components to 0', () => {
+    expect(parseClickHouseVersion('26.4')).toEqual([26, 4, 0, 0]);
+    expect(parseClickHouseVersion('26.4.1')).toEqual([26, 4, 1, 0]);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseClickHouseVersion('  26.4.1.3  ')).toEqual([26, 4, 1, 3]);
+  });
+
+  it('ignores trailing build metadata after the 4th component', () => {
+    expect(parseClickHouseVersion('26.4.1.3-stable')).toEqual([26, 4, 1, 3]);
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(parseClickHouseVersion('')).toBeUndefined();
+    expect(parseClickHouseVersion('   ')).toBeUndefined();
+  });
+
+  it('returns undefined when major or minor are not numeric', () => {
+    expect(parseClickHouseVersion('abc.4.1.3')).toBeUndefined();
+    expect(parseClickHouseVersion('26.xx.1.3')).toBeUndefined();
+  });
+
+  it('returns undefined when there are fewer than two components', () => {
+    expect(parseClickHouseVersion('26')).toBeUndefined();
+  });
+});
+
+describe('compareClickHouseVersion', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareClickHouseVersion([26, 4, 1, 3], [26, 4, 1, 3])).toBe(0);
+  });
+
+  it('compares by major first', () => {
+    expect(
+      compareClickHouseVersion([27, 0, 0, 0], [26, 99, 99, 99]),
+    ).toBeGreaterThan(0);
+  });
+
+  it('compares by minor when major is equal', () => {
+    expect(
+      compareClickHouseVersion([26, 4, 0, 0], [26, 3, 99, 99]),
+    ).toBeGreaterThan(0);
+  });
+
+  it('compares by patch when major and minor are equal', () => {
+    expect(
+      compareClickHouseVersion([26, 4, 2, 0], [26, 4, 1, 99]),
+    ).toBeGreaterThan(0);
+  });
+
+  it('compares by tweak as the lowest-priority component', () => {
+    expect(compareClickHouseVersion([26, 4, 1, 4], [26, 4, 1, 3])).toBe(1);
+    expect(compareClickHouseVersion([26, 4, 1, 2], [26, 4, 1, 3])).toBe(-1);
+  });
+});
+
+describe('isClickHouseVersionAtLeast', () => {
+  const threshold = [26, 4, 1, 3] as const;
+
+  it('accepts the exact threshold version', () => {
+    expect(isClickHouseVersionAtLeast([26, 4, 1, 3], threshold)).toBe(true);
+  });
+
+  it('accepts versions above the threshold', () => {
+    expect(isClickHouseVersionAtLeast([26, 4, 1, 4], threshold)).toBe(true);
+    expect(isClickHouseVersionAtLeast([27, 0, 0, 0], threshold)).toBe(true);
+  });
+
+  it('rejects versions below the threshold', () => {
+    expect(isClickHouseVersionAtLeast([26, 4, 1, 2], threshold)).toBe(false);
+    expect(isClickHouseVersionAtLeast([26, 4, 0, 99], threshold)).toBe(false);
+    expect(isClickHouseVersionAtLeast([26, 2, 0, 0], threshold)).toBe(false);
+    expect(isClickHouseVersionAtLeast([25, 99, 99, 99], threshold)).toBe(false);
+  });
+
+  it('returns false when the version is unknown', () => {
+    expect(isClickHouseVersionAtLeast(undefined, threshold)).toBe(false);
+  });
+});
+
+describe('supportsDirectReadMap', () => {
+  describe('26.2 backport branch (min 26.2.19.43)', () => {
+    it.each<readonly [ClickHouseVersionTuple, boolean]>([
+      [[26, 2, 19, 43], true],
+      [[26, 2, 19, 44], true],
+      [[26, 2, 20, 0], true],
+      [[26, 2, 99, 99], true],
+      [[26, 2, 19, 42], false],
+      [[26, 2, 19, 0], false],
+      [[26, 2, 18, 99], false],
+      [[26, 2, 0, 0], false],
+    ])('%j → %s', (version, expected) => {
+      expect(supportsDirectReadMap(version)).toBe(expected);
+    });
+  });
+
+  describe('26.3 backport branch (min 26.3.12.3)', () => {
+    it.each<readonly [ClickHouseVersionTuple, boolean]>([
+      [[26, 3, 12, 3], true],
+      [[26, 3, 12, 4], true],
+      [[26, 3, 13, 0], true],
+      [[26, 3, 99, 99], true],
+      [[26, 3, 12, 2], false],
+      [[26, 3, 12, 0], false],
+      [[26, 3, 11, 99], false],
+      [[26, 3, 0, 0], false],
+    ])('%j → %s', (version, expected) => {
+      expect(supportsDirectReadMap(version)).toBe(expected);
+    });
+  });
+
+  describe('26.4 backport branch (min 26.4.3.37)', () => {
+    it.each<readonly [ClickHouseVersionTuple, boolean]>([
+      [[26, 4, 3, 37], true],
+      [[26, 4, 3, 38], true],
+      [[26, 4, 4, 0], true],
+      [[26, 4, 99, 99], true],
+      [[26, 4, 3, 36], false],
+      [[26, 4, 3, 0], false],
+      [[26, 4, 2, 99], false],
+      [[26, 4, 1, 3], false],
+      [[26, 4, 0, 99], false],
+    ])('%j → %s', (version, expected) => {
+      expect(supportsDirectReadMap(version)).toBe(expected);
+    });
+  });
+
+  describe('26.5+ baseline (always supported)', () => {
+    it.each<readonly [ClickHouseVersionTuple, boolean]>([
+      [[26, 5, 0, 0], true],
+      [[26, 5, 0, 1], true],
+      [[26, 5, 99, 99], true],
+      [[26, 6, 0, 0], true],
+      [[26, 99, 99, 99], true],
+      [[27, 0, 0, 0], true],
+      [[30, 1, 2, 3], true],
+    ])('%j → %s', (version, expected) => {
+      expect(supportsDirectReadMap(version)).toBe(expected);
+    });
+  });
+
+  describe('unsupported branches', () => {
+    it.each<readonly [ClickHouseVersionTuple, boolean]>([
+      [[26, 1, 99, 99], false],
+      [[26, 0, 0, 0], false],
+      [[25, 12, 0, 0], false],
+      [[25, 99, 99, 99], false],
+      [[24, 0, 0, 0], false],
+    ])('%j → %s', (version, expected) => {
+      expect(supportsDirectReadMap(version)).toBe(expected);
+    });
+  });
+
+  it('returns false when the version is undefined', () => {
+    expect(supportsDirectReadMap(undefined)).toBe(false);
+  });
+});

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -2570,6 +2570,7 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
 
   function buildSerializer(
     serverVersion: readonly [number, number, number, number] | undefined,
+    defaultType: 'ALIAS' | 'MATERIALIZED' = 'ALIAS',
   ) {
     const metadata = getMetadata(
       new ClickhouseClient({ host: 'http://localhost:8123' }),
@@ -2595,7 +2596,7 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
       {
         name: 'LogAttributeItems',
         type: 'Array(String)',
-        default_type: 'ALIAS',
+        default_type: defaultType,
         default_expression:
           "arrayMap((arr) -> concat(arr.1, '=', arr.2), LogAttributes::Array(Tuple(String, String)))",
       },
@@ -2623,8 +2624,9 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
 
   async function buildSql(
     serverVersion: readonly [number, number, number, number] | undefined,
+    defaultType: 'ALIAS' | 'MATERIALIZED' = 'ALIAS',
   ) {
-    const serializer = buildSerializer(serverVersion);
+    const serializer = buildSerializer(serverVersion, defaultType);
     const builder = new SearchQueryBuilder(
       'LogAttributes.service.name:"my-app"',
       serializer,
@@ -2635,7 +2637,7 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
   const HAS_FORM =
     "has(`LogAttributeItems`, concat('service.name', '=', 'my-app'))";
 
-  describe('emits has() direct_read form on supported versions', () => {
+  describe('ALIAS items column - emits has() on supported versions', () => {
     it.each<readonly [number, number, number, number]>([
       [26, 2, 19, 43],
       [26, 2, 20, 0],
@@ -2647,12 +2649,12 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
       [26, 6, 0, 0],
       [27, 0, 0, 0],
     ])('%j', async (...version) => {
-      const sql = await buildSql(version);
+      const sql = await buildSql(version, 'ALIAS');
       expect(sql).toContain(HAS_FORM);
     });
   });
 
-  describe('falls back to Map subscript on unsupported versions', () => {
+  describe('ALIAS items column - falls back on unsupported versions', () => {
     it.each<readonly [number, number, number, number]>([
       [26, 2, 19, 42],
       [26, 2, 0, 0],
@@ -2664,15 +2666,43 @@ describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
       [26, 1, 99, 99],
       [25, 12, 0, 0],
     ])('%j', async (...version) => {
-      const sql = await buildSql(version);
+      const sql = await buildSql(version, 'ALIAS');
       expect(sql).not.toContain('has(`LogAttributeItems`');
       expect(sql).toContain("= 'my-app'");
     });
   });
 
-  it('falls back when server version is unknown', async () => {
-    const sql = await buildSql(undefined);
+  it('ALIAS items column falls back when server version is unknown', async () => {
+    const sql = await buildSql(undefined, 'ALIAS');
     expect(sql).not.toContain('has(`LogAttributeItems`');
     expect(sql).toContain("= 'my-app'");
+  });
+
+  describe('MATERIALIZED items column - emits has() on EVERY version', () => {
+    it.each<readonly [number, number, number, number]>([
+      [26, 2, 19, 43],
+      [26, 2, 19, 42],
+      [26, 2, 0, 0],
+      [26, 3, 12, 3],
+      [26, 3, 12, 2],
+      [26, 3, 0, 0],
+      [26, 4, 3, 37],
+      [26, 4, 3, 36],
+      [26, 4, 1, 3],
+      [26, 4, 0, 99],
+      [26, 1, 99, 99],
+      [26, 0, 0, 0],
+      [25, 12, 0, 0],
+      [26, 5, 0, 0],
+      [27, 0, 0, 0],
+    ])('%j', async (...version) => {
+      const sql = await buildSql(version, 'MATERIALIZED');
+      expect(sql).toContain(HAS_FORM);
+    });
+  });
+
+  it('MATERIALIZED items column emits has() even when server version is unknown', async () => {
+    const sql = await buildSql(undefined, 'MATERIALIZED');
+    expect(sql).toContain(HAS_FORM);
   });
 });

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -2159,6 +2159,9 @@ describe('CustomSchemaSQLSerializerV2 - KV items index optimization', () => {
     },
   ]);
   metadata.getSetting = jest.fn().mockImplementation(async () => '0');
+  metadata.getServerVersion = jest
+    .fn()
+    .mockImplementation(async () => [26, 5, 0, 0] as const);
 
   const serializer = new CustomSchemaSQLSerializerV2({
     metadata,
@@ -2271,6 +2274,9 @@ describe('CustomSchemaSQLSerializerV2 - KV items with MATERIALIZED column', () =
     },
   ]);
   metadata.getSetting = jest.fn().mockImplementation(async () => '0');
+  metadata.getServerVersion = jest
+    .fn()
+    .mockImplementation(async () => [26, 5, 0, 0] as const);
 
   const serializer = new CustomSchemaSQLSerializerV2({
     metadata,
@@ -2292,6 +2298,78 @@ describe('CustomSchemaSQLSerializerV2 - KV items with MATERIALIZED column', () =
   });
 });
 
+describe('CustomSchemaSQLSerializerV2 - KV items with ALIAS column (expanded index expr)', () => {
+  // ClickHouse expands the skip-index `expr` for ALIAS columns to the full
+  // default_expression, instead of keeping it as the bare column name like it
+  // does for MATERIALIZED columns. This matches what the FTS schema emits.
+  const metadata = getMetadata(
+    new ClickhouseClient({ host: 'http://localhost:8123' }),
+  );
+  const databaseName = 'default';
+  const tableName = 'otel_logs';
+  const connectionId = 'test';
+  const aliasDefaultExpression =
+    "arrayMap(arr -> concat(arr.1, '=', arr.2), CAST(LogAttributes, 'Array(Tuple(String, String))'))";
+
+  metadata.getColumn = jest.fn().mockImplementation(async ({ column }) => {
+    if (column === 'LogAttributes') {
+      return { name: 'LogAttributes', type: 'Map(String, String)' };
+    } else if (column === 'Body') {
+      return { name: 'Body', type: 'String' };
+    }
+    return undefined;
+  });
+  metadata.getMaterializedColumnsLookupTable = jest
+    .fn()
+    .mockResolvedValue(new Map());
+  metadata.getColumns = jest.fn().mockResolvedValue([
+    {
+      name: 'LogAttributes',
+      type: 'Map(String, String)',
+      default_type: '',
+      default_expression: '',
+    },
+    {
+      name: 'LogAttributeItems',
+      type: 'Array(String)',
+      default_type: 'ALIAS',
+      default_expression: aliasDefaultExpression,
+    },
+  ]);
+  metadata.getSkipIndices = jest.fn().mockResolvedValue([
+    {
+      name: 'idx_log_attr_items',
+      type: 'text',
+      typeFull: 'text(tokenizer=array)',
+      expression: aliasDefaultExpression,
+      granularity: 1,
+    },
+  ]);
+  metadata.getSetting = jest.fn().mockResolvedValue('0');
+  metadata.getServerVersion = jest
+    .fn()
+    .mockResolvedValue([26, 5, 0, 0] as const);
+
+  const serializer = new CustomSchemaSQLSerializerV2({
+    metadata,
+    databaseName,
+    tableName,
+    connectionId,
+    implicitColumnExpression: 'Body',
+  });
+
+  it('matches the index by its expanded ALIAS expression', async () => {
+    const builder = new SearchQueryBuilder(
+      'LogAttributes.error.message:"Failed to fetch"',
+      serializer,
+    );
+    const sql = await builder.build();
+    expect(sql).toBe(
+      "((has(`LogAttributeItems`, concat('error.message', '=', 'Failed to fetch'))))",
+    );
+  });
+});
+
 describe('CustomSchemaSQLSerializerV2 - KV items fallback cases', () => {
   const databaseName = 'default';
   const tableName = 'otel_logs';
@@ -2301,6 +2379,7 @@ describe('CustomSchemaSQLSerializerV2 - KV items fallback cases', () => {
     columns?: any[];
     skipIndices?: any[];
     getColumn?: (opts: { column: string }) => any;
+    serverVersion?: readonly [number, number, number, number] | undefined;
   }) {
     const metadata = getMetadata(
       new ClickhouseClient({ host: 'http://localhost:8123' }),
@@ -2325,6 +2404,15 @@ describe('CustomSchemaSQLSerializerV2 - KV items fallback cases', () => {
       .fn()
       .mockImplementation(async () => overrides.skipIndices ?? []);
     metadata.getSetting = jest.fn().mockImplementation(async () => '0');
+    const serverVersion = Object.prototype.hasOwnProperty.call(
+      overrides,
+      'serverVersion',
+    )
+      ? overrides.serverVersion
+      : ([26, 5, 0, 0] as const);
+    metadata.getServerVersion = jest
+      .fn()
+      .mockImplementation(async () => serverVersion);
 
     return new CustomSchemaSQLSerializerV2({
       metadata,
@@ -2472,5 +2560,119 @@ describe('CustomSchemaSQLSerializerV2 - KV items fallback cases', () => {
     // Should use CAST for numeric comparison, not has()
     expect(sql).not.toContain('has(');
     expect(sql).toContain('CAST');
+  });
+});
+
+describe('CustomSchemaSQLSerializerV2 - KV items version gate', () => {
+  const databaseName = 'default';
+  const tableName = 'otel_logs';
+  const connectionId = 'test';
+
+  function buildSerializer(
+    serverVersion: readonly [number, number, number, number] | undefined,
+  ) {
+    const metadata = getMetadata(
+      new ClickhouseClient({ host: 'http://localhost:8123' }),
+    );
+    metadata.getColumn = jest.fn().mockImplementation(async ({ column }) => {
+      if (column === 'LogAttributes') {
+        return { name: 'LogAttributes', type: 'Map(String, String)' };
+      } else if (column === 'Body') {
+        return { name: 'Body', type: 'String' };
+      }
+      return undefined;
+    });
+    metadata.getMaterializedColumnsLookupTable = jest
+      .fn()
+      .mockResolvedValue(new Map());
+    metadata.getColumns = jest.fn().mockResolvedValue([
+      {
+        name: 'LogAttributes',
+        type: 'Map(String, String)',
+        default_type: '',
+        default_expression: '',
+      },
+      {
+        name: 'LogAttributeItems',
+        type: 'Array(String)',
+        default_type: 'ALIAS',
+        default_expression:
+          "arrayMap((arr) -> concat(arr.1, '=', arr.2), LogAttributes::Array(Tuple(String, String)))",
+      },
+    ]);
+    metadata.getSkipIndices = jest.fn().mockResolvedValue([
+      {
+        name: 'idx_log_attr_items',
+        type: 'text',
+        typeFull: 'text(tokenizer=array)',
+        expression: 'LogAttributeItems',
+        granularity: 1,
+      },
+    ]);
+    metadata.getSetting = jest.fn().mockResolvedValue('0');
+    metadata.getServerVersion = jest.fn().mockResolvedValue(serverVersion);
+
+    return new CustomSchemaSQLSerializerV2({
+      metadata,
+      databaseName,
+      tableName,
+      connectionId,
+      implicitColumnExpression: 'Body',
+    });
+  }
+
+  async function buildSql(
+    serverVersion: readonly [number, number, number, number] | undefined,
+  ) {
+    const serializer = buildSerializer(serverVersion);
+    const builder = new SearchQueryBuilder(
+      'LogAttributes.service.name:"my-app"',
+      serializer,
+    );
+    return builder.build();
+  }
+
+  const HAS_FORM =
+    "has(`LogAttributeItems`, concat('service.name', '=', 'my-app'))";
+
+  describe('emits has() direct_read form on supported versions', () => {
+    it.each<readonly [number, number, number, number]>([
+      [26, 2, 19, 43],
+      [26, 2, 20, 0],
+      [26, 3, 12, 3],
+      [26, 3, 13, 0],
+      [26, 4, 3, 37],
+      [26, 4, 99, 99],
+      [26, 5, 0, 0],
+      [26, 6, 0, 0],
+      [27, 0, 0, 0],
+    ])('%j', async (...version) => {
+      const sql = await buildSql(version);
+      expect(sql).toContain(HAS_FORM);
+    });
+  });
+
+  describe('falls back to Map subscript on unsupported versions', () => {
+    it.each<readonly [number, number, number, number]>([
+      [26, 2, 19, 42],
+      [26, 2, 0, 0],
+      [26, 3, 12, 2],
+      [26, 3, 0, 0],
+      [26, 4, 3, 36],
+      [26, 4, 1, 3],
+      [26, 4, 0, 99],
+      [26, 1, 99, 99],
+      [25, 12, 0, 0],
+    ])('%j', async (...version) => {
+      const sql = await buildSql(version);
+      expect(sql).not.toContain('has(`LogAttributeItems`');
+      expect(sql).toContain("= 'my-app'");
+    });
+  });
+
+  it('falls back when server version is unknown', async () => {
+    const sql = await buildSql(undefined);
+    expect(sql).not.toContain('has(`LogAttributeItems`');
+    expect(sql).toContain("= 'my-app'");
   });
 });

--- a/packages/common-utils/src/core/clickhouseVersion.ts
+++ b/packages/common-utils/src/core/clickhouseVersion.ts
@@ -1,0 +1,114 @@
+export type ClickHouseVersion = readonly [
+  major: number,
+  minor: number,
+  patch: number,
+  tweak: number,
+];
+
+/**
+ * Parses a ClickHouse `version()` string (e.g. "26.4.1.3" or "25.12.0.1") into a
+ * 4-tuple. Missing trailing components default to 0. Returns undefined if the
+ * leading major.minor cannot be parsed as integers.
+ */
+export function parseClickHouseVersion(
+  version: string,
+): ClickHouseVersion | undefined {
+  const trimmed = version.trim();
+  if (!trimmed) return undefined;
+
+  const parts = trimmed.split('.', 5);
+  if (parts.length < 2) return undefined;
+
+  const nums: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    const raw = parts[i] ?? '0';
+    const match = raw.match(/^\d+/);
+    if (!match) {
+      if (i < 2) return undefined;
+      nums.push(0);
+      continue;
+    }
+    const n = Number.parseInt(match[0], 10);
+    if (!Number.isFinite(n)) {
+      if (i < 2) return undefined;
+      nums.push(0);
+      continue;
+    }
+    nums.push(n);
+  }
+
+  return [nums[0], nums[1], nums[2], nums[3]] as const;
+}
+
+export function compareClickHouseVersion(
+  a: ClickHouseVersion,
+  b: ClickHouseVersion,
+): number {
+  for (let i = 0; i < 4; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+export function isClickHouseVersionAtLeast(
+  version: ClickHouseVersion | undefined,
+  min: ClickHouseVersion,
+): boolean {
+  if (!version) return false;
+  return compareClickHouseVersion(version, min) >= 0;
+}
+
+/**
+ * Per-branch minimum versions required for the direct_read map column
+ * optimization that compiles `Map['key'] = 'value'` filters into
+ * `has(<MapItems>, concat('key', '=', 'value'))`.
+ *
+ * ClickHouse backported the feature into multiple stable release lines, so
+ * there is no single threshold — each major.minor branch has its own cutoff:
+ *
+ *   - 26.2 branch → first available at 26.2.19.43
+ *   - 26.3 branch → first available at 26.3.12.3
+ *   - 26.4 branch → first available at 26.4.3.37
+ *   - 26.5+       → always supported (feature shipped in mainline)
+ *
+ * Earlier 26.x branches (26.0, 26.1) and anything < 26 never received the
+ * backport and are considered unsupported.
+ *
+ * Listed in ascending order — the highest entry defines the last branch that
+ * required a backport; everything above `DIRECT_READ_MAP_BASELINE` is on by
+ * default.
+ */
+const DIRECT_READ_MAP_BACKPORT_MINS: ReadonlyArray<ClickHouseVersion> = [
+  [26, 2, 19, 43],
+  [26, 3, 12, 3],
+  [26, 4, 3, 37],
+];
+
+/**
+ * First release where direct_read map support shipped unconditionally. Any
+ * server with major.minor at or above this is considered supported, even if
+ * its branch is not present in `DIRECT_READ_MAP_BACKPORT_MINS`.
+ */
+const DIRECT_READ_MAP_BASELINE: ClickHouseVersion = [26, 5, 0, 0];
+
+/**
+ * Returns true when the connected ClickHouse server supports the direct_read
+ * map column optimization. Returns false when the version is undefined or
+ * predates every known backport.
+ */
+export function supportsDirectReadMap(
+  version: ClickHouseVersion | undefined,
+): boolean {
+  if (!version) return false;
+
+  if (compareClickHouseVersion(version, DIRECT_READ_MAP_BASELINE) >= 0) {
+    return true;
+  }
+
+  const [vMajor, vMinor] = version;
+  const branchMin = DIRECT_READ_MAP_BACKPORT_MINS.find(
+    ([major, minor]) => major === vMajor && minor === vMinor,
+  );
+  if (!branchMin) return false;
+  return compareClickHouseVersion(version, branchMin) >= 0;
+}

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -21,6 +21,7 @@ import type {
 } from '@/types';
 import { isLogSource, isTraceSource, SourceKind } from '@/types';
 
+import { ClickHouseVersion, parseClickHouseVersion } from './clickhouseVersion';
 import {
   optimizeGetKeyValuesCalls,
   renderStartOfBucketExpr,
@@ -922,6 +923,39 @@ export class Metadata {
         }
 
         throw e;
+      }
+    });
+  }
+
+  /**
+   * Returns the parsed ClickHouse server version (from `SELECT version()`).
+   * Returns undefined when the query fails or the value cannot be parsed; the
+   * result is cached per connection and callers should treat undefined as
+   * "unknown / assume older".
+   */
+  async getServerVersion({
+    connectionId,
+  }: {
+    connectionId: string;
+  }): Promise<ClickHouseVersion | undefined> {
+    return this.cache.getOrFetch(`${connectionId}.serverVersion`, async () => {
+      try {
+        const json = await this.clickhouseClient
+          .query<'JSON'>({
+            connectionId,
+            query: 'SELECT version() AS version',
+            query_params: undefined,
+            clickhouse_settings: this.getClickHouseSettings(),
+            shouldSkipApplySettings: true,
+          })
+          .then(res => res.json<{ version: string }>());
+
+        const versionString = json.data[0]?.version;
+        if (!versionString) return undefined;
+        return parseClickHouseVersion(versionString);
+      } catch (e) {
+        console.warn('Error fetching ClickHouse server version:', e);
+        return undefined;
       }
     });
   }

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -9,6 +9,7 @@ import {
   extractInnerCHArrayJSType,
   JSDataType,
 } from '@/clickhouse';
+import { supportsDirectReadMap } from '@/core/clickhouseVersion';
 import {
   Metadata,
   parseKeyPath,
@@ -1131,6 +1132,13 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
    * a text(tokenizer=array) skip index.
    */
   private async buildKvItemsLookup(): Promise<KvItemsLookup> {
+    const serverVersion = await this.metadata.getServerVersion({
+      connectionId: this.connectionId,
+    });
+    if (!supportsDirectReadMap(serverVersion)) {
+      return new Map();
+    }
+
     const [columns, skipIndices] = await Promise.all([
       this.metadata.getColumns({
         databaseName: this.databaseName,
@@ -1161,15 +1169,14 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
       if (!parsed) continue;
 
       // Check if this column has a text(tokenizer=array) skip index
+      const candidateName = normalizeChExpression(candidate.name);
+      const candidateExpr = normalizeChExpression(candidate.default_expression);
       const hasArrayTextIndex = skipIndices.some(idx => {
         if (idx.type !== 'text') return false;
         const tokenizer = parseTokenizerFromTextIndex(idx);
         if (tokenizer?.type !== 'array') return false;
-        // Require exact match: has() won't benefit from a transformed index like lower(col)
-        return (
-          normalizeChExpression(idx.expression) ===
-          normalizeChExpression(candidate.name)
-        );
+        const idxExpr = normalizeChExpression(idx.expression);
+        return idxExpr === candidateName || idxExpr === candidateExpr;
       });
 
       if (hasArrayTextIndex) {

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -1130,16 +1130,17 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
    * A KV items column is an ALIAS/MATERIALIZED column whose expression is
    * arrayMap((k,v)->concat(k,'=',v), mapKeys(X), mapValues(X)) and which has
    * a text(tokenizer=array) skip index.
+   *
+   * The version gate (`supportsDirectReadMap`) only applies to ALIAS items
+   * columns: ALIAS columns are computed at query time, so `has(items, ...)`
+   * against an ALIAS only realizes its speedup when the server can perform a
+   * direct_read against the underlying Map's tuple storage. MATERIALIZED items
+   * columns are physically stored on disk, so `has()` reads them directly and
+   * is fast on any ClickHouse version that supports the text index itself.
    */
   private async buildKvItemsLookup(): Promise<KvItemsLookup> {
-    const serverVersion = await this.metadata.getServerVersion({
-      connectionId: this.connectionId,
-    });
-    if (!supportsDirectReadMap(serverVersion)) {
-      return new Map();
-    }
-
-    const [columns, skipIndices] = await Promise.all([
+    const [serverVersion, columns, skipIndices] = await Promise.all([
+      this.metadata.getServerVersion({ connectionId: this.connectionId }),
       this.metadata.getColumns({
         databaseName: this.databaseName,
         tableName: this.tableName,
@@ -1148,9 +1149,10 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
       this.skipIndicesPromise ?? Promise.resolve([]),
     ]);
 
+    const directReadSupported = supportsDirectReadMap(serverVersion);
+
     const lookup: KvItemsLookup = new Map();
 
-    // Find columns that are ALIAS or MATERIALIZED with KV items expressions
     const kvItemsCandidates = columns.filter(
       c =>
         (c.default_type === 'ALIAS' || c.default_type === 'MATERIALIZED') &&
@@ -1158,6 +1160,10 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     );
 
     for (const candidate of kvItemsCandidates) {
+      if (candidate.default_type === 'ALIAS' && !directReadSupported) {
+        continue;
+      }
+
       const parsed = (() => {
         let parsed: { mapColumn: string; separator: string } | undefined;
         for (const strategy of KV_ITEMS_STRATEGIES) {
@@ -1168,7 +1174,6 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
       })();
       if (!parsed) continue;
 
-      // Check if this column has a text(tokenizer=array) skip index
       const candidateName = normalizeChExpression(candidate.name);
       const candidateExpr = normalizeChExpression(candidate.default_expression);
       const hasArrayTextIndex = skipIndices.some(idx => {

--- a/packages/otel-collector/cmd/migrate/main.go
+++ b/packages/otel-collector/cmd/migrate/main.go
@@ -410,6 +410,37 @@ func removeCompatLogsSchema(tempDir string) error {
 	return nil
 }
 
+// swapTracesSchemaForCompat replaces the full-text-search traces schema with
+// the compatibility variant (bloom_filter indexes, no items columns) in the
+// processed temp directory. It removes 00005_otel_traces.sql and renames
+// 00005_otel_traces_compat.sql to take its place, so goose runs the compat
+// schema instead.
+func swapTracesSchemaForCompat(tempDir string) error {
+	fullTextPath := filepath.Join(tempDir, "00005_otel_traces.sql")
+	compatPath := filepath.Join(tempDir, "00005_otel_traces_compat.sql")
+
+	if err := os.Remove(fullTextPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove full text traces schema: %w", err)
+	}
+
+	if err := os.Rename(compatPath, fullTextPath); err != nil {
+		return fmt.Errorf("failed to rename compat traces schema: %w", err)
+	}
+
+	return nil
+}
+
+// removeCompatTracesSchema removes the compat traces schema file from the temp
+// directory when full text search is supported, so goose doesn't run both
+// schemas.
+func removeCompatTracesSchema(tempDir string) error {
+	compatPath := filepath.Join(tempDir, "00005_otel_traces_compat.sql")
+	if err := os.Remove(compatPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove compat traces schema: %w", err)
+	}
+	return nil
+}
+
 // listSQLFiles lists all SQL files in a directory for logging purposes
 func listSQLFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
@@ -478,15 +509,21 @@ func main() {
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Select the appropriate logs schema based on ClickHouse version
+	// Select the appropriate logs and traces schemas based on ClickHouse version
 	if supportsFullTextSearch(chMajor, chMinor) {
 		if err := removeCompatLogsSchema(tempDir); err != nil {
-			log.Fatalf("Failed to remove compat schema: %v", err)
+			log.Fatalf("Failed to remove compat logs schema: %v", err)
+		}
+		if err := removeCompatTracesSchema(tempDir); err != nil {
+			log.Fatalf("Failed to remove compat traces schema: %v", err)
 		}
 	} else {
-		log.Printf("ClickHouse %d.%d < 26.2, falling back to compatibility logs schema", chMajor, chMinor)
+		log.Printf("ClickHouse %d.%d < 26.2, falling back to compatibility logs and traces schemas", chMajor, chMinor)
 		if err := swapLogsSchemaForCompat(tempDir); err != nil {
 			log.Fatalf("Failed to swap logs schema: %v", err)
+		}
+		if err := swapTracesSchemaForCompat(tempDir); err != nil {
+			log.Fatalf("Failed to swap traces schema: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Enables the `direct_read` FTS optimization to CH seed by default. This optimization makes map exact queries extremely fast, simply relying on index evaluation and never requiring loading the map. A bug prevented this previously, but now works with the latest versions of 26.2, 26.3, 26.4, and all versions of 26.5 or greater.

### References

- Linear Issue: HDX-4352