### PR TITLE
fix: bump http-proxy-middleware to v4

### DIFF
--- a/.changeset/bump-http-proxy-middleware.md
+++ b/.changeset/bump-http-proxy-middleware.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+Bump http-proxy-middleware to v4, replacing http-proxy with httpxy

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,7 +34,7 @@
     "express-session": "^1.17.3",
     "handlebars": "^4.7.9",
     "http-graceful-shutdown": "^3.1.13",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^4.0.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.18.1",
     "minimist": "^1.2.7",

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -164,123 +164,129 @@ const getConnection: RequestHandler =
   };
 
 // http-proxy-middleware v4 is ESM-only, so we use a dynamic import with a
-// lazy-init wrapper to keep this CJS module compatible.
-let _proxyMiddleware: RequestHandler | undefined;
+// cached promise to keep this CJS module compatible and avoid concurrent-init races.
+let _proxyPromise: Promise<RequestHandler> | undefined;
 
-async function getProxyMiddleware(): Promise<RequestHandler> {
-  if (_proxyMiddleware) return _proxyMiddleware;
+function getProxyMiddleware(): Promise<RequestHandler> {
+  if (_proxyPromise) return _proxyPromise;
 
-  const { createProxyMiddleware } = await import('http-proxy-middleware');
-
-  _proxyMiddleware = createProxyMiddleware({
-    target: '', // doesn't matter. it should be overridden by the router
-    changeOrigin: true,
-    pathFilter: (path, _req) => {
-      return _req.method === 'GET' || _req.method === 'POST';
-    },
-    pathRewrite: function (path, req) {
-      const sanitizedPath = validateAndSanitizePath(
-        path.replace(/^\/clickhouse-proxy/, ''),
-      );
-
-      const parsedUrl = new URL(sanitizedPath, 'http://localhost');
-      const { searchParams, pathname } = parsedUrl;
-
-      // Append user email as custom ClickHouse setting for query log annotation if the prefix was set
-      const hyperdxSettingPrefix = req._hdx_connection?.hyperdxSettingPrefix;
-      if (hyperdxSettingPrefix) {
-        const userEmail = req.user?.email;
-        if (userEmail) {
-          const userSettingKey = `${hyperdxSettingPrefix}${CUSTOM_SETTING_KEY_SEP}${CUSTOM_SETTING_KEY_USER_SUFFIX}`;
-          searchParams.set(userSettingKey, userEmail);
-        } else {
-          logger.debug('hyperdxSettingPrefix set, no session user found');
-        }
-      }
-
-      return `${pathname}?${searchParams.toString()}`;
-    },
-    router: _req => {
-      if (!_req._hdx_connection?.host) {
-        throw new Error('[createProxyMiddleware] Connection not found');
-      }
-      return _req._hdx_connection.host;
-    },
-    on: {
-      proxyReq: (proxyReq, _req, res) => {
-        // set user-agent to the hyperdx version identifier
-        proxyReq.setHeader('user-agent', `hyperdx ${CODE_VERSION}`);
-
-        if (_req._hdx_connection?.username) {
-          proxyReq.setHeader(
-            'X-ClickHouse-User',
-            _req._hdx_connection.username,
+  _proxyPromise = import('http-proxy-middleware').then(
+    ({ createProxyMiddleware }) =>
+      createProxyMiddleware({
+        target: '', // doesn't matter. it should be overridden by the router
+        changeOrigin: true,
+        pathFilter: (path, _req) => {
+          return _req.method === 'GET' || _req.method === 'POST';
+        },
+        pathRewrite: function (path, req) {
+          const sanitizedPath = validateAndSanitizePath(
+            path.replace(/^\/clickhouse-proxy/, ''),
           );
-        }
-        // Passwords can be empty
-        if (_req._hdx_connection?.password) {
-          proxyReq.setHeader('X-ClickHouse-Key', _req._hdx_connection.password);
-        }
 
-        if (_req.method !== 'POST') {
-          console.error(`Unsupported method ${_req.method}`);
-          return res.sendStatus(405);
-        }
+          const parsedUrl = new URL(sanitizedPath, 'http://localhost');
+          const { searchParams, pathname } = parsedUrl;
 
-        let body = _req.body;
-        if (_req.headers['content-type'] === 'application/json') {
-          try {
-            body = JSON.stringify(body);
-          } catch (e) {
-            console.error(e);
+          // Append user email as custom ClickHouse setting for query log annotation if the prefix was set
+          const hyperdxSettingPrefix =
+            req._hdx_connection?.hyperdxSettingPrefix;
+          if (hyperdxSettingPrefix) {
+            const userEmail = req.user?.email;
+            if (userEmail) {
+              const userSettingKey = `${hyperdxSettingPrefix}${CUSTOM_SETTING_KEY_SEP}${CUSTOM_SETTING_KEY_USER_SUFFIX}`;
+              searchParams.set(userSettingKey, userEmail);
+            } else {
+              logger.debug('hyperdxSettingPrefix set, no session user found');
+            }
           }
-        }
 
-        try {
-          proxyReq.write(body);
-        } catch (e) {
-          console.error(
-            `clickhouseProxy error writing body, body is type ${typeof body}`,
-          );
-        }
-      },
-      proxyRes: (proxyRes, _req, res) => {
-        // since clickhouse v24, the cors headers * will be attached to the response by default
-        // which will cause the browser to block the response
-        if (_req.headers['access-control-request-method']) {
-          proxyRes.headers['access-control-allow-methods'] =
-            _req.headers['access-control-request-method'];
-        }
+          return `${pathname}?${searchParams.toString()}`;
+        },
+        router: _req => {
+          if (!_req._hdx_connection?.host) {
+            throw new Error('[createProxyMiddleware] Connection not found');
+          }
+          return _req._hdx_connection.host;
+        },
+        on: {
+          proxyReq: (proxyReq, _req, res) => {
+            // set user-agent to the hyperdx version identifier
+            proxyReq.setHeader('user-agent', `hyperdx ${CODE_VERSION}`);
 
-        if (_req.headers['access-control-request-headers']) {
-          proxyRes.headers['access-control-allow-headers'] =
-            _req.headers['access-control-request-headers'];
-        }
+            if (_req._hdx_connection?.username) {
+              proxyReq.setHeader(
+                'X-ClickHouse-User',
+                _req._hdx_connection.username,
+              );
+            }
+            // Passwords can be empty
+            if (_req._hdx_connection?.password) {
+              proxyReq.setHeader(
+                'X-ClickHouse-Key',
+                _req._hdx_connection.password,
+              );
+            }
 
-        if (_req.headers.origin) {
-          proxyRes.headers['access-control-allow-origin'] = _req.headers.origin;
-          proxyRes.headers['access-control-allow-credentials'] = 'true';
-        }
-      },
-      error: (err, _req, _res) => {
-        console.error('Proxy error:', err);
-        (_res as Response).writeHead(500, {
-          'Content-Type': 'application/json',
-        });
-        _res.end(
-          JSON.stringify({
-            success: false,
-            error: err.message || 'Failed to connect to ClickHouse server',
-          }),
-        );
-      },
-    },
-    // ...(config.IS_DEV && {
-    //   logger: console,
-    // }),
-  });
+            if (_req.method !== 'POST') {
+              console.error(`Unsupported method ${_req.method}`);
+              return res.sendStatus(405);
+            }
 
-  return _proxyMiddleware;
+            let body = _req.body;
+            if (_req.headers['content-type'] === 'application/json') {
+              try {
+                body = JSON.stringify(body);
+              } catch (e) {
+                console.error(e);
+              }
+            }
+
+            try {
+              proxyReq.write(body);
+            } catch (e) {
+              console.error(
+                `clickhouseProxy error writing body, body is type ${typeof body}`,
+              );
+            }
+          },
+          proxyRes: (proxyRes, _req, res) => {
+            // since clickhouse v24, the cors headers * will be attached to the response by default
+            // which will cause the browser to block the response
+            if (_req.headers['access-control-request-method']) {
+              proxyRes.headers['access-control-allow-methods'] =
+                _req.headers['access-control-request-method'];
+            }
+
+            if (_req.headers['access-control-request-headers']) {
+              proxyRes.headers['access-control-allow-headers'] =
+                _req.headers['access-control-request-headers'];
+            }
+
+            if (_req.headers.origin) {
+              proxyRes.headers['access-control-allow-origin'] =
+                _req.headers.origin;
+              proxyRes.headers['access-control-allow-credentials'] = 'true';
+            }
+          },
+          error: (err, _req, _res) => {
+            console.error('Proxy error:', err);
+            (_res as Response).writeHead(500, {
+              'Content-Type': 'application/json',
+            });
+            _res.end(
+              JSON.stringify({
+                success: false,
+                error: err.message || 'Failed to connect to ClickHouse server',
+              }),
+            );
+          },
+        },
+        // ...(config.IS_DEV && {
+        //   logger: console,
+        // }),
+      }),
+  );
+
+  return _proxyPromise;
 }
 
 const proxyMiddleware: RequestHandler = async (req, res, next) => {

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -1,6 +1,5 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import express, { RequestHandler, Response } from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
 import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
 
@@ -164,9 +163,16 @@ const getConnection: RequestHandler =
     }
   };
 
-const proxyMiddleware: RequestHandler =
-  // prettier-ignore-next-line
-  createProxyMiddleware({
+// http-proxy-middleware v4 is ESM-only, so we use a dynamic import with a
+// lazy-init wrapper to keep this CJS module compatible.
+let _proxyMiddleware: RequestHandler | undefined;
+
+async function getProxyMiddleware(): Promise<RequestHandler> {
+  if (_proxyMiddleware) return _proxyMiddleware;
+
+  const { createProxyMiddleware } = await import('http-proxy-middleware');
+
+  _proxyMiddleware = createProxyMiddleware({
     target: '', // doesn't matter. it should be overridden by the router
     changeOrigin: true,
     pathFilter: (path, _req) => {
@@ -231,7 +237,6 @@ const proxyMiddleware: RequestHandler =
         }
 
         try {
-          // TODO: Use fixRequestBody after this issue is resolved: https://github.com/chimurai/http-proxy-middleware/issues/1102
           proxyReq.write(body);
         } catch (e) {
           console.error(
@@ -274,6 +279,18 @@ const proxyMiddleware: RequestHandler =
     //   logger: console,
     // }),
   });
+
+  return _proxyMiddleware;
+}
+
+const proxyMiddleware: RequestHandler = async (req, res, next) => {
+  try {
+    const middleware = await getProxyMiddleware();
+    middleware(req, res, next);
+  } catch (e) {
+    next(e);
+  }
+};
 
 router.get('/*', hasConnectionId, getConnection, proxyMiddleware);
 router.post('/*', hasConnectionId, getConnection, proxyMiddleware);

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -63,7 +63,7 @@
     "dayjs": "^1.11.19",
     "flat": "^5.0.2",
     "fuse.js": "^6.6.2",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^4.0.0",
     "immer": "^9.0.21",
     "jotai": "^2.5.1",
     "ky": "^0.30.0",

--- a/packages/app/pages/api/[...all].ts
+++ b/packages/app/pages/api/[...all].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import type { RequestHandler } from 'http-proxy-middleware';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 
 const DEFAULT_SERVER_URL = `http://127.0.0.1:${process.env.HYPERDX_API_PORT}`;
 
@@ -16,26 +16,7 @@ export const config = {
 // we proxy `/api/*` to a separately-deployed API service as before.
 const isInlineApi = process.env.HDX_PREVIEW_INLINE_API === 'true';
 
-// http-proxy-middleware v4 is ESM-only. Use a dynamic import with a cached
-// promise so the module is loaded once and concurrent requests share the result.
-let _proxyPromise: Promise<RequestHandler> | undefined;
-
-function getProxy(): Promise<RequestHandler> {
-  if (!_proxyPromise) {
-    _proxyPromise = import('http-proxy-middleware').then(
-      ({ createProxyMiddleware }) =>
-        createProxyMiddleware({
-          changeOrigin: true,
-          pathRewrite: { '^/api': '' },
-          target: process.env.SERVER_URL || DEFAULT_SERVER_URL,
-          autoRewrite: true,
-        }),
-    );
-  }
-  return _proxyPromise;
-}
-
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+export default (req: NextApiRequest, res: NextApiResponse) => {
   if (isInlineApi) {
     // Lazy require so non-preview production builds — where the webpack
     // externals hook in next.config.mjs marks @hyperdx/api as external —
@@ -46,7 +27,16 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     return handler(req, res);
   }
 
-  const proxy = await getProxy();
+  const proxy = createProxyMiddleware({
+    changeOrigin: true,
+    // logger: console, // DEBUG
+    pathRewrite: { '^/api': '' },
+    target: process.env.SERVER_URL || DEFAULT_SERVER_URL,
+    autoRewrite: true,
+    // ...(IS_DEV && {
+    //   logger: console,
+    // }),
+  });
   return proxy(req, res, error => {
     if (error) {
       console.error(error);

--- a/packages/app/pages/api/[...all].ts
+++ b/packages/app/pages/api/[...all].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import type { RequestHandler } from 'http-proxy-middleware';
 
 const DEFAULT_SERVER_URL = `http://127.0.0.1:${process.env.HYPERDX_API_PORT}`;
 
@@ -16,7 +16,26 @@ export const config = {
 // we proxy `/api/*` to a separately-deployed API service as before.
 const isInlineApi = process.env.HDX_PREVIEW_INLINE_API === 'true';
 
-export default (req: NextApiRequest, res: NextApiResponse) => {
+// http-proxy-middleware v4 is ESM-only. Use a dynamic import with a cached
+// promise so the module is loaded once and concurrent requests share the result.
+let _proxyPromise: Promise<RequestHandler> | undefined;
+
+function getProxy(): Promise<RequestHandler> {
+  if (!_proxyPromise) {
+    _proxyPromise = import('http-proxy-middleware').then(
+      ({ createProxyMiddleware }) =>
+        createProxyMiddleware({
+          changeOrigin: true,
+          pathRewrite: { '^/api': '' },
+          target: process.env.SERVER_URL || DEFAULT_SERVER_URL,
+          autoRewrite: true,
+        }),
+    );
+  }
+  return _proxyPromise;
+}
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (isInlineApi) {
     // Lazy require so non-preview production builds — where the webpack
     // externals hook in next.config.mjs marks @hyperdx/api as external —
@@ -27,16 +46,7 @@ export default (req: NextApiRequest, res: NextApiResponse) => {
     return handler(req, res);
   }
 
-  const proxy = createProxyMiddleware({
-    changeOrigin: true,
-    // logger: console, // DEBUG
-    pathRewrite: { '^/api': '' },
-    target: process.env.SERVER_URL || DEFAULT_SERVER_URL,
-    autoRewrite: true,
-    // ...(IS_DEV && {
-    //   logger: console,
-    // }),
-  });
+  const proxy = await getProxy();
   return proxy(req, res, error => {
     if (error) {
       console.error(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,7 +4396,7 @@ __metadata:
     express-session: "npm:^1.17.3"
     handlebars: "npm:^4.7.9"
     http-graceful-shutdown: "npm:^3.1.13"
-    http-proxy-middleware: "npm:^3.0.5"
+    http-proxy-middleware: "npm:^4.0.0"
     jest: "npm:^30.2.0"
     jsonwebtoken: "npm:^9.0.0"
     lodash: "npm:^4.18.1"
@@ -4505,7 +4505,7 @@ __metadata:
     eslint-plugin-storybook: "npm:10.1.4"
     flat: "npm:^5.0.2"
     fuse.js: "npm:^6.6.2"
-    http-proxy-middleware: "npm:^3.0.5"
+    http-proxy-middleware: "npm:^4.0.0"
     identity-obj-proxy: "npm:^3.0.0"
     immer: "npm:^9.0.21"
     jest: "npm:^30.2.0"
@@ -9771,15 +9771,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-proxy@npm:^1.17.15":
-  version: 1.17.15
-  resolution: "@types/http-proxy@npm:1.17.15"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/e2bf2fcdf23c88141b8d2c85ed5e5418b62ef78285884a2b5a717af55f4d9062136aa475489d10292093343df58fb81975f34bebd6b9df322288fd9821cbee07
-  languageName: node
-  linkType: hard
-
 "@types/hyperdx__lucene@npm:@types/lucene@*":
   version: 2.1.7
   resolution: "@types/lucene@npm:2.1.7"
@@ -14071,18 +14062,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.6":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
-  languageName: node
-  linkType: hard
-
 "debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -15964,7 +15943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.7":
+"eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.7":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 10c0/5f6d97cbcbac47be798e6355e3a7639a84ee1f7d9b199a07017f1d2f1e2fe236004d14fa5dfaeba661f94ea57805385e326236a6debbc7145c8877fbc0297c6b
@@ -16590,16 +16569,6 @@ __metadata:
   version: 5.0.0
   resolution: "fn-args@npm:5.0.0"
   checksum: 10c0/3f2f73ab3a036014a0188d8a0353ff0d8afddbd4ae48e460da5302b166c10d6b484ce8af444b9b421727d2997f1762e2044498f7e5e8a79deab5d6b2a7191ecc
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
   languageName: node
   linkType: hard
 
@@ -17731,28 +17700,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "http-proxy-middleware@npm:3.0.5"
+"http-proxy-middleware@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "http-proxy-middleware@npm:4.0.0"
   dependencies:
-    "@types/http-proxy": "npm:^1.17.15"
-    debug: "npm:^4.3.6"
-    http-proxy: "npm:^1.18.1"
+    debug: "npm:^4.4.3"
+    httpxy: "npm:^0.5.1"
     is-glob: "npm:^4.0.3"
-    is-plain-object: "npm:^5.0.0"
+    is-plain-obj: "npm:^4.1.0"
     micromatch: "npm:^4.0.8"
-  checksum: 10c0/89ff3c8fe65b22b8042a6173ae1b8f77c5171f7eecf3c8b5d6dcffe3c9d688acae7bcf498cc08d1525f566dc0781efaec4e2ddc49224b1f16f020de7987a446b
-  languageName: node
-  linkType: hard
-
-"http-proxy@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "http-proxy@npm:1.18.1"
-  dependencies:
-    eventemitter3: "npm:^4.0.0"
-    follow-redirects: "npm:^1.0.0"
-    requires-port: "npm:^1.0.0"
-  checksum: 10c0/148dfa700a03fb421e383aaaf88ac1d94521dfc34072f6c59770528c65250983c2e4ec996f2f03aa9f3fe46cd1270a593126068319311e3e8d9e610a37533e94
+  checksum: 10c0/956cfec006b3619433e5c5ce24e9379bbe2e2ae885705df82c261530392c94c101205ef891845fe7d39b9d646a463c302b3b6d90125dc6e8dc42fbd7c6211c69
   languageName: node
   linkType: hard
 
@@ -17780,6 +17737,13 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"httpxy@npm:^0.5.1":
+  version: 0.5.3
+  resolution: "httpxy@npm:0.5.3"
+  checksum: 10c0/8120753638d1a50b13396d7c55536db076a04609dfb7eea19f5b461f9541acf4646fa6bfb8991f14bad62e0037b524481c5d625892b4ff94a6ab744149ed9387
   languageName: node
   linkType: hard
 
@@ -18575,7 +18539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.0.0":
+"is-plain-obj@npm:^4.0.0, is-plain-obj@npm:^4.1.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
@@ -24691,13 +24655,6 @@ __metadata:
   version: 1.1.0
   resolution: "requireindex@npm:1.1.0"
   checksum: 10c0/4d57e7c6d160c4d043a233a6a95a22c792ada72ff378c5ebd415be505b328f3c719f9188dd100f8fcaa8af513a85f39eee0a5047838d715e22e79544a3b7d002
-  languageName: node
-  linkType: hard
-
-"requires-port@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "requires-port@npm:1.0.0"
-  checksum: 10c0/b2bfdd09db16c082c4326e573a82c0771daaf7b53b9ce8ad60ea46aa6e30aaf475fe9b164800b89f93b748d2c234d8abff945d2551ba47bf5698e04cd7713267
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Removes the `util._extend` deprecation warning (`DEP0060`) that `http-proxy` was triggering at runtime.

<img width="1655" height="438" alt="Screenshot 2026-06-12 at 3 26 08 PM" src="https://github.com/user-attachments/assets/dd298e6b-33b9-4875-ab0a-c120c3a45f93" />

Bumps `http-proxy-middleware` from v3 to v4 in both `packages/api` and `packages/app`. v4 swaps the underlying proxy engine from `http-proxy` to [`httpxy`](https://github.com/unjs/httpxy), which eliminates the deprecated `util._extend` call and brings many upstream fixes, HTTP/2 support, and better performance. The `createProxyMiddleware` API surface is unchanged.

Because v4 ships as ESM-only and the API package emits CJS, the static import in `clickhouseProxy.ts` is replaced with a lazy `import()` wrapper that initializes once on first request and caches for subsequent calls.

Also removes a stale TODO referencing [chimurai/http-proxy-middleware#1102](https://github.com/chimurai/http-proxy-middleware/issues/1102) — the underlying `fixRequestBody` issues (text/plain support, content-encoding) are resolved in v4.

> **Note:** Currently pinned to `^4.0.0` (resolves to 4.0.0) because v4.1.0 hasn't cleared the repo's 7-day `npmMinimalAgeGate`. After June 13 we should bump to `^4.1.0` via `yarn up http-proxy-middleware`.
