### PR TITLE
fix(row-panel): hide empty attribute sections and soften body empty-state

### DIFF
--- a/.changeset/hdx-4373-row-panel-empty-sections.md
+++ b/.changeset/hdx-4373-row-panel-empty-sections.md
@@ -1,0 +1,26 @@
+---
+"@hyperdx/app": patch
+---
+
+fix(row-panel): hide empty attribute sections and stop showing "[Empty]"
+when the source's body column isn't configured
+
+The row-expand side panel always rendered `Log/Span Attributes` and
+`Resource Attributes` accordion sections, even when both were empty. The
+body header fell back to a literal `[Empty]` paper in two visually
+identical cases that meant different things: the body column was
+configured but the value was empty, or the body column wasn't configured
+on the source at all.
+
+The two attribute accordions now mirror the existing `topLevelAttributes`
+pattern and only render when their content is non-empty. The body header
+takes a new `bodyConfigured` prop: when `false` (source has neither body
+nor implicit column expression configured), the body paper is suppressed
+entirely. When `true` and the content is empty, the placeholder reads
+"No body for this event." instead of `[Empty]`.
+
+`DBRowOverviewPanel` derives `bodyConfigured` from
+`getEventBody(source) !== undefined`, which already returns `undefined`
+when neither expression is set.
+
+Fixes HDX-4373.

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -194,6 +194,11 @@ export function RowOverviewPanel({
             date={new Date(firstRow?.__hdx_timestamp ?? 0)}
             mainContent={mainContent}
             mainContentHeader={mainContentColumn}
+            // `getEventBody` returns undefined when neither Body Expression
+            // nor Implicit Column Expression is configured on the source.
+            // In that case suppress the body paper entirely instead of
+            // rendering an "[Empty]" placeholder.
+            bodyConfigured={mainContentColumn !== undefined}
             severityText={firstRow?.__hdx_severity_text}
             rowData={firstRow}
           />
@@ -283,63 +288,67 @@ export function RowOverviewPanel({
           </Accordion.Item>
         )}
 
-        <Accordion.Item value="eventAttributes">
-          <Accordion.Control>
-            <Text size="sm" ps="md">
-              {source.kind === 'log' ? 'Log' : 'Span'} Attributes
-            </Text>
-          </Accordion.Control>
-          <Accordion.Panel>
-            <Box px="md">
-              <DBRowJsonViewer
-                data={filteredEventAttributes}
-                jsonColumns={jsonColumns}
-              />
-            </Box>
-          </Accordion.Panel>
-        </Accordion.Item>
-
-        <Accordion.Item value="resourceAttributes">
-          <Accordion.Control>
-            <Text size="sm" ps="md">
-              Resource Attributes
-            </Text>
-          </Accordion.Control>
-          <Accordion.Panel>
-            <Flex wrap="wrap" gap="2px" mx="md" mb="lg">
-              {Object.entries(resourceAttributes).map(([key, value]) => (
-                <EventTag
-                  {...(onPropertyAddClick
-                    ? {
-                        onPropertyAddClick,
-                        sqlExpression:
-                          'resourceAttributesExpression' in source &&
-                          source.resourceAttributesExpression &&
-                          jsonColumns?.includes(
-                            source.resourceAttributesExpression,
-                          )
-                            ? // If resource attributes is a JSON column, we need to cast the key to a string so we can run where X in Y queries
-                              `toString(${source.resourceAttributesExpression}.${key})`
-                            : 'resourceAttributesExpression' in source
-                              ? `${source.resourceAttributesExpression}['${key}']`
-                              : '',
-                      }
-                    : {
-                        onPropertyAddClick: undefined,
-                        sqlExpression: undefined,
-                      })}
-                  generateSearchUrl={
-                    generateSearchUrl ? _generateSearchUrl : undefined
-                  }
-                  displayedKey={key}
-                  name={`${'resourceAttributesExpression' in source ? source.resourceAttributesExpression : ''}.${key}`}
-                  value={value as string}
-                  key={key}
+        {Object.keys(filteredEventAttributes).length > 0 && (
+          <Accordion.Item value="eventAttributes">
+            <Accordion.Control>
+              <Text size="sm" ps="md">
+                {source.kind === 'log' ? 'Log' : 'Span'} Attributes
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Box px="md">
+                <DBRowJsonViewer
+                  data={filteredEventAttributes}
+                  jsonColumns={jsonColumns}
                 />
-              ))}
-            </Flex>
-          </Accordion.Panel>
-        </Accordion.Item>
+              </Box>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+
+        {Object.keys(resourceAttributes).length > 0 && (
+          <Accordion.Item value="resourceAttributes">
+            <Accordion.Control>
+              <Text size="sm" ps="md">
+                Resource Attributes
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Flex wrap="wrap" gap="2px" mx="md" mb="lg">
+                {Object.entries(resourceAttributes).map(([key, value]) => (
+                  <EventTag
+                    {...(onPropertyAddClick
+                      ? {
+                          onPropertyAddClick,
+                          sqlExpression:
+                            'resourceAttributesExpression' in source &&
+                            source.resourceAttributesExpression &&
+                            jsonColumns?.includes(
+                              source.resourceAttributesExpression,
+                            )
+                              ? // If resource attributes is a JSON column, we need to cast the key to a string so we can run where X in Y queries
+                                `toString(${source.resourceAttributesExpression}.${key})`
+                              : 'resourceAttributesExpression' in source
+                                ? `${source.resourceAttributesExpression}['${key}']`
+                                : '',
+                        }
+                      : {
+                          onPropertyAddClick: undefined,
+                          sqlExpression: undefined,
+                        })}
+                    generateSearchUrl={
+                      generateSearchUrl ? _generateSearchUrl : undefined
+                    }
+                    displayedKey={key}
+                    name={`${'resourceAttributesExpression' in source ? source.resourceAttributesExpression : ''}.${key}`}
+                    value={value as string}
+                    key={key}
+                  />
+                ))}
+              </Flex>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
       </Accordion>
     </div>
   );

--- a/packages/app/src/components/DBRowSidePanelHeader.tsx
+++ b/packages/app/src/components/DBRowSidePanelHeader.tsx
@@ -130,6 +130,12 @@ export default function DBRowSidePanelHeader({
   attributes,
   mainContent = '',
   mainContentHeader,
+  // When `true`, the source has a body column configured. An empty value
+  // for that column renders a soft empty-state paper. When `false` (the
+  // source has neither body nor implicit column configured), the body
+  // paper is suppressed entirely; the header still shows timestamp,
+  // severity, and highlighted attributes.
+  bodyConfigured = true,
   date,
   severityText,
   rowData,
@@ -141,6 +147,7 @@ export default function DBRowSidePanelHeader({
   date: Date;
   mainContent?: string;
   mainContentHeader?: string;
+  bodyConfigured?: boolean;
   attributes?: HighlightedAttribute[];
   severityText?: string;
   rowData?: Record<string, any>;
@@ -239,7 +246,7 @@ export default function DBRowSidePanelHeader({
           />
         )}
       </Flex>
-      {mainContent ? (
+      {!bodyConfigured ? null : mainContent ? (
         <Paper
           p="xs"
           mt="sm"
@@ -289,8 +296,8 @@ export default function DBRowSidePanelHeader({
         </Paper>
       ) : (
         <Paper p="xs" mt="sm">
-          <Text size="xs" mb="xs">
-            [Empty]
+          <Text size="xs" c="dimmed">
+            No body for this event.
           </Text>
         </Paper>
       )}

--- a/packages/app/src/components/__tests__/DBRowSidePanelHeader.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanelHeader.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import DBRowSidePanelHeader from '../DBRowSidePanelHeader';
+
+// Stub modules that touch user preferences, AI APIs, or DOM observers; the
+// behavior under test is the body-paper visibility logic, not those deps.
+jest.mock('@/useUserPreferences', () => ({
+  useUserPreferences: jest.fn().mockReturnValue({
+    userPreferences: { expandSidebarHeader: false },
+    setUserPreference: jest.fn(),
+  }),
+}));
+
+jest.mock('@/useFormatTime', () => ({
+  FormatTime: () => null,
+}));
+
+jest.mock('../AISummarizeButton', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../DBHighlightedAttributesList', () => ({
+  DBHighlightedAttributesList: () => null,
+}));
+
+jest.mock('../DBRowSidePanel', () => ({
+  RowSidePanelContext: React.createContext({}),
+}));
+
+jest.mock('../DrawerUtils', () => ({
+  DrawerFullWidthToggle: () => null,
+}));
+
+jest.mock('../LogLevel', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('DBRowSidePanelHeader: body section (HDX-4373)', () => {
+  it('renders the configured body content when bodyConfigured + mainContent are truthy', () => {
+    renderWithMantine(
+      <DBRowSidePanelHeader
+        date={new Date('2026-05-27T12:00:00Z')}
+        mainContent="hello world"
+        mainContentHeader="Body"
+        bodyConfigured
+      />,
+    );
+    expect(screen.queryByText('hello world')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No body for this event.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('[Empty]')).not.toBeInTheDocument();
+  });
+
+  it('renders the softened empty state when body is configured but value is empty', () => {
+    renderWithMantine(
+      <DBRowSidePanelHeader
+        date={new Date('2026-05-27T12:00:00Z')}
+        mainContent=""
+        mainContentHeader="Body"
+        bodyConfigured
+      />,
+    );
+    expect(screen.queryByText('No body for this event.')).toBeInTheDocument();
+    expect(screen.queryByText('[Empty]')).not.toBeInTheDocument();
+  });
+
+  it('suppresses the body paper entirely when body is not configured on the source', () => {
+    renderWithMantine(
+      <DBRowSidePanelHeader
+        date={new Date('2026-05-27T12:00:00Z')}
+        mainContent=""
+        mainContentHeader=""
+        bodyConfigured={false}
+      />,
+    );
+    expect(
+      screen.queryByText('No body for this event.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('[Empty]')).not.toBeInTheDocument();
+  });
+
+  it('defaults bodyConfigured to true (back-compat with callers that do not pass it)', () => {
+    renderWithMantine(
+      <DBRowSidePanelHeader
+        date={new Date('2026-05-27T12:00:00Z')}
+        mainContent=""
+      />,
+    );
+    expect(screen.queryByText('No body for this event.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The row-expand side panel always rendered `Log/Span Attributes` and `Resource Attributes` accordion sections, even when both were empty. The body header in `DBRowSidePanelHeader` fell back to a literal `[Empty]` paper in two visually identical cases that meant different things:

1. body column is configured but the value is genuinely empty, and
2. body column isn't configured on the source at all.

The result is dead space and a confusing placeholder for any source that's partially configured. No crashes; pure UX cleanup.

This PR:
- Gates the two attribute accordion items on non-empty content, mirroring the existing `topLevelAttributes` pattern (already at `DBRowOverviewPanel.tsx:268`).
- Adds an optional `bodyConfigured` prop to `DBRowSidePanelHeader`. When `false`, the body paper is suppressed entirely; the header still leads with timestamp, severity, and highlighted attributes. When `true` and content is empty, the placeholder reads "No body for this event." instead of `[Empty]`.
- `DBRowOverviewPanel` derives `bodyConfigured` from `getEventBody(source) !== undefined`, which already returns `undefined` when neither `bodyExpression` nor `implicitColumnExpression` is set (see `packages/app/src/source.ts:83-93`).

## Test plan

- [x] New component tests in `DBRowSidePanelHeader.test.tsx` covering each combination of `bodyConfigured` and empty/non-empty `mainContent` (4 cases, all passing)
- [x] `yarn jest src/components/__tests__/DBRowSidePanelHeader.test.tsx` — 4 passed
- [x] `make ci-lint` — clean
- [x] `yarn tsc --noEmit` (app) — clean
- [ ] Manual: configure a source without Body Expression, click a row, expect no `[Empty]` paper and no empty attribute accordions

Fixes HDX-4373.