### PR TITLE
fix: parse DateTime to filter by timestamp on search page

### DIFF
--- a/.changeset/datetime-filter-exclude.md
+++ b/.changeset/datetime-filter-exclude.md
@@ -3,4 +3,4 @@
 "@hyperdx/app": patch
 ---
 
-fix(search): wrap date column values in a type-matching parse/convert expression when building IN/NOT IN filters, so including/excluding a timestamp value no longer fails with "Cannot convert string ... to type DateTime64" or "Type mismatch in IN ... Expected: DateTime. Got: Decimal64".
+fix(search): wrap date column values in a type-matching parse/convert expression when building IN/NOT IN filters, so including/excluding a timestamp value no longer fails with "Cannot convert string ... to type DateTime64" or "Type mismatch in IN ... Expected: DateTime. Got: Decimal64". Date column types are now resolved from the query result set, so aliased (`TimestampTime AS time`) and computed (`toDate(TimestampTime)`) DateTime/Date columns are also wrapped correctly when added to filters.

--- a/.changeset/datetime-filter-exclude.md
+++ b/.changeset/datetime-filter-exclude.md
@@ -3,4 +3,4 @@
 "@hyperdx/app": patch
 ---
 
-fix(search): wrap DateTime column values in parseDateTime64BestEffort when building IN/NOT IN filters so including/excluding a timestamp value no longer fails with "Cannot convert string ... to type DateTime64"
+fix(search): wrap date column values in a type-matching parse/convert expression when building IN/NOT IN filters, so including/excluding a timestamp value no longer fails with "Cannot convert string ... to type DateTime64" or "Type mismatch in IN ... Expected: DateTime. Got: Decimal64".

--- a/.changeset/datetime-filter-exclude.md
+++ b/.changeset/datetime-filter-exclude.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+fix(search): wrap DateTime column values in parseDateTime64BestEffort when building IN/NOT IN filters so including/excluding a timestamp value no longer fails with "Cannot convert string ... to type DateTime64"

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -136,7 +136,7 @@ import {
 } from './components/TimePicker/utils';
 import {
   useColumns,
-  useDateTimeColumns,
+  useResolvedDateTimeColumns,
   useTableMetadata,
 } from './hooks/useMetadata';
 import { useSqlSuggestions } from './hooks/useSqlSuggestions';
@@ -1113,7 +1113,8 @@ export function DBSearchPage() {
     { enabled: !!watchedSourceObj },
   );
 
