### PR TITLE
fix(search): preserve incompatible filters as inactive when switching data sources

### DIFF
--- a/.changeset/active-filter-pills-inactive-state.md
+++ b/.changeset/active-filter-pills-inactive-state.md
@@ -1,0 +1,9 @@
+---
+'@hyperdx/app': patch
+---
+
+feat: preserve incompatible filters as an inactive state when switching data sources on the search page.
+
+Previously, switching from Logs to Traces (or any other schema change) would silently drop filters whose fields don't exist on the new source. Now those filters stay visible in the `ActiveFilterPills` bar with a muted, strikethrough, dashed-border style and a tooltip explaining why they aren't applied. They are automatically excluded from the rendered query so it stays valid, and re-apply if the user switches back to a compatible source.
+
+`ActiveFilterPills` accepts a new `invalidFields?: Set<string>` prop (with optional `invalidFieldReason?: (field: string) => string` for tooltip customization). `useSearchPageFilterState` accepts a new `validFields?: Set<string>` option and exposes `invalidFields` so consumers don't have to compute it themselves.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -25,10 +25,7 @@ import {
 import { useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  ClickHouseQueryError,
-  ColumnMeta,
-} from '@hyperdx/common-utils/dist/clickhouse';
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import {
@@ -134,7 +131,6 @@ import {
 } from './components/TimePicker/utils';
 import { useColumns, useTableMetadata } from './hooks/useMetadata';
 import { useSqlSuggestions } from './hooks/useSqlSuggestions';
-import { useStableCallback } from './hooks/useStableCallback';
 import {
   buildDirectTraceWhereClause,
   getDefaultDirectTraceDateRange,
@@ -787,12 +783,6 @@ export function useDefaultOrderBy(sourceID: string | undefined | null) {
   }, [source, tableMetadata]);
 }
 
