### PR TITLE
[HDX-4383] Skip string inference when body parses as JSON with a level field

### DIFF
--- a/.changeset/hdx-4383-skip-string-inference-on-json-level.md
+++ b/.changeset/hdx-4383-skip-string-inference-on-json-level.md
@@ -1,0 +1,43 @@
+---
+"@hyperdx/otel-collector": patch
+---
+
+fix(otel-collector): skip string severity inference when JSON body has a
+`level`/`severity` field
+
+When the log body parsed as JSON and contained a level-like field, the
+pipeline still ran its `\b(alert|crit|emerg|fatal|error|err|warn|notice|debug|dbug|trace)`
+keyword scan over the raw body string. The leading-only `\b` boundary
+matched any word starting with a severity keyword, so bodies containing
+words like `alertmanager`, `alerting`, `errors`, `warning`, etc. produced
+the wrong severity. A Grafana sidecar log with body
+`{"level":"INFO", "msg":"... mimir-alertmanager-dashboard ..."}` was being
+tagged `SeverityText="fatal"`, `SeverityNumber=21` because `alert` matched
+inside `alertmanager`, even though the JSON `level` said `INFO`.
+
+A new OTTL `log_statements` block in
+`docker/otel-collector/config.yaml` runs between the existing JSON-parse
+block and the string-inference block. It promotes a JSON-derived level
+field (now in `log.attributes`) to `log.severity_text`, which causes the
+string-inference block to be skipped via its existing
+`severity_number == 0 and severity_text == ""` guard. The block is
+case-insensitive across keys by enumerating common casings of common field
+names used by mainstream logging frameworks: `level` / `Level` / `LEVEL`
+(pino, winston, zerolog, zap, logrus, slog, Serilog, NLog),
+`severity` / `Severity` / `SEVERITY` (Datadog, GCP Cloud Logging), and
+`log.level` (Elastic ECS, flattened from nested JSON). Each `set`
+self-guards on `severity_text == ""` so the first match wins (priority:
+`level` > `severity` > `log.level`). The block as a whole is gated on no
+producer-set severity, so explicit producer values are always preserved.
+
+`severity_number` is mapped via case-insensitive `(?i)` regex over
+`severity_text`, mirroring the existing string-inference keyword set.
+Unrecognized values (e.g. `"verbose"`) fall back to `INFO`, matching
+block 2's else-branch. The existing `ConvertCase(severity_text, "lower")`
+normalization is unchanged.
+
+Behavior preserved for: non-JSON bodies, JSON bodies without a level
+field, and any log record where the producer already set
+`severity_text` or `severity_number`.
+
+Fixes HDX-4383.

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -7,34 +7,110 @@ processors:
         statements:
           # JSON parsing: Extends log attributes with the fields from structured log body content, either as an OTEL map or
           # as a string containing JSON content.
-          - set(log.cache, ExtractPatterns(log.body, "(?P<0>(\\{.*\\}))")) where IsString(log.body)
-          - merge_maps(log.attributes, ParseJSON(log.cache["0"]), "upsert") where IsMap(log.cache)
+          - set(log.cache, ExtractPatterns(log.body, "(?P<0>(\\{.*\\}))")) where
+            IsString(log.body)
+          - merge_maps(log.attributes, ParseJSON(log.cache["0"]), "upsert")
+            where IsMap(log.cache)
           - flatten(log.attributes) where IsMap(log.cache)
           - merge_maps(log.attributes, log.body, "upsert") where IsMap(log.body)
+      - context: log
+        error_mode: ignore
+        conditions:
+          # Don't overwrite producer-set severity.
+          - severity_number == 0 and severity_text == ""
+        statements:
+          # HDX-4383: Promote a JSON-derived level/severity field from the parsed
+          # body (now in log.attributes) into log.severity_text so the string-
+          # inference block below is short-circuited. Case-insensitive matching
+          # is done by enumerating the common casings of common field names used
+          # by mainstream logging frameworks (pino, winston, zerolog, zap,
+          # logrus, slog, Serilog, GCP Cloud Logging, Elastic ECS, ...).
+          # Each statement self-guards on `severity_text == ""` so the first hit
+          # wins (priority order: level > severity > log.level).
+          - set(log.severity_text, log.attributes["level"])     where
+            log.severity_text == "" and
+            IsString(log.attributes["level"])     and
+            Len(log.attributes["level"]) > 0
+          - set(log.severity_text, log.attributes["Level"])     where
+            log.severity_text == "" and
+            IsString(log.attributes["Level"])     and
+            Len(log.attributes["Level"]) > 0
+          - set(log.severity_text, log.attributes["LEVEL"])     where
+            log.severity_text == "" and
+            IsString(log.attributes["LEVEL"])     and
+            Len(log.attributes["LEVEL"]) > 0
+          - set(log.severity_text, log.attributes["severity"])  where
+            log.severity_text == "" and
+            IsString(log.attributes["severity"])  and
+            Len(log.attributes["severity"]) > 0
+          - set(log.severity_text, log.attributes["Severity"])  where
+            log.severity_text == "" and
+            IsString(log.attributes["Severity"])  and
+            Len(log.attributes["Severity"]) > 0
+          - set(log.severity_text, log.attributes["SEVERITY"])  where
+            log.severity_text == "" and
+            IsString(log.attributes["SEVERITY"])  and
+            Len(log.attributes["SEVERITY"]) > 0
+          - set(log.severity_text, log.attributes["log.level"]) where
+            log.severity_text == "" and IsString(log.attributes["log.level"])
+            and Len(log.attributes["log.level"]) > 0
+          # Best-effort severity_number mapping (case-insensitive via (?i)).
+          - set(log.severity_number, SEVERITY_NUMBER_FATAL) where
+            IsMatch(log.severity_text, "(?i)(alert|crit|emerg|fatal)")
+          - set(log.severity_number, SEVERITY_NUMBER_ERROR) where
+            IsMatch(log.severity_text, "(?i)(error|err)")
+          - set(log.severity_number, SEVERITY_NUMBER_WARN)  where
+            IsMatch(log.severity_text, "(?i)(warn|notice)")
+          - set(log.severity_number, SEVERITY_NUMBER_INFO)  where
+            IsMatch(log.severity_text, "(?i)(info)")
+          - set(log.severity_number, SEVERITY_NUMBER_DEBUG) where
+            IsMatch(log.severity_text, "(?i)(debug|dbug)")
+          - set(log.severity_number, SEVERITY_NUMBER_TRACE) where
+            IsMatch(log.severity_text, "(?i)(trace)")
+          # Fallthrough: promoted a level but couldn't map to a known severity
+          # keyword (e.g. "verbose", "notice"-but-already-handled). Default to
+          # INFO so we always have a numeric severity when text was promoted.
+          # Guarded on severity_text != "" so it never fires when no level field
+          # was found (which would otherwise wrongly skip the inference block).
+          - set(log.severity_number, SEVERITY_NUMBER_INFO) where
+            log.severity_number == 0 and log.severity_text != ""
       - context: log
         error_mode: ignore
         conditions:
           - severity_number == 0 and severity_text == ""
         statements:
           # Infer: extract the first log level keyword from the first 256 characters of the body
-          - set(log.cache["substr"], log.body.string) where Len(log.body.string) < 256
-          - set(log.cache["substr"], Substring(log.body.string, 0, 256)) where Len(log.body.string) >= 256
-          - set(log.cache, ExtractPatterns(log.cache["substr"], "(?i)(?P<0>\\b(alert|crit|emerg|fatal|error|err|warn|notice|debug|dbug|trace))"))
+          - set(log.cache["substr"], log.body.string) where Len(log.body.string)
+            < 256
+          - set(log.cache["substr"], Substring(log.body.string, 0, 256)) where
+            Len(log.body.string) >= 256
+          - set(log.cache, ExtractPatterns(log.cache["substr"],
+            "(?i)(?P<0>\\b(alert|crit|emerg|fatal|error|err|warn|notice|debug|dbug|trace))"))
           # Infer: detect FATAL
-          - set(log.severity_number, SEVERITY_NUMBER_FATAL) where IsMatch(log.cache["0"], "(?i)(alert|crit|emerg|fatal)")
-          - set(log.severity_text, "fatal") where log.severity_number == SEVERITY_NUMBER_FATAL
+          - set(log.severity_number, SEVERITY_NUMBER_FATAL) where
+            IsMatch(log.cache["0"], "(?i)(alert|crit|emerg|fatal)")
+          - set(log.severity_text, "fatal") where log.severity_number ==
+            SEVERITY_NUMBER_FATAL
           # Infer: detect ERROR
-          - set(log.severity_number, SEVERITY_NUMBER_ERROR) where IsMatch(log.cache["0"], "(?i)(error|err)")
-          - set(log.severity_text, "error") where log.severity_number == SEVERITY_NUMBER_ERROR
+          - set(log.severity_number, SEVERITY_NUMBER_ERROR) where
+            IsMatch(log.cache["0"], "(?i)(error|err)")
+          - set(log.severity_text, "error") where log.severity_number ==
+            SEVERITY_NUMBER_ERROR
           # Infer: detect WARN
-          - set(log.severity_number, SEVERITY_NUMBER_WARN) where IsMatch(log.cache["0"], "(?i)(warn|notice)")
-          - set(log.severity_text, "warn") where log.severity_number == SEVERITY_NUMBER_WARN
+          - set(log.severity_number, SEVERITY_NUMBER_WARN) where
+            IsMatch(log.cache["0"], "(?i)(warn|notice)")
+          - set(log.severity_text, "warn") where log.severity_number ==
+            SEVERITY_NUMBER_WARN
           # Infer: detect DEBUG
-          - set(log.severity_number, SEVERITY_NUMBER_DEBUG) where IsMatch(log.cache["0"], "(?i)(debug|dbug)")
-          - set(log.severity_text, "debug") where log.severity_number == SEVERITY_NUMBER_DEBUG
+          - set(log.severity_number, SEVERITY_NUMBER_DEBUG) where
+            IsMatch(log.cache["0"], "(?i)(debug|dbug)")
+          - set(log.severity_text, "debug") where log.severity_number ==
+            SEVERITY_NUMBER_DEBUG
           # Infer: detect TRACE
-          - set(log.severity_number, SEVERITY_NUMBER_TRACE) where IsMatch(log.cache["0"], "(?i)(trace)")
-          - set(log.severity_text, "trace") where log.severity_number == SEVERITY_NUMBER_TRACE
+          - set(log.severity_number, SEVERITY_NUMBER_TRACE) where
+            IsMatch(log.cache["0"], "(?i)(trace)")
+          - set(log.severity_text, "trace") where log.severity_number ==
+            SEVERITY_NUMBER_TRACE
           # Infer: else
           - set(log.severity_text, "info") where log.severity_number == 0
           - set(log.severity_number, SEVERITY_NUMBER_INFO) where

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-ecs-log-level' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/expected.snap
@@ -1,0 +1,1 @@
+"fatal",21,"{""log"":{""level"":""fatal""},""message"":""ECS-style nested log""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-ecs-log-level/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-ecs-log-level"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"log\":{\"level\":\"fatal\"},\"message\":\"ECS-style nested log\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-level-body-keyword-conflict' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/expected.snap
@@ -1,0 +1,1 @@
+"info",9,"{""time"": ""2026-05-27T16:11:46.789392+00:00"", ""level"": ""INFO"", ""msg"": ""Found a folder override annotation, placing the mimir-alertmanager-dashboard in: /tmp/dashboards/Mimir Dashboards""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-body-keyword-conflict/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-level-body-keyword-conflict"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"time\": \"2026-05-27T16:11:46.789392+00:00\", \"level\": \"INFO\", \"msg\": \"Found a folder override annotation, placing the mimir-alertmanager-dashboard in: /tmp/dashboards/Mimir Dashboards\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-level-pascalcase' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/expected.snap
@@ -1,0 +1,1 @@
+"information",9,"{""Level"":""Information"",""msg"":""hello from Serilog""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-pascalcase/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-level-pascalcase"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"Level\":\"Information\",\"msg\":\"hello from Serilog\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-level-producer-wins' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/expected.snap
@@ -1,0 +1,1 @@
+"info",0,"{""level"":""warn"",""msg"":""producer-set severity must win over the JSON level field""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-producer-wins/input.json
@@ -1,0 +1,37 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-level-producer-wins"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "severity_number": 0,
+              "severity_text": "info",
+              "body": {
+                "stringValue": "{\"level\":\"warn\",\"msg\":\"producer-set severity must win over the JSON level field\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-level-unknown' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/expected.snap
@@ -1,0 +1,1 @@
+"verbose",9,"{""level"":""verbose"",""msg"":""unknown level value""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level-unknown/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-level-unknown"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"level\":\"verbose\",\"msg\":\"unknown level value\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-level' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level/expected.snap
@@ -1,0 +1,1 @@
+"warn",13,"{""level"":""warn"",""msg"":""hello from pino""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-level/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-level/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-level"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"level\":\"warn\",\"msg\":\"hello from pino\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-no-level' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/expected.snap
@@ -1,0 +1,1 @@
+"error",17,"{""msg"":""this had an error happen""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-no-level/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-no-level"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"msg\":\"this had an error happen\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/assert_query.sql
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/assert_query.sql
@@ -1,0 +1,1 @@
+SELECT SeverityText, SeverityNumber, Body FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'severity-inference' AND ResourceAttributes['test-id'] = 'from-json-severity-uppercase' ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp) FORMAT CSV

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/expected.snap
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/expected.snap
@@ -1,0 +1,1 @@
+"error",17,"{""SEVERITY"":""ERROR"",""message"":""GCP-style structured log""}"

--- a/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/input.json
+++ b/smoke-tests/otel-collector/data/severity-inference/from-json-severity-uppercase/input.json
@@ -1,0 +1,35 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "severity-inference"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "from-json-severity-uppercase"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999580000000000",
+              "body": {
+                "stringValue": "{\"SEVERITY\":\"ERROR\",\"message\":\"GCP-style structured log\"}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/severity-inference.bats
+++ b/smoke-tests/otel-collector/severity-inference.bats
@@ -56,3 +56,51 @@ load 'test_helpers/assertions.bash'
     sleep 1
     assert_test_data "data/severity-inference/infer-superstring"
 }
+
+@test "HDX-4383: should promote lowercase level from parsed JSON body" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-level"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-level"
+}
+
+@test "HDX-4383: should promote PascalCase Level from parsed JSON body (Serilog)" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-level-pascalcase"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-level-pascalcase"
+}
+
+@test "HDX-4383: should promote uppercase SEVERITY from parsed JSON body (GCP)" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-severity-uppercase"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-severity-uppercase"
+}
+
+@test "HDX-4383: should promote flattened log.level from parsed JSON body (ECS)" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-ecs-log-level"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-ecs-log-level"
+}
+
+@test "HDX-4383: should fall back to INFO severity_number when level value is unknown" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-level-unknown"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-level-unknown"
+}
+
+@test "HDX-4383: should still run string inference when JSON body has no level field" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-no-level"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-no-level"
+}
+
+@test "HDX-4383: producer-set severity must win over JSON level field" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-level-producer-wins"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-level-producer-wins"
+}
+
+@test "HDX-4383: should trust JSON level even when body contains a severity keyword like alertmanager" {
+    emit_otel_data "http://localhost:4318" "data/severity-inference/from-json-level-body-keyword-conflict"
+    sleep 1
+    assert_test_data "data/severity-inference/from-json-level-body-keyword-conflict"
+}


### PR DESCRIPTION
## Summary

Fixes a customer-reported bug where structured JSON logs are tagged with the
wrong severity because the OTel collector's string-keyword inference picks up
incidental severity words inside the body. For example, a Grafana sidecar log
with body `{"level":"INFO", "msg":"... mimir-alertmanager-dashboard ..."}`
gets `SeverityText="fatal"`, `SeverityNumber=21` today because the inference
regex `\b(alert|crit|emerg|fatal|error|err|warn|notice|debug|dbug|trace)`
matches `alert` at the start of `alertmanager`. The JSON-derived `level: INFO`
field is ignored entirely.

