### PR TITLE
fix: Add missing numberFormats, compareToPreviousPeriod fields to MCP Schemas

### DIFF
--- a/.changeset/curvy-foxes-give.md
+++ b/.changeset/curvy-foxes-give.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: Add missing numberFormats, compareToPreviousPeriod fields to MCP Schemas

--- a/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
@@ -371,6 +371,113 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
       expect(output.tiles).toHaveLength(1);
     });
 
+    it('should preserve display fields on raw SQL tiles through save, get, update, and re-get', async () => {
+      const connectionId = ctx.connection._id.toString();
+      const sqlConfig = {
+        configType: 'sql' as const,
+        displayType: 'line' as const,
+        connectionId,
+        sqlTemplate:
+          'SELECT $__timeInterval(Timestamp) AS ts, avg(Duration) AS v FROM otel_traces WHERE $__timeFilter(Timestamp) GROUP BY ts ORDER BY ts LIMIT 1000',
+        numberFormat: {
+          output: 'percent' as const,
+          mantissa: 2,
+          thousandSeparated: true,
+        },
+        compareToPreviousPeriod: true,
+        fitYAxisToData: true,
+      };
+      const sqlNumberConfig = {
+        configType: 'sql' as const,
+        displayType: 'number' as const,
+        connectionId,
+        sqlTemplate: 'SELECT 0.99 AS value LIMIT 1',
+        numberFormat: { output: 'percent' as const, mantissa: 2 },
+      };
+
+      const saveResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        {
+          name: 'SQL NumberFormat Round-Trip',
+          tiles: [
+            { name: 'CPU %', config: sqlConfig },
+            { name: 'SLO', config: sqlNumberConfig },
+            {
+              name: 'Other Tile',
+              config: {
+                configType: 'sql' as const,
+                displayType: 'table' as const,
+                connectionId,
+                sqlTemplate: 'SELECT 1 AS value LIMIT 1',
+              },
+            },
+          ],
+        },
+      );
+      expect(saveResult.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(saveResult));
+      const savedSqlTile = saved.tiles.find(
+        (t: { name: string }) => t.name === 'CPU %',
+      );
+      expect(savedSqlTile.config).toMatchObject(sqlConfig);
+      const savedSqlNumberTile = saved.tiles.find(
+        (t: { name: string }) => t.name === 'SLO',
+      );
+      expect(savedSqlNumberTile.config).toMatchObject(sqlNumberConfig);
+
+      const getResult = await callTool(
+        ctx.client!,
+        'clickstack_get_dashboard',
+        { id: saved.id },
+      );
+      expect(getResult.isError).toBeFalsy();
+      const fetched = JSON.parse(getFirstText(getResult));
+      const fetchedSqlTile = fetched.tiles.find(
+        (t: { name: string }) => t.name === 'CPU %',
+      );
+      expect(fetchedSqlTile.config).toMatchObject(sqlConfig);
+
+      // Update a DIFFERENT tile, passing all fetched tiles back — the
+      // formatted SQL tile must survive the round-trip untouched.
+      const updateResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        {
+          id: saved.id,
+          name: 'SQL NumberFormat Round-Trip',
+          tiles: fetched.tiles.map((t: { name: string; config: object }) =>
+            t.name === 'Other Tile'
+              ? {
+                  ...t,
+                  config: {
+                    ...t.config,
+                    sqlTemplate: 'SELECT 2 AS value LIMIT 1',
+                  },
+                }
+              : t,
+          ),
+        },
+      );
+      expect(updateResult.isError).toBeFalsy();
+
+      const getAfterUpdate = await callTool(
+        ctx.client!,
+        'clickstack_get_dashboard',
+        { id: saved.id },
+      );
+      expect(getAfterUpdate.isError).toBeFalsy();
+      const refetched = JSON.parse(getFirstText(getAfterUpdate));
+      const refetchedSqlTile = refetched.tiles.find(
+        (t: { name: string }) => t.name === 'CPU %',
+      );
+      expect(refetchedSqlTile.config).toMatchObject(sqlConfig);
+      const refetchedSqlNumberTile = refetched.tiles.find(
+        (t: { name: string }) => t.name === 'SLO',
+      );
+      expect(refetchedSqlNumberTile.config).toMatchObject(sqlNumberConfig);
+    });
+
     it('should create a dashboard with a heatmap tile on a Trace source', async () => {
       const sourceId = ctx.traceSource._id.toString();
       const result = await callTool(ctx.client!, 'clickstack_save_dashboard', {
@@ -604,6 +711,108 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
       });
 
       expect(result.isError).toBe(true);
+    });
+
+    it('should preserve display fields on builder tiles through save, get, update, and re-get', async () => {
+      const sourceId = ctx.traceSource._id.toString();
+      const numberFormat = {
+        output: 'percent' as const,
+        mantissa: 2,
+        thousandSeparated: true,
+      };
+      const lineConfig = {
+        displayType: 'line' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const, alias: 'Requests' }],
+        numberFormat,
+        compareToPreviousPeriod: true,
+        fitYAxisToData: true,
+      };
+      const barConfig = {
+        displayType: 'stacked_bar' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const, alias: 'Requests' }],
+        numberFormat,
+      };
+      const tableConfig = {
+        displayType: 'table' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const, alias: 'Requests' }],
+        groupBy: 'SpanName',
+        numberFormat,
+      };
+      const pieConfig = {
+        displayType: 'pie' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const, alias: 'Requests' }],
+        groupBy: 'SpanName',
+        numberFormat,
+      };
+      const numberConfig = {
+        displayType: 'number' as const,
+        sourceId,
+        select: [{ aggFn: 'count' as const, alias: 'Requests' }],
+        numberFormat,
+      };
+      const tiles = [
+        { name: 'Line', config: lineConfig },
+        { name: 'Bar', config: barConfig },
+        { name: 'Table', config: tableConfig },
+        { name: 'Pie', config: pieConfig },
+        { name: 'Number', config: numberConfig },
+      ];
+      const configByName: Record<string, object> = {
+        Line: lineConfig,
+        Bar: barConfig,
+        Table: tableConfig,
+        Pie: pieConfig,
+        Number: numberConfig,
+      };
+      const assertTiles = (output: { tiles: { name: string }[] }) => {
+        for (const [name, config] of Object.entries(configByName)) {
+          const tile = output.tiles.find(t => t.name === name);
+          expect(tile).toMatchObject({ config });
+        }
+      };
+
+      const saveResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        { name: 'Builder Display Fields', tiles },
+      );
+      expect(saveResult.isError).toBeFalsy();
+      const saved = JSON.parse(getFirstText(saveResult));
+      assertTiles(saved);
+
+      const getResult = await callTool(
+        ctx.client!,
+        'clickstack_get_dashboard',
+        { id: saved.id },
+      );
+      expect(getResult.isError).toBeFalsy();
+      const fetched = JSON.parse(getFirstText(getResult));
+      assertTiles(fetched);
+
+      // Update passing all fetched tiles back verbatim — every display
+      // field must survive a second pass through the MCP input schema.
+      const updateResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        {
+          id: saved.id,
+          name: 'Builder Display Fields (updated)',
+          tiles: fetched.tiles,
+        },
+      );
+      expect(updateResult.isError).toBeFalsy();
+
+      const getAfterUpdate = await callTool(
+        ctx.client!,
+        'clickstack_get_dashboard',
+        { id: saved.id },
+      );
+      expect(getAfterUpdate.isError).toBeFalsy();
+      assertTiles(JSON.parse(getFirstText(getAfterUpdate)));
     });
 
     it('should reject heatmap tile on a non-Trace source', async () => {

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -16,67 +16,73 @@ import { z } from 'zod';
 import { externalQuantileLevelSchema, objectIdSchema } from '@/utils/zod';
 
 // ─── Shared tile schemas for MCP dashboard tools ─────────────────────────────
-const mcpNumberFormatSchema = z
-  .object({
-    output: z
-      .enum([
-        'currency',
-        'percent',
-        'byte',
-        'time',
-        'duration',
-        'number',
-        'data_rate',
-        'throughput',
-      ])
-      .describe(
-        'Format category. "duration" auto-formats elapsed times as e.g. "1.2s" (use factor for input unit). ' +
-          '"time" formats clock-style durations. "byte" formats as KB/MB/GB. ' +
-          '"data_rate" formats as bytes/sec. "throughput" formats as count/sec. ' +
-          '"currency" prepends a symbol. "percent" appends %.',
-      ),
-    mantissa: z
-      .number()
-      .int()
-      .optional()
-      .describe(
-        'Decimal places (0–10). Not used for "time" or "duration" output.',
-      ),
-    thousandSeparated: z
-      .boolean()
-      .optional()
-      .describe('Separate thousands (e.g. 1,234,567)'),
-    average: z
-      .boolean()
-      .optional()
-      .describe('Abbreviate large numbers (e.g. 1.2m)'),
-    decimalBytes: z
-      .boolean()
-      .optional()
-      .describe(
-        'Use decimal base for bytes (1KB = 1000). Only for "byte" output.',
-      ),
-    factor: z
-      .number()
-      .optional()
-      .describe(
-        'Input unit factor for "time" or "duration" output. ' +
-          '1 = seconds, 0.001 = milliseconds, 0.000001 = microseconds, 0.000000001 = nanoseconds.',
-      ),
-    currencySymbol: z
-      .string()
-      .optional()
-      .describe('Currency symbol (e.g. "$"). Only for "currency" output.'),
-    unit: z
-      .string()
-      .optional()
-      .describe('Suffix appended to the value (e.g. " req/s")'),
-  })
-  .describe(
-    'Controls how the number value is formatted for display. ' +
-      'Most useful: { output: "duration", factor: 0.000000001 } to auto-format nanosecond durations, ' +
-      'or { output: "number", mantissa: 2, thousandSeparated: true } for clean counts.',
-  );
+
+const seriesLevelNumberFormatDescription =
+  'Per-series display formatting, applied to this series only (overrides any tile-level numberFormat). ' +
+  'Controls how the series number value(s) are formatted for display. ' +
+  'Most useful: { output: "duration", factor: 0.000000001 } to auto-format nanosecond durations, ' +
+  'or { output: "number", mantissa: 2, thousandSeparated: true } for clean counts.';
+
+const tileLevelNumberFormatDescription =
+  'Controls how the number value(s) are formatted for display. Applies to series or numbers without a series-level numberFormat. ' +
+  'Most useful: { output: "duration", factor: 0.000000001 } to auto-format nanosecond durations, ' +
+  'or { output: "number", mantissa: 2, thousandSeparated: true } for clean counts.';
+
+const mcpNumberFormatSchema = z.object({
+  output: z
+    .enum([
+      'currency',
+      'percent',
+      'byte',
+      'time',
+      'duration',
+      'number',
+      'data_rate',
+      'throughput',
+    ])
+    .describe(
+      'Format category. "duration" auto-formats elapsed times as e.g. "1.2s" (use factor for input unit). ' +
+        '"time" formats clock-style durations. "byte" formats as KB/MB/GB. ' +
+        '"data_rate" formats as bytes/sec. "throughput" formats as count/sec. ' +
+        '"currency" prepends a symbol. "percent" appends %, and divides the value by 100 (0.5 becomes 50%).',
+    ),
+  mantissa: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Decimal places (0–10). Not used for "time" or "duration" output.',
+    ),
+  thousandSeparated: z
+    .boolean()
+    .optional()
+    .describe('Separate thousands (e.g. 1,234,567)'),
+  average: z
+    .boolean()
+    .optional()
+    .describe('Abbreviate large numbers (e.g. 1.2m)'),
+  decimalBytes: z
+    .boolean()
+    .optional()
+    .describe(
+      'Use decimal base for bytes (1KB = 1000). Only for "byte" output.',
+    ),
+  factor: z
+    .number()
+    .optional()
+    .describe(
+      'Input unit factor for "time" or "duration" output. ' +
+        '1 = seconds, 0.001 = milliseconds, 0.000001 = microseconds, 0.000000001 = nanoseconds.',
+    ),
+  currencySymbol: z
+    .string()
+    .optional()
+    .describe('Currency symbol (e.g. "$"). Only for "currency" output.'),
+  unit: z
+    .string()
+    .optional()
+    .describe('Suffix appended to the value (e.g. " req/s")'),
+});
 
 const mcpTileSelectItemSchema = z
   .object({
@@ -112,11 +118,7 @@ const mcpTileSelectItemSchema = z
       .describe('Percentile level for aggFn="quantile"'),
     numberFormat: mcpNumberFormatSchema
       .optional()
-      .describe(
-        'Per-series display formatting, applied to this series only (overrides any tile-level numberFormat). ' +
-          'Example: { output: "duration", factor: 0.000000001 } to render a nanosecond Duration series as human-readable time ' +
-          'while leaving sibling count series unformatted.',
-      ),
+      .describe(seriesLevelNumberFormatDescription),
   })
   .superRefine((data, ctx) => {
     if (data.level && data.aggFn !== 'quantile') {
@@ -399,6 +401,19 @@ const mcpLineTileSchema = mcpTileLayoutSchema.extend({
       .describe(
         'Plot as ratio of two metrics (requires exactly 2 select items)',
       ),
+    numberFormat: mcpNumberFormatSchema
+      .optional()
+      .describe(tileLevelNumberFormatDescription),
+    compareToPreviousPeriod: z
+      .boolean()
+      .optional()
+      .describe('Overlay the previous period as a dashed comparison series.'),
+    fitYAxisToData: z
+      .boolean()
+      .optional()
+      .describe(
+        'Scale the y-axis to the data range instead of starting at zero.',
+      ),
   }),
 });
 
@@ -413,6 +428,9 @@ const mcpBarTileSchema = mcpTileLayoutSchema.extend({
     fillNulls: z.boolean().optional().default(true),
     alignDateRangeToGranularity: z.boolean().optional(),
     asRatio: z.boolean().optional(),
+    numberFormat: mcpNumberFormatSchema
+      .optional()
+      .describe(tileLevelNumberFormatDescription),
   }),
 });
 
