### PR TITLE
Document Chart Explorer chunked Run queries

### DIFF
--- a/packages/app/tests/e2e/features/chart-explorer.spec.ts
+++ b/packages/app/tests/e2e/features/chart-explorer.spec.ts
@@ -9,6 +9,30 @@ test.describe('Chart Explorer Functionality', { tag: ['@charts'] }, () => {
     await chartExplorerPage.goto();
   });
 
+  test(
+    'should fire exactly one clickhouse-proxy request when Run is clicked',
+    { tag: ['@full-stack'] },
+    async () => {
+      await test.step('Wait for initial chart explorer activity to settle', async () => {
+        await chartExplorerPage.waitForInitialSettle();
+      });
+
+      // Begin counting proxy responses only after the initial settle so
+      // any auto-run queries fired on page load are excluded from the tally.
+      const proxyCounter =
+        chartExplorerPage.startCountingClickhouseProxyResponses();
+
+      await test.step('Click Run and wait for chart to render', async () => {
+        await chartExplorerPage.chartEditor.runQuery();
+      });
+
+      await test.step('Assert exactly one clickhouse-proxy request was fired', async () => {
+        // Regression: prior to the fix, clicking Run fired duplicate requests.
+        expect(proxyCounter.getCount()).toBe(1);
+      });
+    },
+  );
+
   test('should interact with chart configuration', async () => {
     await test.step('Verify chart configuration form is accessible', async () => {
       await expect(chartExplorerPage.form).toBeVisible();

--- a/packages/app/tests/e2e/features/chart-explorer.spec.ts
+++ b/packages/app/tests/e2e/features/chart-explorer.spec.ts
@@ -1,6 +1,16 @@
 import { ChartExplorerPage } from '../page-objects/ChartExplorerPage';
 import { expect, test } from '../utils/base-test';
 
+function getDateRangeFromProxyUrl(url: string): [number, number] {
+  const timestamps = Array.from(new URL(url).searchParams.values())
+    .filter(value => /^\d{13}$/.test(value))
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  expect(timestamps).toHaveLength(2);
+  return [timestamps[0], timestamps[1]];
+}
+
 test.describe('Chart Explorer Functionality', { tag: ['@charts'] }, () => {
   let chartExplorerPage: ChartExplorerPage;
 
@@ -10,25 +20,37 @@ test.describe('Chart Explorer Functionality', { tag: ['@charts'] }, () => {
   });
 
   test(
-    'should fire exactly one clickhouse-proxy request when Run is clicked',
+    'should split Run chart queries into adjacent ClickHouse chunks',
     { tag: ['@full-stack'] },
     async () => {
       await test.step('Wait for initial chart explorer activity to settle', async () => {
         await chartExplorerPage.waitForInitialSettle();
       });
 
-      // Begin counting proxy responses only after the initial settle so
-      // any auto-run queries fired on page load are excluded from the tally.
-      const proxyCounter =
-        chartExplorerPage.startCountingClickhouseProxyResponses();
+      await chartExplorerPage.chartEditor.setChartName(
+        `E2E Chunked Chart ${Date.now()}`,
+      );
+
+      // Begin recording only after the initial settle so any auto-run queries
+      // fired on page load are excluded from the assertion.
+      const proxyRecorder =
+        chartExplorerPage.startRecordingClickhouseProxyRequests();
 
       await test.step('Click Run and wait for chart to render', async () => {
         await chartExplorerPage.chartEditor.runQuery();
       });
 
-      await test.step('Assert exactly one clickhouse-proxy request was fired', async () => {
-        // Regression: prior to the fix, clicking Run fired duplicate requests.
-        expect(proxyCounter.getCount()).toBe(1);
+      await test.step('Assert Run used adjacent ClickHouse chunks, not duplicates', async () => {
+        const requests = proxyRecorder.getRequests();
+
+        expect(requests).toHaveLength(2);
+        expect(new Set(requests.map(request => request.postData)).size).toBe(2);
+
+        const ranges = requests
+          .map(request => getDateRangeFromProxyUrl(request.url))
+          .sort((a, b) => a[0] - b[0]);
+
+        expect(ranges[0][1]).toBe(ranges[1][0]);
       });
     },
   );

--- a/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
+++ b/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
@@ -38,6 +38,30 @@ export class ChartExplorerPage {
     return this.getChartContainers().first();
   }
 
+  /**
+   * Wait for the initial page load and any auto-triggered queries to settle
+   * before starting to measure subsequent network activity.
+   */
+  async waitForInitialSettle() {
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  /**
+   * Start counting /clickhouse-proxy responses from this point forward.
+   * Returns a handle whose `getCount()` returns the tally at any time.
+   * Call this *after* waitForInitialSettle() so auto-queries on page load
+   * are not included in the count.
+   */
+  startCountingClickhouseProxyResponses(): { getCount: () => number } {
+    let count = 0;
+    this.page.on('response', response => {
+      if (response.url().includes('/clickhouse-proxy')) {
+        count++;
+      }
+    });
+    return { getCount: () => count };
+  }
+
   // Getters for assertions
 
   get form() {

--- a/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
+++ b/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
@@ -47,19 +47,23 @@ export class ChartExplorerPage {
   }
 
   /**
-   * Start counting /clickhouse-proxy responses from this point forward.
-   * Returns a handle whose `getCount()` returns the tally at any time.
+   * Start recording /clickhouse-proxy requests from this point forward.
    * Call this *after* waitForInitialSettle() so auto-queries on page load
-   * are not included in the count.
+   * are not included.
    */
-  startCountingClickhouseProxyResponses(): { getCount: () => number } {
-    let count = 0;
-    this.page.on('response', response => {
-      if (response.url().includes('/clickhouse-proxy')) {
-        count++;
+  startRecordingClickhouseProxyRequests(): {
+    getRequests: () => { postData: string | null; url: string }[];
+  } {
+    const requests: { postData: string | null; url: string }[] = [];
+    this.page.on('request', request => {
+      if (request.url().includes('/clickhouse-proxy')) {
+        requests.push({
+          postData: request.postData(),
+          url: request.url(),
+        });
       }
     });
-    return { getCount: () => count };
+    return { getRequests: () => requests };
   }
 
   // Getters for assertions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds focused E2E coverage documenting the Chart Explorer Run behavior that looked like duplicate chart calls. A single Run click can issue multiple `/clickhouse-proxy` requests because time charts use ClickHouse query chunking; the test asserts the requests are distinct adjacent time windows rather than duplicate submissions.

### Screenshots or video

N/A — test/debug change only.

### How to test on Vercel preview

N/A — non-UI-visible change.

### References

- Linear Issue:
- Related PRs:
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67da141f-5275-4aa0-84bf-5c7e264d6321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67da141f-5275-4aa0-84bf-5c7e264d6321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

