### PR TITLE
feat: add source field suggestions

### DIFF
--- a/.changeset/polite-moons-give.md
+++ b/.changeset/polite-moons-give.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: add source field suggestions

--- a/packages/app/src/components/Sources/ExpressionValidationStatus.tsx
+++ b/packages/app/src/components/Sources/ExpressionValidationStatus.tsx
@@ -1,0 +1,45 @@
+import { Box, MantineSpacing, Text } from '@mantine/core';
+
+import { ErrorCollapse } from '@/components/Error/ErrorCollapse';
+import {
+  TableConnectionLike,
+  useExpressionValidation,
+} from '@/hooks/useExpressionValidation';
+
+export function ExpressionValidationStatus({
+  expression,
+  tableConnection,
+  mt = 'xs',
+}: {
+  expression: string;
+  tableConnection: TableConnectionLike;
+  mt?: MantineSpacing;
+}) {
+  const { shouldShowResult, isInvalid, isValid, error } =
+    useExpressionValidation({ expression, tableConnection });
+
+  if (!shouldShowResult) {
+    return null;
+  }
+
+  if (isInvalid) {
+    return (
+      <Box mt={mt}>
+        <ErrorCollapse
+          summary="Expression is invalid"
+          details={error?.message}
+        />
+      </Box>
+    );
+  }
+
+  if (isValid) {
+    return (
+      <Text c="green" size="xs" mt={mt}>
+        Expression is valid.
+      </Text>
+    );
+  }
+
+  return null;
+}

