### PR TITLE
feat(sources): group the data source selector by section with tag-style search

### DIFF
--- a/.changeset/source-selector-section-grouping.md
+++ b/.changeset/source-selector-section-grouping.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Group the data source selector by section and add tag-style search. When sources have a Section assigned, the selector lists them under section headers; search matches on both the source name and its section, so a section name acts as a tag (typing "billing" returns every source in the Billing section, including ones whose name does not contain "billing"). The selector stays flat until at least one source has a section, so deployments that have not adopted sections see no change.

--- a/.changeset/source-selector-section-grouping.md
+++ b/.changeset/source-selector-section-grouping.md
@@ -2,4 +2,4 @@
 '@hyperdx/app': patch
 ---
 
-Group the data source selector by section and add tag-style search. When sources have a Section assigned, the selector lists them under section headers; search matches on both the source name and its section, so a section name acts as a tag (typing "billing" returns every source in the Billing section, including ones whose name does not contain "billing"). The selector stays flat until at least one source has a section, so deployments that have not adopted sections see no change.
+Group the data source selector by section and add tag-style search. When sources have a Section assigned, the selector lists them under section headers; search matches on both the source name and its section, so a section name acts as a tag (typing "billing" returns every source in the Billing section, including ones whose name does not contain "billing"). The selector stays flat until at least one source has a section, so deployments that have not adopted sections see no change. The grouped dropdown is also widened and pinned to the picker's left edge so section headers and source names are not cramped.

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -224,10 +224,16 @@ function SourceSelectControlledComponent({
       <SelectControlled
         {...props}
         data={sourceItems}
-        comboboxProps={{ withinPortal: false, ...comboboxProps }}
+        comboboxProps={{
+          withinPortal: false,
+          width: 'max-content',
+          position: 'bottom-start',
+          ...comboboxProps,
+        }}
         classNames={{
           input: styles.sourceSelectInput,
           groupLabel: styles.groupLabel,
+          dropdown: styles.sourceSelectDropdown,
         }}
         renderOption={renderOption}
         filter={sourceSelectFilter}

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -22,6 +22,7 @@ import {
 import SelectControlled from '@/components/SelectControlled';
 import {
   SOURCE_KIND_ICONS,
+  sourceSelectFilter,
   useFilteredSortedSourceItems,
   useSourceKindMap,
 } from '@/components/sourceSelectUtils';
@@ -206,6 +207,7 @@ function SourceSelectControlledComponent({
     sources: data,
     allowedSourceKinds,
     connectionId,
+    groupBySection: true,
   });
 
   const hasSelection = !!selectedSourceId;
@@ -228,6 +230,7 @@ function SourceSelectControlledComponent({
           groupLabel: styles.groupLabel,
         }}
         renderOption={renderOption}
+        filter={sourceSelectFilter}
         searchable
         placeholder="Data Source"
         leftSection={leftIcon}

--- a/packages/app/src/components/__tests__/SourceSelect.test.tsx
+++ b/packages/app/src/components/__tests__/SourceSelect.test.tsx
@@ -1,8 +1,36 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { SourceManagementMenu } from '../SourceSelect';
+import { useSources } from '@/source';
+
+import { SourceManagementMenu, SourceSelectControlled } from '../SourceSelect';
+
+jest.mock('@/source', () => ({
+  useSources: jest.fn(),
+}));
+
+// Mantine's Combobox calls scrollIntoView when its dropdown opens; jsdom lacks it.
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+// useSources returns a large UseQueryResult; the selector reads only `data`.
+const asMock = (fn: unknown) => fn as jest.Mock;
+
+const makeSource = (
+  id: string,
+  name: string,
+  kind: SourceKind,
+  overrides: Partial<TSource> = {},
+): TSource =>
+  ({
+    id,
+    name,
+    kind,
+    connection: 'conn-a',
+    ...overrides,
+  }) as unknown as TSource;
 
 describe('SourceManagementMenu', () => {
   it('does not render the kebab trigger when no actions are wired', () => {
@@ -133,5 +161,80 @@ describe('SourceManagementMenu', () => {
     await userEvent.click(screen.getByTestId('source-actions-menu'));
     await userEvent.click(await screen.findByText('Create new source'));
     expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SourceSelectControlled (grouped rendering + tag-style search)', () => {
+  const SECTIONED_SOURCES = [
+    makeSource('billing-logs', 'Billing Logs', SourceKind.Log, {
+      section: 'Billing',
+    }),
+    // No "billing" in the name: it should still surface for a "billing" query
+    // because it sits under the Billing section header (the section is the tag).
+    makeSource('refund-logs', 'Refund Logs', SourceKind.Log, {
+      section: 'Billing',
+    }),
+    makeSource('prod-logs', 'Prod Logs', SourceKind.Log, {
+      section: 'Control Plane Prod',
+    }),
+  ];
+
+  function SelectHarness() {
+    const { control } = useForm();
+    return <SourceSelectControlled control={control} name="source" />;
+  }
+
+  // The searchable Select reuses its placeholder input for typing.
+  const openSelect = async () => {
+    const input = screen.getByPlaceholderText('Data Source');
+    await userEvent.click(input);
+    return input;
+  };
+
+  it('renders sources grouped under their section headers', async () => {
+    asMock(useSources).mockReturnValue({ data: SECTIONED_SOURCES });
+    renderWithMantine(<SelectHarness />);
+    await openSelect();
+
+    // Grouping switches on because at least one source carries a section.
+    expect(await screen.findByText('Billing')).toBeInTheDocument();
+    expect(screen.getByText('Control Plane Prod')).toBeInTheDocument();
+    // Options render under their headers.
+    expect(screen.getByText('Billing Logs')).toBeInTheDocument();
+    expect(screen.getByText('Refund Logs')).toBeInTheDocument();
+    expect(screen.getByText('Prod Logs')).toBeInTheDocument();
+  });
+
+  it('treats the section as a tag: "billing logs" keeps section-mates whose name lacks "billing" and drops other sections', async () => {
+    asMock(useSources).mockReturnValue({ data: SECTIONED_SOURCES });
+    renderWithMantine(<SelectHarness />);
+    const input = await openSelect();
+    await userEvent.type(input, 'billing logs');
+
+    // "Billing Logs" matches on its name; "Refund Logs" matches on the Billing
+    // section tag plus the "logs" name token, even though its name has no "billing".
+    expect(await screen.findByText('Refund Logs')).toBeInTheDocument();
+    expect(screen.getByText('Billing Logs')).toBeInTheDocument();
+    expect(screen.getByText('Billing')).toBeInTheDocument();
+    // "Prod Logs" matches "logs" but not "billing", so its whole section drops out.
+    expect(screen.queryByText('Prod Logs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Control Plane Prod')).not.toBeInTheDocument();
+  });
+
+  it('stays flat with no catch-all header until a source has a section', async () => {
+    asMock(useSources).mockReturnValue({
+      data: [
+        makeSource('a', 'Apple Traces', SourceKind.Trace),
+        makeSource('z', 'Zebra Logs', SourceKind.Log),
+      ],
+    });
+    renderWithMantine(<SelectHarness />);
+    await openSelect();
+
+    // Both options render with no lone "Other" header, matching the flat
+    // selector a deployment that has not adopted sections sees today.
+    expect(await screen.findByText('Apple Traces')).toBeInTheDocument();
+    expect(screen.getByText('Zebra Logs')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
+++ b/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
@@ -246,6 +246,22 @@ describe('sourceSelectFilter', () => {
     expect(run('   ')).toEqual(grouped);
   });
 
+  it('honors the Mantine limit by capping the total options across groups', () => {
+    // Billing has three items; a limit of 2 truncates it and drops the
+    // remaining groups, matching the OptionsFilter contract.
+    expect(
+      sourceSelectFilter({ options: grouped, search: '', limit: 2 }),
+    ).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'billing-logs', label: 'Billing Logs' },
+          { value: 'billing-traces', label: 'Billing Traces' },
+        ],
+      },
+    ]);
+  });
+
   it('treats the section header as a tag: a section name selects the whole section', () => {
     expect(run('billing')).toEqual([
       {

--- a/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
+++ b/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
@@ -2,6 +2,8 @@ import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
 import { renderHook } from '@testing-library/react';
 
 import {
+  sourceSelectFilter,
+  SourceSelectGroup,
   useFilteredSortedSourceItems,
   useSourceKindMap,
 } from '../sourceSelectUtils';
@@ -119,5 +121,228 @@ describe('useFilteredSortedSourceItems', () => {
     const first = result.current;
     rerender({ sources });
     expect(result.current).toBe(first);
+  });
+});
+
+describe('useFilteredSortedSourceItems (grouped by section)', () => {
+  it('returns [] when sources is undefined', () => {
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources: undefined,
+        groupBySection: true,
+      }),
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('groups by section header, sorts groups alphabetically with "Other" last, and labels within a group ascending', () => {
+    const sources = [
+      makeSource('rl', 'Refund Logs', SourceKind.Log, { section: 'Billing' }),
+      makeSource('bl', 'Billing Logs', SourceKind.Log, { section: 'Billing' }),
+      makeSource('cpl', 'Prod Logs', SourceKind.Log, {
+        section: 'Control Plane Prod',
+      }),
+      // no section -> "Other"
+      makeSource('loose', 'Ungrouped Source', SourceKind.Trace),
+      // whitespace-only section is treated as unsectioned -> "Other"
+      makeSource('blank', 'Blank Section', SourceKind.Metric, {
+        section: '  ',
+      } as Partial<TSource>),
+    ];
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({ sources, groupBySection: true }),
+    );
+    expect(result.current).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'bl', label: 'Billing Logs' },
+          { value: 'rl', label: 'Refund Logs' },
+        ],
+      },
+      {
+        group: 'Control Plane Prod',
+        items: [{ value: 'cpl', label: 'Prod Logs' }],
+      },
+      {
+        group: 'Other',
+        items: [
+          { value: 'blank', label: 'Blank Section' },
+          { value: 'loose', label: 'Ungrouped Source' },
+        ],
+      },
+    ]);
+  });
+
+  it('applies kind/connection/disabled filters before grouping', () => {
+    const sources = [
+      makeSource('bl', 'Billing Logs', SourceKind.Log, { section: 'Billing' }),
+      makeSource('bt', 'Billing Traces', SourceKind.Trace, {
+        section: 'Billing',
+      }),
+      makeSource('d', 'Disabled Logs', SourceKind.Log, {
+        section: 'Billing',
+        disabled: true,
+      } as Partial<TSource>),
+    ];
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources,
+        allowedSourceKinds: [SourceKind.Log],
+        groupBySection: true,
+      }),
+    );
+    expect(result.current).toEqual([
+      { group: 'Billing', items: [{ value: 'bl', label: 'Billing Logs' }] },
+    ]);
+  });
+
+  it('stays flat (no lone "Other" header) until a source has a real section', () => {
+    const sources = [
+      makeSource('z', 'Zebra Logs', SourceKind.Log),
+      makeSource('a', 'Apple Traces', SourceKind.Trace),
+      // whitespace-only section is unsectioned, so still no real section
+      makeSource('blank', 'Blank Section', SourceKind.Metric, {
+        section: '  ',
+      } as Partial<TSource>),
+    ];
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({ sources, groupBySection: true }),
+    );
+    expect(result.current).toEqual([
+      { value: 'a', label: 'Apple Traces' },
+      { value: 'blank', label: 'Blank Section' },
+      { value: 'z', label: 'Zebra Logs' },
+    ]);
+  });
+});
+
+describe('sourceSelectFilter', () => {
+  const grouped: SourceSelectGroup[] = [
+    {
+      group: 'Billing',
+      items: [
+        { value: 'billing-logs', label: 'Billing Logs' },
+        { value: 'billing-traces', label: 'Billing Traces' },
+        { value: 'refund-logs', label: 'Refund Logs' },
+      ],
+    },
+    {
+      group: 'Control Plane Prod',
+      items: [
+        { value: 'cp-prod-logs', label: 'Prod Logs' },
+        { value: 'cp-prod-traces', label: 'Prod Traces' },
+      ],
+    },
+    {
+      group: 'Control Plane Staging',
+      items: [{ value: 'cp-staging-logs', label: 'Staging Logs' }],
+    },
+  ];
+  const run = (search: string) =>
+    sourceSelectFilter({ options: grouped, search, limit: Infinity });
+
+  it('returns every group unchanged for a blank query', () => {
+    expect(run('   ')).toEqual(grouped);
+  });
+
+  it('treats the section header as a tag: a section name selects the whole section', () => {
+    expect(run('billing')).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'billing-logs', label: 'Billing Logs' },
+          { value: 'billing-traces', label: 'Billing Traces' },
+          { value: 'refund-logs', label: 'Refund Logs' },
+        ],
+      },
+    ]);
+  });
+
+  it('matches a partial section token', () => {
+    expect(run('bill')).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'billing-logs', label: 'Billing Logs' },
+          { value: 'billing-traces', label: 'Billing Traces' },
+          { value: 'refund-logs', label: 'Refund Logs' },
+        ],
+      },
+    ]);
+  });
+
+  it('AND-s a section token with a name token, including names without the section word', () => {
+    // "Refund Logs" matches: "Billing" from the header, "Logs" from the name.
+    expect(run('billing logs')).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'billing-logs', label: 'Billing Logs' },
+          { value: 'refund-logs', label: 'Refund Logs' },
+        ],
+      },
+    ]);
+  });
+
+  it('spans multiple sections that share the queried tokens', () => {
+    expect(run('control plane')).toEqual([
+      {
+        group: 'Control Plane Prod',
+        items: [
+          { value: 'cp-prod-logs', label: 'Prod Logs' },
+          { value: 'cp-prod-traces', label: 'Prod Traces' },
+        ],
+      },
+      {
+        group: 'Control Plane Staging',
+        items: [{ value: 'cp-staging-logs', label: 'Staging Logs' }],
+      },
+    ]);
+  });
+
+  it('narrows to one section when a name token disambiguates', () => {
+    expect(run('prod logs')).toEqual([
+      {
+        group: 'Control Plane Prod',
+        items: [{ value: 'cp-prod-logs', label: 'Prod Logs' }],
+      },
+    ]);
+  });
+
+  it('drops groups left with no surviving items', () => {
+    expect(run('refund')).toEqual([
+      {
+        group: 'Billing',
+        items: [{ value: 'refund-logs', label: 'Refund Logs' }],
+      },
+    ]);
+  });
+
+  it('matches on name and section text only, not the signal kind', () => {
+    // Through the real pipeline: the grouped builder emits value+label only,
+    // so a Session-kind source named "RUM" cannot match "session", while a
+    // Log-kind source named "Session Replay" matches on its name.
+    const sources = [
+      makeSource('rum', 'RUM', SourceKind.Session, { section: 'Billing' }),
+      makeSource('replay', 'Session Replay', SourceKind.Log, {
+        section: 'Billing',
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({ sources, groupBySection: true }),
+    );
+    expect(
+      sourceSelectFilter({
+        options: result.current,
+        search: 'session',
+        limit: Infinity,
+      }),
+    ).toEqual([
+      {
+        group: 'Billing',
+        items: [{ value: 'replay', label: 'Session Replay' }],
+      },
+    ]);
   });
 });

--- a/packages/app/src/components/sourceSelectUtils.tsx
+++ b/packages/app/src/components/sourceSelectUtils.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import { ComboboxItem, OptionsFilter } from '@mantine/core';
 import {
   IconChartLine,
   IconConnection,
@@ -15,6 +16,11 @@ export const SOURCE_KIND_ICONS: Record<string, React.ReactNode> = {
   [SourceKind.Promql]: <IconChartLine size={16} />,
 };
 
+/** Header for sources that have no section assigned. */
+export const UNSECTIONED_SOURCE_GROUP = 'Other';
+
+export type SourceSelectGroup = { group: string; items: ComboboxItem[] };
+
 export function useSourceKindMap(sources: TSource[] | undefined) {
   return useMemo(() => {
     const map = new Map<string, SourceKind>();
@@ -23,28 +29,109 @@ export function useSourceKindMap(sources: TSource[] | undefined) {
   }, [sources]);
 }
 
+const byLabel = (a: ComboboxItem, b: ComboboxItem) =>
+  a.label.localeCompare(b.label);
+
+// No per-source ordering field exists yet, so sections render
+// alphabetically with the catch-all pinned last. Admin-controlled
+// (positional) ordering is the still-open design question.
+const bySectionOrder = (a: string, b: string) => {
+  if (a === UNSECTIONED_SOURCE_GROUP) return 1;
+  if (b === UNSECTIONED_SOURCE_GROUP) return -1;
+  return a.localeCompare(b);
+};
+
+type FilteredSourceItemsArgs = {
+  sources: TSource[] | undefined;
+  allowedSourceKinds?: SourceKind[];
+  connectionId?: string;
+  groupBySection?: boolean;
+};
+
+export function useFilteredSortedSourceItems(
+  args: FilteredSourceItemsArgs & { groupBySection?: false },
+): ComboboxItem[];
+export function useFilteredSortedSourceItems(
+  args: FilteredSourceItemsArgs & { groupBySection: true },
+): SourceSelectGroup[] | ComboboxItem[];
 export function useFilteredSortedSourceItems({
   sources,
   allowedSourceKinds,
   connectionId,
-}: {
-  sources: TSource[] | undefined;
-  allowedSourceKinds?: SourceKind[];
-  connectionId?: string;
-}) {
-  return useMemo(
-    () =>
-      (
-        sources
-          ?.filter(
-            source =>
-              (!allowedSourceKinds ||
-                allowedSourceKinds.includes(source.kind)) &&
-              (!connectionId || source.connection === connectionId) &&
-              !source.disabled,
-          )
-          .map(s => ({ value: s.id, label: s.name })) ?? []
-      ).sort((a, b) => a.label.localeCompare(b.label)),
-    [sources, allowedSourceKinds, connectionId],
-  );
+  groupBySection = false,
+}: FilteredSourceItemsArgs): ComboboxItem[] | SourceSelectGroup[] {
+  return useMemo(() => {
+    const visible =
+      sources?.filter(
+        source =>
+          (!allowedSourceKinds || allowedSourceKinds.includes(source.kind)) &&
+          (!connectionId || source.connection === connectionId) &&
+          !source.disabled,
+      ) ?? [];
+
+    if (!groupBySection) {
+      return visible.map(s => ({ value: s.id, label: s.name })).sort(byLabel);
+    }
+
+    const bySection = new Map<string, ComboboxItem[]>();
+    for (const source of visible) {
+      const section = source.section?.trim() || UNSECTIONED_SOURCE_GROUP;
+      const items = bySection.get(section) ?? [];
+      items.push({ value: source.id, label: source.name });
+      bySection.set(section, items);
+    }
+
+    // Stay flat until at least one source has a real section. Otherwise a
+    // deployment that has not adopted sections would render a single "Other"
+    // header over its whole list, a change from today's flat selector. The
+    // grouping switches on the moment someone assigns a section.
+    const sectionNames = [...bySection.keys()];
+    const hasRealSection = sectionNames.some(
+      name => name !== UNSECTIONED_SOURCE_GROUP,
+    );
+    if (!hasRealSection) {
+      return visible.map(s => ({ value: s.id, label: s.name })).sort(byLabel);
+    }
+
+    return sectionNames.sort(bySectionOrder).map(group => ({
+      group,
+      items: (bySection.get(group) ?? []).sort(byLabel),
+    }));
+  }, [sources, allowedSourceKinds, connectionId, groupBySection]);
 }
+
+/**
+ * Implicit-tag search for the source selector. A source's match text is its
+ * own label plus the section header it sits under, so the section behaves as
+ * a tag: "Billing" returns every source under the Billing header, and
+ * "Billing Logs" returns the logs in that section, including ones whose name
+ * lacks "Billing" (e.g. "Refund Logs"). Tokens are AND-ed and results stay
+ * grouped so the matched header explains why each result is there. The signal
+ * kind is deliberately not part of the haystack; only name and section match.
+ */
+export const sourceSelectFilter: OptionsFilter = ({ options, search }) => {
+  const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return options;
+  }
+
+  const matches = (label: string, groupLabel?: string) =>
+    tokens.every(token =>
+      `${label} ${groupLabel ?? ''}`.toLowerCase().includes(token),
+    );
+
+  const result: typeof options = [];
+  for (const option of options) {
+    if ('group' in option) {
+      const items = option.items.filter(item =>
+        matches(item.label, option.group),
+      );
+      if (items.length > 0) {
+        result.push({ ...option, items });
+      }
+    } else if (matches(option.label)) {
+      result.push(option);
+    }
+  }
+  return result;
+};

--- a/packages/app/src/components/sourceSelectUtils.tsx
+++ b/packages/app/src/components/sourceSelectUtils.tsx
@@ -109,28 +109,36 @@ export function useFilteredSortedSourceItems({
  * grouped so the matched header explains why each result is there. The signal
  * kind is deliberately not part of the haystack; only name and section match.
  */
-export const sourceSelectFilter: OptionsFilter = ({ options, search }) => {
+export const sourceSelectFilter: OptionsFilter = ({
+  options,
+  search,
+  limit,
+}) => {
   const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) {
-    return options;
-  }
 
   const matches = (label: string, groupLabel?: string) =>
     tokens.every(token =>
       `${label} ${groupLabel ?? ''}`.toLowerCase().includes(token),
     );
 
+  // Honor Mantine's `limit` (Infinity unless a caller sets it) over the total
+  // options across all groups, keeping the group structure intact.
   const result: typeof options = [];
+  let remaining = limit;
   for (const option of options) {
+    if (remaining <= 0) break;
     if ('group' in option) {
-      const items = option.items.filter(item =>
-        matches(item.label, option.group),
-      );
+      const matched = tokens.length
+        ? option.items.filter(item => matches(item.label, option.group))
+        : option.items;
+      const items = matched.slice(0, remaining);
       if (items.length > 0) {
         result.push({ ...option, items });
+        remaining -= items.length;
       }
-    } else if (matches(option.label)) {
+    } else if (!tokens.length || matches(option.label)) {
       result.push(option);
+      remaining -= 1;
     }
   }
   return result;

--- a/packages/app/src/components/sourceSelectUtils.tsx
+++ b/packages/app/src/components/sourceSelectUtils.tsx
@@ -16,8 +16,8 @@ export const SOURCE_KIND_ICONS: Record<string, React.ReactNode> = {
   [SourceKind.Promql]: <IconChartLine size={16} />,
 };
 
-/** Header for sources that have no section assigned. */
-export const UNSECTIONED_SOURCE_GROUP = 'Other';
+/** Header for sources that have no section assigned. Internal to this module. */
+const UNSECTIONED_SOURCE_GROUP = 'Other';
 
 export type SourceSelectGroup = { group: string; items: ComboboxItem[] };
 

--- a/packages/app/styles/SourceSelectControlled.module.scss
+++ b/packages/app/styles/SourceSelectControlled.module.scss
@@ -89,3 +89,12 @@
 .sourceMenuButton {
   flex-shrink: 0;
 }
+
+/* Grouped dropdown decoupled from the compact picker (comboboxProps
+ * width="max-content", floored wider, capped to the viewport, pinned left
+ * via position="bottom-start"). The input keeps its own width.
+ */
+.sourceSelectDropdown {
+  min-width: 22rem;
+  max-width: min(32rem, calc(100vw - 2rem));
+}


### PR DESCRIPTION
Group the data source selector by section and add tag-style search. This is the selector side of HDX-4507; the `section` field, schema, and external API GET landed in #2432.

## Summary

When a source has a **Section**, the selector lists sources under section headers instead of one flat alphabetical list. Search matches on both the source **name** and its **section**, so a section acts as a tag: typing `billing` returns every source in the Billing section, and `billing logs` returns the logs in that section, including `Refund Logs` whose name has no "billing" in it. Tokens are AND-ed and results stay grouped, so the matched header explains why each result is there. The signal kind is deliberately not part of the search text.

The selector stays flat until at least one source has a section, so a deployment that has not adopted sections keeps today's flat list with no lone "Other" header.

## Changes

- `useFilteredSortedSourceItems` gets an opt-in `groupBySection` overload returning `{ group, items }[]`. The default flat `ComboboxItem[]` shape is unchanged, so `SourceMultiSelect` and the other flat callers are untouched.
- New exported `sourceSelectFilter` (`OptionsFilter`): token-AND over `name + section`, drops groups left with no surviving items, and keeps the grouped shape.
- Sections sort alphabetically with the unsectioned catch-all (`Other`) pinned last. There is no per-source ordering field yet, so admin-controlled ordering is left as a follow-up.
- `SourceSelectControlled` opts into the grouped data and passes `filter={sourceSelectFilter}`. The adjacent management kebab is unchanged.
- The grouped dropdown is widened so headers and source names are not cramped: it fits its content (`comboboxProps` `width="max-content"`), floored wider than the compact picker and capped to the viewport, and pinned to the input's left edge with `position="bottom-start"` so it grows rightward instead of re-centering. The input control keeps its own width.

## Why

Grouping is opt-in on the shared hook because `SourceMultiSelect` and the table picker reuse it and expect a flat list; changing the default shape would break them. The flat-until-adopted fallback keeps the change invisible until someone assigns a section, which avoids regressing the current flat selector into a single "Other" group for everyone who has not opted in.

## Test plan

- [x] `make ci-lint` (eslint + `tsc --noEmit` + stylelint) clean.
- [x] `make ci-unit`: `sourceSelectUtils` (21) and `SourceSelect` (15) green; the related source and select suites (39) stay green.
- [x] Unit: grouped-hook shape, alphabetical with "Other" last, flat-until-adopted, and `sourceSelectFilter` token-AND including a section-tag match (`Refund Logs` under Billing) and a case proving the signal kind is not in the haystack.
- [x] Render: `SourceSelectControlled` driven through the real Mantine `Select` asserts the section headers render, `billing logs` surfaces Billing Logs and Refund Logs under Billing, and an unsectioned set stays flat with no "Other" header.
- While sources are loading, or if the fetch returns an error, `data` is undefined and the hook returns an empty list, so the dropdown shows the same empty state as today.

## Verification

Verified in light and dark themes against a 22-source, 8-section set through the production `Select` (same `renderOption`, kind icons, `searchable`, grouped data) fed by the real hook and `sourceSelectFilter`. The screenshots cover the empty (full grouped list) state and the filtered states (`billing`, `billing logs`, `logs`, `control plane`) in both themes. The widened, left-pinned dropdown is verified the same way: the dropdown left edge aligns to the input's left border and grows rightward, in both themes. Grouping and filtering are pure data transforms, so `maxDropdownHeight` scrolling and the narrow-viewport cap are unchanged.

### What's not in this PR (follow-up)

- Section autocomplete in the source form (suggest existing section names while keeping the field free-text) and showing the section on the Manage Sources list: follow-up PRs in this series.
- Explicit / admin-controlled section ordering (today: alphabetical with "Other" last): needs a team-level ordering setting, tracked separately.
- MCP `describeSource` exposure and customer docs for `section`: separate follow-up.
