### PR TITLE
fix(logger): emit string `severity` so logs aren't misclassified as fatal

### DIFF
--- a/.changeset/pino-string-severity-for-collector.md
+++ b/.changeset/pino-string-severity-for-collector.md
@@ -1,0 +1,16 @@
+---
+'@hyperdx/api': patch
+---
+
+fix(logger): emit a string `severity` field so logs are classified correctly
+
+The application logger emitted pino's default numeric `level` (e.g. `30`). The
+OTel collector that tails container stdout can only promote a log's severity
+from a string field, so numeric levels were ignored and the collector fell back
+to scanning the log body for a level keyword — mis-classifying any log
+containing a word like "alert" (e.g. the alert-checking task's output) as
+FATAL.
+
+The logger now adds a string `severity` label while keeping the numeric `level`
+(which the HyperDX OTLP transport still requires), so structured logs are
+classified by their real level instead of the body-keyword fallback.

--- a/packages/api/src/utils/__tests__/logFormatters.test.ts
+++ b/packages/api/src/utils/__tests__/logFormatters.test.ts
@@ -1,0 +1,50 @@
+import pino from 'pino';
+
+import { pinoLevelFormatter } from '../logFormatters';
+
+describe('pinoLevelFormatter', () => {
+  it('returns the numeric level alongside the string label', () => {
+    expect(pinoLevelFormatter('trace', 10)).toEqual({
+      level: 10,
+      severity: 'trace',
+    });
+    expect(pinoLevelFormatter('info', 30)).toEqual({
+      level: 30,
+      severity: 'info',
+    });
+    expect(pinoLevelFormatter('error', 50)).toEqual({
+      level: 50,
+      severity: 'error',
+    });
+    expect(pinoLevelFormatter('fatal', 60)).toEqual({
+      level: 60,
+      severity: 'fatal',
+    });
+  });
+
+  it('serializes both numeric level and string severity in pino output', () => {
+    const lines: string[] = [];
+    const stream: pino.DestinationStream = {
+      write: (chunk: string) => {
+        lines.push(chunk);
+      },
+    };
+
+    const logger = pino(
+      {
+        base: null,
+        timestamp: false,
+        formatters: { level: pinoLevelFormatter },
+      },
+      stream,
+    );
+
+    logger.warn('hello');
+
+    const parsed = JSON.parse(lines[0]);
+    // Numeric level is preserved for the HyperDX OTLP transport.
+    expect(parsed.level).toBe(40);
+    // String severity is what the OTel collector promotes.
+    expect(parsed.severity).toBe('warn');
+  });
+});

--- a/packages/api/src/utils/logFormatters.ts
+++ b/packages/api/src/utils/logFormatters.ts
@@ -1,20 +1,6 @@
-/**
- * Pino `level` formatter used by the application logger.
- *
- * Pino serializes `level` as a number by default (10=trace … 60=fatal). Two
- * downstream consumers read it differently:
- *
- *  - The HyperDX OTLP transport (`@hyperdx/node-opentelemetry`) maps the
- *    NUMERIC level via `PINO_LEVELS[level]`, so `level` must stay a number.
- *  - The OTel collector that tails container stdout can only promote a log's
- *    severity from a STRING field (`level`/`severity`/...). A numeric level is
- *    ignored, which forces the collector into a body-keyword fallback that
- *    mis-classifies logs (e.g. anything containing the word "alert" becomes
- *    FATAL).
- *
- * Emitting both keeps the OTLP path working while giving the collector a string
- * `severity` it can promote, so structured logs are classified correctly.
- */
+// Keep numeric `level` (the HyperDX OTLP transport maps PINO_LEVELS[level]) and
+// add a string `severity`, which the OTel collector needs to classify severity
+// from stdout-scraped logs instead of guessing from the body.
 export const pinoLevelFormatter = (
   label: string,
   level: number,

--- a/packages/api/src/utils/logFormatters.ts
+++ b/packages/api/src/utils/logFormatters.ts
@@ -1,0 +1,21 @@
+/**
+ * Pino `level` formatter used by the application logger.
+ *
+ * Pino serializes `level` as a number by default (10=trace … 60=fatal). Two
+ * downstream consumers read it differently:
+ *
+ *  - The HyperDX OTLP transport (`@hyperdx/node-opentelemetry`) maps the
+ *    NUMERIC level via `PINO_LEVELS[level]`, so `level` must stay a number.
+ *  - The OTel collector that tails container stdout can only promote a log's
+ *    severity from a STRING field (`level`/`severity`/...). A numeric level is
+ *    ignored, which forces the collector into a body-keyword fallback that
+ *    mis-classifies logs (e.g. anything containing the word "alert" becomes
+ *    FATAL).
+ *
+ * Emitting both keeps the OTLP path working while giving the collector a string
+ * `severity` it can promote, so structured logs are classified correctly.
+ */
+export const pinoLevelFormatter = (
+  label: string,
+  level: number,
+): { level: number; severity: string } => ({ level, severity: label });

--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -8,6 +8,8 @@ import pinoHttp from 'pino-http';
 
 import * as config from '@/config';
 
+import { pinoLevelFormatter } from './logFormatters';
+
 const MAX_LEVEL = config.HYPERDX_LOG_LEVEL ?? 'debug';
 
 const hyperdxTransport = config.HYPERDX_API_KEY
@@ -58,6 +60,12 @@ const logger = pino({
   level: MAX_LEVEL,
   transport: getTransport(),
   mixin: getPinoMixinFunction,
+  formatters: {
+    // Keep numeric `level` (the OTLP transport maps PINO_LEVELS[level]) while
+    // adding a string `severity` the OTel collector can promote. See
+    // ./logFormatters for the full rationale.
+    level: pinoLevelFormatter,
+  },
 });
 
 export const expressLogger = pinoHttp({

--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -61,9 +61,6 @@ const logger = pino({
   transport: getTransport(),
   mixin: getPinoMixinFunction,
   formatters: {
-    // Keep numeric `level` (the OTLP transport maps PINO_LEVELS[level]) while
-    // adding a string `severity` the OTel collector can promote. See
-    // ./logFormatters for the full rationale.
     level: pinoLevelFormatter,
   },
 });


### PR DESCRIPTION
## Why

HyperDX's logger emits pino's default **numeric** `level` (e.g. `{"level":30}`). The OTel collector that tails container stdout can only promote a log's severity from a **string** level field — a numeric `level` is ignored, so the collector falls back to scanning the log **body** for a level keyword.

That fallback matches `(?i)\b(alert|crit|emerg|fatal|...)`, so any log whose body contains a word like "alert" gets tagged **FATAL**. The alert-checking task is the worst case: its `concurrently` prefix (`[ALERT-TASK] …`) and its own messages (`check-alerts finished …`) both contain "alert", so a steady stream of `level:30` (INFO) logs are stored as FATAL — false information that drowns out real errors.

## What

Add a pino `level` formatter that **keeps the numeric `level`** and **additionally emits a string `severity`** label:

```jsonc
{"level":30,"severity":"info", ...}
```

- The HyperDX OTLP transport (`@hyperdx/node-opentelemetry`) maps `PINO_LEVELS[level]`, so `level` must stay numeric — unchanged.
- The OTel collector promotes the string `severity` (its existing logic already checks a `severity` field), so structured logs are classified by their real level and never reach the body-keyword fallback. No collector change required.

Extracted the formatter into `logFormatters.ts` with a unit test (pure-function mapping + a pino serialization assertion).

## Notes

- This supersedes the earlier volume-reduction approach on this branch; the branch name is now a slight misnomer but kept to preserve this PR.
- Scope: fixes HyperDX-emitted logs. Other numeric-level loggers would still hit the collector's gap — out of scope here.

## Testing

`packages/api/src/utils/__tests__/logFormatters.test.ts` — verifies the formatter returns `{level, severity}` for each level and that pino serializes both a numeric `level` and a string `severity`. Passing; ESLint clean on changed files.