### PR TITLE
feat(charts): add 'Fit Y-Axis to Data' display setting for line charts

### DIFF
--- a/.changeset/breezy-students-clap.md
+++ b/.changeset/breezy-students-clap.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+feat: Add option to fit time chart y-axis lower bound

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1239,6 +1239,11 @@
             "description": "Fill missing time buckets with zero instead of leaving gaps.",
             "default": true
           },
+          "fitYAxisToData": {
+            "type": "boolean",
+            "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
+            "default": false
+          },
           "numberFormat": {
             "$ref": "#/components/schemas/NumberFormat",
             "description": "Number formatting options for displayed values."
@@ -1301,6 +1306,11 @@
             "type": "boolean",
             "description": "Fill missing time buckets with zero instead of leaving gaps.",
             "default": true
+          },
+          "fitYAxisToData": {
+            "type": "boolean",
+            "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
+            "default": false
           },
           "numberFormat": {
             "$ref": "#/components/schemas/NumberFormat",
@@ -1676,6 +1686,11 @@
                 "type": "boolean",
                 "description": "Expand date range boundaries to the query granularity interval.",
                 "default": true
+              },
+              "fitYAxisToData": {
+                "type": "boolean",
+                "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
+                "default": false
               }
             }
           }
@@ -1710,6 +1725,11 @@
                 "type": "boolean",
                 "description": "Expand date range boundaries to the query granularity interval.",
                 "default": true
+              },
+              "fitYAxisToData": {
+                "type": "boolean",
+                "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
+                "default": false
               }
             }
           }

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1307,11 +1307,6 @@
             "description": "Fill missing time buckets with zero instead of leaving gaps.",
             "default": true
           },
-          "fitYAxisToData": {
-            "type": "boolean",
-            "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
-            "default": false
-          },
           "numberFormat": {
             "$ref": "#/components/schemas/NumberFormat",
             "description": "Number formatting options for displayed values."
@@ -1725,11 +1720,6 @@
                 "type": "boolean",
                 "description": "Expand date range boundaries to the query granularity interval.",
                 "default": true
-              },
-              "fitYAxisToData": {
-                "type": "boolean",
-                "description": "Set the y-axis lower bound to the minimum of the displayed data instead of zero, making small fluctuations between series easier to see.\n",
-                "default": false
               }
             }
           }

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -2193,6 +2193,7 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'line',
           asRatio: true,
           fillNulls: true,
