### PR TITLE
fix(alerts): populate {{attributes.*}} for alerts

### DIFF
--- a/.changeset/tile-alert-attributes.md
+++ b/.changeset/tile-alert-attributes.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix(alerts): populate `{{attributes.*}}` template variables for tile/chart alerts from group-by fields

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -39,6 +39,7 @@ import {
   doesExceedThreshold,
   getPreviousAlertHistories,
   getScheduledWindowStart,
+  parseAlertData,
   processAlert,
 } from '@/tasks/checkAlerts';
 import {
@@ -964,6 +965,97 @@ describe('checkAlerts', () => {
           7,
         ),
       ).toThrow(/thresholdMax is required/);
+    });
+  });
+
+  describe('parseAlertData', () => {
+    const timeSeriesMeta = {
+      type: 'time_series' as const,
+      timestampColumnName: 'ts',
+      valueColumnNames: new Set(['cnt']),
+    };
+
+    it('returns the value and ordered [key, value] field pairs, excluding timestamp and value columns', () => {
+      const { value, extraFields } = parseAlertData(
+        {
+          ts: '2023-11-16T22:12:00.000Z',
+          ServiceName: 'web',
+          SeverityText: 'error',
+          cnt: 5,
+        },
+        timeSeriesMeta,
+      );
+
+      expect(value).toBe(5);
+      // Column order is preserved and the timestamp/value columns are excluded.
+      expect(extraFields).toEqual([
+        ['ServiceName', 'web'],
+        ['SeverityText', 'error'],
+      ]);
+    });
+
+    it('derives a group string byte-identical to the old "k:v, k:v" format', () => {
+      const { extraFields } = parseAlertData(
+        {
+          ts: '2023-11-16T22:12:00.000Z',
+          ServiceName: 'web',
+          SeverityText: 'error',
+          cnt: 5,
+        },
+        timeSeriesMeta,
+      );
+
+      const groupKey = extraFields.map(([k, v]) => `${k}:${v}`).join(', ');
+      expect(groupKey).toBe('ServiceName:web, SeverityText:error');
+    });
+
+    it('derives attributes via Object.fromEntries, preserving values that contain colons', () => {
+      const { extraFields } = parseAlertData(
+        {
+          ts: '2023-11-16T22:12:00.000Z',
+          'k8s.pod.name': 'otel-collector-123',
+          firstSeen: '2023-11-16T22:12:00.000Z',
+          url: 'https://example.com/path',
+          cnt: 5,
+        },
+        timeSeriesMeta,
+      );
+
+      expect(Object.fromEntries(extraFields)).toEqual({
+        'k8s.pod.name': 'otel-collector-123',
+        firstSeen: '2023-11-16T22:12:00.000Z',
+        url: 'https://example.com/path',
+      });
+    });
+
+    it('coerces numeric field values to strings', () => {
+      const { extraFields } = parseAlertData(
+        { ts: '2023-11-16T22:12:00.000Z', StatusCode: 500, cnt: 5 },
+        timeSeriesMeta,
+      );
+
+      expect(extraFields).toEqual([['StatusCode', '500']]);
+    });
+
+    it('returns no fields when there are no group-by columns', () => {
+      const { value, extraFields } = parseAlertData(
+        { ts: '2023-11-16T22:12:00.000Z', cnt: 5 },
+        timeSeriesMeta,
+      );
+
+      expect(value).toBe(5);
+      expect(extraFields).toEqual([]);
+    });
+
+    it('does not treat the timestamp column as a field for single_value results', () => {
+      const { value, extraFields } = parseAlertData(
+        { ts: '2023-11-16T22:12:00.000Z', cnt: 5 },
+        { type: 'single_value' as const, valueColumnNames: new Set(['cnt']) },
+      );
+
+      expect(value).toBe(5);
+      // single_value has no timestamp column, so `ts` is kept as a field.
+      expect(extraFields).toEqual([['ts', '2023-11-16T22:12:00.000Z']]);
     });
   });
 

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -3874,6 +3874,115 @@ describe('checkAlerts', () => {
       expect(workerHistory!.lastValues.map(v => v.count)).toEqual([1]);
     });
 
