### PR TITLE
feat: add refresh button to client sessions page

### DIFF
--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -15,6 +15,7 @@ import {
   SourceKind,
 } from '@hyperdx/common-utils/dist/types';
 import {
+  ActionIcon,
   Anchor,
   Button,
   Code,
@@ -22,6 +23,7 @@ import {
   Group,
   Paper,
   Stepper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconDeviceLaptop,
@@ -340,7 +342,11 @@ export default function SessionsPage() {
     [setSelectedSessionQuery],
   );
 
-  const { data: tableData, isLoading: isSessionsLoading } = useSessions({
+  const {
+    data: tableData,
+    isLoading: isSessionsLoading,
+    refetch: refetchSessions,
+  } = useSessions({
     dateRange: searchedTimeRange,
     sessionSource,
     traceSource: traceTrace,
@@ -428,6 +434,17 @@ export default function SessionsPage() {
                 >
                   Run
                 </Button>
+                <Tooltip label="Refresh results">
+                  <ActionIcon
+                    variant="subtle"
+                    size="lg"
+                    onClick={() => refetchSessions()}
+                    loading={isSessionsLoading}
+                    style={{ flexShrink: 0 }}
+                  >
+                    <IconRefresh size={16} />
+                  </ActionIcon>
+                </Tooltip>
               </Group>
             </PageHeader>
           }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The client sessions page did not have a refresh button to fetch the latest sessions, unlike other pages in the application. This PR adds a refresh `ActionIcon` next to the existing "Run" button in the sessions page toolbar.

The button uses TanStack Query's `refetch` mechanism to re-fetch the sessions query with the current parameters, allowing users to quickly get updated session data without modifying or re-submitting the search form.

### Screenshots or video

| Before | After |
| :----- | :---- |
| Only a "Run" button in toolbar | [Refresh button added next to Run button](https://cursor.com/agents/bc-85fa5767-5115-4bb1-ad2f-66de6c70a6fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_refresh_button.webp) |

Tooltip on hover:

[Refresh button showing tooltip: Refresh results](https://cursor.com/agents/bc-85fa5767-5115-4bb1-ad2f-66de6c70a6fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_refresh_button_tooltip.webp)

### How to test on Vercel preview

**Preview routes:** /sessions

**Steps:**

1. Navigate to the Client Sessions page via the left sidebar
2. Verify that a refresh icon button (circular arrow) appears to the right of the green "Run" button in the toolbar
3. Hover over the refresh icon and verify the tooltip says "Refresh results"

### References

- Linear Issue: HDX-4375

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4375](https://linear.app/clickhouse/issue/HDX-4375/add-refresh-button-to-client-sessions-page)

<div><a href="https://cursor.com/agents/bc-85fa5767-5115-4bb1-ad2f-66de6c70a6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85fa5767-5115-4bb1-ad2f-66de6c70a6fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

