### PR TITLE
fix: don't send prometheus unless remote url is specified

### DIFF
--- a/.changeset/standalone-promql-conditional.md
+++ b/.changeset/standalone-promql-conditional.md
@@ -1,0 +1,22 @@
+---
+'@hyperdx/otel-collector': patch
+---
+
+fix(otel-collector): only enable the prometheus remote-write exporter in
+standalone mode when `CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT` is set
+
+The standalone collector config used to unconditionally declare a
+`prometheusremotewrite` exporter and a `metrics/promql` pipeline. When
+`CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT` was unset the exporter rendered
+with an empty endpoint and every metrics batch failed to export.
+
+The exporter and pipeline have been moved to
+`docker/otel-collector/config.standalone.promql.yaml`, which is now only
+loaded by `entrypoint.sh` when `CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT` is
+non-empty. This mirrors the OpAMP-managed gating in
+`packages/api/src/opamp/controllers/opampController.ts` (which already
+only adds the exporter when `IS_PROMQL_ENABLED` is true).
+
+No action required if `CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT` is set; the
+behavior is unchanged. If it was unset, the collector now stops emitting
+the failing prometheus-remote-write attempts.

--- a/docker/otel-collector/Dockerfile
+++ b/docker/otel-collector/Dockerfile
@@ -75,6 +75,7 @@ LABEL org.opencontainers.image.vendor="HyperDX" \
 COPY --chown=10001:10001 docker/otel-collector/config.yaml /etc/otelcol-contrib/config.yaml
 COPY --chown=10001:10001 docker/otel-collector/config.standalone.yaml /etc/otelcol-contrib/standalone-config.yaml
 COPY --chown=10001:10001 docker/otel-collector/config.standalone.auth.yaml /etc/otelcol-contrib/standalone-auth-config.yaml
+COPY --chown=10001:10001 docker/otel-collector/config.standalone.promql.yaml /etc/otelcol-contrib/standalone-promql-config.yaml
 COPY --chown=10001:10001 docker/otel-collector/supervisor_docker.yaml.tmpl /etc/otel/supervisor.yaml.tmpl
 COPY --chown=10001:10001 docker/otel-collector/schema /etc/otel/schema
 
@@ -97,6 +98,7 @@ LABEL org.opencontainers.image.vendor="HyperDX" \
 COPY --chown=10001:10001 docker/otel-collector/config.yaml /etc/otelcol-contrib/config.yaml
 COPY --chown=10001:10001 docker/otel-collector/config.standalone.yaml /etc/otelcol-contrib/standalone-config.yaml
 COPY --chown=10001:10001 docker/otel-collector/config.standalone.auth.yaml /etc/otelcol-contrib/standalone-auth-config.yaml
+COPY --chown=10001:10001 docker/otel-collector/config.standalone.promql.yaml /etc/otelcol-contrib/standalone-promql-config.yaml
 COPY --chown=10001:10001 docker/otel-collector/supervisor_docker.yaml.tmpl /etc/otel/supervisor.yaml.tmpl
 COPY --chown=10001:10001 docker/otel-collector/schema /etc/otel/schema
 

--- a/docker/otel-collector/config.standalone.promql.yaml
+++ b/docker/otel-collector/config.standalone.promql.yaml
@@ -1,0 +1,22 @@
+# Enables remote-write of OTLP metrics to a Prometheus-compatible endpoint.
+# Only included when CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT is set.
+#
+# Mirrors the OpAMP-managed behavior in
+# packages/api/src/opamp/controllers/opampController.ts (gated on
+# IS_PROMQL_ENABLED). When updating this file, keep it in sync with
+# buildOtelCollectorConfig().
+
+exporters:
+  prometheusremotewrite:
+    endpoint: http://${env:CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT}/write
+    tls:
+      insecure: true
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    metrics/promql:
+      receivers: [otlp/hyperdx]
+      processors: [memory_limiter, batch]
+      exporters: [prometheusremotewrite]

--- a/docker/otel-collector/config.standalone.yaml
+++ b/docker/otel-collector/config.standalone.yaml
@@ -53,12 +53,6 @@ exporters:
       initial_interval: 5s
       max_interval: 30s
       max_elapsed_time: 300s
-  prometheusremotewrite:
-    endpoint: http://${env:CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT}/write
-    tls:
-      insecure: true
-    resource_to_telemetry_conversion:
-      enabled: true
 
 service:
   # Pipeline `processors:` lists live in the base config.yaml so users can
@@ -71,10 +65,6 @@ service:
     metrics:
       receivers: [otlp/hyperdx]
       exporters: [clickhouse]
-    metrics/promql:
-      receivers: [otlp/hyperdx]
-      processors: [memory_limiter, batch]
-      exporters: [prometheusremotewrite]
     logs/in:
       receivers: [otlp/hyperdx]
       exporters: [routing/logs]

--- a/docker/otel-collector/entrypoint.sh
+++ b/docker/otel-collector/entrypoint.sh
@@ -51,6 +51,15 @@ if [ -z "$OPAMP_SERVER_URL" ]; then
     COLLECTOR_ARGS="$COLLECTOR_ARGS --config /etc/otelcol-contrib/standalone-auth-config.yaml"
   fi
 
+  # Enable prometheus remote-write of OTLP metrics only when an endpoint is
+  # configured. Mirrors the OpAMP-managed IS_PROMQL_ENABLED gating in
+  # packages/api/src/opamp/controllers/opampController.ts so the standalone
+  # collector does not attempt to export to a missing endpoint.
+  if [ -n "$CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT" ]; then
+    echo "CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT is set, enabling prometheus remote-write"
+    COLLECTOR_ARGS="$COLLECTOR_ARGS --config /etc/otelcol-contrib/standalone-promql-config.yaml"
+  fi
+
   # Add custom config file if specified
   if [ -n "$CUSTOM_OTELCOL_CONFIG_FILE" ]; then
     echo "Including custom config: $CUSTOM_OTELCOL_CONFIG_FILE"


### PR DESCRIPTION
## Summary

In standalone mode, the ClickStack Otel Collector will attempt to send metrics via the prometheusremotewrite exporter. It shouldn't unless a URL is set.

### References

- Linear Issue: HDX-4545