### PR TITLE
fix: map alias with filters

### DIFF
--- a/.changeset/thin-pets-relate.md
+++ b/.changeset/thin-pets-relate.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+fix: make filters aware of map column return arrayElement

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -29,6 +29,7 @@ import {
   isJSDataTypeJSONStringifiable,
   JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
+import { parseKeyPath } from '@hyperdx/common-utils/dist/core/metadata';
 import { splitAndTrimWithBracket } from '@hyperdx/common-utils/dist/core/utils';
 import {
   BuilderChartConfigWithDateRange,
@@ -100,7 +101,6 @@ import {
   usePrevious,
 } from '@/utils';
 
-import { parseMapFieldName } from './DBSearchPageFilters/utils';
 import DBRowTableFieldWithPopover from './DBTable/DBRowTableFieldWithPopover';
 import DBRowTableRowButtons from './DBTable/DBRowTableRowButtons';
 import TableHeader from './DBTable/TableHeader';
@@ -1513,10 +1513,9 @@ export function addMapAliasesToSelect(select: string): string {
   const selects = splitAndTrimWithBracket(select);
   for (let i = 0; i < selects.length; i++) {
     const key = selects[i];
-    const mapField = parseMapFieldName(key);
-    if (mapField) {
-      selects[i] =
-        `${key} as "${mapField.baseName}['${mapField.propertyPath}']"`;
+    const path = parseKeyPath(key);
+    if (path.length === 2) {
+      selects[i] = `${key} as "${path[0]}['${path[1]}']"`;
     }
   }
   return selects.join(',');

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1509,7 +1509,7 @@ function selectColumnMapWithoutAdditionalKeys(
   );
 }
 
-function addMapAliasesToSelect(select: string): string {
+export function addMapAliasesToSelect(select: string): string {
   const selects = splitAndTrimWithBracket(select);
   for (let i = 0; i < selects.length; i++) {
     const key = selects[i];

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1510,7 +1510,7 @@ function selectColumnMapWithoutAdditionalKeys(
 }
 
 function addMapAliasesToSelect(select: string): string {
-  const selects = select.split(',');
+  const selects = splitAndTrimWithBracket(select);
   for (let i = 0; i < selects.length; i++) {
     const key = selects[i];
     const mapField = parseMapFieldName(key);

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -100,6 +100,7 @@ import {
   usePrevious,
 } from '@/utils';
 
+import { parseMapFieldName } from './DBSearchPageFilters/utils';
 import DBRowTableFieldWithPopover from './DBTable/DBRowTableFieldWithPopover';
 import DBRowTableRowButtons from './DBTable/DBRowTableRowButtons';
 import TableHeader from './DBTable/TableHeader';
@@ -1508,6 +1509,19 @@ function selectColumnMapWithoutAdditionalKeys(
   );
 }
 
+function addMapAliasesToSelect(select: string): string {
+  const selects = select.split(',');
+  for (let i = 0; i < selects.length; i++) {
+    const key = selects[i];
+    const mapField = parseMapFieldName(key);
+    if (mapField) {
+      selects[i] =
+        `${key} as "${mapField.baseName}['${mapField.propertyPath}']"`;
+    }
+  }
+  return selects.join(',');
+}
+
 export type DBRowTableVariant = 'default' | 'muted';
 
 function DBSqlRowTableComponent({
@@ -1602,6 +1616,9 @@ function DBSqlRowTableComponent({
       ...searchChartConfigDefaults(me?.team),
       ...config,
     };
+    if (typeof base.select === 'string') {
+      base.select = addMapAliasesToSelect(base.select);
+    }
     if (orderByArray.length) {
       base.orderBy = orderByArray.map(o => {
         return {

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -449,10 +449,55 @@ describe('addMapAliasesToSelect', () => {
     ).toBe(`Timestamp,toDateTime(now64(3, 'UTC')),ServiceName`);
   });
 
+  it('aliases an arrayElement(Col, key) Map subscript', () => {
+    expect(
+      addMapAliasesToSelect("arrayElement(ResourceAttributes, 'service.name')"),
+    ).toBe(
+      `arrayElement(ResourceAttributes, 'service.name') as "ResourceAttributes['service.name']"`,
+    );
+  });
+
   it('passes already-aliased plain columns through unchanged', () => {
     expect(addMapAliasesToSelect('Timestamp as ts, ServiceName as svc')).toBe(
       'Timestamp as ts,ServiceName as svc',
     );
+  });
+
+  it('does NOT re-alias a bracket-form map subscript that already carries an "as <alias>" clause', () => {
+    expect(
+      addMapAliasesToSelect("ResourceAttributes['service.name'] as svc"),
+    ).toBe("ResourceAttributes['service.name'] as svc");
+  });
+
+  it('does NOT re-alias an already-aliased map subscript within a multi-column input', () => {
+    expect(
+      addMapAliasesToSelect(
+        "Timestamp, ResourceAttributes['service.name'] as svc, SeverityText",
+      ),
+    ).toBe("Timestamp,ResourceAttributes['service.name'] as svc,SeverityText");
+  });
+
+  it('does NOT alias unbracketed dot-notation tokens', () => {
+    expect(addMapAliasesToSelect('user_data.name')).toBe('user_data.name');
+    expect(addMapAliasesToSelect('user_data.address.city')).toBe(
+      'user_data.address.city',
+    );
+  });
+
+  it('does NOT alias multi-segment dotted native columns', () => {
+    expect(addMapAliasesToSelect('SpanAttributes.k8s.resource.name')).toBe(
+      'SpanAttributes.k8s.resource.name',
+    );
+  });
+
+  it('does NOT alias toString(x).y attribute-access expressions', () => {
+    expect(addMapAliasesToSelect('toString(SpanAttributes).k8s')).toBe(
+      'toString(SpanAttributes).k8s',
+    );
+  });
+
+  it('does NOT alias backtick-quoted dotted JSON paths', () => {
+    expect(addMapAliasesToSelect('`host`.`arch`')).toBe('`host`.`arch`');
   });
 
   it('returns an empty string for empty input', () => {

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
+  addMapAliasesToSelect,
   appendSelectWithAdditionalKeys,
   RawLogTable,
 } from '@/components/DBRowTable';
@@ -414,5 +415,47 @@ describe('appendSelectWithAdditionalKeys', () => {
       select:
         'Timestamp,ServiceName,Body,__hdx_id,toDate(Timestamp),toStartOfFiveMinutes(Timestamp),_block_number,_block_offset',
     });
+  });
+});
+
+describe('addMapAliasesToSelect', () => {
+  it('leaves plain columns unchanged and collapses ", " to ","', () => {
+    expect(addMapAliasesToSelect('Timestamp, ServiceName, SeverityText')).toBe(
+      'Timestamp,ServiceName,SeverityText',
+    );
+  });
+
+  it('aliases a single-quoted bracket-form map key', () => {
+    expect(addMapAliasesToSelect("ResourceAttributes['service.name']")).toBe(
+      `ResourceAttributes['service.name'] as "ResourceAttributes['service.name']"`,
+    );
+  });
+
+  it('aliases only the map keys in a mixed multi-column input', () => {
+    expect(
+      addMapAliasesToSelect(
+        "Timestamp, ResourceAttributes['service.name'], SeverityText",
+      ),
+    ).toBe(
+      `Timestamp,ResourceAttributes['service.name'] as "ResourceAttributes['service.name']",SeverityText`,
+    );
+  });
+
+  it('preserves function-call expressions whose arguments contain commas', () => {
+    expect(
+      addMapAliasesToSelect(
+        "Timestamp, toDateTime(now64(3, 'UTC')), ServiceName",
+      ),
+    ).toBe(`Timestamp,toDateTime(now64(3, 'UTC')),ServiceName`);
+  });
+
+  it('passes already-aliased plain columns through unchanged', () => {
+    expect(addMapAliasesToSelect('Timestamp as ts, ServiceName as svc')).toBe(
+      'Timestamp as ts,ServiceName as svc',
+    );
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(addMapAliasesToSelect('')).toBe('');
   });
 });

--- a/packages/common-utils/src/__tests__/metadata.test.ts
+++ b/packages/common-utils/src/__tests__/metadata.test.ts
@@ -1471,4 +1471,28 @@ describe('parseKeyPath', () => {
       "ResourceAttributes['service.name",
     ]);
   });
+
+  it('parses single-quoted arrayElement function-call form', () => {
+    expect(
+      parseKeyPath("arrayElement(ResourceAttributes, 'service.name')"),
+    ).toEqual(['ResourceAttributes', 'service.name']);
+  });
+
+  it('parses arrayElement keys with dots in the map key', () => {
+    expect(
+      parseKeyPath("arrayElement(SpanAttributes, 'http.request.method')"),
+    ).toEqual(['SpanAttributes', 'http.request.method']);
+  });
+
+  it('tolerates whitespace inside arrayElement', () => {
+    expect(
+      parseKeyPath("arrayElement( ResourceAttributes ,  'service.name' )"),
+    ).toEqual(['ResourceAttributes', 'service.name']);
+  });
+
+  it('does not parse arrayElement with a missing closing paren', () => {
+    expect(
+      parseKeyPath("arrayElement(ResourceAttributes, 'service.name'"),
+    ).toEqual(["arrayElement(ResourceAttributes, 'service.name'"]);
+  });
 });

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -1768,9 +1768,17 @@ export type Field = {
 };
 
 /**
- * Parses a bracket-notation key string into a path array.
- * e.g. `ResourceAttributes['service.name']` → `['ResourceAttributes', 'service.name']`
- *      `ServiceName` → `['ServiceName']`
+ * Parses a Map-access key string into a path array.
+ *
+ * Handles both ClickHouse Map access forms:
+ *   - Bracket form (canonical input):
+ *       `ResourceAttributes['service.name']` → `['ResourceAttributes', 'service.name']`
+ *       `ResourceAttributes["service.name"]` → `['ResourceAttributes', 'service.name']`
+ *   - Function-call form (what ClickHouse renders in result column names):
+ *       `arrayElement(ResourceAttributes, 'service.name')` → `['ResourceAttributes', 'service.name']`
+ *
+ * Native columns return a single-element path:
+ *   `ServiceName` → `['ServiceName']`
  */
 export function parseKeyPath(key: string): string[] {
   const singleIdx = key.indexOf("['");
@@ -1780,6 +1788,15 @@ export function parseKeyPath(key: string): string[] {
   const doubleIdx = key.indexOf('["');
   if (doubleIdx !== -1 && key.endsWith('"]')) {
     return [key.slice(0, doubleIdx), key.slice(doubleIdx + 2, -2)];
+  }
+  // ClickHouse Map access function-call form. ClickHouse renders Map
+  // subscript expressions (e.g. `SpanAttributes['http.route']`) as
+  // `arrayElement(SpanAttributes, 'http.route')` in result column names.
+  const ARRAY_ELEMENT_PREFIX = 'arrayElement(';
+  if (key.startsWith(ARRAY_ELEMENT_PREFIX) && key.endsWith(')')) {
+    const inner = key.slice(ARRAY_ELEMENT_PREFIX.length, -1);
+    const parts = inner.split(',').map(e => e.trim());
+    return [parts[0], parts[1].replaceAll("'", '')];
   }
   return [key];
 }


### PR DESCRIPTION
## Summary

If you try and add a filter for an existing column that is a map access column, (ex: `ResourceAttributes['service.name']`), ClickHouse will return the column as `arrayElement(ResourceAttributes, 'service.name')`. Previously filters were defined in SQL, but now they are lucene, which means it doesn't automatically translate anymore.

We could either make the filters aware of how to parse and translate that statement, or add an alias to the SELECT if a map is accessed. This PR adds both.

### Screenshots or video

https://github.com/user-attachments/assets/d278962c-c33c-4c5e-a00e-90f8bee16f1b


### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] -->

**Steps:**

1. Add a `ResourceAttributes['service.name']
2. Hover over the column titled `ResourceAttributes['service.name']` on any row
3. Click "toggle filter"
4. Observe that the behavior is handled correctly

### References

- Linear Issue: Closes HDX-4411