### PR TITLE
Add refresh button to client sessions page

### DIFF
--- a/packages/app/src/SessionsPage.tsx
+++ b/packages/app/src/SessionsPage.tsx
@@ -15,6 +15,7 @@ import {
   SourceKind,
 } from '@hyperdx/common-utils/dist/types';
 import {
+  ActionIcon,
   Anchor,
   Button,
   Code,
@@ -22,6 +23,7 @@ import {
   Group,
   Paper,
   Stepper,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconDeviceLaptop,
@@ -35,6 +37,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { PageLayout } from '@/components/PageLayout';
 import { SourceSelectControlled } from '@/components/SourceSelect';
 import { TimePicker } from '@/components/TimePicker';
+import { useDashboardRefresh } from '@/hooks/useDashboardRefresh';
 import { parseTimeQuery, useNewTimeQuery } from '@/timeQuery';
 
 import OnboardingModal from './components/OnboardingModal';
@@ -276,10 +279,16 @@ export default function SessionsPage() {
   const [displayedTimeInputValue, setDisplayedTimeInputValue] =
     useState(DEFAULT_INTERVAL);
 
-  const { searchedTimeRange, onSearch } = useNewTimeQuery({
+  const { searchedTimeRange, onSearch, onTimeRangeSelect } = useNewTimeQuery({
     initialDisplayValue: DEFAULT_INTERVAL,
     initialTimeRange: defaultTimeRange,
     setDisplayedTimeInputValue,
+  });
+
+  const { refresh, manualRefreshCooloff } = useDashboardRefresh({
+    searchedTimeRange,
+    onTimeRangeSelect,
+    isLive: false,
   });
 
   const onSubmit = useCallback(() => {
@@ -428,6 +437,18 @@ export default function SessionsPage() {
                 >
                   Run
                 </Button>
+                <Tooltip withArrow label="Refresh results" fz="xs" color="gray">
+                  <ActionIcon
+                    onClick={refresh}
+                    loading={manualRefreshCooloff}
+                    disabled={manualRefreshCooloff}
+                    variant="secondary"
+                    title="Refresh results"
+                    size="input-sm"
+                  >
+                    <IconRefresh size={18} />
+                  </ActionIcon>
+                </Tooltip>
               </Group>
             </PageHeader>
           }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a refresh button to the client sessions page toolbar that shifts the searched time range to be the latest time range (anchored to "now") while preserving the window duration. This matches the same refresh behavior used on dashboard pages.

The implementation reuses the existing `useDashboardRefresh` hook, which:
1. Computes the current window width (end - start)
2. Sets the new end to `new Date()` (now)
3. Sets the new start to `now - windowWidth`
4. Calls `onTimeRangeSelect` to update the time range state and URL params

The button is positioned next to the existing "Run" button, uses `variant="secondary"` styling with an `IconRefresh` icon, and includes a 1-second cooloff to prevent rapid repeated clicks.

### Screenshots or video

| Before | After |
| :----- | :---- |
| No refresh button | [Toolbar with refresh button](https://cursor.com/agents/bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_toolbar_with_refresh.png) |

Tooltip on hover:

[Refresh button tooltip](https://cursor.com/agents/bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_refresh_tooltip.png)

After clicking refresh (time range shifts to now):

[Time range updated after refresh](https://cursor.com/agents/bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_after_refresh.png)

[sessions_refresh_button_demo.mp4](https://cursor.com/agents/bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsessions_refresh_button_demo.mp4)

### How to test on Vercel preview

**Preview routes:** /sessions

**Steps:**

1. Navigate to /sessions
2. Observe the time picker displays "Past 1h" or an absolute time range
3. Click the refresh icon button (circular arrow) next to the "Run" button
4. Verify the time picker value updates to an absolute time range anchored at the current time
5. Hover over the refresh button and verify tooltip reads "Refresh results"

### References

- Linear Issue: HDX-4375
- Related PRs: Reuses `useDashboardRefresh` hook from dashboard pages

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4375](https://linear.app/clickhouse/issue/HDX-4375/add-refresh-button-to-client-sessions-page)

<div><a href="https://cursor.com/agents/bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d6497fa-c3b8-4dec-83d4-fc6ae3928e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