--- a/packages/app/src/components/Sources/SourceFieldCandidateHint.tsx
+++ b/packages/app/src/components/Sources/SourceFieldCandidateHint.tsx
@@ -1,0 +1,61 @@
+import { Anchor, Code, Group, Text } from '@mantine/core';
+import { IconBulb } from '@tabler/icons-react';
+
+import { FieldCandidates } from '@/utils/sourceFieldSuggestions';
+
+export function SourceFieldCandidateHint({
+  candidates,
+  onApply,
+}: {
+  candidates?: FieldCandidates;
+  onApply: (value: string) => void;
+}) {
+  if (!candidates) {
+    return null;
+  }
+
+  const { canonical, alternates } = candidates;
+
+  if (!canonical && alternates.length === 0) {
+    return null;
+  }
+
+  return (
+    <Group gap={6} mt={4} align="center" wrap="wrap">
+      <IconBulb size={13} color="var(--mantine-color-yellow-6)" />
+      {canonical ? (
+        <>
+          <Text size="xs" c="dimmed">
+            Detected
+          </Text>
+          <Anchor size="xs" onClick={() => onApply(canonical)}>
+            <Code>{canonical}</Code> — apply
+          </Anchor>
+        </>
+      ) : (
+        <Text size="xs" c="dimmed">
+          Multiple candidates:
+        </Text>
+      )}
+      {alternates.length > 0 && (
+        <>
+          {canonical && (
+            <Text size="xs" c="dimmed">
+              Other candidates:
+            </Text>
+          )}
+          {alternates.map(name => (
+            <Anchor
+              key={name}
+              size="xs"
+              c="dimmed"
+              onClick={() => onApply(name)}
+            >
+              <Code>{name}</Code>
+            </Anchor>
+          ))}
+        </>
+      )}
+    </Group>
+  );
+}

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -2,6 +2,7 @@ import React, {
   Fragment,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -14,7 +15,10 @@ import {
   useWatch,
 } from 'react-hook-form';
 import { z } from 'zod';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+import {
+  ClickHouseQueryError,
+  ColumnMetaType,
+} from '@hyperdx/common-utils/dist/clickhouse';
 import {
   MetricsDataType,
   SourceKind,
@@ -33,6 +37,7 @@ import {
   Flex,
   Grid,
   Group,
+  Modal,
   Radio,
   Select,
   Slider,
@@ -61,7 +66,8 @@ import {
 } from '@/config';
 import { useConnections } from '@/connection';
 import { useExplainQuery } from '@/hooks/useExplainQuery';
-import { useMetadataWithSettings } from '@/hooks/useMetadata';
+import { useExpressionValidation } from '@/hooks/useExpressionValidation';
+import { useColumns, useMetadataWithSettings } from '@/hooks/useMetadata';
 import {
   inferTableSourceConfig,
   isValidMetricTable,
@@ -77,6 +83,12 @@ import {
   MV_AGGREGATE_FUNCTIONS,
   MV_GRANULARITY_OPTIONS,
 } from '@/utils/materializedViews';
+import {
+  getSourceConfigPairingWarnings,
+  inferSourceFieldCandidates,
+  PairingWarning,
+  SourceFieldKind,
+} from '@/utils/sourceFieldSuggestions';
 
 import ConfirmDeleteMenu from '../ConfirmDeleteMenu';
 import { ConnectionSelectControlled } from '../ConnectionSelect';
@@ -85,6 +97,9 @@ import { DBTableSelectControlled } from '../DBTableSelect';
 import { ErrorCollapse } from '../Error/ErrorCollapse';
 import { InputControlled } from '../InputControlled';
 import SelectControlled from '../SelectControlled';
+
+import { ExpressionValidationStatus } from './ExpressionValidationStatus';
+import { SourceFieldCandidateHint } from './SourceFieldCandidateHint';
 
 type CorrelationField =
   | 'logSourceId'
@@ -167,6 +182,17 @@ const MV_AGGREGATE_FUNCTION_OPTIONS = MV_AGGREGATE_FUNCTIONS.map(fn => ({
 const OTEL_CLICKHOUSE_EXPRESSIONS = {
   timestampValueExpression: 'TimeUnix',
   resourceAttributesExpression: 'ResourceAttributes',
+};
+
+const SOURCE_FIELD_LABELS: Record<SourceFieldKind, string> = {
+  bodyExpression: 'Body Expression',
+  implicitColumnExpression: 'Implicit Column Expression',
+  serviceNameExpression: 'Service Name Expression',
+  severityTextExpression: 'Log Level Expression',
+  eventAttributesExpression: 'Event Attributes Expression',
+  resourceAttributesExpression: 'Resource Attributes Expression',
+  traceIdExpression: 'Trace Id Expression',
+  spanIdExpression: 'Span Id Expression',
 };
 
 const CORRELATION_FIELD_MAP: Record<
@@ -261,6 +287,67 @@ function FormRow({
   );
 }
 
+function ExpressionFormRow({
+  control,
+  setValue,
+  name,
+  label,
+  placeholder,
+  helpText,
+  columns,
+  sourceKind,
+  tableConnection,
+}: {
+  control: Control<TSource>;
+  setValue: UseFormSetValue<TSource>;
+  name: SourceFieldKind;
+  label: string;
+  placeholder?: string;
+  helpText?: string;
+  columns?: ColumnMetaType[];
+  sourceKind: SourceKind;
+  tableConnection: {
+    databaseName: string;
+    tableName: string;
+    connectionId: string;
+  };
+}) {
+  const currentValue = useWatch({ control, name });
+  const value = typeof currentValue === 'string' ? currentValue : '';
+
+  const candidates = useMemo(
+    () =>
+      columns
+        ? inferSourceFieldCandidates(columns, name, sourceKind)
+        : undefined,
+    [columns, name, sourceKind],
+  );
+
+  return (
+    <FormRow label={label} helpText={helpText}>
+      <SQLInlineEditorControlled
+        tableConnection={tableConnection}
+        control={control}
+        name={name}
+        placeholder={placeholder}
+      />
+      {value.trim() ? (
+        <ExpressionValidationStatus
+          expression={value}
+          tableConnection={tableConnection}
+        />
+      ) : (
+        <SourceFieldCandidateHint
+          candidates={candidates}
+          onApply={applied => {
+            setValue(name, applied, { shouldDirty: true });
+          }}
+        />
+      )}
+    </FormRow>
+  );
+}
+
 type HighlightedAttributeRowProps = Omit<TableModelProps, 'setValue'> & {
   id: string;
   index: number;
@@ -293,61 +380,18 @@ function HighlightedAttributeRow({
     name: `${name}.${index}.alias`,
   });
 
-  const [explainParams, setExplainParams] = useState<{
-    expression: typeof expressionInput;
-    alias: typeof aliasInput;
-  }>();
-
-  const setExplainParamsDebounced = useDebouncedCallback(
-    (params: typeof explainParams) => {
-      setExplainParams(params);
-    },
-    1_000,
-  );
-
-  useDidUpdate(() => {
-    setExplainParamsDebounced({
-      expression: expressionInput,
-      alias: aliasInput,
-    });
-  }, [expressionInput, aliasInput]);
-
   const {
-    data: explainData,
-    error: explainError,
-    isLoading: explainLoading,
-  } = useExplainQuery(
-    {
-      from: { databaseName, tableName },
-      connection: connectionId,
-      select: [
-        {
-          alias: explainParams?.alias,
-          valueExpression: explainParams?.expression ?? '',
-        },
-      ],
-      where: '',
-    },
-
-    {
-      enabled: !!explainParams?.expression,
-    },
-  );
-
-  const runExpression = () => {
-    setExplainParams({
-      expression: expressionInput,
-      alias: aliasInput,
-    });
-  };
-
-  const isExpressionValid = !!explainData?.length;
-  const isExpressionInvalid = explainError instanceof ClickHouseQueryError;
-
-  const shouldShowResult =
-    explainParams?.expression === expressionInput &&
-    explainParams?.alias === aliasInput &&
-    (isExpressionValid || isExpressionInvalid);
+    isLoading: isExplainLoading,
+    validateNow,
+    shouldShowResult,
+    isValid,
+    isInvalid,
+    error,
+  } = useExpressionValidation({
+    expression: expressionInput,
+    alias: aliasInput,
+    tableConnection: { databaseName, tableName, connectionId },
+  });
 
   return (
     <React.Fragment key={id}>
@@ -383,9 +427,9 @@ function HighlightedAttributeRow({
               size="xs"
               variant="subtle"
               color="gray"
-              loading={explainLoading}
-              disabled={!expressionInput || explainLoading}
-              onClick={runExpression}
+              loading={isExplainLoading}
+              disabled={!expressionInput || isExplainLoading}
+              onClick={validateNow}
             >
               <IconCheck size={16} />
             </ActionIcon>
@@ -403,15 +447,15 @@ function HighlightedAttributeRow({
 
       {shouldShowResult && (
         <Grid.Col span={5} pe={0} pt={0}>
-          {isExpressionValid && (
+          {isValid && (
             <Text c="green" size="xs">
               Expression is valid.
             </Text>
           )}
-          {isExpressionInvalid && (
+          {isInvalid && (
             <ErrorCollapse
               summary="Expression is invalid"
-              details={explainError?.message}
+              details={error?.message}
             />
           )}
         </Grid.Col>
@@ -1207,7 +1251,7 @@ function UseTextIndexFormRow({ control }: { control: Control<TSource> }) {
 }
 
 function LogTableModelForm(props: TableModelProps) {
-  const { control } = props;
+  const { control, setValue } = props;
   const brandName = useBrandDisplayName();
   const databaseName = useWatch({
     control,
@@ -1216,6 +1260,13 @@ function LogTableModelForm(props: TableModelProps) {
   });
   const tableName = useWatch({ control, name: 'from.tableName' });
   const connectionId = useWatch({ control, name: 'connection' });
+
+  const tableConnection = { databaseName, tableName, connectionId };
+  const { data: columns } = useColumns({
+    databaseName,
+    tableName,
+    connectionId,
+  });
 
   const [showOptionalFields, setShowOptionalFields] = useState(false);
 
@@ -1283,66 +1334,56 @@ function LogTableModelForm(props: TableModelProps) {
         }}
       >
         <Divider />
-        <FormRow label={'Service Name Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="serviceNameExpression"
-            placeholder="ServiceName"
-          />
-        </FormRow>
-        <FormRow label={'Log Level Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="severityTextExpression"
-            placeholder="SeverityText"
-          />
-        </FormRow>
-        <FormRow label={'Body Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="bodyExpression"
-            placeholder="Body"
-          />
-        </FormRow>
-        <FormRow label={'Log Attributes Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="eventAttributesExpression"
-            placeholder="LogAttributes"
-          />
-        </FormRow>
-        <FormRow label={'Resource Attributes Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="resourceAttributesExpression"
-            placeholder="ResourceAttributes"
-          />
-        </FormRow>
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="serviceNameExpression"
+          label="Service Name Expression"
+          placeholder="ServiceName"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="severityTextExpression"
+          label="Log Level Expression"
+          placeholder="SeverityText"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="bodyExpression"
+          label="Body Expression"
+          placeholder="Body"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="eventAttributesExpression"
+          label="Log Attributes Expression"
+          placeholder="LogAttributes"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="resourceAttributesExpression"
+          label="Resource Attributes Expression"
+          placeholder="ResourceAttributes"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
         <FormRow
           label={'Displayed Timestamp Column'}
           helpText="This DateTime column is used to display and order search results."
@@ -1372,30 +1413,26 @@ function LogTableModelForm(props: TableModelProps) {
           <SourceSelectControlled control={control} name="traceSourceId" />
         </FormRow>
 
-        <FormRow label={'Trace Id Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="traceIdExpression"
-            placeholder="TraceId"
-          />
-        </FormRow>
-        <FormRow label={'Span Id Expression'}>
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="spanIdExpression"
-            placeholder="SpanId"
-          />
-        </FormRow>
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="traceIdExpression"
+          label="Trace Id Expression"
+          placeholder="TraceId"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="spanIdExpression"
+          label="Span Id Expression"
+          placeholder="SpanId"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
 
         <Divider />
         {/* <FormRow label={'Table Filter Expression'}>
@@ -1410,21 +1447,17 @@ function LogTableModelForm(props: TableModelProps) {
             placeholder="ServiceName = 'only_this_service'"
           />
         </FormRow> */}
-        <FormRow
-          label={'Implicit Column Expression'}
+        <ExpressionFormRow
+          control={control}
+          setValue={setValue}
+          name="implicitColumnExpression"
+          label="Implicit Column Expression"
           helpText="Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log."
-        >
-          <SQLInlineEditorControlled
-            tableConnection={{
-              databaseName,
-              tableName,
-              connectionId,
-            }}
-            control={control}
-            name="implicitColumnExpression"
-            placeholder="Body"
-          />
-        </FormRow>
+          placeholder="Body"
+          columns={columns}
+          sourceKind={SourceKind.Log}
+          tableConnection={tableConnection}
+        />
         <UseTextIndexFormRow control={control} />
         <Divider />
         <HighlightedAttributeExpressionsFormRow
@@ -1456,7 +1489,7 @@ function LogTableModelForm(props: TableModelProps) {
 }
 
 function TraceTableModelForm(props: TableModelProps) {
-  const { control } = props;
+  const { control, setValue } = props;
   const brandName = useBrandDisplayName();
   const databaseName = useWatch({
     control,
@@ -1465,6 +1498,13 @@ function TraceTableModelForm(props: TableModelProps) {
   });
   const tableName = useWatch({ control, name: 'from.tableName' });
   const connectionId = useWatch({ control, name: 'connection' });
+
+  const tableConnection = { databaseName, tableName, connectionId };
+  const { data: columns } = useColumns({
+    databaseName,
+    tableName,
+    connectionId,
+  });
 
   return (
     <Stack gap="sm">
@@ -1591,30 +1631,26 @@ function TraceTableModelForm(props: TableModelProps) {
           />
         </Box>
       </FormRow>
-      <FormRow label={'Trace Id Expression'}>
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="traceIdExpression"
-          placeholder="TraceId"
-        />
-      </FormRow>
-      <FormRow label={'Span Id Expression'}>
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="spanIdExpression"
-          placeholder="SpanId"
-        />
-      </FormRow>
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="traceIdExpression"
+        label="Trace Id Expression"
+        placeholder="TraceId"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="spanIdExpression"
+        label="Span Id Expression"
+        placeholder="SpanId"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
       <FormRow label={'Parent Span Id Expression'}>
         <SQLInlineEditorControlled
           tableConnection={{
@@ -1694,42 +1730,36 @@ function TraceTableModelForm(props: TableModelProps) {
           placeholder="StatusMessage"
         />
       </FormRow>
-      <FormRow label={'Service Name Expression'}>
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="serviceNameExpression"
-          placeholder="ServiceName"
-        />
-      </FormRow>
-      <FormRow label={'Resource Attributes Expression'}>
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="resourceAttributesExpression"
-          placeholder="ResourceAttributes"
-        />
-      </FormRow>
-      <FormRow label={'Event Attributes Expression'}>
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="eventAttributesExpression"
-          placeholder="SpanAttributes"
-        />
-      </FormRow>
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="serviceNameExpression"
+        label="Service Name Expression"
+        placeholder="ServiceName"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="resourceAttributesExpression"
+        label="Resource Attributes Expression"
+        placeholder="ResourceAttributes"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="eventAttributesExpression"
+        label="Event Attributes Expression"
+        placeholder="SpanAttributes"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
       <FormRow
         label={'Sample Rate Expression'}
         helpText="Column or expression for upstream sampling weight (1/N). When set, aggregations (count, avg, sum, quantile) are corrected for sampling. Percentiles use quantileTDigestWeighted, which is an approximation -- exact values may differ slightly. Leave empty if spans are not sampled."
@@ -1760,21 +1790,17 @@ function TraceTableModelForm(props: TableModelProps) {
           placeholder="Events"
         />
       </FormRow>
-      <FormRow
-        label={'Implicit Column Expression'}
+      <ExpressionFormRow
+        control={control}
+        setValue={setValue}
+        name="implicitColumnExpression"
+        label="Implicit Column Expression"
         helpText="Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log."
-      >
-        <SQLInlineEditorControlled
-          tableConnection={{
-            databaseName,
-            tableName,
-            connectionId,
-          }}
-          control={control}
-          name="implicitColumnExpression"
-          placeholder="SpanName"
-        />
-      </FormRow>
+        placeholder="SpanName"
+        columns={columns}
+        sourceKind={SourceKind.Trace}
+        tableConnection={tableConnection}
+      />
       <UseTextIndexFormRow control={control} />
       <FormRow
         label={'Displayed Timestamp Column'}
@@ -2296,6 +2322,40 @@ export function TableSourceForm({
     [setError],
   );
 
+  const [pendingSave, setPendingSave] = useState<{
+    warnings: PairingWarning[];
+    parsedData: any;
+    persist: (data: any) => void;
+  }>();
+
+  const applyPairingFix = useCallback(
+    (warning: PairingWarning) => {
+      if (!pendingSave || !warning.suggestedFix) {
+        return;
+      }
+
+      const { field, value } = warning.suggestedFix;
+
+      setValue(field, value, { shouldDirty: true });
+
+      const remaining = pendingSave.warnings.filter(w => w !== warning);
+
+      const patched = { ...pendingSave.parsedData, [field]: value };
+
+      if (remaining.length === 0) {
+        setPendingSave(undefined);
+        pendingSave.persist(patched);
+      } else {
+        setPendingSave({
+          ...pendingSave,
+          warnings: remaining,
+          parsedData: patched,
+        });
+      }
+    },
+    [pendingSave, setValue],
+  );
+
   const _onCreate = useCallback(() => {
     clearErrors();
     handleSubmit(async data => {
@@ -2305,58 +2365,68 @@ export function TableSourceForm({
         return;
       }
 
-      createSource.mutate(
-        { source: parseResult.data },
-        {
-          onSuccess: async newSource => {
-            // Handle bidirectional linking for new sources
-            const correlationFields = CORRELATION_FIELD_MAP[newSource.kind];
-            if (correlationFields && sources) {
-              for (const [fieldName, targetConfigs] of Object.entries(
-                correlationFields,
-              )) {
-                const targetSourceId = getCorrelationFieldValue(
-                  newSource,
-                  fieldName as CorrelationField,
-                );
-                if (targetSourceId) {
-                  for (const { targetKind, targetField } of targetConfigs) {
-                    const targetSource = sources.find(
-                      s => s.id === targetSourceId,
-                    );
-                    if (targetSource && targetSource.kind === targetKind) {
-                      // Only update if the target field is empty to avoid overwriting existing correlations
-                      if (
-                        !getCorrelationFieldValue(targetSource, targetField)
-                      ) {
-                        await updateSource.mutateAsync({
-                          source: setCorrelationFieldValue(
-                            targetSource,
-                            targetField,
-                            newSource.id,
-                          ),
-                        });
+      const persist = (source: typeof parseResult.data) =>
+        createSource.mutate(
+          { source },
+          {
+            onSuccess: async newSource => {
+              // Handle bidirectional linking for new sources
+              const correlationFields = CORRELATION_FIELD_MAP[newSource.kind];
+              if (correlationFields && sources) {
+                for (const [fieldName, targetConfigs] of Object.entries(
+                  correlationFields,
+                )) {
+                  const targetSourceId = getCorrelationFieldValue(
+                    newSource,
+                    fieldName as CorrelationField,
+                  );
+                  if (targetSourceId) {
+                    for (const { targetKind, targetField } of targetConfigs) {
+                      const targetSource = sources.find(
+                        s => s.id === targetSourceId,
+                      );
+                      if (targetSource && targetSource.kind === targetKind) {
+                        // Only update if the target field is empty to avoid overwriting existing correlations
+                        if (
+                          !getCorrelationFieldValue(targetSource, targetField)
+                        ) {
+                          await updateSource.mutateAsync({
+                            source: setCorrelationFieldValue(
+                              targetSource,
+                              targetField,
+                              newSource.id,
+                            ),
+                          });
+                        }
                       }
                     }
                   }
                 }
               }
-            }
 
-            onCreate?.(newSource);
-            notifications.show({
-              color: 'green',
-              message: 'Source created',
-            });
+              onCreate?.(newSource);
+              notifications.show({
+                color: 'green',
+                message: 'Source created',
+              });
+            },
+            onError: error => {
+              notifications.show({
+                color: 'red',
+                message: `Failed to create source - ${error.message}`,
+              });
+            },
           },
-          onError: error => {
-            notifications.show({
-              color: 'red',
-              message: `Failed to create source - ${error.message}`,
-            });
-          },
-        },
-      );
+        );
+
+      const warnings = getSourceConfigPairingWarnings(data);
+
+      if (warnings.length > 0) {
+        setPendingSave({ warnings, parsedData: parseResult.data, persist });
+        return;
+      }
+
+      persist(parseResult.data);
     })();
   }, [
     clearErrors,
@@ -2376,24 +2446,35 @@ export function TableSourceForm({
         handleError(parseResult.error, 'save');
         return;
       }
-      updateSource.mutate(
-        { source: parseResult.data },
-        {
-          onSuccess: () => {
-            onSave?.();
-            notifications.show({
-              color: 'green',
-              message: 'Source updated',
-            });
+
+      const persist = (source: typeof parseResult.data) =>
+        updateSource.mutate(
+          { source },
+          {
+            onSuccess: () => {
+              onSave?.();
+              notifications.show({
+                color: 'green',
+                message: 'Source updated',
+              });
+            },
+            onError: () => {
+              notifications.show({
+                color: 'red',
+                message: 'Failed to update source',
+              });
+            },
           },
-          onError: () => {
-            notifications.show({
-              color: 'red',
-              message: 'Failed to update source',
-            });
-          },
-        },
-      );
+        );
+
+      const warnings = getSourceConfigPairingWarnings(data);
+
+      if (warnings.length > 0) {
+        setPendingSave({ warnings, parsedData: parseResult.data, persist });
+        return;
+      }
+
+      persist(parseResult.data);
     })();
   }, [handleSubmit, updateSource, onSave, clearErrors, handleError]);
 
@@ -2588,6 +2669,52 @@ export function TableSourceForm({
           </>
         )}
       </Group>
+      <Modal
+        opened={!!pendingSave}
+        onClose={() => setPendingSave(undefined)}
+        title="Review source configuration"
+        centered
+      >
+        <Stack gap="md">
+          {pendingSave?.warnings.map(warning => (
+            <Box key={warning.field}>
+              <Text size="sm">{warning.message}</Text>
+              {warning.suggestedFix && (
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  mt="xs"
+                  onClick={() => applyPairingFix(warning)}
+                >
+                  {`Set ${SOURCE_FIELD_LABELS[warning.suggestedFix.field]} to "${
+                    warning.suggestedFix.value
+                  }"`}
+                </Button>
+              )}
+            </Box>
+          ))}
+          <Group justify="flex-end" mt="sm">
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => setPendingSave(undefined)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="xs"
+              onClick={() => {
+                const p = pendingSave;
+                setPendingSave(undefined);
+                p?.persist(p.parsedData);
+              }}
+            >
+              Save anyway
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 }

--- a/packages/app/src/hooks/useExpressionValidation.ts
+++ b/packages/app/src/hooks/useExpressionValidation.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react';
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+import { useDebouncedCallback, useDidUpdate } from '@mantine/hooks';
+
+import { useExplainQuery } from '@/hooks/useExplainQuery';
+
+export type TableConnectionLike = {
+  databaseName: string;
+  tableName: string;
+  connectionId: string;
+};
+
+export function useExpressionValidation({
+  expression,
+  alias,
+  tableConnection,
+  debounceMs = 1000,
+}: {
+  expression: string | undefined;
+  alias?: string;
+  tableConnection: TableConnectionLike;
+  debounceMs?: number;
+}) {
+  const [explainParams, setExplainParams] = useState<{
+    expression?: string;
+    alias?: string;
+  }>();
+
+  const setExplainParamsDebounced = useDebouncedCallback(
+    (params: { expression?: string; alias?: string }) => {
+      setExplainParams(params);
+    },
+    debounceMs,
+  );
+
+  useDidUpdate(() => {
+    setExplainParamsDebounced({ expression, alias });
+  }, [expression, alias]);
+
+  const { databaseName, tableName, connectionId } = tableConnection;
+
+  const { data, error, isLoading } = useExplainQuery(
+    {
+      from: { databaseName, tableName },
+      connection: connectionId,
+      select: [
+        {
+          alias: explainParams?.alias,
+          valueExpression: explainParams?.expression ?? '',
+        },
+      ],
+      where: '',
+    },
+    {
+      enabled: !!explainParams?.expression,
+    },
+  );
+
+  const isValid = !!data?.length;
+
+  const isInvalid = error instanceof ClickHouseQueryError;
+
+  const matchesCurrentInput =
+    explainParams?.expression === expression && explainParams?.alias === alias;
+
+  const shouldShowResult = matchesCurrentInput && (isValid || isInvalid);
+
+  const validateNow = useCallback(() => {
+    setExplainParams({ expression, alias });
+  }, [expression, alias]);
+
+  return {
+    isValid,
+    isInvalid,
+    isLoading,
+    error,
+    shouldShowResult,
+    validateNow,
+  };
+}

--- a/packages/app/src/utils/__tests__/sourceFieldSuggestions.test.ts
+++ b/packages/app/src/utils/__tests__/sourceFieldSuggestions.test.ts
@@ -1,0 +1,221 @@
+import { ColumnMetaType } from '@hyperdx/common-utils/dist/clickhouse';
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+
+import {
+  getSourceConfigPairingWarnings,
+  inferSourceFieldCandidates,
+} from '../sourceFieldSuggestions';
+
+const col = (name: string, type: string): ColumnMetaType => ({ name, type });
+
+describe('inferSourceFieldCandidates', () => {
+  it('recommends an exact canonical name match', () => {
+    const columns = [
+      col('Timestamp', 'DateTime64(9)'),
+      col('Body', 'String'),
+      col('ServiceName', 'LowCardinality(String)'),
+    ];
+    expect(
+      inferSourceFieldCandidates(columns, 'bodyExpression', SourceKind.Log),
+    ).toEqual({ canonical: 'Body', alternates: [] });
+  });
+
+  it('matches canonical names case-insensitively', () => {
+    const columns = [col('traceid', 'String')];
+    expect(
+      inferSourceFieldCandidates(columns, 'traceIdExpression', SourceKind.Log),
+    ).toEqual({ canonical: 'traceid', alternates: [] });
+  });
+
+  it('lists other name-matched columns as alternates (not every string column)', () => {
+    const columns = [
+      col('Body', 'String'),
+      col('message', 'String'),
+      col('msg', 'String'),
+      col('some_unrelated_string', 'String'),
+    ];
+    expect(
+      inferSourceFieldCandidates(columns, 'bodyExpression', SourceKind.Log),
+    ).toEqual({ canonical: 'Body', alternates: ['message', 'msg'] });
+  });
+
+  it('resolves eventAttributesExpression per source kind', () => {
+    const columns = [
+      col('LogAttributes', 'Map(String, String)'),
+      col('SpanAttributes', 'Map(LowCardinality(String), String)'),
+    ];
+    expect(
+      inferSourceFieldCandidates(
+        columns,
+        'eventAttributesExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('LogAttributes');
+    expect(
+      inferSourceFieldCandidates(
+        columns,
+        'eventAttributesExpression',
+        SourceKind.Trace,
+      ).canonical,
+    ).toBe('SpanAttributes');
+  });
+
+  it('recommends none but lists all when multiple unnamed Map columns exist', () => {
+    const columns = [
+      col('vendor_a', 'Map(String, String)'),
+      col('vendor_b', 'Map(String, String)'),
+    ];
+    expect(
+      inferSourceFieldCandidates(
+        columns,
+        'resourceAttributesExpression',
+        SourceKind.Log,
+      ),
+    ).toEqual({ canonical: undefined, alternates: ['vendor_a', 'vendor_b'] });
+  });
+
+  it('recommends a lone Map column for an attributes field', () => {
+    const columns = [col('attrs', 'Map(String, String)')];
+    expect(
+      inferSourceFieldCandidates(
+        columns,
+        'resourceAttributesExpression',
+        SourceKind.Log,
+      ),
+    ).toEqual({ canonical: 'attrs', alternates: [] });
+  });
+
+  it('matches TraceId on UUID / FixedString(16) but not FixedString(8)', () => {
+    expect(
+      inferSourceFieldCandidates(
+        [col('TraceId', 'UUID')],
+        'traceIdExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('TraceId');
+    expect(
+      inferSourceFieldCandidates(
+        [col('TraceId', 'FixedString(16)')],
+        'traceIdExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('TraceId');
+    expect(
+      inferSourceFieldCandidates(
+        [col('TraceId', 'FixedString(8)')],
+        'traceIdExpression',
+        SourceKind.Log,
+      ),
+    ).toEqual({ canonical: undefined, alternates: [] });
+  });
+
+  it('matches SpanId on FixedString(8)', () => {
+    expect(
+      inferSourceFieldCandidates(
+        [col('SpanId', 'FixedString(8)')],
+        'spanIdExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('SpanId');
+  });
+
+  it('treats LowCardinality(String) and Nullable(String) as stringy', () => {
+    expect(
+      inferSourceFieldCandidates(
+        [col('Body', 'LowCardinality(String)')],
+        'bodyExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('Body');
+    expect(
+      inferSourceFieldCandidates(
+        [col('Body', 'Nullable(String)')],
+        'bodyExpression',
+        SourceKind.Log,
+      ).canonical,
+    ).toBe('Body');
+  });
+
+  it('excludes type-incompatible columns', () => {
+    expect(
+      inferSourceFieldCandidates(
+        [col('Body', 'Int64')],
+        'bodyExpression',
+        SourceKind.Log,
+      ),
+    ).toEqual({ canonical: undefined, alternates: [] });
+  });
+});
+
+describe('getSourceConfigPairingWarnings', () => {
+  it('warns when Body is set but Implicit Column is empty, suggesting Body as the fix', () => {
+    const warnings = getSourceConfigPairingWarnings({
+      kind: SourceKind.Log,
+      bodyExpression: 'Body',
+      implicitColumnExpression: '',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('implicitColumnExpression');
+    expect(warnings[0].suggestedFix).toEqual({
+      field: 'implicitColumnExpression',
+      value: 'Body',
+    });
+  });
+
+  it('warns when Implicit Column is set but Body is empty, suggesting Implicit as the fix', () => {
+    const warnings = getSourceConfigPairingWarnings({
+      kind: SourceKind.Log,
+      bodyExpression: '',
+      implicitColumnExpression: 'Body',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('bodyExpression');
+    expect(warnings[0].suggestedFix).toEqual({
+      field: 'bodyExpression',
+      value: 'Body',
+    });
+  });
+
+  it('does not warn when both are set', () => {
+    expect(
+      getSourceConfigPairingWarnings({
+        kind: SourceKind.Log,
+        bodyExpression: 'Body',
+        implicitColumnExpression: 'Body',
+      }),
+    ).toEqual([]);
+  });
+
+  it('does not warn when both are empty', () => {
+    expect(
+      getSourceConfigPairingWarnings({
+        kind: SourceKind.Log,
+        bodyExpression: '',
+        implicitColumnExpression: '',
+      }),
+    ).toEqual([]);
+    expect(getSourceConfigPairingWarnings({ kind: SourceKind.Log })).toEqual(
+      [],
+    );
+  });
+
+  it('treats whitespace-only values as empty', () => {
+    const warnings = getSourceConfigPairingWarnings({
+      kind: SourceKind.Log,
+      bodyExpression: '   ',
+      implicitColumnExpression: 'Body',
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('bodyExpression');
+  });
+
+  it('returns no warnings for non-log sources even when only one field is set', () => {
+    const fields = { bodyExpression: 'Body', implicitColumnExpression: '' };
+    expect(
+      getSourceConfigPairingWarnings({ kind: SourceKind.Trace, ...fields }),
+    ).toEqual([]);
+    expect(
+      getSourceConfigPairingWarnings({ kind: SourceKind.Metric, ...fields }),
+    ).toEqual([]);
+  });
+});

--- a/packages/app/src/utils/__tests__/sourceFieldSuggestions.test.ts
+++ b/packages/app/src/utils/__tests__/sourceFieldSuggestions.test.ts
@@ -27,6 +27,34 @@ describe('inferSourceFieldCandidates', () => {
     ).toEqual({ canonical: 'traceid', alternates: [] });
   });
 
+  it('keeps columns that differ only by case rather than dropping one', () => {
+    const columns = [col('Body', 'String'), col('BODY', 'String')];
+    expect(
+      inferSourceFieldCandidates(columns, 'bodyExpression', SourceKind.Log),
+    ).toEqual({ canonical: 'Body', alternates: ['BODY'] });
+  });
+
+  it('picks the first column in table order as canonical on a case collision', () => {
+    const columns = [col('BODY', 'String'), col('Body', 'String')];
+    expect(
+      inferSourceFieldCandidates(columns, 'bodyExpression', SourceKind.Log),
+    ).toEqual({ canonical: 'BODY', alternates: ['Body'] });
+  });
+
+  it('surfaces every case-colliding Map column as an alternate', () => {
+    const columns = [
+      col('Attributes', 'Map(String, String)'),
+      col('ATTRIBUTES', 'Map(String, String)'),
+    ];
+    expect(
+      inferSourceFieldCandidates(
+        columns,
+        'eventAttributesExpression',
+        SourceKind.Log,
+      ),
+    ).toEqual({ canonical: 'Attributes', alternates: ['ATTRIBUTES'] });
+  });
+
   it('lists other name-matched columns as alternates (not every string column)', () => {
     const columns = [
       col('Body', 'String'),

--- a/packages/app/src/utils/sourceFieldSuggestions.ts
+++ b/packages/app/src/utils/sourceFieldSuggestions.ts
@@ -160,15 +160,24 @@ export function inferSourceFieldCandidates(
   // 1. type-compatible columns only
   const compatible = columns.filter(c => rule.typeMatches(c.type));
 
-  // 2. case-insensitive name match, ranked by `canonicalNames` order
-  const byLowerName = new Map(
-    compatible.map(c => [c.name.toLowerCase(), c.name]),
-  );
+  // 2. case-insensitive name match, ranked by `canonicalNames` order.
+  const byLowerName = new Map<string, string[]>();
+
+  for (const c of compatible) {
+    const key = c.name.toLowerCase();
+
+    const existing = byLowerName.get(key);
+
+    if (existing) {
+      existing.push(c.name);
+    } else {
+      byLowerName.set(key, [c.name]);
+    }
+  }
+
   const rankedNameMatches = [
     ...new Set(
-      canonicalNames
-        .map(n => byLowerName.get(n.toLowerCase()))
-        .filter((x): x is string => !!x),
+      canonicalNames.flatMap(n => byLowerName.get(n.toLowerCase()) ?? []),
     ),
   ];
 
@@ -179,8 +188,7 @@ export function inferSourceFieldCandidates(
 
     return {
       canonical,
-      // surface all type-compatible columns so ambiguous multi-Map schemas
-      // present every option
+      // surface all type-compatible columns so ambiguous multi-Map schemas present every option
       alternates: compatible.map(c => c.name).filter(n => n !== canonical),
     };
   }

--- a/packages/app/src/utils/sourceFieldSuggestions.ts
+++ b/packages/app/src/utils/sourceFieldSuggestions.ts
@@ -1,0 +1,241 @@
+import {
+  ColumnMetaType,
+  convertCHDataTypeToJSType,
+  JSDataType,
+} from '@hyperdx/common-utils/dist/clickhouse';
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+
+export type SourceFieldKind =
+  | 'bodyExpression'
+  | 'implicitColumnExpression'
+  | 'serviceNameExpression'
+  | 'severityTextExpression'
+  | 'eventAttributesExpression'
+  | 'resourceAttributesExpression'
+  | 'traceIdExpression'
+  | 'spanIdExpression';
+
+export type FieldCandidates = {
+  /** The single column we recommend, when there is a clear winner. */
+  canonical?: string;
+  /** Other type-compatible, name-matched columns. Excludes `canonical`. */
+  alternates: string[];
+};
+
+type TypePredicate = (chType: string) => boolean;
+
+/** Peel LowCardinality(...) / Nullable(...) wrappers off a CH type string. */
+function unwrap(chType: string): string {
+  let t = chType.trim();
+
+  while (true) {
+    if (t.startsWith('LowCardinality(') && t.endsWith(')')) {
+      t = t.slice('LowCardinality('.length, -1).trim();
+    } else if (t.startsWith('Nullable(') && t.endsWith(')')) {
+      t = t.slice('Nullable('.length, -1).trim();
+    } else {
+      break;
+    }
+  }
+  return t;
+}
+
+/** String, LowCardinality(String), Nullable(String), FixedString, Enum, UUID. */
+const isStringy: TypePredicate = t =>
+  convertCHDataTypeToJSType(t) === JSDataType.String;
+
+/** Map(String, *) or JSON. */
+const isMapLike: TypePredicate = t => {
+  const js = convertCHDataTypeToJSType(t);
+  return js === JSDataType.Map || js === JSDataType.JSON;
+};
+
+/** TraceId is 16 bytes: String / UUID / FixedString(16). */
+const isTraceIdType: TypePredicate = t => {
+  const u = unwrap(t);
+  return u === 'String' || u === 'UUID' || u === 'FixedString(16)';
+};
+
+/** SpanId is 8 bytes: String / FixedString(8). */
+const isSpanIdType: TypePredicate = t => {
+  const u = unwrap(t);
+  return u === 'String' || u === 'FixedString(8)';
+};
+
+type FieldRule = {
+  /** Preferred names, highest-rank first. Matched case-insensitively. */
+  canonicalNames: string[];
+  /** A column must satisfy this to be considered a candidate at all. */
+  typeMatches: TypePredicate;
+  /**
+   * 'name-only' — only ever recommend a column whose name matches one of
+   *   `canonicalNames` (don't guess a lone String column as e.g. the Body).
+   * 'single' — additionally recommend the lone type-compatible column when no
+   *   name matched (safe for Map attribute columns).
+   */
+  recommendStrategy: 'name-only' | 'single';
+  /** Per-kind overrides of `canonicalNames` (e.g. Log vs Trace attributes). */
+  canonicalNamesByKind?: Partial<Record<SourceKind, string[]>>;
+};
+
+const FIELD_RULES: Record<SourceFieldKind, FieldRule> = {
+  bodyExpression: {
+    canonicalNames: ['Body', 'message', 'msg', 'log', 'LogMessage', 'content'],
+    typeMatches: isStringy,
+    recommendStrategy: 'name-only',
+  },
+  implicitColumnExpression: {
+    canonicalNames: ['Body', 'message', 'msg', 'log', 'LogMessage', 'content'],
+    canonicalNamesByKind: {
+      [SourceKind.Trace]: ['SpanName', 'OperationName', 'name'],
+    },
+    typeMatches: isStringy,
+    recommendStrategy: 'name-only',
+  },
+  serviceNameExpression: {
+    canonicalNames: ['ServiceName', 'service', 'service.name', 'service_name'],
+    typeMatches: isStringy,
+    recommendStrategy: 'name-only',
+  },
+  severityTextExpression: {
+    canonicalNames: [
+      'SeverityText',
+      'severity',
+      'level',
+      'log_level',
+      'loglevel',
+    ],
+    typeMatches: isStringy,
+    recommendStrategy: 'name-only',
+  },
+  eventAttributesExpression: {
+    canonicalNames: ['LogAttributes', 'Attributes', 'attributes', 'tags'],
+    canonicalNamesByKind: {
+      [SourceKind.Trace]: [
+        'SpanAttributes',
+        'Attributes',
+        'attributes',
+        'tags',
+      ],
+    },
+    typeMatches: isMapLike,
+    recommendStrategy: 'single',
+  },
+  resourceAttributesExpression: {
+    canonicalNames: [
+      'ResourceAttributes',
+      'resource_attributes',
+      'resource.attributes',
+      'resource',
+      'resources',
+    ],
+    typeMatches: isMapLike,
+    recommendStrategy: 'single',
+  },
+  traceIdExpression: {
+    canonicalNames: ['TraceId', 'trace_id', 'traceId', 'trace.id'],
+    typeMatches: isTraceIdType,
+    recommendStrategy: 'name-only',
+  },
+  spanIdExpression: {
+    canonicalNames: ['SpanId', 'span_id', 'spanId', 'span.id'],
+    typeMatches: isSpanIdType,
+    recommendStrategy: 'name-only',
+  },
+};
+
+/**
+ * Inspect a table's columns and return the recommended column for a given
+ * source-config field, plus any other type-compatible candidates.
+ */
+export function inferSourceFieldCandidates(
+  columns: ColumnMetaType[],
+  fieldKind: SourceFieldKind,
+  sourceKind: SourceKind,
+): FieldCandidates {
+  const rule = FIELD_RULES[fieldKind];
+  const canonicalNames =
+    rule.canonicalNamesByKind?.[sourceKind] ?? rule.canonicalNames;
+
+  // 1. type-compatible columns only
+  const compatible = columns.filter(c => rule.typeMatches(c.type));
+
+  // 2. case-insensitive name match, ranked by `canonicalNames` order
+  const byLowerName = new Map(
+    compatible.map(c => [c.name.toLowerCase(), c.name]),
+  );
+  const rankedNameMatches = [
+    ...new Set(
+      canonicalNames
+        .map(n => byLowerName.get(n.toLowerCase()))
+        .filter((x): x is string => !!x),
+    ),
+  ];
+
+  if (rule.recommendStrategy === 'single') {
+    const canonical =
+      rankedNameMatches[0] ??
+      (compatible.length === 1 ? compatible[0].name : undefined);
+
+    return {
+      canonical,
+      // surface all type-compatible columns so ambiguous multi-Map schemas
+      // present every option
+      alternates: compatible.map(c => c.name).filter(n => n !== canonical),
+    };
+  }
+
+  // 'name-only': never dump every String column as an alternate
+  const canonical = rankedNameMatches[0];
+  return {
+    canonical,
+    alternates: rankedNameMatches.filter(n => n !== canonical),
+  };
+}
+
+export type SourceConfigPairingInput = {
+  kind: SourceKind;
+  bodyExpression?: string | null;
+  implicitColumnExpression?: string | null;
+};
+
+export type PairingWarning = {
+  field: SourceFieldKind;
+  message: string;
+  suggestedFix?: { field: SourceFieldKind; value: string };
+};
+
+export function getSourceConfigPairingWarnings(
+  formValues: SourceConfigPairingInput,
+): PairingWarning[] {
+  // Body / Implicit Column pairing only applies to log sources.
+  if (formValues.kind !== SourceKind.Log) {
+    return [];
+  }
+
+  const warnings: PairingWarning[] = [];
+  const body = formValues.bodyExpression?.trim();
+  const implicit = formValues.implicitColumnExpression?.trim();
+
+  if (body && !implicit) {
+    warnings.push({
+      field: 'implicitColumnExpression',
+      message:
+        'Body Expression is set but Implicit Column Expression is empty. ' +
+        'Bare-text Lucene search will fail on this source. ' +
+        'Use the same column as Body Expression?',
+      suggestedFix: { field: 'implicitColumnExpression', value: body },
+    });
+  } else if (implicit && !body) {
+    warnings.push({
+      field: 'bodyExpression',
+      message:
+        'Implicit Column Expression is set but Body Expression is empty. ' +
+        'Row-panel body display will fall back to Implicit Column Expression. ' +
+        'Set Body Expression explicitly?',
+      suggestedFix: { field: 'bodyExpression', value: implicit },
+    });
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

**Why:** Configuring a source against a custom (non-OTel) table means typing column names from memory into free-text inputs, with no schema inspection, no validation, and no warning when a config will silently break search (e.g. `bodyExpression` set but `implicitColumnExpression` empty — the HDX-4376 trap). This adds the form-side prevention to pair with HDX-4376 (runtime fallback) and HDX-4373 (row-panel cleanup).

**What changed:**
- **Candidate hints** — after Database + Table are picked, scans columns (cached via `useColumns`) and suggests the likely column under each empty optional-expression field, with one-click apply. Type-aware, name-matched, resolves per source kind (logs vs traces). Suggests, never pre-fills; lists all candidates when ambiguous.
- **Live validation** — filled expressions are validated against the real table via a debounced `EXPLAIN` query, showing valid/invalid inline.
- **Pairing warnings** — `getSourceConfigPairingWarnings` flags body/implicit-column mismatches (log sources only) in a non-blocking save-time modal with one-click fixes or "Save anyway".

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->


https://github.com/user-attachments/assets/d862f021-c81e-4c4f-b3ba-3c6d9872db95



### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/team`

**Steps:**

1. Create a new source, or edit an existing one and check the suggestions for fields are correct.
2. Check the warning modal displays in one of two ways when _Body_ or _Implicit Column Expression_ fields are unset.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4374
- Related PRs: https://github.com/hyperdxio/hyperdx/pull/2354