-  const dateTimeColumns = useDateTimeColumns(watchedSourceColumns);
+  const { dateTimeColumns, onResolvedColumnsChange } =
+    useResolvedDateTimeColumns(watchedSourceColumns);
 
   const filters = useWatch({ name: 'filters', control });
   const searchFilters = useSearchPageFilterState({
@@ -2429,6 +2430,7 @@ export function DBSearchPage() {
                             onSortingChange={onSortingChange}
                             initialSortBy={initialSortBy}
                             enableSmallFirstWindow
+                            onResolvedColumnsChange={onResolvedColumnsChange}
                           />
                         )}
                     </Box>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -28,6 +28,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   ClickHouseQueryError,
   ColumnMeta,
+  convertCHDataTypeToJSType,
+  JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
@@ -1084,12 +1086,6 @@ export function DBSearchPage() {
     [debouncedSubmit, setValue],
   );
 
-  const filters = useWatch({ name: 'filters', control });
-  const searchFilters = useSearchPageFilterState({
-    searchQuery: filters ?? undefined,
-    onFilterChange: handleSetFilters,
-  });
-
   const watchedSource = useWatch({
     control,
     name: 'source',
@@ -1114,6 +1110,27 @@ export function DBSearchPage() {
     },
     { enabled: !!watchedSourceObj },
   );
+
+  // DateTime/DateTime64 column names, so the filter pipeline wraps their values
+  // in parseDateTime64BestEffort() rather than emitting a bare string literal
+  // that ClickHouse can't cast (covers DateTime, DateTime64, Date, Date32 and
+  // their LowCardinality/Nullable wrappers via convertCHDataTypeToJSType).
+  const dateTimeColumns = useMemo(
+    () =>
+      new Set(
+        (watchedSourceColumns ?? [])
+          .filter(c => convertCHDataTypeToJSType(c.type) === JSDataType.Date)
+          .map(c => c.name),
+      ),
+    [watchedSourceColumns],
+  );
+
+  const filters = useWatch({ name: 'filters', control });
+  const searchFilters = useSearchPageFilterState({
+    searchQuery: filters ?? undefined,
+    onFilterChange: handleSetFilters,
+    dateTimeColumns,
+  });
 
   useEffect(() => {
     // If the user changes the source dropdown, reset the select and orderby fields

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -28,8 +28,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   ClickHouseQueryError,
   ColumnMeta,
-  convertCHDataTypeToJSType,
-  JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
@@ -136,7 +134,11 @@ import {
   getRelativeTimeOptionLabel,
   LIVE_TAIL_DURATION_MS,
 } from './components/TimePicker/utils';
-import { useColumns, useTableMetadata } from './hooks/useMetadata';
+import {
+  useColumns,
+  useDateTimeColumns,
+  useTableMetadata,
+} from './hooks/useMetadata';
 import { useSqlSuggestions } from './hooks/useSqlSuggestions';
 import { useStableCallback } from './hooks/useStableCallback';
 import {
@@ -1111,19 +1113,7 @@ export function DBSearchPage() {
     { enabled: !!watchedSourceObj },
   );
 
-  // DateTime/DateTime64 column names, so the filter pipeline wraps their values
-  // in parseDateTime64BestEffort() rather than emitting a bare string literal
-  // that ClickHouse can't cast (covers DateTime, DateTime64, Date, Date32 and
-  // their LowCardinality/Nullable wrappers via convertCHDataTypeToJSType).
-  const dateTimeColumns = useMemo(
-    () =>
-      new Set(
-        (watchedSourceColumns ?? [])
-          .filter(c => convertCHDataTypeToJSType(c.type) === JSDataType.Date)
-          .map(c => c.name),
-      ),
-    [watchedSourceColumns],
-  );
+  const dateTimeColumns = useDateTimeColumns(watchedSourceColumns);
 
   const filters = useWatch({ name: 'filters', control });
   const searchFilters = useSearchPageFilterState({

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -2087,6 +2087,7 @@ export function DBSearchPage() {
         <ActiveFilterPills
           searchFilters={searchFilters}
           chartConfig={filtersChartConfig}
+          dateTimeColumns={dateTimeColumns}
           mt={6}
         />
       </form>

--- a/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
@@ -128,6 +128,7 @@ jest.mock('@/theme/ThemeProvider', () => ({
 }));
 
 jest.mock('../hooks/useMetadata', () => ({
+  ...jest.requireActual('../hooks/useMetadata'),
   useTableMetadata: () => ({
     data: { sorting_key: 'Timestamp' },
     isLoading: false,

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -631,7 +631,10 @@ describe('searchFilters', () => {
   });
 
   describe('round-trip: DateTime columns', () => {
-    const dateTimeColumns = new Set(['Timestamp']);
+    const dateTimeColumns = new Map<string, string>([
+      ['Timestamp', 'DateTime64(9)'],
+      ['TimestampTime', 'DateTime'],
+    ]);
 
     it('round-trips an excluded DateTime value (no areFiltersEqual reset)', () => {
       const originalFilters = {
@@ -727,6 +730,43 @@ describe('searchFilters', () => {
           included: new Set(["a', 9)b"]),
           excluded: new Set(),
         },
+      });
+    });
+
+    it('round-trips a plain DateTime column (parseDateTimeBestEffort wrapper)', () => {
+      const originalFilters = {
+        TimestampTime: {
+          included: new Set<string | boolean>(['2026-06-17T11:56:41Z']),
+          excluded: new Set<string | boolean>(),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, { dateTimeColumns });
+      // Sanity: produces the DateTime (non-64) wrapper.
+      expect(query[0].condition).toBe(
+        "TimestampTime IN (parseDateTimeBestEffort('2026-06-17T11:56:41Z'))",
+      );
+
+      expect(parseQuery(query).filters).toEqual({
+        TimestampTime: {
+          included: new Set(['2026-06-17T11:56:41Z']),
+          excluded: new Set(),
+        },
+      });
+    });
+
+    it('parseQuery unwraps parseDateTimeBestEffort and toDate wrappers', () => {
+      const parsed = parseQuery([
+        {
+          type: 'sql',
+          condition: "TimestampTime IN (parseDateTimeBestEffort('a'))",
+        },
+        { type: 'sql', condition: "day NOT IN (toDate('2026-06-17'))" },
+      ]);
+
+      expect(parsed.filters).toEqual({
+        TimestampTime: { included: new Set(['a']), excluded: new Set() },
+        day: { included: new Set(), excluded: new Set(['2026-06-17']) },
       });
     });
   });

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -630,6 +630,107 @@ describe('searchFilters', () => {
     });
   });
 
+  describe('round-trip: DateTime columns', () => {
+    const dateTimeColumns = new Set(['Timestamp']);
+
+    it('round-trips an excluded DateTime value (no areFiltersEqual reset)', () => {
+      const originalFilters = {
+        Timestamp: {
+          included: new Set<string | boolean>(),
+          excluded: new Set<string | boolean>([
+            '2026-06-16T15:35:16.731000000Z',
+          ]),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, { dateTimeColumns });
+      const parsed = parseQuery(query);
+
+      expect(parsed.filters).toEqual({
+        Timestamp: {
+          included: new Set(),
+          excluded: new Set(['2026-06-16T15:35:16.731000000Z']),
+        },
+      });
+    });
+
+    it('round-trips an included DateTime value with multiple entries', () => {
+      const originalFilters = {
+        Timestamp: {
+          included: new Set<string | boolean>(['2026-06-16', '2026-06-17']),
+          excluded: new Set<string | boolean>(),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, { dateTimeColumns });
+      const parsed = parseQuery(query);
+
+      expect(parsed.filters).toEqual({
+        Timestamp: {
+          included: new Set(['2026-06-16', '2026-06-17']),
+          excluded: new Set(),
+        },
+      });
+    });
+
+    it('parseQuery unwraps the DateTime wrapper independently of the producer', () => {
+      const parsed = parseQuery([
+        {
+          type: 'sql',
+          condition:
+            "Timestamp NOT IN (parseDateTime64BestEffort('a', 9), parseDateTime64BestEffort('b', 9))",
+        },
+      ]);
+
+      expect(parsed.filters).toEqual({
+        Timestamp: {
+          included: new Set(),
+          excluded: new Set(['a', 'b']),
+        },
+      });
+    });
+
+    it('unwraps the DateTime part of a compound AND condition', () => {
+      const parsed = parseQuery([
+        {
+          type: 'sql',
+          condition:
+            "ServiceName IN ('api') AND Timestamp NOT IN (parseDateTime64BestEffort('2026-06-16', 9))",
+        },
+      ]);
+
+      expect(parsed.filters).toEqual({
+        ServiceName: {
+          included: new Set(['api']),
+          excluded: new Set(),
+        },
+        Timestamp: {
+          included: new Set(),
+          excluded: new Set(['2026-06-16']),
+        },
+      });
+    });
+
+    it('round-trips a DateTime value containing the wrapper suffix', () => {
+      const originalFilters = {
+        Timestamp: {
+          included: new Set<string | boolean>(["a', 9)b"]),
+          excluded: new Set<string | boolean>(),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, { dateTimeColumns });
+      const parsed = parseQuery(query);
+
+      expect(parsed.filters).toEqual({
+        Timestamp: {
+          included: new Set(["a', 9)b"]),
+          excluded: new Set(),
+        },
+      });
+    });
+  });
+
   describe('useSearchPageFilterState', () => {
     const onFilterChange = jest.fn();
 

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -10,6 +10,8 @@ import {
 
 enableMapSet();
 
+type ConditionFilter = { type: 'sql' | 'lucene'; condition: string };
+
 describe('searchFilters', () => {
   describe('parseQuery', () => {
     it('empty query', () => {
@@ -743,7 +745,8 @@ describe('searchFilters', () => {
 
       const query = filtersToQuery(originalFilters, { dateTimeColumns });
       // Sanity: produces the DateTime (non-64) wrapper.
-      expect(query[0].condition).toBe(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      expect((query[0] as ConditionFilter).condition).toBe(
         "TimestampTime IN (parseDateTimeBestEffort('2026-06-17T11:56:41Z'))",
       );
 
@@ -768,6 +771,55 @@ describe('searchFilters', () => {
         TimestampTime: { included: new Set(['a']), excluded: new Set() },
         day: { included: new Set(), excluded: new Set(['2026-06-17']) },
       });
+    });
+
+    // The map key can be a query-result column name that isn't a table column:
+    // an alias (`TimestampTime AS time`) or a computed expression
+    // (`toDate(TimestampTime)`). These only become filterable correctly when the
+    // type map is sourced from the result set rather than the table schema.
+    it('wraps and round-trips an aliased DateTime column', () => {
+      const aliasColumns = new Map<string, string>([['time', 'DateTime64(9)']]);
+      const originalFilters = {
+        time: {
+          included: new Set<string | boolean>(['2026-06-18T10:33:55Z']),
+          excluded: new Set<string | boolean>(),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, {
+        dateTimeColumns: aliasColumns,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      expect((query[0] as ConditionFilter).condition).toBe(
+        "time IN (parseDateTime64BestEffort('2026-06-18T10:33:55Z', 9))",
+      );
+
+      expect(parseQuery(query).filters).toEqual({
+        time: {
+          included: new Set(['2026-06-18T10:33:55Z']),
+          excluded: new Set(),
+        },
+      });
+    });
+
+    it('wraps a computed DateTime expression with the type-matched function', () => {
+      const exprColumns = new Map<string, string>([
+        ['toDate(TimestampTime)', 'Date'],
+      ]);
+      const originalFilters = {
+        'toDate(TimestampTime)': {
+          included: new Set<string | boolean>(['2026-06-18']),
+          excluded: new Set<string | boolean>(),
+        },
+      };
+
+      const query = filtersToQuery(originalFilters, {
+        dateTimeColumns: exprColumns,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      expect((query[0] as ConditionFilter).condition).toBe(
+        "toDate(TimestampTime) IN (toDate('2026-06-18'))",
+      );
     });
   });
 

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -20,6 +20,7 @@ import {
 
 import { useGetKeyValues } from '@/hooks/useMetadata';
 import type { FilterStateHook } from '@/searchFilters';
+import { useFormatTime } from '@/useFormatTime';
 import {
   CLIPBOARD_ERROR_MESSAGE,
   copyTextToClipboard,
@@ -29,15 +30,37 @@ const MAX_VISIBLE_PILLS = 8;
 // Cap the value list fetched for the in-pill value picker.
 const VALUE_EDIT_LIMIT = 50;
 
+// Stable identity so a caller that omits the prop doesn't invalidate the
+// flattenFilters useMemo on every render.
+const EMPTY_DATE_TIME_COLUMNS: ReadonlySet<string> = new Set();
+
+type FormatTime = ReturnType<typeof useFormatTime>;
+
 type PillItem = {
   field: string;
   value: string;
   type: 'included' | 'excluded' | 'range';
   rawValue?: string | boolean;
+  // Display-only label for the pill (e.g. a DateTime value formatted to the
+  // user's locale/timezone). The raw `value`/`rawValue` are kept intact for
+  // SQL generation, value editing, copy, and the URL round-trip.
+  displayValue?: string;
 };
 
-function flattenFilters(filters: FilterStateHook['filters']): PillItem[] {
+function flattenFilters(
+  filters: FilterStateHook['filters'],
+  {
+    dateTimeColumns,
+    formatTime,
+  }: { dateTimeColumns: ReadonlySet<string>; formatTime: FormatTime },
+): PillItem[] {
   const pills: PillItem[] = [];
+
+  const formatDisplayValue = (field: string, val: string | boolean) =>
+    dateTimeColumns.has(field) && typeof val === 'string'
+      ? formatTime(val, { format: 'withMs' })
+      : undefined;
+
   for (const [field, state] of Object.entries(filters)) {
     for (const val of state.included) {
       pills.push({
@@ -45,6 +68,7 @@ function flattenFilters(filters: FilterStateHook['filters']): PillItem[] {
         value: String(val),
         type: 'included',
         rawValue: val,
+        displayValue: formatDisplayValue(field, val),
       });
     }
     for (const val of state.excluded) {
@@ -53,6 +77,7 @@ function flattenFilters(filters: FilterStateHook['filters']): PillItem[] {
         value: String(val),
         type: 'excluded',
         rawValue: val,
+        displayValue: formatDisplayValue(field, val),
       });
     }
     if (state.range != null) {
@@ -140,10 +165,11 @@ function FilterPill({
     [keyValues, pill.value],
   );
 
+  const label = pill.displayValue ?? pill.value;
   const tooltipLabel = isInvalid
     ? (invalidReason ??
       `Filter not applied: "${pill.field}" isn't a column on the current source. It will reapply if you switch back.`)
-    : `${pill.field}${operator}${pill.value}`;
+    : `${pill.field}${operator}${label}`;
 
   const showDangerAccent = isExcluded && !isInvalid;
 
@@ -218,7 +244,7 @@ function FilterPill({
           truncate
           style={{ textDecoration: isInvalid ? 'line-through' : undefined }}
         >
-          {pill.value}
+          {label}
         </Text>
         <ActionIcon
           size={14}
@@ -319,9 +345,11 @@ export const ActiveFilterPills = memo(function ActiveFilterPills({
   invalidFields,
   invalidFieldReason,
   chartConfig,
+  dateTimeColumns = EMPTY_DATE_TIME_COLUMNS,
   ...flexProps
 }: {
   searchFilters: FilterStateHook;
+  dateTimeColumns?: ReadonlySet<string>;
   /**
    * Field names whose filters are present in state but not applied to the
    * current query (e.g. column doesn't exist on the active source). These
@@ -348,7 +376,11 @@ export const ActiveFilterPills = memo(function ActiveFilterPills({
     clearAllFilters,
   } = searchFilters;
 
-  const pills = useMemo(() => flattenFilters(filters), [filters]);
+  const formatTime = useFormatTime();
+  const pills = useMemo(
+    () => flattenFilters(filters, { dateTimeColumns, formatTime }),
+    [filters, dateTimeColumns, formatTime],
+  );
   const [expanded, setExpanded] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
   const confirmTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);

--- a/packages/app/src/components/ActiveFilterPills.tsx
+++ b/packages/app/src/components/ActiveFilterPills.tsx
@@ -32,7 +32,7 @@ const VALUE_EDIT_LIMIT = 50;
 
 // Stable identity so a caller that omits the prop doesn't invalidate the
 // flattenFilters useMemo on every render.
-const EMPTY_DATE_TIME_COLUMNS: ReadonlySet<string> = new Set();
+const EMPTY_DATE_TIME_COLUMNS: ReadonlyMap<string, string> = new Map();
 
 type FormatTime = ReturnType<typeof useFormatTime>;
 
@@ -52,7 +52,7 @@ function flattenFilters(
   {
     dateTimeColumns,
     formatTime,
-  }: { dateTimeColumns: ReadonlySet<string>; formatTime: FormatTime },
+  }: { dateTimeColumns: ReadonlyMap<string, string>; formatTime: FormatTime },
 ): PillItem[] {
   const pills: PillItem[] = [];
 
@@ -349,7 +349,12 @@ export const ActiveFilterPills = memo(function ActiveFilterPills({
   ...flexProps
 }: {
   searchFilters: FilterStateHook;
-  dateTimeColumns?: ReadonlySet<string>;
+  /**
+   * Map of DateTime/Date column name → ClickHouse type. Their pill values are
+   * formatted to the user's locale/timezone for display, matching the results
+   * table, while the underlying raw value is preserved for SQL/editing/copy.
+   */
+  dateTimeColumns?: ReadonlyMap<string, string>;
   /**
    * Field names whose filters are present in state but not applied to the
    * current query (e.g. column doesn't exist on the active source). These

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -1520,6 +1520,7 @@ function DBSqlRowTableComponent({
   enableSmallFirstWindow,
   tableId,
   errorVariant,
+  onResolvedColumnsChange,
 }: {
   config: BuilderChartConfigWithDateRange;
   sourceId?: string;
@@ -1546,6 +1547,7 @@ function DBSqlRowTableComponent({
   enableSmallFirstWindow?: boolean;
   tableId?: string;
   errorVariant?: ChartErrorStateVariant;
+  onResolvedColumnsChange?: (meta: ColumnMetaType[]) => void;
 }) {
   const { data: me } = api.useMe();
   const { toggleColumn, displayedColumns: contextDisplayedColumns } =
@@ -1715,6 +1717,14 @@ function DBSqlRowTableComponent({
       onError(error);
     }
   }, [isError, onError, error]);
+
+  // Surface the result-set column types upward.
+  // `data?.meta` keeps a stable identity per query result.
+  useEffect(() => {
+    if (data?.meta != null && data.meta.length > 0) {
+      onResolvedColumnsChange?.(data.meta);
+    }
+  }, [data?.meta, onResolvedColumnsChange]);
 
   const { data: source } = useSource({ id: sourceId });
   const patternColumn = columns[columns.length - 1];

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1,10 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
 import {
-  convertCHDataTypeToJSType,
-  JSDataType,
-} from '@hyperdx/common-utils/dist/clickhouse';
-import {
   TableMetadata,
   tcFromSource,
 } from '@hyperdx/common-utils/dist/core/metadata';
@@ -65,6 +61,7 @@ import {
   useAllFields,
   useAllFieldsAndValues,
   useColumns,
+  useDateTimeColumns,
   useGetKeyValues,
   useGetValuesDistribution,
   useJsonColumns,
@@ -1209,17 +1206,7 @@ const DBSearchPageFiltersComponent = ({
     connectionId: chartConfig.connection,
   });
 
-  // DateTime/DateTime64 column names so filtersToQuery wraps their values in
-  // parseDateTime64BestEffort() rather than a bare literal ClickHouse can't cast.
-  const dateTimeColumns = useMemo(
-    () =>
-      new Set(
-        (columns ?? [])
-          .filter(c => convertCHDataTypeToJSType(c.type) === JSDataType.Date)
-          .map(c => c.name),
-      ),
-    [columns],
-  );
+  const dateTimeColumns = useDateTimeColumns(columns);
 
   const { data: tableMetadata } = useTableMetadata(sourceTableConnection);
 

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1,6 +1,10 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
 import {
+  convertCHDataTypeToJSType,
+  JSDataType,
+} from '@hyperdx/common-utils/dist/clickhouse';
+import {
   TableMetadata,
   tcFromSource,
 } from '@hyperdx/common-utils/dist/core/metadata';
@@ -1205,6 +1209,18 @@ const DBSearchPageFiltersComponent = ({
     connectionId: chartConfig.connection,
   });
 
+  // DateTime/DateTime64 column names so filtersToQuery wraps their values in
+  // parseDateTime64BestEffort() rather than a bare literal ClickHouse can't cast.
+  const dateTimeColumns = useMemo(
+    () =>
+      new Set(
+        (columns ?? [])
+          .filter(c => convertCHDataTypeToJSType(c.type) === JSDataType.Date)
+          .map(c => c.name),
+      ),
+    [columns],
+  );
+
   const { data: tableMetadata } = useTableMetadata(sourceTableConnection);
 
   useEffect(() => {
@@ -1378,7 +1394,7 @@ const DBSearchPageFiltersComponent = ({
             chartConfig: {
               ...chartConfig,
               dateRange,
-              filters: filtersToQuery(strippedFilterState),
+              filters: filtersToQuery(strippedFilterState, { dateTimeColumns }),
             },
             keys: [sqlKey],
             limit: LOAD_MORE_LOAD_LIMIT,
@@ -1407,6 +1423,7 @@ const DBSearchPageFiltersComponent = ({
       chartConfig,
       setExtraFacets,
       dateRange,
+      dateTimeColumns,
       filterState,
       metadata,
       source,

--- a/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
+++ b/packages/app/src/components/DBSqlRowTableWithSidebar.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useState } from 'react';
 import { useQueryState } from 'nuqs';
-import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+import {
+  ClickHouseQueryError,
+  ColumnMetaType,
+} from '@hyperdx/common-utils/dist/clickhouse';
 import {
   BuilderChartConfigWithDateRange,
   TSource,
@@ -46,6 +49,7 @@ interface Props {
   enableSmallFirstWindow?: boolean;
   tableId?: string;
   errorVariant?: ChartErrorStateVariant;
+  onResolvedColumnsChange?: (meta: ColumnMetaType[]) => void;
 }
 
 export default function DBSqlRowTableWithSideBar({
@@ -68,6 +72,7 @@ export default function DBSqlRowTableWithSideBar({
   enableSmallFirstWindow,
   tableId,
   errorVariant,
+  onResolvedColumnsChange,
 }: Props) {
   const { data: sourceData } = useSource({ id: sourceId });
   const [rowId, setRowId] = useQueryState('rowWhere', parseAsStringEncoded);
@@ -149,6 +154,7 @@ export default function DBSqlRowTableWithSideBar({
         enableSmallFirstWindow={enableSmallFirstWindow}
         tableId={tableId}
         errorVariant={errorVariant}
+        onResolvedColumnsChange={onResolvedColumnsChange}
       />
     </RowSidePanelContext.Provider>
   );

--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -19,6 +19,13 @@ jest.mock('@/hooks/useMetadata', () => ({
   useGetKeyValues: jest.fn(() => ({ data: [], isFetching: false })),
 }));
 
+// Deterministic stand-in for the locale/timezone-aware formatter so assertions
+// don't depend on the test runner's timezone or clock preference.
+jest.mock('@/useFormatTime', () => ({
+  __esModule: true,
+  useFormatTime: () => (value: unknown) => `formatted(${String(value)})`,
+}));
+
 const mockedUseGetKeyValues = useGetKeyValues as jest.Mock;
 
 // Mantine's Combobox calls scrollIntoView when its dropdown opens; jsdom lacks
@@ -580,5 +587,66 @@ describe('ActiveFilterPills', () => {
       '502',
       'exclude',
     );
+  });
+
+  describe('DateTime value formatting', () => {
+    const TS = '2026-06-16T15:35:16.731000000Z';
+
+    function renderWithDateTime(
+      searchFilters: FilterStateHook,
+      dateTimeColumns: Set<string>,
+    ) {
+      return renderWithMantine(
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          chartConfig={CHART_CONFIG}
+          dateTimeColumns={dateTimeColumns}
+        />,
+      );
+    }
+
+    it('formats a DateTime column pill value for display', () => {
+      const searchFilters = makeSearchFilters({
+        Timestamp: {
+          included: new Set<string | boolean>(),
+          excluded: new Set<string | boolean>([TS]),
+        },
+      });
+      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+
+      expect(screen.getByText(`formatted(${TS})`)).toBeInTheDocument();
+      // The raw, unformatted value is not shown.
+      expect(screen.queryByText(TS)).not.toBeInTheDocument();
+    });
+
+    it('does not format pill values for non-DateTime columns', () => {
+      const searchFilters = makeSearchFilters({
+        status: {
+          included: new Set<string | boolean>([TS]),
+          excluded: new Set<string | boolean>(),
+        },
+      });
+      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+
+      expect(screen.getByText(TS)).toBeInTheDocument();
+      expect(screen.queryByText(`formatted(${TS})`)).not.toBeInTheDocument();
+    });
+
+    it('preserves the raw value for filter operations despite the formatted label', () => {
+      const searchFilters = makeSearchFilters({
+        Timestamp: {
+          included: new Set<string | boolean>(),
+          excluded: new Set<string | boolean>([TS]),
+        },
+      });
+      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Remove filter' }));
+      expect(searchFilters.setFilterValue).toHaveBeenCalledWith(
+        'Timestamp',
+        TS,
+        'exclude',
+      );
+    });
   });
 });

--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -594,7 +594,7 @@ describe('ActiveFilterPills', () => {
 
     function renderWithDateTime(
       searchFilters: FilterStateHook,
-      dateTimeColumns: Set<string>,
+      dateTimeColumns: Map<string, string>,
     ) {
       return renderWithMantine(
         <ActiveFilterPills
@@ -612,7 +612,10 @@ describe('ActiveFilterPills', () => {
           excluded: new Set<string | boolean>([TS]),
         },
       });
-      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+      renderWithDateTime(
+        searchFilters,
+        new Map([['Timestamp', 'DateTime64(9)']]),
+      );
 
       expect(screen.getByText(`formatted(${TS})`)).toBeInTheDocument();
       // The raw, unformatted value is not shown.
@@ -626,7 +629,10 @@ describe('ActiveFilterPills', () => {
           excluded: new Set<string | boolean>(),
         },
       });
-      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+      renderWithDateTime(
+        searchFilters,
+        new Map([['Timestamp', 'DateTime64(9)']]),
+      );
 
       expect(screen.getByText(TS)).toBeInTheDocument();
       expect(screen.queryByText(`formatted(${TS})`)).not.toBeInTheDocument();
@@ -639,7 +645,10 @@ describe('ActiveFilterPills', () => {
           excluded: new Set<string | boolean>([TS]),
         },
       });
-      renderWithDateTime(searchFilters, new Set(['Timestamp']));
+      renderWithDateTime(
+        searchFilters,
+        new Map([['Timestamp', 'DateTime64(9)']]),
+      );
 
       fireEvent.click(screen.getByRole('button', { name: 'Remove filter' }));
       expect(searchFilters.setFilterValue).toHaveBeenCalledWith(

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -101,14 +101,15 @@ export function useColumns(
   });
 }
 
+// Derives a map of DateTime/Date column name → ClickHouse type.
 export function useDateTimeColumns(
   columns: ColumnMeta[] | undefined,
-): Set<string> {
+): Map<string, string> {
   return useMemo(
     () =>
-      new Set(
+      new Map(
         filterColumnMetaByType(columns ?? [], [JSDataType.Date])?.map(
-          c => c.name,
+          c => [c.name, c.type] as const,
         ),
       ),
     [columns],

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import objectHash from 'object-hash';
 import {
   ColumnMeta,
+  ColumnMetaType,
   filterColumnMetaByType,
   JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
@@ -103,7 +104,7 @@ export function useColumns(
 
 // Derives a map of DateTime/Date column name → ClickHouse type.
 export function useDateTimeColumns(
-  columns: ColumnMeta[] | undefined,
+  columns: ColumnMetaType[] | undefined,
 ): Map<string, string> {
   return useMemo(
     () =>
@@ -114,6 +115,49 @@ export function useDateTimeColumns(
       ),
     [columns],
   );
+}
+
+/**
+ * Resolves the Date/DateTime columns from two sources, with the live
+ * query result taking precedence.
+ *
+ * - **Table schema** (`schemaColumns`): every column on the table, available
+ *   before any query runs — but blind to SELECT aliases and computed
+ *   expressions, which don't exist on the table.
+ * - **Query result** (fed via the returned `onResolvedColumnsChange`): the
+ *   resolved type of every column the current query actually returns, including
+ *   aliases (`Timestamp AS time`) and expressions (`toDate(Timestamp)`). These
+ *   are exactly the cells a user can click to filter on, so they win.
+ */
+export function useResolvedDateTimeColumns(
+  schemaColumns: ColumnMetaType[] | undefined,
+): {
+  dateTimeColumns: Map<string, string>;
+  onResolvedColumnsChange: (meta: ColumnMetaType[]) => void;
+} {
+  const schemaDateTimeColumns = useDateTimeColumns(schemaColumns);
+
+  const [resultColumns, setResultColumns] = useState<ColumnMetaType[]>([]);
+  const resultDateTimeColumns = useDateTimeColumns(resultColumns);
+
+  const dateTimeColumns = useMemo(() => {
+    const merged = new Map(schemaDateTimeColumns);
+
+    // The query result is authoritative for the columns it returns. A column
+    // can be a date on the table yet non-date as displayed (e.g.
+    // `toString(Timestamp) AS Timestamp`); drop any such column so its string
+    // value isn't wrongly date-wrapped.
+    for (const { name } of resultColumns) {
+      if (!resultDateTimeColumns.has(name)) merged.delete(name);
+    }
+    // Add or override the columns the query reports as dates — this is what
+    // brings in aliases and computed expressions absent from the schema.
+    for (const [name, type] of resultDateTimeColumns) merged.set(name, type);
+
+    return merged;
+  }, [schemaDateTimeColumns, resultDateTimeColumns, resultColumns]);
+
+  return { dateTimeColumns, onResolvedColumnsChange: setResultColumns };
 }
 
 export function useJsonColumns(

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import objectHash from 'object-hash';
 import {
   ColumnMeta,
@@ -99,6 +99,20 @@ export function useColumns(
     enabled: !!databaseName && !!tableName && !!connectionId,
     ...options,
   });
+}
+
+export function useDateTimeColumns(
+  columns: ColumnMeta[] | undefined,
+): Set<string> {
+  return useMemo(
+    () =>
+      new Set(
+        filterColumnMetaByType(columns ?? [], [JSDataType.Date])?.map(
+          c => c.name,
+        ),
+      ),
+    [columns],
+  );
 }
 
 export function useJsonColumns(

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -280,15 +280,17 @@ function extractInClauses(condition: string): Array<{
           ? trimmedValues.slice(1, -1)
           : trimmedValues;
 
-      // Unwrap DateTime literals emitted by filtersToQuery for DateTime columns
-      // (parseDateTime64BestEffort('X', 9)) back into the plain quoted literal
-      // 'X' before splitting on commas. The wrapper itself contains an
-      // unquoted comma (before the `9` argument), so this must run before
-      // splitValuesOnComma. The capture group `'(?:[^']|'')*'` consumes the
-      // SQL-escaped quoted string ('' for embedded quotes), keeping the
-      // round-trip exact even if a value contained quotes.
+      // Unwrap the date-value expressions filtersToQuery emits for date columns
+      // back into the plain quoted literal 'X' before splitting on commas. The
+      // DateTime64 wrapper contains an unquoted comma (before its precision
+      // argument), so this must run before splitValuesOnComma. The capture
+      // group `'(?:[^']|'')*'` consumes the SQL-escaped quoted string ('' for
+      // embedded quotes), keeping the round-trip exact even if a value
+      // contained quotes; the optional `, N` covers parseDateTime64BestEffort's
+      // precision argument. Matches the four producers in `dateTimeValueExpr`:
+      // parseDateTime64BestEffort, parseDateTimeBestEffort, toDate32, toDate.
       const unwrapped = withoutParens.replace(
-        /parseDateTime64BestEffort\(('(?:[^']|'')*'),\s*9\)/g,
+        /(?:parseDateTime64BestEffort|parseDateTimeBestEffort|toDate32|toDate)\(('(?:[^']|'')*')(?:\s*,\s*\d+)?\)/g,
         '$1',
       );
 
@@ -374,7 +376,7 @@ export const useSearchPageFilterState = ({
 }: {
   searchQuery?: Filter[];
   onFilterChange: (filters: Filter[]) => void;
-  dateTimeColumns?: Set<string>;
+  dateTimeColumns?: ReadonlyMap<string, string>;
 }) => {
   const parsedQuery = useMemo(() => {
     try {

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -280,7 +280,19 @@ function extractInClauses(condition: string): Array<{
           ? trimmedValues.slice(1, -1)
           : trimmedValues;
 
-      const valuesArray = splitValuesOnComma(withoutParens);
+      // Unwrap DateTime literals emitted by filtersToQuery for DateTime columns
+      // (parseDateTime64BestEffort('X', 9)) back into the plain quoted literal
+      // 'X' before splitting on commas. The wrapper itself contains an
+      // unquoted comma (before the `9` argument), so this must run before
+      // splitValuesOnComma. The capture group `'(?:[^']|'')*'` consumes the
+      // SQL-escaped quoted string ('' for embedded quotes), keeping the
+      // round-trip exact even if a value contained quotes.
+      const unwrapped = withoutParens.replace(
+        /parseDateTime64BestEffort\(('(?:[^']|'')*'),\s*9\)/g,
+        '$1',
+      );
+
+      const valuesArray = splitValuesOnComma(unwrapped);
 
       results.push({
         key: keyStr,
@@ -358,9 +370,11 @@ export const parseQuery = (
 export const useSearchPageFilterState = ({
   searchQuery = [],
   onFilterChange,
+  dateTimeColumns,
 }: {
   searchQuery?: Filter[];
   onFilterChange: (filters: Filter[]) => void;
+  dateTimeColumns?: Set<string>;
 }) => {
   const parsedQuery = useMemo(() => {
     try {
@@ -383,9 +397,9 @@ export const useSearchPageFilterState = ({
 
   const updateFilterQuery = useCallback(
     (newFilters: FilterState) => {
-      onFilterChange(filtersToQuery(newFilters));
+      onFilterChange(filtersToQuery(newFilters, { dateTimeColumns }));
     },
-    [onFilterChange],
+    [onFilterChange, dateTimeColumns],
   );
 
   const setFilterValue = useCallback(

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -170,9 +170,12 @@ describe('filters', () => {
     });
 
     describe('dateTimeColumns', () => {
-      const dateTimeColumns = new Set(['Timestamp']);
+      const dateTimeColumns = new Map<string, string>([
+        ['Timestamp', 'DateTime64(9)'],
+        ['TimestampTime', 'DateTime'],
+      ]);
 
-      it('wraps an excluded DateTime value in parseDateTime64BestEffort', () => {
+      it('wraps an excluded DateTime64 value in parseDateTime64BestEffort', () => {
         const filters = {
           Timestamp: {
             included: new Set<string | boolean>(),
@@ -190,7 +193,7 @@ describe('filters', () => {
         ]);
       });
 
-      it('wraps an included DateTime value in parseDateTime64BestEffort', () => {
+      it('wraps an included DateTime64 value in parseDateTime64BestEffort', () => {
         const filters = {
           Timestamp: {
             included: new Set<string | boolean>([
@@ -208,7 +211,59 @@ describe('filters', () => {
         ]);
       });
 
-      it('wraps multiple DateTime values', () => {
+      it('wraps a plain DateTime column with parseDateTimeBestEffort (IN does not promote DateTime↔DateTime64)', () => {
+        const filters = {
+          TimestampTime: {
+            included: new Set<string | boolean>(['2026-06-17T11:56:41Z']),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "TimestampTime IN (parseDateTimeBestEffort('2026-06-17T11:56:41Z'))",
+          },
+        ]);
+      });
+
+      it('matches the precision of a non-9 DateTime64 column', () => {
+        const filters = {
+          ts3: {
+            included: new Set<string | boolean>(['2026-06-17T11:56:41.123Z']),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(
+          filtersToQuery(filters, {
+            dateTimeColumns: new Map([['ts3', "DateTime64(3, 'UTC')"]]),
+          }),
+        ).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "ts3 IN (parseDateTime64BestEffort('2026-06-17T11:56:41.123Z', 3))",
+          },
+        ]);
+      });
+
+      it('wraps a Date column with toDate', () => {
+        const filters = {
+          day: {
+            included: new Set<string | boolean>(['2026-06-17']),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(
+          filtersToQuery(filters, {
+            dateTimeColumns: new Map([['day', 'Date']]),
+          }),
+        ).toEqual([
+          { type: 'sql', condition: "day IN (toDate('2026-06-17'))" },
+        ]);
+      });
+
+      it('wraps multiple DateTime64 values', () => {
         const filters = {
           Timestamp: {
             included: new Set<string | boolean>(),

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -168,6 +168,136 @@ describe('filters', () => {
         },
       ]);
     });
+
+    describe('dateTimeColumns', () => {
+      const dateTimeColumns = new Set(['Timestamp']);
+
+      it('wraps an excluded DateTime value in parseDateTime64BestEffort', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>(),
+            excluded: new Set<string | boolean>([
+              '2026-06-16T15:35:16.731000000Z',
+            ]),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "Timestamp NOT IN (parseDateTime64BestEffort('2026-06-16T15:35:16.731000000Z', 9))",
+          },
+        ]);
+      });
+
+      it('wraps an included DateTime value in parseDateTime64BestEffort', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>([
+              '2026-06-16T15:35:16.731000000Z',
+            ]),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "Timestamp IN (parseDateTime64BestEffort('2026-06-16T15:35:16.731000000Z', 9))",
+          },
+        ]);
+      });
+
+      it('wraps multiple DateTime values', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>(),
+            excluded: new Set<string | boolean>(['2026-06-16', '2026-06-17']),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "Timestamp NOT IN (parseDateTime64BestEffort('2026-06-16', 9), parseDateTime64BestEffort('2026-06-17', 9))",
+          },
+        ]);
+      });
+
+      it('wraps both included and excluded values for the same DateTime key', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>(['2026-06-16']),
+            excluded: new Set<string | boolean>(['2026-06-17']),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          {
+            type: 'sql',
+            condition:
+              "Timestamp IN (parseDateTime64BestEffort('2026-06-16', 9))",
+          },
+          {
+            type: 'sql',
+            condition:
+              "Timestamp NOT IN (parseDateTime64BestEffort('2026-06-17', 9))",
+          },
+        ]);
+      });
+
+      it('does not wrap when stringifyKeys is set (string comparison)', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>(),
+            excluded: new Set<string | boolean>(['2026-06-16']),
+          },
+        };
+        expect(
+          filtersToQuery(filters, { dateTimeColumns, stringifyKeys: true }),
+        ).toEqual([
+          {
+            type: 'sql',
+            condition: "toString(Timestamp) NOT IN ('2026-06-16')",
+          },
+        ]);
+      });
+
+      it('does not wrap non-DateTime keys', () => {
+        const filters = {
+          ServiceName: {
+            included: new Set<string | boolean>(['api']),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          { type: 'sql', condition: "ServiceName IN ('api')" },
+        ]);
+      });
+
+      it('does not wrap boolean values on a DateTime key', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>([true]),
+            excluded: new Set<string | boolean>(),
+          },
+        };
+        expect(filtersToQuery(filters, { dateTimeColumns })).toEqual([
+          { type: 'sql', condition: 'Timestamp IN (true)' },
+        ]);
+      });
+
+      it('leaves output unchanged when no dateTimeColumns are provided', () => {
+        const filters = {
+          Timestamp: {
+            included: new Set<string | boolean>(),
+            excluded: new Set<string | boolean>(['2026-06-16']),
+          },
+        };
+        expect(filtersToQuery(filters)).toEqual([
+          { type: 'sql', condition: "Timestamp NOT IN ('2026-06-16')" },
+        ]);
+      });
+    });
   });
 
   describe('validateSavedFilterValues', () => {

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -18,7 +18,10 @@ const escapeString = (s: string) => {
 
 export const filtersToQuery = (
   filters: FilterState,
-  { stringifyKeys = false }: { stringifyKeys?: boolean } = {},
+  {
+    stringifyKeys = false,
+    dateTimeColumns,
+  }: { stringifyKeys?: boolean; dateTimeColumns?: Set<string> } = {},
 ): Filter[] => {
   return Object.entries(filters)
     .filter(
@@ -31,11 +34,23 @@ export const filtersToQuery = (
       const conditions: Filter[] = [];
       const actualKey = stringifyKeys ? `toString(${key})` : key;
 
+      // DateTime/DateTime64 columns can't be compared against a bare string
+      // literal in ClickHouse, so wrap each value in parseDateTime64BestEffort.
+      // Skip when stringifyKeys is set: the key is cast via toString(), so the
+      // comparison is string-vs-string and a plain literal is correct.
+      const isDateTime = !stringifyKeys && (dateTimeColumns?.has(key) ?? false);
+      const formatValue = (v: string | boolean): string | boolean =>
+        typeof v !== 'string'
+          ? v
+          : isDateTime
+            ? `parseDateTime64BestEffort('${escapeString(v)}', 9)`
+            : `'${escapeString(v)}'`;
+
       if (values.included.size > 0) {
         conditions.push({
           type: 'sql' as const,
           condition: `${actualKey} IN (${Array.from(values.included)
-            .map(v => (typeof v === 'string' ? `'${escapeString(v)}'` : v))
+            .map(formatValue)
             .join(', ')})`,
         });
       }
@@ -43,7 +58,7 @@ export const filtersToQuery = (
         conditions.push({
           type: 'sql' as const,
           condition: `${actualKey} NOT IN (${Array.from(values.excluded)
-            .map(v => (typeof v === 'string' ? `'${escapeString(v)}'` : v))
+            .map(formatValue)
             .join(', ')})`,
         });
       }

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -16,12 +16,41 @@ const escapeString = (s: string) => {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "''");
 };
 
+// Wrap a quoted string literal in a ClickHouse expression whose result type
+// matches the date column's type.
+const dateTimeValueExpr = (chType: string, quotedValue: string): string => {
+  const dt64 = chType.match(/DateTime64\((\d+)/);
+
+  if (dt64) {
+    return `parseDateTime64BestEffort(${quotedValue}, ${dt64[1]})`;
+  }
+
+  if (/\bDateTime\b/.test(chType)) {
+    return `parseDateTimeBestEffort(${quotedValue})`;
+  }
+
+  if (/\bDate32\b/.test(chType)) {
+    return `toDate32(${quotedValue})`;
+  }
+
+  if (/\bDate\b/.test(chType)) {
+    return `toDate(${quotedValue})`;
+  }
+
+  // Fallback for an unexpected type; DateTime64(9) covers the widest range.
+  return `parseDateTime64BestEffort(${quotedValue}, 9)`;
+};
+
 export const filtersToQuery = (
   filters: FilterState,
   {
     stringifyKeys = false,
     dateTimeColumns,
-  }: { stringifyKeys?: boolean; dateTimeColumns?: Set<string> } = {},
+  }: {
+    stringifyKeys?: boolean;
+    /** Map of DateTime/Date column name → its ClickHouse type. */
+    dateTimeColumns?: ReadonlyMap<string, string>;
+  } = {},
 ): Filter[] => {
   return Object.entries(filters)
     .filter(
@@ -35,15 +64,14 @@ export const filtersToQuery = (
       const actualKey = stringifyKeys ? `toString(${key})` : key;
 
       // DateTime/DateTime64 columns can't be compared against a bare string
-      // literal in ClickHouse, so wrap each value in parseDateTime64BestEffort.
-      // Skip when stringifyKeys is set: the key is cast via toString(), so the
-      // comparison is string-vs-string and a plain literal is correct.
-      const isDateTime = !stringifyKeys && (dateTimeColumns?.has(key) ?? false);
+      // literal in ClickHouse, so wrap each value in a parse/convert expression whose
+      // result type matches the column type.
+      const chType = stringifyKeys ? undefined : dateTimeColumns?.get(key);
       const formatValue = (v: string | boolean): string | boolean =>
         typeof v !== 'string'
           ? v
-          : isDateTime
-            ? `parseDateTime64BestEffort('${escapeString(v)}', 9)`
+          : chType != null
+            ? dateTimeValueExpr(chType, `'${escapeString(v)}'`)
             : `'${escapeString(v)}'`;
 
       if (values.included.size > 0) {


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

On the search page, including or excluding a value from a DateTime column (e.g. `Timestamp`, type `DateTime64(9)`) generated SQL that ClickHouse rejects:

```sql
Timestamp NOT IN ('2026-06-16T15:35:16.731000000Z')
-- DB::Exception: Cannot convert string '2026-06-16T15:35:16.731000000Z' to type DateTime64(9)
```

The filter value was emitted as a bare string literal, but ClickHouse will not implicitly cast an ISO-8601 string to `DateTime64`, so the entire query failed and the filter was unusable. This is reachable from the grid cell popover (the "Include"/"Exclude" actions in `DBRowTableFieldWithPopover`) — both polarities were broken.

`filtersToQuery` now wraps DateTime column values in `parseDateTime64BestEffort('<value>', 9)` instead of emitting a plain literal, reusing the exact pattern the codebase already uses for DateTime values in `useRowWhere.tsx`. The result for the case above is `Timestamp NOT IN (parseDateTime64BestEffort('2026-06-16T15:35:16.731000000Z', 9))`, which is valid SQL.

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->

| Before | After |
| :----- | :---- |
| <video src="https://github.com/user-attachments/assets/d91d3be2-4b02-4b4e-a579-d3649174745a" controls></video> | <video src="https://github.com/user-attachments/assets/0c944efb-2fcc-4eb3-aba8-a49798ad8534" controls></video> |

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/search`

**Steps:**

1. Go the search page and apply timestamp filtering (exclude and include).


### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4506
- Related PRs:
