### PR TITLE
feat(hdx-eval): support multi-model comparison in eval batches

### DIFF
--- a/.changeset/good-parents-check.md
+++ b/.changeset/good-parents-check.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/hdx-eval': patch
+---
+
+Support multi-model comparison in eval batches via comma-separated --model flag

--- a/packages/hdx-eval/scripts/viewer/public/app.js
+++ b/packages/hdx-eval/scripts/viewer/public/app.js
@@ -221,6 +221,18 @@
 
   // ----- rendering: sidebar nav -----
 
+  /** True when the current batch has more than one distinct model across cells. */
+  function isMultiModel() {
+    const models = new Set();
+    for (const c of state.cells) if (c.model) models.add(c.model);
+    return models.size > 1;
+  }
+
+  /** Heading for a cell: matches the columnKeyFor logic in aggregate.ts. */
+  function cellHeading(c) {
+    return c.model && isMultiModel() ? `${c.mcp}/${c.model}` : c.mcp;
+  }
+
   function renderNav() {
     const root = $('#nav');
     root.innerHTML = '';
@@ -238,7 +250,7 @@
         el('div', { class: 'head' }, scenario),
       );
       for (const c of cells) {
-        const heading = c.model ? `${c.mcp}/${c.model}` : c.mcp;
+        const heading = cellHeading(c);
         const mNode = el(
           'div',
           { class: 'nav-mcp' },
@@ -1022,8 +1034,7 @@
       const maxRuns = Math.max(...scenarioCells.map((c) => c.runs.length));
       const runHeader = [el('th', {}, 'Run')];
       for (const c of scenarioCells) {
-        const heading = c.model ? `${c.mcp}/${c.model}` : c.mcp;
-        runHeader.push(el('th', {}, heading));
+        runHeader.push(el('th', {}, cellHeading(c)));
       }
       const runRows = [];
       for (let i = 0; i < maxRuns; i++) {

--- a/packages/hdx-eval/scripts/viewer/public/app.js
+++ b/packages/hdx-eval/scripts/viewer/public/app.js
@@ -20,7 +20,7 @@
     batch: null,
     cells: [],
     summary: null,
-    selectedRun: null, // { scenario, mcp, idx }
+    selectedRun: null, // { scenario, mcp, model, idx }
     runData: null, // { trajectory, grade }
     activeTab: 'trajectory',
     view: 'summary', // 'summary' | 'run'
@@ -177,9 +177,12 @@
     showView('summary');
   }
 
-  async function loadRun(scenario, mcp, idx) {
-    state.selectedRun = { scenario, mcp, idx };
-    const u = `/api/batches/${encodeURIComponent(state.batch)}/runs/${encodeURIComponent(scenario)}/${encodeURIComponent(mcp)}/${idx}`;
+  async function loadRun(scenario, mcp, model, idx) {
+    state.selectedRun = { scenario, mcp, model, idx };
+    const base = `/api/batches/${encodeURIComponent(state.batch)}/runs/${encodeURIComponent(scenario)}/${encodeURIComponent(mcp)}`;
+    const u = model
+      ? `${base}/${encodeURIComponent(model)}/${idx}`
+      : `${base}/${idx}`;
     state.runData = await fetchJson(u);
     renderNav();
     showView('run');
@@ -235,16 +238,18 @@
         el('div', { class: 'head' }, scenario),
       );
       for (const c of cells) {
+        const heading = c.model ? `${c.mcp}/${c.model}` : c.mcp;
         const mNode = el(
           'div',
           { class: 'nav-mcp' },
-          el('div', { class: 'head' }, c.mcp),
+          el('div', { class: 'head' }, heading),
         );
         for (const r of c.runs) {
           const active =
             state.selectedRun &&
             state.selectedRun.scenario === scenario &&
             state.selectedRun.mcp === c.mcp &&
+            state.selectedRun.model === c.model &&
             state.selectedRun.idx === r.idx;
           const chip = el(
             'span',
@@ -263,7 +268,7 @@
             'div',
             {
               class: `nav-run ${active ? 'active' : ''}`,
-              onclick: () => loadRun(scenario, c.mcp, r.idx),
+              onclick: () => loadRun(scenario, c.mcp, c.model, r.idx),
             },
             el(
               'span',
@@ -735,7 +740,7 @@
     }
     root.className = 'summary-dashboard';
 
-    const mcpOrder = s.mcpOrder || Object.keys(s.scenarios[0]?.cells || {}).sort();
+    const mcpOrder = s.columnOrder || s.mcpOrder || Object.keys(s.scenarios[0]?.cells || {}).sort();
     const baseline = s.baseline || mcpOrder[0];
     const challengers = mcpOrder.filter((m) => m !== baseline);
 
@@ -1017,7 +1022,8 @@
       const maxRuns = Math.max(...scenarioCells.map((c) => c.runs.length));
       const runHeader = [el('th', {}, 'Run')];
       for (const c of scenarioCells) {
-        runHeader.push(el('th', {}, c.mcp));
+        const heading = c.model ? `${c.mcp}/${c.model}` : c.mcp;
+        runHeader.push(el('th', {}, heading));
       }
       const runRows = [];
       for (let i = 0; i < maxRuns; i++) {
@@ -1046,7 +1052,7 @@
               'td',
               {
                 class: 'run-cell clickable',
-                onclick: () => loadRun(scenario.scenario, c.mcp, r.idx),
+                onclick: () => loadRun(scenario.scenario, c.mcp, c.model, r.idx),
               },
               chip,
               ' ',

--- a/packages/hdx-eval/scripts/viewer/server.js
+++ b/packages/hdx-eval/scripts/viewer/server.js
@@ -60,6 +60,33 @@ function listBatches() {
     .reverse();
 }
 
+function isRunJson(f) {
+  return /^\d+\.json$/.test(f);
+}
+
+function collectRuns(cellDir) {
+  const files = fs.readdirSync(cellDir);
+  const runIdxs = new Set();
+  for (const f of files) {
+    const m = /^(\d+)\.json$/.exec(f);
+    if (m) runIdxs.add(Number(m[1]));
+  }
+  return [...runIdxs].sort((a, b) => a - b).map((i) => {
+    const grade = readJsonSafe(path.join(cellDir, `${i}.grade.json`));
+    const traj = readJsonSafe(path.join(cellDir, `${i}.json`));
+    return {
+      idx: i,
+      combinedScore: grade?.combinedScore ?? null,
+      programmaticScore: grade?.programmatic?.score ?? null,
+      judgeScore: grade?.judge?.weightedScore ?? null,
+      termination: traj?.termination ?? null,
+      durationMs: traj?.durationMs ?? null,
+      toolCalls: traj?.toolCalls?.length ?? null,
+      toolErrors: grade?.toolErrors?.errors ?? null,
+    };
+  });
+}
+
 function listCells(batch) {
   const batchDir = safeJoin(RUNS_DIR, batch);
   if (!fs.existsSync(batchDir)) return null;
@@ -75,28 +102,23 @@ function listCells(batch) {
       .filter((d) => d.isDirectory())
       .map((d) => d.name);
     for (const mcp of mcps) {
-      const cellDir = path.join(scenarioDir, mcp);
-      const files = fs.readdirSync(cellDir);
-      const runIdxs = new Set();
-      for (const f of files) {
-        const m = /^(\d+)\.json$/.exec(f);
-        if (m) runIdxs.add(Number(m[1]));
+      const mcpDir = path.join(scenarioDir, mcp);
+      const entries = fs.readdirSync(mcpDir, { withFileTypes: true });
+
+      // Legacy layout: <scenario>/<mcp>/<index>.json
+      const hasRunFiles = entries.some((e) => !e.isDirectory() && isRunJson(e.name));
+      if (hasRunFiles) {
+        const runs = collectRuns(mcpDir);
+        if (runs.length > 0) out.push({ scenario, mcp, model: null, runs });
       }
-      const runs = [...runIdxs].sort((a, b) => a - b).map((i) => {
-        const grade = readJsonSafe(path.join(cellDir, `${i}.grade.json`));
-        const traj = readJsonSafe(path.join(cellDir, `${i}.json`));
-        return {
-          idx: i,
-          combinedScore: grade?.combinedScore ?? null,
-          programmaticScore: grade?.programmatic?.score ?? null,
-          judgeScore: grade?.judge?.weightedScore ?? null,
-          termination: traj?.termination ?? null,
-          durationMs: traj?.durationMs ?? null,
-          toolCalls: traj?.toolCalls?.length ?? null,
-          toolErrors: grade?.toolErrors?.errors ?? null,
-        };
-      });
-      out.push({ scenario, mcp, runs });
+
+      // New layout: <scenario>/<mcp>/<model>/<index>.json
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const modelDir = path.join(mcpDir, entry.name);
+        const runs = collectRuns(modelDir);
+        if (runs.length > 0) out.push({ scenario, mcp, model: entry.name, runs });
+      }
     }
   }
   return out;
@@ -127,6 +149,21 @@ const ROUTES = [
       sendJson(res, 200, { batch, summary, cells });
     },
   ],
+  // New layout: /runs/:scenario/:mcp/:model/:idx
+  [
+    /^\/api\/batches\/([^/]+)\/runs\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
+    (m, _q, res) => {
+      const [, batch, scenario, mcp, model, idx] = m.map((x, i) =>
+        i === 0 ? x : decodeURIComponent(x),
+      );
+      const base = safeJoin(RUNS_DIR, batch, scenario, mcp, model);
+      const trajectory = readJsonSafe(path.join(base, `${idx}.json`));
+      const grade = readJsonSafe(path.join(base, `${idx}.grade.json`));
+      if (!trajectory) return sendJson(res, 404, { error: 'run not found' });
+      sendJson(res, 200, { trajectory, grade });
+    },
+  ],
+  // Legacy layout: /runs/:scenario/:mcp/:idx (no model segment)
   [
     /^\/api\/batches\/([^/]+)\/runs\/([^/]+)\/([^/]+)\/(\d+)$/,
     (m, _q, res) => {

--- a/packages/hdx-eval/scripts/viewer/server.js
+++ b/packages/hdx-eval/scripts/viewer/server.js
@@ -65,7 +65,12 @@ function isRunJson(f) {
 }
 
 function collectRuns(cellDir) {
-  const files = fs.readdirSync(cellDir);
+  let files;
+  try {
+    files = fs.readdirSync(cellDir);
+  } catch {
+    return []; // directory may have been removed between discovery and read
+  }
   const runIdxs = new Set();
   for (const f of files) {
     const m = /^(\d+)\.json$/.exec(f);

--- a/packages/hdx-eval/src/__tests__/aggregate.test.ts
+++ b/packages/hdx-eval/src/__tests__/aggregate.test.ts
@@ -128,11 +128,14 @@ describe('buildAggregate', () => {
         durationMs: 50_000,
       }),
     ];
-    // Baseline defaults to first MCP alphabetically: 'clickhouse'.
+    // Baseline defaults to first column alphabetically: 'clickhouse'.
     const summary = buildAggregate({ batchDir: '/tmp/x', pairs });
     expect(summary.scenarios).toHaveLength(1);
     expect(summary.baseline).toBe('clickhouse');
+    expect(summary.columnOrder).toEqual(['clickhouse', 'hyperdx']);
+    // Deprecated alias:
     expect(summary.mcpOrder).toEqual(['clickhouse', 'hyperdx']);
+    expect(summary.multiModel).toBe(false);
     const sc = summary.scenarios[0];
     const h = sc.cells['hyperdx']!;
     const c = sc.cells['clickhouse']!;
@@ -253,6 +256,7 @@ describe('buildAggregate', () => {
       pairs,
       baseline: 'alpha',
     });
+    expect(summary.columnOrder).toEqual(['alpha', 'beta', 'gamma']);
     expect(summary.mcpOrder).toEqual(['alpha', 'beta', 'gamma']);
     const sc = summary.scenarios[0];
     // Challengers: beta and gamma
@@ -260,5 +264,46 @@ describe('buildAggregate', () => {
     expect(sc.deltas['beta']).toBeDefined();
     expect(sc.deltas['gamma']).toBeDefined();
     expect(sc.deltas['gamma'].toolCalls).toBeCloseTo(-2, 5);
+  });
+
+  it('groups by (mcp, model) when multiple models are present', () => {
+    const pairs: GradedRunPair[] = [
+      pair({
+        scenario: 'error-root-cause',
+        mcp: 'hyperdx',
+        i: 0,
+        programmaticScore: 1,
+        judgeScore: 0.9,
+        toolCalls: 13,
+        outputTokens: 4000,
+        durationMs: 60_000,
+      }),
+      pair({
+        scenario: 'error-root-cause',
+        mcp: 'hyperdx',
+        i: 1,
+        programmaticScore: 0.8,
+        judgeScore: 0.8,
+        toolCalls: 11,
+        outputTokens: 3500,
+        durationMs: 50_000,
+      }),
+    ];
+    // Change the model on the second pair to trigger multi-model grouping.
+    pairs[1].run.model = 'claude-haiku-4-5';
+    const summary = buildAggregate({ batchDir: '/tmp/x', pairs });
+    expect(summary.multiModel).toBe(true);
+    expect(summary.columnOrder).toEqual([
+      'hyperdx/claude-haiku-4-5',
+      'hyperdx/claude-sonnet-4-6',
+    ]);
+    const sc = summary.scenarios[0];
+    expect(sc.cells['hyperdx/claude-sonnet-4-6']).toBeDefined();
+    expect(sc.cells['hyperdx/claude-haiku-4-5']).toBeDefined();
+    // Each cell should have n=1
+    expect(sc.cells['hyperdx/claude-sonnet-4-6'].n).toBe(1);
+    expect(sc.cells['hyperdx/claude-haiku-4-5'].n).toBe(1);
+    // Deltas: challenger vs baseline (first alphabetically)
+    expect(sc.deltas['hyperdx/claude-sonnet-4-6']?.combinedScore).toBeDefined();
   });
 });

--- a/packages/hdx-eval/src/cli.ts
+++ b/packages/hdx-eval/src/cli.ts
@@ -27,6 +27,7 @@ import {
   readConfig,
 } from './hyperdx/config';
 import { runCheck, runSetup } from './hyperdx/setup';
+import { columnKeyFor } from './reports/aggregate';
 import { writeBatchSummary } from './reports/store';
 import { instrumentBatch, summarizeTimingRecord } from './runs/instrument';
 import { batchDirName } from './runs/path';
@@ -319,7 +320,12 @@ program
     'MCP to use as baseline in reports (default: first MCP in list)',
   )
   .option('--runs <n>', 'Number of runs per (scenario,MCP) cell', '3')
-  .option('--model <id>', 'Model ID to pass to Claude Code', 'claude-opus-4-6')
+  .option(
+    '--model <ids>',
+    'Comma-separated model IDs to pass to Claude Code. When multiple ' +
+      'models are given, every (mcp, model) pair is compared in reports.',
+    'claude-opus-4-6',
+  )
   // Lower than the previous 25 — tightens the budget so sloppy agents that
   // make 20+ exploratory calls can't paper over correctness with volume.
   // Override with --max-turns if a specific scenario needs more.
@@ -415,11 +421,22 @@ program
       for (const mcp of mcpKinds) {
         getMcpDefinition(config, mcp);
       }
-      const baseline = cmdOpts.baseline ?? mcpKinds[0];
-      if (cmdOpts.baseline && !mcpKinds.includes(cmdOpts.baseline)) {
-        throw new Error(
-          `--baseline "${cmdOpts.baseline}" is not in the MCP list: ${mcpKinds.join(', ')}`,
+      const models = parseModelFlag(cmdOpts.model);
+      const multiModel = models.length > 1;
+      // For baseline resolution: when multi-model, the column key is
+      // mcp/sanitizedModel; otherwise just mcp.
+      const firstColumnKey = columnKeyFor(mcpKinds[0], models[0], multiModel);
+      const baseline = cmdOpts.baseline ?? firstColumnKey;
+      if (cmdOpts.baseline) {
+        // Validate: baseline must match one of the column keys.
+        const allColumnKeys = mcpKinds.flatMap(m =>
+          models.map(mod => columnKeyFor(m, mod, multiModel)),
         );
+        if (!allColumnKeys.includes(cmdOpts.baseline)) {
+          throw new Error(
+            `--baseline "${cmdOpts.baseline}" is not in the column list: ${[...new Set(allColumnKeys)].join(', ')}`,
+          );
+        }
       }
       const promptVariant: PromptVariant = parsePromptVariant(
         cmdOpts.promptVariant,
@@ -517,12 +534,14 @@ program
       console.log(`\nBatch: runs/${batchDir}`);
       console.log(`Scenario: ${scenario.name}`);
       console.log(`MCPs: ${mcpKinds.join(', ')}`);
+      console.log(`Models: ${models.join(', ')}`);
       console.log(
-        `Runs/cell: ${runs}, model: ${cmdOpts.model}, max-turns: ${maxTurns}, concurrency: ${concurrency}, prompt-variant: ${promptVariant}\n`,
+        `Runs/cell: ${runs}, max-turns: ${maxTurns}, concurrency: ${concurrency}, prompt-variant: ${promptVariant}\n`,
       );
 
       type SummaryRow = {
         mcp: McpKind;
+        model: string;
         i: number;
         toolCalls: number;
         inputTokens: number;
@@ -532,25 +551,33 @@ program
         path: string;
       };
 
-      // Flatten the (mcp, runIndex) matrix into a single queue and pull from it
-      // with a worker pool of size `concurrency`.
-      const cells: Array<{ mcp: McpKind; i: number }> = [];
+      // Flatten the (mcp, model, runIndex) matrix into a single queue and
+      // pull from it with a worker pool of size `concurrency`.
+      const cells: Array<{ mcp: McpKind; model: string; i: number }> = [];
       for (const mcp of mcpKinds) {
-        for (let i = 0; i < runs; i++) cells.push({ mcp, i });
+        for (const model of models) {
+          for (let i = 0; i < runs; i++) cells.push({ mcp, model, i });
+        }
       }
 
       const summary: SummaryRow[] = [];
       let cursor = 0;
-      const errors: Array<{ mcp: string; i: number; error: string }> = [];
+      const errors: Array<{
+        mcp: string;
+        model: string;
+        i: number;
+        error: string;
+      }> = [];
       async function worker(workerId: number): Promise<void> {
         while (true) {
           const idx = cursor++;
           if (idx >= cells.length) return;
-          const { mcp, i } = cells[idx];
+          const { mcp, model, i } = cells[idx];
+          const cellLabel = columnKeyFor(mcp, model, multiModel);
           const label = concurrency > 1 ? `[w${workerId}] ` : '  ';
           try {
             process.stdout.write(
-              `${label}${mcp} run ${i + 1}/${runs}... starting\n`,
+              `${label}${cellLabel} run ${i + 1}/${runs}... starting\n`,
             );
             const startedMs = Date.now();
             const record = await runCell({
@@ -558,7 +585,7 @@ program
               scenario: scenario.name,
               agentPrompt: scenario.agentPrompt,
               mcp,
-              model: cmdOpts.model,
+              model,
               maxTurns,
               timeoutMs,
               runIndex: i,
@@ -570,10 +597,11 @@ program
             const path = writeRun({ record, batchDir });
             const seconds = ((Date.now() - startedMs) / 1000).toFixed(1);
             console.log(
-              `${label}${mcp} run ${i + 1}/${runs}: ${record.termination} · ${record.toolCalls.length} tool calls · ${record.tokens.input}+${record.tokens.output} tok · ${seconds}s`,
+              `${label}${cellLabel} run ${i + 1}/${runs}: ${record.termination} · ${record.toolCalls.length} tool calls · ${record.tokens.input}+${record.tokens.output} tok · ${seconds}s`,
             );
             summary.push({
               mcp,
+              model,
               i,
               toolCalls: record.toolCalls.length,
               inputTokens: record.tokens.input,
@@ -585,9 +613,9 @@ program
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             console.error(
-              `${label}${mcp} run ${i + 1}/${runs}: FAILED — ${msg}`,
+              `${label}${cellLabel} run ${i + 1}/${runs}: FAILED — ${msg}`,
             );
-            errors.push({ mcp, i, error: msg });
+            errors.push({ mcp, model, i, error: msg });
           }
         }
       }
@@ -599,15 +627,26 @@ program
       if (errors.length > 0) {
         console.error(
           `\n${errors.length} run(s) failed:\n` +
-            errors.map(e => `  ${e.mcp} #${e.i}: ${e.error}`).join('\n'),
+            errors
+              .map(e => {
+                const cl = columnKeyFor(e.mcp, e.model, multiModel);
+                return `  ${cl} #${e.i}: ${e.error}`;
+              })
+              .join('\n'),
         );
       }
       console.log('\nResults written under runs/' + batchDir);
-      // Sort by (mcp, i) for stable summary output even with parallel workers.
-      summary.sort((a, b) => a.mcp.localeCompare(b.mcp) || a.i - b.i);
+      // Sort by (mcp, model, i) for stable summary output.
+      summary.sort(
+        (a, b) =>
+          a.mcp.localeCompare(b.mcp) ||
+          a.model.localeCompare(b.model) ||
+          a.i - b.i,
+      );
       for (const row of summary) {
+        const cl = columnKeyFor(row.mcp, row.model, multiModel);
         console.log(
-          `  ${row.mcp.padEnd(10)} #${row.i}  ${row.termination.padEnd(13)}  tools=${row.toolCalls}  tokens=${row.inputTokens}+${row.outputTokens}  ${row.durationS}s`,
+          `  ${cl.padEnd(multiModel ? 30 : 10)} #${row.i}  ${row.termination.padEnd(13)}  tools=${row.toolCalls}  tokens=${row.inputTokens}+${row.outputTokens}  ${row.durationS}s`,
         );
       }
 
@@ -879,6 +918,17 @@ function parseMcpFlag(
     }
   }
   return names;
+}
+
+function parseModelFlag(v: string): string[] {
+  const models = v
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (models.length === 0) {
+    throw new Error(`--model must be a comma-separated list of model IDs`);
+  }
+  return models;
 }
 
 function parsePromptVariant(v: string): PromptVariant {

--- a/packages/hdx-eval/src/cli.ts
+++ b/packages/hdx-eval/src/cli.ts
@@ -921,10 +921,14 @@ function parseMcpFlag(
 }
 
 function parseModelFlag(v: string): string[] {
-  const models = v
-    .split(',')
-    .map(s => s.trim())
-    .filter(Boolean);
+  const models = [
+    ...new Set(
+      v
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean),
+    ),
+  ];
   if (models.length === 0) {
     throw new Error(`--model must be a comma-separated list of model IDs`);
   }

--- a/packages/hdx-eval/src/grading/grade.ts
+++ b/packages/hdx-eval/src/grading/grade.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import type { RunRecord } from '../harness/types';
-import { runsRoot } from '../runs/path';
+import { isModelSubdir, isRunJson, runsRoot, safeReaddir } from '../runs/path';
 import { readRun } from '../runs/store';
 import { getScenario, SCENARIO_NAMES } from '../scenarios';
 import type { BlindingEntry } from './blind';
@@ -215,6 +215,11 @@ async function gradeOne(args: {
   };
 }
 
+/**
+ * List run JSON files. Supports both the new
+ * `<scenario>/<mcp>/<model>/<index>.json` layout and the legacy
+ * `<scenario>/<mcp>/<index>.json` layout.
+ */
 function listRunFiles(batchDir: string): string[] {
   const out: string[] = [];
   for (const scenario of safeReaddir(batchDir)) {
@@ -222,22 +227,21 @@ function listRunFiles(batchDir: string): string[] {
     const sceneDir = join(batchDir, scenario);
     for (const mcp of safeReaddir(sceneDir)) {
       const mcpDir = join(sceneDir, mcp);
-      for (const file of safeReaddir(mcpDir)) {
-        if (file.endsWith('.grade.json')) continue;
-        if (file.endsWith('.timing.json')) continue;
-        if (file.endsWith('.json')) out.push(join(mcpDir, file));
+      for (const entry of safeReaddir(mcpDir)) {
+        if (isRunJson(entry)) {
+          // Legacy layout: <scenario>/<mcp>/<index>.json
+          out.push(join(mcpDir, entry));
+        } else if (isModelSubdir(mcpDir, entry)) {
+          // New layout: <scenario>/<mcp>/<model>/<index>.json
+          const modelDir = join(mcpDir, entry);
+          for (const file of safeReaddir(modelDir)) {
+            if (isRunJson(file)) out.push(join(modelDir, file));
+          }
+        }
       }
     }
   }
   return out.sort();
-}
-
-function safeReaddir(path: string): string[] {
-  try {
-    return readdirSync(path);
-  } catch {
-    return [];
-  }
 }
 
 function readExistingGrade(path: string): GradeRecord | null {

--- a/packages/hdx-eval/src/reports/aggregate.ts
+++ b/packages/hdx-eval/src/reports/aggregate.ts
@@ -1,9 +1,21 @@
 import type { GradeRecord } from '../grading/types';
 import type { McpKind, RunRecord } from '../harness/types';
+import { modelDirName } from '../runs/path';
+
+/**
+ * A column key uniquely identifies a (mcp, model) combination in reports.
+ * When a batch has a single model, the column key equals the MCP name
+ * (backward-compatible). When multiple models are present, the column
+ * key is `mcp/model`.
+ */
+export type ColumnKey = string;
 
 export type CellSummary = {
   scenario: string;
   mcp: McpKind;
+  model: string;
+  /** Display key used in report columns. */
+  columnKey: ColumnKey;
   n: number;
   programmatic: { mean: number; perCheck: Record<string, number> };
   judge: {
@@ -35,22 +47,29 @@ export type DeltaSummary = {
 
 export type ScenarioSummary = {
   scenario: string;
-  /** All MCP cells keyed by MCP name. */
-  cells: Record<McpKind, CellSummary>;
-  /** Which MCP is the baseline (first MCP, or explicitly set). */
-  baseline?: McpKind;
-  /** Per-challenger deltas vs the baseline. Keyed by challenger MCP name. */
-  deltas: Record<McpKind, DeltaSummary>;
+  /** Cells keyed by column key (mcp or mcp/model). */
+  cells: Record<ColumnKey, CellSummary>;
+  /** Which column key is the baseline. */
+  baseline?: ColumnKey;
+  /** Per-challenger deltas vs the baseline. Keyed by challenger column key. */
+  deltas: Record<ColumnKey, DeltaSummary>;
 };
 
 export type BatchSummary = {
   batchDir: string;
   generatedAt: string;
-  /** The baseline MCP used for delta computation. */
-  baseline?: McpKind;
-  /** Ordered list of MCP names as they appear in the report columns. */
-  mcpOrder: McpKind[];
+  /** The baseline column key used for delta computation. */
+  baseline?: ColumnKey;
+  /** Ordered list of column keys as they appear in the report columns. */
+  columnOrder: ColumnKey[];
+  /** Whether this batch compares multiple models. */
+  multiModel: boolean;
   scenarios: ScenarioSummary[];
+  /**
+   * @deprecated Use `columnOrder`. Preserved for backward compatibility
+   * with older viewer code.
+   */
+  mcpOrder: ColumnKey[];
 };
 
 export type GradedRunPair = {
@@ -58,41 +77,65 @@ export type GradedRunPair = {
   grade: GradeRecord;
 };
 
+/**
+ * Build a column key from a (mcp, model) pair.
+ * When `multiModel` is false the column key is just the mcp name.
+ *
+ * The model component is sanitized through `modelDirName` so that the
+ * column key matches the directory name on disk (which is what the
+ * viewer reads). Without this, model IDs containing `/`, `:`, or `.`
+ * would produce different keys in the summary JSON vs the viewer.
+ */
+export function columnKeyFor(
+  mcp: McpKind,
+  model: string,
+  multiModel: boolean,
+): ColumnKey {
+  return multiModel ? `${mcp}/${modelDirName(model)}` : mcp;
+}
+
 export function buildAggregate(args: {
   batchDir: string;
   pairs: GradedRunPair[];
-  /** Explicit baseline MCP. If not set, the first MCP encountered is used. */
-  baseline?: McpKind;
+  /** Explicit baseline column key. If not set, the first column encountered
+   *  is used. When using a single model, pass just the mcp name. */
+  baseline?: ColumnKey;
 }): BatchSummary {
+  // Detect whether this batch involves multiple models.
+  const modelSet = new Set<string>();
+  for (const p of args.pairs) modelSet.add(p.run.model);
+  const multiModel = modelSet.size > 1;
+
   const byScenario = new Map<string, GradedRunPair[]>();
-  // Track all MCP names in insertion order.
-  const mcpSet = new Set<McpKind>();
+  const columnSet = new Set<ColumnKey>();
   for (const p of args.pairs) {
     if (!byScenario.has(p.run.scenario)) byScenario.set(p.run.scenario, []);
     byScenario.get(p.run.scenario)!.push(p);
-    mcpSet.add(p.run.mcp);
+    columnSet.add(columnKeyFor(p.run.mcp, p.run.model, multiModel));
   }
-  const mcpOrder = [...mcpSet].sort();
-  const baseline = args.baseline ?? mcpOrder[0];
+  const columnOrder = [...columnSet].sort();
+  const baseline = args.baseline ?? columnOrder[0];
 
   const scenarios: ScenarioSummary[] = [];
   for (const [name, ps] of byScenario.entries()) {
-    const byMcp = new Map<McpKind, GradedRunPair[]>();
+    const byCol = new Map<ColumnKey, GradedRunPair[]>();
     for (const p of ps) {
-      if (!byMcp.has(p.run.mcp)) byMcp.set(p.run.mcp, []);
-      byMcp.get(p.run.mcp)!.push(p);
+      const key = columnKeyFor(p.run.mcp, p.run.model, multiModel);
+      if (!byCol.has(key)) byCol.set(key, []);
+      byCol.get(key)!.push(p);
     }
-    const cells: Record<McpKind, CellSummary> = {};
-    for (const [mcp, list] of byMcp.entries()) {
-      cells[mcp] = buildCellSummary(name, mcp, list);
+    const cells: Record<ColumnKey, CellSummary> = {};
+    for (const [col, list] of byCol.entries()) {
+      const first = list[0].run;
+      cells[col] = buildCellSummary(name, first.mcp, first.model, col, list);
     }
 
-    // Compute deltas: each non-baseline MCP vs the baseline.
-    const deltas: Record<McpKind, DeltaSummary> = {};
+    // Compute deltas: each non-baseline column vs the baseline.
+    const deltas: Record<ColumnKey, DeltaSummary> = {};
     const baselineCell = cells[baseline];
-    for (const mcp of Object.keys(cells)) {
-      if (mcp === baseline) continue;
-      deltas[mcp] = computeDelta(cells[mcp], baselineCell);
+    for (const col of Object.keys(cells)) {
+      if (col === baseline) continue;
+      deltas[col] = computeDelta(cells[col], baselineCell);
     }
 
     scenarios.push({
@@ -108,7 +151,9 @@ export function buildAggregate(args: {
     batchDir: args.batchDir,
     generatedAt: new Date().toISOString(),
     baseline,
-    mcpOrder,
+    columnOrder,
+    multiModel,
+    mcpOrder: columnOrder,
     scenarios,
   };
 }
@@ -116,6 +161,8 @@ export function buildAggregate(args: {
 function buildCellSummary(
   scenario: string,
   mcp: McpKind,
+  model: string,
+  columnKey: ColumnKey,
   pairs: GradedRunPair[],
 ): CellSummary {
   const n = pairs.length;
@@ -179,6 +226,8 @@ function buildCellSummary(
   return {
     scenario,
     mcp,
+    model,
+    columnKey,
     n,
     programmatic: { mean: programmaticScore, perCheck },
     judge: {

--- a/packages/hdx-eval/src/reports/markdown.ts
+++ b/packages/hdx-eval/src/reports/markdown.ts
@@ -1,12 +1,13 @@
-import type { McpKind } from '../harness/types';
 import type {
   BatchSummary,
   CellSummary,
+  ColumnKey,
   DeltaSummary,
   ScenarioSummary,
 } from './aggregate';
 
 export function renderMarkdownReport(summary: BatchSummary): string {
+  const columns = summary.columnOrder;
   const lines: string[] = [];
   lines.push(`# Eval Batch — ${basename(summary.batchDir)}`);
   lines.push('');
@@ -14,24 +15,28 @@ export function renderMarkdownReport(summary: BatchSummary): string {
   if (summary.baseline) {
     lines.push(`Baseline: ${summary.baseline}`);
   }
-  lines.push(`MCPs: ${summary.mcpOrder.join(', ')}`);
+  if (summary.multiModel) {
+    lines.push(`Columns: ${columns.join(', ')}  _(mcp/model)_`);
+  } else {
+    lines.push(`MCPs: ${columns.join(', ')}`);
+  }
   lines.push('');
-  lines.push(renderTopVerdict(summary));
+  lines.push(renderTopVerdict(summary, columns));
   lines.push('');
 
   for (const scenario of summary.scenarios) {
     lines.push(`## ${scenario.scenario}`);
     lines.push('');
-    lines.push(renderScenarioTable(scenario, summary.mcpOrder));
+    lines.push(renderScenarioTable(scenario, columns));
     lines.push('');
-    const judgeBreakdown = renderJudgeBreakdown(scenario, summary.mcpOrder);
+    const judgeBreakdown = renderJudgeBreakdown(scenario, columns);
     if (judgeBreakdown) {
       lines.push(judgeBreakdown);
       lines.push('');
     }
     const programmaticBreakdown = renderProgrammaticBreakdown(
       scenario,
-      summary.mcpOrder,
+      columns,
     );
     if (programmaticBreakdown) {
       lines.push(programmaticBreakdown);
@@ -41,22 +46,21 @@ export function renderMarkdownReport(summary: BatchSummary): string {
   return lines.join('\n');
 }
 
-function renderTopVerdict(summary: BatchSummary): string {
-  const mcps = summary.mcpOrder;
+function renderTopVerdict(summary: BatchSummary, columns: ColumnKey[]): string {
   const baseline = summary.baseline;
-  // Header: | Scenario | MCP1 | MCP2 | ... | Δ₁ | Δ₂ | ...
-  const mcpHeaders = mcps.map(m => m).join(' | ');
-  const challengers = mcps.filter(m => m !== baseline);
+  // Header: | Scenario | Col1 | Col2 | ... | Δ₁ | Δ₂ | ...
+  const colHeaders = columns.join(' | ');
+  const challengers = columns.filter(m => m !== baseline);
   const deltaHeaders =
     challengers.length > 0
       ? ' | ' + challengers.map(m => `Δ (${m})`).join(' | ')
       : '';
-  const header = `| Scenario | ${mcpHeaders}${deltaHeaders} |`;
-  const sep = '|---' + '|---'.repeat(mcps.length + challengers.length) + '|';
+  const header = `| Scenario | ${colHeaders}${deltaHeaders} |`;
+  const sep = '|---' + '|---'.repeat(columns.length + challengers.length) + '|';
 
   const rows = [header, sep];
   for (const s of summary.scenarios) {
-    const mcpCells = mcps.map(m => {
+    const colCells = columns.map(m => {
       const c = s.cells[m];
       return c ? pct(c.combinedScore.mean) : '—';
     });
@@ -66,7 +70,7 @@ function renderTopVerdict(summary: BatchSummary): string {
         ? signedPct(d.combinedScore)
         : '—';
     });
-    const allCells = [...mcpCells, ...deltaCells];
+    const allCells = [...colCells, ...deltaCells];
     rows.push(`| ${s.scenario} | ${allCells.join(' | ')} |`);
   }
   return ['### Top-line verdict', '', ...rows].join('\n');
@@ -74,36 +78,37 @@ function renderTopVerdict(summary: BatchSummary): string {
 
 function renderScenarioTable(
   scenario: ScenarioSummary,
-  mcpOrder: McpKind[],
+  columns: ColumnKey[],
 ): string {
   const baseline = scenario.baseline;
-  const challengers = mcpOrder.filter(m => m !== baseline);
+  const challengers = columns.filter(m => m !== baseline);
   const hasDelta = challengers.length > 0;
 
-  // Build dynamic headers: | Metric | MCP1 | MCP2 | ... | Δ₁ | ...
-  const mcpHeaders = mcpOrder.map(m => m).join(' | ');
+  // Build dynamic headers: | Metric | Col1 | Col2 | ... | Δ₁ | ...
+  const colHeaders = columns.join(' | ');
   const deltaHeaders = hasDelta
     ? ' | ' + challengers.map(m => `Δ (${m})`).join(' | ')
     : '';
-  const header = `| Metric | ${mcpHeaders}${deltaHeaders} |`;
-  const sep =
-    '|---' + '|---'.repeat(mcpOrder.length + challengers.length) + '|';
+  const header = `| Metric | ${colHeaders}${deltaHeaders} |`;
+  const sep = '|---' + '|---'.repeat(columns.length + challengers.length) + '|';
 
   const rows = [header, sep];
 
-  const cellFor = (m: McpKind): CellSummary | undefined => scenario.cells[m];
-  const deltaFor = (m: McpKind): DeltaSummary | undefined => scenario.deltas[m];
+  const cellFor = (col: ColumnKey): CellSummary | undefined =>
+    scenario.cells[col];
+  const deltaFor = (col: ColumnKey): DeltaSummary | undefined =>
+    scenario.deltas[col];
 
   function addRow(
     label: string,
     valueFn: (c: CellSummary | undefined) => string,
     deltaFn?: (d: DeltaSummary | undefined) => string,
   ) {
-    const mcpCells = mcpOrder.map(m => valueFn(cellFor(m)));
+    const colCells = columns.map(m => valueFn(cellFor(m)));
     const deltaCells = hasDelta
       ? challengers.map(m => (deltaFn ? deltaFn(deltaFor(m)) : '—'))
       : [];
-    rows.push(`| ${label} | ${[...mcpCells, ...deltaCells].join(' | ')} |`);
+    rows.push(`| ${label} | ${[...colCells, ...deltaCells].join(' | ')} |`);
   }
 
   addRow(
@@ -152,7 +157,7 @@ function renderScenarioTable(
 
 function renderJudgeBreakdown(
   scenario: ScenarioSummary,
-  mcpOrder: McpKind[],
+  columns: ColumnKey[],
 ): string | null {
   const allCriteria = new Set<string>();
   for (const cell of Object.values(scenario.cells)) {
@@ -161,26 +166,26 @@ function renderJudgeBreakdown(
   }
   if (allCriteria.size === 0) return null;
 
-  const mcpHeaders = mcpOrder.join(' | ');
+  const colHeaders = columns.join(' | ');
   const rows = [
     '#### Judge per-criterion (mean 0–5)',
     '',
-    `| Criterion | ${mcpHeaders} |`,
-    '|---' + '|---'.repeat(mcpOrder.length) + '|',
+    `| Criterion | ${colHeaders} |`,
+    '|---' + '|---'.repeat(columns.length) + '|',
   ];
   for (const id of [...allCriteria].sort()) {
-    const mcpCells = mcpOrder.map(m => {
+    const colCells = columns.map(m => {
       const v = scenario.cells[m]?.judge.perCriterion[id];
       return fmtScore(v);
     });
-    rows.push(`| ${id} | ${mcpCells.join(' | ')} |`);
+    rows.push(`| ${id} | ${colCells.join(' | ')} |`);
   }
   return rows.join('\n');
 }
 
 function renderProgrammaticBreakdown(
   scenario: ScenarioSummary,
-  mcpOrder: McpKind[],
+  columns: ColumnKey[],
 ): string | null {
   const allChecks = new Set<string>();
   for (const cell of Object.values(scenario.cells)) {
@@ -189,23 +194,23 @@ function renderProgrammaticBreakdown(
   }
   if (allChecks.size === 0) return null;
 
-  const mcpHeaders = mcpOrder.join(' | ');
+  const colHeaders = columns.join(' | ');
   const rows = [
     '#### Programmatic per-check (pass rate)',
     '',
     'Pass rate = positive checks matched + negative checks not matched.',
     '',
-    `| Check | ${mcpHeaders} |`,
-    '|---' + '|---'.repeat(mcpOrder.length) + '|',
+    `| Check | ${colHeaders} |`,
+    '|---' + '|---'.repeat(columns.length) + '|',
   ];
   for (const id of [...allChecks].sort()) {
-    const mcpCells = mcpOrder.map(m => {
+    const colCells = columns.map(m => {
       const v = scenario.cells[m]?.programmatic.perCheck[id];
       return fmtRate(v);
     });
     const isNegative = id.startsWith('false_');
     const label = isNegative ? `${id} (neg)` : id;
-    rows.push(`| ${label} | ${mcpCells.join(' | ')} |`);
+    rows.push(`| ${label} | ${colCells.join(' | ')} |`);
   }
   return rows.join('\n');
 }

--- a/packages/hdx-eval/src/reports/store.ts
+++ b/packages/hdx-eval/src/reports/store.ts
@@ -1,12 +1,37 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 import type { GradeRecord } from '../grading/types';
 import type { McpKind, RunRecord } from '../harness/types';
+import { isModelSubdir, isRunJson, safeReaddir } from '../runs/path';
 import { SCENARIO_NAMES } from '../scenarios';
 import { buildAggregate, type GradedRunPair } from './aggregate';
 import { renderMarkdownReport } from './markdown';
 
+function collectRunGradePairs(dir: string, pairs: GradedRunPair[]): void {
+  for (const file of safeReaddir(dir)) {
+    if (isRunJson(file)) {
+      const runPath = join(dir, file);
+      const gradePath = runPath.replace(/\.json$/, '.grade.json');
+      if (!existsSync(gradePath)) continue;
+      try {
+        const run = JSON.parse(readFileSync(runPath, 'utf8')) as RunRecord;
+        const grade = JSON.parse(
+          readFileSync(gradePath, 'utf8'),
+        ) as GradeRecord;
+        pairs.push({ run, grade });
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+}
+
+/**
+ * Load graded pairs from a batch. Supports both the new
+ * `<scenario>/<mcp>/<model>/<index>.json` layout and the legacy
+ * `<scenario>/<mcp>/<index>.json` layout.
+ */
 function loadGradedPairs(batchDir: string): GradedRunPair[] {
   const pairs: GradedRunPair[] = [];
   for (const scenario of safeReaddir(batchDir)) {
@@ -14,20 +39,12 @@ function loadGradedPairs(batchDir: string): GradedRunPair[] {
     const sceneDir = join(batchDir, scenario);
     for (const mcp of safeReaddir(sceneDir)) {
       const mcpDir = join(sceneDir, mcp);
-      for (const file of safeReaddir(mcpDir)) {
-        if (!file.endsWith('.json')) continue;
-        if (file.endsWith('.grade.json')) continue;
-        const runPath = join(mcpDir, file);
-        const gradePath = runPath.replace(/\.json$/, '.grade.json');
-        if (!existsSync(gradePath)) continue;
-        try {
-          const run = JSON.parse(readFileSync(runPath, 'utf8')) as RunRecord;
-          const grade = JSON.parse(
-            readFileSync(gradePath, 'utf8'),
-          ) as GradeRecord;
-          pairs.push({ run, grade });
-        } catch {
-          // skip malformed
+      // Collect runs directly in mcpDir (legacy layout).
+      collectRunGradePairs(mcpDir, pairs);
+      // Also check subdirectories (new model layout).
+      for (const entry of safeReaddir(mcpDir)) {
+        if (isModelSubdir(mcpDir, entry)) {
+          collectRunGradePairs(join(mcpDir, entry), pairs);
         }
       }
     }
@@ -49,12 +66,4 @@ export function writeBatchSummary(
   writeFileSync(outPath, md, 'utf8');
 
   return { jsonPath, mdPath: outPath, pairsCount: pairs.length };
-}
-
-function safeReaddir(path: string): string[] {
-  try {
-    return readdirSync(path);
-  } catch {
-    return [];
-  }
 }

--- a/packages/hdx-eval/src/runs/instrument.ts
+++ b/packages/hdx-eval/src/runs/instrument.ts
@@ -1,12 +1,12 @@
 import type { ClickHouseClient } from '@clickhouse/client';
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 import { createEvalClient, defaultClickHouseUrl } from '../clickhouse/client';
 import { scenarioTables } from '../clickhouse/schema';
 import type { RunRecord } from '../harness/types';
 import { SCENARIO_NAMES } from '../scenarios';
-import { runsRoot } from './path';
+import { isModelSubdir, isRunJson, runsRoot, safeReaddir } from './path';
 
 const QUERY_LOG_BUFFER_MS = 5_000;
 
@@ -287,30 +287,33 @@ export async function instrumentBatch(
       const sceneDir = join(resolved, scenario);
       for (const mcp of safeReaddir(sceneDir)) {
         const mcpDir = join(sceneDir, mcp);
-        for (const file of safeReaddir(mcpDir)) {
-          if (!file.endsWith('.json')) continue;
-          if (file.endsWith('.grade.json') || file.endsWith('.timing.json')) {
-            continue;
+        for (const entry of safeReaddir(mcpDir)) {
+          if (isRunJson(entry)) {
+            // Legacy layout: <scenario>/<mcp>/<index>.json
+            const timing = await instrumentRun({
+              runPath: join(mcpDir, entry),
+              client,
+            });
+            out.push(timing);
+          } else if (isModelSubdir(mcpDir, entry)) {
+            // New layout: <scenario>/<mcp>/<model>/<index>.json
+            const modelDir = join(mcpDir, entry);
+            for (const file of safeReaddir(modelDir)) {
+              if (isRunJson(file)) {
+                const timing = await instrumentRun({
+                  runPath: join(modelDir, file),
+                  client,
+                });
+                out.push(timing);
+              }
+            }
           }
-          const timing = await instrumentRun({
-            runPath: join(mcpDir, file),
-            client,
-          });
-          out.push(timing);
         }
       }
     }
     return out;
   } finally {
     await client.close();
-  }
-}
-
-function safeReaddir(path: string): string[] {
-  try {
-    return readdirSync(path);
-  } catch {
-    return [];
   }
 }
 

--- a/packages/hdx-eval/src/runs/path.ts
+++ b/packages/hdx-eval/src/runs/path.ts
@@ -1,3 +1,4 @@
+import { readdirSync, statSync } from 'fs';
 import { resolve } from 'path';
 
 import type { McpKind } from '../harness/types';
@@ -10,10 +11,22 @@ export function batchDirName(date: Date = new Date()): string {
   return date.toISOString().replace(/[:.]/g, '-');
 }
 
+/**
+ * Sanitize a model ID for use as a directory name. Replaces characters
+ * that are problematic in file paths (`:`, `/`, `\`, `.`) with dashes.
+ *
+ * Dots are replaced to avoid confusion with file extensions when listing
+ * directory entries alongside run files like `0.json`.
+ */
+export function modelDirName(model: string): string {
+  return model.replace(/[:/\\.]/g, '-');
+}
+
 export function runFilePath(args: {
   batchDir: string;
   scenario: string;
   mcp: McpKind;
+  model: string;
   runIndex: number;
 }): string {
   return resolve(
@@ -21,6 +34,48 @@ export function runFilePath(args: {
     args.batchDir,
     args.scenario,
     args.mcp,
+    modelDirName(args.model),
     `${args.runIndex}.json`,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Shared filesystem helpers — used by store, instrument, grade, reports, and
+// the viewer. Centralised here to avoid duplication.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `file` is a numeric-indexed run JSON filename (e.g.
+ * `0.json`, `12.json`). Excludes sidecar files (`.grade.json`,
+ * `.timing.json`) and any other non-run JSON by requiring the `^\d+\.json$`
+ * pattern.
+ */
+export function isRunJson(file: string): boolean {
+  return /^\d+\.json$/.test(file);
+}
+
+/**
+ * Like `readdirSync` but returns `[]` on any error (missing dir, permission
+ * issues, etc.).
+ */
+export function safeReaddir(dirPath: string): string[] {
+  try {
+    return readdirSync(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Returns true when `entry` inside `parentDir` is a subdirectory (i.e. a
+ * model directory in the new layout), as opposed to a file. Uses `stat`
+ * instead of a heuristic so model names containing dots are handled
+ * correctly.
+ */
+export function isModelSubdir(parentDir: string, entry: string): boolean {
+  try {
+    return statSync(resolve(parentDir, entry)).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/packages/hdx-eval/src/runs/store.ts
+++ b/packages/hdx-eval/src/runs/store.ts
@@ -2,7 +2,13 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import type { RunRecord } from '../harness/types';
-import { runFilePath, runsRoot } from './path';
+import {
+  isModelSubdir,
+  isRunJson,
+  runFilePath,
+  runsRoot,
+  safeReaddir,
+} from './path';
 
 export function writeRun(args: {
   record: RunRecord;
@@ -12,6 +18,7 @@ export function writeRun(args: {
     batchDir: args.batchDir,
     scenario: args.record.scenario,
     mcp: args.record.mcp,
+    model: args.record.model,
     runIndex: args.record.runIndex,
   });
   mkdirSync(dirname(path), { recursive: true });
@@ -31,34 +38,34 @@ export function listBatches(): string[] {
   }
 }
 
+/**
+ * List run JSON files in a batch.  Supports both the new
+ * `<scenario>/<mcp>/<model>/<index>.json` layout and the legacy
+ * `<scenario>/<mcp>/<index>.json` layout (for batches created before
+ * the multi-model feature).
+ */
 export function listRunsInBatch(batchDir: string): string[] {
   const root = join(runsRoot(), batchDir);
   const out: string[] = [];
-  try {
-    for (const scenario of readdirSync(root)) {
-      const sceneDir = join(root, scenario);
-      try {
-        for (const mcp of readdirSync(sceneDir)) {
-          const mcpDir = join(sceneDir, mcp);
-          try {
-            for (const file of readdirSync(mcpDir)) {
-              if (
-                file.endsWith('.json') &&
-                !file.endsWith('.grade.json') &&
-                !file.endsWith('.timing.json')
-              )
-                out.push(join(mcpDir, file));
+  for (const scenario of safeReaddir(root)) {
+    const sceneDir = join(root, scenario);
+    for (const mcp of safeReaddir(sceneDir)) {
+      const mcpDir = join(sceneDir, mcp);
+      for (const entry of safeReaddir(mcpDir)) {
+        if (isRunJson(entry)) {
+          // Legacy layout: <scenario>/<mcp>/<index>.json
+          out.push(join(mcpDir, entry));
+        } else if (isModelSubdir(mcpDir, entry)) {
+          // New layout: <scenario>/<mcp>/<model>/<index>.json
+          const modelDir = join(mcpDir, entry);
+          for (const file of safeReaddir(modelDir)) {
+            if (isRunJson(file)) {
+              out.push(join(modelDir, file));
             }
-          } catch {
-            // skip
           }
         }
-      } catch {
-        // skip
       }
     }
-  } catch {
-    // none
   }
   return out.sort();
 }


### PR DESCRIPTION
## What

Adds multi-model support to `hdx-eval` so a single batch can compare different LLM models across MCP configurations.

The `--model` flag now accepts comma-separated model IDs:
```bash
yarn eval run --mcp hyperdx --model claude-opus-4-6,claude-haiku-4-5 --runs 3
```

This creates a matrix of `(mcp, model, runIndex)` cells, enabling apples-to-apples comparison across models within the same batch.

## Why

Previously, comparing models required running separate batches and manually collating results. This makes model comparison a first-class feature of the eval framework.

## Key changes

- **New directory layout**: `<scenario>/<mcp>/<model>/<index>.json` — legacy `<scenario>/<mcp>/<index>.json` layout is still supported for backward compatibility
- **`ColumnKey` type**: Reports now use `mcp` (single-model) or `mcp/model` (multi-model) as column identifiers throughout
- **Centralized helpers**: `isRunJson`, `safeReaddir`, `isModelSubdir` consolidated in `runs/path.ts`, removing duplication from 4 modules
- **Viewer**: Routes and UI updated to show `mcp/model` headings and navigate to model-specific runs
- **`BatchSummary`**: Gains `columnOrder`, `multiModel` fields (`mcpOrder` kept as deprecated alias)
- **Tests**: New test case for multi-model grouping in `aggregate.test.ts`

## Backward compatibility

- Existing batches (single-model, legacy layout) continue to work without changes
- `mcpOrder` is preserved as a deprecated alias of `columnOrder` for older viewer code
- Viewer server handles both old and new API routes