### PR TITLE
testing(e2e): backport e2e action split from EE

### DIFF
--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -1,0 +1,91 @@
+name: E2E Setup
+description: |
+  Shared setup for E2E test workflows: sets the HDX_E2E_* port env vars and
+  common Playwright env vars, then runs Node.js setup, dependency install,
+  build, Playwright browser install, and starts the E2E Docker Compose stack
+  (MongoDB + ClickHouse) with health checks. The caller is responsible for
+  `actions/checkout`, running Playwright, uploading artifacts, and tearing
+  down the Docker stack.
+runs:
+  using: composite
+  steps:
+    # E2E port configuration (slot 0 defaults — must match scripts/test-e2e.sh)
+    - name: Set E2E environment variables
+      shell: bash
+      run: |
+        MONGO_PORT=21100
+        echo "HDX_E2E_SLOT=0" >> $GITHUB_ENV
+        echo "HDX_E2E_OPAMP_PORT=20320" >> $GITHUB_ENV
+        echo "HDX_E2E_CH_PORT=20500" >> $GITHUB_ENV
+        echo "HDX_E2E_CH_NATIVE_PORT=20600" >> $GITHUB_ENV
+        echo "HDX_E2E_API_PORT=21000" >> $GITHUB_ENV
+        echo "HDX_E2E_MONGO_PORT=$MONGO_PORT" >> $GITHUB_ENV
+        echo "HDX_E2E_APP_LOCAL_PORT=21200" >> $GITHUB_ENV
+        echo "HDX_E2E_APP_PORT=21300" >> $GITHUB_ENV
+        echo "MONGO_URI=mongodb://localhost:$MONGO_PORT/hyperdx-e2e" >> $GITHUB_ENV
+        echo "E2E_FULLSTACK=true" >> $GITHUB_ENV
+        echo "E2E_UNIQUE_USER=true" >> $GITHUB_ENV
+        echo "E2E_API_HEALTH_CHECK_MAX_RETRIES=60" >> $GITHUB_ENV
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: .nvmrc
+        cache-dependency-path: yarn.lock
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install
+
+    - name: Build dependencies
+      shell: bash
+      run: npx nx run-many -t ci:build
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: cd packages/app && npx playwright install --with-deps chromium
+
+    - name: Start E2E Docker Compose
+      shell: bash
+      run: |
+        # Pre-pull images with retries to handle transient Docker Hub timeouts
+        for attempt in 1 2 3; do
+          if docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml pull; then
+            echo "Docker images pulled successfully on attempt $attempt"
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "Failed to pull Docker images after 3 attempts"
+            exit 1
+          fi
+          echo "Docker pull failed (attempt $attempt/3), retrying in 10s..."
+          sleep 10
+        done
+        docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml up -d
+        echo "Waiting for MongoDB..."
+        for i in $(seq 1 30); do
+          if docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml exec -T db mongosh --quiet --eval "db.adminCommand({ping:1})" >/dev/null 2>&1; then
+            echo "MongoDB is ready"
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "MongoDB failed to become ready after 30 seconds"
+            exit 1
+          fi
+          echo "Waiting for MongoDB... ($i/30)"
+          sleep 1
+        done
+        echo "Waiting for ClickHouse..."
+        for i in $(seq 1 60); do
+          if curl -sf http://localhost:${HDX_E2E_CH_PORT}/ping >/dev/null 2>&1; then
+            echo "ClickHouse is ready"
+            break
+          fi
+          if [ "$i" -eq 60 ]; then
+            echo "ClickHouse failed to become ready after 60 seconds"
+            exit 1
+          fi
+          echo "Waiting for ClickHouse... ($i/60)"
+          sleep 1
+        done

--- a/.github/actions/e2e-teardown/action.yml
+++ b/.github/actions/e2e-teardown/action.yml
@@ -1,0 +1,35 @@
+name: E2E Teardown
+description: |
+  Upload Playwright artifacts and stop the E2E Docker Compose stack.
+  Always runs (even on failure) so containers are cleaned up and reports
+  are available for failed runs.
+inputs:
+  artifact-suffix:
+    description: >
+      Suffix appended to artifact names, e.g. "1" → playwright-report-1.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Upload Playwright report
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: playwright-report-${{ inputs.artifact-suffix }}
+        path: packages/app/playwright-report/
+        retention-days: 30
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: test-results-${{ inputs.artifact-suffix }}
+        path: packages/app/test-results/
+        retention-days: 30
+
+    - name: Stop E2E containers
+      if: always()
+      shell: bash
+      run:
+        docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml
+        down -v

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,109 +14,20 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
 