+    it('TILE alert (raw SQL) - group-by fields are exposed as {{attributes.*}} in the notification payload', async () => {
+      const { team, webhook, connection, teamWebhooksById, clickhouseClient } =
+        await setupSavedSearchAlertTest();
+
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      const eventMs = now.getTime() - ms('5m');
+
+      // Two errors from a single service so the group "ServiceName:web" fires.
+      await bulkInsertLogs([
+        {
+          ServiceName: 'web',
+          Timestamp: new Date(eventMs),
+          SeverityText: 'error',
+          Body: 'web error 1',
+        },
+        {
+          ServiceName: 'web',
+          Timestamp: new Date(eventMs),
+          SeverityText: 'error',
+          Body: 'web error 2',
+        },
+      ]);
+
+      const groupedSqlTemplate = `
+        SELECT
+          toStartOfInterval(Timestamp, INTERVAL {intervalSeconds:Int64} second) AS ts,
+          ServiceName,
+          count() AS cnt
+        FROM default.otel_logs
+        WHERE Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64})
+          AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64})
+        GROUP BY ts, ServiceName
+        ORDER BY ts`;
+
+      const dashboard = await new Dashboard({
+        name: 'Raw SQL Grouped Attributes Dashboard',
+        team: team._id,
+        tiles: [
+          {
+            id: 'rawsql-grouped-attrs',
+            x: 0,
+            y: 0,
+            w: 6,
+            h: 4,
+            config: {
+              configType: 'sql',
+              displayType: 'line',
+              sqlTemplate: groupedSqlTemplate,
+              connection: connection.id,
+            },
+          },
+        ],
+      }).save();
+
+      const tile = dashboard.tiles?.find(
+        (t: any) => t.id === 'rawsql-grouped-attrs',
+      );
+      if (!tile) throw new Error('tile not found');
+
+      const details = await createAlertDetails(
+        team,
+        undefined,
+        {
+          source: AlertSource.TILE,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 2,
+          dashboardId: dashboard.id,
+          tileId: 'rawsql-grouped-attrs',
+          // The title and body templates reference the per-group field directly.
+          name: 'Errors for {{attributes.ServiceName}}',
+          message: 'Affected service: {{attributes.ServiceName}}',
+        },
+        {
+          taskType: AlertTaskType.TILE,
+          tile,
+          dashboard,
+        },
+      );
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+
+      // The webhook payload is captured via the mocked slack sender. Its
+      // rendered title/body must resolve {{attributes.ServiceName}} to the
+      // firing group's value ("web"), not an empty string.
+      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(1);
+      const [, payload] = (slack.postMessageToWebhook as jest.Mock).mock
+        .calls[0];
+
+      expect(payload.text).toContain('Errors for web');
+
+      const renderedBody = payload.blocks[0].text.text;
+      expect(renderedBody).toContain('Affected service: web');
+      expect(renderedBody).toContain('Group: "ServiceName:web"');
+    });
+
     it('TILE alert (raw SQL) - alert is evaluated using the last numeric column', async () => {
       const { team, webhook, connection, teamWebhooksById, clickhouseClient } =
         await setupSavedSearchAlertTest();

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -698,16 +698,15 @@ const getResponseMetadata = (
  * Parses the following from the given alert query result:
  * - `value`: the numeric value to compare against the alert threshold, taken
  *   from the last column in the result which is included in valueColumnNames
- * - `extraFields`: an array of strings representing the names and values of
- *   each column in the result which is neither the timestampColumnName nor a
- *   valueColumnName, formatted as "columnName:value".
+ * - `extraFields`: ordered `[columnName, value]` tuples for each column in the
+ *   result which is neither the timestampColumnName nor a valueColumnName.
  */
-const parseAlertData = (
+export const parseAlertData = (
   data: Record<string, string | number>,
   meta: ResponseMetadata,
 ) => {
   let value: number | null = null;
-  const extraFields: string[] = [];
+  const extraFields: Array<[string, string]> = [];
 
   for (const [k, v] of Object.entries(data)) {
     if (meta.valueColumnNames.has(k)) {
@@ -716,7 +715,7 @@ const parseAlertData = (
       // Floats are not returned as strings (unless output_format_json_quote_64bit_floats=1, which is not the default).
       value = isString(v) ? parseInt(v) : v;
     } else if (meta.type !== 'time_series' || k !== meta.timestampColumnName) {
-      extraFields.push(`${k}:${v}`);
+      extraFields.push([k, `${v}`]);
     }
   }
 
@@ -950,11 +949,13 @@ export const processAlert = async (
       totalCount,
       state,
       startTime = nowInMinsRoundDown,
+      attributes = {},
     }: {
       state: AlertState;
       totalCount: number;
       group: string;
       startTime?: Date;
+      attributes?: Record<string, string>;
     }) => {
       logger.info(
         { alertId: alert.id, group, totalCount },
@@ -971,7 +972,7 @@ export const processAlert = async (
         await fireChannelEvent({
           alert,
           alertProvider,
-          attributes: {}, // FIXME: support attributes (logs + resources ?)
+          attributes,
           clickhouseClient,
           dashboard: (details as any).dashboard,
           startTime,
@@ -1132,8 +1133,10 @@ export const processAlert = async (
           continue;
         }
 
-        // Group key is the joined extraFields for group-by alerts, or empty string for non-grouped
-        const groupKey = hasGroupBy ? extraFields.join(', ') : '';
+        const groupKey = hasGroupBy
+          ? extraFields.map(([k, v]) => `${k}:${v}`).join(', ')
+          : '';
+        const attributes = hasGroupBy ? Object.fromEntries(extraFields) : {};
         const history = getOrCreateHistory(groupKey);
 
         if (doesExceedThreshold(alert, value)) {
@@ -1143,6 +1146,7 @@ export const processAlert = async (
             group: groupKey,
             totalCount: value,
             startTime: bucketStart,
+            attributes,
           });
 
           history.counts += 1;


### PR DESCRIPTION
## Summary

Tile/chart alerts always rendered `{{attributes.*}}` empty — notifications could only use the joined `{{group}}` string, not individual fields like `{{attributes.k8s.pod.name}}`.

Root cause: the firing path passed a literal `attributes: {}` to `fireChannelEvent` (a `// FIXME`); the group-by fields were parsed per row but never forwarded.

Fix: `parseAlertData` now returns the group-by columns as ordered `[key, value]` tuples; the firing path derives `group` (unchanged join — dedup/history keys stay identical) and `attributes` (`Object.fromEntries`) from them.

Backward compatible: `{{group}}` unchanged; `attributes` defaults to `{}` for non-grouped alerts. The auto-resolve path keeps `{{group}}` only (history persists just the joined string — out of scope).

Tests: `parseAlertData` unit suite added; `tsc`/`eslint` clean, `renderAlertTemplate` snapshots intact.

### How to test on Vercel preview

N/A — non-UI change

### References

- Linear Issue: N/A
- Related PRs: N/A
