### PR TITLE
fix: fallback to body or implicit column expression when other empty

### DIFF
--- a/.changeset/serious-gifts-rest.md
+++ b/.changeset/serious-gifts-rest.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+fix: fallback to body or implicit column expression when other empty

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -33,11 +33,13 @@ import {
   Box,
   Button,
   Center,
+  Code,
   Divider,
   Flex,
   Grid,
   Group,
   Modal,
+  Paper,
   Radio,
   Select,
   Slider,
@@ -182,17 +184,6 @@ const MV_AGGREGATE_FUNCTION_OPTIONS = MV_AGGREGATE_FUNCTIONS.map(fn => ({
 const OTEL_CLICKHOUSE_EXPRESSIONS = {
   timestampValueExpression: 'TimeUnix',
   resourceAttributesExpression: 'ResourceAttributes',
-};
-
-const SOURCE_FIELD_LABELS: Record<SourceFieldKind, string> = {
-  bodyExpression: 'Body Expression',
-  implicitColumnExpression: 'Implicit Column Expression',
-  serviceNameExpression: 'Service Name Expression',
-  severityTextExpression: 'Log Level Expression',
-  eventAttributesExpression: 'Event Attributes Expression',
-  resourceAttributesExpression: 'Resource Attributes Expression',
-  traceIdExpression: 'Trace Id Expression',
-  spanIdExpression: 'Span Id Expression',
 };
 
 const CORRELATION_FIELD_MAP: Record<
@@ -2330,7 +2321,7 @@ export function TableSourceForm({
 
   const applyPairingFix = useCallback(
     (warning: PairingWarning) => {
-      if (!pendingSave || !warning.suggestedFix) {
+      if (!pendingSave) {
         return;
       }
 
@@ -2670,6 +2661,7 @@ export function TableSourceForm({
         )}
       </Group>
       <Modal
+        size="lg"
         opened={!!pendingSave}
         onClose={() => setPendingSave(undefined)}
         title="Review source configuration"
@@ -2677,21 +2669,41 @@ export function TableSourceForm({
       >
         <Stack gap="md">
           {pendingSave?.warnings.map(warning => (
-            <Box key={warning.field}>
+            <Paper key={warning.field} p="sm">
               <Text size="sm">{warning.message}</Text>
-              {warning.suggestedFix && (
+              <Text mt="md" fw="bold" color="green" size="sm">
+                Recommended ({warning.recommendation}):
+              </Text>
+
+              <Group
+                mt="sm"
+                justify="space-between"
+                align="center"
+                wrap="nowrap"
+              >
+                <Code
+                  block
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    maxHeight: 200,
+                    overflowY: 'auto',
+                  }}
+                >
+                  {warning.suggestedFix.value}
+                </Code>
                 <Button
                   variant="secondary"
                   size="xs"
-                  mt="xs"
+                  style={{ flexShrink: 0 }}
                   onClick={() => applyPairingFix(warning)}
                 >
-                  {`Set ${SOURCE_FIELD_LABELS[warning.suggestedFix.field]} to "${
-                    warning.suggestedFix.value
-                  }"`}
+                  Use this value
                 </Button>
-              )}
-            </Box>
+              </Group>
+            </Paper>
           ))}
           <Group justify="flex-end" mt="sm">
             <Button

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -81,10 +81,10 @@ export function getDisplayedTimestampValueExpression(eventModel: TSource) {
 export function getEventBody(eventModel: TSource) {
   let expression: string | undefined;
   if (eventModel.kind === SourceKind.Trace) {
-    expression = eventModel.spanNameExpression ?? undefined;
+    expression = eventModel.spanNameExpression || undefined;
   } else if (eventModel.kind === SourceKind.Log) {
     expression =
-      eventModel.bodyExpression ?? eventModel.implicitColumnExpression;
+      eventModel.bodyExpression || eventModel.implicitColumnExpression;
   }
   const multiExpr = splitAndTrimWithBracket(expression ?? '');
   return multiExpr.length === 1 ? expression : multiExpr[0];

--- a/packages/app/src/utils/sourceFieldSuggestions.tsx
+++ b/packages/app/src/utils/sourceFieldSuggestions.tsx
@@ -237,7 +237,7 @@ export function getSourceConfigPairingWarnings(
           search will fall back to <strong>Body Expression</strong>.
         </>
       ),
-      recommendation: 'use Body Expression value',
+      recommendation: 'Body Expression value',
       suggestedFix: { field: 'implicitColumnExpression', value: body },
     });
   } else if (implicit && !body) {
@@ -250,7 +250,7 @@ export function getSourceConfigPairingWarnings(
           fall back to <strong>Implicit Column Expression</strong>.
         </>
       ),
-      recommendation: 'Implicit Column Expression',
+      recommendation: 'Implicit Column Expression value',
       suggestedFix: { field: 'bodyExpression', value: implicit },
     });
   }

--- a/packages/app/src/utils/sourceFieldSuggestions.tsx
+++ b/packages/app/src/utils/sourceFieldSuggestions.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import {
   ColumnMetaType,
   convertCHDataTypeToJSType,
@@ -209,8 +210,9 @@ export type SourceConfigPairingInput = {
 
 export type PairingWarning = {
   field: SourceFieldKind;
-  message: string;
-  suggestedFix?: { field: SourceFieldKind; value: string };
+  message: JSX.Element;
+  recommendation: string;
+  suggestedFix: { field: SourceFieldKind; value: string };
 };
 
 export function getSourceConfigPairingWarnings(
@@ -228,19 +230,27 @@ export function getSourceConfigPairingWarnings(
   if (body && !implicit) {
     warnings.push({
       field: 'implicitColumnExpression',
-      message:
-        'Body Expression is set but Implicit Column Expression is empty. ' +
-        'Bare-text Lucene search will fail on this source. ' +
-        'Use the same column as Body Expression?',
+      message: (
+        <>
+          <strong>Body Expression</strong> is set but{' '}
+          <strong>Implicit Column Expression</strong> is empty. Bare-text Lucene
+          search will fall back to <strong>Body Expression</strong>.
+        </>
+      ),
+      recommendation: 'use Body Expression value',
       suggestedFix: { field: 'implicitColumnExpression', value: body },
     });
   } else if (implicit && !body) {
     warnings.push({
       field: 'bodyExpression',
-      message:
-        'Implicit Column Expression is set but Body Expression is empty. ' +
-        'Row-panel body display will fall back to Implicit Column Expression. ' +
-        'Set Body Expression explicitly?',
+      message: (
+        <>
+          <strong>Implicit Column Expression</strong> is set but{' '}
+          <strong>Body Expression</strong> is empty. Row-panel body display will
+          fall back to <strong>Implicit Column Expression</strong>.
+        </>
+      ),
+      recommendation: 'Implicit Column Expression',
       suggestedFix: { field: 'bodyExpression', value: implicit },
     });
   }

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -1708,7 +1708,8 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
   }
 
   async getColumnForField(field: string, context: SerializerContext) {
-    // Fall back to bodyExpression for implicit column expression
+    // Fall back to bodyExpression for implicit column expression.
+    // values can be empty if previously configured then removed.
     const implicitColumnExpression =
       context.implicitColumnExpression ||
       this.implicitColumnExpression ||
@@ -1729,8 +1730,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     // applied. Mirrors the original "source's implicit column has not been
     // overridden" intent.
     const isSourceImplicit =
-      context.implicitColumnExpression === undefined &&
-      context.bodyExpression === undefined;
+      !context.implicitColumnExpression && !context.bodyExpression;
     if (field === IMPLICIT_FIELD && isSourceImplicit) {
       // Sources can specify multi-column implicit columns, eg. Body and Message, in
       // which case we search the combined string `concatWithSeparator(';', Body, Message)`.

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -1708,15 +1708,11 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
   }
 
   async getColumnForField(field: string, context: SerializerContext) {
-    // Two-stage fallback: implicit wins over body, and per-call context
-    // overrides win over the source defaults. The body fallback lets log
-    // sources that only set Body Expression still serve bare-text Lucene
-    // search; this is the symmetric counterpart to `getEventBody` in
-    // packages/app/src/source.ts.
+    // Fall back to bodyExpression for implicit column expression
     const implicitColumnExpression =
-      context.implicitColumnExpression ??
-      this.implicitColumnExpression ??
-      context.bodyExpression ??
+      context.implicitColumnExpression ||
+      this.implicitColumnExpression ||
+      context.bodyExpression ||
       this.bodyExpression;
     if (field === IMPLICIT_FIELD && !implicitColumnExpression) {
       throw new Error(


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Polishes the source field pairing warnings introduced in #2436 and fixes two related expression-fallback bugs where an empty string would defeat the intended fallback.

The `??` fallbacks only fired on `null`/`undefined`, so a field set then cleared (saved as `''`) never fell back — breaking Lucene search and body display; `||` fixes this by treating `''` as absent. The warning copy now reflects the real fallback behavior and the review modal surfaces the recommended value more clearly.

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->

Improved pairing warning modal layout:

<img width="660" height="321" alt="Screenshot 2026-06-15 at 12 39 13" src="https://github.com/user-attachments/assets/3fb6eb97-9a3c-4ffd-bf62-dae74f539dc3" />
<img width="673" height="330" alt="Screenshot 2026-06-15 at 12 39 02" src="https://github.com/user-attachments/assets/2e947980-f895-40a1-80b2-8464a57b5482" />


### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/team`

**Steps:**

1. Edit some sources and remove a previously defined bodyExpression or implicitColumnExpression field and leave the other defined.
2. Check the modal appears correctly with correct suggestions.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: HDX-4374
- Related PRs:
https://github.com/hyperdxio/hyperdx/pull/2436
https://github.com/hyperdxio/hyperdx/pull/2358
https://github.com/hyperdxio/hyperdx/pull/2354
