### PR TITLE
fix: Fix height of source select RHS menu

### DIFF
--- a/.changeset/smooth-turkeys-dream.md
+++ b/.changeset/smooth-turkeys-dream.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix height of source select RHS menu

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -46,6 +46,7 @@ interface SourceManagementMenuProps {
    */
   onManageSources?: () => void;
   onCreate?: () => void;
+  size?: string;
 }
 
 /**
@@ -63,6 +64,7 @@ interface SourceManagementMenuProps {
  */
 export const SourceManagementMenu = ({
   hasSelection,
+  size = 'sm',
   onSchemaPreview,
   isSchemaPreviewEnabled = true,
   onEdit,
@@ -133,7 +135,7 @@ export const SourceManagementMenu = ({
           <ActionIcon
             variant="subtle"
             color="gray"
-            size="input-xs"
+            size={`input-${size}`}
             className={styles.sourceMenuButton}
             data-testid="source-actions-menu"
             aria-label="Source actions"
@@ -236,6 +238,7 @@ function SourceSelectControlledComponent({
       {hasMenu && (
         <SourceManagementMenu
           hasSelection={hasSelection}
+          size={size}
           onSchemaPreview={onSchemaPreview}
           isSchemaPreviewEnabled={isSchemaPreviewEnabled}
           onEdit={onEdit}

--- a/packages/app/styles/SourceSelectControlled.module.scss
+++ b/packages/app/styles/SourceSelectControlled.module.scss
@@ -46,14 +46,13 @@
       border-bottom-left-radius: var(--mantine-radius-default);
     }
 
-    /* Square only the left edge of the kebab. Fixed 30px height matches the
-     * input chip; -1px margin overlaps the input's right edge so the shared
-     * border is one pixel wide, not two. */
+    /* Square only the left edge of the kebab. The ActionIcon's `input-*`
+     * size (driven by the adjacent Select's `size`) makes it square and
+     * matches the input chip's height; -1px margin overlaps the input's
+     * right edge so the shared border is one pixel wide, not two. */
     .sourceMenuButton {
       --ai-radius: 0;
 
-      width: 30px;
-      height: 30px;
       margin-left: -1px;
       background-color: var(--color-bg-field-addon);
       border: 1px solid var(--input-bd, var(--color-border));


### PR DESCRIPTION
## Summary

This PR ensures the height of the RHS kebab menu on the source select component matches the height of the source select input.

### Screenshots or video

Before:

<img width="330" height="98" alt="Screenshot 2026-06-04 at 1 25 37 PM" src="https://github.com/user-attachments/assets/da02d64e-ba3e-4445-b255-37915102ca3c" />

After:

<img width="346" height="78" alt="Screenshot 2026-06-04 at 1 31 20 PM" src="https://github.com/user-attachments/assets/8cef7357-3c49-4036-8810-88c68f89a095" />
<img width="332" height="98" alt="Screenshot 2026-06-04 at 1 31 14 PM" src="https://github.com/user-attachments/assets/c25d5b99-6dc6-4c5a-a126-d680b5fee5b6" />

### How to test on Vercel preview

This can be tested on the preview, wherever the source select is available.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue:
- Related PRs:
