### PR TITLE
refactor(source-picker): glue kebab to Select as a split-button chip

### DIFF
--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -129,7 +129,7 @@ export const SourceManagementMenu = ({
   return (
     <Menu width={220} withinPortal position="bottom-end">
       <Menu.Target>
-        <Tooltip label="Source actions" color="dark" position="top">
+        <Tooltip label="Source actions" position="top" withArrow>
           <ActionIcon
             variant="subtle"
             color="gray"
@@ -212,7 +212,7 @@ function SourceSelectControlledComponent({
 
   return (
     <Group
-      gap={4}
+      gap={0}
       wrap="nowrap"
       className={styles.sourceSelectGroup}
       data-with-menu={hasMenu || undefined}

--- a/packages/app/styles/SourceSelectControlled.module.scss
+++ b/packages/app/styles/SourceSelectControlled.module.scss
@@ -20,12 +20,47 @@
   }
 }
 
-/* Chip + kebab wrapper. Holds the Mantine Select and the adjacent
- * SourceManagementMenu ActionIcon as a single inline-flex unit.
+/* Chip + kebab wrapper. Holds the Mantine Select and the SourceManagementMenu
+ * ActionIcon as a single inline-flex unit. When the kebab is present
+ * (`[data-with-menu]`), the two surfaces are "glued" into a split-button chip:
+ * the adjoining corners are squared, the kebab overlaps the input's right
+ * border by 1px so they share a single vertical seam, and the kebab stretches
+ * to match the input's height so the chip reads as one unit.
+ *
+ * Override Mantine via its own CSS variables (`--input-radius`, `--ai-radius`)
+ * rather than fighting class-level `border-radius`: Mantine v7 reads these
+ * vars to compute the rounded corners, so setting them is the canonical
+ * override path.
  */
 .sourceSelectGroup {
   display: inline-flex;
-  align-items: center;
+  align-items: stretch;
+  gap: 0;
+
+  &[data-with-menu] {
+    /* Square only the right edge of the input. */
+    .sourceSelectInput {
+      --input-radius: 0;
+
+      border-top-left-radius: var(--mantine-radius-default);
+      border-bottom-left-radius: var(--mantine-radius-default);
+    }
+
+    /* Square only the left edge of the kebab. Fixed 30px height matches the
+     * input chip; -1px margin overlaps the input's right edge so the shared
+     * border is one pixel wide, not two. */
+    .sourceMenuButton {
+      --ai-radius: 0;
+
+      width: 30px;
+      height: 30px;
+      margin-left: -1px;
+      background-color: var(--color-bg-field-addon);
+      border: 1px solid var(--input-bd, var(--color-border));
+      border-top-right-radius: var(--mantine-radius-default);
+      border-bottom-right-radius: var(--mantine-radius-default);
+    }
+  }
 }
 
 /* Chip hover state. The Mantine Select input is the "chip" surface;
@@ -49,9 +84,8 @@
   }
 }
 
-/* Kebab button hover. Mantine's subtle variant already provides a hover
- * tint; we just tighten the margin and ensure the icon sits flush with
- * the chip baseline.
+/* Kebab button. Mantine's subtle variant gives the hover tint; layout shared
+ * with the input is set up in the `[data-with-menu]` block above.
  */
 .sourceMenuButton {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Restyles `SourceSelect` + `SourceManagementMenu` from "Select plus a floating icon button" into a single split-button chip.

Also normalizes the kebab `Tooltip` to the app-wide convention (`withArrow`, default color) so it reads the same as `Filter Settings` and other gray tooltips across the app — `color=\"dark\"` was an inconsistency, not an intentional variant.

When `hasMenu` is false (e.g. `DBTableSelect` callers that don't wire `onEditCurrentSource` / `onCreateSource`), the `[data-with-menu]` attribute is omitted and the original side-by-side layout is preserved, so this is a
zero-risk change for non-source callers.

<img width="306" height="87" alt="Screenshot 2026-05-29 at 13 16 35" src="https://github.com/user-attachments/assets/dd924a11-1bd1-465d-bc28-f53e50dca1cb" />


## Why

The kebab being its own visually detached `ActionIcon` makes it ambiguous whether the menu acts on the selected source or on something more global (e.g. the page). Treating Select + kebab as a unified chip makes "actions on
this source" the obvious read at a glance, mirroring the split-button pattern in the Mantine docs.

## Test plan

- [ ] `SourceSelect` in search / dashboard tile editor / alert editor renders as a single chip with no visible gap or double border between input and kebab.
- [ ] Hover on the kebab tints only the kebab; hover on the input tints only the input (no shared hover state — they're still independent triggers).
- [ ] Tooltip on the kebab matches `Filter Settings` / other gray tooltips (with arrow, default color).
- [ ] `DBTableSelect` (no menu wired) renders the input alone with its original rounded corners and no orphaned styles.
- [ ] Theme switch (HyperDX ↔ ClickStack) keeps the seam at 1px on both themes (kebab border uses `var(--input-bd, var(--color-border))`).


Made with [Cursor](https://cursor.com)