### PR TITLE
style(search): unify xs input height to 30px across search header

### DIFF
--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -277,6 +277,7 @@ function SearchSubmitButton({
       type="submit"
       leftSection={<IconPlayerPlay size={16} />}
       style={{ flexShrink: 0 }}
+      size="xs"
     >
       Run
     </Button>
@@ -1982,6 +1983,7 @@ export function DBSearchPage() {
             minWidth="min(600px, 100%)"
             dateRange={searchedTimeRange}
             sourceId={inputSource}
+            size="xs"
           />
           <Flex
             gap="sm"
@@ -2001,12 +2003,13 @@ export function DBSearchPage() {
                 isLive && interval !== LIVE_TAIL_DURATION_MS
               }
               width="100%"
+              size="xs"
             />
             {isLive && (
               <Tooltip label="Live tail refresh interval">
                 <Box style={{ width: 80, minWidth: 80, flexShrink: 0 }}>
                   <Select
-                    size="sm"
+                    size="xs"
                     w="100%"
                     data={LIVE_TAIL_REFRESH_FREQUENCY_OPTIONS}
                     value={String(refreshFrequency)}

--- a/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
+++ b/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
@@ -305,7 +305,7 @@ export default function SQLInlineEditor({
 
   // Only apply expanded styling when multiline is enabled and focused
   const isExpanded = allowMultiline && isFocused;
-  const baseHeight = size === 'xs' ? 32 : 36;
+  const baseHeight = size === 'xs' ? 30 : 36;
 
   return (
     <div

--- a/packages/app/src/components/SearchInput/AutocompleteInput.tsx
+++ b/packages/app/src/components/SearchInput/AutocompleteInput.tsx
@@ -154,7 +154,7 @@ export default function AutocompleteInput({
   }, [language, onLanguageChange, inputRef]);
 
   // Height including the 2px border from .textarea (1px top + 1px bottom)
-  const baseHeight = size === 'xs' ? 32 : size === 'lg' ? 44 : 38;
+  const baseHeight = size === 'xs' ? 30 : size === 'lg' ? 44 : 38;
 
   return (
     <div

--- a/packages/app/src/components/SearchInput/SearchWhereInput.module.scss
+++ b/packages/app/src/components/SearchInput/SearchWhereInput.module.scss
@@ -56,10 +56,13 @@
     }
   }
 
-  /* !important overrides the inline min-height set by react-textarea-autosize */
+  /* !important overrides the inline min-height set by react-textarea-autosize.
+     Inner textarea is 2px shorter than the wrapper because the wrapper adds
+     a 1px border top/bottom, so 28px + 2px border = 30px outer (matches the
+     SQL inline editor's xs height). */
   /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
   &.sizeXs :global(.mantine-InputWrapper-root) textarea {
-    min-height: 30px !important;
+    min-height: 28px !important;
   }
 
   /* stylelint-disable-next-line selector-pseudo-class-no-unknown */

--- a/packages/app/src/components/SearchInput/SearchWhereInput.module.scss
+++ b/packages/app/src/components/SearchInput/SearchWhereInput.module.scss
@@ -79,7 +79,7 @@
   background-color: var(--color-bg-field-addon);
 
   &.sizeXs {
-    height: 32px;
+    height: 30px;
   }
 
   &.sizeSm {

--- a/packages/app/src/components/TimePicker/TimePicker.tsx
+++ b/packages/app/src/components/TimePicker/TimePicker.tsx
@@ -106,6 +106,7 @@ const TimePickerComponent = ({
   isLiveMode = false,
   defaultRelativeTimeMode = false,
   width = 350,
+  size = 'sm',
 }: {
   inputValue: string;
   setInputValue: (str: string) => any;
@@ -116,6 +117,7 @@ const TimePickerComponent = ({
   isLiveMode?: boolean;
   defaultRelativeTimeMode?: boolean;
   width?: number | string;
+  size?: 'xs' | 'sm';
 }) => {
   const {
     userPreferences: { timeFormat },
@@ -278,7 +280,7 @@ const TimePickerComponent = ({
           onChange={event => onChange(event.currentTarget.value)}
           onClick={toggle}
           placeholder="Time Range"
-          size="sm"
+          size={size}
           w={width}
           onKeyDown={e => {
             if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {


### PR DESCRIPTION
## Summary

- Reduce the `xs` input height from 32px to 30px in `SearchWhereInput`, `AutocompleteInput`, and `SQLInlineEditor` so all search-row inputs line up at the same height.
- Add an optional `size` prop (`'xs' | 'sm'`) to `TimePicker` so it can be rendered at the same compact height as the rest of the search header.
- In `DBSearchPage`, switch the `TimePicker`, the `SearchSubmitButton`, the where-input row, and the live-tail refresh-frequency `Select` to `size="xs"` so the header is visually consistent.

<img width="2374" height="508" alt="image" src="https://github.com/user-attachments/assets/31a58cec-6805-4425-99f2-9c33b49d29c1" />


## Why

The search header was previously mixing `sm` (TimePicker, refresh Select) and `xs` (where input) sized controls, which made the row feel uneven. Dropping `xs` from 32px to 30px and applying `xs` consistently aligns every control in the row to the same height.

## Test plan

- [ ] Open the search page and confirm the time picker, run button, where input, and live-tail refresh selector all share the same height.
- [ ] Toggle live mode on/off and confirm the refresh-frequency selector still aligns with the rest of the row.
- [ ] Verify other usages of `SQLInlineEditor` / `AutocompleteInput` at `xs` size still look correct.


Made with [Cursor](https://cursor.com)