### PR TITLE
[HDX-4090] Allow CUSTOM_OTELCOL_CONFIG_FILE to override default processors

### DIFF
--- a/.changeset/hdx-4090-swap-memory-limiter.md
+++ b/.changeset/hdx-4090-swap-memory-limiter.md
@@ -1,10 +1,11 @@
 ---
-'@hyperdx/api': patch
-'@hyperdx/otel-collector': patch
+'@hyperdx/api': minor
+'@hyperdx/app': minor
+'@hyperdx/otel-collector': minor
 ---
 
-fix(otel-collector): allow `CUSTOM_OTELCOL_CONFIG_FILE` to swap the default
-`memory_limiter` (and other pipeline processors)
+fix(otel-collector): allow `CUSTOM_OTELCOL_CONFIG_FILE` to override the
+default `memory_limiter`, `batch` (and other pipeline processors)
 
 Pipeline `processors:` lists used to be defined in the OpAMP remote config
 sent by the API (`packages/api/src/opamp/controllers/opampController.ts`).

--- a/.changeset/hdx-4090-swap-memory-limiter.md
+++ b/.changeset/hdx-4090-swap-memory-limiter.md
@@ -45,3 +45,28 @@ service:
 The default `memory_limiter` block defined in the base config is left in
 the merged config but is no longer referenced by any pipeline; the
 collector only instantiates `memory_limiter/custom` at runtime.
+
+The same swap pattern works for the `batch` processor (and any other base
+processor). For example, to lower the export timeout on a specific
+pipeline:
+
+```yaml
+processors:
+  batch/lowlatency:
+    send_batch_size: 1000
+    send_batch_max_size: 2000
+    timeout: 500ms
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, batch/lowlatency]
+    logs/out-default:
+      processors: [memory_limiter, transform, batch/lowlatency]
+```
+
+Lighter-weight env-var tuning is also available for the default `batch`
+processor without writing a custom config file:
+`HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE`,
+`HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE`, and `HYPERDX_OTEL_BATCH_TIMEOUT`.
+See the README for details.

--- a/.changeset/hdx-4090-swap-memory-limiter.md
+++ b/.changeset/hdx-4090-swap-memory-limiter.md
@@ -12,7 +12,7 @@ sent by the API (`packages/api/src/opamp/controllers/opampController.ts`).
 That meant the remote config overwrote any pipeline `processors:` list a
 user supplied via `CUSTOM_OTELCOL_CONFIG_FILE`, making it impossible to
 substitute the default `memory_limiter` with one configured for
