### PR TITLE
fix(search): make excluded filter pills readable in the light theme

### DIFF
--- a/.changeset/fix-exclude-filter-pill-contrast.md
+++ b/.changeset/fix-exclude-filter-pill-contrast.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: improve contrast of excluded search filter pills
+
+Excluded ("!=") filter pills above the search results used a saturated red background with red text and a red remove button, which made them hard to read in the light theme. They now use a soft red tint with a readable accent, legible in both light and dark themes.

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -176,7 +176,7 @@ function FilterPill({
           backgroundColor: isInvalid
             ? 'transparent'
             : isExcluded
-              ? 'var(--color-bg-danger)'
+              ? 'var(--mantine-color-red-light)'
               : 'var(--color-bg-hover)',
           border: isInvalid
             ? '1px dashed var(--color-border-emphasis)'
@@ -203,7 +203,9 @@ function FilterPill({
           size="xxs"
           c="dimmed"
           style={{
-            color: showDangerAccent ? 'var(--color-text-danger)' : undefined,
+            color: showDangerAccent
+              ? 'var(--mantine-color-red-light-color)'
+              : undefined,
             textDecoration: isInvalid ? 'line-through' : undefined,
           }}
         >
@@ -230,7 +232,9 @@ function FilterPill({
           style={{
             flexShrink: 0,
             marginLeft: 2,
-            color: showDangerAccent ? 'var(--color-text-danger)' : undefined,
+            color: showDangerAccent
+              ? 'var(--mantine-color-red-light-color)'
+              : undefined,
           }}
           aria-label="Remove filter"
         >

--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -102,6 +102,26 @@ describe('ActiveFilterPills', () => {
     expect(screen.getByText('status')).toBeInTheDocument();
   });
 
+  it('styles the excluded pill with a soft red-light background and the included pill with neutral hover', () => {
+    const searchFilters = makeSearchFilters({
+      status: {
+        included: new Set<string | boolean>(['200']),
+        excluded: new Set<string | boolean>(),
+      },
+      level: {
+        included: new Set<string | boolean>(),
+        excluded: new Set<string | boolean>(['error']),
+      },
+    });
+    renderPills(searchFilters);
+    expect(screen.getByTestId('active-filter-pill-status')).toHaveStyle({
+      backgroundColor: 'var(--color-bg-hover)',
+    });
+    expect(screen.getByTestId('active-filter-pill-level')).toHaveStyle({
+      backgroundColor: 'var(--mantine-color-red-light)',
+    });
+  });
+
   it('renders range filter pills', () => {
     const searchFilters = makeSearchFilters({
       duration: {

--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -114,12 +114,21 @@ describe('ActiveFilterPills', () => {
       },
     });
     renderPills(searchFilters);
-    expect(screen.getByTestId('active-filter-pill-status')).toHaveStyle({
-      backgroundColor: 'var(--color-bg-hover)',
-    });
-    expect(screen.getByTestId('active-filter-pill-level')).toHaveStyle({
-      backgroundColor: 'var(--mantine-color-red-light)',
-    });
+
+    const included = screen.getByTestId('active-filter-pill-status');
+    const excluded = screen.getByTestId('active-filter-pill-level');
+
+    // Assert on the raw inline-style string so the token check can't silently
+    // no-op on a jsdom that drops unresolved CSS custom properties.
+    expect(included.getAttribute('style')).toContain('var(--color-bg-hover)');
+    expect(excluded.getAttribute('style')).toContain(
+      'var(--mantine-color-red-light)',
+    );
+    expect(
+      excluded
+        .querySelector('button[aria-label="Remove filter"]')
+        ?.getAttribute('style'),
+    ).toContain('var(--mantine-color-red-light-color)');
   });
 
   it('renders range filter pills', () => {


### PR DESCRIPTION
Excluded ("!=") filter pills above the search results were drawn with a saturated red background plus red text and a red remove button. In the light theme that meant the `!=` operator, the value, and the `x` were red on red and effectively unreadable. This swaps the excluded pill to Mantine's `red-light` variant: a soft red tint with its paired readable accent.

## Summary

- `ActiveFilterPills` excluded pills now use `--mantine-color-red-light` for the background and `--mantine-color-red-light-color` for the `!=` operator and the remove `x`, instead of `--color-bg-danger` / `--color-text-danger`.
- The change is local to the pill, so the shared `--color-bg-danger` / `--color-text-danger` tokens (also used by `GroupTabBar`, the SQL editor border, the filter panel label, and dashboards) are unchanged.
- Included pills stay neutral and the inactive/not-applied pill keeps its strikethrough and dashed border, so the three states stay distinct. An exclude still reads as an exclude (red hue), not as a disabled filter.

## Why red-light

`red-light` / `red-light-color` is Mantine's scheme-aware light variant (autoContrast is on), already used here for destructive buttons and menu items. It is a guaranteed-legible background and text pair, so one local change fixes both light and dark, and both the hyperdx and clickstack themes.

## Verification

Rendered the pill states in Storybook and read the computed colors of the excluded pill in both themes:

- Light, before: background `rgb(224,49,49)`, remove button `rgb(224,49,49)` (identical, invisible)
- Light, after: background `rgb(255,227,227)`, accent `rgb(201,42,42)` (clear contrast)
- Dark, after: background `rgb(101,21,21)`, accent `rgb(255,245,245)`

Before/after screenshots in light and dark are attached below.

<img width="657" height="125" alt="image" src="https://github.com/user-attachments/assets/72f58975-3d07-408e-b69d-14ceedf5fac6" />

after

<img width="634" height="115" alt="image" src="https://github.com/user-attachments/assets/9a8be923-209e-4f60-8439-4ffd3f3b0900" />


## Test plan

- [x] `eslint` (changed files) clean
- [x] `yarn tsc --noEmit`
- [x] `jest` ActiveFilterPills (27 passing, including a new assertion that the excluded pill uses the soft red-light background and the included pill stays neutral)
- [x] Storybook: pill states checked in light and dark, hyperdx and clickstack
