### PR TITLE
fix(mcp): reduce describe_source timeouts by using rollup tables for map key discovery

### DIFF
--- a/.changeset/fix-describe-source-timeout.md
+++ b/.changeset/fix-describe-source-timeout.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix(mcp): reduce describe_source timeouts by using rollup tables for map key discovery

--- a/packages/api/src/mcp/tools/sources/describeSource.ts
+++ b/packages/api/src/mcp/tools/sources/describeSource.ts
@@ -185,6 +185,7 @@ async function describeSourceSchema(
             connectionId,
             metadataMVs,
             dateRange,
+            signal,
           });
           mapKeysResults[col.name] = keys;
         } catch (e) {

--- a/packages/api/src/mcp/tools/sources/describeSource.ts
+++ b/packages/api/src/mcp/tools/sources/describeSource.ts
@@ -143,6 +143,19 @@ async function describeSourceSchema(
   // Track which sampling stages were skipped due to timeout
   const skippedStages: string[] = [];
 
+  // Shared by stages 2–4 so map-key discovery can use rollup tables
+  // instead of falling back to expensive main-table scans.
+  const metadataMVs =
+    'metadataMaterializedViews' in source
+      ? source.metadataMaterializedViews
+      : undefined;
+
+  const now = new Date();
+  const dateRange: [Date, Date] = [
+    new Date(now.getTime() - VALUE_SAMPLE_LOOKBACK_MS),
+    now,
+  ];
+
   // ── 1. Column schema ──────────────────────────────────────────────────
   const columns = await metadata.getColumns({
     databaseName,
@@ -170,6 +183,8 @@ async function describeSourceSchema(
             column: col.name,
             maxKeys: 50,
             connectionId,
+            metadataMVs,
+            dateRange,
           });
           mapKeysResults[col.name] = keys;
         } catch (e) {
@@ -199,17 +214,6 @@ async function describeSourceSchema(
   });
 
   const lowCardinalityValues: Record<string, string[]> = {};
-
-  const metadataMVs =
-    'metadataMaterializedViews' in source
-      ? source.metadataMaterializedViews
-      : undefined;
-
-  const now = new Date();
-  const dateRange: [Date, Date] = [
-    new Date(now.getTime() - VALUE_SAMPLE_LOOKBACK_MS),
-    now,
-  ];
 
   if (lcColumns.length > 0 && !signal.aborted) {
     try {

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -640,6 +640,7 @@ export class Metadata {
     connectionId,
     dateRange,
     timestampValueExpression,
+    signal,
   }: {
     databaseName: string;
     tableName: string;
@@ -649,6 +650,7 @@ export class Metadata {
     dateRange?: [Date, Date];
     timestampValueExpression?: string;
     connectionId: string;
+    signal?: AbortSignal;
   }) {
     const dateRangeCacheSuffix =
       dateRange && timestampValueExpression
@@ -719,6 +721,7 @@ export class Metadata {
             read_overflow_mode: 'break',
             ...this.getClickHouseSettings(),
           },
+          abort_signal: signal,
         })
         .then(res => res.json<{ value: string }>())
         .then(d => d.data.map(row => row.value));
@@ -1464,6 +1467,7 @@ export class Metadata {
             connectionId,
             dateRange,
             timestampValueExpression,
+            signal,
           });
           return { key: p.keyExpression, value: fallback };
         }),
@@ -1482,6 +1486,7 @@ export class Metadata {
           connectionId,
           dateRange,
           timestampValueExpression,
+          signal,
         });
         return { key: p.keyExpression, value };
       }),

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -351,6 +351,7 @@ export class Metadata {
     metadataMVs,
     dateRange,
     timestampValueExpression,
+    signal,
   }: {
     databaseName: string;
     tableName: string;
@@ -361,6 +362,7 @@ export class Metadata {
     metadataMVs?: MetadataMaterializedViews;
     dateRange?: [Date, Date];
     timestampValueExpression?: string;
+    signal?: AbortSignal;
   }) {
     // Align date range to rollup granularity for consistent cache keys
     const alignedDateRange =
@@ -419,6 +421,7 @@ export class Metadata {
                   max_execution_time: 15,
                   max_rows_to_read: '0',
                 },
+                abort_signal: signal,
               })
               .then(res => res.json<{ Key: string }>())
               .then(d => d.data.map(row => row.Key).filter(k => k));
@@ -524,6 +527,7 @@ export class Metadata {
             // Set the value to 0 (unlimited) so that the LIMIT is used instead
             max_rows_to_read: '0',
           },
+          abort_signal: signal,
         })
         .then(res => res.json<{ keysArr?: string[]; key?: string }>())
         .then(d => {


### PR DESCRIPTION
## Summary

`clickstack_describe_source` can time out (10s wall-clock limit) when discovering map attribute keys on large tables. Stage 2 (map key discovery) was always falling back to a full main-table scan—up to 3M rows per Map column—even when rollup tables were available, because `metadataMVs` and `dateRange` weren't computed yet at that point in the pipeline.

This hoists the rollup config and date range above Stage 2 so `getMapKeys` can use the fast rollup path. On the traces table in large environments this reduces Stage 2 from ~5-10s to <1s, keeping the full describe call well within the 10s budget.

Additionally, `getMapValues` now accepts an `AbortSignal` so that any per-key fallback queries are cancelled when the timeout fires, rather than running to completion against ClickHouse after the caller has already given up.