+          fitYAxisToData: true,
           sourceId: traceSource._id.toString(),
           numberFormat: {
             output: 'time',
@@ -2240,6 +2241,7 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'stacked_bar',
           asRatio: false,
           fillNulls: false,
+          fitYAxisToData: false,
           sourceId: metricSource._id.toString(),
           numberFormat: {
             output: 'byte',
@@ -2703,6 +2705,7 @@ describe('External API v2 Dashboards - new format', () => {
           compareToPreviousPeriod: true,
           fillNulls: true,
           alignDateRangeToGranularity: true,
+          fitYAxisToData: true,
           numberFormat: { output: 'number', mantissa: 2 },
         },
       };
@@ -2721,6 +2724,7 @@ describe('External API v2 Dashboards - new format', () => {
           sourceId,
           fillNulls: false,
           alignDateRangeToGranularity: false,
+          fitYAxisToData: false,
           numberFormat: { output: 'byte', decimalBytes: true },
         },
       };
@@ -2794,6 +2798,74 @@ describe('External API v2 Dashboards - new format', () => {
       expect(omit(response.body.data.tiles[2], ['id'])).toEqual(tableRawSql);
       expect(omit(response.body.data.tiles[3], ['id'])).toEqual(numberRawSql);
       expect(omit(response.body.data.tiles[4], ['id'])).toEqual(pieRawSql);
+    });
+
+    it('persists fitYAxisToData on line/bar tiles and reads it back on GET', async () => {
+      const sourceId = traceSource._id.toString();
+
+      // A line tile that opts into fitYAxisToData and a bar tile that
+      // explicitly opts out; a third tile omits the field entirely to
+      // confirm it stays absent (it is optional with no default).
+      const fitLine: ExternalDashboardTile = {
+        name: 'Fit Line',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'line',
+          sourceId,
+          fitYAxisToData: true,
+          select: [{ aggFn: 'count', where: '', whereLanguage: 'sql' }],
+        },
+      };
+
+      const noFitBar: ExternalDashboardTile = {
+        name: 'No Fit Bar',
+        x: 6,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'stacked_bar',
+          sourceId,
+          fitYAxisToData: false,
+          select: [{ aggFn: 'count', where: '', whereLanguage: 'sql' }],
+        },
+      };
+
+      const unsetLine: ExternalDashboardTile = {
+        name: 'Unset Line',
+        x: 12,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'line',
+          sourceId,
+          select: [{ aggFn: 'count', where: '', whereLanguage: 'sql' }],
+        },
+      };
+
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'fitYAxisToData dashboard',
+          tiles: [fitLine, noFitBar, unsetLine],
+          tags: [],
+        })
+        .expect(200);
+
+      const { id } = createResponse.body.data;
+
+      const getResponse = await authRequest('get', `${BASE_URL}/${id}`).expect(
+        200,
+      );
+      const tiles = getResponse.body.data.tiles;
+
+      expect(tiles[0].config.fitYAxisToData).toBe(true);
+      expect(tiles[1].config.fitYAxisToData).toBe(false);
+      // Omitted on input → absent on read-back (optional, no default).
+      expect(tiles[2].config).not.toHaveProperty('fitYAxisToData');
     });
 
     it('should return 400 when source IDs do not exist', async () => {
@@ -3628,6 +3700,7 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'line',
           asRatio: true,
           fillNulls: true,
+          fitYAxisToData: true,
           sourceId: traceSource._id.toString(),
           numberFormat: {
             output: 'time',
@@ -3676,6 +3749,7 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'stacked_bar',
           asRatio: false,
           fillNulls: false,
+          fitYAxisToData: false,
           sourceId: metricSource._id.toString(),
           numberFormat: {
             output: 'byte',
@@ -3889,6 +3963,7 @@ describe('External API v2 Dashboards - new format', () => {
           compareToPreviousPeriod: true,
           fillNulls: true,
           alignDateRangeToGranularity: true,
+          fitYAxisToData: true,
           numberFormat: { output: 'number', mantissa: 2 },
         },
       };
@@ -3908,6 +3983,7 @@ describe('External API v2 Dashboards - new format', () => {
           sourceId,
           fillNulls: false,
           alignDateRangeToGranularity: false,
+          fitYAxisToData: false,
           numberFormat: { output: 'byte', decimalBytes: true },
         },
       };

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -2241,7 +2241,6 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'stacked_bar',
           asRatio: false,
           fillNulls: false,
-          fitYAxisToData: false,
           sourceId: metricSource._id.toString(),
           numberFormat: {
             output: 'byte',
@@ -2724,7 +2723,6 @@ describe('External API v2 Dashboards - new format', () => {
           sourceId,
           fillNulls: false,
           alignDateRangeToGranularity: false,
-          fitYAxisToData: false,
           numberFormat: { output: 'byte', decimalBytes: true },
         },
       };
@@ -2800,12 +2798,13 @@ describe('External API v2 Dashboards - new format', () => {
       expect(omit(response.body.data.tiles[4], ['id'])).toEqual(pieRawSql);
     });
 
-    it('persists fitYAxisToData on line/bar tiles and reads it back on GET', async () => {
+    it('persists fitYAxisToData on line tiles only and reads it back on GET', async () => {
       const sourceId = traceSource._id.toString();
 
-      // A line tile that opts into fitYAxisToData and a bar tile that
-      // explicitly opts out; a third tile omits the field entirely to
-      // confirm it stays absent (it is optional with no default).
+      // A line tile that opts into fitYAxisToData; a bar tile that attempts to
+      // set it (it is line-only, so it must be dropped); and a line tile that
+      // omits the field entirely to confirm it stays absent (optional, no
+      // default).
       const fitLine: ExternalDashboardTile = {
         name: 'Fit Line',
         x: 0,
@@ -2820,8 +2819,8 @@ describe('External API v2 Dashboards - new format', () => {
         },
       };
 
-      const noFitBar: ExternalDashboardTile = {
-        name: 'No Fit Bar',
+      const bar: ExternalDashboardTile = {
+        name: 'Bar',
         x: 6,
         y: 0,
         w: 6,
@@ -2829,9 +2828,11 @@ describe('External API v2 Dashboards - new format', () => {
         config: {
           displayType: 'stacked_bar',
           sourceId,
+          // fitYAxisToData only applies to line charts; setting it on a bar
+          // tile should be ignored rather than persisted.
           fitYAxisToData: false,
           select: [{ aggFn: 'count', where: '', whereLanguage: 'sql' }],
-        },
+        } as ExternalDashboardTile['config'],
       };
 
       const unsetLine: ExternalDashboardTile = {
@@ -2850,7 +2851,7 @@ describe('External API v2 Dashboards - new format', () => {
       const createResponse = await authRequest('post', BASE_URL)
         .send({
           name: 'fitYAxisToData dashboard',
-          tiles: [fitLine, noFitBar, unsetLine],
+          tiles: [fitLine, bar, unsetLine],
           tags: [],
         })
         .expect(200);
@@ -2863,7 +2864,8 @@ describe('External API v2 Dashboards - new format', () => {
       const tiles = getResponse.body.data.tiles;
 
       expect(tiles[0].config.fitYAxisToData).toBe(true);
-      expect(tiles[1].config.fitYAxisToData).toBe(false);
+      // Bar charts never carry fitYAxisToData — it is dropped on write.
+      expect(tiles[1].config).not.toHaveProperty('fitYAxisToData');
       // Omitted on input → absent on read-back (optional, no default).
       expect(tiles[2].config).not.toHaveProperty('fitYAxisToData');
     });
@@ -3749,7 +3751,6 @@ describe('External API v2 Dashboards - new format', () => {
           displayType: 'stacked_bar',
           asRatio: false,
           fillNulls: false,
-          fitYAxisToData: false,
           sourceId: metricSource._id.toString(),
           numberFormat: {
             output: 'byte',
@@ -3983,7 +3984,6 @@ describe('External API v2 Dashboards - new format', () => {
           sourceId,
           fillNulls: false,
           alignDateRangeToGranularity: false,
-          fitYAxisToData: false,
           numberFormat: { output: 'byte', decimalBytes: true },
         },
       };

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -479,6 +479,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           type: boolean
  *           description: Fill missing time buckets with zero instead of leaving gaps.
  *           default: true
+ *         fitYAxisToData:
+ *           type: boolean
+ *           description: >
+ *             Set the y-axis lower bound to the minimum of the displayed data
+ *             instead of zero, making small fluctuations between series easier
+ *             to see.
+ *           default: false
  *         numberFormat:
  *           $ref: '#/components/schemas/NumberFormat'
  *           description: Number formatting options for displayed values.
@@ -530,6 +537,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           type: boolean
  *           description: Fill missing time buckets with zero instead of leaving gaps.
  *           default: true
+ *         fitYAxisToData:
+ *           type: boolean
+ *           description: >
+ *             Set the y-axis lower bound to the minimum of the displayed data
+ *             instead of zero, making small fluctuations between series easier
+ *             to see.
+ *           default: false
  *         numberFormat:
  *           $ref: '#/components/schemas/NumberFormat'
  *           description: Number formatting options for displayed values.
@@ -835,6 +849,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *               type: boolean
  *               description: Expand date range boundaries to the query granularity interval.
  *               default: true
+ *             fitYAxisToData:
+ *               type: boolean
+ *               description: >
+ *                 Set the y-axis lower bound to the minimum of the displayed
+ *                 data instead of zero, making small fluctuations between
+ *                 series easier to see.
+ *               default: false
  *
  *     BarRawSqlChartConfig:
  *       description: Raw SQL configuration for a stacked-bar time-series chart.
@@ -857,6 +878,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *               type: boolean
  *               description: Expand date range boundaries to the query granularity interval.
  *               default: true
+ *             fitYAxisToData:
+ *               type: boolean
+ *               description: >
+ *                 Set the y-axis lower bound to the minimum of the displayed
+ *                 data instead of zero, making small fluctuations between
+ *                 series easier to see.
+ *               default: false
  *
  *     TableRawSqlChartConfig:
  *       description: Raw SQL configuration for a table chart.

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -537,13 +537,6 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           type: boolean
  *           description: Fill missing time buckets with zero instead of leaving gaps.
  *           default: true
- *         fitYAxisToData:
- *           type: boolean
- *           description: >
- *             Set the y-axis lower bound to the minimum of the displayed data
- *             instead of zero, making small fluctuations between series easier
- *             to see.
- *           default: false
  *         numberFormat:
  *           $ref: '#/components/schemas/NumberFormat'
  *           description: Number formatting options for displayed values.
@@ -878,13 +871,6 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *               type: boolean
  *               description: Expand date range boundaries to the query granularity interval.
  *               default: true
- *             fitYAxisToData:
- *               type: boolean
- *               description: >
- *                 Set the y-axis lower bound to the minimum of the displayed
- *                 data instead of zero, making small fluctuations between
- *                 series easier to see.
- *               default: false
  *
  *     TableRawSqlChartConfig:
  *       description: Raw SQL configuration for a table chart.

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -175,7 +175,6 @@ const convertToExternalTileChartConfig = (
           sourceId: config.source,
           alignDateRangeToGranularity: config.alignDateRangeToGranularity,
           fillNulls: config.fillNulls !== false,
-          fitYAxisToData: config.fitYAxisToData,
           numberFormat: config.numberFormat,
         };
       case DisplayType.Table:
@@ -263,7 +262,6 @@ const convertToExternalTileChartConfig = (
           config.select.length == 2,
         alignDateRangeToGranularity: config.alignDateRangeToGranularity,
         fillNulls: config.fillNulls !== false,
-        fitYAxisToData: config.fitYAxisToData,
         groupBy: stringValueOrDefault(config.groupBy, undefined),
         select: Array.isArray(config.select)
           ? config.select.map(convertToExternalSelectItem)

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -162,6 +162,7 @@ const convertToExternalTileChartConfig = (
           sourceId: config.source,
           alignDateRangeToGranularity: config.alignDateRangeToGranularity,
           fillNulls: config.fillNulls !== false,
+          fitYAxisToData: config.fitYAxisToData,
           numberFormat: config.numberFormat,
           compareToPreviousPeriod: config.compareToPreviousPeriod,
         };
@@ -174,6 +175,7 @@ const convertToExternalTileChartConfig = (
           sourceId: config.source,
           alignDateRangeToGranularity: config.alignDateRangeToGranularity,
           fillNulls: config.fillNulls !== false,
+          fitYAxisToData: config.fitYAxisToData,
           numberFormat: config.numberFormat,
         };
       case DisplayType.Table:
@@ -243,6 +245,7 @@ const convertToExternalTileChartConfig = (
           config.select.length == 2,
         alignDateRangeToGranularity: config.alignDateRangeToGranularity,
         fillNulls: config.fillNulls !== false,
+        fitYAxisToData: config.fitYAxisToData,
         groupBy: stringValueOrDefault(config.groupBy, undefined),
         select: Array.isArray(config.select)
           ? config.select.map(convertToExternalSelectItem)
@@ -260,6 +263,7 @@ const convertToExternalTileChartConfig = (
           config.select.length == 2,
         alignDateRangeToGranularity: config.alignDateRangeToGranularity,
         fillNulls: config.fillNulls !== false,
+        fitYAxisToData: config.fitYAxisToData,
         groupBy: stringValueOrDefault(config.groupBy, undefined),
         select: Array.isArray(config.select)
           ? config.select.map(convertToExternalSelectItem)
@@ -541,6 +545,7 @@ export function convertToInternalTileConfig(
             'numberFormat',
             'alignDateRangeToGranularity',
             'compareToPreviousPeriod',
+            'fitYAxisToData',
           ]),
           displayType:
             externalConfig.displayType === 'stacked_bar'
@@ -593,6 +598,7 @@ export function convertToInternalTileConfig(
             'numberFormat',
             'alignDateRangeToGranularity',
             'compareToPreviousPeriod',
+            'fitYAxisToData',
           ]),
           displayType:
             externalConfig.displayType === 'stacked_bar'

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -248,6 +248,7 @@ const externalDashboardTimeChartConfigSchema = z.object({
   asRatio: z.boolean().optional(),
   alignDateRangeToGranularity: z.boolean().optional(),
   fillNulls: z.boolean().optional(),
+  fitYAxisToData: z.boolean().optional(),
   numberFormat: NumberFormatSchema.optional(),
 });
 
@@ -263,6 +264,7 @@ const externalDashboardLineRawSqlChartConfigSchema =
     compareToPreviousPeriod: z.boolean().optional(),
     fillNulls: z.boolean().optional(),
     alignDateRangeToGranularity: z.boolean().optional(),
+    fitYAxisToData: z.boolean().optional(),
   });
 
 const externalDashboardBarChartConfigSchema =
@@ -275,6 +277,7 @@ const externalDashboardBarRawSqlChartConfigSchema =
     displayType: z.literal('stacked_bar'),
     fillNulls: z.boolean().optional(),
     alignDateRangeToGranularity: z.boolean().optional(),
+    fitYAxisToData: z.boolean().optional(),
   });
 
 const externalDashboardTableChartConfigSchema = z.object({

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -248,7 +248,6 @@ const externalDashboardTimeChartConfigSchema = z.object({
   asRatio: z.boolean().optional(),
   alignDateRangeToGranularity: z.boolean().optional(),
   fillNulls: z.boolean().optional(),
-  fitYAxisToData: z.boolean().optional(),
   numberFormat: NumberFormatSchema.optional(),
 });
 
@@ -256,6 +255,7 @@ const externalDashboardLineChartConfigSchema =
   externalDashboardTimeChartConfigSchema.extend({
     displayType: z.literal('line'),
     compareToPreviousPeriod: z.boolean().optional(),
+    fitYAxisToData: z.boolean().optional(),
   });
 
 const externalDashboardLineRawSqlChartConfigSchema =
@@ -277,7 +277,6 @@ const externalDashboardBarRawSqlChartConfigSchema =
     displayType: z.literal('stacked_bar'),
     fillNulls: z.boolean().optional(),
     alignDateRangeToGranularity: z.boolean().optional(),
-    fitYAxisToData: z.boolean().optional(),
   });
 
 const externalDashboardTableChartConfigSchema = z.object({

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -354,6 +354,7 @@ export const MemoChart = memo(function MemoChart({
   onToggleSeries,
   granularity,
   dateRangeEndInclusive = true,
+  fitYAxisToData = false,
 }: {
   graphResults: any[];
   setIsClickActive: (v: any) => void;
@@ -375,6 +376,11 @@ export const MemoChart = memo(function MemoChart({
   onToggleSeries?: (seriesName: string, isShiftKey?: boolean) => void;
   granularity: string;
   dateRangeEndInclusive?: boolean;
+  /**
+   * When true, the y-axis lower bound is the minimum of the displayed data
+   * (with padding) instead of zero.
+   **/
+  fitYAxisToData?: boolean;
 }) {
   const _id = useId();
   const id = _id.replace(/:/g, '');
@@ -441,20 +447,23 @@ export const MemoChart = memo(function MemoChart({
   const yAxisDomain: AxisDomain = useMemo(() => {
     const hasSelection = selectedSeriesNames && selectedSeriesNames.size > 0;
 
-    if (!hasSelection) {
-      // No selection, let Recharts auto-calculate based on all data
+    // The data min/max is only needed to either zoom into a selection or to
+    // fit the lower bound to the data. When neither applies, let Recharts
+    // auto-calculate the upper bound while pinning the lower bound to zero.
+    if (!hasSelection && !fitYAxisToData) {
       return [0, 'auto'];
     }
 
-    // When series are selected, calculate domain based only on visible series
+    // Calculate domain based on visible series (all series when there's no
+    // explicit selection).
     let minValue = Infinity;
     let maxValue = -Infinity;
 
     graphResults.forEach(dataPoint => {
       lineData.forEach(ld => {
         const seriesName = ld.displayName || ld.dataKey;
-        // Only consider selected series
-        if (selectedSeriesNames.has(seriesName)) {
+        // Only consider visible series
+        if (!hasSelection || selectedSeriesNames.has(seriesName)) {
           const value = dataPoint[ld.dataKey];
           if (typeof value === 'number' && !isNaN(value)) {
             minValue = Math.min(minValue, value);
@@ -466,15 +475,21 @@ export const MemoChart = memo(function MemoChart({
 
     // If we found valid values, return them with some padding
     if (minValue !== Infinity && maxValue !== -Infinity) {
-      const padding = (maxValue - minValue) * 0.1; // 10% padding
-      return [
-        Math.max(0, minValue - padding), // Don't go below 0
-        maxValue + padding,
-      ];
+      const padding = (maxValue - minValue) * 0.05; // 5% padding
+      // When fitting to data, allow the lower bound to follow the data
+      // minimum; otherwise keep it pinned at zero. The 5% padding must not
+      // drag the axis below zero unless the data itself is negative, so
+      // clamp at zero whenever the minimum is non-negative.
+      const lowerBound =
+        fitYAxisToData && minValue < 0
+          ? minValue - padding
+          : Math.max(0, minValue - padding);
+      const upperBound = maxValue + padding;
+      return [lowerBound, upperBound];
     }
 
     return ['auto', 'auto'];
-  }, [graphResults, lineData, selectedSeriesNames]);
+  }, [graphResults, lineData, selectedSeriesNames, fitYAxisToData]);
 
   const sizeRef = useRef<[number, number]>([0, 0]);
   const [containerWidth, setContainerWidth] = useState(0);

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -447,10 +447,16 @@ export const MemoChart = memo(function MemoChart({
   const yAxisDomain: AxisDomain = useMemo(() => {
     const hasSelection = selectedSeriesNames && selectedSeriesNames.size > 0;
 
+    // Fitting the y-axis lower bound to the data only applies to line charts.
+    // Bar charts are always anchored at zero so the bar lengths stay
+    // proportional to their values.
+    const shouldFitYAxis =
+      fitYAxisToData && displayType !== DisplayType.StackedBar;
+
     // The data min/max is only needed to either zoom into a selection or to
     // fit the lower bound to the data. When neither applies, let Recharts
     // auto-calculate the upper bound while pinning the lower bound to zero.
-    if (!hasSelection && !fitYAxisToData) {
+    if (!hasSelection && !shouldFitYAxis) {
       return [0, 'auto'];
     }
 
@@ -481,7 +487,7 @@ export const MemoChart = memo(function MemoChart({
       // drag the axis below zero unless the data itself is negative, so
       // clamp at zero whenever the minimum is non-negative.
       const lowerBound =
-        fitYAxisToData && minValue < 0
+        shouldFitYAxis && minValue < 0
           ? minValue - padding
           : Math.max(0, minValue - padding);
       const upperBound = maxValue + padding;
@@ -489,7 +495,13 @@ export const MemoChart = memo(function MemoChart({
     }
 
     return ['auto', 'auto'];
-  }, [graphResults, lineData, selectedSeriesNames, fitYAxisToData]);
+  }, [
+    graphResults,
+    lineData,
+    selectedSeriesNames,
+    fitYAxisToData,
+    displayType,
+  ]);
 
   const sizeRef = useRef<[number, number]>([0, 0]);
   const [containerWidth, setContainerWidth] = useState(0);

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -172,7 +172,7 @@ export default function ChartDisplaySettingsDrawer({
               name="fitYAxisToData"
               size="xs"
               label="Fit Y-Axis to Data"
-              description="Start the y-axis at the minimum of the displayed data instead of zero"
+              description="Start the y-axis at the minimum of the displayed data instead of zero. Only applicable to line charts."
             />
             <Divider />
           </>

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -30,6 +30,7 @@ export type ChartConfigDisplaySettings = Pick<
   | 'alignDateRangeToGranularity'
   | 'fillNulls'
   | 'compareToPreviousPeriod'
+  | 'fitYAxisToData'
   | 'color'
 > & {
   groupByColumnsOnLeft?: boolean;
@@ -63,6 +64,7 @@ function applyDefaultSettings(
         : settings.alignDateRangeToGranularity,
     fillNulls: settings.fillNulls ?? 0,
     compareToPreviousPeriod: settings.compareToPreviousPeriod ?? false,
+    fitYAxisToData: settings.fitYAxisToData ?? false,
     groupByColumnsOnLeft: settings.groupByColumnsOnLeft ?? false,
     color: settings.color,
   };
@@ -164,6 +166,13 @@ export default function ChartDisplaySettingsDrawer({
                   </>
                 )
               }
+            />
+            <CheckBoxControlled
+              control={control}
+              name="fitYAxisToData"
+              size="xs"
+              label="Fit Y-Axis to Data"
+              description="Start the y-axis at the minimum of the displayed data instead of zero"
             />
             <Divider />
           </>

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -221,6 +221,7 @@ export default function EditTimeChartForm({
     alignDateRangeToGranularity,
     fillNulls,
     compareToPreviousPeriod,
+    fitYAxisToData,
     numberFormat,
     groupByColumnsOnLeft,
     color,
@@ -230,6 +231,7 @@ export default function EditTimeChartForm({
       'alignDateRangeToGranularity',
       'fillNulls',
       'compareToPreviousPeriod',
+      'fitYAxisToData',
       'numberFormat',
       'groupByColumnsOnLeft',
       'color',
@@ -250,6 +252,7 @@ export default function EditTimeChartForm({
       alignDateRangeToGranularity,
       fillNulls,
       compareToPreviousPeriod,
+      fitYAxisToData,
       numberFormat,
       groupByColumnsOnLeft,
       color,
@@ -258,6 +261,7 @@ export default function EditTimeChartForm({
       alignDateRangeToGranularity,
       fillNulls,
       compareToPreviousPeriod,
+      fitYAxisToData,
       numberFormat,
       groupByColumnsOnLeft,
       color,
@@ -539,6 +543,7 @@ export default function EditTimeChartForm({
       alignDateRangeToGranularity,
       fillNulls,
       compareToPreviousPeriod,
+      fitYAxisToData,
       groupByColumnsOnLeft,
       color,
     }: ChartConfigDisplaySettings) => {
@@ -546,6 +551,7 @@ export default function EditTimeChartForm({
       setValue('alignDateRangeToGranularity', alignDateRangeToGranularity);
       setValue('fillNulls', fillNulls);
       setValue('compareToPreviousPeriod', compareToPreviousPeriod);
+      setValue('fitYAxisToData', fitYAxisToData);
       setValue('groupByColumnsOnLeft', groupByColumnsOnLeft);
       setValue('color', color);
       onSubmit();

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -740,6 +740,7 @@ function DBTimeChartComponent({
             onToggleSeries={handleToggleSeries}
             granularity={granularity}
             dateRangeEndInclusive={queriedConfig.dateRangeEndInclusive}
+            fitYAxisToData={queriedConfig.fitYAxisToData}
           />
         </>
       )}

--- a/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
+++ b/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
@@ -109,4 +109,68 @@ describe('ChartDisplaySettingsDrawer', () => {
       });
     });
   });
+
+  describe('fit y-axis to data setting', () => {
+    it('shows the "Fit Y-Axis to Data" checkbox for line charts', () => {
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...baseProps}
+          displayType={DisplayType.Line}
+        />,
+      );
+
+      expect(
+        screen.getByRole('checkbox', { name: /fit y-axis to data/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the "Fit Y-Axis to Data" checkbox for table charts', () => {
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...baseProps}
+          displayType={DisplayType.Table}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('checkbox', { name: /fit y-axis to data/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('defaults to unchecked (lower bound = 0)', () => {
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...baseProps}
+          displayType={DisplayType.Line}
+        />,
+      );
+
+      expect(
+        screen.getByRole('checkbox', { name: /fit y-axis to data/i }),
+      ).not.toBeChecked();
+    });
+
+    it('calls onChange with fitYAxisToData = true when enabled and applied', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...baseProps}
+          displayType={DisplayType.Line}
+          onChange={onChange}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole('checkbox', { name: /fit y-axis to data/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toMatchObject({
+        fitYAxisToData: true,
+      });
+    });
+  });
 });

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -861,6 +861,7 @@ const SharedChartSettingsSchema = z.object({
   compareToPreviousPeriod: z.boolean().optional(),
   fillNulls: z.union([z.number(), z.literal(false)]).optional(),
   alignDateRangeToGranularity: z.boolean().optional(),
+  fitYAxisToData: z.boolean().optional(),
   onClick: OnClickSchema.optional(),
   // Palette-token color override. Applied by the renderer for number
   // tiles only (gated in `ChartDisplaySettingsDrawer`); other display


### PR DESCRIPTION
# Summary

Adds an optional `fitYAxisToData` display setting for line charts. When enabled, the y-axis lower bound follows the minimum of the displayed data (with padding) instead of being pinned at zero, making small fluctuations between series easier to see. The default remains lower bound = 0.

The setting appears in Display Settings for Line and Stacked Bar charts, persists on the chart config, and is exposed in the External API v2 line chart schemas.

Closes #1619

## Demo


https://github.com/user-attachments/assets/7c4ab4c8-962d-4526-9dc2-6c997b477f9f



## How to test

This can be tested in the preview environment

Closes #1619 Closes HDX-3242