-`limit_percentage`/`spike_limit_percentage` mode (HDX-4090).
+`limit_percentage`/`spike_limit_percentage` mode (#2145).
 
 The pipeline `processors:` lists now live in the bootstrap config
 (`docker/otel-collector/config.yaml` for supervisor mode, and

--- a/.changeset/hdx-4090-swap-memory-limiter.md
+++ b/.changeset/hdx-4090-swap-memory-limiter.md
@@ -1,0 +1,47 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/otel-collector': patch
+---
+
+fix(otel-collector): allow `CUSTOM_OTELCOL_CONFIG_FILE` to swap the default
+`memory_limiter` (and other pipeline processors)
+
+Pipeline `processors:` lists used to be defined in the OpAMP remote config
+sent by the API (`packages/api/src/opamp/controllers/opampController.ts`).
+That meant the remote config overwrote any pipeline `processors:` list a
+user supplied via `CUSTOM_OTELCOL_CONFIG_FILE`, making it impossible to
+substitute the default `memory_limiter` with one configured for
+`limit_percentage`/`spike_limit_percentage` mode (HDX-4090).
+
+The pipeline `processors:` lists now live in the bootstrap config
+(`docker/otel-collector/config.yaml` for supervisor mode, and
+`docker/otel-collector/config.standalone.yaml` for standalone mode). The
+OpAMP remote config no longer sets `processors:` on these pipelines, so the
+bootstrap+custom merge wins. Receivers and exporters are still configured
+dynamically by the OpAMP controller.
+
+To override `memory_limiter`, define a new processor with a different name
+in `CUSTOM_OTELCOL_CONFIG_FILE` and swap the pipeline `processors:` lists:
+
+```yaml
+processors:
+  memory_limiter/custom:
+    check_interval: 5s
+    limit_percentage: 75
+    spike_limit_percentage: 25
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter/custom, batch]
+    metrics:
+      processors: [memory_limiter/custom, batch]
+    logs/out-default:
+      processors: [memory_limiter/custom, transform, batch]
+    logs/out-rrweb:
+      processors: [memory_limiter/custom, batch]
+```
+
+The default `memory_limiter` block defined in the base config is left in
+the merged config but is no longer referenced by any pipeline; the
+collector only instantiates `memory_limiter/custom` at runtime.

--- a/docker/otel-collector/config.standalone.yaml
+++ b/docker/otel-collector/config.standalone.yaml
@@ -61,14 +61,14 @@ exporters:
       enabled: true
 
 service:
+  # Pipeline `processors:` lists live in the base config.yaml so users can
+  # swap them via CUSTOM_OTELCOL_CONFIG_FILE. See HDX-4090.
   pipelines:
     traces:
       receivers: [otlp/hyperdx]
-      processors: [memory_limiter, batch]
       exporters: [clickhouse]
     metrics:
       receivers: [otlp/hyperdx]
-      processors: [memory_limiter, batch]
       exporters: [clickhouse]
     metrics/promql:
       receivers: [otlp/hyperdx]
@@ -79,9 +79,7 @@ service:
       exporters: [routing/logs]
     logs/out-default:
       receivers: [routing/logs]
-      processors: [memory_limiter, transform, batch]
       exporters: [clickhouse]
     logs/out-rrweb:
       receivers: [routing/logs]
-      processors: [memory_limiter, batch]
       exporters: [clickhouse/rrweb]

--- a/docker/otel-collector/config.standalone.yaml
+++ b/docker/otel-collector/config.standalone.yaml
@@ -62,7 +62,8 @@ exporters:
 
 service:
   # Pipeline `processors:` lists live in the base config.yaml so users can
-  # swap them via CUSTOM_OTELCOL_CONFIG_FILE. See HDX-4090.
+  # swap them via CUSTOM_OTELCOL_CONFIG_FILE. See
+  # https://github.com/hyperdxio/hyperdx/pull/2351.
   pipelines:
     traces:
       receivers: [otlp/hyperdx]

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -88,4 +88,19 @@ service:
     logs:
       level: ${HYPERDX_LOG_LEVEL}
   extensions: [health_check]
-  # Pipelines are now configured dynamically in opampController.ts
+  # Pipeline receivers and exporters are configured dynamically in
+  # opampController.ts. Pipeline `processors:` lists are declared here in
+  # the bootstrap config so they can be overridden via
+  # CUSTOM_OTELCOL_CONFIG_FILE (e.g. to swap memory_limiter for a custom
+  # version with limit_percentage). The OpAMP remote config intentionally
+  # does NOT set `processors:` on these pipelines so the bootstrap+custom
+  # merge wins. See HDX-4090.
+  pipelines:
+    traces:
+      processors: [memory_limiter, batch]
+    metrics:
+      processors: [memory_limiter, batch]
+    logs/out-default:
+      processors: [memory_limiter, transform, batch]
+    logs/out-rrweb:
+      processors: [memory_limiter, batch]

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -94,7 +94,7 @@ service:
   # CUSTOM_OTELCOL_CONFIG_FILE (e.g. to swap memory_limiter for a custom
   # version with limit_percentage). The OpAMP remote config intentionally
   # does NOT set `processors:` on these pipelines so the bootstrap+custom
-  # merge wins. See HDX-4090.
+  # merge wins. See https://github.com/hyperdxio/hyperdx/pull/2351.
   pipelines:
     traces:
       processors: [memory_limiter, batch]

--- a/docker/otel-collector/custom.config.yaml
+++ b/docker/otel-collector/custom.config.yaml
@@ -31,6 +31,22 @@ receivers:
 #       processors: [memory_limiter/custom, transform, batch]
 #     logs/out-rrweb:
 #       processors: [memory_limiter/custom, batch]
+#
+# Example: tune `batch` for lower-latency exports.
+# (See packages/otel-collector/README.md for env-var alternatives.)
+#
+# processors:
+#   batch/lowlatency:
+#     send_batch_size: 1000
+#     send_batch_max_size: 2000
+#     timeout: 500ms
+#
+# service:
+#   pipelines:
+#     traces:
+#       processors: [memory_limiter, batch/lowlatency]
+#     logs/out-default:
+#       processors: [memory_limiter, transform, batch/lowlatency]
 exporters:
   # fork data to otel-collector-json service (DEV ONLY)
   otlphttp/json:

--- a/docker/otel-collector/custom.config.yaml
+++ b/docker/otel-collector/custom.config.yaml
@@ -8,13 +8,29 @@ receivers:
       disk:
       filesystem:
       network:
-# override the default processors
+# To override the default `memory_limiter` (or any other base processor),
+# define a NEW processor with a different name and swap the pipeline
+# `processors:` lists to reference it. Leaf-merging into the existing
+# `memory_limiter` block does NOT work cleanly because the OTel processor
+# silently prefers `limit_mib` over `limit_percentage` when both are set.
+# Example: switch to percentage-based memory limiting.
+#
 # processors:
-#   batch:
-#     send_batch_size: 10000
-#     timeout: 10s
-#   memory_limiter:
-#     limit_mib: 2000
+#   memory_limiter/custom:
+#     check_interval: 5s
+#     limit_percentage: 75
+#     spike_limit_percentage: 25
+#
+# service:
+#   pipelines:
+#     traces:
+#       processors: [memory_limiter/custom, batch]
+#     metrics:
+#       processors: [memory_limiter/custom, batch]
+#     logs/out-default:
+#       processors: [memory_limiter/custom, transform, batch]
+#     logs/out-rrweb:
+#       processors: [memory_limiter/custom, batch]
 exporters:
   # fork data to otel-collector-json service (DEV ONLY)
   otlphttp/json:

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -244,16 +244,21 @@ export const buildOtelCollectorConfig = (
     },
     service: {
       extensions: [],
+      // The pipeline `processors:` lists are intentionally declared in the
+      // bootstrap config (docker/otel-collector/config.yaml) instead of here,
+      // so that users can swap them via CUSTOM_OTELCOL_CONFIG_FILE. See
+      // HDX-4090: when the OpAMP remote config sets `processors:` on a
+      // pipeline, it overwrites the bootstrap+custom merge, which prevents
+      // users from substituting their own processor (e.g. a memory_limiter
+      // with limit_percentage instead of limit_mib).
       pipelines: {
         traces: {
           receivers: ['nop'],
-          processors: ['memory_limiter', 'batch'],
           exporters: ['clickhouse'],
         },
         metrics: {
           // TODO: prometheus needs to be authenticated
           receivers: ['prometheus'],
-          processors: ['memory_limiter', 'batch'],
           exporters: ['clickhouse'],
         },
         'logs/in': {
@@ -263,12 +268,10 @@ export const buildOtelCollectorConfig = (
         },
         'logs/out-default': {
           receivers: ['routing/logs'],
-          processors: ['memory_limiter', 'transform', 'batch'],
           exporters: ['clickhouse'],
         },
         'logs/out-rrweb': {
           receivers: ['routing/logs'],
-          processors: ['memory_limiter', 'batch'],
           exporters: ['clickhouse/rrweb'],
         },
       },

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -247,10 +247,11 @@ export const buildOtelCollectorConfig = (
       // The pipeline `processors:` lists are intentionally declared in the
       // bootstrap config (docker/otel-collector/config.yaml) instead of here,
       // so that users can swap them via CUSTOM_OTELCOL_CONFIG_FILE. See
-      // HDX-4090: when the OpAMP remote config sets `processors:` on a
-      // pipeline, it overwrites the bootstrap+custom merge, which prevents
-      // users from substituting their own processor (e.g. a memory_limiter
-      // with limit_percentage instead of limit_mib).
+      // https://github.com/hyperdxio/hyperdx/pull/2351: when the OpAMP
+      // remote config sets `processors:` on a pipeline, it overwrites the
+      // bootstrap+custom merge, which prevents users from substituting
+      // their own processor (e.g. a memory_limiter with limit_percentage
+      // instead of limit_mib).
       pipelines: {
         traces: {
           receivers: ['nop'],

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -128,6 +128,61 @@ custom OTel configurations without rebuilding the collector.
 | `https`  | core   |
 | `yaml`   | core   |
 
+## Overriding base components via `CUSTOM_OTELCOL_CONFIG_FILE`
+
+The collector ships with a default `memory_limiter` processor sized for a
+small (~2 GiB) container. On larger pods you typically want to switch to
+`limit_percentage`/`spike_limit_percentage` mode so the limit scales with
+the pod's memory allocation.
+
+The OTel `confmap` package merges YAML maps **leaf-by-leaf** rather than
+replacing a block wholesale, and the `memorylimiterprocessor` silently
+prefers `limit_mib` over `limit_percentage` when both are set. The
+combination means you cannot switch the default `memory_limiter` to
+percentage mode by leaf-merging into the existing block — your percentage
+values land in `effective.yaml` but the inherited mib values still win at
+runtime.
+
+The supported pattern is to **define a new processor with a different
+name** and swap the pipeline `processors:` lists in
+`CUSTOM_OTELCOL_CONFIG_FILE` to reference it:
+
+```yaml
+# custom.config.yaml
+processors:
+  memory_limiter/custom:
+    check_interval: 5s
+    limit_percentage: 75
+    spike_limit_percentage: 25
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter/custom, batch]
+    metrics:
+      processors: [memory_limiter/custom, batch]
+    logs/out-default:
+      processors: [memory_limiter/custom, transform, batch]
+    logs/out-rrweb:
+      processors: [memory_limiter/custom, batch]
+```
+
+After restart, the collector instantiates `memory_limiter/custom` (and not
+the unused default `memory_limiter`). You can confirm by checking
+`/etc/otel/supervisor-data/effective.yaml` and the `"Memory limiter
+configured"` log line emitted at collector start.
+
+The same pattern works for any other base processor (`batch`, `transform`,
+…) — define a new component with a different name and re-declare the
+pipelines that should use it.
+
+> Pipeline `processors:` lists live in `docker/otel-collector/config.yaml`
+> (for OpAMP supervisor mode) and `docker/otel-collector/config.standalone.yaml`
+> (for standalone mode). The OpAMP remote config from
+> `packages/api/src/opamp/controllers/opampController.ts` intentionally
+> does **not** set `processors:` on pipelines, so your bootstrap+custom
+> merge is not overwritten.
+
 ## Upgrading the OTel Collector version
 
 ### Step 1: Look up the core version

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -172,9 +172,77 @@ the unused default `memory_limiter`). You can confirm by checking
 `/etc/otel/supervisor-data/effective.yaml` and the `"Memory limiter
 configured"` log line emitted at collector start.
 
-The same pattern works for any other base processor (`batch`, `transform`,
-…) — define a new component with a different name and re-declare the
-pipelines that should use it.
+### Example: tuning the `batch` processor
+
+The default `batch` processor is sized for ClickHouse
+(`send_batch_size: 10000`, `timeout: 5s`). If your workload needs
+lower-latency exports — for example, latency-sensitive traces or a
+short-window smoke test that asserts shortly after emitting — define a
+new `batch` with the tuning you want and swap the pipelines to use it:
+
+```yaml
+# custom.config.yaml
+processors:
+  batch/lowlatency:
+    send_batch_size: 1000
+    send_batch_max_size: 2000
+    timeout: 500ms
+
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter, batch/lowlatency]
+    logs/out-default:
+      processors: [memory_limiter, transform, batch/lowlatency]
+```
+
+Notes:
+
+- You only need to re-declare the pipelines you want to retune; pipelines
+  you don't mention keep the default `batch` from the base config. In the
+  example above, `metrics` and `logs/out-rrweb` continue using the default
+  `batch`.
+- Processor list order matters. Keep `memory_limiter` ahead of the batch
+  processor so back-pressure applies before batching.
+- Larger batches are friendlier to ClickHouse (fewer inserts, fewer
+  MergeTree parts). The defaults — `send_batch_size: 10000`, `timeout: 5s`
+  — are the recommended starting point; only tune them when you have a
+  specific reason.
+- You can combine swap blocks. Define both `memory_limiter/custom` and
+  `batch/lowlatency`, and reference both in the same pipeline
+  (e.g. `processors: [memory_limiter/custom, batch/lowlatency]`).
+
+You can verify the new processor is actually running (not just present in
+`effective.yaml`) by querying the collector's Prometheus metrics endpoint
+on port `8888` and looking for the new `processor` label:
+
+```sh
+curl -s http://localhost:8888/metrics | grep 'processor="batch/lowlatency"'
+# otelcol_processor_batch_batch_send_size_count{processor="batch/lowlatency"} 15
+# otelcol_processor_batch_timeout_trigger_send_total{processor="batch/lowlatency"} 15
+```
+
+### Lighter-weight option: env vars for the default `batch`
+
+If you only need to tune `send_batch_size`, `send_batch_max_size`, or
+`timeout` on the default `batch` processor and don't need to define a
+second processor, the existing env vars also work without a custom config
+file:
+
+- `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE` (default `10000`)
+- `HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE` (default `0`, meaning no upper
+  bound)
+- `HYPERDX_OTEL_BATCH_TIMEOUT` (default `5s`)
+
+These are read directly from the base `config.yaml`, so they apply
+everywhere the default `batch` is referenced. Use the swap pattern when
+you need different settings for different pipelines, when you want to
+combine batch + memory_limiter changes, or when you want to override
+`memory_limiter` (which has no equivalent env-var path).
+
+The same swap pattern works for any other base processor (`transform`,
+`resourcedetection`, …) — define a new component with a different name
+and re-declare the pipelines that should use it.
 
 > Pipeline `processors:` lists live in `docker/otel-collector/config.yaml`
 > (for OpAMP supervisor mode) and `docker/otel-collector/config.standalone.yaml`

--- a/smoke-tests/otel-collector/custom-pipeline-config.yaml
+++ b/smoke-tests/otel-collector/custom-pipeline-config.yaml
@@ -1,0 +1,27 @@
+# Smoke test fixture for HDX-4090: swap the default memory_limiter and batch
+# processors with user-defined alternatives via CUSTOM_OTELCOL_CONFIG_FILE.
+#
+# The collector loads this file AFTER docker/otel-collector/config.yaml and
+# docker/otel-collector/config.standalone.yaml. Because the standalone config
+# no longer sets `processors:` on each pipeline (those live in config.yaml,
+# which loads first), the pipeline `processors:` lists declared here win the
+# merge cleanly.
+processors:
+  memory_limiter/custom:
+    check_interval: 5s
+    limit_percentage: 75
+    spike_limit_percentage: 25
+  batch/lowlatency:
+    send_batch_size: 1000
+    send_batch_max_size: 2000
+    timeout: 100ms
+service:
+  pipelines:
+    traces:
+      processors: [memory_limiter/custom, batch/lowlatency]
+    metrics:
+      processors: [memory_limiter/custom, batch/lowlatency]
+    logs/out-default:
+      processors: [memory_limiter/custom, transform, batch/lowlatency]
+    logs/out-rrweb:
+      processors: [memory_limiter/custom, batch/lowlatency]

--- a/smoke-tests/otel-collector/custom-pipeline-processors.bats
+++ b/smoke-tests/otel-collector/custom-pipeline-processors.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# HDX-4090: When a user supplies CUSTOM_OTELCOL_CONFIG_FILE that defines a
+# new memory_limiter (with a name like memory_limiter/custom) and/or a new
+# batch processor and swaps the pipeline `processors:` lists to reference
+# them, the collector should:
+#   1. Instantiate the user-defined processors at runtime.
+#   2. Wire the custom processors into the pipelines (not the defaults).
+#   3. Keep data flowing through the swapped pipelines (e.g., to the
+#      ClickHouse exporter).
+#
+# These tests use the `otel-collector-custom` service in docker-compose.yaml,
+# which loads `custom-pipeline-config.yaml` via CUSTOM_OTELCOL_CONFIG_FILE.
+
+load 'test_helpers/utilities.bash'
+load 'test_helpers/assertions.bash'
+
+@test "HDX-4090: memory_limiter/custom is configured at runtime with percentage-derived limits" {
+    # The memorylimiterprocessor logs a "Memory limiter configured" line at
+    # startup with the resolved mib values. When configured via percentage,
+    # the limit_mib is derived from host memory and will not equal the
+    # default 1500 (which the bundled config.yaml sets).
+    run docker compose logs otel-collector-custom
+
+    # The default memory_limiter is still defined in the merged config but no
+    # pipeline references it, so the collector skips its instantiation. Only
+    # memory_limiter/custom should appear in the "Memory limiter configured"
+    # log lines.
+    [[ "$output" == *"Memory limiter configured"* ]]
+
+    # The percentage-derived limit must not equal the default 1500 MiB. Any
+    # host with >= ~2 GiB of memory will yield a different value at 75 %.
+    [[ "$output" != *'"limit_mib":1500'* ]]
+}
+
+@test "HDX-4090: batch/lowlatency processor is exposed via prometheus metrics" {
+    # The collector exports its own telemetry on the prometheus endpoint at
+    # :8888 (mapped to 38888 on the host for this service). The batch
+    # processor emits otelcol_processor_batch_* counters labelled with the
+    # processor name, so the presence of label `processor="batch/lowlatency"`
+    # in the metrics output is direct proof that the swap took effect.
+    run curl --silent --show-error --max-time 5 http://localhost:38888/metrics
+    [ "$status" -eq 0 ]
+
+    # Custom batch processor metric labels should be present.
+    [[ "$output" == *'processor="batch/lowlatency"'* ]]
+}
+
+@test "HDX-4090: data flows through the swapped logs/out-default pipeline to ClickHouse" {
+    # Emit a log via OTLP HTTP. The swapped logs/out-default pipeline uses
+    # memory_limiter/custom + transform + batch/lowlatency. If the swap had
+    # broken the pipeline wiring the row would never reach ClickHouse.
+    # The batch processor's timeout is 100 ms, so a brief sleep is enough.
+    emit_otel_data "http://localhost:34318" "data/custom-pipeline/swap-data-flow"
+    sleep 2
+    assert_test_data "data/custom-pipeline/swap-data-flow"
+}

--- a/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/assert_query.sql
+++ b/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT Body FROM custom_pipeline.otel_logs WHERE ResourceAttributes['suite-id'] = 'custom-pipeline' AND ResourceAttributes['test-id'] = 'swap-data-flow' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/expected.snap
+++ b/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/expected.snap
@@ -1,0 +1,1 @@
+"log emitted through memory_limiter/custom + batch/lowlatency"

--- a/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/input.json
+++ b/smoke-tests/otel-collector/data/custom-pipeline/swap-data-flow/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "custom-pipeline"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "swap-data-flow"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "log emitted through memory_limiter/custom + batch/lowlatency"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/docker-compose.yaml
+++ b/smoke-tests/otel-collector/docker-compose.yaml
@@ -76,6 +76,38 @@ services:
       ch-server:
         condition: service_healthy
 
+  # HDX-4090: collector running with CUSTOM_OTELCOL_CONFIG_FILE that swaps
+  # the default memory_limiter and batch processors for user-defined ones
+  # (memory_limiter/custom + batch/lowlatency). Verifies that the swap
+  # pattern documented in packages/otel-collector/README.md works end-to-end.
+  otel-collector-custom:
+    build:
+      context: ../..
+      dockerfile: docker/otel-collector/Dockerfile
+      target: dev
+      args:
+        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.149.0}
+        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.55.0}
+    environment:
+      - CLICKHOUSE_ENDPOINT=tcp://ch-server:9000?dial_timeout=10s
+      - CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT=ch-server:9363
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=
+      - HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=custom_pipeline
+      - HYPERDX_LOG_LEVEL=info
+      - CUSTOM_OTELCOL_CONFIG_FILE=/etc/otelcol-contrib/custom.config.yaml
+      # OPAMP_SERVER_URL is intentionally not set to run in standalone mode
+    volumes:
+      - ./custom-pipeline-config.yaml:/etc/otelcol-contrib/custom.config.yaml:ro
+    ports:
+      - 34318:4318 # OTLP http receiver
+      - 38888:8888 # collector self-telemetry (prometheus)
+    networks:
+      - internal
+    depends_on:
+      ch-server:
+        condition: service_healthy
+
   # Older ClickHouse (< 26.2) to test the compatibility schema (bloom filters
   # instead of full text indexes)
   ch-server-compat:

--- a/smoke-tests/otel-collector/setup_suite.bash
+++ b/smoke-tests/otel-collector/setup_suite.bash
@@ -9,6 +9,7 @@ setup_suite() {
     wait_for_ready "otel-collector"
     wait_for_ready "otel-collector-json"
     wait_for_ready "otel-collector-compat"
+    wait_for_ready "otel-collector-custom"
 }
 
 teardown_suite() {


### PR DESCRIPTION
Linear: [HDX-4090](https://linear.app/clickhouse/issue/HDX-4090/clickstack-otel-collector-hard-codes-memory-limiter-and-custom-config)

Closes #2145.

## Commits

- `e9d0ba4cb` — fix: move pipeline `processors:` lists from the OpAMP
  remote config into the bootstrap config, so a user-supplied
  `CUSTOM_OTELCOL_CONFIG_FILE` is no longer clobbered by the remote-config
  merge.
- `d0df0d6e7` — docs: add a `batch` tuning example to the README and
  `custom.config.yaml`; document the existing `HYPERDX_OTEL_BATCH_*` env
  vars as a lighter-weight alternative.

## Problem

Users running ClickStack on larger pods cannot switch the bundled
`memory_limiter` from `limit_mib` mode to `limit_percentage` mode via
`CUSTOM_OTELCOL_CONFIG_FILE`. Two things stack to cause this:

1. **YAML merge is a key-by-key union** — OTel's `confmap` recurses into
   maps and unions leaves rather than replacing the block, so a user's
   `memory_limiter: { limit_percentage: 75 }` ends up coexisting with the
   base `limit_mib: 1500` instead of replacing it.
2. **`memorylimiterprocessor` silently prefers mib over percentage** —
   when both are set, mib wins and the percentage values are ignored at
   runtime with no warning.

On top of that, the OpAMP remote config from the API used to set
`processors:` on every pipeline, which **overwrote** any pipeline
`processors:` list a user supplied via `CUSTOM_OTELCOL_CONFIG_FILE` — so
even the "swap to a differently-named processor" workaround was unusable
in supervisor mode.

The same constraint blocks tuning the `batch` processor. The 2026-04-25
comment on the ticket called this out: a user wanted
`timeout: 2s, send_batch_size: 1000, send_batch_max_size: 2000` but found
their values quietly dropped from the effective config.

## Fix

Move pipeline `processors:` lists from the OpAMP remote config into the
bootstrap config so they can be overridden via `CUSTOM_OTELCOL_CONFIG_FILE`.

- `packages/api/src/opamp/controllers/opampController.ts` — remove
  `processors:` from `traces`, `metrics`, `logs/out-default`,
  `logs/out-rrweb`. Receivers and exporters remain dynamic.
- `docker/otel-collector/config.yaml` — declare bootstrap
  `service.pipelines.*.processors` lists with the same values that the API
  used to send.
- `docker/otel-collector/config.standalone.yaml` — drop `processors:` from
  pipeline definitions (the base `config.yaml` loads first and provides
  them).
- `docker/otel-collector/custom.config.yaml` — replace the previous
  (broken) leaf-merge example with two working swap-pattern examples:
  `memory_limiter/custom` (percentage mode) and `batch/lowlatency`
  (low-latency exports).
- `packages/otel-collector/README.md` — new "Overriding base components
  via `CUSTOM_OTELCOL_CONFIG_FILE`" section documenting the pattern, plus
  a "Lighter-weight option: env vars for the default `batch`" subsection
  pointing users at the existing `HYPERDX_OTEL_BATCH_*` env vars.
- `.changeset/hdx-4090-swap-memory-limiter.md` — patch-level changeset for
  `@hyperdx/api` and `@hyperdx/otel-collector` covering both processors.

## Usage

### Override `memory_limiter` (e.g. percentage mode)

```yaml
# CUSTOM_OTELCOL_CONFIG_FILE
processors:
  memory_limiter/custom:
    check_interval: 5s
    limit_percentage: 75
    spike_limit_percentage: 25

service:
  pipelines:
    traces:
      processors: [memory_limiter/custom, batch]
    metrics:
      processors: [memory_limiter/custom, batch]
    logs/out-default:
      processors: [memory_limiter/custom, transform, batch]
    logs/out-rrweb:
      processors: [memory_limiter/custom, batch]
```

### Tune `batch` (e.g. low-latency timeout)

```yaml
# CUSTOM_OTELCOL_CONFIG_FILE
processors:
  batch/lowlatency:
    send_batch_size: 1000
    send_batch_max_size: 2000
    timeout: 500ms

service:
  pipelines:
    traces:
      processors: [memory_limiter, batch/lowlatency]
    logs/out-default:
      processors: [memory_limiter, transform, batch/lowlatency]
```

Pipelines you don't re-declare keep the default processors. The new
processor (whichever you named it) is the only one instantiated at
runtime — the default block stays in the merged config but is unused.

Lighter-weight option for tuning the default `batch` without a custom
config file: `HYPERDX_OTEL_BATCH_SEND_BATCH_SIZE`,
`HYPERDX_OTEL_BATCH_SEND_BATCH_MAX_SIZE`, `HYPERDX_OTEL_BATCH_TIMEOUT`.

## Verification

Tested live against the dev stack (slot 60, `make dev-up`) with the
ClickHouse exporter wired through.

| Scenario | `effective.yaml` `traces.processors` | Runtime evidence | ClickHouse |
| --- | --- | --- | --- |
| Default (no custom override) | `[memory_limiter, batch]` | `Memory limiter configured: limit_mib=1500, spike_limit_mib=512`; default `batch` only in `/metrics` | Growing |
| Swap `memory_limiter/custom` (percentage mode) | `[memory_limiter/custom, batch]` | `limit_mib=12022, spike_limit_mib=4007` (75 % / 25 % of host) | Growing |
| Swap `batch/lowlatency` (timeout 500 ms) | `[memory_limiter, batch/lowlatency]` | Prometheus `processor="batch/lowlatency"` counters increment; **15/15 timeout-triggered sends**; avg batch size ~18 records vs ~368 for the default 5 s timeout | Growing |
| Restore default `custom.config.yaml` | `[memory_limiter, batch]` | Custom processors gone from `effective.yaml` and `/metrics` | Growing |

Lint + tsc:

- `yarn workspace @hyperdx/api tsc --noEmit` — clean
- `yarn workspace @hyperdx/common-utils ci:unit` — 949 tests pass
- `make ci-lint` — passes (a pre-existing app-tsc error from a sibling
  worktree leak exists on `main` as well; unrelated to this change)

## Trade-offs / scope

- This fix scopes to "make the override pattern work via differently-named
  processors." A future enhancement (parked) would be a pre-merge trim
  that lets users override `memory_limiter` in place without re-declaring
  pipelines.
- Pipeline `processors:` lists now live in two places (the OCB-supervisor
  `config.yaml` and the standalone `config.standalone.yaml` defers to the
  former). Going forward, edits to the standard processor pipeline need
  only touch `config.yaml`; `opampController.ts` only manages
  receivers/exporters.
