### PR TITLE
fix(mcp): remove max_result_rows from MCP safety settings

### DIFF
--- a/.changeset/remove-mcp-max-result-rows.md
+++ b/.changeset/remove-mcp-max-result-rows.md
@@ -1,0 +1,14 @@
+---
+'@hyperdx/api': patch
+---
+
+fix(mcp): remove max_result_rows from MCP safety settings
+
+Remove the hardcoded max_result_rows=100000 setting from MCP query
+execution. Some ClickHouse connections impose profile constraints that
+cap max_result_rows below our default, causing SETTING_CONSTRAINT_VIOLATION
+errors. The remaining safety settings (max_execution_time=30, readonly=2)
+and trimToolResponse provide sufficient protection.
+
+Add a SETTING_CONSTRAINT_VIOLATION error hint so constrained settings
+surface actionable guidance instead of raw ClickHouse errors.

--- a/packages/api/src/mcp/__tests__/query.test.ts
+++ b/packages/api/src/mcp/__tests__/query.test.ts
@@ -238,6 +238,15 @@ describe('errorHint', () => {
     expect(hint).toContain('too many rows');
   });
 
+  it('should match SETTING_CONSTRAINT_VIOLATION errors', () => {
+    const hint = errorHint(
+      "Setting max_result_rows shouldn't be greater than 1000. (SETTING_CONSTRAINT_VIOLATION)",
+    );
+    expect(hint).not.toBeNull();
+    expect(hint).toContain('profile');
+    expect(hint).toContain('constraint');
+  });
+
   it('should return null for unrecognized errors', () => {
     const hint = errorHint('Connection refused');
     expect(hint).toBeNull();

--- a/packages/api/src/mcp/__tests__/query.test.ts
+++ b/packages/api/src/mcp/__tests__/query.test.ts
@@ -228,14 +228,14 @@ describe('errorHint', () => {
   it('should match RESULT_IS_TOO_LARGE errors', () => {
     const hint = errorHint('Code: 396. DB::Exception: RESULT_IS_TOO_LARGE');
     expect(hint).not.toBeNull();
-    expect(hint).toContain('100,000 rows');
+    expect(hint).toContain('too many rows');
     expect(hint).toContain('LIMIT');
   });
 
   it('should match TOO_MANY_ROWS_OR_BYTES errors', () => {
     const hint = errorHint('Code: 396. DB::Exception: TOO_MANY_ROWS_OR_BYTES');
     expect(hint).not.toBeNull();
-    expect(hint).toContain('100,000 rows');
+    expect(hint).toContain('too many rows');
   });
 
   it('should return null for unrecognized errors', () => {

--- a/packages/api/src/mcp/__tests__/queryTool.test.ts
+++ b/packages/api/src/mcp/__tests__/queryTool.test.ts
@@ -771,17 +771,6 @@ describe('MCP Query Tools', () => {
         expect(parsed.result?.data?.[0]?.value).toBe(30);
       });
 
-      it('should propagate max_result_rows=100000 to ClickHouse', async () => {
-        const result = await callTool(client, 'clickstack_sql', {
-          connectionId: connection._id.toString(),
-          sql: "SELECT getSetting('max_result_rows') AS value",
-        });
-
-        expect(result.isError).toBeFalsy();
-        const parsed = JSON.parse(getFirstText(result));
-        expect(parsed.result?.data?.[0]?.value).toBe(100000);
-      });
-
       it('should propagate readonly=2 to ClickHouse', async () => {
         const result = await callTool(client, 'clickstack_sql', {
           connectionId: connection._id.toString(),
@@ -794,16 +783,15 @@ describe('MCP Query Tools', () => {
       });
 
       it('should apply all safety settings together without readonly conflicts', async () => {
-        // readonly=1 rejects setting changes, so max_execution_time and
-        // max_result_rows would be silently ignored. readonly=2 allows
-        // setting changes while still blocking writes. This test verifies
-        // all three settings are applied in a single query.
+        // readonly=1 rejects setting changes, so max_execution_time
+        // would be silently ignored. readonly=2 allows setting changes
+        // while still blocking writes. This test verifies both settings
+        // are applied in a single query.
         const result = await callTool(client, 'clickstack_sql', {
           connectionId: connection._id.toString(),
           sql: `SELECT
               getSetting('readonly') AS readonly_mode,
-              getSetting('max_execution_time') AS max_exec_time,
-              getSetting('max_result_rows') AS max_rows`,
+              getSetting('max_execution_time') AS max_exec_time`,
         });
 
         expect(result.isError).toBeFalsy();
@@ -811,7 +799,6 @@ describe('MCP Query Tools', () => {
         const row = parsed.result?.data?.[0];
         expect(row?.readonly_mode).toBe(2);
         expect(row?.max_exec_time).toBe(30);
-        expect(row?.max_rows).toBe(100000);
       });
     });
   });

--- a/packages/api/src/mcp/tools/query/helpers.ts
+++ b/packages/api/src/mcp/tools/query/helpers.ts
@@ -64,11 +64,10 @@ export const SAFE_BODY_EXPR_CHARS = /^[\w.':\[\]\-]+$/;
 // ─── Safety limits ───────────────────────────────────────────────────────────
 
 /** ClickHouse settings applied to all MCP query-tool executions.
- *  readonly=2 so max_execution_time and max_result_rows can be set
+ *  readonly=2 so max_execution_time can be set
  *  (readonly=1 rejects all setting changes). */
 const MCP_CLICKHOUSE_SETTINGS = {
   max_execution_time: 30,
-  max_result_rows: '100000',
   readonly: 2,
 } as const;
 
@@ -477,7 +476,7 @@ export function errorHint(msg: string): string | null {
   }
   if (/TOO_MANY_ROWS_OR_BYTES|RESULT_IS_TOO_LARGE/i.test(msg)) {
     return (
-      'The query returned more than 100,000 rows. ' +
+      'The query returned too many rows. ' +
       'Add a LIMIT, narrow the time range, or add filters to reduce the result set.'
     );
   }

--- a/packages/api/src/mcp/tools/query/helpers.ts
+++ b/packages/api/src/mcp/tools/query/helpers.ts
@@ -490,5 +490,13 @@ export function errorHint(msg: string): string | null {
       'map attribute keys before retrying.'
     );
   }
+  if (/SETTING_CONSTRAINT_VIOLATION|shouldn't be greater than/i.test(msg)) {
+    return (
+      'This ClickHouse connection has a profile that restricts one or more ' +
+      'settings to a value lower than requested. This is a server-side ' +
+      'constraint — the query cannot override it. Try running the query ' +
+      'without the constrained setting, or contact the connection administrator.'
+    );
+  }
   return null;
 }


### PR DESCRIPTION
## Problem

MCP queries fail with `SETTING_CONSTRAINT_VIOLATION` on ClickHouse connections where a profile constrains `max_result_rows` below our hardcoded default of 100,000 (e.g. ClickHouse Cloud Demo at play-clickstack.clickhouse.com, which caps it at 1,000):

```
Setting max_result_rows shouldn't be greater than 1000. (SETTING_CONSTRAINT_VIOLATION)
```

## Solution

Remove `max_result_rows` from `MCP_CLICKHOUSE_SETTINGS` entirely. The remaining safety settings provide sufficient protection:

- **`max_execution_time=30`** — kills runaway queries after 30 seconds regardless of row count
- **`readonly=2`** — blocks all write operations (DDL/DML)

The `max_result_rows` cap was a defense-in-depth measure to prevent slow queries returning too many rows and to reduce context window usage, but we already have `trimToolResponse` to cap the response size sent to the agent, and the 30s execution timeout bounds what a query can produce. Removing it avoids the need to detect and clamp per-connection constraints, which would require querying `system.settings` metadata and handling edge cases around profile defaults vs constraint ceilings.

## Changes

- `helpers.ts` — removed `max_result_rows` from settings constant, updated error hint text
- `queryTool.test.ts` — removed `max_result_rows` propagation test, updated combined settings test
- `query.test.ts` — updated error hint assertions