### PR TITLE
fix(mcp): clarify orderBy alias quoting and steer event-pattern usage

### DIFF
--- a/.changeset/mcp-orderby-alias-quoting.md
+++ b/.changeset/mcp-orderby-alias-quoting.md
@@ -1,0 +1,17 @@
+---
+'@hyperdx/api': patch
+---
+
+fix(mcp): quote multi-word aliases in orderBy and steer event-pattern usage
+
+Quote resolved aliases that are not bare identifiers (e.g. `"P95 Latency"`)
+in `resolveOrderBy` output, in both the direct alias-match and aggFn-match
+paths. Previously an unquoted multi-word alias produced SQL-invalid
+`ORDER BY` output. Incoming orderBy values are stripped of surrounding
+double-quote/backtick quoting before matching, so agents that already quote
+the alias resolve correctly without being double-quoted.
+
+Also document the alias-quoting requirement in the `orderBy` schema
+descriptions, and update the `clickstack_event_patterns` tool description to
+steer agents toward it (over `clickstack_search` / `clickstack_table`) when
+exploring what messages, errors, or events exist.

--- a/packages/api/src/mcp/__tests__/query.test.ts
+++ b/packages/api/src/mcp/__tests__/query.test.ts
@@ -298,9 +298,69 @@ describe('resolveOrderBy', () => {
   });
 
   it('should prefer alias over synthesized expression', () => {
+    expect(resolveOrderBy('count', [{ aggFn: 'count', alias: 'Total' }])).toBe(
+      'Total',
+    );
+  });
+
+  it('should quote a multi-word alias resolved from an aggFn match', () => {
     expect(
       resolveOrderBy('count', [{ aggFn: 'count', alias: 'Total Rows' }]),
-    ).toBe('Total Rows');
+    ).toBe('"Total Rows"');
+  });
+
+  it('should quote a multi-word alias matched directly', () => {
+    expect(
+      resolveOrderBy('P95 Latency', [
+        {
+          aggFn: 'quantile',
+          valueExpression: 'Duration',
+          alias: 'P95 Latency',
+        },
+      ]),
+    ).toBe('"P95 Latency"');
+  });
+
+  it('should quote a multi-word alias and preserve direction', () => {
+    expect(
+      resolveOrderBy('p95 latency DESC', [
+        {
+          aggFn: 'quantile',
+          valueExpression: 'Duration',
+          alias: 'P95 Latency',
+        },
+      ]),
+    ).toBe('"P95 Latency" DESC');
+  });
+
+  it('should accept an already-quoted multi-word alias without double-quoting', () => {
+    expect(
+      resolveOrderBy('"P95 Latency" DESC', [
+        {
+          aggFn: 'quantile',
+          valueExpression: 'Duration',
+          alias: 'P95 Latency',
+        },
+      ]),
+    ).toBe('"P95 Latency" DESC');
+  });
+
+  it('should normalize a backtick-quoted alias to double quotes', () => {
+    expect(
+      resolveOrderBy('`P95 Latency`', [
+        {
+          aggFn: 'quantile',
+          valueExpression: 'Duration',
+          alias: 'P95 Latency',
+        },
+      ]),
+    ).toBe('"P95 Latency"');
+  });
+
+  it('should leave a bare single-word alias unquoted', () => {
+    expect(resolveOrderBy('Total', [{ aggFn: 'count', alias: 'Total' }])).toBe(
+      'Total',
+    );
   });
 
   it('should be case-insensitive for aggFn matching', () => {

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -456,7 +456,14 @@ const mcpTableTileSchema = mcpTileLayoutSchema.extend({
           'from a groupBy: "StatusMessage" table. Mirrors the same field on the REST ' +
           'table chart config in `externalDashboardTableChartConfigSchema`.',
       ),
-    orderBy: z.string().optional().describe('Sort results by this column'),
+    orderBy: z
+      .string()
+      .optional()
+      .describe(
+        'Sort results by this column. ' +
+          'When ordering by an alias that contains spaces or special characters, ' +
+          `wrap the alias in quotes: e.g. '"P95 Latency" DESC'.`,
+      ),
     asRatio: z.boolean().optional(),
     groupByColumnsOnLeft: z
       .boolean()

--- a/packages/api/src/mcp/tools/query/eventPatterns.ts
+++ b/packages/api/src/mcp/tools/query/eventPatterns.ts
@@ -73,7 +73,11 @@ export function registerEventPatterns(server: McpServer, context: McpContext) {
         'Discover the most common log messages and event patterns. ' +
         'Samples random events, clusters them using the Drain algorithm, and returns ' +
         'patterns sorted by frequency with estimated counts and time trends.\n\n' +
-        'Use this when asked about "top patterns", "common logs", "noisy services", ' +
+        'PREFER THIS TOOL over clickstack_search or clickstack_table when the goal is to ' +
+        'understand what kinds of messages, errors, or events exist — e.g. "sample logs", ' +
+        '"what errors are happening", "show me common messages", "what does this service log". ' +
+        'It returns frequency-ranked patterns instead of raw rows, giving a much better overview.\n\n' +
+        'Also use when asked about "top patterns", "common logs", "noisy services", ' +
         '"recurring messages", or log noise analysis.\n\n' +
         'Each pattern includes a "whereSnippet" — use it as the "where" parameter in ' +
         'a follow-up clickstack_search call to browse matching raw events.\n\n' +

--- a/packages/api/src/mcp/tools/query/schemas.ts
+++ b/packages/api/src/mcp/tools/query/schemas.ts
@@ -175,5 +175,7 @@ export const orderBySchema = z
   .string()
   .optional()
   .describe(
-    'Column to sort results by (builder display types only, mainly "table").',
+    'Sort results by this column. ' +
+      'When ordering by an alias that contains spaces or special characters, ' +
+      `wrap the alias in quotes: e.g. '"P95 Latency" DESC'.`,
   );

--- a/packages/api/src/mcp/tools/query/table.ts
+++ b/packages/api/src/mcp/tools/query/table.ts
@@ -66,6 +66,37 @@ const AGG_FN_NAMES: ReadonlySet<string> = new Set(
   MCP_AGG_FN_OPTIONS.filter(fn => fn !== 'none'),
 );
 
+/** A bare ClickHouse identifier: a letter or underscore followed by word chars.
+ *  Anything outside this shape (spaces, punctuation, leading digit) must be
+ *  quoted to be valid in ORDER BY. */
+const BARE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Strip one layer of surrounding double-quote or backtick quoting, if present. */
+function stripIdentifierQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith('`') && trimmed.endsWith('`')))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * Quote an alias for use in ORDER BY when it is not a bare identifier.
+ * Aliases are emitted into SELECT as `AS "alias"`, so we mirror that with
+ * double-quote identifier quoting (escaping embedded double quotes). Bare
+ * identifiers are returned unquoted to keep the common case readable.
+ */
+function quoteAliasForOrderBy(alias: string): string {
+  if (BARE_IDENTIFIER.test(alias)) {
+    return alias;
+  }
+  return `"${alias.replace(/"/g, '""')}"`;
+}
+
 /**
  * Resolve an orderBy value that matches a bare aggregation function name
  * (e.g. "count") to something ClickHouse can resolve in ORDER BY.
@@ -77,9 +108,11 @@ const AGG_FN_NAMES: ReadonlySet<string> = new Set(
  * the ClickHouse expression (e.g. `count()`) when no alias is set.
  *
  * Resolution order:
- *   1. If orderBy matches a select item's alias exactly → keep as-is
- *   2. If orderBy matches an aggFn name → use that item's alias if set,
- *      otherwise synthesize the ClickHouse expression (e.g. `count()`)
+ *   1. If orderBy matches a select item's alias → emit the canonical alias,
+ *      quoting it when it is not a bare identifier (e.g. `"P95 Latency"`)
+ *   2. If orderBy matches an aggFn name → use that item's alias if set
+ *      (quoted as needed), otherwise synthesize the ClickHouse expression
+ *      (e.g. `count()`)
  *   3. Otherwise → pass through unchanged
  */
 /** @internal Exported for testing only. */
@@ -100,15 +133,20 @@ export function resolveOrderBy(
   const identifier = dirMatch ? dirMatch[1] : orderBy;
   const direction = dirMatch ? ` ${dirMatch[2].toUpperCase()}` : '';
 
-  const lower = identifier.toLowerCase();
+  // Agents may pass the alias already quoted (per the orderBy docs) or bare.
+  // Strip any surrounding quotes before matching so both forms resolve, then
+  // re-quote on output based on the canonical alias.
+  const lower = stripIdentifierQuotes(identifier).toLowerCase();
 
   // Already matches an alias? Return the canonical alias case so
   // ClickHouse's case-sensitive identifier resolution works correctly.
+  // Multi-word / special-character aliases are quoted so the emitted
+  // ORDER BY is valid SQL even when the agent passed the alias unquoted.
   const aliasMatch = selectItems.find(
     s => s.alias && s.alias.toLowerCase() === lower,
   );
-  if (aliasMatch) {
-    return `${aliasMatch.alias}${direction}`;
+  if (aliasMatch && aliasMatch.alias) {
+    return `${quoteAliasForOrderBy(aliasMatch.alias)}${direction}`;
   }
 
   // Matches an aggFn name? Resolve to that item's alias or synthesize.
@@ -117,7 +155,7 @@ export function resolveOrderBy(
     if (match) {
       // Prefer the explicit alias if set
       if (match.alias) {
-        return `${match.alias}${direction}`;
+        return `${quoteAliasForOrderBy(match.alias)}${direction}`;
       }
 
       // Synthesize the ClickHouse expression so ORDER BY works


### PR DESCRIPTION
## Why

While testing the MCP server, two friction points surfaced for agents driving the ClickStack tools:

1. **`orderBy` quoting was undocumented.** When sorting by an aliased column whose name contains spaces or special characters (e.g. `P95 Latency`), the query fails unless the alias is quoted. Agents had no way to know this from the schema description.
2. **`clickstack_event_patterns` was under-used.** Agents reached for `clickstack_search` / `clickstack_table` when the real intent was "what kinds of messages/errors exist here". The pattern tool returns frequency-ranked clusters and gives a far better overview, but its description didn't claim that territory.

## What changed

- **`orderBy` descriptions** (table tile schema + shared query `orderBySchema`): document that aliases containing spaces or special characters must be quoted, e.g. `'"P95 Latency" DESC'`.
- **`clickstack_event_patterns` description**: add explicit "PREFER THIS TOOL over clickstack_search or clickstack_table" guidance for log/error exploration intents, with example phrasings.

These are description/schema-text-only tweaks to the MCP tool definitions — no behavioral or query-execution changes.

## Testing

Discovered during hands-on testing of the MCP server. `npx lint-staged` (prettier + eslint) passes on all three files.