### PR TITLE
fix(vercel): make hyperdx-storybook deployment actually build Storybook

### DIFF
--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "yarn install --immutable",
+  "buildCommand": "yarn workspace @hyperdx/common-utils build && yarn workspace @hyperdx/app storybook:build",
+  "outputDirectory": "storybook-static",
   "ignoreCommand": "git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD packages/app packages/api packages/common-utils"
 }

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD packages/app packages/api packages/common-utils"
+}


### PR DESCRIPTION
## Summary

Every deployment of the `hyperdx/hyperdx-storybook` Vercel project has been failing. This PR fixes two distinct issues in the project's build pipeline by giving it a project-scoped `packages/app/vercel.json`.

## Why

The Vercel project `hyperdx-storybook` has:
- `rootDirectory = "packages/app"`
- `framework = "storybook"`
- `installCommand` / `buildCommand` / `outputDirectory` = `null`

It was sharing the repo-root `vercel.json` with `hyperdx-oss` and `hyperdx-private`. That file is shaped for the Next.js app deployments, not for Storybook, and it assumes Vercel's CWD is the repo root. Two failures fell out of that mismatch:

### Failure 1 — `ignoreCommand` aborted every deployment in 2–6s

The repo-root `vercel.json` declares:
```
"ignoreCommand": "git diff --quiet HEAD^ HEAD ./packages/app ./packages/api ./packages/common-utils"
```
Vercel runs `ignoreCommand` from the project's Root Directory (`packages/app/`). From there, `./packages/app` etc. don't exist as paths, so git treats them as revisions and errors out:
```
fatal: ambiguous argument './packages/app': unknown revision or path not in the working tree.
```
Non-zero exit = build failure. Deployment marked `● Error` before install or build ever ran.

### Failure 2 — Wrong build target, missing output directory

After overriding `ignoreCommand`, install + build actually ran, but the Vercel Nx auto-detection picked up `@hyperdx/app:build` (the **Next.js** build target) instead of `storybook build`. Result:
```
NX   Successfully ran target build for project @hyperdx/app
Error: No Output Directory named "storybook-static" found after the Build completed.
```
Next.js had built into `.next/` while Vercel (because `framework: storybook`) was looking for `storybook-static/`.

## What

Adds `packages/app/vercel.json`:
```json
{
  "$schema": "https://openapi.vercel.sh/vercel.json",
  "installCommand": "yarn install --immutable",
  "buildCommand": "yarn workspace @hyperdx/common-utils build && yarn workspace @hyperdx/app storybook:build",
  "outputDirectory": "storybook-static",
  "ignoreCommand": "git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD packages/app packages/api packages/common-utils"
}
```

Why these specific fields:
- **`ignoreCommand`** — uses `git -C $(git rev-parse --show-toplevel)` so it's CWD-agnostic; same intent as the repo-root one (skip build when none of `packages/app`, `packages/api`, `packages/common-utils` changed).
- **`buildCommand`** — pins the actual build to `storybook:build` instead of letting Nx auto-detection pick the Next.js target. Builds `common-utils` first because `@hyperdx/app` imports from it.
- **`outputDirectory`** — relative to Vercel's Root Directory (`packages/app/`), so just `storybook-static`.
- **`installCommand`** — explicit so the workspace installs deterministically.

Vercel prefers a `vercel.json` inside the Root Directory when one exists, so this file overrides the repo-root `vercel.json` **for the storybook project only**. `hyperdx-oss` and `hyperdx-private` (`rootDirectory = null`) continue to use the repo-root `vercel.json` unchanged.

## Verification

End-to-end build verified locally from Vercel's CWD (`packages/app/`):
```
cd packages/app
yarn install --immutable
yarn workspace @hyperdx/common-utils build && yarn workspace @hyperdx/app storybook:build
```
→ Produces `packages/app/storybook-static/` (20 MB, contains `index.html` + `iframe.html`). Matches `outputDirectory: "storybook-static"`.

`ignoreCommand` smoke-tested both ways from `packages/app/`:
- With diffs vs `HEAD^` → exit `1` (Vercel builds) ✅
- Without diffs → exit `0` (Vercel skips) ✅

## Commits

1. `d70de0a` — fix the `ignoreCommand` path-resolution failure
2. `687337e` — override `buildCommand` + `outputDirectory` so Storybook actually builds and Vercel finds its output