### PR TITLE
feat: show icon on tiles with excluded source-scoped filters

### DIFF
--- a/.changeset/tile-source-filter-indicator.md
+++ b/.changeset/tile-source-filter-indicator.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/app': patch
+---
+
+feat: show icon indicator on tiles where dashboard filters are excluded due to source scoping
+
+Dashboard tiles now display a filter icon in the toolbar when active dashboard filter values are not being applied to the tile because those filters are scoped to other sources via "Applies to sources". Hovering the icon shows a tooltip explaining why the tile may not update when filter values change.

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -83,6 +83,7 @@ import {
   IconDeviceFloppy,
   IconDotsVertical,
   IconDownload,
+  IconFilter,
   IconFilterEdit,
   IconLayoutSidebarRightCollapse,
   IconLayoutSidebarRightExpand,
@@ -356,6 +357,7 @@ const Tile = forwardRef(
       granularity,
       onTimeRangeSelect,
       filters,
+      hasExcludedSourceFilters,
 
       // Properties forwarded by grid layout
       className,
@@ -381,6 +383,7 @@ const Tile = forwardRef(
       granularity: SQLInterval | undefined;
       onTimeRangeSelect: (start: Date, end: Date) => void;
       filters?: Filter[];
+      hasExcludedSourceFilters?: boolean;
 
       // Properties forwarded by grid layout
       className?: string;
@@ -649,6 +652,24 @@ const Tile = forwardRef(
       );
     }, [filters, queriedConfig, source]);
 
+    const sourceFilterIndicator = useMemo(() => {
+      if (!hasExcludedSourceFilters) return null;
+      return (
+        <Tooltip
+          multiline
+          maw={300}
+          label="Some dashboard filters are not applied to this tile because they are scoped to other sources"
+          key="source-filter-indicator"
+        >
+          <IconFilter
+            data-testid={`tile-source-filter-indicator-${chart.id}`}
+            size={16}
+            color="var(--mantine-color-dimmed)"
+          />
+        </Tooltip>
+      );
+    }, [hasExcludedSourceFilters, chart.id]);
+
     const hoverToolbar = useMemo(() => {
       const isRawSql = isRawSqlSavedChartConfig(chart.config);
       const displayTypeSupportsAlerts = isRawSql
@@ -823,8 +844,8 @@ const Tile = forwardRef(
     const renderChartContent = useCallback(
       (hideToolbar: boolean = false, isFullscreenView: boolean = false) => {
         const toolbar = hideToolbar
-          ? [filterWarning]
-          : [hoverToolbar, filterWarning];
+          ? [sourceFilterIndicator, filterWarning]
+          : [hoverToolbar, sourceFilterIndicator, filterWarning];
         const keyPrefix = isFullscreenView ? 'fullscreen' : 'tile';
 
         // The fullscreen view is always visible, so it should always load.
@@ -1028,6 +1049,7 @@ const Tile = forwardRef(
         fullscreenDateRange,
         fullscreenGranularity,
         filterWarning,
+        sourceFilterIndicator,
         isSourceMissing,
         isSourceUnset,
         hasBeenVisible,
@@ -1421,6 +1443,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setFilterQueries,
     ignoredFilterExpressions,
     getFilterQueriesForSource,
+    hasExcludedFiltersForSource,
   } = useDashboardFilters(filters);
 
   const dashboardReady =
@@ -1861,6 +1884,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             },
             ...getFilterQueriesForSource(tileSourceId),
           ]}
+          hasExcludedSourceFilters={hasExcludedFiltersForSource(tileSourceId)}
           onTimeRangeSelect={onTimeRangeSelect}
           isHighlighted={highlightedTileId === chart.id}
           onUpdateChart={newChart => {
@@ -1952,6 +1976,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       whereLanguage,
       onTimeRangeSelect,
       getFilterQueriesForSource,
+      hasExcludedFiltersForSource,
       moveTargetContainers,
       handleMoveTileToGroup,
       selectedTileIds,

--- a/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
+++ b/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
@@ -111,6 +111,7 @@ describe('usePresetDashboardFilters', () => {
       setFilterQueries: jest.fn(),
       ignoredFilterExpressions: [],
       getFilterQueriesForSource: jest.fn().mockReturnValue(mockFilterQueries),
+      hasExcludedFiltersForSource: jest.fn().mockReturnValue(false),
     });
   });
 

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -115,6 +115,29 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
     [valuesForExistingFilters, filtersByExpression],
   );
 
+  // Returns true when there are active filter values that are NOT being applied
+  // to a tile with the given sourceId due to `appliesToSourceIds` scoping.
+  const hasExcludedFiltersForSource = useCallback(
+    (sourceId: string | undefined): boolean => {
+      for (const [expression, state] of Object.entries(
+        valuesForExistingFilters,
+      )) {
+        if (!state.included || state.included.size === 0) continue;
+        const definitions = filtersByExpression.get(expression) ?? [];
+        const applies = definitions.some(def => {
+          const appliesTo = def.appliesToSourceIds;
+          if (!appliesTo || appliesTo.length === 0) return true;
+          return !!sourceId && appliesTo.includes(sourceId);
+        });
+        if (!applies) {
+          return true;
+        }
+      }
+      return false;
+    },
+    [valuesForExistingFilters, filtersByExpression],
+  );
+
   return {
     filterValues: valuesForExistingFilters,
     filterQueries: queriesForExistingFilters,
@@ -133,6 +156,13 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
      * whose source ID is in the list.
      */
     getFilterQueriesForSource,
+    /**
+     * Returns true when there are active filter values that are NOT being
+     * applied to a tile with the given `sourceId` because of
+     * `appliesToSourceIds` scoping. Used to show a visual indicator on tiles
+     * where some dashboard filters are intentionally excluded.
+     */
+    hasExcludedFiltersForSource,
   };
 };
 

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -575,6 +575,28 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
           timeout: 15000,
         });
       });
