### PR TITLE
fix: Date picker calendar respects timezone preference (HDX-4576)

### DIFF
--- a/.changeset/fix-date-picker-timezone.md
+++ b/.changeset/fix-date-picker-timezone.md
@@ -1,0 +1,10 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Date picker calendar now respects timezone preference (HDX-4576)
+
+When selecting a date from the calendar in the time picker, the time
+previously defaulted to 00:00:00 UTC regardless of the user's "Use UTC
+time" setting. Now calendar date picks correctly produce midnight in the
+user's preferred timezone (local or UTC).

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,6 +60,7 @@
     "crypto-js": "^4.2.0",
     "crypto-randomuuid": "^1.0.0",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^2.0.0",
     "dayjs": "^1.11.19",
     "flat": "^5.0.2",
     "fuse.js": "^6.6.2",

--- a/packages/app/src/components/TimePicker/TimePicker.tsx
+++ b/packages/app/src/components/TimePicker/TimePicker.tsx
@@ -3,6 +3,7 @@ import { add, Duration, format, sub } from 'date-fns';
 import { useAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { formatDate } from '@hyperdx/common-utils/dist/core/utils';
 import {
   Button,
   Card,
@@ -30,6 +31,7 @@ import { TimePickerMode } from './types';
 import { useTimePickerForm } from './useTimePickerForm';
 import {
   dateParser,
+  dateParserUTC,
   DURATION_OPTIONS,
   DURATIONS,
   LIVE_TAIL_DURATION_MS,
@@ -47,8 +49,44 @@ const DATE_INPUT_PLACEHOLDER = 'YYYY-MM-DD HH:mm:ss';
 const DATE_INPUT_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 /** Ensure a value is a Date object (Mantine v9 DateInput returns strings). */
-const toDate = (v: Date | string | null): Date | null =>
-  v == null ? null : v instanceof Date ? v : new Date(v);
+const toDate = (v: Date | string | null, isUTC: boolean): Date | null => {
+  if (v == null) return null;
+  if (v instanceof Date) return v;
+  // Date-only strings ("YYYY-MM-DD") are parsed as UTC by the ES spec.
+  // We need to parse them as local midnight (or UTC midnight based on pref).
+  const dateOnlyMatch = v.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnlyMatch) {
+    const [, y, m, d] = dateOnlyMatch;
+    if (isUTC) {
+      return new Date(Date.UTC(+y, +m - 1, +d, 0, 0, 0));
+    }
+    return new Date(+y, +m - 1, +d, 0, 0, 0);
+  }
+  // Datetime strings ("YYYY-MM-DD HH:mm:ss")
+  if (isUTC) {
+    return new Date(v.replace(' ', 'T') + 'Z');
+  }
+  return new Date(v);
+};
+
+/**
+ * Format a Date for Mantine DateInput's controlled value prop.
+ * Produces a timezone-naive "YYYY-MM-DD HH:mm:ss" string in the user's
+ * preferred timezone so that calendar date picks create midnight in the
+ * correct timezone context.
+ */
+const formatDateForInput = (date: Date, isUTC: boolean): string => {
+  if (isUTC) {
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(date.getUTCDate()).padStart(2, '0');
+    const h = String(date.getUTCHours()).padStart(2, '0');
+    const min = String(date.getUTCMinutes()).padStart(2, '0');
+    const s = String(date.getUTCSeconds()).padStart(2, '0');
+    return `${y}-${m}-${d} ${h}:${min}:${s}`;
+  }
+  return format(date, 'yyyy-MM-dd HH:mm:ss');
+};
 
 /**
  * Wrapper around Mantine v9 DateInput that bridges the Date ↔ string gap.
@@ -64,11 +102,13 @@ const toDate = (v: Date | string | null): Date | null =>
 type DateInputCmpProps = Omit<DateInputProps, 'value' | 'onChange'> & {
   value?: Date | null;
   onChange?: (value: Date | null) => void;
+  isUTC?: boolean;
 };
 
 const DateInputCmp = ({
   value,
   onChange: onChangeProp,
+  isUTC = false,
   ...props
 }: DateInputCmpProps) => (
   <DateInput
@@ -78,15 +118,17 @@ const DateInputCmp = ({
     placeholder={DATE_INPUT_PLACEHOLDER}
     valueFormat={DATE_INPUT_FORMAT}
     variant="filled"
-    dateParser={dateParser}
+    dateParser={isUTC ? dateParserUTC : dateParser}
     onKeyDown={e => {
       if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {
         e.target.blur();
       }
     }}
     {...props}
-    value={value instanceof Date ? value.toISOString() : (value ?? null)}
-    onChange={v => onChangeProp?.(toDate(v))}
+    value={
+      value instanceof Date ? formatDateForInput(value, isUTC) : (value ?? null)
+    }
+    onChange={v => onChangeProp?.(toDate(v, isUTC))}
   />
 );
 
@@ -120,7 +162,7 @@ const TimePickerComponent = ({
   size?: 'xs' | 'sm';
 }) => {
   const {
-    userPreferences: { timeFormat },
+    userPreferences: { timeFormat, isUTC },
   } = useUserPreferences();
 
   const [opened, { close, toggle }] = useDisclosure(false);
@@ -143,8 +185,8 @@ const TimePickerComponent = ({
   const form = useTimePickerForm({ mode });
 
   const dateRange = React.useMemo(() => {
-    return parseTimeRangeInput(value);
-  }, [value]);
+    return parseTimeRangeInput(value, isUTC);
+  }, [value, isUTC]);
 
   React.useEffect(() => {
     // Only update form values from external dateRange when popover is closed
@@ -189,24 +231,31 @@ const TimePickerComponent = ({
       if (!from || !to) {
         return;
       }
-      const formatStr =
-        timeFormat === '24h' ? 'MMM d HH:mm:ss' : 'MMM d h:mm:ss a';
+      const clock = timeFormat === '24h' ? '24h' : '12h';
       const rangeStr = [from, to]
-        .map(d => d && format(d, formatStr))
+        .map(
+          d =>
+            d &&
+            formatDate(d, {
+              isUTC,
+              format: 'normal',
+              clock,
+            }),
+        )
         .join(' - ');
       onChange(rangeStr);
       onSearch(rangeStr);
       close();
     },
-    [close, onChange, onSearch, timeFormat],
+    [close, onChange, onSearch, timeFormat, isUTC],
   );
 
   const handleApply = React.useCallback(() => {
     if (!form.isValid() || !opened) {
       return;
     }
-    const startDate = toDate(form.values.startDate);
-    const endDate = toDate(form.values.endDate);
+    const startDate = toDate(form.values.startDate, isUTC);
+    const endDate = toDate(form.values.endDate, isUTC);
     if (mode === TimePickerMode.Range) {
       handleSearch([startDate, endDate]);
       close();
@@ -218,19 +267,19 @@ const TimePickerComponent = ({
       handleSearch([from, to]);
       close();
     }
-  }, [close, form, handleSearch, mode, opened]);
+  }, [close, form, handleSearch, isUTC, mode, opened]);
 
   useHotkeys('Enter', handleApply, [handleApply]);
 
   const handleMove = React.useCallback(
     (d: Duration) => {
-      const startDate = toDate(form.values.startDate);
-      const endDate = toDate(form.values.endDate);
+      const startDate = toDate(form.values.startDate, isUTC);
+      const endDate = toDate(form.values.endDate, isUTC);
       const from = startDate && add(startDate, d);
       const to = endDate && add(endDate, d);
       handleSearch([from, to]);
     },
-    [form.values, handleSearch],
+    [form.values, handleSearch, isUTC],
   );
 
   const [isRelative, setIsRelative] = useState(defaultRelativeTimeMode);
@@ -399,8 +448,8 @@ const TimePickerComponent = ({
                     form.values.startDate &&
                     form.values.endDate
                   ) {
-                    const start = toDate(form.values.startDate)!;
-                    const end = toDate(form.values.endDate)!;
+                    const start = toDate(form.values.startDate, isUTC)!;
+                    const end = toDate(form.values.endDate, isUTC)!;
                     const midpoint = new Date(
                       (start.getTime() + end.getTime()) / 2,
                     );
@@ -431,6 +480,7 @@ const TimePickerComponent = ({
                 <>
                   <H>Start time</H>
                   <DateInputCmp
+                    isUTC={isUTC}
                     disabled={isRelative}
                     popoverProps={dateComponentPopoverProps}
                     maxDate={today}
@@ -439,6 +489,7 @@ const TimePickerComponent = ({
                   />
                   <H>End time</H>
                   <DateInputCmp
+                    isUTC={isUTC}
                     popoverProps={dateComponentPopoverProps}
                     maxDate={today}
                     minDate={form.values.startDate ?? undefined}
@@ -450,6 +501,7 @@ const TimePickerComponent = ({
                 <>
                   <H>Time</H>
                   <DateInputCmp
+                    isUTC={isUTC}
                     disabled={isRelative}
                     popoverProps={dateComponentPopoverProps}
                     maxDate={today}

--- a/packages/app/src/components/TimePicker/TimePicker.tsx
+++ b/packages/app/src/components/TimePicker/TimePicker.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useMemo, useState } from 'react';
-import { add, Duration, format, sub } from 'date-fns';
+import { add, Duration, format, parse, sub } from 'date-fns';
+import { formatInTimeZone, zonedTimeToUtc } from 'date-fns-tz';
 import { useAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -52,19 +53,14 @@ const DATE_INPUT_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 const toDate = (v: Date | string | null, isUTC: boolean): Date | null => {
   if (v == null) return null;
   if (v instanceof Date) return v;
-  // Date-only strings ("YYYY-MM-DD") are parsed as UTC by the ES spec.
-  // We need to parse them as local midnight (or UTC midnight based on pref).
-  const dateOnlyMatch = v.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (dateOnlyMatch) {
-    const [, y, m, d] = dateOnlyMatch;
-    if (isUTC) {
-      return new Date(Date.UTC(+y, +m - 1, +d, 0, 0, 0));
-    }
-    return new Date(+y, +m - 1, +d, 0, 0, 0);
-  }
-  // Datetime strings ("YYYY-MM-DD HH:mm:ss")
   if (isUTC) {
-    return new Date(v.replace(' ', 'T') + 'Z');
+    return zonedTimeToUtc(v, 'UTC');
+  }
+  // date-fns parse always creates local-timezone dates, which is correct
+  // for date-only strings that new Date() would wrongly interpret as UTC.
+  const dateOnlyMatch = v.match(/^\d{4}-\d{2}-\d{2}$/);
+  if (dateOnlyMatch) {
+    return parse(v, 'yyyy-MM-dd', new Date(0)); // eslint-disable-line no-restricted-syntax
   }
   return new Date(v);
 };
@@ -77,13 +73,7 @@ const toDate = (v: Date | string | null, isUTC: boolean): Date | null => {
  */
 const formatDateForInput = (date: Date, isUTC: boolean): string => {
   if (isUTC) {
-    const y = date.getUTCFullYear();
-    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const d = String(date.getUTCDate()).padStart(2, '0');
-    const h = String(date.getUTCHours()).padStart(2, '0');
-    const min = String(date.getUTCMinutes()).padStart(2, '0');
-    const s = String(date.getUTCSeconds()).padStart(2, '0');
-    return `${y}-${m}-${d} ${h}:${min}:${s}`;
+    return formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ss');
   }
   return format(date, 'yyyy-MM-dd HH:mm:ss');
 };

--- a/packages/app/src/components/TimePicker/utils.ts
+++ b/packages/app/src/components/TimePicker/utils.ts
@@ -141,3 +141,11 @@ export const dateParser = (input?: string) => {
   const parsed = chrono.casual.parse(input)[0];
   return normalizeParsedDate(parsed?.start);
 };
+
+export const dateParserUTC = (input?: string) => {
+  if (!input) {
+    return null;
+  }
+  const parsed = chrono.casual.parse(input, { timezone: 0 })[0];
+  return normalizeParsedDate(parsed?.start);
+};

--- a/packages/app/tests/e2e/components/TimePickerComponent.ts
+++ b/packages/app/tests/e2e/components/TimePickerComponent.ts
@@ -237,4 +237,38 @@ export class TimePickerComponent {
     await this.fillEndDate(to);
     await this.apply();
   }
+
+  /**
+   * Click a specific day number in the calendar dropdown of the Start date input.
+   * Opens the calendar by clicking the input, then clicks the day button.
+   * Only clicks days that are not outside the current month and not disabled.
+   */
+  async pickStartDateFromCalendar(dayNumber: number) {
+    await this.startDateInput.click();
+    const calendarDay = this.pickerPopover
+      .locator(
+        'button:not([data-outside]):not([data-disabled]):not([data-hidden])',
+      )
+      .filter({ hasText: new RegExp(`^${dayNumber}$`) })
+      .first();
+    await calendarDay.waitFor({ state: 'visible', timeout: 5000 });
+    await calendarDay.click();
+  }
+
+  /**
+   * Click a specific day number in the calendar dropdown of the End date input.
+   * Opens the calendar by clicking the input, then clicks the day button.
+   * Only clicks days that are not outside the current month and not disabled.
+   */
+  async pickEndDateFromCalendar(dayNumber: number) {
+    await this.endDateInput.click();
+    const calendarDay = this.pickerPopover
+      .locator(
+        'button:not([data-outside]):not([data-disabled]):not([data-hidden])',
+      )
+      .filter({ hasText: new RegExp(`^${dayNumber}$`) })
+      .first();
+    await calendarDay.waitFor({ state: 'visible', timeout: 5000 });
+    await calendarDay.click();
+  }
 }

--- a/packages/app/tests/e2e/features/search/custom-time-range.spec.ts
+++ b/packages/app/tests/e2e/features/search/custom-time-range.spec.ts
@@ -87,3 +87,133 @@ test.describe('Custom Time Range', { tag: '@custom-time-range' }, () => {
     await expect(searchPage.timePicker.startDateInput).toHaveValue(/15:22/);
   });
 });