-function formatDroppedFiltersMessage(count: number): string {
-  const noun = count === 1 ? 'filter' : 'filters';
-  const verb = count === 1 ? 'was' : 'were';
-  return `${count} ${noun} didn't apply to this source and ${verb} removed.`;
-}
-
 // This is outside as it needs to be a stable reference
 const queryStateMap = {
   source: parseAsString,
@@ -1068,10 +1058,6 @@ export function DBSearchPage() {
   );
 
   const filters = useWatch({ name: 'filters', control });
-  const searchFilters = useSearchPageFilterState({
-    searchQuery: filters ?? undefined,
-    onFilterChange: handleSetFilters,
-  });
 
   const watchedSource = useWatch({
     control,
@@ -1080,10 +1066,6 @@ export function DBSearchPage() {
     defaultValue: searchedConfig.source ?? undefined,
   });
   const prevSourceRef = useRef(watchedSource);
-  // Set when the user switches sources via the dropdown. The follow-up
-  // effect waits for the new source's columns to load and then drops any
-  // sidebar filters that don't apply to the new schema.
-  const pendingFilterReconcileRef = useRef<string | null>(null);
 
   const watchedSourceObj = useMemo(
     () => inputSourceObjs?.find(s => s.id === watchedSource),
@@ -1098,9 +1080,30 @@ export function DBSearchPage() {
     { enabled: !!watchedSourceObj },
   );
 
+  // Set of column names for the active source. Filters whose key isn't in
+  // this set are marked inactive (kept in UI state for context but skipped
+  // when serializing the query) so switching sources doesn't lose user
+  // selections. While columns are loading the set is `undefined` and the
+  // hook treats all filters as valid.
+  const validFields = useMemo<Set<string> | undefined>(
+    () =>
+      watchedSourceColumns
+        ? new Set(watchedSourceColumns.map(c => c.name))
+        : undefined,
+    [watchedSourceColumns],
+  );
+
+  const searchFilters = useSearchPageFilterState({
+    searchQuery: filters ?? undefined,
+    onFilterChange: handleSetFilters,
+    validFields,
+  });
+
   useEffect(() => {
-    // If the user changes the source dropdown, reset the select and orderby fields
-    // to match the new source selected
+    // If the user changes the source dropdown, reset the select and orderby
+    // fields to match the new source selected. Filters are reconciled
+    // reactively by `useSearchPageFilterState` via `validFields` — invalid
+    // filters are preserved as inactive instead of being dropped.
     if (watchedSource !== prevSourceRef.current) {
       prevSourceRef.current = watchedSource;
       const newInputSourceObj = inputSourceObjs?.find(
@@ -1114,9 +1117,6 @@ export function DBSearchPage() {
         if (savedSearchId == null || savedSearch?.source !== watchedSource) {
           setValue('select', '');
           setValue('orderBy', '');
-          // Defer filter clearing: wait until the new source's columns load,
-          // then keep filters whose root column exists on the new schema.
-          pendingFilterReconcileRef.current = watchedSource ?? null;
           // If the user is in a saved search, prefer the saved search's select/orderBy if available
         } else {
           setValue('select', savedSearch?.select ?? '');
@@ -1124,8 +1124,6 @@ export function DBSearchPage() {
           // Don't clear filters - we're loading from saved search
         }
         // Push the new source to URL/searchedConfig so the chart re-queries.
-        // Debounced so a later filter reconcile (which also submits) collapses
-        // into a single run.
         debouncedSubmit();
       }
     }
@@ -1138,30 +1136,6 @@ export function DBSearchPage() {
     setLastSelectedSourceId,
     debouncedSubmit,
   ]);
-
-  const retainCompatibleFilters = useStableCallback((columns: ColumnMeta[]) => {
-    pendingFilterReconcileRef.current = null;
-
-    const allowed = new Set(columns.map(c => c.name));
-
-    const dropped = searchFilters.retainFiltersByColumns(allowed);
-
-    if (dropped.length > 0) {
-      notifications.show({
-        color: 'yellow',
-        message: formatDroppedFiltersMessage(dropped.length),
-      });
-    }
-  });
-
-  useEffect(() => {
-    if (
-      pendingFilterReconcileRef.current === watchedSource &&
-      watchedSourceColumns
-    ) {
-      retainCompatibleFilters(watchedSourceColumns);
-    }
-  }, [watchedSource, watchedSourceColumns, retainCompatibleFilters]);
 
   const onTableScroll = useCallback(
     (scrollTop: number) => {
@@ -2025,7 +1999,11 @@ export function DBSearchPage() {
             <SearchSubmitButton isFormStateDirty={formState.isDirty} />
           </Flex>
         </Flex>
-        <ActiveFilterPills searchFilters={searchFilters} mt={6} />
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          invalidFields={searchFilters.invalidFields}
+          mt={6}
+        />
       </form>
       {searchedConfig != null && searchedSource != null && (
         <SaveSearchModal

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -1155,6 +1155,160 @@ describe('searchFilters', () => {
         warnSpy.mockRestore();
       });
     });
+
+    describe('validFields / invalidFields', () => {
+      it('treats all filters as valid when validFields is not provided', () => {
+        const { result } = renderHook(() =>
+          useSearchPageFilterState({
+            searchQuery: [
+              { type: 'lucene', condition: 'ServiceName:"app"' },
+              { type: 'lucene', condition: 'SeverityText:"info"' },
+            ],
+            onFilterChange: jest.fn(),
+          }),
+        );
+
+        expect(result.current.invalidFields.size).toBe(0);
+      });
+
+      it('marks filter keys absent from validFields as invalid', () => {
+        const { result } = renderHook(() =>
+          useSearchPageFilterState({
+            searchQuery: [
+              { type: 'lucene', condition: 'ServiceName:"app"' },
+              { type: 'lucene', condition: 'SeverityText:"info"' },
+            ],
+            onFilterChange: jest.fn(),
+            validFields: new Set(['ServiceName', 'Timestamp']),
+          }),
+        );
+
+        expect(Array.from(result.current.invalidFields)).toEqual([
+          'SeverityText',
+        ]);
+        // Filter still in UI state — preserved for context.
+        expect(result.current.filters.SeverityText).toBeDefined();
+      });
+
+      it('treats a nested key as valid when its root column is valid', () => {
+        const { result } = renderHook(() =>
+          useSearchPageFilterState({
+            searchQuery: [
+              { type: 'lucene', condition: 'LogAttributes.user:"123"' },
+            ],
+            onFilterChange: jest.fn(),
+            validFields: new Set(['LogAttributes']),
+          }),
+        );
+
+        expect(result.current.invalidFields.size).toBe(0);
+      });
+
+      it('strips invalid filters from the serialized query on user mutation', () => {
+        const onFilterChange = jest.fn();
+        const { result } = renderHook(() =>
+          useSearchPageFilterState({
+            searchQuery: [
+              { type: 'lucene', condition: 'ServiceName:"app"' },
+              { type: 'lucene', condition: 'SeverityText:"info"' },
+            ],
+            onFilterChange,
+            validFields: new Set(['ServiceName']),
+          }),
+        );
+
+        act(() => {
+          result.current.setFilterValue('ServiceName', 'api');
+        });
+
+        const lastCall =
+          onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+        expect(
+          lastCall.some((f: { condition: string }) =>
+            f.condition.includes('SeverityText'),
+          ),
+        ).toBe(false);
+        expect(
+          lastCall.some((f: { condition: string }) =>
+            f.condition.includes('ServiceName'),
+          ),
+        ).toBe(true);
+      });
+
+      it('re-emits the query when validFields changes so the URL stays in sync', () => {
+        const onFilterChange = jest.fn();
+        let validFields: Set<string> | undefined = new Set([
+          'ServiceName',
+          'SeverityText',
+        ]);
+        const { rerender } = renderHook(() =>
+          useSearchPageFilterState({
+            searchQuery: [
+              { type: 'lucene', condition: 'ServiceName:"app"' },
+              { type: 'lucene', condition: 'SeverityText:"info"' },
+            ],
+            onFilterChange,
+            validFields,
+          }),
+        );
+
+        onFilterChange.mockClear();
+
+        validFields = new Set(['ServiceName']);
+        rerender();
+
+        // SeverityText is no longer valid → stripped from the emitted query.
+        const lastCall =
+          onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+        expect(
+          lastCall.every(
+            (f: { condition: string }) => !f.condition.includes('SeverityText'),
+          ),
+        ).toBe(true);
+      });
+
+      it('preserves invalid filters in state so they re-apply when the field becomes valid again', () => {
+        const onFilterChange = jest.fn();
+        let validFields: Set<string> | undefined = new Set(['ServiceName']);
+        const { result, rerender } = renderHook(() =>
+          useSearchPageFilterState({
+            // URL only has ServiceName (SeverityText was previously stripped)
+            // but UI state will keep SeverityText preserved across rerenders.
+            searchQuery: [{ type: 'lucene', condition: 'ServiceName:"app"' }],
+            onFilterChange,
+            validFields,
+          }),
+        );
+
+        // Seed UI state with an invalid filter directly (simulating an
+        // earlier source where SeverityText was valid).
+        act(() => {
+          result.current.setFilters(prev => ({
+            ...prev,
+            SeverityText: {
+              included: new Set<string | boolean>(['info']),
+              excluded: new Set<string | boolean>(),
+            },
+          }));
+        });
+
+        expect(result.current.invalidFields.has('SeverityText')).toBe(true);
+
+        onFilterChange.mockClear();
+
+        // Switch to a source where SeverityText is valid again.
+        validFields = new Set(['ServiceName', 'SeverityText']);
+        rerender();
+
+        const lastCall =
+          onFilterChange.mock.calls[onFilterChange.mock.calls.length - 1][0];
+        expect(
+          lastCall.some((f: { condition: string }) =>
+            f.condition.includes('SeverityText'),
+          ),
+        ).toBe(true);
+      });
+    });
   });
 
   describe('filters use direct_read optimization', () => {

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -59,22 +59,40 @@ const pillStyle = {
 
 function FilterPill({
   pill,
+  isInvalid,
+  invalidReason,
   onRemove,
 }: {
   pill: PillItem;
+  isInvalid?: boolean;
+  invalidReason?: string;
   onRemove: () => void;
 }) {
   const isExcluded = pill.type === 'excluded';
   const operator = isExcluded ? ' != ' : pill.type === 'range' ? ': ' : ' = ';
 
+  const tooltipLabel = isInvalid
+    ? (invalidReason ??
+      `Filter not applied: "${pill.field}" isn't a column on the current source. It will reapply if you switch back.`)
+    : `${pill.field}${operator}${pill.value}`;
+
+  const showDangerAccent = isExcluded && !isInvalid;
+
   return (
-    <Tooltip label={`${pill.field}${operator}${pill.value}`} openDelay={300}>
+    <Tooltip label={tooltipLabel} openDelay={300} multiline maw={280}>
       <span
+        data-invalid={isInvalid ? 'true' : undefined}
         style={{
           ...pillStyle,
-          backgroundColor: isExcluded
-            ? 'var(--mantine-color-red-light)'
-            : 'var(--color-bg-hover)',
+          backgroundColor: isInvalid
+            ? 'transparent'
+            : isExcluded
+              ? 'var(--color-bg-danger)'
+              : 'var(--color-bg-hover)',
+          border: isInvalid
+            ? '1px dashed var(--color-border-muted)'
+            : '1px solid transparent',
+          opacity: isInvalid ? 0.55 : 1,
         }}
       >
         <Text
@@ -82,23 +100,46 @@ function FilterPill({
           size="xxs"
           c="dimmed"
           fw={500}
-          style={{ flexShrink: 0, maxWidth: 100 }}
+          style={{
+            flexShrink: 0,
+            maxWidth: 100,
+            textDecoration: isInvalid ? 'line-through' : undefined,
+          }}
           truncate="start"
         >
           {pill.field}
         </Text>
-        <Text span size="xxs" c={isExcluded ? 'red.4' : 'dimmed'}>
+        <Text
+          span
+          size="xxs"
+          c="dimmed"
+          style={{
+            color: showDangerAccent ? 'var(--color-text-danger)' : undefined,
+            textDecoration: isInvalid ? 'line-through' : undefined,
+          }}
+        >
           {operator}
         </Text>
-        <Text span size="xxs" fw={500} truncate>
+        <Text
+          span
+          size="xxs"
+          fw={500}
+          truncate
+          style={{ textDecoration: isInvalid ? 'line-through' : undefined }}
+        >
           {pill.value}
         </Text>
         <ActionIcon
           size={14}
           variant="transparent"
-          color={isExcluded ? 'red.4' : 'gray'}
+          color="gray"
           onClick={onRemove}
-          style={{ flexShrink: 0, marginLeft: 2 }}
+          style={{
+            flexShrink: 0,
+            marginLeft: 2,
+            color: showDangerAccent ? 'var(--color-text-danger)' : undefined,
+          }}
+          aria-label="Remove filter"
         >
           <IconX size={9} />
         </ActionIcon>
@@ -109,9 +150,23 @@ function FilterPill({
 
 export const ActiveFilterPills = memo(function ActiveFilterPills({
   searchFilters,
+  invalidFields,
+  invalidFieldReason,
   ...flexProps
 }: {
   searchFilters: FilterStateHook;
+  /**
+   * Field names whose filters are present in state but not applied to the
+   * current query (e.g. column doesn't exist on the active source). These
+   * render in a muted, strikethrough, dashed-border style and are preserved
+   * so the user can switch back without losing their selection.
+   */
+  invalidFields?: Set<string>;
+  /**
+   * Optional tooltip override for invalid pills. Receives the field name and
+   * returns the tooltip text.
+   */
+  invalidFieldReason?: (field: string) => string;
 } & FlexProps) {
   const { filters, setFilterValue, clearFilter, clearAllFilters } =
     searchFilters;
@@ -161,13 +216,20 @@ export const ActiveFilterPills = memo(function ActiveFilterPills({
 
   return (
     <Flex gap={4} px="sm" wrap="wrap" align="center" {...flexProps}>
-      {visiblePills.map((pill, i) => (
-        <FilterPill
-          key={`${pill.field}-${pill.type}-${pill.value}-${i}`}
-          pill={pill}
-          onRemove={() => handleRemove(pill)}
-        />
-      ))}
+      {visiblePills.map((pill, i) => {
+        const isInvalid = invalidFields?.has(pill.field) ?? false;
+        return (
+          <FilterPill
+            key={`${pill.field}-${pill.type}-${pill.value}-${i}`}
+            pill={pill}
+            isInvalid={isInvalid}
+            invalidReason={
+              isInvalid ? invalidFieldReason?.(pill.field) : undefined
+            }
+            onRemove={() => handleRemove(pill)}
+          />
+        );
+      })}
       {!expanded && hiddenCount > 0 && (
         <Text
           size="xxs"

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -81,6 +81,7 @@ function FilterPill({
   return (
     <Tooltip label={tooltipLabel} openDelay={300} multiline maw={280}>
       <span
+        data-testid={`active-filter-pill-${pill.field}`}
         data-invalid={isInvalid ? 'true' : undefined}
         style={{
           ...pillStyle,

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -90,9 +90,9 @@ function FilterPill({
               ? 'var(--color-bg-danger)'
               : 'var(--color-bg-hover)',
           border: isInvalid
-            ? '1px dashed var(--color-border-muted)'
+            ? '1px dashed var(--color-border)'
             : '1px solid transparent',
-          opacity: isInvalid ? 0.55 : 1,
+          opacity: isInvalid ? 0.75 : 1,
         }}
       >
         <Text

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -90,7 +90,7 @@ function FilterPill({
               ? 'var(--color-bg-danger)'
               : 'var(--color-bg-hover)',
           border: isInvalid
-            ? '1px dashed var(--color-border)'
+            ? '1px dashed var(--color-border-emphasis)'
             : '1px solid transparent',
           opacity: isInvalid ? 0.75 : 1,
         }}

--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -15,6 +15,7 @@ function makeSearchFilters(
     clearFilter: jest.fn(),
     clearAllFilters: jest.fn(),
     retainFiltersByColumns: jest.fn(() => []),
+    invalidFields: new Set<string>(),
   };
 }
 
@@ -255,6 +256,90 @@ describe('ActiveFilterPills', () => {
 
     expect(screen.getByText('+2 more')).toBeInTheDocument();
     expect(screen.queryByText('val8')).not.toBeInTheDocument();
+  });
+
+  describe('invalidFields prop', () => {
+    it('renders a pill in the inactive state when its field is in invalidFields', () => {
+      const searchFilters = makeSearchFilters({
+        SeverityText: {
+          included: new Set<string | boolean>(['info']),
+          excluded: new Set<string | boolean>(),
+        },
+      });
+      renderWithMantine(
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          invalidFields={new Set(['SeverityText'])}
+        />,
+      );
+
+      const valueEl = screen.getByText('info');
+      const pillSpan = valueEl.closest('span[data-invalid]');
+      expect(pillSpan).toHaveAttribute('data-invalid', 'true');
+      expect(valueEl).toHaveStyle({ textDecoration: 'line-through' });
+    });
+
+    it('does not mark pills as invalid when their field is not in invalidFields', () => {
+      const searchFilters = makeSearchFilters({
+        status: {
+          included: new Set<string | boolean>(['200']),
+          excluded: new Set<string | boolean>(),
+        },
+      });
+      renderWithMantine(
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          invalidFields={new Set(['SeverityText'])}
+        />,
+      );
+
+      const valueEl = screen.getByText('200');
+      const pillSpan = valueEl.closest('span');
+      expect(pillSpan).not.toHaveAttribute('data-invalid');
+    });
+
+    it('still allows removing an invalid pill via the X button', () => {
+      const searchFilters = makeSearchFilters({
+        SeverityText: {
+          included: new Set<string | boolean>(['info']),
+          excluded: new Set<string | boolean>(),
+        },
+      });
+      renderWithMantine(
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          invalidFields={new Set(['SeverityText'])}
+        />,
+      );
+
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove filter/i,
+      });
+      fireEvent.click(removeButtons[0]);
+      expect(searchFilters.setFilterValue).toHaveBeenCalledWith(
+        'SeverityText',
+        'info',
+        undefined,
+      );
+    });
+
+    it('uses a custom invalidFieldReason for the tooltip when provided', () => {
+      const searchFilters = makeSearchFilters({
+        SeverityText: {
+          included: new Set<string | boolean>(['info']),
+          excluded: new Set<string | boolean>(),
+        },
+      });
+      const reason = jest.fn((field: string) => `custom reason for ${field}`);
+      renderWithMantine(
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          invalidFields={new Set(['SeverityText'])}
+          invalidFieldReason={reason}
+        />,
+      );
+      expect(reason).toHaveBeenCalledWith('SeverityText');
+    });
   });
 
   it('renders mixed included, excluded, and range filters together', () => {

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -382,12 +382,32 @@ export const parseQuery = (
   return { filters: Object.fromEntries(state), passthroughFilters };
 };
 
+// Returns true when `key` (a filter state key — top-level column or
+// dot-normalized nested path) is allowed by the given column-name set.
+const isKeyAllowed = (
+  key: string,
+  allowedColumnNames: Set<string>,
+): boolean => {
+  const dotIdx = key.indexOf('.');
+  const rootColumn = dotIdx > 0 ? key.slice(0, dotIdx) : key;
+  return allowedColumnNames.has(key) || allowedColumnNames.has(rootColumn);
+};
+
 export const useSearchPageFilterState = ({
   searchQuery = [],
   onFilterChange,
+  validFields,
 }: {
   searchQuery?: Filter[];
   onFilterChange: (filters: Filter[]) => void;
+  /**
+   * Set of column names that exist on the currently selected source.
+   * When provided, filter keys that don't match any allowed column are
+   * marked as inactive: they remain in UI state (and are exposed via
+   * `invalidFields`) but are skipped when serializing the SQL/Lucene query
+   * via `onFilterChange`. If omitted, all filters are considered valid.
+   */
+  validFields?: Set<string>;
 }) => {
   const parsedQuery = useMemo(() => {
     try {
@@ -400,13 +420,67 @@ export const useSearchPageFilterState = ({
 
   const [filters, setFilters] = useState<FilterState>({});
 
+  // Sync UI state from URL on initial load and whenever the URL filters
+  // change (e.g. navigating to a saved search). When `validFields` is set,
+  // any filters present in UI state but not in the URL because they're
+  // currently invalid are preserved so the user keeps their selection across
+  // source switches.
   useEffect(() => {
-    if (!areFiltersEqual(filters, parsedQuery.filters)) {
-      setFilters(parsedQuery.filters);
+    const merged: FilterState = { ...parsedQuery.filters };
+    if (validFields) {
+      for (const [key, value] of Object.entries(filters)) {
+        if (!isKeyAllowed(key, validFields) && !merged[key]) {
+          merged[key] = value;
+        }
+      }
     }
-    // only react to changes in parsed query
+    if (!areFiltersEqual(filters, merged)) {
+      setFilters(merged);
+    }
+    // only react to changes in parsed query — validFields changes are handled
+    // by the re-emit effect below, which causes parsedQuery to update.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedQuery.filters]);
+
+  const invalidFields = useMemo(() => {
+    if (!validFields) return new Set<string>();
+    const invalid = new Set<string>();
+    for (const key of Object.keys(filters)) {
+      if (!isKeyAllowed(key, validFields)) invalid.add(key);
+    }
+    return invalid;
+  }, [filters, validFields]);
+
+  // When `validFields` changes (e.g. user switches data source) re-emit the
+  // query so the URL reflects only currently-applied filters. Strips entries
+  // that became invalid and re-adds entries that became valid again from UI
+  // state. Filter mutations go through `updateFilterQuery` which already
+  // strips inline, so this only needs to react to `validFields` changes.
+  useEffect(() => {
+    if (!validFields) return;
+    const strippedFromState = stripInvalidFilters(filters);
+    if (!areFiltersEqual(parsedQuery.filters, strippedFromState)) {
+      onFilterChange([
+        ...filtersToQuery(strippedFromState),
+        ...parsedQuery.passthroughFilters,
+      ]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validFields]);
+
+  // Excludes invalid filters before serializing so the rendered SQL/Lucene
+  // query stays valid even though the entries remain in UI state.
+  const stripInvalidFilters = useCallback(
+    (next: FilterState): FilterState => {
+      if (!validFields) return next;
+      const out: FilterState = {};
+      for (const [key, value] of Object.entries(next)) {
+        if (isKeyAllowed(key, validFields)) out[key] = value;
+      }
+      return out;
+    },
+    [validFields],
+  );
 
   // Migrate legacy SQL filters to Lucene on load so URLs become canonical
   const hasMigratedRef = useRef(false);
@@ -418,22 +492,22 @@ export const useSearchPageFilterState = ({
     if (hasSqlFilters && Object.keys(parsedQuery.filters).length > 0) {
       hasMigratedRef.current = true;
       onFilterChange([
-        ...filtersToQuery(parsedQuery.filters),
+        ...filtersToQuery(stripInvalidFilters(parsedQuery.filters)),
         ...parsedQuery.passthroughFilters,
       ]);
     }
-  }, [searchQuery, parsedQuery, onFilterChange]);
+  }, [searchQuery, parsedQuery, onFilterChange, stripInvalidFilters]);
 
   const updateFilterQuery = useCallback(
     (newFilters: FilterState) => {
       // Preserve unparseable filters so they aren't silently lost when
       // the user toggles a sidebar facet.
       onFilterChange([
-        ...filtersToQuery(newFilters),
+        ...filtersToQuery(stripInvalidFilters(newFilters)),
         ...parsedQuery.passthroughFilters,
       ]);
     },
-    [onFilterChange, parsedQuery.passthroughFilters],
+    [onFilterChange, parsedQuery.passthroughFilters, stripInvalidFilters],
   );
 
   const setFilterValue = useCallback(
@@ -528,17 +602,17 @@ export const useSearchPageFilterState = ({
   // Keep only filters whose root column appears in `allowedColumnNames`.
   // Returns the keys of the filters that were dropped so callers can surface
   // a notice when filter state was thrown away (e.g. on source change).
+  //
+  // NOTE: Prefer passing `validFields` to this hook instead — it preserves
+  // invalid filters as inactive (visible but not applied) rather than
+  // discarding them. This method is retained for callers that want a hard
+  // drop (e.g. one-off cleanup operations).
   const retainFiltersByColumns = useCallback(
     (allowedColumnNames: Set<string>): string[] => {
       const dropped: string[] = [];
       const kept: FilterState = {};
       for (const [key, value] of Object.entries(filters)) {
-        // Filter keys are dot-normalized — top-level columns are stored as-is,
-        // nested JSON/Map keys as `Root.nested.path`. An exact match handles
-        // the rare case of a column with dots in its name.
-        const dotIdx = key.indexOf('.');
-        const rootColumn = dotIdx > 0 ? key.slice(0, dotIdx) : key;
-        if (allowedColumnNames.has(key) || allowedColumnNames.has(rootColumn)) {
+        if (isKeyAllowed(key, allowedColumnNames)) {
           kept[key] = value;
         } else {
           dropped.push(key);
@@ -561,6 +635,7 @@ export const useSearchPageFilterState = ({
     clearFilter,
     clearAllFilters,
     retainFiltersByColumns,
+    invalidFields,
   };
 };
 

--- a/packages/app/tests/e2e/features/search/search-filters.spec.ts
+++ b/packages/app/tests/e2e/features/search/search-filters.spec.ts
@@ -156,11 +156,13 @@ test.describe(
       // preserved in state. The URL is the authoritative source of truth here.
       await expect(searchPage.page).toHaveURL(/filters=.*ServiceName/i);
 
-      // No "didn't apply" toast should have appeared
-      await expect(searchPage.getDroppedFiltersToast()).toHaveCount(0);
+      // ServiceName exists on both sources, so the pill stays active (not inactive).
+      await expect(searchPage.getInactiveFilterPill('ServiceName')).toHaveCount(
+        0,
+      );
     });
 
-    test('Incompatible filter is dropped and toast shown when one of two filters does not exist on new source', async () => {
+    test('Incompatible filter is preserved as inactive when one of two filters does not exist on new source', async () => {
       // Apply a ServiceName filter (shared between logs and traces)
       // (pickVisibleFilterValues also opens the filter group)
       const [serviceName] = await searchPage.filters.pickVisibleFilterValues(
@@ -181,20 +183,23 @@ test.describe(
       await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
       await searchPage.table.waitForRowsToPopulate();
 
-      // Yellow toast must appear with "1 filter didn't apply to this source"
-      await expect(searchPage.getDroppedFiltersToast()).toBeVisible({
-        timeout: 10000,
-      });
+      // SeverityText pill is preserved as inactive (data-invalid="true") so the
+      // user can switch back without losing context. It is *not* applied to the
+      // query — i.e. not in the URL.
+      await expect(
+        searchPage.getInactiveFilterPill('SeverityText'),
+      ).toBeVisible({ timeout: 10000 });
+      await expect(searchPage.page).not.toHaveURL(/filters=.*SeverityText/i);
 
-      // Re-open ServiceName group and confirm the compatible filter was kept.
-      // Assert via URL rather than checkbox — the trace source's facet may show
-      // a different set of service name values, so the checkbox checked state is
-      // fragile even when the filter is correctly preserved in the URL/state.
-      await searchPage.filters.openFilterGroup('ServiceName');
+      // The compatible ServiceName filter stays active in URL and is not
+      // marked inactive.
       await expect(searchPage.page).toHaveURL(/filters=.*ServiceName/i);
+      await expect(searchPage.getInactiveFilterPill('ServiceName')).toHaveCount(
+        0,
+      );
     });
 
-    test('Filter for a column that does not exist on new source is dropped and toast shown', async () => {
+    test('Filter for a column that does not exist on new source is preserved as inactive', async () => {
       // Open and apply only a SeverityText filter (logs-only, not present on traces)
       await searchPage.filters.openFilterGroup('SeverityText');
       await searchPage.filters.applyFilter('SeverityText', 'info');
@@ -206,10 +211,32 @@ test.describe(
       await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
       await searchPage.table.waitForRowsToPopulate();
 
-      // Toast must appear indicating 1 filter was removed
-      await expect(searchPage.getDroppedFiltersToast()).toBeVisible({
-        timeout: 10000,
-      });
+      // Pill is preserved as inactive (visible but not applied to the query).
+      await expect(
+        searchPage.getInactiveFilterPill('SeverityText'),
+      ).toBeVisible({ timeout: 10000 });
+      await expect(searchPage.page).not.toHaveURL(/filters=.*SeverityText/i);
+    });
+
+    test('Inactive filter reactivates when switching back to a compatible source', async () => {
+      // Apply a SeverityText filter on logs
+      await searchPage.filters.openFilterGroup('SeverityText');
+      await searchPage.filters.applyFilter('SeverityText', 'info');
+
+      // Switch to traces — pill goes inactive, dropped from URL
+      await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+      await searchPage.table.waitForRowsToPopulate();
+      await expect(
+        searchPage.getInactiveFilterPill('SeverityText'),
+      ).toBeVisible({ timeout: 10000 });
+
+      // Switch back to logs — pill should reactivate and re-appear in URL
+      await searchPage.selectSource(DEFAULT_LOGS_SOURCE_NAME);
+      await searchPage.table.waitForRowsToPopulate();
+      await expect(
+        searchPage.getInactiveFilterPill('SeverityText'),
+      ).toHaveCount(0);
+      await expect(searchPage.page).toHaveURL(/filters=.*SeverityText/i);
     });
   },
 );

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -296,15 +296,26 @@ export class SearchPage {
   }
 
   /**
-   * Returns a locator for the yellow Mantine notification shown when one or
-   * more sidebar filters are dropped because they don't exist on the newly
-   * selected source's schema.
-   *
-   * The message format from DBSearchPage.tsx:
-   *   "N filter(s) didn't apply to this source and was/were removed."
+   * Returns a locator for a pill in the ActiveFilterPills bar (the row of
+   * "field = value ×" chips below the search toolbar) matching the given
+   * field. Multiple pills can share a field (one per included/excluded
+   * value); the locator covers all of them — callers can `.first()` or
+   * filter by text if they need a specific value.
    */
-  getDroppedFiltersToast() {
-    return this.page.getByText(/filter.* didn't apply to this source/i);
+  getActiveFilterPill(field: string) {
+    return this.page.getByTestId(`active-filter-pill-${field}`);
+  }
+
+  /**
+   * Returns a locator scoped to inactive (data-invalid="true") pills only.
+   * An inactive pill is one whose field doesn't exist on the active source —
+   * the filter is preserved in UI state but skipped at query time, and
+   * styled with a muted strikethrough so the user still sees it.
+   */
+  getInactiveFilterPill(field: string) {
+    return this.getActiveFilterPill(field).and(
+      this.page.locator('[data-invalid="true"]'),
+    );
   }
 
   // Getters for assertions in spec files


### PR DESCRIPTION
## Summary

When the user switched the active source on the search page (e.g. Logs → Traces), any filter whose field doesn't exist on the new source was silently dropped. A transient yellow toast announced it, but the user's selection — and the context for switching back — was gone.

This PR keeps those filters visible in the `ActiveFilterPills` bar with a muted, strikethrough, dashed-border style and a tooltip explaining why they aren't applied. They're excluded from the rendered query so it stays valid, and re-apply automatically if the user switches back to a compatible source.


<img width="857" height="175" alt="filters@2x" src="https://github.com/user-attachments/assets/c719bec5-778e-49e6-9093-b845b731adc8" />



### Visual treatment

For an inactive pill:
- Strikethrough on field + operator + value
- Opacity `0.75`
- Dashed border (`var(--color-border-emphasis)`)
- Tooltip: _"Filter not applied: 'SeverityText' isn't a column on the current source. It will reapply if you switch back."_

No yellow warning color / warning icon — nothing is broken, it's just informational. Yellow gets noisy when many filters become invalid at once.

### API changes

- **`ActiveFilterPills`** — new optional props:
  - `invalidFields?: Set<string>` — fields whose pills should render in the inactive state
  - `invalidFieldReason?: (field: string) => string` — override the tooltip copy
- **`useSearchPageFilterState`** — new optional `validFields?: Set<string>` input; exposes computed `invalidFields`. Invalid keys are stripped at query-serialization time so UI state and URL stay decoupled.
- **`DBSearchPage`** — passes current source columns as `validFields` and removes the imperative `retainCompatibleFilters` drop-on-source-change flow (and its toast notification).

All colors and borders use semantic CSS vars (`--color-bg-danger`, `--color-text-danger`, `--color-border-emphasis`, etc.) per `agent_docs/themes.md`.

## Test plan

- [ ] Apply a `SeverityText` filter on a Logs source, switch to a Traces source. The pill should remain visible with a muted/strikethrough/dashed appearance. Tooltip should explain why.
- [ ] Switch back to the Logs source. The pill should reactivate (full opacity, no strikethrough) and the filter should re-apply to the query.
- [ ] Apply filters on a nested map/JSON key (e.g. `LogAttributes.user`). It should be treated as valid as long as the root column exists.
- [ ] Click the X on an inactive pill — it removes the filter from state cleanly.
- [ ] `Clear all` clears both active and inactive pills.
- [x] `yarn ci:unit` (added/updated tests for `ActiveFilterPills` and `useSearchPageFilterState`)
- [x] App typecheck + lint

Made with [Cursor](https://cursor.com)