### PR TITLE
[HDX-4355] fix(cli): exit non-zero from upload-sourcemaps on failure

### DIFF
--- a/.changeset/cli-upload-sourcemaps-exit-code.md
+++ b/.changeset/cli-upload-sourcemaps-exit-code.md
@@ -1,0 +1,11 @@
+---
+"@hyperdx/cli": patch
+---
+
+fix(cli): exit with non-zero code when `upload-sourcemaps` fails
+
+The `upload-sourcemaps` command now exits with code 1 when uploads fail
+(missing source maps, pre-signed URL request failure, authentication failure,
+or any per-file upload failure after retries). Previously these failures were
+logged to stderr but the process exited cleanly with code 0, causing CI
+pipelines to treat failed uploads as successes.

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -11,6 +11,7 @@ export default [
     ignores: [
       'node_modules/**',
       'dist/**',
+      '**/*.config.cjs',
       '**/*.config.mjs',
       '**/*.config.ts',
     ],

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import("jest").Config} **/
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  rootDir: './src',
+  testMatch: ['**/__tests__/*.test.ts?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    // ts-jest ESM: strip the `.js` suffix that ESM imports require
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
+  },
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,19 @@
     "compile": "bun build src/cli.tsx --compile --outfile dist/hdx",
     "compile:linux": "bun build src/cli.tsx --compile --target=bun-linux-x64 --outfile dist/hdx-linux-x64",
     "compile:macos": "bun build src/cli.tsx --compile --target=bun-darwin-arm64 --outfile dist/hdx-darwin-arm64",
