### PR TITLE
refractor: Make TeamPage settings tabs and admin-access extensible

### DIFF
--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -16,6 +16,12 @@ import {
 import { notifications } from '@mantine/notifications';
 import { IconPencil } from '@tabler/icons-react';
 
+import {
+  type TeamTab,
+  useTeamAdminAccess,
+  useTeamSettingsTabs,
+} from '@/extensions/teamSettings';
+
 import { PageHeader } from './components/PageHeader';
 import ApiKeysSection from './components/TeamSettings/ApiKeysSection';
 import ConnectionsSection from './components/TeamSettings/ConnectionsSection';
@@ -27,15 +33,6 @@ import TeamQueryConfigSection from './components/TeamSettings/TeamQueryConfigSec
 import { useBrandDisplayName } from './theme/ThemeProvider';
 import api from './api';
 import { withAppNav } from './layout';
-
-type TeamTab = {
-  value: string;
-  label: string;
-  sections: {
-    id: string;
-    content: ReactNode;
-  }[];
-};
 
 function TeamTabContent({ sections }: { sections: TeamTab['sections'] }) {
   return (
@@ -57,7 +54,7 @@ export default function TeamPage() {
   const allowedAuthMethods = team?.allowedAuthMethods ?? [];
   const hasAllowedAuthMethods = allowedAuthMethods.length > 0;
 
-  const hasAdminAccess = true;
+  const hasAdminAccess = useTeamAdminAccess();
   const [isEditingTeamName, setIsEditingTeamName] = useState(false);
   const form = useForm<{ name: string }>({
     defaultValues: { name: team?.name },
@@ -88,7 +85,7 @@ export default function TeamPage() {
     [refetchTeam, setTeamName],
   );
 
-  const tabs: TeamTab[] = [
+  const baseTabs: TeamTab[] = [
     {
       value: 'data',
       label: 'Data',
@@ -156,6 +153,8 @@ export default function TeamPage() {
       ],
     },
   ];
+
+  const tabs = useTeamSettingsTabs(baseTabs);
 
   const queryTab =
     typeof router.query.tab === 'string' ? router.query.tab : null;

--- a/packages/app/src/extensions/teamSettings.tsx
+++ b/packages/app/src/extensions/teamSettings.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from 'react';
+
+/**
+ * Team settings extension points.
+ *
+ * `TeamPage` builds its tabs from a declarative list and renders them
+ * generically. The two hooks below are the extension seam: builds that ship
+ * additional team-settings surfaces can supply their own implementations of
+ * this module (resolved via the `@/extensions` import) to contribute or
+ * rearrange tabs and to gate administrative affordances, without editing
+ * `TeamPage` itself. The defaults here preserve the standard behavior.
+ */
+
+export type TeamTab = {
+  value: string;
+  label: string;
+  sections: {
+    id: string;
+    content: ReactNode;
+  }[];
+};
+
+/**
+ * Transform the team-settings tabs before they are rendered. Receives the
+ * base tabs and returns the tabs to display. Default: unchanged.
+ *
+ * This is a hook so implementations may read state (current team, feature
+ * flags, etc.) when deciding which tabs and sections to show.
+ */
+// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- hook by contract: override implementations call hooks
+export function useTeamSettingsTabs(tabs: TeamTab[]): TeamTab[] {
+  return tabs;
+}
+
+/**
+ * Whether the current user may administer the team (controls the team-name
+ * edit affordance). Default: always allowed.
+ */
+// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- hook by contract: override implementations call hooks
+export function useTeamAdminAccess(): boolean {
+  return true;
+}


### PR DESCRIPTION
## What

Extracts two small extension points out of `TeamPage` into `@/extensions/teamSettings`:

- **`useTeamSettingsTabs(baseTabs)`** — transforms the settings tab/section list before render (default: identity).
- **`useTeamAdminAccess()`** — whether the current user can administer the team, gating the team-name edit affordance (default: always allowed).

`TeamPage` builds its base tabs, passes them through the transform, and reads admin access via the hook.

## Why

The team-settings page is a single component that mixes tab composition, admin gating, and rendering. Pulling the composition + admin-access decisions behind small, well-typed seams makes the page **composable and testable** without editing it directly, and keeps future tab/section additions out of the page body.

## Behavior

**No behavior change.** The default implementations (identity transform, always-allowed admin) preserve current behavior exactly. No resolution plumbing needed — `@/extensions/*` already resolves to `src/extensions/*` via the existing tsconfig/jest/next config.

## Validation

- `yarn ci:lint` ✅ (lint + tsc + stylelint)
- `yarn ci:unit` ✅ (1752 passed)

Draft for review.