@@ -447,6 +465,9 @@ const mcpTableTileSchema = mcpTileLayoutSchema.extend({
         'Render Group By columns on the left side of the table, before the series columns. ' +
           'Default false (Group By columns on the right).',
       ),
+    numberFormat: mcpNumberFormatSchema
+      .optional()
+      .describe(tileLevelNumberFormatDescription),
     onClick: mcpOnClickSchema.optional(),
   }),
 });
@@ -461,10 +482,7 @@ const mcpNumberTileSchema = mcpTileLayoutSchema.extend({
       .describe('Exactly one metric to display'),
     numberFormat: mcpNumberFormatSchema
       .optional()
-      .describe(
-        'Display formatting for the number value. Example: { output: "duration", factor: 0.000000001 } ' +
-          'to auto-format nanosecond durations as human-readable time.',
-      ),
+      .describe(tileLevelNumberFormatDescription),
   }),
 });
 
@@ -480,6 +498,9 @@ const mcpPieTileSchema = mcpTileLayoutSchema.extend({
         'Column that defines pie slices. Use PascalCase for top-level columns. ' +
           "For attributes: SpanAttributes['key'] or ResourceAttributes['key'].",
       ),
+    numberFormat: mcpNumberFormatSchema
+      .optional()
+      .describe(tileLevelNumberFormatDescription),
   }),
 });
 