-    "compile:macos-x64": "bun build src/cli.tsx --compile --target=bun-darwin-x64 --outfile dist/hdx-darwin-x64"
+    "compile:macos-x64": "bun build src/cli.tsx --compile --target=bun-darwin-x64 --outfile dist/hdx-darwin-x64",
+    "lint": "npx eslint --quiet . --ext .ts,.tsx",
+    "ci:lint": "yarn lint && yarn tsc --noEmit",
+    "ci:unit": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --ci --passWithNoTests",
+    "dev:unit": "NODE_OPTIONS=--experimental-vm-modules jest --watchAll --runInBand"
   },
   "devDependencies": {
     "@clickhouse/client": "^1.12.1",
     "@clickhouse/client-common": "^1.12.1",
     "@hyperdx/common-utils": "^0.19.0",
+    "@jest/globals": "^30.2.0",
     "@types/crypto-js": "^4.2.2",
+    "@types/jest": "^29.5.14",
     "@types/react": "^19.0.0",
     "@types/sqlstring": "^2.3.2",
     "chalk": "^5.3.0",
@@ -48,9 +54,11 @@
     "ink": "6.8.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
+    "jest": "^30.2.0",
     "react": "^19.0.0",
     "react-devtools-core": "^7.0.1",
     "sqlstring": "^2.3.3",
+    "ts-jest": "^29.4.5",
     "tsup": "^8.4.0",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3"

--- a/packages/cli/src/__tests__/sourcemaps.test.ts
+++ b/packages/cli/src/__tests__/sourcemaps.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+
+import { uploadSourcemaps } from '@/sourcemaps';
+
+type FetchMock = jest.Mock<typeof fetch>;
+
+describe('uploadSourcemaps', () => {
+  let tempDir: string;
+  let originalFetch: typeof globalThis.fetch;
+  let mockFetch: FetchMock;
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+  let originalEnvServiceKey: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sourcemaps-test-'));
+    originalFetch = globalThis.fetch;
+    mockFetch = jest.fn<typeof fetch>();
+    globalThis.fetch = mockFetch;
+    // Silence stdout/stderr by swapping write() with a no-op. Doing this via
+    // jest.spyOn() trips overload-resolution on TS, so swap directly.
+    originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    originalEnvServiceKey = process.env.HYPERDX_SERVICE_KEY;
+    delete process.env.HYPERDX_SERVICE_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    rmSync(tempDir, { recursive: true, force: true });
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    if (originalEnvServiceKey != null) {
+      process.env.HYPERDX_SERVICE_KEY = originalEnvServiceKey;
+    } else {
+      delete process.env.HYPERDX_SERVICE_KEY;
+    }
+  });
+
+  const okJson = (body: unknown): Response =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    }) as Response;
+
+  const httpStatus = (status: number): Response =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => ({}),
+    }) as Response;
+
+  const createFile = (name: string, content = 'sourcemap content'): void => {
+    writeFileSync(join(tempDir, name), content);
+  };
+
+  it('throws when serviceKey is empty and HYPERDX_SERVICE_KEY is unset', async () => {
+    await expect(
+      uploadSourcemaps({ serviceKey: '', path: tempDir }),
+    ).rejects.toThrow('service key cannot be empty');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to HYPERDX_SERVICE_KEY env var when serviceKey arg is empty', async () => {
+    process.env.HYPERDX_SERVICE_KEY = 'env-key';
+    mockFetch.mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }));
+
+    // No files in tempDir + allowNoop=true → expected throw for "No source maps found".
+    // The point of this test is to verify the env-key flows into the auth header.
+    await expect(
+      uploadSourcemaps({ serviceKey: '', path: tempDir, allowNoop: true }),
+    ).rejects.toThrow('No source maps found');
+
+    const [, init] = mockFetch.mock.calls[0];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer env-key');
+  });
+
+  it('throws "invalid service key" when authentication returns 401', async () => {
+    mockFetch.mockResolvedValueOnce(httpStatus(401));
+    await expect(
+      uploadSourcemaps({ serviceKey: 'bad-key', path: tempDir }),
+    ).rejects.toThrow('invalid service key');
+  });
+
+  it('throws when no .js.map files are found and allowNoop is false', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }));
+    // tempDir is empty and allowNoop defaults to false → getAllSourceMapFiles
+    // throws the "No .js.map files found" error, which now propagates.
+    await expect(
+      uploadSourcemaps({ serviceKey: 'key', path: tempDir }),
+    ).rejects.toThrow('No .js.map files found');
+  });
+
+  it('throws when no source maps are found and allowNoop is true', async () => {
+    mockFetch.mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }));
+    await expect(
+      uploadSourcemaps({
+        serviceKey: 'key',
+        path: tempDir,
+        allowNoop: true,
+      }),
+    ).rejects.toThrow(`No source maps found in ${tempDir}`);
+  });
+
+  it('throws when the pre-signed URL endpoint returns a non-array', async () => {
+    createFile('a.js.map');
+    mockFetch
+      .mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }))
+      .mockResolvedValueOnce(
+        okJson({
+          /* missing data field */
+        }),
+      );
+
+    await expect(
+      uploadSourcemaps({ serviceKey: 'key', path: tempDir }),
+    ).rejects.toThrow('Failed to get source map upload URLs');
+  });
+
+  it('throws when one or more file uploads fail after retries', async () => {
+    createFile('a.js.map');
+    createFile('b.js.map');
+    mockFetch
+      .mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }))
+      .mockResolvedValueOnce(
+        okJson({ data: ['https://upload-1', 'https://upload-2'] }),
+      )
+      // First PUT succeeds.
+      .mockResolvedValueOnce(httpStatus(200))
+      // Second PUT returns 4xx (permanent failure, no retry per uploadFile()).
+      .mockResolvedValueOnce(httpStatus(403));
+
+    await expect(
+      uploadSourcemaps({ serviceKey: 'key', path: tempDir }),
+    ).rejects.toThrow(/source map upload\(s\) failed/);
+  });
+
+  it('resolves cleanly when all files upload successfully', async () => {
+    createFile('a.js');
+    createFile('a.js.map');
+    mockFetch
+      .mockResolvedValueOnce(okJson({ user: { team: 'team-1' } }))
+      .mockResolvedValueOnce(
+        okJson({ data: ['https://upload-1', 'https://upload-2'] }),
+      )
+      .mockResolvedValueOnce(httpStatus(200))
+      .mockResolvedValueOnce(httpStatus(200));
+
+    await expect(
+      uploadSourcemaps({ serviceKey: 'key', path: tempDir }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -1300,6 +1300,16 @@ program
     'The API version to use (v1 for HyperDX V1 Cloud, v2 for latest)',
     'v1',
   )
-  .action(uploadSourcemaps);
+  .action(async opts => {
+    try {
+      await uploadSourcemaps(opts);
+    } catch (err) {
+      // uploadSourcemaps already prints user-facing messages via logError().
+      // Append a short reason line for machine-readable CI logs and exit non-zero.
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`${chalk.red(`Upload failed: ${msg}`)}\n`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/packages/cli/src/sourcemaps.ts
+++ b/packages/cli/src/sourcemaps.ts
@@ -101,7 +101,7 @@ export async function uploadSourcemaps({
       `Error: No source maps found in ${path}, is this the correct path?`,
     );
     logError('Failed to upload source maps. Please see reason above.');
-    return;
+    throw new Error(`No source maps found in ${path}`);
   }
 
   const uploadKeys = fileList.map(({ name }) => ({
@@ -143,7 +143,7 @@ export async function uploadSourcemaps({
       `Error: Unable to generate source map upload urls. Response: ${JSON.stringify(urlRes)}`,
     );
     logError('Failed to upload source maps. Please see reason above.');
-    return;
+    throw new Error('Failed to get source map upload URLs');
   }
 
   const uploadUrls = urlRes.data;
@@ -161,6 +161,7 @@ export async function uploadSourcemaps({
   );
   if (failed > 0) {
     logError('[HyperDX] Some files failed to upload. See errors above.');
+    throw new Error(`${failed} source map upload(s) failed`);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,7 +4554,9 @@ __metadata:
     "@clickhouse/client": "npm:^1.12.1"
     "@clickhouse/client-common": "npm:^1.12.1"
     "@hyperdx/common-utils": "npm:^0.19.0"
+    "@jest/globals": "npm:^30.2.0"
     "@types/crypto-js": "npm:^4.2.2"
+    "@types/jest": "npm:^29.5.14"
     "@types/react": "npm:^19.0.0"
     "@types/sqlstring": "npm:^2.3.2"
     chalk: "npm:^5.3.0"
@@ -4564,9 +4566,11 @@ __metadata:
     ink: "npm:6.8.0"
     ink-spinner: "npm:^5.0.0"
     ink-text-input: "npm:^6.0.0"
+    jest: "npm:^30.2.0"
     react: "npm:^19.0.0"
     react-devtools-core: "npm:^7.0.1"
     sqlstring: "npm:^2.3.3"
+    ts-jest: "npm:^29.4.5"
     tsup: "npm:^8.4.0"
     tsx: "npm:^4.19.0"
     typescript: "npm:^5.9.3"
@@ -5129,6 +5133,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/diff-sequences@npm:30.4.0":
+  version: 30.4.0
+  resolution: "@jest/diff-sequences@npm:30.4.0"
+  checksum: 10c0/b4358b1b885098b905cb777f58788ddd45f90c4ebc3ce2c04fb1d4c9516f35ac2d9daef8263cd21c537bd7a52ab320f03e4ba9521677959ae20e3d405356b420
+  languageName: node
+  linkType: hard
+
 "@jest/environment-jsdom-abstract@npm:30.2.0":
   version: 30.2.0
   resolution: "@jest/environment-jsdom-abstract@npm:30.2.0"
@@ -5162,12 +5173,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/environment@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/environment@npm:30.4.1"
+  dependencies:
+    "@jest/fake-timers": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    jest-mock: "npm:30.4.1"
+  checksum: 10c0/704987ff8650c91a8ed13796ce47e9c55da3c12a01902d9e384330cead18eb4d34ce665a8d9962dddf2736fac006f92efc1039b8da424adf8fdc16f8d81aff6c
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:30.2.0":
   version: 30.2.0
   resolution: "@jest/expect-utils@npm:30.2.0"
   dependencies:
     "@jest/get-type": "npm:30.1.0"
   checksum: 10c0/e25a809ff2ab62292e2569f8d97f89168d27d078903f0306af5f70f1771b7efc62c458eca1dcb491ab1ed96cefedf403bd7acbb050c997105bc29b220fd9d61a
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/expect-utils@npm:30.4.1"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+  checksum: 10c0/6dea9e11ebcc7be68fea5950ae5a1b7ff9fd1490101ee8af0aede336b9934ab24a28bcafe2f1171dac0f95982406386c609ca2659b9132e1a9d419e8d69b9cd4
   languageName: node
   linkType: hard
 
@@ -5190,6 +5222,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/expect@npm:30.4.1"
+  dependencies:
+    expect: "npm:30.4.1"
+    jest-snapshot: "npm:30.4.1"
+  checksum: 10c0/2133183e735982879408036237b115abc2e57fa52bb7324be0a1f2ab6941a57da93b2e6f498dc110b7d007dd20463013fbcc5b24377cf65e6a8518d3b2ff76bd
+  languageName: node
+  linkType: hard
+
 "@jest/fake-timers@npm:30.2.0":
   version: 30.2.0
   resolution: "@jest/fake-timers@npm:30.2.0"
@@ -5201,6 +5243,20 @@ __metadata:
     jest-mock: "npm:30.2.0"
     jest-util: "npm:30.2.0"
   checksum: 10c0/b29505528e546f08489535814f7dfcd3a2318660b987d605f44d41672e91a0c8c0dfc01e3dd1302e66e511409c3012d41e2e16703b214502b54ccc023773e3dc
+  languageName: node
+  linkType: hard
+
+"@jest/fake-timers@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/fake-timers@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@sinonjs/fake-timers": "npm:^15.4.0"
+    "@types/node": "npm:*"
+    jest-message-util: "npm:30.4.1"
+    jest-mock: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+  checksum: 10c0/4a10e4eb64bb5ea2531cdcc79f3058731f5c14faf2a74f498fcb37f6690c3c0f9b12a9856736d26e34631eb38db12e12812da71de27b9d332df44dda9f460fbe
   languageName: node
   linkType: hard
 
@@ -5230,6 +5286,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/globals@npm:^30.2.0":
+  version: 30.4.1
+  resolution: "@jest/globals@npm:30.4.1"
+  dependencies:
+    "@jest/environment": "npm:30.4.1"
+    "@jest/expect": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    jest-mock: "npm:30.4.1"
+  checksum: 10c0/7961eefdc9e69ba7754d11a1bae4bc2960f33e03d9c1d6c73f27895b8cf92a9118a234330f31dc8efe16e835fe70ef9cc6c26f60121f6b6e9fac71c8b1bcd709
+  languageName: node
+  linkType: hard
+
 "@jest/pattern@npm:30.0.1":
   version: 30.0.1
   resolution: "@jest/pattern@npm:30.0.1"
@@ -5237,6 +5305,16 @@ __metadata:
     "@types/node": "npm:*"
     jest-regex-util: "npm:30.0.1"
   checksum: 10c0/32c5a7bfb6c591f004dac0ed36d645002ed168971e4c89bd915d1577031672870032594767557b855c5bc330aa1e39a2f54bf150d2ee88a7a0886e9cb65318bc
+  languageName: node
+  linkType: hard
+
+"@jest/pattern@npm:30.4.0":
+  version: 30.4.0
+  resolution: "@jest/pattern@npm:30.4.0"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.4.0"
+  checksum: 10c0/05bc0799f84f3750bbbff0f9a546979efd0dbcee86c1be98b9e2811a68885809ec7b5cca39b8dda1497cb7cf17b7be936019fba8dfbcd9c53b181e03e67f4f82
   languageName: node
   linkType: hard
 
@@ -5285,6 +5363,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/schemas@npm:30.4.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/96f388ebfc1974457fcbde2ad36c40a0b549cba3f624fe8d9d6e5903a152dc75e4043f4ac9ac7668622f2ecb0f9a4dcb9a38edf3bc0d52b82045b2bb2b69b72a
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
@@ -5303,6 +5390,18 @@ __metadata:
     graceful-fs: "npm:^4.2.11"
     natural-compare: "npm:^1.4.0"
   checksum: 10c0/df69ee3b95d64db6d1e79e39d5dc226e417b412a1d5113264b487eb3a8887366a7952c350c378e2292f8e83ec1b3be22040317b795e85eb431830cbde06d09d8
+  languageName: node
+  linkType: hard
+
+"@jest/snapshot-utils@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/snapshot-utils@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    chalk: "npm:^4.1.2"
+    graceful-fs: "npm:^4.2.11"
+    natural-compare: "npm:^1.4.0"
+  checksum: 10c0/81da9079719eece02b89c45cb97162b5b7d794981652c8d8fe2846843ac81ce219ea4bc21bde7cf76c9032006435f82bd9aee8d6139d90b77078ddad4865af02
   languageName: node
   linkType: hard
 
@@ -5364,6 +5463,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/transform@npm:30.4.1"
+  dependencies:
+    "@babel/core": "npm:^7.27.4"
+    "@jest/types": "npm:30.4.1"
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    babel-plugin-istanbul: "npm:^7.0.1"
+    chalk: "npm:^4.1.2"
+    convert-source-map: "npm:^2.0.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    graceful-fs: "npm:^4.2.11"
+    jest-haste-map: "npm:30.4.1"
+    jest-regex-util: "npm:30.4.0"
+    jest-util: "npm:30.4.1"
+    pirates: "npm:^4.0.7"
+    slash: "npm:^3.0.0"
+    write-file-atomic: "npm:^5.0.1"
+  checksum: 10c0/194f463f179f6ab3ccd6f4f0f03a117e3c01a7ce098ebf562250aca4c900ed3a9ec08b694227788eabd7cb4e0597f1d0788077c7550ddc679f68a0ad21cc87e0
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:30.2.0":
   version: 30.2.0
   resolution: "@jest/types@npm:30.2.0"
@@ -5376,6 +5497,21 @@ __metadata:
     "@types/yargs": "npm:^17.0.33"
     chalk: "npm:^4.1.2"
   checksum: 10c0/ae121f6963bd9ed1cd9651db7be91bf14c05bff0d0eec4fca9fecf586bea4005e8f1de8cc9b8ef72e424ea96a309d123bef510b55a6a17a3b4b91a39d775e5cd
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/types@npm:30.4.1"
+  dependencies:
+    "@jest/pattern": "npm:30.4.0"
+    "@jest/schemas": "npm:30.4.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/4c79f6dbdb1c7eaab5da255fc696c7cae744759d4020e42da8aa63b37fe55ce594be73075fe1ee5407dd59d7e47975be9f674bfc81e91bae2c89c62d27ba55a1
   languageName: node
   linkType: hard
 
@@ -8300,6 +8436,15 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10c0/a707476efd523d2138ef6bba916c83c4a377a8372ef04fad87499458af9f01afc58f4f245c5fd062793d6d70587309330c6f96947b5bd5697961c18004dc3e26
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^15.4.0":
+  version: 15.4.0
+  resolution: "@sinonjs/fake-timers@npm:15.4.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.1"
+  checksum: 10c0/de4522afe0699fa8d3ae9d1715cbaa4b47e518c707bb7988a9ec6c7c67557d9f6df451f6be0338598b984a86f65aab9fab38dd9ce75a3c0ffb801a9500d5b10d
   languageName: node
   linkType: hard
 
@@ -15832,6 +15977,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect@npm:30.4.1":
+  version: 30.4.1
+  resolution: "expect@npm:30.4.1"
+  dependencies:
+    "@jest/expect-utils": "npm:30.4.1"
+    "@jest/get-type": "npm:30.1.0"
+    jest-matcher-utils: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-mock: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+  checksum: 10c0/ad04fbdffac5a2bae186478938a60f737e3aac823db9a80c87f3f390f9f458bddcc454dc3a3997d715706747c6aff928923e6a71db3a221adb89a51cc1582e72
+  languageName: node
+  linkType: hard
+
 "expect@npm:^29.0.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
@@ -18792,6 +18951,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-diff@npm:30.4.1"
+  dependencies:
+    "@jest/diff-sequences": "npm:30.4.0"
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    pretty-format: "npm:30.4.1"
+  checksum: 10c0/787e11f0ea27e94815479d6c5415e4173da1e74bede34c1515b8515fc9d1fe053e2ad25a3c31f9998a7292c186a0e4d395ed82e0e149d57d7708ee6759b442e9
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
@@ -18900,6 +19071,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-haste-map@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    anymatch: "npm:^3.1.3"
+    fb-watchman: "npm:^2.0.2"
+    fsevents: "npm:^2.3.3"
+    graceful-fs: "npm:^4.2.11"
+    jest-regex-util: "npm:30.4.0"
+    jest-util: "npm:30.4.1"
+    jest-worker: "npm:30.4.1"
+    picomatch: "npm:^4.0.3"
+    walker: "npm:^1.0.8"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10c0/1350c24952bbf31c86cb1ed4e2e5edd4766a93e2be8816c4648c05463d06cfae89f3c73732f9274fdb626fdfdfe6605ed6f259b6c21257df536a6379d4b9a5e7
+  languageName: node
+  linkType: hard
+
 "jest-leak-detector@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-leak-detector@npm:30.2.0"
@@ -18919,6 +19112,18 @@ __metadata:
     jest-diff: "npm:30.2.0"
     pretty-format: "npm:30.2.0"
   checksum: 10c0/f221c8afa04cee693a2be735482c5db4ec6f845f8ca3a04cb419be34c6257f4531dab89c836251f31d1859318c38997e8e9f34bf7b4cdcc8c7be8ae6e2ecb9f2
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-matcher-utils@npm:30.4.1"
+  dependencies:
+    "@jest/get-type": "npm:30.1.0"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.4.1"
+    pretty-format: "npm:30.4.1"
+  checksum: 10c0/ddbb0c7075def27ba30160883c327cb3fd13f561f5789d00a1edca1b48b0651f8ea23a1c51bcfcb6413a68c47d658bcf47a34701b8a39ce135dd28d87a3117af
   languageName: node
   linkType: hard
 
@@ -18951,6 +19156,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-message-util@npm:30.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/stack-utils": "npm:^2.0.3"
+    chalk: "npm:^4.1.2"
+    graceful-fs: "npm:^4.2.11"
+    jest-util: "npm:30.4.1"
+    picomatch: "npm:^4.0.3"
+    pretty-format: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.6"
+  checksum: 10c0/ae7427544e042bc1c14abf3c0dbe8b83d0dbec22a9a5efefaca5b8ccb6b9bf391abe732e6f2117ca995c6889bfe1be35c78cec75e5ea0a50e28cffe1ba6f9fdf
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-message-util@npm:29.7.0"
@@ -18979,6 +19202,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-mock@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-mock@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    jest-util: "npm:30.4.1"
+  checksum: 10c0/5185a41255285c1634c5d85dda037afaaadfc12793b3293c9e253a30bb67449f8df968447f830abb9cf7a52e63694e6734680130e8085ce119056280890bf6fc
+  languageName: node
+  linkType: hard
+
 "jest-pnp-resolver@npm:^1.2.3":
   version: 1.2.3
   resolution: "jest-pnp-resolver@npm:1.2.3"
@@ -18995,6 +19229,13 @@ __metadata:
   version: 30.0.1
   resolution: "jest-regex-util@npm:30.0.1"
   checksum: 10c0/f30c70524ebde2d1012afe5ffa5691d5d00f7d5ba9e43d588f6460ac6fe96f9e620f2f9b36a02d0d3e7e77bc8efb8b3450ae3b80ac53c8be5099e01bf54f6728
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:30.4.0":
+  version: 30.4.0
+  resolution: "jest-regex-util@npm:30.4.0"
+  checksum: 10c0/fe7426f67b54d38bed8e9d6e6a099d63d72f41f5bf65b922d9d03fedcb55c614b45657207632f6ee22d0a59d8d11327891f258d23f68a58912fcdb0f7db48435
   languageName: node
   linkType: hard
 
@@ -19113,6 +19354,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-snapshot@npm:30.4.1"
+  dependencies:
+    "@babel/core": "npm:^7.27.4"
+    "@babel/generator": "npm:^7.27.5"
+    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
+    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
+    "@babel/types": "npm:^7.27.3"
+    "@jest/expect-utils": "npm:30.4.1"
+    "@jest/get-type": "npm:30.1.0"
+    "@jest/snapshot-utils": "npm:30.4.1"
+    "@jest/transform": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    babel-preset-current-node-syntax: "npm:^1.2.0"
+    chalk: "npm:^4.1.2"
+    expect: "npm:30.4.1"
+    graceful-fs: "npm:^4.2.11"
+    jest-diff: "npm:30.4.1"
+    jest-matcher-utils: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    pretty-format: "npm:30.4.1"
+    semver: "npm:^7.7.2"
+    synckit: "npm:^0.11.8"
+  checksum: 10c0/cebd70277b6f0d2606f22815480146cf1e37295ed69a1d16e260a99a2ab48db167857e2fb9a938923d22ac13203c83a5e31d7f066b58d87c6d42db58c914ff13
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-util@npm:30.2.0"
@@ -19124,6 +19394,20 @@ __metadata:
     graceful-fs: "npm:^4.2.11"
     picomatch: "npm:^4.0.2"
   checksum: 10c0/896d663554b35258a87ec1a0a0fdd8741fdf4f3239d09fc52fdd88fa5c411a5ece7903bbbbd7d5194743fcb69f62afc3287e90f57736a91e7df95ad421937936
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-util@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    graceful-fs: "npm:^4.2.11"
+    picomatch: "npm:^4.0.3"
+  checksum: 10c0/3efe1f25e5a172d04c6af8612d82867ab603b7c1bd8cb89073ff834679b44eba178793cf3af162cf5e25be13aa736ebd23a7826683acc85bddc5873f305b1f6e
   languageName: node
   linkType: hard
 
@@ -19181,6 +19465,19 @@ __metadata:
     merge-stream: "npm:^2.0.0"
     supports-color: "npm:^8.1.1"
   checksum: 10c0/1ea47f6c682ba6cdbd50630544236aabccacf1d88335607206c10871a9777a45b0fc6336c8eb6344e32e69dd7681de17b2199b4d4552b00d48aade303627125c
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-worker@npm:30.4.1"
+  dependencies:
+    "@types/node": "npm:*"
+    "@ungap/structured-clone": "npm:^1.3.0"
+    jest-util: "npm:30.4.1"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^8.1.1"
+  checksum: 10c0/3eb7ec7e928b82491e66ae6709e3a1eef3edad2bc351514a5d52037b997151989de6ce2912d6a5a3806ae3ae3bf6a1c36b1ad7bbc567d0790503fdb74576f140
   languageName: node
   linkType: hard
 
@@ -23151,6 +23448,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.4.1":
+  version: 30.4.1
+  resolution: "pretty-format@npm:30.4.1"
+  dependencies:
+    "@jest/schemas": "npm:30.4.1"
+    ansi-styles: "npm:^5.2.0"
+    react-is-18: "npm:react-is@^18.3.1"
+    react-is-19: "npm:react-is@^19.2.5"
+  checksum: 10c0/c7e6633740cd2f6d382f188c00c8b4b3f2bee3cda16db6753471c6bb4b94f76531358d3a7793062a0fb00d72ebfb934e8ae1d4f5ced6bb34c8e7f60996f90076
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^27.0.2":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
@@ -23717,6 +24026,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is-18@npm:react-is@^18.3.1, react-is@npm:^18.0.0, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"react-is-19@npm:react-is@^19.2.5":
+  version: 19.2.6
+  resolution: "react-is@npm:19.2.6"
+  checksum: 10c0/263177f370fc156b279d22570dd6e922a0ad641a4a426a4cb70284b8003b00ef532d59f2beca1d22a1ca0b37f85f9077d7733ca5d344ebecd2942e9bc2a2a3c0
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -23728,13 +24051,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.0.0, react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes [HDX-4355](https://linear.app/clickhouse/issue/HDX-4355/fix-upload-sourcemaps-cli-to-exit-with-non-zero-code-on-upload-failure). The `upload-sourcemaps` CLI command previously logged errors to stderr but returned cleanly on most failure paths, so the Node process exited with code `0`. CI pipelines using the command as a build step (notably the LogHouse pipeline being wired up in HDX-4087) could not distinguish a failed upload from a clean one, which would let silently-missing sourcemaps slip into production unnoticed.

This PR makes the command exit with code `1` on:

- No source map files found in the target path (both `allowNoop=true` and `allowNoop=false`)
- Pre-signed URL request returns a non-array response
- Authentication fails (already threw — now propagates cleanly through the action wrapper)
- One or more individual file uploads fail after all retries

The command still exits `0` only when every file uploads successfully. **All existing `logError(…)` and `log(…)` messages are preserved verbatim** so CI log output is unchanged — the action wrapper just appends a single `Upload failed: <reason>` line for machine-readable signal.

### How this PR is structured

Three logically distinct commits, intended to be reviewed in order:

1. **`fix(cli): exit non-zero from upload-sourcemaps on failure (HDX-4355)`** — Production change only. Converts the three silent `return` paths in `uploadSourcemaps()` to `throw`s, adds a final `throw` after the per-file upload summary when any uploads failed, and wraps `.action(uploadSourcemaps)` in `cli.tsx` with a try/catch that exits 1. Also adds a changeset entry.
2. **`chore(cli): add jest test infrastructure`** — Stands up Jest for `@hyperdx/cli` so it can be picked up by the monorepo's `make ci-unit` and `make ci-lint` targets. Because the CLI is ESM (`"type": "module"`), uses ts-jest's `default-esm` preset and runs jest with `--experimental-vm-modules`. The jest config file is `.cjs` so it can use `module.exports` inside an ESM package. Adds `lint`, `ci:lint`, `ci:unit`, `dev:unit` scripts; `--passWithNoTests` is included on `ci:unit` so this commit passes in isolation (no-op after the next commit lands tests).
3. **`test(cli): add tests for upload-sourcemaps exit conditions (HDX-4355)`** — 8 test cases covering every failure path the ticket calls out plus the happy path. Uses real temp dirs (`fs.mkdtempSync` + `fs.writeFileSync`) for file-system input and mocks `globalThis.fetch` for HTTP; no `jest.mock()` calls so the suite avoids ESM module-mocking limitations.

### Test coverage

```
PASS src/__tests__/sourcemaps.test.ts
  uploadSourcemaps
    ✓ throws when serviceKey is empty and HYPERDX_SERVICE_KEY is unset
    ✓ falls back to HYPERDX_SERVICE_KEY env var when serviceKey arg is empty
    ✓ throws "invalid service key" when authentication returns 401
    ✓ throws when no .js.map files are found and allowNoop is false
    ✓ throws when no source maps are found and allowNoop is true
    ✓ throws when the pre-signed URL endpoint returns a non-array
    ✓ throws when one or more file uploads fail after retries
    ✓ resolves cleanly when all files upload successfully

Tests:       8 passed, 8 total
```

### Screenshots or video

N/A — CLI behaviour change, no UI.

### How to test on Vercel preview

N/A — non-UI change.

### References

- Linear Issue: [HDX-4355](https://linear.app/clickhouse/issue/HDX-4355/fix-upload-sourcemaps-cli-to-exit-with-non-zero-code-on-upload-failure)
- Related: HDX-4087 (LogHouse sourcemap upload integration — depends on this fix to detect failures from the exit code)