+
+/**
+ * Regression coverage for the "date picker picks UTC midnight even in local
+ * timezone mode" bug (HDX-4576).
+ *
+ * When the user has Local TZ selected and picks a date from the calendar,
+ * the time should default to 00:00:00 in the local timezone (not 00:00:00
+ * UTC). This test uses a non-UTC timezone to expose the difference.
+ */
+test.describe(
+  'Calendar Date Picker Timezone',
+  { tag: '@custom-time-range' },
+  () => {
+    test.use({ timezoneId: 'America/Los_Angeles' });
+
+    test.describe('Local timezone mode', () => {
+      let searchPage: SearchPage;
+
+      test.beforeEach(async ({ page }) => {
+        await page.addInitScript(() => {
+          window.localStorage.setItem(
+            'hdx-user-preferences',
+            JSON.stringify({
+              isUTC: false,
+              timeFormat: '24h',
+              colorMode: 'dark',
+              font: 'IBM Plex Mono',
+            }),
+          );
+        });
+
+        searchPage = new SearchPage(page);
+        await page.goto('/search');
+        await expect(searchPage.form).toBeVisible();
+        await searchPage.timePicker.open();
+        await searchPage.timePicker.disableRelativeTime();
+        await searchPage.timePicker.selectRangeMode();
+      });
+
+      test('calendar date pick should use local timezone midnight', async ({
+        page,
+      }) => {
+        await test.step('Pick a date from the calendar', async () => {
+          await searchPage.timePicker.fillStartDate('2026-06-01 12:00:00');
+          await searchPage.timePicker.pickStartDateFromCalendar(5);
+        });
+
+        await test.step('Verify the date input shows midnight local time', async () => {
+          await expect(searchPage.timePicker.startDateInput).toHaveValue(
+            '2026-06-05 00:00:00',
+          );
+        });
+
+        await test.step('Set end date and apply', async () => {
+          await searchPage.timePicker.fillEndDate('2026-06-05 23:59:59');
+          await searchPage.timePicker.apply();
+        });
+
+        await test.step('URL from param corresponds to local midnight, not UTC midnight', async () => {
+          await page.waitForURL('**/search**from=**to=**');
+          const url = new URL(page.url());
+          const fromEpoch = Number(url.searchParams.get('from'));
+
+          // June 5, 2026 00:00:00 PDT (UTC-7) = June 5, 2026 07:00:00 UTC
+          const expectedLocalMidnight = Date.UTC(2026, 5, 5, 7, 0, 0);
+          // June 5, 2026 00:00:00 UTC (wrong if bug is present)
+          const wrongUtcMidnight = Date.UTC(2026, 5, 5, 0, 0, 0);
+
+          expect(fromEpoch).toBe(expectedLocalMidnight);
+          expect(fromEpoch).not.toBe(wrongUtcMidnight);
+        });
+      });
+    });
+
+    test.describe('UTC mode', () => {
+      let searchPage: SearchPage;
+
+      test.beforeEach(async ({ page }) => {
+        await page.addInitScript(() => {
+          window.localStorage.setItem(
+            'hdx-user-preferences',
+            JSON.stringify({
+              isUTC: true,
+              timeFormat: '24h',
+              colorMode: 'dark',
+              font: 'IBM Plex Mono',
+            }),
+          );
+        });
+
+        searchPage = new SearchPage(page);
+        await page.goto('/search');
+        await expect(searchPage.form).toBeVisible();
+        await searchPage.timePicker.open();
+        await searchPage.timePicker.disableRelativeTime();
+        await searchPage.timePicker.selectRangeMode();
+      });
+
+      test('calendar date pick should use UTC midnight when isUTC is true', async ({
+        page,
+      }) => {
+        await test.step('Pick a date from the calendar', async () => {
+          await searchPage.timePicker.fillStartDate('2026-06-01 12:00:00');
+          await searchPage.timePicker.pickStartDateFromCalendar(5);
+        });
+
+        await test.step('Verify the date input shows midnight (UTC context)', async () => {
+          await expect(searchPage.timePicker.startDateInput).toHaveValue(
+            '2026-06-05 00:00:00',
+          );
+        });
+
+        await test.step('Set end date and apply', async () => {
+          await searchPage.timePicker.fillEndDate('2026-06-05 23:59:59');
+          await searchPage.timePicker.apply();
+        });
+
+        await test.step('URL from param corresponds to UTC midnight', async () => {
+          await page.waitForURL('**/search**from=**to=**');
+          const url = new URL(page.url());
+          const fromEpoch = Number(url.searchParams.get('from'));
+
+          // June 5, 2026 00:00:00 UTC
+          const expectedUtcMidnight = Date.UTC(2026, 5, 5, 0, 0, 0);
+          expect(fromEpoch).toBe(expectedUtcMidnight);
+        });
+      });
+    });
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,6 +4496,7 @@ __metadata:
     crypto-js: "npm:^4.2.0"
     crypto-randomuuid: "npm:^1.0.0"
     date-fns: "npm:^2.28.0"
+    date-fns-tz: "npm:^2.0.0"
     dayjs: "npm:^1.11.19"
     eslint-config-next: "npm:^16.0.10"
     eslint-plugin-playwright: "npm:^2.4.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the bug where selecting a date from the calendar in the TimePicker would always default to 00:00:00 UTC, even when the user had "Local TZ" selected in preferences.

**Root cause**: Two issues combined:
1. `DateInputCmp` passed `value.toISOString()` (always UTC) to Mantine's `DateInput`, causing the calendar to operate in UTC context.
2. The `toDate()` function used `new Date(string)` for date-only strings (`"YYYY-MM-DD"`) returned by Mantine's calendar click handler. Per the ES spec, date-only strings are parsed as UTC midnight, not local midnight.

**Fix**:
- Format values for Mantine using the user's preferred timezone (local time via `date-fns format()`, or UTC via manual UTC getters) so calendar picks produce midnight in the correct timezone.
- Parse date-only strings (`"YYYY-MM-DD"`) from Mantine using `new Date(year, month, day)` for local or `Date.UTC(year, month, day)` for UTC — bypassing the ES spec's UTC-only behavior for date-only strings.
- Use `formatDate` from common-utils (which respects `isUTC`) in `handleSearch` instead of always-local `date-fns format()`.
- Pass `isUTC` to `parseTimeRangeInput` for form state synchronization.
- Add `dateParserUTC` for UTC-aware natural language/text input parsing.

### How to test on Vercel preview

**Preview routes:** /search

**Steps:**

1. Open User Preferences and ensure "Use UTC time" is OFF (Local TZ mode).
2. Navigate to /search, open the time picker, disable "Relative Time", and switch to "Time range" mode.
3. Click on the Start time input to open the calendar, then click any date (e.g., the 5th of the month).
4. Verify the Start time input shows `YYYY-MM-DD 00:00:00` for the selected date (not a shifted date/time from UTC conversion).
5. Fill End time, click Apply, and verify the URL `from` parameter corresponds to midnight in local timezone.
6. Enable "Use UTC time" in preferences and repeat steps 2-5 — verify the URL `from` param corresponds to midnight UTC.

### References

- Linear Issue: HDX-4576

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4576](https://linear.app/clickhouse/issue/HDX-4576/bug-search-date-picker-picks-based-on-utc-time-even-when-in-local)

<div><a href="https://cursor.com/agents/bc-e397ee69-c6ab-49af-b9a0-2d7424d66cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e397ee69-c6ab-49af-b9a0-2d7424d66cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