@@ -616,6 +637,23 @@ const mcpSqlTileSchema = mcpTileLayoutSchema.extend({
       ),
     fillNulls: z.boolean().optional(),
     alignDateRangeToGranularity: z.boolean().optional(),
+    numberFormat: mcpNumberFormatSchema
+      .optional()
+      .describe(tileLevelNumberFormatDescription),
+    compareToPreviousPeriod: z
+      .boolean()
+      .optional()
+      .describe(
+        'Overlay the previous period as a dashed comparison series. ' +
+          'Valid only when displayType is "line", ignored otherwise.',
+      ),
+    fitYAxisToData: z
+      .boolean()
+      .optional()
+      .describe(
+        'Scale the y-axis to the data range instead of starting at zero. ' +
+          'Valid only when displayType is "line", ignored otherwise.',
+      ),
     onClick: mcpOnClickSchema.optional(),
   }),
 });


### PR DESCRIPTION
## Summary

This PR adds a few missing display properties to the MCP schemas, so that the agent can use them, and so that they're not stripped when the agent edits an existing dashboard.

- Tile-level number formats
- Number format on Raw SQL Charts
- Compare to Previous Period on line charts

### Screenshots or video

The agent can now create and update dashboards leveraging all of these fields:

<img width="488" height="157" alt="Screenshot 2026-06-11 at 8 17 48 AM" src="https://github.com/user-attachments/assets/dce27b5c-2657-4bbb-9e5e-c0e2b8809f08" />
<img width="2260" height="237" alt="Screenshot 2026-06-11 at 8 25 37 AM" src="https://github.com/user-attachments/assets/196c30ae-4a5a-412b-b0e7-6b267af4ee0f" />
<img width="2276" height="240" alt="Screenshot 2026-06-11 at 8 27 25 AM" src="https://github.com/user-attachments/assets/9cbee8bd-4453-4280-82b0-3d35bef61ec3" />
<img width="1827" height="191" alt="Screenshot 2026-06-11 at 8 21 18 AM" src="https://github.com/user-attachments/assets/3129c3f9-02b8-455d-ad9e-773a883e105f" />


### How to test on Vercel preview

This can be tested locally by connecting to MCP and requesting the agent creates and updates dashboards with these properties.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4519 Fixes #2435 
- Related PRs:
