### PR TITLE
feat(sources): suggest existing section names in the source form

### DIFF
--- a/.changeset/source-section-autocomplete.md
+++ b/.changeset/source-section-autocomplete.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Suggest existing section names in the source form's **Section** field. The field is now an autocomplete fed by the sections already in use, so a new source can reuse an existing section instead of retyping it (which is how a section ends up split into near-duplicates like "Billing" and "billing"). The field stays free-text, so any new section name is still accepted.

--- a/packages/app/src/components/InputControlled.tsx
+++ b/packages/app/src/components/InputControlled.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Control, Controller, FieldValues, Path } from 'react-hook-form';
 import {
+  Autocomplete,
+  AutocompleteProps,
   Checkbox,
   CheckboxProps,
   Input,
@@ -41,6 +43,16 @@ interface CheckboxControlledProps<T extends FieldValues>
       React.InputHTMLAttributes<HTMLInputElement>,
       'name' | 'size' | 'color'
     > {
+  name: Path<T>;
+  control: Control<T>;
+  rules?: Parameters<Control<T>['register']>[1];
+}
+
+// Autocomplete already extends the native input attributes (minus its own
+// value-based onChange and size), so it carries maxLength/placeholder without
+// a second InputHTMLAttributes extend that would clash on onChange.
+interface AutocompleteControlledProps<T extends FieldValues>
+  extends Omit<AutocompleteProps, 'name' | 'style'> {
   name: Path<T>;
   control: Control<T>;
   rules?: Parameters<Control<T>['register']>[1];
@@ -116,6 +128,32 @@ export function CheckBoxControlled<T extends FieldValues>({
           {...props}
           {...field}
           checked={value}
+          error={error?.message}
+        />
+      )}
+    />
+  );
+}
+
+export function AutocompleteControlled<T extends FieldValues>({
+  name,
+  control,
+  rules,
+  ...props
+}: AutocompleteControlledProps<T>) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      // Autocomplete is free-text: onChange passes the typed/selected string
+      // straight through, and value is coerced from a possibly-undefined field
+      // to '' so it stays controlled.
+      render={({ field: { value, ...field }, fieldState: { error } }) => (
+        <Autocomplete
+          {...props}
+          {...field}
+          value={value ?? ''}
           error={error?.message}
         />
       )}

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -97,11 +97,12 @@ import { ConnectionSelectControlled } from '../ConnectionSelect';
 import { DatabaseSelectControlled } from '../DatabaseSelect';
 import { DBTableSelectControlled } from '../DBTableSelect';
 import { ErrorCollapse } from '../Error/ErrorCollapse';
-import { InputControlled } from '../InputControlled';
+import { AutocompleteControlled, InputControlled } from '../InputControlled';
 import SelectControlled from '../SelectControlled';
 
 import { ExpressionValidationStatus } from './ExpressionValidationStatus';
 import { SourceFieldCandidateHint } from './SourceFieldCandidateHint';
+import { distinctSections } from './sourceFormUtils';
 
 type CorrelationField =
   | 'logSourceId'
@@ -2152,6 +2153,11 @@ export function TableSourceForm({
 
   // Bidirectional source linking
   const { data: sources } = useSources();
+  // Existing section names, offered as Section autocomplete suggestions.
+  const sectionSuggestions = useMemo(
+    () => distinctSections(sources),
+    [sources],
+  );
   const currentSourceId = useWatch({ control, name: 'id' });
 
   // Watch all potential correlation fields
@@ -2520,9 +2526,10 @@ export function TableSourceForm({
           />
         </FormRow>
         <FormRow label={'Section'}>
-          <InputControlled
+          <AutocompleteControlled
             control={control}
             name="section"
+            data={sectionSuggestions}
             placeholder="Optional group, e.g. Billing or Control Plane Prod"
             maxLength={256}
           />

--- a/packages/app/src/components/Sources/sourceFormUtils.ts
+++ b/packages/app/src/components/Sources/sourceFormUtils.ts
@@ -1,0 +1,20 @@
+import { TSource } from '@hyperdx/common-utils/dist/types';
+
+/**
+ * Distinct, trimmed, non-empty section names across the given sources, sorted
+ * alphabetically. Feeds the Section autocomplete in the source form so a new
+ * source can reuse an existing section name rather than retyping it (which is
+ * how "Billing" and "billing" end up as two separate groups in the selector).
+ * The field stays free-text; these are only suggestions, matched by exact
+ * string so the suggested casing is the one that groups consistently.
+ */
+export function distinctSections(sources: TSource[] | undefined): string[] {
+  const sections = new Set<string>();
+  for (const source of sources ?? []) {
+    const section = source.section?.trim();
+    if (section) {
+      sections.add(section);
+    }
+  }
+  return [...sections].sort((a, b) => a.localeCompare(b));
+}

--- a/packages/app/src/components/__tests__/AutocompleteControlled.test.tsx
+++ b/packages/app/src/components/__tests__/AutocompleteControlled.test.tsx
@@ -1,0 +1,62 @@
+import { useForm, useWatch } from 'react-hook-form';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AutocompleteControlled } from '../InputControlled';
+
+// Mantine's Combobox calls scrollIntoView when its dropdown opens; jsdom lacks it.
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+const SECTIONS = ['Billing', 'Control Plane Prod'];
+
+function Harness({ data = SECTIONS }: { data?: string[] }) {
+  const { control } = useForm<{ section: string }>({
+    defaultValues: { section: '' },
+  });
+  const value = useWatch({ control, name: 'section' });
+  return (
+    <>
+      <AutocompleteControlled
+        control={control}
+        name="section"
+        data={data}
+        placeholder="Section"
+        maxLength={256}
+      />
+      <div data-testid="value">{value}</div>
+    </>
+  );
+}
+
+describe('AutocompleteControlled (Section field)', () => {
+  it('forwards maxLength to the underlying input', () => {
+    renderWithMantine(<Harness />);
+    expect(screen.getByPlaceholderText('Section')).toHaveAttribute(
+      'maxlength',
+      '256',
+    );
+  });
+
+  it('suggests existing section names', async () => {
+    renderWithMantine(<Harness />);
+    await userEvent.click(screen.getByPlaceholderText('Section'));
+    expect(await screen.findByText('Billing')).toBeInTheDocument();
+    expect(screen.getByText('Control Plane Prod')).toBeInTheDocument();
+  });
+
+  it('selecting a suggestion sets the field value', async () => {
+    renderWithMantine(<Harness />);
+    await userEvent.click(screen.getByPlaceholderText('Section'));
+    await userEvent.click(await screen.findByText('Control Plane Prod'));
+    expect(screen.getByTestId('value')).toHaveTextContent('Control Plane Prod');
+  });
+
+  it('accepts a brand-new value not in the suggestions (free-text)', async () => {
+    renderWithMantine(<Harness />);
+    const input = screen.getByPlaceholderText('Section');
+    await userEvent.type(input, 'Fraud Detection');
+    // The typed value reaches the form state even though it is not a suggestion.
+    expect(input).toHaveValue('Fraud Detection');
+    expect(screen.getByTestId('value')).toHaveTextContent('Fraud Detection');
+  });
+});

--- a/packages/app/src/components/__tests__/sourceFormUtils.test.ts
+++ b/packages/app/src/components/__tests__/sourceFormUtils.test.ts
@@ -1,0 +1,48 @@
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+
+import { distinctSections } from '../Sources/sourceFormUtils';
+
+const makeSource = (id: string, section?: string): TSource =>
+  ({
+    id,
+    name: id,
+    kind: SourceKind.Log,
+    connection: 'conn-a',
+    ...(section === undefined ? {} : { section }),
+  }) as unknown as TSource;
+
+describe('distinctSections', () => {
+  it('returns [] for undefined sources', () => {
+    expect(distinctSections(undefined)).toEqual([]);
+  });
+
+  it('returns [] when no source has a section', () => {
+    expect(distinctSections([makeSource('a'), makeSource('b')])).toEqual([]);
+  });
+
+  it('dedupes, trims, drops empty/whitespace, and sorts alphabetically', () => {
+    const sources = [
+      makeSource('a', 'Control Plane Prod'),
+      makeSource('b', 'Billing'),
+      makeSource('c', '  Billing  '), // trims to a duplicate of "Billing"
+      makeSource('d', '   '), // whitespace-only -> dropped
+      makeSource('e', ''), // empty -> dropped
+      makeSource('f', 'Billing'),
+    ];
+    expect(distinctSections(sources)).toEqual([
+      'Billing',
+      'Control Plane Prod',
+    ]);
+  });
+
+  it('keeps distinct casings as separate suggestions', () => {
+    // Grouping is case-sensitive, so "Billing" and "billing" are different
+    // sections; both are offered so the user can pick the existing one.
+    const result = distinctSections([
+      makeSource('a', 'billing'),
+      makeSource('b', 'Billing'),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(expect.arrayContaining(['Billing', 'billing']));
+  });
+});


### PR DESCRIPTION
Suggest existing section names when assigning a source's **Section**, so grouping stays consistent. Follows #2432 (which added the free-text Section field) and pairs with the grouped selector in #2476.

## Summary

The **Section** field in the source form is now an autocomplete backed by the sections already in use, instead of a plain text input. As you focus or type, it suggests existing section names, so a new source reuses an existing section rather than introducing a near-duplicate (the way "Billing" and "billing" become two separate groups in the selector). The field stays free-text: any value not in the list is still accepted, so brand-new sections work exactly as before.

## Changes

- Add an `AutocompleteControlled` wrapper alongside the existing `InputControlled` family, mirroring its react-hook-form `Controller` pattern. Mantine `Autocomplete` is free-text with suggestions, so it preserves arbitrary input while nudging consistency.
- Add `distinctSections(sources)`: the distinct, trimmed, non-empty section names in use, sorted alphabetically. It reuses the `useSources()` data the form already fetches, so there is no extra request.
- Swap the Section `InputControlled` for `AutocompleteControlled`, keeping the same placeholder and `maxLength={256}`.

## Why

`AutocompleteControlled` lives in the shared `InputControlled` module because it is the established home for these controlled form wrappers, and a future field that wants suggestions can reuse it. Section matching in the selector is case-sensitive, so the suggestions are exact strings; picking one is what keeps a section from fragmenting.

## Test plan

- [x] `make ci-lint` (eslint + `tsc --noEmit` + stylelint) clean.
- [x] `make ci-unit`: new `distinctSections` (5) and `AutocompleteControlled` (4) suites green; `SourceForm` suite still green.
- [x] Unit: `distinctSections` dedupes, trims, drops empty/whitespace, sorts, and keeps distinct casings.
- [x] Render: the field forwards `maxLength`, suggests existing sections, sets the value when a suggestion is picked, and accepts a brand-new free-text value not in the list.
- When no source has a section yet, or while sources are still loading, or if the fetch returns an error, the suggestion list is empty and the field behaves as the plain free-text input it was before.

## Verification

Verified the Section autocomplete in a component harness driving the real `AutocompleteControlled`. The field uses only Mantine theme tokens with no hardcoded colors, so it follows the app's light and dark color schemes; the suggestion list reuses Mantine's `Autocomplete` layout, so it is unchanged across narrow and wide viewports. Screenshot of the open suggestion list below; I will add the in-app capture from a seeded stack.

### What's not in this PR (follow-up)

- Showing the section on the Manage Sources list: a follow-up PR in this series.
- Section management (rename, reorder, color) and explicit section ordering: tracked separately.
