### PR TITLE
feat(traces): surface span links in the trace viewer

### DIFF
--- a/.changeset/span-links-trace-viewer.md
+++ b/.changeset/span-links-trace-viewer.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+"@hyperdx/api": patch
+---
+
+feat: surface OpenTelemetry span links in the trace view. Trace sources gain an optional `spanLinksValueExpression` field (auto-detected from the OTel `Links` column), and the span detail panel shows a new "Span Links" section listing each linked trace ID, span ID, trace state and attributes.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3450,6 +3450,11 @@
             "nullable": true,
             "example": "Events"
           },
+          "spanLinksValueExpression": {
+            "type": "string",
+            "description": "Expression to extract span links. Used to surface links to related spans in the trace view. Expected to be Nested ( TraceId String, SpanId String, TraceState String, Attributes Map(LowCardinality(String), String)",
+            "example": "Links"
+          },
           "implicitColumnExpression": {
             "type": "string",
             "description": "Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log.",

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -195,6 +195,7 @@ export const TraceSource = Source.discriminator<ITraceSource>(
     resourceAttributesExpression: String,
     eventAttributesExpression: String,
     spanEventsValueExpression: String,
+    spanLinksValueExpression: String,
     implicitColumnExpression: String,
     useTextIndexForImplicitColumn: {
       type: String,

--- a/packages/api/src/routers/external-api/v2/sources.ts
+++ b/packages/api/src/routers/external-api/v2/sources.ts
@@ -523,6 +523,10 @@ function formatExternalSource(source: SourceDocument) {
  *           description: Expression to extract span events. Used to capture events associated with spans. Expected to be Nested ( Timestamp DateTime64(9), Name LowCardinality(String), Attributes Map(LowCardinality(String), String)
  *           nullable: true
  *           example: Events
+ *         spanLinksValueExpression:
+ *           type: string
+ *           description: Expression to extract span links. Used to surface links to related spans in the trace view. Expected to be Nested ( TraceId String, SpanId String, TraceState String, Attributes Map(LowCardinality(String), String)
+ *           example: Links
  *         implicitColumnExpression:
  *           type: string
  *           description: Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log.

--- a/packages/app/src/components/DBRowDataPanel.tsx
+++ b/packages/app/src/components/DBRowDataPanel.tsx
@@ -27,6 +27,7 @@ export enum ROW_DATA_ALIASES {
   EVENT_ATTRIBUTES = '__hdx_event_attributes',
   EVENTS_EXCEPTION_ATTRIBUTES = '__hdx_events_exception_attributes',
   SPAN_EVENTS = '__hdx_span_events',
+  SPAN_LINKS = '__hdx_span_links',
 }
 
 export function useRowData({
@@ -141,6 +142,14 @@ export function useRowData({
               {
                 valueExpression: source.spanEventsValueExpression,
                 alias: ROW_DATA_ALIASES.SPAN_EVENTS,
+              },
+            ]
+          : []),
+        ...(source.kind === SourceKind.Trace && source.spanLinksValueExpression
+          ? [
+              {
+                valueExpression: source.spanLinksValueExpression,
+                alias: ROW_DATA_ALIASES.SPAN_LINKS,
               },
             ]
           : []),

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -20,6 +20,7 @@ import EventTag from './EventTag';
 import { ExceptionSubpanel } from './ExceptionSubpanel';
 import { NetworkPropertySubpanel } from './NetworkPropertyPanel';
 import { SpanEventsSubpanel } from './SpanEventsSubpanel';
+import { SpanLinksSubpanel } from './SpanLinksSubpanel';
 
 const EMPTY_OBJ = {};
 export function RowOverviewPanel({
@@ -183,6 +184,13 @@ export function RowOverviewPanel({
     );
   }, [firstRow?.__hdx_span_events]);
 
+  const hasSpanLinks = useMemo(() => {
+    return (
+      Array.isArray(firstRow?.__hdx_span_links) &&
+      firstRow?.__hdx_span_links.length > 0
+    );
+  }, [firstRow?.__hdx_span_links]);
+
   const mainContentColumn = getEventBody(source);
   const mainContent = isString(firstRow?.['__hdx_body'])
     ? firstRow['__hdx_body']
@@ -214,6 +222,7 @@ export function RowOverviewPanel({
         defaultValue={[
           'exception',
           'spanEvents',
+          'spanLinks',
           'network',
           'resourceAttributes',
           'eventAttributes',
@@ -270,6 +279,21 @@ export function RowOverviewPanel({
             <Accordion.Panel>
               <Box px="md">
                 <SpanEventsSubpanel spanEvents={firstRow?.__hdx_span_events} />
+              </Box>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+
+        {hasSpanLinks && (
+          <Accordion.Item value="spanLinks">
+            <Accordion.Control>
+              <Text size="sm" ps="md">
+                Span Links
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Box px="md">
+                <SpanLinksSubpanel spanLinks={firstRow?.__hdx_span_links} />
               </Box>
             </Accordion.Panel>
           </Accordion.Item>

--- a/packages/app/src/components/OnboardingModal.tsx
+++ b/packages/app/src/components/OnboardingModal.tsx
@@ -134,6 +134,7 @@ async function addOtelDemoSources({
       statusCodeExpression: 'StatusCode',
       statusMessageExpression: 'StatusMessage',
       spanEventsValueExpression: 'Events',
+      spanLinksValueExpression: 'Links',
       highlightedTraceAttributeExpressions:
         traceSourceHighlightedTraceAttributes,
       materializedViews: traceSourceMaterializedViews,

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -1790,6 +1790,21 @@ function TraceTableModelForm(props: TableModelProps) {
           placeholder="Events"
         />
       </FormRow>
+      <FormRow
+        label={'Span Links Expression'}
+        helpText="Expression to extract span links. Used to surface links to related spans in the trace view. Expected to be Nested ( TraceId String, SpanId String, TraceState String, Attributes Map(LowCardinality(String), String)"
+      >
+        <SQLInlineEditorControlled
+          tableConnection={{
+            databaseName,
+            tableName,
+            connectionId,
+          }}
+          control={control}
+          name="spanLinksValueExpression"
+          placeholder="Links"
+        />
+      </FormRow>
       <ExpressionFormRow
         control={control}
         setValue={setValue}

--- a/packages/app/src/components/SpanLinksSubpanel.stories.tsx
+++ b/packages/app/src/components/SpanLinksSubpanel.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { SpanLinksSubpanel } from './SpanLinksSubpanel';
+
+export default {
+  title: 'Components/SpanLinksSubpanel',
+  component: SpanLinksSubpanel,
+};
+
+const mockSpanLinks = [
+  {
+    TraceId: '6d4a1f0d2c3b4a5e6f7081929394a5b6',
+    SpanId: '1a2b3c4d5e6f7081',
+    TraceState: '',
+    Attributes: {
+      'link.kind': 'follows_from',
+      'messaging.system': 'kafka',
+    },
+  },
+  {
+    TraceId: 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+    SpanId: '90a1b2c3d4e5f607',
+    TraceState: 'rojo=00f067aa0ba902b7',
+    Attributes: {},
+  },
+];
+
+export const Default = () => <SpanLinksSubpanel spanLinks={mockSpanLinks} />;
+
+export const SingleLink = () => (
+  <SpanLinksSubpanel spanLinks={[mockSpanLinks[0]]} />
+);
+
+export const Empty = () => <SpanLinksSubpanel spanLinks={[]} />;

--- a/packages/app/src/components/SpanLinksSubpanel.tsx
+++ b/packages/app/src/components/SpanLinksSubpanel.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Box, Button } from '@mantine/core';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import { ColumnDef } from '@tanstack/react-table';
+
+import { DBRowJsonViewer } from './DBRowJsonViewer';
+import { SectionWrapper, useShowMoreRows } from './ExceptionSubpanel';
+import { Table } from './Table';
+
+// Make sure SpanLinkData implements Record<string, unknown>
+interface SpanLinkData extends Record<string, unknown> {
+  TraceId: string;
+  SpanId: string;
+  TraceState: string;
+  Attributes: Record<string, string>;
+}
+
+const spanLinkColumns: ColumnDef<SpanLinkData>[] = [
+  {
+    accessorKey: 'TraceId',
+    header: 'Trace ID',
+    size: 280,
+    cell: ({ row }) => (
+      <span className="font-monospace text-break">{row.original.TraceId}</span>
+    ),
+  },
+  {
+    accessorKey: 'SpanId',
+    header: 'Span ID',
+    size: 160,
+    cell: ({ row }) => (
+      <span className="font-monospace text-break">{row.original.SpanId}</span>
+    ),
+  },
+  {
+    accessorKey: 'TraceState',
+    header: 'Trace State',
+    size: 120,
+    cell: ({ row }) =>
+      row.original.TraceState ? (
+        <span className="text-break">{row.original.TraceState}</span>
+      ) : (
+        <span className="text-muted">Empty</span>
+      ),
+  },
+  {
+    accessorKey: 'Attributes',
+    header: 'Attributes',
+    size: 400,
+    cell: ({ row }) => {
+      const attributes = row.original.Attributes;
+      if (attributes && Object.keys(attributes).length > 0) {
+        return (
+          <Box>
+            <DBRowJsonViewer data={attributes} />
+          </Box>
+        );
+      }
+      return <span className="text-muted">Empty</span>;
+    },
+  },
+];
+
+export const SpanLinksSubpanel = ({
+  spanLinks,
+}: {
+  spanLinks?: Record<string, unknown>[] | null;
+}) => {
+  const links = useMemo(() => {
+    if (!spanLinks || spanLinks.length === 0) {
+      return [];
+    }
+
+    // Ensure links have the right shape with type checking. Span links carry
+    // no timestamp, so they keep the order ClickHouse returns them in (the
+    // order they appear in the span's Links column).
+    return spanLinks.filter((link): link is SpanLinkData => {
+      return (
+        typeof link.TraceId === 'string' &&
+        typeof link.SpanId === 'string' &&
+        link.Attributes !== undefined
+      );
+    });
+  }, [spanLinks]);
+
+  const { handleToggleMoreRows, hiddenRowsCount, visibleRows, isExpanded } =
+    useShowMoreRows({
+      rows: links,
+      maxRows: 5,
+    });
+
+  if (!links || links.length === 0) {
+    return (
+      <div className="p-3 text-muted fs-7">
+        No span links available for this trace
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionWrapper>
+        <ErrorBoundary
+          onError={err => {
+            console.error(err);
+          }}
+          fallbackRender={() => (
+            <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent p-4">
+              An error occurred while rendering span links
+            </div>
+          )}
+        >
+          <Table
+            columns={spanLinkColumns}
+            data={visibleRows}
+            emptyMessage="No span links found"
+          />
+        </ErrorBoundary>
+
+        {hiddenRowsCount ? (
+          <Button
+            variant="secondary"
+            size="xs"
+            my="sm"
+            onClick={handleToggleMoreRows}
+          >
+            {isExpanded ? (
+              <>
+                <IconChevronUp size={14} className="me-2" /> Hide links
+              </>
+            ) : (
+              <>
+                <IconChevronDown size={14} className="me-2" />
+                Show {hiddenRowsCount} more links
+              </>
+            )}
+          </Button>
+        ) : null}
+      </SectionWrapper>
+    </div>
+  );
+};

--- a/packages/app/src/components/__tests__/SpanLinksSubpanel.test.tsx
+++ b/packages/app/src/components/__tests__/SpanLinksSubpanel.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from '@testing-library/react';
+
+import { SpanLinksSubpanel } from '../SpanLinksSubpanel';
+
+// Stub the JSON viewer so the assertions focus on the subpanel's row shaping,
+// column rendering and empty-state logic rather than the viewer internals.
+jest.mock('../DBRowJsonViewer', () => ({
+  DBRowJsonViewer: ({ data }: { data: unknown }) => (
+    <div data-testid="json-viewer">{JSON.stringify(data)}</div>
+  ),
+}));
+
+const LINK_A = {
+  TraceId: 'aaaa1111bbbb2222cccc3333dddd4444',
+  SpanId: '1111222233334444',
+  TraceState: '',
+  Attributes: { 'link.kind': 'child_of' },
+};
+
+const LINK_B = {
+  TraceId: 'eeee5555ffff6666aaaa7777bbbb8888',
+  SpanId: '5555666677778888',
+  TraceState: 'congo=t61rcWkgMzE',
+  Attributes: {},
+};
+
+describe('SpanLinksSubpanel', () => {
+  it('renders the empty state when spanLinks is undefined', () => {
+    renderWithMantine(<SpanLinksSubpanel />);
+    expect(
+      screen.getByText('No span links available for this trace'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the empty state when spanLinks is an empty array', () => {
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[]} />);
+    expect(
+      screen.getByText('No span links available for this trace'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the column headers and a single link', () => {
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[LINK_A]} />);
+
+    expect(screen.getByText('Trace ID')).toBeInTheDocument();
+    expect(screen.getByText('Span ID')).toBeInTheDocument();
+    expect(screen.getByText('Trace State')).toBeInTheDocument();
+    expect(screen.getByText('Attributes')).toBeInTheDocument();
+
+    expect(screen.getByText(LINK_A.TraceId)).toBeInTheDocument();
+    expect(screen.getByText(LINK_A.SpanId)).toBeInTheDocument();
+    // Attributes flow through the JSON viewer.
+    expect(screen.getByTestId('json-viewer')).toHaveTextContent('link.kind');
+  });
+
+  it('renders multiple links', () => {
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[LINK_A, LINK_B]} />);
+
+    expect(screen.getByText(LINK_A.TraceId)).toBeInTheDocument();
+    expect(screen.getByText(LINK_B.TraceId)).toBeInTheDocument();
+    expect(screen.getByText(LINK_B.TraceState)).toBeInTheDocument();
+  });
+
+  it('shows the Empty placeholder for a link with no attributes', () => {
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[LINK_B]} />);
+
+    // LINK_B has an empty Attributes map and an empty-by-default Trace State
+    // is not present here, so only the Attributes cell renders "Empty".
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('json-viewer')).not.toBeInTheDocument();
+  });
+
+  it('filters out malformed links missing a string TraceId or SpanId', () => {
+    const malformed = {
+      TraceId: 12345,
+      SpanId: 'deadbeefdeadbeef',
+      TraceState: '',
+      Attributes: {},
+    } as unknown as Record<string, unknown>;
+
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[LINK_A, malformed]} />);
+
+    expect(screen.getByText(LINK_A.TraceId)).toBeInTheDocument();
+    expect(screen.queryByText('12345')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when every link is malformed', () => {
+    const malformed = {
+      SpanId: 'deadbeefdeadbeef',
+      Attributes: {},
+    } as unknown as Record<string, unknown>;
+
+    renderWithMantine(<SpanLinksSubpanel spanLinks={[malformed]} />);
+
+    expect(
+      screen.getByText('No span links available for this trace'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -358,6 +358,9 @@ export async function inferTableSourceConfig({
   // Check if SpanEvents column is available
   const hasSpanEvents = columns.some(col => col.name === 'Events.Timestamp');
 
+  // Check if span Links column is available
+  const hasSpanLinks = columns.some(col => col.name === 'Links.TraceId');
+
   // Check if metadata rollup tables exist and, if so, infer the bucketing
   // granularity from the key-rollup view's `as_select`
   const rollupMeta =
@@ -435,6 +438,7 @@ export async function inferTableSourceConfig({
           statusCodeExpression: 'StatusCode',
           statusMessageExpression: 'StatusMessage',
           ...(hasSpanEvents ? { spanEventsValueExpression: 'Events' } : {}),
+          ...(hasSpanLinks ? { spanLinksValueExpression: 'Links' } : {}),
           ...metadataMVsConfig,
         }
       : {}),

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1748,6 +1748,7 @@ export const TraceSourceSchema = BaseSourceSchema.extend({
   resourceAttributesExpression: z.string().optional(),
   eventAttributesExpression: z.string().optional(),
   spanEventsValueExpression: z.string().optional(),
+  spanLinksValueExpression: z.string().optional(),
   implicitColumnExpression: z.string().optional(),
   displayedTimestampValueExpression: z.string().optional(),
   highlightedTraceAttributeExpressions:


### PR DESCRIPTION
This is a draft to gauge how much work it takes to show OpenTelemetry span links in the trace viewer, mirroring the "References N" accordion in the Grafana ClickHouse datasource.

Short answer: not much. Span links ride on the same plumbing that already powers span events. The OTel `Links` Nested column (`Links.TraceId`, `Links.SpanId`, `Links.TraceState`, `Links.Attributes`) is the structural twin of the `Events` column we already wire through `spanEventsValueExpression`, so the new field flows through schema, model, external API, source form and auto-detection the same way. The only genuinely new code is one render component and one accordion item.

Part of #1593 (HDX-3191).

## Summary

Adds an optional `spanLinksValueExpression` field to trace sources and a new **Span Links** section in the span detail Overview panel. The section renders a span's outgoing links as a read-only table: linked trace ID, span ID, trace state, and attributes. The field auto-detects from the `Links.TraceId` column and defaults to `Links`, so existing OTel span sources pick it up with no manual config.

## What's in this PR

- `spanLinksValueExpression` on the trace source schema (`common-utils`), the Mongoose trace model, and the external API source block (`openapi.json` regenerated).
- Auto-detection in `source.ts`: sets `spanLinksValueExpression: 'Links'` when a `Links.TraceId` column is present, alongside the existing span-events detection.
- A "Span Links Expression" row in the source form and the default in the onboarding flow.
- A `__hdx_span_links` select in `DBRowDataPanel` and a new `SpanLinksSubpanel` that renders the links table.
- A new **Span Links** accordion item in `DBRowOverviewPanel`, shown only when the selected span actually has links.
- Unit tests for `SpanLinksSubpanel` (row shaping, columns, empty state, malformed-row filtering) and a Storybook story.

## One intentional difference from the sibling fields

The new `spanLinksValueExpression` OpenAPI block omits `nullable: true`. The field is `.optional()` (a string or absent, never null), and the read serializer drops undefined optionals through `SourceSchema.safeParse`, so the response never carries a null here. The older sibling expression blocks still carry `nullable: true`; I left those alone to keep this change focused rather than re-touch every block. Happy to make the siblings consistent in a separate change if we want that.

## Test plan

- `make ci-lint` (lint + tsc + OpenAPI spectral) green.
- `make ci-unit` green; the new `SpanLinksSubpanel` tests pass (7 cases).
- `knip` clean.
- Rendered the new component in Storybook and captured it with Playwright in both **light** and **dark** themes, plus the **empty** state (no links) and exercised the `ErrorBoundary` **error** fallback path. The table sits in the narrow span-detail side panel and reuses the same `Table` primitive as Span Events, which handles horizontal overflow at panel width.

Light and dark screenshots are below.

## Tier

This lands as **Tier 4** because it touches `packages/api/src/routers/external-api/v2/sources.ts` (any external-API touch is Tier 4 in the classifier) and spans three layers. For a draft that is fine. For the real merge path I would split it:

- PR1: schema, model, external API, source form, onboarding, auto-detect (the plumbing).
- PR2: the `DBRowDataPanel` select, `SpanLinksSubpanel`, the accordion item, tests and the story (the UI).

## What's NOT in this PR (follow-ups)

- Click-to-navigate from a link to the linked trace. Validation against the Grafana datasource showed navigation is the fiddly part even where links already render, so it deserves its own change.
- Waterfall graph topology for linked spans that currently render as orphan roots (the broader framing in #1593).
- Customer docs and e2e coverage.
