### PR TITLE
fix: Navigate to the dashboard listing page after deleting a dashboard

### DIFF
--- a/.changeset/giant-waves-argue.md
+++ b/.changeset/giant-waves-argue.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Navigate to the dashboard listing page after deleting a dashboard

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -2415,7 +2415,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             onClick={() =>
               deleteDashboard.mutate(dashboard?.id ?? '', {
                 onSuccess: () => {
-                  router.push('/dashboards');
+                  router.push('/dashboards/list');
                 },
               })
             }

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -1487,4 +1487,34 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       });
     },
   );
+
+  test(
+    'should navigate to the dashboard listing page after deleting a dashboard',
+    { tag: '@full-stack' },
+    async ({ page }) => {
+      const ts = Date.now();
+      const uniqueName = `E2E Delete Nav Dashboard ${ts}`;
+
+      await test.step('Create a new saved dashboard', async () => {
+        await dashboardsListPage.goto();
+        await dashboardsListPage.createNewDashboard();
+        await dashboardPage.editDashboardName(uniqueName);
+      });
+
+      await test.step('Delete the dashboard via the dashboard menu', async () => {
+        await dashboardPage.deleteDashboard();
+      });
+
+      await test.step('Verify navigation to the dashboards listing page', async () => {
+        await expect(page).toHaveURL(/\/dashboards\/list/);
+        await expect(dashboardsListPage.pageContainer).toBeVisible();
+      });
+
+      await test.step('Verify the deleted dashboard is not listed', async () => {
+        await expect(
+          dashboardsListPage.getDashboardCard(uniqueName),
+        ).toBeHidden();
+      });
+    },
+  );
 });

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -84,6 +84,7 @@ export class DashboardPage {
   private readonly confirmCancelButton: Locator;
   private readonly confirmConfirmButton: Locator;
   private readonly dashboardMenuButton: Locator;
+  private readonly deleteDashboardMenuItem: Locator;
   private readonly saveDefaultQueryAndFiltersMenuItem: Locator;
   private readonly removeDefaultQueryAndFiltersMenuItem: Locator;
   private readonly exportDashboardMenuItem: Locator;
@@ -132,6 +133,9 @@ export class DashboardPage {
     this.confirmCancelButton = page.getByTestId('confirm-cancel-button');
     this.confirmConfirmButton = page.getByTestId('confirm-confirm-button');
     this.dashboardMenuButton = page.getByTestId('dashboard-menu-button');
+    this.deleteDashboardMenuItem = page.getByRole('menuitem', {
+      name: 'Delete Dashboard',
+    });
     this.saveDefaultQueryAndFiltersMenuItem = page.getByTestId(
       'save-default-query-filters-menu-item',
     );
@@ -634,6 +638,11 @@ export class DashboardPage {
   async removeSavedQueryAndFiltersDefaults() {
     await this.dashboardMenuButton.click();
     await this.removeDefaultQueryAndFiltersMenuItem.click();
+  }
+
+  async deleteDashboard() {
+    await this.dashboardMenuButton.click();
+    await this.deleteDashboardMenuItem.click();
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When deleting a dashboard from the dashboard detail page (via the three-dot menu), the user was incorrectly navigated to the temporary dashboard page (`/dashboards`). This changes the post-delete navigation to redirect to the dashboard listing page (`/dashboards/list`) instead, which is consistent with the breadcrumbs and app navigation.

### How to test on Vercel preview

Create a dashboard, then delete it and note that you are now navigated to the dashboards listing page.

### References

- Linear Issue: Closes HDX-4529

Linear Issue: [HDX-4529](https://linear.app/clickhouse/issue/HDX-4529/navigate-to-the-dashboard-listing-page-after-deleting-a-dashboard)

<div><a href="https://cursor.com/agents/bc-c42113c9-7438-425b-b9a6-b1ec55795b75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c42113c9-7438-425b-b9a6-b1ec55795b75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

