### PR TITLE
chore: Make dashboard tile error state consistent across chart types

### DIFF
--- a/.changeset/wet-ties-kneel.md
+++ b/.changeset/wet-ties-kneel.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+chore: Make error states consistent across chart types

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -975,6 +975,7 @@ const Tile = forwardRef(
                         isLive={false}
                         queryKeyPrefix={'search'}
                         variant="muted"
+                        errorVariant="collapsible"
                       />
                     </ChartContainer>
                   )}

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -45,7 +45,12 @@ function HeatmapPreview({
   const { heatmapConfig, scaleType } = toHeatmapChartConfig(config);
   return (
     <div className="flex-grow-1 d-flex flex-column" style={{ height: 400 }}>
-      <DBHeatmapChart config={heatmapConfig} scaleType={scaleType} showLegend />
+      <DBHeatmapChart
+        config={heatmapConfig}
+        scaleType={scaleType}
+        showLegend
+        errorVariant="inline"
+      />
     </div>
   );
 }
@@ -196,6 +201,7 @@ export function ChartPreviewPanel({
             onSortingChange={onTableSortingChange}
             sort={tableSortState}
             showMVOptimizationIndicator={false}
+            errorVariant="inline"
           />
         </div>
       )}

--- a/packages/app/src/components/DBHeatmapChart.tsx
+++ b/packages/app/src/components/DBHeatmapChart.tsx
@@ -3,26 +3,12 @@ import dynamic from 'next/dynamic';
 import type { Plugin } from 'uplot';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
-import {
-  ClickHouseQueryError,
-  inferTimestampColumn,
-} from '@hyperdx/common-utils/dist/clickhouse';
+import { inferTimestampColumn } from '@hyperdx/common-utils/dist/clickhouse';
 import { convertDateRangeToGranularityString } from '@hyperdx/common-utils/dist/core/utils';
 import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
 import { DisplayType } from '@hyperdx/common-utils/dist/types';
-import {
-  Box,
-  Button,
-  Code,
-  Divider,
-  Flex,
-  Group,
-  Modal,
-  Text,
-  useMantineColorScheme,
-} from '@mantine/core';
-import { useDisclosure, useElementSize } from '@mantine/hooks';
-import { IconArrowsDiagonal } from '@tabler/icons-react';
+import { Divider, Flex, Text, useMantineColorScheme } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
 
 import { isAggregateFunction, timeBucketByGranularity } from '@/ChartUtils';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
@@ -31,7 +17,9 @@ import { FormatTime } from '@/useFormatTime';
 import { formatDurationMsCompact, formatNumber } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
-import { SQLPreview } from './ChartSQLPreview';
+import ChartErrorState, {
+  ChartErrorStateVariant,
+} from './charts/ChartErrorState';
 
 type Mode2DataArray = [number[], number[], number[]];
 
@@ -619,6 +607,7 @@ function HeatmapContainer({
   toolbarSuffix,
   scaleType = 'log',
   showLegend = false,
+  errorVariant,
 }: {
   config: HeatmapChartConfig;
   enabled?: boolean;
@@ -637,6 +626,7 @@ function HeatmapContainer({
   toolbarSuffix?: React.ReactNode[];
   scaleType?: HeatmapScaleType;
   showLegend?: boolean;
+  errorVariant?: ChartErrorStateVariant;
 }) {
   const dateRange = config.dateRange;
   const granularity = convertDateRangeToGranularityString(dateRange, 245);
@@ -661,8 +651,6 @@ function HeatmapContainer({
     queryKey: ['heatmap', minMaxConfig],
     enabled: enabled,
   });
-
-  const [errorModal, errorModalControls] = useDisclosure();
 
   // UInt64 are returned as strings; quantile returns floats
   const min = Number.parseFloat(minMaxData?.data?.[0]?.['min'] ?? '0');
@@ -799,49 +787,7 @@ function HeatmapContainer({
           Loading...
         </Text>
       ) : _error ? (
-        <Box p="xl" ta="center" h="100%">
-          <Text size="sm" mt="sm">
-            Error loading chart, please check your query or try again later.
-          </Text>
-          <Button
-            className="mx-auto"
-            variant="subtle"
-            color="red"
-            onClick={() => errorModalControls.open()}
-          >
-            <Group gap="xxs">
-              <IconArrowsDiagonal size={16} />
-              See Error Details
-            </Group>
-          </Button>
-          <Modal
-            opened={errorModal}
-            onClose={() => errorModalControls.close()}
-            title="Error Details"
-          >
-            <Group align="start">
-              <Text size="sm" ta="center">
-                Error Message:
-              </Text>
-              <Code
-                block
-                style={{
-                  whiteSpace: 'pre-wrap',
-                }}
-              >
-                {_error.message}
-              </Code>
-              {_error instanceof ClickHouseQueryError && (
-                <>
-                  <Text my="sm" size="sm" ta="center">
-                    Sent Query:
-                  </Text>
-                  <SQLPreview data={_error?.query} enableCopy />
-                </>
-              )}
-            </Group>
-          </Modal>
-        </Box>
+        <ChartErrorState error={_error} variant={errorVariant} />
       ) : time.length < 2 || generatedTsBuckets?.length < 2 ? (
         <Text size="sm" ta="center" p="xl">
           Not enough data points to render heatmap. Try expanding your search

--- a/packages/app/src/components/DBHistogramChart.tsx
+++ b/packages/app/src/components/DBHistogramChart.tsx
@@ -11,9 +11,7 @@ import {
   YAxis,
 } from 'recharts';
 import { CategoricalChartState } from 'recharts/types/chart/types';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
-import { Box, Code, Text } from '@mantine/core';
 
 import { buildMVDateRangeIndicator } from '@/ChartUtils';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
@@ -21,8 +19,10 @@ import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanati
 import { useSource } from '@/source';
 
 import ChartContainer from './charts/ChartContainer';
+import ChartErrorState, {
+  ChartErrorStateVariant,
+} from './charts/ChartErrorState';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
-import { SQLPreview } from './ChartSQLPreview';
 
 function HistogramChart({
   graphResults,
@@ -197,6 +197,7 @@ export default function DBHistogramChart({
   toolbarPrefix,
   toolbarSuffix,
   showMVOptimizationIndicator = true,
+  errorVariant,
 }: {
   config: BuilderChartConfigWithDateRange;
   queryKeyPrefix?: string;
@@ -205,6 +206,7 @@ export default function DBHistogramChart({
   toolbarPrefix?: React.ReactNode[];
   toolbarSuffix?: React.ReactNode[];
   showMVOptimizationIndicator?: boolean;
+  errorVariant?: ChartErrorStateVariant;
 }) {
   const queriedConfig = omit(config, ['granularity']);
   const { data, isLoading, isError, error } = useQueriedChartConfig(
@@ -272,32 +274,7 @@ export default function DBHistogramChart({
           Loading Chart Data...
         </div>
       ) : isError ? (
-        <div className="h-100 w-100 align-items-center justify-content-center text-muted">
-          <Text ta="center" size="sm" mt="sm">
-            Error loading chart, please check your query or try again later.
-          </Text>
-          <Box mt="sm">
-            <Text my="sm" size="sm" ta="center">
-              Error Message:
-            </Text>
-            <Code
-              block
-              style={{
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {error.message}
-            </Code>
-            {error instanceof ClickHouseQueryError && (
-              <>
-                <Text my="sm" size="sm" ta="center">
-                  Sent Query:
-                </Text>
-                <SQLPreview data={error?.query} />
-              </>
-            )}
-          </Box>
-        </div>
+        <ChartErrorState error={error} variant={errorVariant} />
       ) : data?.data.length === 0 ? (
         <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
           No data found within time range.

--- a/packages/app/src/components/DBListBarChart.tsx
+++ b/packages/app/src/components/DBListBarChart.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 import Link from 'next/link';
 import { omit } from 'lodash';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
 import type { FloatingPosition } from '@mantine/core';
-import { Box, Code, Flex, HoverCard, Text } from '@mantine/core';
+import { Box, Flex, HoverCard, Text } from '@mantine/core';
 
 import { buildMVDateRangeIndicator } from '@/ChartUtils';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
@@ -14,8 +13,10 @@ import type { NumberFormat } from '@/types';
 import { formatNumber, semanticKeyedColor } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
+import ChartErrorState, {
+  ChartErrorStateVariant,
+} from './charts/ChartErrorState';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
-import { SQLPreview } from './ChartSQLPreview';
 
 function ListItem({
   title,
@@ -184,6 +185,7 @@ export default function DBListBarChart({
   title,
   toolbarItems,
   showMVOptimizationIndicator = true,
+  errorVariant,
 }: {
   config: BuilderChartConfigWithDateRange;
   onSettled?: () => void;
@@ -197,6 +199,7 @@ export default function DBListBarChart({
   title?: React.ReactNode;
   toolbarItems?: React.ReactNode[];
   showMVOptimizationIndicator?: boolean;
+  errorVariant?: ChartErrorStateVariant;
 }) {
   const queriedConfig = omit(config, ['granularity']);
   const { data, isLoading, isError, error } = useQueriedChartConfig(
@@ -273,32 +276,7 @@ export default function DBListBarChart({
           Loading Chart Data...
         </div>
       ) : isError ? (
-        <div className="h-100 w-100 align-items-center justify-content-center text-muted">
-          <Text ta="center" size="sm" mt="sm">
-            Error loading chart, please check your query or try again later.
-          </Text>
-          <Box mt="sm">
-            <Text my="sm" size="sm" ta="center">
-              Error Message:
-            </Text>
-            <Code
-              block
-              style={{
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {error.message}
-            </Code>
-            {error instanceof ClickHouseQueryError && (
-              <>
-                <Text my="sm" size="sm" ta="center">
-                  Sent Query:
-                </Text>
-                <SQLPreview data={error?.query} />
-              </>
-            )}
-          </Box>
-        </div>
+        <ChartErrorState error={error} variant={errorVariant} />
       ) : data?.data.length === 0 ? (
         <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
           No data found within time range.

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -38,7 +38,6 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import {
   Box,
-  Code,
   Flex,
   Group,
   Modal,
@@ -100,6 +99,9 @@ import {
   usePrevious,
 } from '@/utils';
 
+import ChartErrorState, {
+  ChartErrorStateVariant,
+} from './charts/ChartErrorState';
 import DBRowTableFieldWithPopover from './DBTable/DBRowTableFieldWithPopover';
 import DBRowTableRowButtons from './DBTable/DBRowTableRowButtons';
 import TableHeader from './DBTable/TableHeader';
@@ -342,6 +344,7 @@ export const RawLogTable = memo(
     dedupRows,
     isError,
     error,
+    errorVariant = 'inline',
     columnTypeMap,
     dateRange,
     loadingDate,
@@ -378,6 +381,7 @@ export const RawLogTable = memo(
 
     isError?: boolean;
     error?: ClickHouseQueryError | Error;
+    errorVariant?: ChartErrorStateVariant;
     dateRange?: [Date, Date];
     loadingDate?: Date;
     config?: BuilderChartConfigWithDateRange;
@@ -1226,7 +1230,16 @@ export const RawLogTable = memo(
                 })}
                 <tr>
                   <td colSpan={800}>
-                    <div className="rounded fs-7 bg-muted text-center d-flex align-items-center justify-content-center mt-3">
+                    <div
+                      className={cx(
+                        'rounded fs-7 d-flex align-items-center justify-content-center mt-3',
+                        // Errors render the shared ChartErrorState, which carries
+                        // its own styling/alignment; drop the muted background and
+                        // centered text so it matches the error state of other
+                        // chart types.
+                        { 'bg-muted text-center': !isError },
+                      )}
+                    >
                       {isLoading ? (
                         <div className="my-3">
                           <div className="d-inline-block">
@@ -1265,40 +1278,8 @@ export const RawLogTable = memo(
                         isLoading == false &&
                         dedupedRows.length > 0 ? (
                         <div className="my-3">End of Results</div>
-                      ) : isError ? (
-                        <div className="my-3">
-                          <Text ta="center" size="sm">
-                            Error loading results, please check your query or
-                            try again.
-                          </Text>
-                          <Box p="sm">
-                            <Box mt="sm">
-                              <Code
-                                block
-                                style={{
-                                  whiteSpace: 'pre-wrap',
-                                }}
-                              >
-                                {error?.message}
-                              </Code>
-                            </Box>
-                            {error instanceof ClickHouseQueryError && (
-                              <>
-                                <Text my="sm" size="sm" ta="center">
-                                  Sent Query:
-                                </Text>
-                                <Flex
-                                  w="100%"
-                                  ta="initial"
-                                  align="center"
-                                  justify="center"
-                                >
-                                  <SQLPreview data={error?.query} />
-                                </Flex>
-                              </>
-                            )}
-                          </Box>
-                        </div>
+                      ) : isError && error ? (
+                        <ChartErrorState error={error} variant={errorVariant} />
                       ) : hasNextPage == false &&
                         isLoading == false &&
                         dedupedRows.length === 0 ? (
@@ -1531,6 +1512,7 @@ function DBSqlRowTableComponent({
   variant = 'default',
   enableSmallFirstWindow,
   tableId,
+  errorVariant,
 }: {
   config: BuilderChartConfigWithDateRange;
   sourceId?: string;
@@ -1556,6 +1538,7 @@ function DBSqlRowTableComponent({
   variant?: DBRowTableVariant;
   enableSmallFirstWindow?: boolean;
   tableId?: string;
+  errorVariant?: ChartErrorStateVariant;
 }) {
   const { data: me } = api.useMe();
   const { toggleColumn, displayedColumns: contextDisplayedColumns } =
@@ -1850,6 +1833,7 @@ function DBSqlRowTableComponent({
         generateRowId={getRowWhere}
         isError={isError}
         error={error ?? undefined}
+        errorVariant={errorVariant}
         columnTypeMap={columnMap}
         dateRange={config.dateRange}
         loadingDate={loadingDate}

--- a/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
+++ b/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
@@ -13,6 +13,7 @@ import TabBar from '@/TabBar';
 import { useLocalStorage } from '@/utils';
 import { parseAsStringEncoded } from '@/utils/queryParsers';
 
+import { ChartErrorStateVariant } from './charts/ChartErrorState';
 import { useNestedPanelState } from './ContextSidePanel';
 import { RowDataPanel } from './DBRowDataPanel';
 import { RowOverviewPanel } from './DBRowOverviewPanel';
@@ -44,6 +45,7 @@ interface Props {
   variant?: DBRowTableVariant;
   enableSmallFirstWindow?: boolean;
   tableId?: string;
+  errorVariant?: ChartErrorStateVariant;
 }
 
 export default function DBSqlRowTableWithSideBar({
@@ -65,6 +67,7 @@ export default function DBSqlRowTableWithSideBar({
   variant,
   enableSmallFirstWindow,
   tableId,
+  errorVariant,
 }: Props) {
   const { data: sourceData } = useSource({ id: sourceId });
   const [rowId, setRowId] = useQueryState('rowWhere', parseAsStringEncoded);
@@ -145,6 +148,7 @@ export default function DBSqlRowTableWithSideBar({
         variant={variant}
         enableSmallFirstWindow={enableSmallFirstWindow}
         tableId={tableId}
+        errorVariant={errorVariant}
       />
     </RowSidePanelContext.Provider>
   );

--- a/packages/app/src/components/DBTableChart.tsx
+++ b/packages/app/src/components/DBTableChart.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { isRatioChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
 import {
   isBuilderChartConfig,
@@ -7,7 +6,7 @@ import {
   isRawSqlChartConfig,
 } from '@hyperdx/common-utils/dist/guards';
 import { ChartConfigWithOptTimestamp } from '@hyperdx/common-utils/dist/types';
-import { Box, Code, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { SortingState } from '@tanstack/react-table';
 
 import {
@@ -22,9 +21,11 @@ import { useChartNumberFormats, useSource } from '@/source';
 import { useIntersectionObserver } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
+import ChartErrorState, {
+  ChartErrorStateVariant,
+} from './charts/ChartErrorState';
 import { getClientSideSortingFn } from './DBTable/sorting';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
-import { SQLPreview } from './ChartSQLPreview';
 
 export default function DBTableChart({
   config,
@@ -39,6 +40,7 @@ export default function DBTableChart({
   toolbarSuffix,
   showMVOptimizationIndicator = true,
   variant,
+  errorVariant,
 }: {
   config: ChartConfigWithOptTimestamp;
   getRowSearchLink?: (row: any) => string | null;
@@ -52,6 +54,7 @@ export default function DBTableChart({
   toolbarSuffix?: React.ReactNode[];
   showMVOptimizationIndicator?: boolean;
   variant?: TableVariant;
+  errorVariant?: ChartErrorStateVariant;
 }) {
   const [sort, setSort] = useState<SortingState>([]);
 
@@ -230,32 +233,7 @@ export default function DBTableChart({
           Loading Chart Data...
         </div>
       ) : isError && error ? (
-        <div className="h-100 w-100 align-items-center justify-content-center text-muted overflow-scroll">
-          <Text ta="center" size="sm" mt="sm">
-            Error loading chart, please check your query or try again later.
-          </Text>
-          <Box mt="sm">
-            <Text my="sm" size="sm" ta="center">
-              Error Message:
-            </Text>
-            <Code
-              block
-              style={{
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {error.message}
-            </Code>
-            {error instanceof ClickHouseQueryError && (
-              <>
-                <Text my="sm" size="sm" ta="center">
-                  Sent Query:
-                </Text>
-                <SQLPreview data={error?.query} />
-              </>
-            )}
-          </Box>
-        </div>
+        <ChartErrorState error={error} variant={errorVariant} />
       ) : data?.data.length === 0 ? (
         <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
           No data found within time range.

--- a/packages/app/src/components/ServiceDashboardSlowestEventsTile.tsx
+++ b/packages/app/src/components/ServiceDashboardSlowestEventsTile.tsx
@@ -1,17 +1,16 @@
 import { pick } from 'lodash';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import {
   type Filter,
   pickSampleWeightExpressionProps,
   type TTraceSource,
 } from '@hyperdx/common-utils/dist/types';
-import { Box, Code, Group, Text } from '@mantine/core';
+import { Group, Text } from '@mantine/core';
 
 import { ChartBox } from '@/components/ChartBox';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useServiceDashboardExpressions } from '@/serviceDashboard';
 
-import { SQLPreview } from './ChartSQLPreview';
+import ChartErrorState from './charts/ChartErrorState';
 import DBSqlRowTableWithSideBar from './DBSqlRowTableWithSidebar';
 
 export default function SlowestEventsTile({
@@ -77,32 +76,7 @@ export default function SlowestEventsTile({
           Loading Chart Data...
         </div>
       ) : isError ? (
-        <div className="h-100 w-100 align-items-center justify-content-center text-muted">
-          <Text ta="center" size="sm" mt="sm">
-            Error loading chart, please check your query or try again later.
-          </Text>
-          <Box mt="sm">
-            <Text my="sm" size="sm" ta="center">
-              Error Message:
-            </Text>
-            <Code
-              block
-              style={{
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {error.message}
-            </Code>
-            {error instanceof ClickHouseQueryError && (
-              <>
-                <Text my="sm" size="sm" ta="center">
-                  Sent Query:
-                </Text>
-                <SQLPreview data={error?.query} />
-              </>
-            )}
-          </Box>
-        </div>
+        <ChartErrorState error={error} />
       ) : data?.data.length === 0 ? (
         <div className="d-flex h-100 w-100 align-items-center justify-content-center text-muted">
           No data found within time range.


### PR DESCRIPTION
## Summary

This PR updates each chart type to have a consistent error state, using the shared `ChartErrorState` component. Further, the variant of the component now matches ("collapsible" when the chart is a dashboard tile, "inline" when editing the chart or viewing on the search page).

### Before:

<img width="1477" height="1092" alt="Screenshot 2026-06-02 at 10 16 19 AM" src="https://github.com/user-attachments/assets/7703fdf1-791c-4752-869c-2e58355c0cc5" />

### After:

https://github.com/user-attachments/assets/4659c525-6042-404c-a820-5fc6d58d0eb0

### How to test on Vercel preview

This can be tested in the preview environment - any invalid SQL WHERE filter should trigger a query failure and cause an error state, on dashboards or elsewhere.

### References

- Linear Issue: Closes HDX-4430