This PR adds a new OTTL `log_statements` block between the existing JSON-parse
block and the string-inference block in `docker/otel-collector/config.yaml`.
The new block promotes a JSON-derived level/severity field to
`log.severity_text`, which causes the string-inference block to be skipped via
its existing `severity_number == 0 and severity_text == ""` guard.

### What it does

- **Reads only from `log.attributes`**, which is where Block 1 (JSON parse +
  `flatten()`, or OTel map body merge) puts the parsed fields. So the
  promotion fires only when a JSON body was actually parsed.
- **Case-insensitive across keys** by enumerating common casings of common
  field names used by mainstream logging frameworks: `level` / `Level` /
  `LEVEL` (pino, winston, zerolog, zap, logrus, slog, Serilog, NLog),
  `severity` / `Severity` / `SEVERITY` (Datadog, GCP Cloud Logging), and
  `log.level` (Elastic ECS, flattened from nested JSON).
- **Priority-ordered cascade**: each `set` self-guards on
  `severity_text == ""`, so the first match wins (`level` > `severity` >
  `log.level`). The block as a whole is gated on no producer-set severity,
  so producer-supplied values are always preserved.
- **`severity_number` mapping** uses the same case-insensitive `(?i)` regex
  keyword set as the existing string-inference block, so values like
  `"Information"`, `"WARN"`, `"Critical"` resolve correctly. Unrecognized
  values (e.g. `"verbose"`) fall through to INFO — same default as Block 2.
- **`severity_text` is normalized** by the unchanged Block 3
  (`ConvertCase(severity_text, "lower")`), so `"INFO"` becomes `"info"`.

### Behavior matrix

| Scenario | Result |
| :--- | :--- |
| `{"level":"warn", ...}` | `("warn", 13)` |
| `{"Level":"Information", ...}` (Serilog) | `("information", 9)` |
| `{"SEVERITY":"ERROR", ...}` (GCP) | `("error", 17)` |
| `{"log":{"level":"fatal"}, ...}` (ECS, flattened) | `("fatal", 21)` |
| `{"level":"verbose", ...}` (unknown text) | `("verbose", 9)` — INFO default |
| `{"msg":"something error happened"}` (no level field) | `("error", 17)` — string inference still runs |
| Non-JSON body | Unchanged — string inference still runs |
| Producer pre-set `severity_text` or `severity_number` | Producer values preserved |

### How to test on Vercel preview

N/A — non-UI change. This modifies the OTel collector's OTTL config; no
frontend code is touched.

### Testing

- New `make ci-lint` and `make ci-unit` both green.
- New bats smoke tests (8 cases) under
  `smoke-tests/otel-collector/data/severity-inference/from-json-*/`:
  - `from-json-level/` — lowercase `level`
  - `from-json-level-pascalcase/` — Serilog `Level: "Information"`
  - `from-json-severity-uppercase/` — GCP `SEVERITY: "ERROR"`
  - `from-json-ecs-log-level/` — Elastic ECS nested `log.level`
  - `from-json-level-unknown/` — unrecognized value falls back to INFO
  - `from-json-no-level/` — JSON body without level → string inference runs
  - `from-json-level-producer-wins/` — producer-set severity preserved
  - `from-json-level-body-keyword-conflict/` — the exact customer payload
    from the linked support escalation (body has `alertmanager-dashboard`
    plus `level: INFO`); confirms the customer scenario no longer
    reproduces.
- All 21 bats tests in `severity-inference.bats`, `auto-parse-json.bats`,
  and `normalize-severity.bats` pass against a freshly-rebuilt collector
  image.

### References

- Linear Issue: [HDX-4383](https://linear.app/clickhouse/issue/HDX-4383/skip-string-inference-when-body-parses-as-json-with-a-level-field)
- Support escalation: ClickHouse/support-escalation#7812
