### PR TITLE
feat: use optimistic updates for favorite toggling

### DIFF
--- a/.changeset/eight-phones-protect.md
+++ b/.changeset/eight-phones-protect.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: Use optimistic updates for favorites

--- a/packages/app/src/favorites.ts
+++ b/packages/app/src/favorites.ts
@@ -23,6 +23,7 @@ export function useFavorites() {
   return useQuery({
     queryKey: ['favorites'],
     queryFn: fetchFavorites,
+    staleTime: 5_000,
   });
 }
 
@@ -30,6 +31,8 @@ function useAddFavorite() {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // shared key with useRemoveFavorite to coordinate refetching and optimistic updates
+    mutationKey: ['favorites'],
     mutationFn: (data: {
       resourceType: Favorite['resourceType'];
       resourceId: string;
@@ -42,8 +45,32 @@ function useAddFavorite() {
         json: data,
       }).json<Favorite>();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+    onMutate: async data => {
+      // Cancel any outgoing favorites refetches (so they don't overwrite our optimistic update)
+      await queryClient.cancelQueries({ queryKey: ['favorites'] });
+
+      // Get the previous value so that we can roll back if the mutation fails
+      const previous = queryClient.getQueryData<Favorite[]>(['favorites']);
+
+      // Optimistically update to the new value
+      queryClient.setQueryData<Favorite[]>(['favorites'], old => [
+        ...(old ?? []),
+        { id: `optimistic-${Math.random().toString(36).slice(2)}`, ...data },
+      ]);
+      return { previous };
+    },
+    onError: (_err, _data, context) => {
+      if (context !== undefined) {
+        queryClient.setQueryData(['favorites'], context.previous);
+      }
+    },
+    onSettled: () => {
+      // Only refetch once the last in-flight favorites mutation settles, so a
+      // refetch with partially-committed server state can't clobber the
+      // still-pending optimistic updates from other mutations.
+      if (queryClient.isMutating({ mutationKey: ['favorites'] }) === 1) {
+        queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      }
     },
   });
 }
@@ -52,6 +79,8 @@ function useRemoveFavorite() {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // shared key with useRemoveFavorite to coordinate refetching and optimistic updates
+    mutationKey: ['favorites'],
     mutationFn: (data: {
       resourceType: Favorite['resourceType'];
       resourceId: string;
@@ -72,8 +101,37 @@ function useRemoveFavorite() {
         method: 'DELETE',
       }).json<void>();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['favorites'] });
+    onMutate: async data => {
+      // Cancel any outgoing favorites refetches (so they don't overwrite our optimistic update)
+      await queryClient.cancelQueries({ queryKey: ['favorites'] });
+
+      // Get the previous value so that we can roll back if the mutation fails
+      const previous = queryClient.getQueryData<Favorite[]>(['favorites']);
+
+      // Optimistically update to the new value
+      queryClient.setQueryData<Favorite[]>(['favorites'], old =>
+        (old ?? []).filter(
+          f =>
+            !(
+              f.resourceType === data.resourceType &&
+              f.resourceId === data.resourceId
+            ),
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _data, context) => {
+      if (context !== undefined) {
+        queryClient.setQueryData(['favorites'], context.previous);
+      }
+    },
+    onSettled: () => {
+      // Only refetch once the last in-flight favorites mutation settles, so a
+      // refetch with partially-committed server state can't clobber the
+      // still-pending optimistic updates from other mutations.
+      if (queryClient.isMutating({ mutationKey: ['favorites'] }) === 1) {
+        queryClient.invalidateQueries({ queryKey: ['favorites'] });
+      }
     },
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When toggling a saved search or dashboard's favorited status, there was a noticeable delay between clicking the star button and seeing the new favorite state. This was because the mutations waited for the network round-trip to complete before invalidating and refetching the favorites query.

This PR adds React Query optimistic updates to the `useAddFavorite` and `useRemoveFavorite` mutation hooks so the UI updates instantly

### Screenshots or video

Before (with artificial 1s endpoint delay locally):

https://github.com/user-attachments/assets/fce0c94f-b3db-4805-bdc0-573b9f230299

After (with artificial 1s endpoint delay locally):

https://github.com/user-attachments/assets/bb1db54d-db34-4f7c-a841-3d412ff18e12

### How to test on Vercel preview

To really illustrate the difference, run locally with the following added to the favorites route to create an exxagerated network delay:

```
      await new Promise(resolve => setTimeout(resolve, 1000));
```

### References

- Linear Issue: Closes HDX-4528