### PR TITLE
fix: Prevent various invalid DESCRIBE queries

### DIFF
--- a/.changeset/fuzzy-knives-bathe.md
+++ b/.changeset/fuzzy-knives-bathe.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/common-utils": patch
+---
+
+fix: Skip rendering empty aggConditions

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -2121,6 +2121,66 @@ describe('CustomSchemaSQLSerializerV2 - Array and Nested Fields', () => {
   );
 });
 
+describe('genEnglishExplanation', () => {
+  const metadata = getMetadata(
+    new ClickhouseClient({ host: 'http://localhost:8123' }),
+  );
+  metadata.getColumn = jest.fn().mockImplementation(async () => undefined);
+  metadata.getMaterializedColumnsLookupTable = jest
+    .fn()
+    .mockImplementation(async () => new Map());
+
+  const databaseName = 'testName';
+  const tableName = 'testTable';
+  const connectionId = 'testId';
+  const query = 'bar';
+
+  it('serializes to english when table, database, and connection are present', async () => {
+    const actual = await genEnglishExplanation({
+      query,
+      tableConnection: { tableName, databaseName, connectionId },
+      metadata,
+    });
+    expect(actual).toBe('event has whole word bar');
+  });
+
+  it('falls back to the raw message when tableName is missing', async () => {
+    const actual = await genEnglishExplanation({
+      query,
+      tableConnection: { tableName: '', databaseName, connectionId },
+      metadata,
+    });
+    expect(actual).toBe(`Message containing ${query}`);
+  });
+
+  it('falls back to the raw message when databaseName is missing', async () => {
+    const actual = await genEnglishExplanation({
+      query,
+      tableConnection: { tableName, databaseName: '', connectionId },
+      metadata,
+    });
+    expect(actual).toBe(`Message containing ${query}`);
+  });
+
+  it('falls back to the raw message when connectionId is missing', async () => {
+    const actual = await genEnglishExplanation({
+      query,
+      tableConnection: { tableName, databaseName, connectionId: '' },
+      metadata,
+    });
+    expect(actual).toBe(`Message containing ${query}`);
+  });
+
+  it('falls back to the raw message when all table connection fields are missing', async () => {
+    const actual = await genEnglishExplanation({
+      query,
+      tableConnection: { tableName: '', databaseName: '', connectionId: '' },
+      metadata,
+    });
+    expect(actual).toBe(`Message containing ${query}`);
+  });
+});
+
 describe('parseKvItemsExpression', () => {
   it('parses standard KV items expression', () => {
     expect(

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -691,18 +691,20 @@ async function renderSelectList(
 
   const selectsSQL = await Promise.all(
     selectList.map(async select => {
-      const whereClause = await renderWhereExpression({
-        condition: select.aggCondition ?? '',
-        from: chartConfig.from,
-        language: select.aggConditionLanguage ?? 'lucene',
-        implicitColumnExpression: chartConfig.implicitColumnExpression,
-        bodyExpression: chartConfig.bodyExpression,
-        useTextIndexForImplicitColumn:
-          chartConfig.useTextIndexForImplicitColumn,
-        metadata,
-        connectionId: chartConfig.connection,
-        with: chartConfig.with,
-      });
+      const whereClause = isNonEmptyWhereExpr(select.aggCondition)
+        ? await renderWhereExpression({
+            condition: select.aggCondition ?? '',
+            from: chartConfig.from,
+            language: select.aggConditionLanguage ?? 'lucene',
+            implicitColumnExpression: chartConfig.implicitColumnExpression,
+            bodyExpression: chartConfig.bodyExpression,
+            useTextIndexForImplicitColumn:
+              chartConfig.useTextIndexForImplicitColumn,
+            metadata,
+            connectionId: chartConfig.connection,
+            with: chartConfig.with,
+          })
+        : chSql``;
 
       let expr: ChSql;
       if (select.aggFn == null) {

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -2022,7 +2022,7 @@ export async function genEnglishExplanation({
     const { tableName, databaseName, connectionId } = tableConnection;
     const parsedQ = parse(query);
 
-    if (parsedQ) {
+    if (parsedQ && tableName && databaseName && connectionId) {
       const serializer = new EnglishSerializer({
         metadata,
         tableName,


### PR DESCRIPTION
## Summary

This PR adds some conditions that prevent a few invalid DESCRIBE queries, which resulted in console errors:

1. Prevent calling renderWhereExpression for an empty `aggCondition` on a select item. This fixes the invalid DESCRIBE queries mentioned in #2409
2. Prevent Lucene --> English translation when the table/database/connection is not provided. These will error, and are typically due to the sources not being loaded yet (they happen on page load)

### Screenshots or video

#### Before - Invalid `DESCRIBE .Bucket` and `DESCRIBE .` queries being issued from renderWhereExpression and Lucene --> English translation:

<img width="2557" height="1097" alt="Screenshot 2026-06-11 at 11 53 24 AM" src="https://github.com/user-attachments/assets/24f176b8-90da-4694-bb14-91e92b954210" />

#### After - No such invalid queries:

<img width="2552" height="1288" alt="Screenshot 2026-06-11 at 11 49 14 AM" src="https://github.com/user-attachments/assets/497a4d04-bd4d-47e1-a04c-937c647b8589" />

### How to test on Vercel preview

- Create a chart that targets a metric. Add a where condition and optionally a group by.
- Run the query, reload the page, and check the console logs or network tab for invalid describe queries

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4442 Closes #2409
- Related PRs:
