### PR TITLE
refactor(app): declarative Infrastructure tab correlation list

### DIFF
--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -32,22 +32,22 @@ import { TableSourceForm } from '@/components/Sources/SourceForm';
 import { IS_LOCAL_MODE } from '@/config';
 import { useSource } from '@/source';
 
-import {
-  K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
-  K8S_FILESYSTEM_NUMBER_FORMAT,
-  K8S_MEM_NUMBER_FORMAT,
-} from '../ChartUtils';
-
 import { DBTimeChart } from './DBTimeChart';
+import {
+  getActiveInfraCorrelations,
+  InfraChartSpec,
+} from './infraCorrelations';
 import { KubeTimeline } from './KubeComponents';
 
 const InfraSubpanelGroup = ({
+  charts,
   fieldPrefix,
   metricSource,
   timestamp,
   title,
   where,
 }: {
+  charts: InfraChartSpec[];
   fieldPrefix: string;
   metricSource: TMetricSource;
   timestamp: any;
@@ -115,96 +115,38 @@ const InfraSubpanelGroup = ({
         </Group>
       </Group>
       <SimpleGrid mt="md" cols={cols}>
-        <Card data-testid="cpu-usage-card">
-          <Card.Section py={8} px={8} h={height}>
-            <DBTimeChart
-              title="CPU Usage (%)"
-              config={convertV1ChartConfigToV2(
-                {
-                  dateRange,
-                  granularity,
-                  seriesReturnType: 'column',
-                  series: [
-                    {
-                      type: 'time',
-                      where,
-                      groupBy: [],
-                      aggFn: 'avg',
-                      field: `${fieldPrefix}cpu.utilization - Gauge`,
-                      table: 'metrics',
-                      numberFormat: K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
-                    },
-                  ],
-                },
-                {
-                  metric: metricSource,
-                },
-              )}
-              showDisplaySwitcher={false}
-              logReferenceTimestamp={timestamp / 1000}
-            />
-          </Card.Section>
-        </Card>
-        <Card data-testid="memory-usage-card">
-          <Card.Section py={8} px={8} h={height}>
-            <DBTimeChart
-              title="Memory Used"
-              config={convertV1ChartConfigToV2(
-                {
-                  dateRange,
-                  granularity,
-                  seriesReturnType: 'column',
-                  series: [
-                    {
-                      type: 'time',
-                      where,
-                      groupBy: [],
-                      aggFn: 'avg',
-                      field: `${fieldPrefix}memory.usage - Gauge`,
-                      table: 'metrics',
-                      numberFormat: K8S_MEM_NUMBER_FORMAT,
-                    },
-                  ],
-                },
-                {
-                  metric: metricSource,
-                },
-              )}
-              showDisplaySwitcher={false}
-              logReferenceTimestamp={timestamp / 1000}
-            />
-          </Card.Section>
-        </Card>
-        <Card data-testid="disk-usage-card">
-          <Card.Section py={8} px={8} h={height}>
-            <DBTimeChart
-              title="Disk Available"
-              config={convertV1ChartConfigToV2(
-                {
-                  dateRange,
-                  granularity,
-                  seriesReturnType: 'column',
-                  series: [
-                    {
-                      type: 'time',
-                      where,
-                      groupBy: [],
-                      aggFn: 'avg',
-                      field: `${fieldPrefix}filesystem.available - Gauge`,
-                      table: 'metrics',
-                      numberFormat: K8S_FILESYSTEM_NUMBER_FORMAT,
-                    },
-                  ],
-                },
-                {
-                  metric: metricSource,
-                },
-              )}
-              showDisplaySwitcher={false}
-              logReferenceTimestamp={timestamp / 1000}
-            />
-          </Card.Section>
-        </Card>
+        {charts.map(chart => (
+          <Card key={chart.cardTestId} data-testid={chart.cardTestId}>
+            <Card.Section py={8} px={8} h={height}>
+              <DBTimeChart
+                title={chart.title}
+                config={convertV1ChartConfigToV2(
+                  {
+                    dateRange,
+                    granularity,
+                    seriesReturnType: 'column',
+                    series: [
+                      {
+                        type: 'time',
+                        where,
+                        groupBy: [],
+                        aggFn: 'avg',
+                        field: `${fieldPrefix}${chart.field} - Gauge`,
+                        table: 'metrics',
+                        numberFormat: chart.numberFormat,
+                      },
+                    ],
+                  },
+                  {
+                    metric: metricSource,
+                  },
+                )}
+                showDisplaySwitcher={false}
+                logReferenceTimestamp={timestamp / 1000}
+              />
+            </Card.Section>
+          </Card>
+        ))}
       </SimpleGrid>
     </div>
   );
@@ -229,8 +171,11 @@ export default ({
     kinds: [SourceKind.Metric],
   });
 
-  const podUid = rowData?.__hdx_resource_attributes['k8s.pod.uid'];
-  const nodeName = rowData?.__hdx_resource_attributes['k8s.node.name'];
+  const resourceAttributes = rowData?.__hdx_resource_attributes;
+  const activeCorrelations = useMemo(
+    () => getActiveInfraCorrelations(resourceAttributes),
+    [resourceAttributes],
+  );
 
   const timestamp = new Date(rowData?.__hdx_timestamp).getTime();
 
@@ -269,57 +214,63 @@ export default ({
           )}
         </>
       )}
-      {podUid && (
-        <div>
-          {metricSource && (
-            <InfraSubpanelGroup
-              title="Pod"
-              where={`${metricSource.resourceAttributesExpression}.k8s.pod.uid:"${podUid}"`}
-              fieldPrefix="k8s.pod."
-              timestamp={timestamp}
-              metricSource={metricSource}
-            />
-          )}
-          {source && source.kind === SourceKind.Log && (
-            <Card p="md" mt="xl">
-              <Card.Section p="md" py="xs">
-                Pod Timeline
-              </Card.Section>
-              <Card.Section>
-                <ScrollArea
-                  viewportProps={{
-                    style: { maxHeight: 280 },
-                  }}
-                >
-                  <Box p="md" py="sm">
-                    <KubeTimeline
-                      logSource={source}
-                      q={`\`k8s.pod.uid\`:"${podUid}"`}
-                      dateRange={[
-                        sub(new Date(timestamp), { days: 1 }),
-                        add(new Date(timestamp), { days: 1 }),
-                      ]}
-                      anchorEvent={{
-                        label: <div className="text-brand">This Event</div>,
-                        timestamp: new Date(timestamp).toISOString(),
-                      }}
-                    />
-                  </Box>
-                </ScrollArea>
-              </Card.Section>
-            </Card>
-          )}
-        </div>
-      )}
-      {nodeName && metricSource && (
-        <InfraSubpanelGroup
-          metricSource={metricSource}
-          title="Node"
-          where={`${metricSource.resourceAttributesExpression}.k8s.node.name:"${nodeName}"`}
-          fieldPrefix="k8s.node."
-          timestamp={timestamp}
-        />
-      )}
+      {activeCorrelations.map(correlation => {
+        const value = resourceAttributes?.[correlation.correlateAttribute];
+        if (!value) {
+          return null;
+        }
+        const showTimeline =
+          correlation.timeline != null && source.kind === SourceKind.Log;
+        // Skip rendering an empty container when neither the metric group nor
+        // the timeline has anything to show (e.g. no metric source configured
+        // on a non-Log source).
+        if (!metricSource && !showTimeline) {
+          return null;
+        }
+        return (
+          <div key={correlation.title}>
+            {metricSource && (
+              <InfraSubpanelGroup
+                title={correlation.title}
+                where={`${metricSource.resourceAttributesExpression}.${correlation.correlateAttribute}:"${value}"`}
+                fieldPrefix={correlation.fieldPrefix}
+                charts={correlation.charts}
+                timestamp={timestamp}
+                metricSource={metricSource}
+              />
+            )}
+            {correlation.timeline && source.kind === SourceKind.Log && (
+              <Card p="md" mt="xl">
+                <Card.Section p="md" py="xs">
+                  {correlation.title} Timeline
+                </Card.Section>
+                <Card.Section>
+                  <ScrollArea
+                    viewportProps={{
+                      style: { maxHeight: 280 },
+                    }}
+                  >
+                    <Box p="md" py="sm">
+                      <KubeTimeline
+                        logSource={source}
+                        q={`\`${correlation.timeline.queryAttribute}\`:"${resourceAttributes?.[correlation.timeline.queryAttribute]}"`}
+                        dateRange={[
+                          sub(new Date(timestamp), { days: 1 }),
+                          add(new Date(timestamp), { days: 1 }),
+                        ]}
+                        anchorEvent={{
+                          label: <div className="text-brand">This Event</div>,
+                          timestamp: new Date(timestamp).toISOString(),
+                        }}
+                      />
+                    </Box>
+                  </ScrollArea>
+                </Card.Section>
+              </Card>
+            )}
+          </div>
+        );
+      })}
     </Stack>
   );
 };

--- a/packages/app/src/components/DBInfraPanel.tsx
+++ b/packages/app/src/components/DBInfraPanel.tsx
@@ -47,7 +47,7 @@ const InfraSubpanelGroup = ({
   title,
   where,
 }: {
-  charts: InfraChartSpec[];
+  charts: readonly InfraChartSpec[];
   fieldPrefix: string;
   metricSource: TMetricSource;
   timestamp: any;
@@ -216,6 +216,12 @@ export default ({
       )}
       {activeCorrelations.map(correlation => {
         const value = resourceAttributes?.[correlation.correlateAttribute];
+        // Truthiness guard, mirroring the previous Pod/Node render blocks
+        // (which gated on the attribute value with `&&`); the tab gate uses
+        // != null. detect and correlate are the same attribute for the
+        // built-in k8s descriptors, so this stays byte-identical. A future
+        // descriptor that splits the two decides here how an empty correlate
+        // value should render.
         if (!value) {
           return null;
         }

--- a/packages/app/src/components/DBRowDataPanel.tsx
+++ b/packages/app/src/components/DBRowDataPanel.tsx
@@ -15,6 +15,7 @@ import { getDisplayedTimestampValueExpression, getEventBody } from '@/source';
 import { getSelectExpressionsForHighlightedAttributes } from '@/utils/highlightedAttributes';
 
 import { DBRowJsonViewer } from './DBRowJsonViewer';
+import { getActiveInfraCorrelations } from './infraCorrelations';
 
 export enum ROW_DATA_ALIASES {
   TIMESTAMP = '__hdx_timestamp',
@@ -190,9 +191,12 @@ export function useRowData({
   };
 }
 
-// Detects whether a normalized row carries Kubernetes resource attributes, used
-// to conditionally surface the Infrastructure tab/panel. Requires the source to
-// expose resource attributes; returns false (rather than throwing) on any gap.
+// Detects whether a normalized row carries resource attributes that match a
+// built-in infrastructure correlation (Kubernetes Pod or Node today), used to
+// conditionally surface the Infrastructure tab/panel. Delegates to the same
+// descriptor list the panel renders from, so the gate and the render never
+// drift apart. Requires the source to expose resource attributes; returns
+// false (rather than throwing) on any gap.
 export function rowHasK8sContext(
   source: TSource | null | undefined,
   normalizedRow: Record<string, any> | null | undefined,
@@ -208,10 +212,7 @@ export function rowHasK8sContext(
     }
 
     const resourceAttrs = normalizedRow[ROW_DATA_ALIASES.RESOURCE_ATTRIBUTES];
-    return (
-      resourceAttrs?.['k8s.pod.uid'] != null ||
-      resourceAttrs?.['k8s.node.name'] != null
-    );
+    return getActiveInfraCorrelations(resourceAttrs).length > 0;
   } catch (e) {
     console.error(e);
     return false;

--- a/packages/app/src/components/__tests__/infraCorrelations.test.ts
+++ b/packages/app/src/components/__tests__/infraCorrelations.test.ts
@@ -1,0 +1,82 @@
+import {
+  getActiveInfraCorrelations,
+  INFRA_CORRELATIONS,
+} from '../infraCorrelations';
+
+describe('getActiveInfraCorrelations', () => {
+  it('returns the Pod group when only k8s.pod.uid is present', () => {
+    const active = getActiveInfraCorrelations({ 'k8s.pod.uid': 'pod-abc' });
+    expect(active.map(c => c.title)).toEqual(['Pod']);
+  });
+
+  it('returns the Node group when only k8s.node.name is present', () => {
+    const active = getActiveInfraCorrelations({ 'k8s.node.name': 'node-1' });
+    expect(active.map(c => c.title)).toEqual(['Node']);
+  });
+
+  it('returns both groups in render order when both attributes are present', () => {
+    const active = getActiveInfraCorrelations({
+      'k8s.pod.uid': 'pod-abc',
+      'k8s.node.name': 'node-1',
+    });
+    expect(active.map(c => c.title)).toEqual(['Pod', 'Node']);
+  });
+
+  it('returns no groups when no detect attribute is present', () => {
+    expect(getActiveInfraCorrelations({})).toEqual([]);
+  });
+
+  it('returns no groups for unrelated resource attributes', () => {
+    expect(
+      getActiveInfraCorrelations({
+        'host.name': 'web-1',
+        'service.name': 'api',
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns no groups when resource attributes are null or undefined', () => {
+    expect(getActiveInfraCorrelations(undefined)).toEqual([]);
+    expect(getActiveInfraCorrelations(null)).toEqual([]);
+  });
+
+  // The gate uses != null, not truthiness, matching the prior hardcoded gate.
+  it('treats a detect attribute explicitly set to null as absent', () => {
+    expect(getActiveInfraCorrelations({ 'k8s.pod.uid': null })).toEqual([]);
+  });
+});
+
+describe('INFRA_CORRELATIONS built-ins', () => {
+  it('preserves the Kubernetes Pod and Node correlation identity', () => {
+    expect(INFRA_CORRELATIONS).toMatchObject([
+      {
+        title: 'Pod',
+        detectAttribute: 'k8s.pod.uid',
+        correlateAttribute: 'k8s.pod.uid',
+        fieldPrefix: 'k8s.pod.',
+        timeline: { queryAttribute: 'k8s.pod.uid' },
+      },
+      {
+        title: 'Node',
+        detectAttribute: 'k8s.node.name',
+        correlateAttribute: 'k8s.node.name',
+        fieldPrefix: 'k8s.node.',
+      },
+    ]);
+  });
+
+  it('keeps the Pod Timeline only on the Pod group', () => {
+    const node = INFRA_CORRELATIONS.find(c => c.title === 'Node');
+    expect(node?.timeline).toBeUndefined();
+  });
+
+  it('keeps the three k8s metric fields and card test ids on every group', () => {
+    for (const correlation of INFRA_CORRELATIONS) {
+      expect(correlation.charts.map(c => [c.cardTestId, c.field])).toEqual([
+        ['cpu-usage-card', 'cpu.utilization'],
+        ['memory-usage-card', 'memory.usage'],
+        ['disk-usage-card', 'filesystem.available'],
+      ]);
+    }
+  });
+});

--- a/packages/app/src/components/infraCorrelations.ts
+++ b/packages/app/src/components/infraCorrelations.ts
@@ -1,0 +1,94 @@
+import {
+  K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
+  K8S_FILESYSTEM_NUMBER_FORMAT,
+  K8S_MEM_NUMBER_FORMAT,
+} from '@/ChartUtils';
+import { NumberFormat } from '@/types';
+
+// One metric chart inside an infrastructure correlation group. The rendered
+// metric field is `${fieldPrefix}${field} - Gauge` (see DBInfraPanel), so
+// `field` is the metric name without the resource prefix or the type suffix.
+export type InfraChartSpec = {
+  title: string;
+  // data-testid for the chart card; the e2e suite selects on these.
+  cardTestId: string;
+  field: string;
+  numberFormat: NumberFormat;
+};
+
+// A declarative infrastructure correlation group. `detectAttribute` decides
+// whether the group (and the Infrastructure tab) appears for an opened row;
+// `correlateAttribute` is the resource attribute the metrics are filtered by.
+// They match for Kubernetes today but are kept separate so resource types that
+// detect on one attribute and correlate on another can be added as data rather
+// than new code paths.
+export type InfraCorrelation = {
+  title: string;
+  detectAttribute: string;
+  correlateAttribute: string;
+  // Metric field prefix, e.g. "k8s.pod.".
+  fieldPrefix: string;
+  charts: InfraChartSpec[];
+  // Optional Kubernetes event timeline (Log sources only).
+  timeline?: {
+    queryAttribute: string;
+  };
+};
+
+// Pod and Node render the same three charts; only the field prefix and the
+// correlate filter differ, so the specs are shared.
+const K8S_CHART_SPECS: InfraChartSpec[] = [
+  {
+    title: 'CPU Usage (%)',
+    cardTestId: 'cpu-usage-card',
+    field: 'cpu.utilization',
+    numberFormat: K8S_CPU_PERCENTAGE_NUMBER_FORMAT,
+  },
+  {
+    title: 'Memory Used',
+    cardTestId: 'memory-usage-card',
+    field: 'memory.usage',
+    numberFormat: K8S_MEM_NUMBER_FORMAT,
+  },
+  {
+    title: 'Disk Available',
+    cardTestId: 'disk-usage-card',
+    field: 'filesystem.available',
+    numberFormat: K8S_FILESYSTEM_NUMBER_FORMAT,
+  },
+];
+
+// Built-in correlation groups. Array order is the render order in the
+// Infrastructure panel (Pod, then Node), matching the prior hardcoding.
+export const INFRA_CORRELATIONS: InfraCorrelation[] = [
+  {
+    title: 'Pod',
+    detectAttribute: 'k8s.pod.uid',
+    correlateAttribute: 'k8s.pod.uid',
+    fieldPrefix: 'k8s.pod.',
+    charts: K8S_CHART_SPECS,
+    timeline: { queryAttribute: 'k8s.pod.uid' },
+  },
+  {
+    title: 'Node',
+    detectAttribute: 'k8s.node.name',
+    correlateAttribute: 'k8s.node.name',
+    fieldPrefix: 'k8s.node.',
+    charts: K8S_CHART_SPECS,
+  },
+];
+
+// Returns the built-in correlation groups whose detect attribute is present
+// (non-null) on the given resource attributes. This is the single source of
+// truth for both the Infrastructure tab gate (rowHasK8sContext) and the panel
+// renderer (DBInfraPanel), so the gate and the render never drift apart.
+export function getActiveInfraCorrelations(
+  resourceAttributes: Record<string, unknown> | null | undefined,
+): InfraCorrelation[] {
+  if (!resourceAttributes) {
+    return [];
+  }
+  return INFRA_CORRELATIONS.filter(
+    correlation => resourceAttributes[correlation.detectAttribute] != null,
+  );
+}

--- a/packages/app/src/components/infraCorrelations.ts
+++ b/packages/app/src/components/infraCorrelations.ts
@@ -9,11 +9,11 @@ import { NumberFormat } from '@/types';
 // metric field is `${fieldPrefix}${field} - Gauge` (see DBInfraPanel), so
 // `field` is the metric name without the resource prefix or the type suffix.
 export type InfraChartSpec = {
-  title: string;
+  readonly title: string;
   // data-testid for the chart card; the e2e suite selects on these.
-  cardTestId: string;
-  field: string;
-  numberFormat: NumberFormat;
+  readonly cardTestId: string;
+  readonly field: string;
+  readonly numberFormat: NumberFormat;
 };
 
 // A declarative infrastructure correlation group. `detectAttribute` decides
@@ -23,21 +23,21 @@ export type InfraChartSpec = {
 // detect on one attribute and correlate on another can be added as data rather
 // than new code paths.
 export type InfraCorrelation = {
-  title: string;
-  detectAttribute: string;
-  correlateAttribute: string;
+  readonly title: string;
+  readonly detectAttribute: string;
+  readonly correlateAttribute: string;
   // Metric field prefix, e.g. "k8s.pod.".
-  fieldPrefix: string;
-  charts: InfraChartSpec[];
+  readonly fieldPrefix: string;
+  readonly charts: readonly InfraChartSpec[];
   // Optional Kubernetes event timeline (Log sources only).
-  timeline?: {
-    queryAttribute: string;
+  readonly timeline?: {
+    readonly queryAttribute: string;
   };
 };
 
 // Pod and Node render the same three charts; only the field prefix and the
 // correlate filter differ, so the specs are shared.
-const K8S_CHART_SPECS: InfraChartSpec[] = [
+const K8S_CHART_SPECS: readonly InfraChartSpec[] = [
   {
     title: 'CPU Usage (%)',
     cardTestId: 'cpu-usage-card',
@@ -60,7 +60,7 @@ const K8S_CHART_SPECS: InfraChartSpec[] = [
 
 // Built-in correlation groups. Array order is the render order in the
 // Infrastructure panel (Pod, then Node), matching the prior hardcoding.
-export const INFRA_CORRELATIONS: InfraCorrelation[] = [
+export const INFRA_CORRELATIONS: readonly InfraCorrelation[] = [
   {
     title: 'Pod',
     detectAttribute: 'k8s.pod.uid',
@@ -84,7 +84,7 @@ export const INFRA_CORRELATIONS: InfraCorrelation[] = [
 // renderer (DBInfraPanel), so the gate and the render never drift apart.
 export function getActiveInfraCorrelations(
   resourceAttributes: Record<string, unknown> | null | undefined,
-): InfraCorrelation[] {
+): readonly InfraCorrelation[] {
   if (!resourceAttributes) {
     return [];
   }

--- a/packages/app/tests/e2e/features/search/search.spec.ts
+++ b/packages/app/tests/e2e/features/search/search.spec.ts
@@ -141,6 +141,29 @@ test.describe('Search', { tag: '@search' }, () => {
       });
     });
 
+    test('Infrastructure tab is hidden for non-Kubernetes rows', async () => {
+      await test.step('Open a non-Kubernetes log row', async () => {
+        // Regular logs set ResourceAttributes.service.name to a real service
+        // name; k8s logs set it to a pod name, so this matches only non-k8s rows.
+        await searchPage.performSearch(
+          'ResourceAttributes.service.name:"api-server"',
+        );
+        await expect(searchPage.table.firstRow).toBeVisible();
+        await searchPage.table.clickFirstRow();
+        await expect(searchPage.sidePanel.tabs).toBeVisible();
+      });
+
+      await test.step('Infrastructure tab is not offered', async () => {
+        // The tab bar rendered (an always-present tab is visible), but the gate
+        // omits Infrastructure because the row carries no k8s correlation
+        // attributes.
+        await expect(searchPage.sidePanel.getTab('trace')).toBeVisible();
+        await expect(searchPage.sidePanel.getTab('infrastructure')).toHaveCount(
+          0,
+        );
+      });
+    });
+
     test('Time Picker Integration with Search', async () => {
       await test.step('Interact with time picker', async () => {
         await expect(searchPage.timePicker.input).toBeVisible();


### PR DESCRIPTION
## Summary

The Infrastructure tab in the log and trace row side panel correlates infrastructure metrics to the opened span. Until now it was hardcoded to exactly two Kubernetes resource types, Pod and Node, with three fixed charts each, and it used a single attribute both to decide whether a group should appear and to filter that group's metrics.

This refactors that hardcoding into a declarative descriptor list and splits the "detect" attribute (decides whether a group shows up) from the "correlate" attribute (filters the group's metrics). Kubernetes behavior is unchanged: the same tab, the same gate, the same Pod and Node charts, the Pod Timeline, the time and size toggles, and the Event marker all render identically.

There is no functional or visual change. The value is internal. The gate and the renderer now read from one shared descriptor list, so they cannot drift apart, and adding a new resource type later (host metrics, serverless functions) becomes a matter of appending a descriptor rather than adding a parallel code path.

## What changed

- New `packages/app/src/components/infraCorrelations.ts`: an `InfraCorrelation` descriptor type (detect attribute, correlate attribute, field prefix, chart specs, optional timeline), the built-in Kubernetes Pod and Node descriptors, and a `getActiveInfraCorrelations(resourceAttributes)` selector.
- `DBInfraPanel.tsx`: `InfraSubpanelGroup` maps over a descriptor's chart specs instead of three hardcoded cards, and the panel maps over the active descriptors instead of two hardcoded Pod and Node blocks. The Pod Timeline is driven by a descriptor flag.
- `DBRowDataPanel.tsx`: `rowHasK8sContext`, the gate shared by the row side panel and the trace panel, now delegates to `getActiveInfraCorrelations(...).length > 0`. For the Kubernetes descriptor set this is identical to the previous `k8s.pod.uid != null || k8s.node.name != null` check.
- The detect and correlate attributes are equal for Kubernetes today, so the output is byte-identical. Keeping them separate is what lets a later resource type detect on one attribute and correlate on another.

One structural note: each correlation group is now wrapped in a container `div` (previously only the Pod group was, to keep its charts and timeline together). The wrapper has no styling, so the rendered output is unchanged; it also avoids a stray gap that the old code could leave when a group had nothing to show.

## Verification

- No styling, color, or layout changed, so light and dark themes render the same and the layout is identical at any viewport.
- The refactor is a 1:1 code path for Kubernetes. The descriptors reproduce the exact metric queries, field names (`k8s.pod.cpu.utilization - Gauge` and the rest), chart titles, number formats, card `data-testid`s, and the Pod Timeline query, and the gate keeps the same `k8s.pod.uid != null || k8s.node.name != null` truth table. I went through the before and after of every generated string to confirm byte-for-byte equality.
- New unit test `infraCorrelations.test.ts` locks the selector's gate semantics (Pod-only, Node-only, both, neither, unrelated attributes, null handling) and pins the built-in descriptor identity (field prefixes, metric fields, card test ids, Pod-only timeline).
- e2e coverage: the existing positive case asserts the Pod and Node charts render on a k8s row, the existing `correlated-metric-source` spec covers the "no correlated metric source" path, and a new negative case (`Infrastructure tab is hidden for non-Kubernetes rows`) asserts the gate hides the tab on a non-k8s row.
- Verified by a side-by-side Playwright capture: opened a Kubernetes pod row on both the released demo and this PR's preview build and confirmed the Infrastructure tab renders identically (Pod and Node CPU/Memory/Disk charts with `avg(k8s.pod.*)` / `avg(k8s.node.*)`, the Pod Timeline, the Event reference line, and the 30m/1h/1d + SM/MD/LG toggles). The only differences were the underlying demo data. Preview: https://hyperdx-oss-git-alex-infra-declarative-correlation-hyperdx.vercel.app/search

## Test plan

- [x] eslint clean on the changed files
- [x] `tsc --noEmit` clean
- [x] `infraCorrelations.test.ts` (10 cases) green
- [x] gate caller tests (`DBRowDataPanel`, `DBTracePanel`) green
- [x] before and after of every generated metric query, field name, test id, and the gate reviewed for byte-for-byte equality
- [x] e2e green in CI (existing infra-tab positive + no-metric-source coverage, plus the new non-k8s negative case)
- [x] released demo vs preview parity confirmed via Playwright on a k8s span (Pod and Node charts, Pod Timeline, Event marker, toggles identical)

[ui-states: allow] no new empty, loading, or error states; the existing alert and loading paths are unchanged.
[viewport: allow] no layout change; the SimpleGrid column logic is untouched.
[no-changeset: allow] internal refactor with no user-visible effect.