+
+      await test.step('Source filter indicator icon appears on logs tile with tooltip', async () => {
+        const logsTile = dashboardPage.getTile(0);
+        const indicator = logsTile.locator(
+          '[data-testid^="tile-source-filter-indicator-"]',
+        );
+        await expect(indicator).toBeVisible();
+
+        await indicator.hover();
+        await expect(
+          dashboardPage.page.getByText(
+            'Some dashboard filters are not applied to this tile because they are scoped to other sources',
+          ),
+        ).toBeVisible();
+
+        // The traces tile (which receives the filter) should NOT show the indicator.
+        const tracesTile = dashboardPage.getTile(1);
+        const tracesIndicator = tracesTile.locator(
+          '[data-testid^="tile-source-filter-indicator-"]',
+        );
+        await expect(tracesIndicator).toBeHidden();
+      });
     },
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When dashboard filters are scoped to specific sources via "Applies to sources", tiles whose source is not in the scope won't update when those filter values change. This can confuse users who don't realize the filter is intentionally not applied to certain tiles.

This PR adds a filter icon indicator (`IconFilter`) in the tile toolbar that appears whenever a tile has active dashboard filter values excluded from it due to source scoping. Hovering the icon shows a tooltip: "Some dashboard filters are not applied to this tile because they are scoped to other sources."

**Changes:**
- `useDashboardFilters.tsx` — Added `hasExcludedFiltersForSource(sourceId)` function that checks whether any active filter values are being excluded from the given source
- `DBDashboardPage.tsx` — Added `hasExcludedSourceFilters` prop to the `Tile` component and a `sourceFilterIndicator` element with tooltip, rendered in the always-visible section of the tile toolbar
- Updated the existing E2E test "should scope a filter to a specific source" to validate that the indicator icon appears on the excluded tile (with correct tooltip) and does NOT appear on the tile that receives the filter

### Screenshots or video

N/A — UI change is validated by E2E test (icon + tooltip visibility assertions).

### How to test on Vercel preview

**Preview routes:** /dashboards

**Steps:**

1. Create a new dashboard with two tiles from different sources (e.g., one Logs, one Traces)
2. Add a filter with "Applies to sources" set to only one of the sources (e.g., Traces)
3. Select a filter value from the dropdown
4. Verify that the tile whose source is NOT in the filter scope shows a small filter icon in its toolbar
5. Hover the icon and verify the tooltip reads "Some dashboard filters are not applied to this tile because they are scoped to other sources"
6. Verify the tile whose source IS in the filter scope does NOT show the icon

### References

- Linear Issue: HDX-4534

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4534](https://linear.app/clickhouse/issue/HDX-4534/show-icon-on-tiles-with-tile-level-source-filters)

<div><a href="https://cursor.com/agents/bc-25a844ee-133c-48af-860a-a2a1bd0e74b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25a844ee-133c-48af-860a-a2a1bd0e74b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

