### PR TITLE
feat: add pattern column selector for event pattern matching on any column

### DIFF
--- a/.changeset/event-patterns-column-selector.md
+++ b/.changeset/event-patterns-column-selector.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+feat: Allow selecting the column used for event pattern grouping with URL state

--- a/.changeset/event-patterns-column-selector.md
+++ b/.changeset/event-patterns-column-selector.md
@@ -2,4 +2,4 @@
 '@hyperdx/app': patch
 ---
 
-feat: Allow selecting the column used for event pattern grouping with URL state
+feat: Allow selecting the column or SQL expression used for event pattern grouping (with shareable URL state)

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -853,6 +853,11 @@ export function DBSearchPage() {
     ]).withDefault('results'),
   );
 
+  const [patternColumn, setPatternColumn] = useQueryState(
+    'patternColumn',
+    parseAsString,
+  );
+
   const [isLive, setIsLive] = useQueryState(
     'isLive',
     parseAsBoolean.withDefault(true),
@@ -2181,6 +2186,8 @@ export function DBSearchPage() {
                             ? (getEventBody(searchedSource) ?? '')
                             : (chartConfig.implicitColumnExpression ?? '')
                         }
+                        patternColumn={patternColumn}
+                        onPatternColumnChange={setPatternColumn}
                         totalCountConfig={histogramTimeChartConfig}
                         totalCountQueryKeyPrefix={QUERY_KEY_PREFIX}
                       />

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -857,6 +857,12 @@ export function DBSearchPage() {
     'patternColumn',
     parseAsString,
   );
+  const [draftPatternColumn, setDraftPatternColumn] = useState(
+    patternColumn ?? '',
+  );
+  useEffect(() => {
+    setDraftPatternColumn(patternColumn ?? '');
+  }, [patternColumn]);
 
   const [isLive, setIsLive] = useQueryState(
     'isLive',
@@ -1056,6 +1062,7 @@ export function DBSearchPage() {
         });
       },
     )();
+    setPatternColumn(draftPatternColumn || null);
     // clear query errors
     setQueryErrors({});
   }, [
@@ -1064,6 +1071,8 @@ export function DBSearchPage() {
     displayedTimeInputValue,
     onSearch,
     setQueryErrors,
+    draftPatternColumn,
+    setPatternColumn,
   ]);
 
   const debouncedSubmit = useDebouncedCallback(onSubmit, 1000);
@@ -2187,7 +2196,9 @@ export function DBSearchPage() {
                             : (chartConfig.implicitColumnExpression ?? '')
                         }
                         patternColumn={patternColumn}
-                        onPatternColumnChange={setPatternColumn}
+                        draftPatternColumn={draftPatternColumn}
+                        onDraftPatternColumnChange={setDraftPatternColumn}
+                        onSubmit={onSubmit}
                         totalCountConfig={histogramTimeChartConfig}
                         totalCountQueryKeyPrefix={QUERY_KEY_PREFIX}
                       />

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -13,8 +13,8 @@ import { useSearchTotalCount } from '@/components/SearchTotalCountChart';
 import { Pattern, useGroupedPatterns } from '@/hooks/usePatterns';
 
 import {
+  buildPatternColumnExpression,
   PatternColumnSelector,
-  usePatternColumnExpression,
 } from './Patterns/PatternColumnSelector';
 import PatternSidePanel from './PatternSidePanel';
 
@@ -26,14 +26,18 @@ export default function PatternTable({
   totalCountQueryKeyPrefix,
   bodyValueExpression,
   patternColumn,
-  onPatternColumnChange,
+  draftPatternColumn,
+  onDraftPatternColumnChange,
+  onSubmit,
   source,
 }: {
   config: BuilderChartConfigWithDateRange;
   totalCountConfig: BuilderChartConfigWithDateRange;
   bodyValueExpression: string;
   patternColumn?: string | null;
-  onPatternColumnChange?: (column: string | null) => void;
+  draftPatternColumn?: string;
+  onDraftPatternColumnChange?: (value: string) => void;
+  onSubmit?: () => void;
   totalCountQueryKeyPrefix: string;
   source?: TSource;
 }) {
@@ -41,8 +45,7 @@ export default function PatternTable({
 
   const [selectedPattern, setSelectedPattern] = useState<Pattern | null>(null);
 
-  const effectiveBodyValueExpression = usePatternColumnExpression({
-    sourceId: source?.id,
+  const effectiveBodyValueExpression = buildPatternColumnExpression({
     patternColumn,
     fallback: bodyValueExpression,
   });
@@ -85,8 +88,10 @@ export default function PatternTable({
     <Container style={{ overflow: 'auto' }}>
       <PatternColumnSelector
         sourceId={source?.id}
-        patternColumn={patternColumn}
-        onChange={onPatternColumnChange}
+        value={draftPatternColumn ?? ''}
+        onChange={onDraftPatternColumnChange}
+        onSubmit={onSubmit}
+        dateRange={config.dateRange}
       />
       <Box mt="lg">
         <Text my="sm" size="sm">
@@ -121,8 +126,10 @@ export default function PatternTable({
     <>
       <PatternColumnSelector
         sourceId={source?.id}
-        patternColumn={patternColumn}
-        onChange={onPatternColumnChange}
+        value={draftPatternColumn ?? ''}
+        onChange={onDraftPatternColumnChange}
+        onSubmit={onSubmit}
+        dateRange={config.dateRange}
       />
       <RawLogTable
         isLive={false}

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -84,45 +84,7 @@ export default function PatternTable({
     ) as Pattern[];
   }, [groupedResults]);
 
-  return error ? (
-    <Container style={{ overflow: 'auto' }}>
-      <PatternColumnSelector
-        sourceId={source?.id}
-        value={draftPatternColumn ?? ''}
-        onChange={onDraftPatternColumnChange}
-        onSubmit={onSubmit}
-        dateRange={config.dateRange}
-      />
-      <Box mt="lg">
-        <Text my="sm" size="sm">
-          Error Message:
-        </Text>
-        <Code
-          block
-          style={{
-            whiteSpace: 'pre-wrap',
-          }}
-        >
-          {error.message}
-        </Code>
-      </Box>
-      {error instanceof ClickHouseQueryError && (
-        <Box mt="lg">
-          <Text my="sm" size="sm">
-            Original Query:
-          </Text>
-          <Code
-            block
-            style={{
-              whiteSpace: 'pre-wrap',
-            }}
-          >
-            <SQLPreview data={error.query} formatData />
-          </Code>
-        </Box>
-      )}
-    </Container>
-  ) : (
+  return (
     <>
       <PatternColumnSelector
         sourceId={source?.id}
@@ -130,41 +92,77 @@ export default function PatternTable({
         onChange={onDraftPatternColumnChange}
         onSubmit={onSubmit}
         dateRange={config.dateRange}
+        bodyValueExpression={bodyValueExpression}
       />
-      <RawLogTable
-        isLive={false}
-        wrapLines={true}
-        isLoading={isLoading}
-        rows={sortedGroupedResults ?? []}
-        displayedColumns={[
-          '__hdx_pattern_trend',
-          'countStr',
-          'severityText',
-          'pattern',
-        ]}
-        onRowDetailsClick={row => setSelectedPattern(row as Pattern)}
-        hasNextPage={false}
-        fetchNextPage={() => {}}
-        highlightedLineId={''}
-        columnTypeMap={emptyMap}
-        generateRowId={row => ({ where: row.id, aliasWith: [] })}
-        columnNameMap={{
-          __hdx_pattern_trend: 'Trend',
-          countStr: 'Count',
-          pattern: 'Pattern',
-          severityText: 'Level',
-        }}
-        config={patternQueryConfig}
-        showExpandButton={false}
-      />
-      {selectedPattern && source && (
-        <PatternSidePanel
-          isOpen
-          source={source}
-          pattern={selectedPattern}
-          bodyValueExpression={effectiveBodyValueExpression}
-          onClose={() => setSelectedPattern(null)}
-        />
+      {error ? (
+        <Container style={{ overflow: 'auto' }}>
+          <Box mt="lg">
+            <Text my="sm" size="sm">
+              Error Message:
+            </Text>
+            <Code
+              block
+              style={{
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {error.message}
+            </Code>
+          </Box>
+          {error instanceof ClickHouseQueryError && (
+            <Box mt="lg">
+              <Text my="sm" size="sm">
+                Original Query:
+              </Text>
+              <Code
+                block
+                style={{
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                <SQLPreview data={error.query} formatData />
+              </Code>
+            </Box>
+          )}
+        </Container>
+      ) : (
+        <>
+          <RawLogTable
+            isLive={false}
+            wrapLines={true}
+            isLoading={isLoading}
+            rows={sortedGroupedResults ?? []}
+            displayedColumns={[
+              '__hdx_pattern_trend',
+              'countStr',
+              'severityText',
+              'pattern',
+            ]}
+            onRowDetailsClick={row => setSelectedPattern(row as Pattern)}
+            hasNextPage={false}
+            fetchNextPage={() => {}}
+            highlightedLineId={''}
+            columnTypeMap={emptyMap}
+            generateRowId={row => ({ where: row.id, aliasWith: [] })}
+            columnNameMap={{
+              __hdx_pattern_trend: 'Trend',
+              countStr: 'Count',
+              pattern: 'Pattern',
+              severityText: 'Level',
+            }}
+            config={patternQueryConfig}
+            showExpandButton={false}
+          />
+          {selectedPattern && source && (
+            <PatternSidePanel
+              isOpen
+              source={source}
+              pattern={selectedPattern}
+              bodyValueExpression={effectiveBodyValueExpression}
+              onClose={() => setSelectedPattern(null)}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -12,6 +12,10 @@ import { RawLogTable } from '@/components/DBRowTable';
 import { useSearchTotalCount } from '@/components/SearchTotalCountChart';
 import { Pattern, useGroupedPatterns } from '@/hooks/usePatterns';
 
+import {
+  PatternColumnSelector,
+  usePatternColumnExpression,
+} from './Patterns/PatternColumnSelector';
 import PatternSidePanel from './PatternSidePanel';
 
 const emptyMap = new Map();
@@ -21,17 +25,27 @@ export default function PatternTable({
   totalCountConfig,
   totalCountQueryKeyPrefix,
   bodyValueExpression,
+  patternColumn,
+  onPatternColumnChange,
   source,
 }: {
   config: BuilderChartConfigWithDateRange;
   totalCountConfig: BuilderChartConfigWithDateRange;
   bodyValueExpression: string;
+  patternColumn?: string | null;
+  onPatternColumnChange?: (column: string | null) => void;
   totalCountQueryKeyPrefix: string;
   source?: TSource;
 }) {
   const SAMPLES = 10_000;
 
   const [selectedPattern, setSelectedPattern] = useState<Pattern | null>(null);
+
+  const effectiveBodyValueExpression = usePatternColumnExpression({
+    sourceId: source?.id,
+    patternColumn,
+    fallback: bodyValueExpression,
+  });
 
   const {
     error: totalCountError,
@@ -48,7 +62,7 @@ export default function PatternTable({
   } = useGroupedPatterns({
     config,
     samples: SAMPLES,
-    bodyValueExpression,
+    bodyValueExpression: effectiveBodyValueExpression,
     severityTextExpression:
       (source?.kind === SourceKind.Log && source.severityTextExpression) || '',
     statusCodeExpression:
@@ -69,6 +83,11 @@ export default function PatternTable({
 
   return error ? (
     <Container style={{ overflow: 'auto' }}>
+      <PatternColumnSelector
+        sourceId={source?.id}
+        patternColumn={patternColumn}
+        onChange={onPatternColumnChange}
+      />
       <Box mt="lg">
         <Text my="sm" size="sm">
           Error Message:
@@ -100,6 +119,11 @@ export default function PatternTable({
     </Container>
   ) : (
     <>
+      <PatternColumnSelector
+        sourceId={source?.id}
+        patternColumn={patternColumn}
+        onChange={onPatternColumnChange}
+      />
       <RawLogTable
         isLive={false}
         wrapLines={true}
@@ -131,7 +155,7 @@ export default function PatternTable({
           isOpen
           source={source}
           pattern={selectedPattern}
-          bodyValueExpression={bodyValueExpression}
+          bodyValueExpression={effectiveBodyValueExpression}
           onClose={() => setSelectedPattern(null)}
         />
       )}

--- a/packages/app/src/components/Patterns/PatternColumnSelector.tsx
+++ b/packages/app/src/components/Patterns/PatternColumnSelector.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import {
+  ColumnMeta,
+  convertCHDataTypeToJSType,
+  JSDataType,
+} from '@hyperdx/common-utils/dist/clickhouse';
+import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
+import { Box, Group, Select, Text } from '@mantine/core';
+
+import { useColumns } from '@/hooks/useMetadata';
+import { useSource } from '@/source';
+
+export function buildPatternColumnExpression({
+  patternColumn,
+  fallback,
+  columns,
+}: {
+  patternColumn: string | null | undefined;
+  fallback: string;
+  columns: ColumnMeta[] | undefined;
+}): string {
+  if (!patternColumn) return fallback;
+  const col = columns?.find(c => c.name === patternColumn);
+  if (!col) return patternColumn;
+  const jsType = convertCHDataTypeToJSType(col.type);
+  if (jsType === JSDataType.String) return patternColumn;
+  return `toString(${patternColumn})`;
+}
+
+function useSourceColumns(sourceId: string | undefined) {
+  const { data: source } = useSource({ id: sourceId });
+  const tc = tcFromSource(source);
+  return useColumns(tc, {
+    enabled: !!tc.databaseName && !!tc.tableName && !!tc.connectionId,
+  });
+}
+
+export function usePatternColumnExpression({
+  sourceId,
+  patternColumn,
+  fallback,
+}: {
+  sourceId: string | undefined;
+  patternColumn: string | null | undefined;
+  fallback: string;
+}): string {
+  const { data: columns } = useSourceColumns(sourceId);
+  return useMemo(
+    () => buildPatternColumnExpression({ patternColumn, fallback, columns }),
+    [patternColumn, fallback, columns],
+  );
+}
+
+export function PatternColumnSelector({
+  sourceId,
+  patternColumn,
+  onChange,
+}: {
+  sourceId: string | undefined;
+  patternColumn: string | null | undefined;
+  onChange?: (column: string | null) => void;
+}) {
+  const { data: columns } = useSourceColumns(sourceId);
+  const options = useMemo(
+    () => columns?.map(col => ({ value: col.name, label: col.name })) ?? [],
+    [columns],
+  );
+
+  if (!onChange) return null;
+
+  return (
+    <Box py="xs">
+      <Group gap="xs" align="center" wrap="nowrap">
+        <Text size="xs" c="dimmed">
+          Pattern Column
+        </Text>
+        <Select
+          size="xs"
+          searchable
+          clearable
+          value={patternColumn ?? null}
+          onChange={onChange}
+          data={options}
+          placeholder="Default (body)"
+          w={300}
+          data-testid="pattern-column-select"
+          comboboxProps={{ withinPortal: true }}
+        />
+      </Group>
+    </Box>
+  );
+}

--- a/packages/app/src/components/Patterns/PatternColumnSelector.tsx
+++ b/packages/app/src/components/Patterns/PatternColumnSelector.tsx
@@ -1,92 +1,53 @@
-import { useMemo } from 'react';
-import {
-  ColumnMeta,
-  convertCHDataTypeToJSType,
-  JSDataType,
-} from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
-import { Box, Group, Select, Text } from '@mantine/core';
+import { Box } from '@mantine/core';
 
-import { useColumns } from '@/hooks/useMetadata';
+import SQLInlineEditor from '@/components/SQLEditor/SQLInlineEditor';
 import { useSource } from '@/source';
 
 export function buildPatternColumnExpression({
   patternColumn,
   fallback,
-  columns,
 }: {
   patternColumn: string | null | undefined;
   fallback: string;
-  columns: ColumnMeta[] | undefined;
 }): string {
   if (!patternColumn) return fallback;
-  const col = columns?.find(c => c.name === patternColumn);
-  if (!col) return patternColumn;
-  const jsType = convertCHDataTypeToJSType(col.type);
-  if (jsType === JSDataType.String) return patternColumn;
   return `toString(${patternColumn})`;
-}
-
-function useSourceColumns(sourceId: string | undefined) {
-  const { data: source } = useSource({ id: sourceId });
-  const tc = tcFromSource(source);
-  return useColumns(tc, {
-    enabled: !!tc.databaseName && !!tc.tableName && !!tc.connectionId,
-  });
-}
-
-export function usePatternColumnExpression({
-  sourceId,
-  patternColumn,
-  fallback,
-}: {
-  sourceId: string | undefined;
-  patternColumn: string | null | undefined;
-  fallback: string;
-}): string {
-  const { data: columns } = useSourceColumns(sourceId);
-  return useMemo(
-    () => buildPatternColumnExpression({ patternColumn, fallback, columns }),
-    [patternColumn, fallback, columns],
-  );
 }
 
 export function PatternColumnSelector({
   sourceId,
-  patternColumn,
+  value,
   onChange,
+  onSubmit,
+  dateRange,
 }: {
   sourceId: string | undefined;
-  patternColumn: string | null | undefined;
-  onChange?: (column: string | null) => void;
+  value: string;
+  onChange?: (value: string) => void;
+  onSubmit?: () => void;
+  dateRange?: [Date, Date];
 }) {
-  const { data: columns } = useSourceColumns(sourceId);
-  const options = useMemo(
-    () => columns?.map(col => ({ value: col.name, label: col.name })) ?? [],
-    [columns],
-  );
+  const { data: source } = useSource({ id: sourceId });
+  const tableConnection = tcFromSource(source);
 
   if (!onChange) return null;
 
   return (
-    <Box py="xs">
-      <Group gap="xs" align="center" wrap="nowrap">
-        <Text size="xs" c="dimmed">
-          Pattern Column
-        </Text>
-        <Select
-          size="xs"
-          searchable
-          clearable
-          value={patternColumn ?? null}
-          onChange={onChange}
-          data={options}
-          placeholder="Default (body)"
-          w={300}
-          data-testid="pattern-column-select"
-          comboboxProps={{ withinPortal: true }}
-        />
-      </Group>
+    <Box py="xs" maw={600}>
+      <SQLInlineEditor
+        tableConnection={tableConnection}
+        value={value}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        enableHotkey
+        label="Pattern Expression"
+        placeholder="Default (body) — column name or expression"
+        size="xs"
+        allowMultiline={false}
+        sourceId={sourceId}
+        dateRange={dateRange}
+      />
     </Box>
   );
 }

--- a/packages/app/src/components/Patterns/PatternColumnSelector.tsx
+++ b/packages/app/src/components/Patterns/PatternColumnSelector.tsx
@@ -21,17 +21,23 @@ export function PatternColumnSelector({
   onChange,
   onSubmit,
   dateRange,
+  bodyValueExpression,
 }: {
   sourceId: string | undefined;
   value: string;
   onChange?: (value: string) => void;
   onSubmit?: () => void;
   dateRange?: [Date, Date];
+  bodyValueExpression?: string;
 }) {
   const { data: source } = useSource({ id: sourceId });
   const tableConnection = tcFromSource(source);
 
   if (!onChange) return null;
+
+  const placeholder = bodyValueExpression
+    ? `Default (${bodyValueExpression}) — column name or expression`
+    : 'Default — column name or expression';
 
   return (
     <Box py="xs" maw={600}>
@@ -42,7 +48,7 @@ export function PatternColumnSelector({
         onSubmit={onSubmit}
         enableHotkey
         label="Pattern Expression"
-        placeholder="Default (body) — column name or expression"
+        placeholder={placeholder}
         size="xs"
         allowMultiline={false}
         sourceId={sourceId}

--- a/packages/app/src/components/Patterns/__tests__/PatternColumnSelector.test.tsx
+++ b/packages/app/src/components/Patterns/__tests__/PatternColumnSelector.test.tsx
@@ -1,114 +1,42 @@
-import { ColumnMeta } from '@hyperdx/common-utils/dist/clickhouse';
-
 import { buildPatternColumnExpression } from '../PatternColumnSelector';
-
-function makeColumn(name: string, type: string): ColumnMeta {
-  return {
-    name,
-    type,
-    codec_expression: '',
-    comment: '',
-    default_expression: '',
-    default_type: '',
-    ttl_expression: '',
-  };
-}
 
 describe('buildPatternColumnExpression', () => {
   const fallback = 'Body';
 
-  it('returns the fallback when no pattern column is selected', () => {
+  it('returns the fallback when no expression is provided', () => {
     expect(
-      buildPatternColumnExpression({
-        patternColumn: null,
-        fallback,
-        columns: [makeColumn('Body', 'String')],
-      }),
+      buildPatternColumnExpression({ patternColumn: null, fallback }),
     ).toBe(fallback);
-
     expect(
-      buildPatternColumnExpression({
-        patternColumn: undefined,
-        fallback,
-        columns: [],
-      }),
+      buildPatternColumnExpression({ patternColumn: undefined, fallback }),
     ).toBe(fallback);
-
-    expect(
-      buildPatternColumnExpression({
-        patternColumn: '',
-        fallback,
-        columns: [],
-      }),
-    ).toBe(fallback);
+    expect(buildPatternColumnExpression({ patternColumn: '', fallback })).toBe(
+      fallback,
+    );
   });
 
-  it('uses the column directly when it is a String type', () => {
-    expect(
-      buildPatternColumnExpression({
-        patternColumn: 'ServiceName',
-        fallback,
-        columns: [makeColumn('ServiceName', 'String')],
-      }),
-    ).toBe('ServiceName');
-  });
-
-  it('uses the column directly when it is a LowCardinality(String) type', () => {
-    expect(
-      buildPatternColumnExpression({
-        patternColumn: 'SeverityText',
-        fallback,
-        columns: [makeColumn('SeverityText', 'LowCardinality(String)')],
-      }),
-    ).toBe('SeverityText');
-  });
-
-  it('wraps non-string columns in toString()', () => {
+  it('wraps a plain column reference in toString()', () => {
     expect(
       buildPatternColumnExpression({
         patternColumn: 'ResourceAttributes',
         fallback,
-        columns: [
-          makeColumn(
-            'ResourceAttributes',
-            'Map(LowCardinality(String), String)',
-          ),
-        ],
       }),
     ).toBe('toString(ResourceAttributes)');
-
-    expect(
-      buildPatternColumnExpression({
-        patternColumn: 'Timestamp',
-        fallback,
-        columns: [makeColumn('Timestamp', 'DateTime64(9)')],
-      }),
-    ).toBe('toString(Timestamp)');
-
-    expect(
-      buildPatternColumnExpression({
-        patternColumn: 'SpanCount',
-        fallback,
-        columns: [makeColumn('SpanCount', 'UInt32')],
-      }),
-    ).toBe('toString(SpanCount)');
   });
 
-  it('falls back to the raw column name when columns metadata is not loaded', () => {
+  it('wraps an arbitrary SQL expression in toString()', () => {
     expect(
       buildPatternColumnExpression({
-        patternColumn: 'CustomColumn',
+        patternColumn: "concatWithSeparator(' ', Body, LogAttributes)",
         fallback,
-        columns: undefined,
       }),
-    ).toBe('CustomColumn');
+    ).toBe("toString(concatWithSeparator(' ', Body, LogAttributes))");
 
     expect(
       buildPatternColumnExpression({
-        patternColumn: 'MissingColumn',
+        patternColumn: "JSONExtractString(Body, 'message')",
         fallback,
-        columns: [makeColumn('OtherColumn', 'String')],
       }),
-    ).toBe('MissingColumn');
+    ).toBe("toString(JSONExtractString(Body, 'message'))");
   });
 });

--- a/packages/app/src/components/Patterns/__tests__/PatternColumnSelector.test.tsx
+++ b/packages/app/src/components/Patterns/__tests__/PatternColumnSelector.test.tsx
@@ -1,0 +1,114 @@
+import { ColumnMeta } from '@hyperdx/common-utils/dist/clickhouse';
+
+import { buildPatternColumnExpression } from '../PatternColumnSelector';
+
+function makeColumn(name: string, type: string): ColumnMeta {
+  return {
+    name,
+    type,
+    codec_expression: '',
+    comment: '',
+    default_expression: '',
+    default_type: '',
+    ttl_expression: '',
+  };
+}
+
+describe('buildPatternColumnExpression', () => {
+  const fallback = 'Body';
+
+  it('returns the fallback when no pattern column is selected', () => {
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: null,
+        fallback,
+        columns: [makeColumn('Body', 'String')],
+      }),
+    ).toBe(fallback);
+
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: undefined,
+        fallback,
+        columns: [],
+      }),
+    ).toBe(fallback);
+
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: '',
+        fallback,
+        columns: [],
+      }),
+    ).toBe(fallback);
+  });
+
+  it('uses the column directly when it is a String type', () => {
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'ServiceName',
+        fallback,
+        columns: [makeColumn('ServiceName', 'String')],
+      }),
+    ).toBe('ServiceName');
+  });
+
+  it('uses the column directly when it is a LowCardinality(String) type', () => {
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'SeverityText',
+        fallback,
+        columns: [makeColumn('SeverityText', 'LowCardinality(String)')],
+      }),
+    ).toBe('SeverityText');
+  });
+
+  it('wraps non-string columns in toString()', () => {
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'ResourceAttributes',
+        fallback,
+        columns: [
+          makeColumn(
+            'ResourceAttributes',
+            'Map(LowCardinality(String), String)',
+          ),
+        ],
+      }),
+    ).toBe('toString(ResourceAttributes)');
+
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'Timestamp',
+        fallback,
+        columns: [makeColumn('Timestamp', 'DateTime64(9)')],
+      }),
+    ).toBe('toString(Timestamp)');
+
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'SpanCount',
+        fallback,
+        columns: [makeColumn('SpanCount', 'UInt32')],
+      }),
+    ).toBe('toString(SpanCount)');
+  });
+
+  it('falls back to the raw column name when columns metadata is not loaded', () => {
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'CustomColumn',
+        fallback,
+        columns: undefined,
+      }),
+    ).toBe('CustomColumn');
+
+    expect(
+      buildPatternColumnExpression({
+        patternColumn: 'MissingColumn',
+        fallback,
+        columns: [makeColumn('OtherColumn', 'String')],
+      }),
+    ).toBe('MissingColumn');
+  });
+});

--- a/packages/app/src/components/Patterns/__tests__/reconstructTemplate.test.ts
+++ b/packages/app/src/components/Patterns/__tests__/reconstructTemplate.test.ts
@@ -1,0 +1,59 @@
+import { reconstructTemplate } from '../reconstructTemplate';
+
+describe('reconstructTemplate', () => {
+  it('returns the original log when the template is empty', () => {
+    expect(reconstructTemplate('hello world', '')).toBe('hello world');
+  });
+
+  it('restores JSON separators around stable and variable tokens', () => {
+    expect(
+      reconstructTemplate(
+        `{"hostname":"foo","pid":12345,"time":1700000000}`,
+        'hostname foo pid <*> time <*>',
+      ),
+    ).toBe(`{"hostname":"foo","pid":<*>,"time":<*>}`);
+  });
+
+  it('restores ClickHouse Map (single-quoted) separators', () => {
+    expect(
+      reconstructTemplate(
+        `{'hostname':'Aarons-MacBook-Pro.local','pid':12345,'time':1700000000}`,
+        'hostname Aarons MacBook Pro local pid <*> time <*>',
+      ),
+    ).toBe(`{'hostname':'Aarons-MacBook-Pro.local','pid':<*>,'time':<*>}`);
+  });
+
+  it('restores key=value separators', () => {
+    expect(
+      reconstructTemplate(
+        'level=info msg=hello user_id=42',
+        'level info msg hello user id <*>',
+      ),
+    ).toBe('level=info msg=hello user_id=<*>');
+  });
+
+  it('keeps the original token when the template runs short', () => {
+    expect(reconstructTemplate('alpha beta gamma delta', 'alpha beta')).toBe(
+      'alpha beta gamma delta',
+    );
+  });
+
+  it('preserves leading and trailing separators', () => {
+    expect(reconstructTemplate('[INFO] hello world', 'INFO hello world')).toBe(
+      '[INFO] hello world',
+    );
+  });
+
+  it('collapses newlines and tabs in the original log to single spaces', () => {
+    expect(
+      reconstructTemplate(
+        'Error:\n  message: "failed"\n  code: 500',
+        'Error message failed code <*>',
+      ),
+    ).toBe('Error: message: "failed" code: <*>');
+
+    expect(reconstructTemplate('foo\n\n\nbar', 'foo bar')).toBe('foo bar');
+
+    expect(reconstructTemplate('foo\tbar', 'foo bar')).toBe('foo bar');
+  });
+});

--- a/packages/app/src/components/Patterns/reconstructTemplate.ts
+++ b/packages/app/src/components/Patterns/reconstructTemplate.ts
@@ -1,0 +1,24 @@
+const TOKEN_OR_SEPARATOR = /([A-Za-z0-9]+)|([^A-Za-z0-9]+)/g;
+
+export function reconstructTemplate(
+  originalLog: string,
+  templateMined: string,
+): string {
+  const normalized = originalLog.replace(/\s+/g, ' ');
+  const tokens = templateMined.split(' ').filter(t => t.length > 0);
+  if (tokens.length === 0) return normalized;
+
+  let result = '';
+  let tokenIdx = 0;
+  TOKEN_OR_SEPARATOR.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_OR_SEPARATOR.exec(normalized)) !== null) {
+    if (match[1] !== undefined) {
+      result += tokens[tokenIdx] ?? match[1];
+      tokenIdx++;
+    } else {
+      result += match[2];
+    }
+  }
+  return result;
+}

--- a/packages/app/src/components/Patterns/reconstructTemplate.ts
+++ b/packages/app/src/components/Patterns/reconstructTemplate.ts
@@ -1,5 +1,3 @@
-const TOKEN_OR_SEPARATOR = /([A-Za-z0-9]+)|([^A-Za-z0-9]+)/g;
-
 export function reconstructTemplate(
   originalLog: string,
   templateMined: string,

--- a/packages/app/src/components/Patterns/reconstructTemplate.ts
+++ b/packages/app/src/components/Patterns/reconstructTemplate.ts
@@ -6,11 +6,11 @@ export function reconstructTemplate(
   const tokens = templateMined.split(' ').filter(t => t.length > 0);
   if (tokens.length === 0) return normalized;
 
+  const tokenOrSeparator = /([A-Za-z0-9]+)|([^A-Za-z0-9]+)/g;
   let result = '';
   let tokenIdx = 0;
-  TOKEN_OR_SEPARATOR.lastIndex = 0;
   let match: RegExpExecArray | null;
-  while ((match = TOKEN_OR_SEPARATOR.exec(normalized)) !== null) {
+  while ((match = tokenOrSeparator.exec(normalized)) !== null) {
     if (match[1] !== undefined) {
       result += tokens[tokenIdx] ?? match[1];
       tokenIdx++;

--- a/packages/app/src/hooks/usePatterns.tsx
+++ b/packages/app/src/hooks/usePatterns.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { timeBucketByGranularity, toStartOfInterval } from '@/ChartUtils';
 import { useConfigWithAdditionalSelect } from '@/components/DBRowTable';
+import { reconstructTemplate } from '@/components/Patterns/reconstructTemplate';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { getFirstTimestampValueExpression } from '@/source';
 
@@ -54,10 +55,14 @@ class Miner {
     await this.pyodide.runPythonAsync(`
 import js
 import json
+import string
 from drain3 import TemplateMiner
 from drain3.template_miner_config import TemplateMinerConfig
 
-${this.minerVariableName} = TemplateMiner(None, TemplateMinerConfig())
+_config = TemplateMinerConfig()
+_config.drain_extra_delimiters = list(string.punctuation)
+
+${this.minerVariableName} = TemplateMiner(None, _config)
     `);
   }
 
@@ -168,7 +173,7 @@ function usePatterns({
   } = usePyodide({ enabled });
 
   const query = useQuery({
-    queryKey: ['patterns', config],
+    queryKey: ['patterns', config, bodyValueExpression],
     queryFn: () => {
       if (configWithPrimaryAndPartitionKey == null) {
         throw new Error('Unexpected configWithPrimaryAndPartitionKey is null');
@@ -290,10 +295,16 @@ export function useGroupedPatterns({
       // return at least 1
       const count = Math.max(Math.round(rows.length * sampleMultiplier), 1);
       const lastRow = rows.at(-1);
+      const reconstructedPattern = lastRow
+        ? reconstructTemplate(
+            stripAnsi((lastRow[PATTERN_COLUMN_ALIAS] ?? '') as string),
+            (lastRow.__hdx_pattern ?? '') as string,
+          )
+        : undefined;
 
       fullPatternGroups[patternId] = {
         id: patternId,
-        pattern: lastRow?.__hdx_pattern, // last pattern is usually the most up to date templated pattern
+        pattern: reconstructedPattern, // last pattern is usually the most up to date templated pattern
         count,
         countStr: `~${count}`,
         severityText: lastRow?.[SEVERITY_TEXT_COLUMN_ALIAS], // last severitytext is usually representative of the entire pattern set


### PR DESCRIPTION
## Summary

Adds a selector to do event pattern matching on any column or expression, not just Body.
Also changes the drain tokenizer. 

Drain collapses any token to a space character and then runs the drain algorithm. To make things look fine in the event patterns, I had to add some reconstruction logic.

### Screenshots or video

<img width="1212" height="671" alt="image" src="https://github.com/user-attachments/assets/31dfbf63-9871-4f3c-944a-3065643a1df3" />



### How to test on Vercel preview

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] -->

**Steps:**

1. Go to "Event Patterns" on the search page
2. Change to an expression like `concatWithSeparator(' ', Body, LogAttributes)`
3. Enjoy

### References

- Linear Issue: Closes HDX-4523