### PR TITLE
Add raw SQL chart run shortcut

### DIFF
--- a/.changeset/raw-sql-chart-shortcut.md
+++ b/.changeset/raw-sql-chart-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Add Cmd/Ctrl+Enter support for running raw SQL chart queries from the SQL editor.

--- a/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
@@ -262,6 +262,7 @@ export default function RawSqlChartEditor({
           placeholder={placeholderSQl}
           tableConnections={tableConnections}
           additionalCompletions={additionalCompletions}
+          onSubmit={onSubmit}
         />
         <div className={resizeStyles.resizeYHandle} onMouseDown={startResize} />
       </Box>

--- a/packages/app/src/components/SQLEditor/SQLEditor.tsx
+++ b/packages/app/src/components/SQLEditor/SQLEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useController, UseControllerProps } from 'react-hook-form';
 import { acceptCompletion } from '@codemirror/autocomplete';
 import { TableConnection } from '@hyperdx/common-utils/dist/core/metadata';
@@ -7,6 +7,7 @@ import CodeMirror, {
   Compartment,
   EditorView,
   keymap,
+  Prec,
   ReactCodeMirrorRef,
 } from '@uiw/react-codemirror';
 
@@ -30,7 +31,16 @@ type SQLEditorProps = {
   additionalCompletions?: SQLCompletion[];
   dateRange?: [Date, Date];
   timestampValueExpression?: string;
+  onSubmit?: () => void;
 };
+
+export const createRunQueryKeyBinding = (onSubmit: () => void) => ({
+  key: 'Mod-Enter',
+  run: () => {
+    onSubmit();
+    return true;
+  },
+});
 
 export default function SQLEditor({
   onChange,
@@ -42,10 +52,19 @@ export default function SQLEditor({
   additionalCompletions,
   dateRange,
   timestampValueExpression,
+  onSubmit,
 }: SQLEditorProps) {
   const { colorScheme } = useMantineColorScheme();
   const ref = useRef<ReactCodeMirrorRef>(null);
   const compartmentRef = useRef<Compartment>(new Compartment());
+
+  const runQueryKeymap = useMemo(
+    () =>
+      onSubmit == null
+        ? []
+        : [Prec.highest(keymap.of([createRunQueryKeyBinding(onSubmit)]))],
+    [onSubmit],
+  );
 
   const { data: fields } = useMultipleAllFields(tableConnections ?? [], {
     dateRange,
@@ -111,6 +130,7 @@ export default function SQLEditor({
               upperCaseKeywords: true,
             }),
           ),
+          ...runQueryKeymap,
           keymap.of([
             {
               key: 'Tab',

--- a/packages/app/src/components/SQLEditor/__tests__/SQLEditor.test.tsx
+++ b/packages/app/src/components/SQLEditor/__tests__/SQLEditor.test.tsx
@@ -1,0 +1,16 @@
+import { createRunQueryKeyBinding } from '../SQLEditor';
+
+jest.mock('@/hooks/useMetadata', () => ({
+  useMultipleAllFields: jest.fn().mockReturnValue({ data: [] }),
+}));
+
+describe('SQLEditor', () => {
+  it('creates a Cmd/Ctrl+Enter key binding that submits the query', () => {
+    const onSubmit = jest.fn();
+    const binding = createRunQueryKeyBinding(onSubmit);
+
+    expect(binding.key).toBe('Mod-Enter');
+    expect(binding.run()).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a Cmd/Ctrl+Enter shortcut to run raw SQL chart queries directly from the SQL editor. The shortcut uses the same submit path as the existing Run button, so validation and chart preview updates remain consistent.

### Screenshots or video

[raw_sql_ctrl_enter_shortcut_updates_preview.mp4](https://cursor.com/agents/bc-d4fc2504-d420-4c4c-88bf-faaa1e2c2f7f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fraw_sql_ctrl_enter_shortcut_updates_preview.mp4)

### How to test on Vercel preview

**Preview routes:** /chart

**Steps:**

1. Open the chart editor and switch a raw-SQL-supported chart type to SQL mode.
2. Type a valid raw SQL query in the SQL editor.
3. Press Cmd+Enter on macOS or Ctrl+Enter on Windows/Linux.
4. Verify the chart query runs and the preview updates without clicking the Run button.

### References

- Linear Issue: Closes HDX-4524
- Related PRs: N/A

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4524](https://linear.app/clickhouse/issue/HDX-4524/granola-press-cmdenter-to-run-query-for-raw-sql-charts)

<div><a href="https://cursor.com/agents/bc-d4fc2504-d420-4c4c-88bf-faaa1e2c2f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4fc2504-d420-4c4c-88bf-faaa1e2c2f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