-    # E2E port configuration (slot 0 defaults — must match scripts/test-e2e.sh)
-    env:
-      HDX_E2E_SLOT: '0'
-      HDX_E2E_OPAMP_PORT: '20320'
-      HDX_E2E_CH_PORT: '20500'
-      HDX_E2E_CH_NATIVE_PORT: '20600'
-      HDX_E2E_API_PORT: '21000'
-      HDX_E2E_MONGO_PORT: '21100'
-      HDX_E2E_APP_LOCAL_PORT: '21200'
-      HDX_E2E_APP_PORT: '21300'
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache-dependency-path: 'yarn.lock'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Build dependencies
-        run: npx nx run-many -t ci:build
-
-      - name: Install Playwright browsers
-        run: cd packages/app && npx playwright install --with-deps chromium
-
-      - name: Start E2E Docker Compose
-        run: |
-          # Pre-pull images with retries to handle transient Docker Hub timeouts
-          for attempt in 1 2 3; do
-            if docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml pull; then
-              echo "Docker images pulled successfully on attempt $attempt"
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Failed to pull Docker images after 3 attempts"
-              exit 1
-            fi
-            echo "Docker pull failed (attempt $attempt/3), retrying in 10s..."
-            sleep 10
-          done
-          docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml up -d
-          echo "Waiting for MongoDB..."
-          for i in $(seq 1 30); do
-            if docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml exec -T db mongosh --quiet --eval "db.adminCommand({ping:1})" >/dev/null 2>&1; then
-              echo "MongoDB is ready"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "MongoDB failed to become ready after 30 seconds"
-              exit 1
-            fi
-            echo "Waiting for MongoDB... ($i/30)"
-            sleep 1
-          done
-          echo "Waiting for ClickHouse..."
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:${HDX_E2E_CH_PORT}/ping >/dev/null 2>&1; then
-              echo "ClickHouse is ready"
-              break
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "ClickHouse failed to become ready after 60 seconds"
-              exit 1
-            fi
-            echo "Waiting for ClickHouse... ($i/60)"
-            sleep 1
-          done
+      - name: E2E setup
+        uses: ./.github/actions/e2e-setup
 
       - name: Run Playwright tests (full-stack mode)
-        env:
-          E2E_FULLSTACK: 'true'
-          E2E_UNIQUE_USER: 'true'
-          E2E_API_HEALTH_CHECK_MAX_RETRIES: '60'
-          MONGO_URI:
-            mongodb://localhost:${{ env.HDX_E2E_MONGO_PORT }}/hyperdx-e2e
         run: |
           cd packages/app
           yarn test:e2e --shard=${{ matrix.shard }}/4
 
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+      - name: E2E teardown
         if: always()
+        uses: ./.github/actions/e2e-teardown
         with:
-          name: playwright-report-${{ matrix.shard }}
-          path: packages/app/playwright-report/
-          retention-days: 30
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-results-${{ matrix.shard }}
-          path: packages/app/test-results/
-          retention-days: 30
-
-      - name: Stop E2E containers
-        if: always()
-        run:
-          docker compose -p e2e-0 -f packages/app/tests/e2e/docker-compose.yml
-          down -v
+          artifact-suffix: ${{ matrix.shard }}


### PR DESCRIPTION
## Summary

Backports the reusable **E2E composite-action split** from the EE PR [DeploySentinel/hyperdx-ee#2178](https://github.com/DeploySentinel/hyperdx-ee/pull/2178) into OSS.

**Why:** `e2e-tests.yml` carried ~100 lines of inlined setup/teardown (port env vars, Node/yarn/build, Playwright install, Docker Compose with health checks, artifact upload, container teardown). Over in EE that block was extracted into two composite actions so the pipeline lives in one place. Backporting the same extraction keeps the OSS and EE E2E pipelines structurally aligned, removes the duplicated block, and reduces future merge conflicts whenever the setup pipeline changes on either side.

**Behavior is unchanged** — same slot-0 ports, same `[1,2,3,4]` sharding, same artifacts, same health checks and teardown. The moved shell pipeline is byte-identical to the original (the only additions are the `shell: bash` lines that composite-action `run` steps require). The `main.yml` call site is untouched, since `e2e-tests.yml` keeps the same `workflow_call` interface.

### What changed

- **New `.github/actions/e2e-setup/action.yml`** — composite action that sets the `HDX_E2E_*` port env vars and common Playwright env vars via `$GITHUB_ENV`, then runs Node setup, `yarn install`, `nx run-many -t ci:build`, Playwright browser install, and the E2E Docker Compose stack (MongoDB + ClickHouse) with health checks.
- **New `.github/actions/e2e-teardown/action.yml`** — composite action that uploads `playwright-report-<suffix>` / `test-results-<suffix>` and stops the Docker stack. All steps run with `if: always()`. Takes an `artifact-suffix` input (`${{ matrix.shard }}`).
- **Modified `.github/workflows/e2e-tests.yml`** — the inlined setup/teardown blocks are replaced by the two composite actions (94 deletions → 5 insertions). Trigger, job structure, `runs-on`, sharding, and the `main.yml` call site are unchanged.

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] -->

N/A — non-UI change (CI configuration only).

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes [HDX-4428](https://linear.app/clickhouse/issue/HDX-4428/backport-e2e-ci-split-to-oss)
- Related PRs: https://github.com/DeploySentinel/hyperdx-ee/pull/2178
