### PR TITLE
fix(search): keep select-alias filters working in Event Patterns

### DIFF
--- a/.changeset/pattern-table-alias-with.md
+++ b/.changeset/pattern-table-alias-with.md
@@ -1,0 +1,13 @@
+---
+'@hyperdx/app': patch
+---
+
+fix(search): keep select-alias filters working in Event Patterns
+
+Filtering on a column the source exposes only under an alias (for example a
+default select of `ServiceName as service`) failed in the Event Patterns view
+with `Unknown expression or table expression identifier 'service'`. The
+results table works because its own SELECT defines the alias, but Event
+Patterns rebuilds the SELECT and did not carry the alias definitions. The
+pattern query now receives the same alias `WITH` clauses already threaded into
+the results, histogram, and heatmap queries, so the filter resolves.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -2221,6 +2221,12 @@ export function DBSearchPage() {
                         config={{
                           ...chartConfig,
                           dateRange: searchedTimeRange,
+                          // Carry the source's select-alias definitions so the
+                          // rebuilt pattern query can filter on aliased columns
+                          // (e.g. `ServiceName as service`) without hitting
+                          // "Unknown identifier". Mirrors the results,
+                          // histogram, and heatmap configs.
+                          with: aliasWith,
                         }}
                         bodyValueExpression={
                           searchedSource

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -552,7 +552,7 @@ describe('renderChartConfig', () => {
         );
 
       // Two chunked windows of the same chart (most recent window first,
-      // older windows are end-exclusive — mirrors fetchDataInChunks).
+      // older windows are end-exclusive, mirroring fetchDataInChunks).
       const recentChunk = await renderWindow(
         [new Date('2025-02-12T18:00:00Z'), rankingRange[1]],
         true,
@@ -562,7 +562,7 @@ describe('renderChartConfig', () => {
         false,
       );
 
-      // The CTE end is the first `) SELECT` — the outer query starts there.
+      // The CTE end is the first `) SELECT`; the outer query starts there.
       const cteOf = (sql: string) => {
         const start = sql.indexOf('`__hdx_series_limit` AS (');
         const end = sql.indexOf(') SELECT ');
@@ -667,7 +667,7 @@ describe('renderChartConfig', () => {
         ),
       );
       expect(sql).toContain('__hdx_series_limit');
-      // Each column gets its own NULL check, split on the top-level comma — not
+      // Each column gets its own NULL check, split on the top-level comma, not
       // the comma inside Map['...'].
       expect(sql).toMatch(
         /LogAttributes\[['"]agentToServer\.capabilities['"]\]\s+IS\s+NOT\s+NULL/,
@@ -3281,7 +3281,7 @@ describe('renderChartConfig', () => {
         undefined,
       );
 
-      // PromQL configs return empty SQL — queries go through the Prometheus API route
+      // PromQL configs return empty SQL; queries go through the Prometheus API route
       expect(generatedSql.sql).toBe('');
       expect(generatedSql.params).toEqual({});
     });

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -6,6 +6,7 @@ import {
   timeFilterExpr,
 } from '@/core/renderChartConfig';
 import {
+  BuilderChartConfig,
   ChartConfigWithOptDateRange,
   DisplayType,
   MetricsDataType,
@@ -1211,6 +1212,61 @@ describe('renderChartConfig', () => {
       expect(
         mockMetadata.getMaterializedColumnsLookupTable,
       ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Event Patterns query with select-alias filter (HDX-1879)', () => {
+    // The Event Patterns view rebuilds the SELECT (sampled body + timestamp,
+    // ORDER BY rand() LIMIT) instead of reusing the results-table SELECT. When
+    // the user filters on a column the source exposes only under an alias
+    // (e.g. `ServiceName as service`), that alias is out of scope in the
+    // rebuilt query unless its definition is carried through `with`. Threading
+    // the source's alias map into the pattern config defines the alias in a
+    // WITH clause so the filter resolves.
+    const patternConfig = (
+      withClauses: BuilderChartConfig['with'],
+    ): ChartConfigWithOptDateRange => ({
+      connection: 'test-connection',
+      from: { databaseName: 'default', tableName: 'otel_logs' },
+      with: withClauses,
+      select: 'Body as __hdx_pattern_field, Timestamp as __hdx_timestamp',
+      where: "service = 'api'",
+      whereLanguage: 'sql',
+      orderBy: [{ ordering: 'DESC', valueExpression: 'rand()' }],
+      limit: { limit: 10000 },
+      timestampValueExpression: 'Timestamp',
+      dateRange: [new Date('2025-01-01'), new Date('2025-01-02')],
+    });
+
+    it('defines the select alias in a WITH clause so the filter resolves', async () => {
+      const generatedSql = await renderChartConfig(
+        patternConfig([
+          { name: 'service', sql: chSql`ServiceName`, isSubquery: false },
+        ]),
+        mockMetadata,
+        querySettings,
+      );
+      const sql = parameterizedQueryToSql(generatedSql);
+
+      // Alias is defined in the rebuilt pattern query...
+      expect(sql).toContain('(ServiceName) AS service');
+      // ...and the filter still references it.
+      expect(sql).toContain("service = 'api'");
+    });
+
+    it('omits the alias definition when no alias map is threaded (the bug)', async () => {
+      const generatedSql = await renderChartConfig(
+        patternConfig(undefined),
+        mockMetadata,
+        querySettings,
+      );
+      const sql = parameterizedQueryToSql(generatedSql);
+
+      // Without the threaded WITH clauses the alias is undefined, so the
+      // filter references a `service` column that does not exist in the
+      // rebuilt SELECT (ClickHouse rejects this with "Unknown identifier").
+      expect(sql).not.toContain('AS service');
+      expect(sql).toContain("service = 'api'");
     });
   });
 


### PR DESCRIPTION
Filtering Event Patterns on a column the source exposes only under an alias (for example a default select of `ServiceName as service`) failed with `Unknown expression or table expression identifier 'service'`. The results table works because its own SELECT defines the alias, but Event Patterns rebuilds the SELECT (sampled body and timestamp, `ORDER BY rand() LIMIT`) and did not carry the alias definitions, so the filter referenced a column that did not exist in the rebuilt query.

## Summary

The `PatternTable` config now receives the same alias `WITH` clauses (`aliasWith`) already threaded into the results, histogram, and heatmap configs in `DBSearchPage`. `usePatterns` spreads the config into the sampled query, so the rebuilt pattern query defines the alias in a `WITH` clause and the filter resolves.

This is the one-field change at the `PatternTable` call site plus a regression test. It reuses the existing `useAliasMapFromChartConfig` -> `aliasMapToWithClauses` -> `with` mechanism, no new code paths.

<img width="2549" height="1317" alt="image" src="https://github.com/user-attachments/assets/b0acc59f-2881-476e-88d9-2b71f45dff8f" />


## Why this was invisible to the results table

The results table renders the source's own SELECT, which defines `service`. ClickHouse resolves a `WITH (ServiceName) AS service` expression alias inside `WHERE`, so the filter works there. Event Patterns, histogram, and heatmap all rebuild the SELECT; the other two already passed `aliasWith`, Event Patterns was the one that did not.

## Test plan

- [x] `make ci-lint` (eslint + tsc) on `@hyperdx/app` and `@hyperdx/common-utils`
- [x] `make ci-unit`
- [x] new `renderChartConfig` tests: a pattern-shaped config (rebuilt select, `ORDER BY rand()`, filter on `service`) renders `(ServiceName) AS service` in `WITH` and references it in the predicate; the same config without a threaded alias map omits the definition (the bug). The negative case fails before this change.
- [x] verified against a live ClickHouse (dev stack) that the rebuilt pattern shape fails with `UNKNOWN_IDENTIFIER` for an undefined `service` and succeeds once the `(ServiceName) AS service` `WITH` clause is present. Single-node CI with snapshot SQL tests cannot see this class, so I checked it against a running server directly.

The diff also drops 4 stray em-dashes from comments in `renderChartConfig.test.ts` (repo style; the file was already in the diff).

Companion to #2486, which makes the underlying alias map resilient to ClickHouse-specific SQL the parser rejects. The two touch disjoint files and are independent; this change fixes the common `ServiceName as service` case on its own.
