### PR TITLE
feat: add copy button to "Sent Query" in error modal

### DIFF
--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -2361,13 +2361,23 @@ export function DBSearchPage() {
                             <Text my="sm" size="sm">
                               Original Query:
                             </Text>
-                            <SQLPreview
-                              data={queryError.query}
-                              formatData
-                              enableCopy
-                              copyButtonSize="xs"
-                              enableLineWrapping
-                            />
+                            <Box
+                              p="xs"
+                              style={{
+                                borderRadius: 'var(--mantine-radius-sm)',
+                                backgroundColor:
+                                  'light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5))',
+                                overflow: 'hidden',
+                              }}
+                            >
+                              <SQLPreview
+                                data={queryError.query}
+                                formatData
+                                enableCopy
+                                copyButtonSize="xs"
+                                enableLineWrapping
+                              />
+                            </Box>
                           </Box>
                         )}
                       </div>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -2365,6 +2365,7 @@ export function DBSearchPage() {
                               data={queryError.query}
                               formatData
                               enableCopy
+                              copyButtonSize="xs"
                               enableLineWrapping
                             />
                           </Box>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -2361,18 +2361,12 @@ export function DBSearchPage() {
                             <Text my="sm" size="sm">
                               Original Query:
                             </Text>
-                            <Code
-                              block
-                              style={{
-                                whiteSpace: 'pre-wrap',
-                              }}
-                            >
-                              <SQLPreview
-                                data={queryError.query}
-                                formatData
-                                enableLineWrapping
-                              />
-                            </Code>
+                            <SQLPreview
+                              data={queryError.query}
+                              formatData
+                              enableCopy
+                              enableLineWrapping
+                            />
                           </Box>
                         )}
                       </div>

--- a/packages/app/src/components/charts/ChartErrorState.tsx
+++ b/packages/app/src/components/charts/ChartErrorState.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import cx from 'classnames';
 import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
-import { Button, Code, Group, Modal, Stack, Text } from '@mantine/core';
+import { Box, Button, Code, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconArrowsDiagonal } from '@tabler/icons-react';
 
@@ -20,7 +20,7 @@ export default function ChartErrorState({
 
   const details = useMemo(() => {
     return (
-      <Stack align="start">
+      <Stack align="start" w="100%">
         <Text size="sm" mt={10}>
           Error Message:
         </Text>
@@ -34,12 +34,12 @@ export default function ChartErrorState({
           {error.message}
         </Code>
         {error instanceof ClickHouseQueryError && (
-          <>
-            <Text size="sm" ta="center">
+          <Box w="100%">
+            <Text size="sm" mb="xs">
               Sent Query:
             </Text>
             <SQLPreview data={error?.query} enableCopy enableLineWrapping />
-          </>
+          </Box>
         )}
       </Stack>
     );

--- a/packages/app/src/components/charts/ChartErrorState.tsx
+++ b/packages/app/src/components/charts/ChartErrorState.tsx
@@ -38,7 +38,7 @@ export default function ChartErrorState({
             <Text size="sm" ta="center">
               Sent Query:
             </Text>
-            <SQLPreview data={error?.query} enableLineWrapping />
+            <SQLPreview data={error?.query} enableCopy enableLineWrapping />
           </>
         )}
       </Stack>

--- a/packages/app/src/components/charts/ChartErrorState.tsx
+++ b/packages/app/src/components/charts/ChartErrorState.tsx
@@ -38,7 +38,12 @@ export default function ChartErrorState({
             <Text size="sm" mb="xs">
               Sent Query:
             </Text>
-            <SQLPreview data={error?.query} enableCopy enableLineWrapping />
+            <SQLPreview
+              data={error?.query}
+              enableCopy
+              copyButtonSize="xs"
+              enableLineWrapping
+            />
           </Box>
         )}
       </Stack>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds "Copy" buttons to SQL query previews in a few error states across the app, making it easy to copy failing queries for debugging. Uses the compact (`xs`) button size to minimize overlap with the SQL code.

### Screenshots or video

<img width="1925" height="560" alt="Screenshot 2026-06-11 at 8 12 59 AM" src="https://github.com/user-attachments/assets/3a538a9e-bda2-41f2-b86f-11ed9bbaac76" />
<img width="659" height="726" alt="Screenshot 2026-06-11 at 8 13 24 AM" src="https://github.com/user-attachments/assets/2a8edf8e-8f00-4557-928e-74401fd915f1" />
<img width="2296" height="543" alt="Screenshot 2026-06-11 at 8 13 15 AM" src="https://github.com/user-attachments/assets/c9b0075d-ea3f-4f1e-963e-97ab294e5db8" />

### How to test on Vercel preview

Open the preview environment and create failed query errors by setting invalid where conditions. Validate that the query can be copied.

### References

- Linear Issue: Closes HDX-4527

