### PR TITLE
feat(theme): add viz-range and drawer-elevation design tokens (HDX-3950)

### DIFF
--- a/packages/app/src/theme/themes/clickstack/_tokens.scss
+++ b/packages/app/src/theme/themes/clickstack/_tokens.scss
@@ -200,6 +200,17 @@
   --color-chart-warning-highlight: #f5c94d;
   --color-chart-error-highlight: #ffa090;
 
+  /* Visualization Range Selector (minimap viewports, brush ranges, etc.) */
+  --color-viz-range-handle: var(--palette-brand-300);
+  --color-viz-range-handle-grip: var(--color-text-inverted);
+  --color-viz-range-border: var(--palette-brand-700);
+  --color-viz-range-overlay: rgb(0 0 0 / 20%);
+  --color-viz-range-brush: rgb(250 255 105 / 20%);
+  --color-viz-range-brush-border: rgb(250 255 105 / 50%);
+
+  /* Shadows */
+  --shadow-drawer: -4px 0 24px rgb(0 0 0 / 25%);
+
   /* Mantine Overrides */
   --mantine-color-body: var(--color-bg-body) !important;
   --mantine-color-text: var(--color-text) !important;
@@ -400,6 +411,17 @@
   --color-chart-success-highlight: #80d9b3;
   --color-chart-warning-highlight: #f5c94d;
   --color-chart-error-highlight: #ffa090;
+
+  /* Visualization Range Selector (minimap viewports, brush ranges, etc.) */
+  --color-viz-range-handle: var(--mantine-color-indigo-8);
+  --color-viz-range-handle-grip: var(--mantine-color-indigo-1);
+  --color-viz-range-border: var(--mantine-color-indigo-8);
+  --color-viz-range-overlay: rgb(0 0 0 / 4%);
+  --color-viz-range-brush: rgb(67 126 239 / 20%);
+  --color-viz-range-brush-border: var(--mantine-color-indigo-8);
+
+  /* Shadows */
+  --shadow-drawer: -4px 0 24px rgb(0 0 0 / 4%);
 
   /* Mantine Overrides */
   --mantine-color-body: var(--color-bg-body) !important;

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -116,6 +116,17 @@
   --color-chart-warning-highlight: #f5c94d;
   --color-chart-error-highlight: #ffa090;
 
+  /* Visualization Range Selector (minimap viewports, brush ranges, etc.) */
+  --color-viz-range-handle: var(--mantine-color-dark-2);
+  --color-viz-range-handle-grip: rgb(255 255 255 / 45%);
+  --color-viz-range-border: var(--mantine-color-dark-3);
+  --color-viz-range-overlay: rgb(0 0 0 / 20%);
+  --color-viz-range-brush: rgb(100 149 237 / 25%);
+  --color-viz-range-brush-border: rgb(100 149 237 / 60%);
+
+  /* Shadows */
+  --shadow-drawer: -4px 0 24px rgb(0 0 0 / 25%);
+
   /* Mantine Overrides */
   --mantine-color-body: var(--color-bg-body) !important;
   --mantine-color-text: var(--color-text);
@@ -227,6 +238,17 @@
   --color-chart-success-highlight: #80d9b3;
   --color-chart-warning-highlight: #f5c94d;
   --color-chart-error-highlight: #ffa090;
+
+  /* Visualization Range Selector (minimap viewports, brush ranges, etc.) */
+  --color-viz-range-handle: var(--mantine-color-gray-5);
+  --color-viz-range-handle-grip: rgb(255 255 255 / 80%);
+  --color-viz-range-border: var(--mantine-color-gray-4);
+  --color-viz-range-overlay: rgb(0 0 0 / 10%);
+  --color-viz-range-brush: rgb(66 105 208 / 20%);
+  --color-viz-range-brush-border: rgb(66 105 208 / 50%);
+
+  /* Shadows */
+  --shadow-drawer: -4px 0 24px rgb(0 0 0 / 4%);
 
   /* Mantine Overrides */
   --mantine-color-body: var(--color-bg-body);


### PR DESCRIPTION
## Summary

Adds reusable design tokens for visualization range selectors (minimap viewports, brush ranges, time-window resize handles) and drawer elevation, in both **HyperDX** and **ClickStack** themes, dark + light variants.

These tokens replace ad-hoc colors/shadows scattered across timeline/minimap and drawer components, so future range-selector and drawer surfaces stay on-theme.

## Why

Workstream 6 of the trace viewer redesign prototype ([#1970](https://github.com/hyperdxio/hyperdx/pull/1970)) introduced:
- `--color-viz-range-*` (handle, handle-grip, border, overlay, brush, brush-border) — needed by the new trace minimap, but also reusable by any future range-selector surface.
- `--shadow-drawer` — themed drawer elevation, applied to log/trace/session drawers.

This PR lands **only the tokens** so consumer components can be wired up in follow-up PRs without coupling the foundation to any single UI change.

Tracks [HDX-3950](https://linear.app/clickhouse/issue/HDX-3950/add-design-tokens-for-viz-range-controls-and-drawer-elevation).

## Changes

Two files, +44 / -0:

- \`packages/app/src/theme/themes/hyperdx/_tokens.scss\` — dark + light token sets
- \`packages/app/src/theme/themes/clickstack/_tokens.scss\` — dark + light token sets

| Token | Purpose |
|---|---|
| \`--color-viz-range-handle\` | Range selector edge handle |
| \`--color-viz-range-handle-grip\` | Grip dots inside the handle |
| \`--color-viz-range-border\` | Border around the selected viewport |
| \`--color-viz-range-overlay\` | Dimmed area outside the viewport |
| \`--color-viz-range-brush\` | Fill while brushing a new range |
| \`--color-viz-range-brush-border\` | Border of the brushed range |
| \`--shadow-drawer\` | Right-side drawer elevation (stronger in dark, subtler in light) |

## Test plan

- [ ] No consumers yet — verify the SCSS compiles and themes still render unchanged in `yarn dev`.
- [ ] Optional sanity check: inspect `:root` in DevTools under both themes and both color schemes; confirm all 7 variables are defined with expected values.
- [ ] CI: lint + type check + unit tests pass.

## Out of scope (follow-ups)

- Wiring \`--shadow-drawer\` into the log/trace/session drawer components.
- Wiring \`--color-viz-range-*\` into the trace minimap and any other range-selector surfaces.

Both will land in separate PRs split out from #1970.

Made with [Cursor](https://cursor.com)