### PR TITLE
fix: backtick-escape column names in filter queries

### DIFF
--- a/.changeset/filter-key-special-characters.md
+++ b/.changeset/filter-key-special-characters.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+---
+
+fix: Correct filter handling for filter keys with special characters

--- a/docker/clickhouse/local/init-db-e2e.sh
+++ b/docker/clickhouse/local/init-db-e2e.sh
@@ -242,5 +242,195 @@ FROM ${DATABASE}.e2e_otel_traces
 GROUP BY
     Timestamp,
     ServiceName,
-    StatusCode
+    StatusCode;
+
+-- Table covering "interesting" filter key edge cases: a column whose name
+-- contains dots (\`__hdx_materialized_k8s.cluster.name\`),
+-- a column whose name contains a hyphen (\`service-name\`), a Map column accessed
+-- by a dotted key (ResourceAttributes['key.subKey.subSubKey']), a JSON column
+-- accessed by a nested path (ResourceAttributesJSON.key.subKey.subSubKey), a Map
+-- column whose NAME contains a hyphen (\`Map-Attributes\`['pod-name']), and a JSON
+-- column whose name AND nested keys contain hyphens (\`JSON-Attributes\`.\`key-1\`.\`key-2\`).
+-- Used by the filter-key edge case E2E tests to verify identifier escaping in filters.
+SET allow_experimental_json_type = 1;
+CREATE TABLE IF NOT EXISTS ${DATABASE}.otel_logs_interesting_filter_keys
+(
+    \`Timestamp\` DateTime64(9),
+    \`TraceId\` String,
+    \`SpanId\` String,
+    \`SeverityText\` LowCardinality(String),
+    \`ServiceName\` LowCardinality(String),
+    \`Body\` String,
+    \`ResourceAttributes\` Map(LowCardinality(String), String),
+    \`ResourceAttributesJSON\` JSON,
+    \`__hdx_materialized_k8s.cluster.name\` LowCardinality(String),
+    \`service-name\` String,
+    \`Map-Attributes\` Map(LowCardinality(String), String),
+    \`JSON-Attributes\` JSON
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+PRIMARY KEY (ServiceName, Timestamp)
+ORDER BY (ServiceName, Timestamp);
+
+-- ---------------------------------------------------------------------------
+-- Metadata materialized-view source
+-- ---------------------------------------------------------------------------
+-- A standard otel_logs-schema base table (\`e2e_otel_logs_metadata_mv\`) plus a
+-- pair of "metadata" rollup tables that pre-aggregate facet keys and key/values
+-- per ColumnIdentifier in 15-minute buckets. The rollups are populated by
+-- materialized views that fire on insert into the base table. The
+-- 'E2E Metadata MV Logs' fixture source registers these rollups via its
+-- \`metadataMaterializedViews\` config, so the filter-key edge case tests exercise
+-- the rollup-backed facet path (keys/values read from the rollups instead of the
+-- base table) for the ServiceName native column and a LogAttributes map key.
+CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_otel_logs_metadata_mv
+(
+  \`Timestamp\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+  \`TraceId\` String CODEC(ZSTD(1)),
+  \`SpanId\` String CODEC(ZSTD(1)),
+  \`TraceFlags\` UInt8,
+  \`SeverityText\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`SeverityNumber\` UInt8,
+  \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`Body\` String CODEC(ZSTD(1)),
+  \`ResourceSchemaUrl\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+  \`ScopeSchemaUrl\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`ScopeName\` String CODEC(ZSTD(1)),
+  \`ScopeVersion\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+  \`LogAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+  \`EventName\` String CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.cluster.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.cluster.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.container.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.container.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.deployment.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.deployment.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.namespace.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.namespace.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.node.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.node.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.pod.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.name'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_k8s.pod.uid\` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.uid'] CODEC(ZSTD(1)),
+  \`__hdx_materialized_deployment.environment.name\` LowCardinality(String) MATERIALIZED ResourceAttributes['deployment.environment.name'] CODEC(ZSTD(1))
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (toStartOfFiveMinutes(Timestamp), ServiceName, Timestamp)
+TTL toDateTime(Timestamp) + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_otel_logs_kv_rollup_15m
+(
+    \`Timestamp\` DateTime,
+    \`ColumnIdentifier\` LowCardinality(String),
+    \`Key\` LowCardinality(String),
+    \`Value\` String,
+    \`count\` UInt64,
+    INDEX idx_count_minmax count TYPE minmax GRANULARITY 1,
+    INDEX idx_timestamp_minmax Timestamp TYPE minmax GRANULARITY 1
+)
+ENGINE = SummingMergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ColumnIdentifier, Key, Timestamp, Value)
+TTL Timestamp + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DATABASE}.e2e_otel_logs_attr_kv_rollup_15m_mv TO ${DATABASE}.e2e_otel_logs_kv_rollup_15m
+(
+    \`Timestamp\` DateTime,
+    \`ColumnIdentifier\` String,
+    \`Key\` String,
+    \`Value\` String,
+    \`count\` UInt64
+)
+AS WITH elements AS
+    (
+        SELECT
+            'ResourceAttributes' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            replaceRegexpAll(entry.1, '\\\\[\\\\d+\\\\]', '[*]') AS Key,
+            CAST(entry.2, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+        ARRAY JOIN ResourceAttributes AS entry
+        UNION ALL
+        SELECT
+            'LogAttributes' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            replaceRegexpAll(entry.1, '\\\\[\\\\d+\\\\]', '[*]') AS Key,
+            CAST(entry.2, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+        ARRAY JOIN LogAttributes AS entry
+        UNION ALL
+        SELECT
+            'ScopeAttributes' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            replaceRegexpAll(entry.1, '\\\\[\\\\d+\\\\]', '[*]') AS Key,
+            CAST(entry.2, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+        ARRAY JOIN ScopeAttributes AS entry
+        UNION ALL
+        SELECT
+            'NativeColumn' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            'SeverityText' AS Key,
+            CAST(SeverityText, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+        UNION ALL
+        SELECT
+            'NativeColumn' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            'ServiceName' AS Key,
+            CAST(ServiceName, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+        UNION ALL
+        SELECT
+            'NativeColumn' AS ColumnIdentifier,
+            toStartOfFifteenMinutes(Timestamp) AS Timestamp,
+            'ScopeName' AS Key,
+            CAST(ScopeName, 'String') AS Value
+        FROM ${DATABASE}.e2e_otel_logs_metadata_mv
+    )
+SELECT
+    Timestamp,
+    ColumnIdentifier,
+    Key,
+    Value,
+    count() AS count
+FROM elements
+GROUP BY
+    Timestamp,
+    ColumnIdentifier,
+    Key,
+    Value;
+
+CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_otel_logs_key_rollup_15m
+(
+    \`Timestamp\` DateTime,
+    \`ColumnIdentifier\` LowCardinality(String),
+    \`Key\` LowCardinality(String),
+    \`count\` UInt64,
+    INDEX idx_count_minmax count TYPE minmax GRANULARITY 1,
+    INDEX idx_timestamp_minmax Timestamp TYPE minmax GRANULARITY 1
+)
+ENGINE = SummingMergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ColumnIdentifier, Key, Timestamp)
+TTL Timestamp + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DATABASE}.e2e_otel_logs_key_rollup_15m_mv TO ${DATABASE}.e2e_otel_logs_key_rollup_15m
+(
+    \`Timestamp\` DateTime,
+    \`ColumnIdentifier\` LowCardinality(String),
+    \`Key\` LowCardinality(String),
+    \`count\` UInt64
+)
+AS SELECT
+    Timestamp,
+    ColumnIdentifier,
+    Key,
+    sum(count) AS count
+FROM ${DATABASE}.e2e_otel_logs_kv_rollup_15m
+GROUP BY
+    ColumnIdentifier,
+    Key,
+    Timestamp;
 EOFSQL

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.test.ts
@@ -2510,6 +2510,118 @@ describe('checkAlerts', () => {
       expect(slack.postMessageToWebhook).not.toHaveBeenCalled();
     });
 
+    it('SAVED_SEARCH alert - applies a saved filter whose column needs backtick-quoting', async () => {
+      const { team, webhook, connection, teamWebhooksById, clickhouseClient } =
+        await setupSavedSearchAlertTest();
+
+      // A table with a column whose name requires backtick-quoting. The default
+      // otel_logs schema has no such column, so create a dedicated one.
+      const nativeClient = await getTestFixtureClickHouseClient();
+      const ESCAPED_FILTER_TABLE = 'otel_logs_alert_escaped_filter';
+      await nativeClient.command({
+        query: `CREATE OR REPLACE TABLE ${DEFAULT_DATABASE}.${ESCAPED_FILTER_TABLE} (
+          Timestamp DateTime64(9),
+          \`service-name\` String,
+          Body String
+        ) ENGINE = MergeTree ORDER BY Timestamp`,
+        clickhouse_settings: { wait_end_of_query: 1 },
+      });
+
+      try {
+        const source = await Source.create({
+          kind: 'log',
+          team: team._id,
+          from: {
+            databaseName: DEFAULT_DATABASE,
+            tableName: ESCAPED_FILTER_TABLE,
+          },
+          timestampValueExpression: 'Timestamp',
+          connection: connection.id,
+          name: 'Escaped Filter Logs',
+        });
+
+        // The condition is in the exact shape the UI saves to Mongo: the
+        // special-char column key is backtick-quoted in the persisted SQL.
+        const savedSearch = await new SavedSearch({
+          team: team._id,
+          name: 'Escaped Filter Search',
+          select: 'Body',
+          where: '',
+          whereLanguage: 'sql',
+          orderBy: 'Timestamp',
+          source: source.id,
+          tags: ['test'],
+          filters: [{ type: 'sql', condition: "`service-name` IN ('svc-a')" }],
+        }).save();
+
+        const details = await createAlertDetails(
+          team,
+          source,
+          {
+            source: AlertSource.SAVED_SEARCH,
+            channel: { type: 'webhook', webhookId: webhook._id.toString() },
+            interval: '5m',
+            thresholdType: AlertThresholdType.ABOVE,
+            threshold: 1,
+            savedSearchId: savedSearch.id,
+          },
+          {
+            taskType: AlertTaskType.SAVED_SEARCH,
+            savedSearch,
+          },
+        );
+
+        const now = new Date('2023-11-16T22:12:00.000Z');
+        const eventMs = new Date('2023-11-16T22:05:00.000Z');
+
+        // Two rows in the alert window; only the 'svc-a' row matches the
+        // saved filter, so a correctly-quoted query counts exactly one.
+        await bulkInsertData(`${DEFAULT_DATABASE}.${ESCAPED_FILTER_TABLE}`, [
+          {
+            Timestamp: eventMs,
+            'service-name': 'svc-a',
+            Body: 'matches the saved filter',
+          },
+          {
+            Timestamp: eventMs,
+            'service-name': 'svc-b',
+            Body: 'excluded by the saved filter',
+          },
+        ]);
+
+        const querySpy = jest.spyOn(clickhouseClient, 'queryChartConfig');
+
+        await processAlertAtTime(
+          now,
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+        );
+
+        // The query ran (no SQL error from an unquoted key) ...
+        expect(querySpy).toHaveBeenCalledTimes(1);
+
+        // ... and counted exactly the one matching row — not two (filter
+        // dropped) and not zero (filter over-matched / errored).
+        expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+        const alertHistories = await AlertHistory.find({
+          alert: details.alert.id,
+        }).sort({ createdAt: 1 });
+        expect(alertHistories.length).toBe(1);
+        expect(alertHistories[0].state).toBe('ALERT');
+        expect(alertHistories[0].lastValues).toEqual([
+          expect.objectContaining({ count: 1 }),
+        ]);
+      } finally {
+        await nativeClient.command({
+          query: `DROP TABLE IF EXISTS ${DEFAULT_DATABASE}.${ESCAPED_FILTER_TABLE}`,
+          clickhouse_settings: { wait_end_of_query: 1 },
+        });
+      }
+    });
+
     it('TILE alert (events) - slack webhook', async () => {
       const {
         team,

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1085,9 +1085,29 @@ export function DBSearchPage() {
   );
 
   const filters = useWatch({ name: 'filters', control });
+
+  // Top-level column names for the active source, used to quote
+  // filter keys that contain special characters.
+  const { data: inputSourceColumns } = useColumns(
+    {
+      databaseName: inputSourceObj?.from?.databaseName ?? '',
+      tableName: inputSourceObj?.from?.tableName ?? '',
+      connectionId: inputSourceObj?.connection ?? '',
+    },
+    { enabled: !!inputSourceObj },
+  );
+  const knownColumns = useMemo(
+    () =>
+      inputSourceColumns
+        ? new Set(inputSourceColumns.map(c => c.name))
+        : new Set<string>(),
+    [inputSourceColumns],
+  );
+
   const searchFilters = useSearchPageFilterState({
     searchQuery: filters ?? undefined,
     onFilterChange: handleSetFilters,
+    knownColumns,
   });
 
   const watchedSource = useWatch({

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -638,6 +638,7 @@ describe('searchFilters', () => {
         useSearchPageFilterState({
           searchQuery: [],
           onFilterChange,
+          knownColumns: new Set(),
         }),
       );
 
@@ -667,6 +668,7 @@ describe('searchFilters', () => {
             { type: 'sql', condition: `level IN ('info', 'ok')` },
           ],
           onFilterChange,
+          knownColumns: new Set(),
         }),
       );
 
@@ -691,6 +693,7 @@ describe('searchFilters', () => {
             { type: 'sql', condition: `level IN ('info', 'ok')` },
           ],
           onFilterChange,
+          knownColumns: new Set(),
         }),
       );
 
@@ -713,6 +716,7 @@ describe('searchFilters', () => {
             { type: 'sql', condition: `level IN ('info', 'ok')` },
           ],
           onFilterChange,
+          knownColumns: new Set(),
         }),
       );
 
@@ -737,6 +741,7 @@ describe('searchFilters', () => {
             { type: 'sql', condition: `level NOT IN ('error')` },
           ],
           onFilterChange,
+          knownColumns: new Set(),
         }),
       );
 
@@ -757,6 +762,7 @@ describe('searchFilters', () => {
           useSearchPageFilterState({
             searchQuery: [],
             onFilterChange: onFilterChangeLocal,
+            knownColumns: new Set(),
           }),
         );
 
@@ -780,6 +786,7 @@ describe('searchFilters', () => {
               { type: 'lucene', condition: 'SeverityText:"error"' },
             ],
             onFilterChange: onFilterChangeLocal,
+            knownColumns: new Set(),
           }),
         );
 
@@ -806,6 +813,7 @@ describe('searchFilters', () => {
               },
             ],
             onFilterChange: onFilterChangeLocal,
+            knownColumns: new Set(),
           }),
         );
 
@@ -829,6 +837,7 @@ describe('searchFilters', () => {
               { type: 'sql', condition: `AnotherGone IN ('y')` },
             ],
             onFilterChange: onFilterChangeLocal,
+            knownColumns: new Set(),
           }),
         );
 
@@ -852,6 +861,7 @@ describe('searchFilters', () => {
               { type: 'sql', condition: `Body IN ('oops')` },
             ],
             onFilterChange: onFilterChangeLocal,
+            knownColumns: new Set(),
           }),
         );
 

--- a/packages/app/src/components/DBNumberChart.tsx
+++ b/packages/app/src/components/DBNumberChart.tsx
@@ -87,7 +87,7 @@ function SimpleNumber({
 }) {
   return (
     <Flex align="center" justify="center" h="100%" style={{ flexGrow: 1 }}>
-      <Text size="4rem" c={color}>
+      <Text size="4rem" c={color} data-testid="number-chart-value">
         {children}
       </Text>
     </Flex>
@@ -167,6 +167,7 @@ function AutoSizeNumber({
       <Text
         ref={textRef}
         c={color}
+        data-testid="number-chart-value"
         style={{
           fontSize,
           lineHeight: 1.1,

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -71,6 +71,7 @@ import { useMetadataWithSettings } from '@/hooks/useMetadata';
 import useResizable from '@/hooks/useResizable';
 import { usePinnedFiltersApi } from '@/pinnedFilters';
 import {
+  escapeFilterStateKeys,
   FilterStateHook,
   IS_ROOT_SPAN_COLUMN_NAME,
   usePinnedFilters,
@@ -88,7 +89,7 @@ import { SharedFiltersSection } from './DBSearchPageFilters/SharedFilters';
 import {
   getFilterStateEntry,
   groupFacetsByBaseName,
-  toClickHouseKeyExpression,
+  toQuotedClickHouseKeyExpression,
 } from './DBSearchPageFilters/utils';
 
 import resizeStyles from '../../styles/ResizablePanel.module.scss';
@@ -183,9 +184,14 @@ const TextButton = ({
 type FilterPercentageProps = {
   percentage: number;
   isLoading?: boolean;
+  'data-testid'?: string;
 };
 
-const FilterPercentage = ({ percentage, isLoading }: FilterPercentageProps) => {
+const FilterPercentage = ({
+  percentage,
+  isLoading,
+  'data-testid': dataTestId,
+}: FilterPercentageProps) => {
   const formattedPercentage =
     percentage < 1
       ? `<1%`
@@ -194,7 +200,11 @@ const FilterPercentage = ({ percentage, isLoading }: FilterPercentageProps) => {
         : `~${Math.round(percentage)}%`;
 
   return (
-    <Text size="xs" className={isLoading ? 'effect-pulse' : ''}>
+    <Text
+      size="xs"
+      className={isLoading ? 'effect-pulse' : ''}
+      data-testid={dataTestId}
+    >
       {formattedPercentage}
     </Text>
   );
@@ -277,6 +287,7 @@ const FilterCheckbox = ({
               <FilterPercentage
                 percentage={percentage}
                 isLoading={isPercentageLoading}
+                data-testid={`filter-distribution-${columnName}-${label}`}
               />
             )}
           </Group>
@@ -1199,7 +1210,7 @@ const DBSearchPageFiltersComponent = ({
   const isLoading = useExactPipeline ? isFieldsLoading : isMVLoading;
   const error = useExactPipeline ? fieldsError : mvError;
 
-  const { data: columns } = useColumns({
+  const { data: columns, isLoading: isColumnsLoading } = useColumns({
     databaseName: chartConfig.from.databaseName,
     tableName: chartConfig.from.tableName,
     connectionId: chartConfig.connection,
@@ -1293,18 +1304,51 @@ const DBSearchPageFiltersComponent = ({
     [chartConfig, dateRange, filterMode],
   );
 
+  // Conditionally backtick-quote facet keys that contain special characters and
+  // match known column names, so they can be used in the ClickHouse query to get
+  // key values.
+  const knownColumns = useMemo(
+    () => (columns ? new Set(columns.map(c => c.name)) : new Set<string>()),
+    [columns],
+  );
+  const { escapedKeysToFetch, sqlKeyToUiKey } = useMemo(() => {
+    // Don't fetch any keys until the column list is loaded,
+    // since we need the real column names to escape correctly.
+    if (isColumnsLoading) {
+      return { escapedKeysToFetch: [], sqlKeyToUiKey: new Map() };
+    }
+
+    const sqlKeyToUiKey = new Map<string, string>();
+    const escapedKeysToFetch = keysToFetch.map(key => {
+      const sqlKey = toQuotedClickHouseKeyExpression(key, knownColumns);
+      sqlKeyToUiKey.set(sqlKey, key);
+      return sqlKey;
+    });
+    return { escapedKeysToFetch, sqlKeyToUiKey };
+  }, [isColumnsLoading, keysToFetch, knownColumns]);
+
   // Exact pipeline step 2: fetch values for discovered keys
   const {
-    data: exactFacets,
+    data: rawExactFacets,
     isLoading: isExactFacetsLoading,
     isFetching: isExactFacetsFetching,
   } = useGetKeyValues(
     {
       chartConfig: facetsChartConfig,
       limit: INITIAL_LOAD_LIMIT,
-      keys: keysToFetch,
+      keys: escapedKeysToFetch,
     },
     { enabled: useExactPipeline },
+  );
+
+  // Map the (escaped) result keys back to the original UI keys.
+  const exactFacets = useMemo(
+    () =>
+      rawExactFacets?.map(f => ({
+        ...f,
+        key: sqlKeyToUiKey.get(f.key) ?? f.key,
+      })),
+    [rawExactFacets, sqlKeyToUiKey],
   );
 
   const facets = useExactPipeline ? exactFacets : mvFieldsAndValues;
@@ -1344,12 +1388,13 @@ const DBSearchPageFiltersComponent = ({
       setLoadMoreLoadingKeys(prev => new Set(prev).add(key));
       try {
         // Coerce dot-form Map sub-keys (LogAttributes.foo) into bracket form
-        // (LogAttributes['foo']) before handing them to ClickHouse. Bracket
-        // form is the canonical SQL key produced by mergePath; dot form ends
+        // (LogAttributes['foo']) and conditionally backtick-quote special-char
+        // identifiers before handing them to ClickHouse. `getKeyValues` no
+        // longer escapes, so the caller must pass a valid SQL key; dot form ends
         // up in filterState after setFilterValue's parseKeyPath().join('.')
         // normalization or after a Lucene URL round-trip, and ClickHouse
         // cannot resolve it as map access.
-        const sqlKey = toClickHouseKeyExpression(key);
+        const sqlKey = toQuotedClickHouseKeyExpression(key, knownColumns);
         let newValues: string[];
         if (!useExactPipeline) {
           const results = await metadata.getAllKeyValues({
@@ -1378,7 +1423,9 @@ const DBSearchPageFiltersComponent = ({
             chartConfig: {
               ...chartConfig,
               dateRange,
-              filters: filtersToQuery(strippedFilterState),
+              filters: filtersToQuery(
+                escapeFilterStateKeys(strippedFilterState, knownColumns),
+              ),
             },
             keys: [sqlKey],
             limit: LOAD_MORE_LOAD_LIMIT,
@@ -1412,6 +1459,7 @@ const DBSearchPageFiltersComponent = ({
       source,
       useExactPipeline,
       sourceTableConnection.metadataMVs,
+      knownColumns,
     ],
   );
 
@@ -1675,7 +1723,16 @@ const DBSearchPageFiltersComponent = ({
               key={`${keyPrefix}${group.key}`}
               data-testid={`${keyPrefix}nested-filter-group-${group.key}`}
               name={group.key}
-              childFilters={group.children}
+              // sqlKey is the canonical (quoted/bracket) SQL form used wherever
+              // the key becomes raw SQL (distribution query, "Add column"
+              // SELECT); child.key stays clean for the UI.
+              childFilters={group.children.map(child => ({
+                ...child,
+                sqlKey: toQuotedClickHouseKeyExpression(
+                  child.key,
+                  knownColumns,
+                ),
+              }))}
               selectedValues={group.children.reduce((acc, child) => {
                 acc[child.key] = getFilterStateEntry(
                   filterState,
@@ -1736,56 +1793,63 @@ const DBSearchPageFiltersComponent = ({
               isLive={isLive}
             />
           ))}
-          {nonGrouped.map(facet => (
-            <FilterGroup
-              key={`${keyPrefix}${facet.key}`}
-              data-testid={`${keyPrefix}filter-group-${facet.key}`}
-              name={cleanedFacetName(facet.key)}
-              showFilterCounts={showFilterCounts}
-              options={facet.value.map(value => ({
-                value,
-                label: value.toString(),
-              }))}
-              optionsLoading={isFacetsLoading}
-              selectedValues={
-                getFilterStateEntry(filterState, facet.key) ?? {
-                  included: new Set(),
-                  excluded: new Set(),
+          {nonGrouped.map(facet => {
+            const facetSqlKey = toQuotedClickHouseKeyExpression(
+              facet.key,
+              knownColumns,
+            );
+            return (
+              <FilterGroup
+                key={`${keyPrefix}${facet.key}`}
+                data-testid={`${keyPrefix}filter-group-${facet.key}`}
+                name={cleanedFacetName(facet.key)}
+                distributionKey={facetSqlKey}
+                showFilterCounts={showFilterCounts}
+                options={facet.value.map(value => ({
+                  value,
+                  label: value.toString(),
+                }))}
+                optionsLoading={isFacetsLoading}
+                selectedValues={
+                  getFilterStateEntry(filterState, facet.key) ?? {
+                    included: new Set(),
+                    excluded: new Set(),
+                  }
                 }
-              }
-              onChange={value => setFilterValue(facet.key, value)}
-              onClearClick={() => clearFilter(facet.key)}
-              onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
-              onExcludeClick={value =>
-                setFilterValue(facet.key, value, 'exclude')
-              }
-              valuePins={makeValuePins(facet.key)}
-              fieldPins={makeFieldPins(facet.key)}
-              onColumnToggle={
-                onColumnToggle ? () => onColumnToggle(facet.key) : undefined
-              }
-              isColumnDisplayed={displayedColumns?.includes(facet.key)}
-              onLoadMore={loadMoreFilterValuesForKey}
-              loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
-              hasLoadedMore={Boolean(extraFacets[facet.key])}
-              isDefaultExpanded={(() => {
-                const entry = getFilterStateEntry(filterState, facet.key);
-                return (
-                  forceExpanded ??
-                  (isFieldPrimary(tableMetadata, facet.key) ||
-                    isFieldPinned(facet.key) ||
-                    isSharedFieldPinned(facet.key) ||
-                    (entry != null &&
-                      (entry.included.size > 0 ||
-                        entry.excluded.size > 0 ||
-                        entry.range != null)))
-                );
-              })()}
-              chartConfig={chartConfig}
-              isLive={isLive}
-              onRangeChange={range => setFilterRange(facet.key, range)}
-            />
-          ))}
+                onChange={value => setFilterValue(facet.key, value)}
+                onClearClick={() => clearFilter(facet.key)}
+                onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
+                onExcludeClick={value =>
+                  setFilterValue(facet.key, value, 'exclude')
+                }
+                valuePins={makeValuePins(facet.key)}
+                fieldPins={makeFieldPins(facet.key)}
+                onColumnToggle={
+                  onColumnToggle ? () => onColumnToggle(facetSqlKey) : undefined
+                }
+                isColumnDisplayed={displayedColumns?.includes(facetSqlKey)}
+                onLoadMore={loadMoreFilterValuesForKey}
+                loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
+                hasLoadedMore={Boolean(extraFacets[facet.key])}
+                isDefaultExpanded={(() => {
+                  const entry = getFilterStateEntry(filterState, facet.key);
+                  return (
+                    forceExpanded ??
+                    (isFieldPrimary(tableMetadata, facet.key) ||
+                      isFieldPinned(facet.key) ||
+                      isSharedFieldPinned(facet.key) ||
+                      (entry != null &&
+                        (entry.included.size > 0 ||
+                          entry.excluded.size > 0 ||
+                          entry.range != null)))
+                  );
+                })()}
+                chartConfig={chartConfig}
+                isLive={isLive}
+                onRangeChange={range => setFilterRange(facet.key, range)}
+              />
+            );
+          })}
         </>
       );
     },
@@ -1812,6 +1876,7 @@ const DBSearchPageFiltersComponent = ({
       isLive,
       setFilterRange,
       tableMetadata,
+      knownColumns,
     ],
   );
 

--- a/packages/app/src/components/DBSearchPageFilters/NestedFilterGroup.tsx
+++ b/packages/app/src/components/DBSearchPageFilters/NestedFilterGroup.tsx
@@ -13,6 +13,10 @@ type NestedFilterGroupProps = {
     key: string;
     value: (string | boolean)[];
     propertyPath: string;
+    // Canonical (quoted/bracket) SQL form of `key`, used wherever the key
+    // becomes a raw SQL expression (distribution query, "Add column" SELECT).
+    // Falls back to `key` when absent.
+    sqlKey?: string;
   }[];
   selectedValues?: FilterState;
   onChange: (key: string, value: string | boolean) => void;
@@ -200,7 +204,7 @@ export const NestedFilterGroup = ({
                           <FilterGroup
                             data-testid={`nested-filter-group-${child.key}`}
                             name={child.propertyPath}
-                            distributionKey={child.key}
+                            distributionKey={child.sqlKey ?? child.key}
                             options={child.value.map(value => ({
                               value: value,
                               label: value.toString(),
@@ -235,11 +239,12 @@ export const NestedFilterGroup = ({
                             }}
                             onColumnToggle={
                               onColumnToggle
-                                ? () => onColumnToggle(child.key)
+                                ? () =>
+                                    onColumnToggle(child.sqlKey ?? child.key)
                                 : undefined
                             }
                             isColumnDisplayed={displayedColumns?.includes(
-                              child.key,
+                              child.sqlKey ?? child.key,
                             )}
                             onLoadMore={() => onLoadMore(child.key)}
                             loadMoreLoading={

--- a/packages/app/src/components/DBSearchPageFilters/utils.test.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.test.ts
@@ -1,10 +1,32 @@
 import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
 import {
+  cleanClickHouseExpression,
   getFilterStateEntry,
   groupFacetsByBaseName,
   toClickHouseKeyExpression,
+  toQuotedClickHouseKeyExpression,
 } from './utils';
+
+describe('cleanClickHouseExpression', () => {
+  it('strips backticks from a bare quoted identifier', () => {
+    expect(cleanClickHouseExpression('`service-name`')).toBe('service-name');
+  });
+
+  it('unwraps toString() and strips inner backticks', () => {
+    expect(
+      cleanClickHouseExpression('toString(ResourceAttributes.`hdx`.`sdk`)'),
+    ).toBe('ResourceAttributes.hdx.sdk');
+  });
+
+  it('leaves a plain identifier unchanged', () => {
+    expect(cleanClickHouseExpression('ServiceName')).toBe('ServiceName');
+  });
+
+  it('strips the quoted root of a bracket-form Map key', () => {
+    expect(cleanClickHouseExpression("`my-map`['k']")).toBe("my-map['k']");
+  });
+});
 
 describe('groupFacetsByBaseName — dot/bracket de-duplication', () => {
   it('collapses bracket-form and dot-form entries for the same logical key', () => {
@@ -157,5 +179,105 @@ describe('toClickHouseKeyExpression', () => {
     expect(toClickHouseKeyExpression('LogAttributes.42.foo')).toBe(
       "LogAttributes['42.foo']",
     );
+  });
+});
+
+describe('toQuotedClickHouseKeyExpression', () => {
+  const knownColumns = new Set([
+    'ServiceName',
+    'my column',
+    'LogAttributes',
+    'service-name',
+    'my-map',
+  ]);
+
+  it('leaves a valid bare column unchanged', () => {
+    expect(toQuotedClickHouseKeyExpression('ServiceName', knownColumns)).toBe(
+      'ServiceName',
+    );
+  });
+
+  it('quotes a column only when it needs it', () => {
+    expect(toQuotedClickHouseKeyExpression('service-name', knownColumns)).toBe(
+      '`service-name`',
+    );
+    expect(toQuotedClickHouseKeyExpression('my column', knownColumns)).toBe(
+      '`my column`',
+    );
+  });
+
+  it('converts a dot-form map sub-key to bracket form (valid root unquoted)', () => {
+    expect(
+      toQuotedClickHouseKeyExpression('LogAttributes.host', knownColumns),
+    ).toBe("LogAttributes['host']");
+  });
+
+  it('quotes only the root of a bracket map access that needs it', () => {
+    expect(toQuotedClickHouseKeyExpression("my-map['k']", knownColumns)).toBe(
+      "`my-map`['k']",
+    );
+    expect(
+      toQuotedClickHouseKeyExpression("LogAttributes['k']", knownColumns),
+    ).toBe("LogAttributes['k']");
+  });
+
+  it('leaves already-backticked JSON path segments untouched, quoting only a bare root that needs it', () => {
+    // Backtick-form JSON paths short-circuit toClickHouseKeyExpression, so they
+    // reach the dotted-segment branch: already-quoted segments are preserved.
+    expect(
+      toQuotedClickHouseKeyExpression('Body.`json`.`field`', knownColumns),
+    ).toBe('Body.`json`.`field`');
+  });
+
+  it('is idempotent on an already-quoted key', () => {
+    expect(
+      toQuotedClickHouseKeyExpression('`service-name`', knownColumns),
+    ).toBe('`service-name`');
+    expect(
+      toQuotedClickHouseKeyExpression(
+        toQuotedClickHouseKeyExpression('service-name', knownColumns),
+        new Set(['service-name']),
+      ),
+    ).toBe('`service-name`');
+  });
+
+  describe('with knownColumns (schema-aware)', () => {
+    it('quotes a flat column whose name contains dots as a single identifier', () => {
+      const cols = new Set(['__hdx_materialized_k8s.cluster.name']);
+      expect(
+        toQuotedClickHouseKeyExpression(
+          '__hdx_materialized_k8s.cluster.name',
+          cols,
+        ),
+      ).toBe('`__hdx_materialized_k8s.cluster.name`');
+    });
+
+    it('leaves a valid flat column name unquoted', () => {
+      const cols = new Set(['ServiceName']);
+      expect(toQuotedClickHouseKeyExpression('ServiceName', cols)).toBe(
+        'ServiceName',
+      );
+    });
+
+    it('still treats a dotted key as Map access when it is NOT a known column', () => {
+      const cols = new Set(['LogAttributes']);
+      expect(toQuotedClickHouseKeyExpression('LogAttributes.host', cols)).toBe(
+        "LogAttributes['host']",
+      );
+    });
+
+    it('does not affect bracket-form map access for a known map column', () => {
+      const cols = new Set(['LogAttributes']);
+      expect(
+        toQuotedClickHouseKeyExpression("LogAttributes['host']", cols),
+      ).toBe("LogAttributes['host']");
+    });
+
+    it('does not affect bracket-form map access with a dot in the key', () => {
+      const cols = new Set(['LogAttributes']);
+      expect(
+        toQuotedClickHouseKeyExpression("LogAttributes['host.name']", cols),
+      ).toBe("LogAttributes['host.name']");
+    });
   });
 });

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -1,5 +1,6 @@
 // Utility functions for parsing and grouping map-like field names
 
+import SqlString from 'sqlstring';
 import { parseKeyPath } from '@hyperdx/common-utils/dist/core/metadata';
 import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
@@ -172,4 +173,51 @@ export function toClickHouseKeyExpression(key: string): string {
     [],
     [parsed.baseName],
   );
+}
+
+/**
+ * Quote a single identifier if it isn't already a valid bare ClickHouse identifier.
+ * @param id - The identifier to quote
+ * @returns The quoted identifier if needed, otherwise the original identifier
+ */
+function quoteIdentifierIfNeeded(id: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(id)
+    ? id
+    : SqlString.escapeId(id, true);
+}
+
+/**
+ * Coerce a filterState key into a ClickHouse expression suitable for raw SQL,
+ * backtick-quoting identifiers with special characters.
+ *
+ * `knownColumns` is the set of real top-level column names on the table. Only
+ * keys matching a known column or accessing a map key of a known column will
+ * be quoted.
+ */
+export function toQuotedClickHouseKeyExpression(
+  key: string,
+  knownColumns: Set<string>,
+): string {
+  // A whole-key match against a real column wins: quote the entire name as one
+  // identifier (handles flat columns whose name contains dots/hyphens/etc.).
+  if (knownColumns.has(key)) {
+    return quoteIdentifierIfNeeded(key);
+  }
+
+  // Normalize dot-form (ResourceAttributes.host.name) to map access form (ResourceAttributes['host.name'])
+  const expr = toClickHouseKeyExpression(key);
+
+  // Already quoted: leave untouched
+  if (expr.startsWith('`') || expr.startsWith('"')) {
+    return expr;
+  }
+
+  // Quote a map column name and leave the property path untouched, e.g. `LogAttributes`['host.name'].
+  const path = parseKeyPath(expr);
+  if (path.length >= 2 && knownColumns.has(path[0])) {
+    const bracketStart = expr.indexOf('[');
+    return `${quoteIdentifierIfNeeded(path[0])}${expr.slice(bracketStart)}`;
+  }
+
+  return expr;
 }

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -110,7 +110,9 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
           scoped[expression] = state;
         }
       }
-      return filtersToQuery(scoped);
+      // Wrap keys in `toString()` to support JSON/Dynamic-type columns,
+      // consistent with the transformation applied in `queriesForExistingFilters` above.
+      return filtersToQuery(scoped, { stringifyKeys: true });
     },
     [valuesForExistingFilters, filtersByExpression],
   );

--- a/packages/app/src/searchFilters.test.ts
+++ b/packages/app/src/searchFilters.test.ts
@@ -2,7 +2,7 @@ import { enableMapSet } from 'immer';
 import { Filter } from '@hyperdx/common-utils/dist/types';
 import { act, renderHook } from '@testing-library/react';
 
-import { useSearchPageFilterState } from '@/searchFilters';
+import { parseQuery, useSearchPageFilterState } from '@/searchFilters';
 
 // Filter state stores values in Sets; the app enables immer's MapSet plugin at
 // startup, but this isolated hook test must enable it explicitly.
@@ -20,6 +20,7 @@ describe('useSearchPageFilterState replaceFilterValue', () => {
       useSearchPageFilterState({
         searchQuery: EMPTY_SEARCH_QUERY,
         onFilterChange,
+        knownColumns: new Set(),
       }),
     );
 
@@ -40,6 +41,7 @@ describe('useSearchPageFilterState replaceFilterValue', () => {
       useSearchPageFilterState({
         searchQuery: EMPTY_SEARCH_QUERY,
         onFilterChange,
+        knownColumns: new Set(),
       }),
     );
 
@@ -60,6 +62,7 @@ describe('useSearchPageFilterState replaceFilterValue', () => {
       useSearchPageFilterState({
         searchQuery: EMPTY_SEARCH_QUERY,
         onFilterChange,
+        knownColumns: new Set(),
       }),
     );
 
@@ -72,5 +75,120 @@ describe('useSearchPageFilterState replaceFilterValue', () => {
     });
 
     expect(onFilterChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('canonical key escaping at the persistence boundary', () => {
+  // In-memory FilterState keys stay clean (what the sidebar/comparisons use);
+  // the persisted Filter[] handed to onFilterChange (URL + saved search) carries
+  // the canonical backtick-quoted/bracket ClickHouse key.
+
+  describe('parseQuery stays verbatim (no key transformation)', () => {
+    it('keeps an already-quoted leading key as-is', () => {
+      const result = parseQuery([
+        { type: 'sql', condition: "`service-name` IN ('a')" },
+      ]);
+      expect(result.filters).toEqual({
+        '`service-name`': { included: new Set(['a']), excluded: new Set() },
+      });
+    });
+
+    it('keeps a dot-form key as-is (dashboards rely on verbatim keys)', () => {
+      const result = parseQuery([
+        { type: 'sql', condition: "service.name IN ('a')" },
+      ]);
+      expect(result.filters).toEqual({
+        'service.name': { included: new Set(['a']), excluded: new Set() },
+      });
+    });
+  });
+
+  describe('useSearchPageFilterState', () => {
+    // Stable references so the hook's parsed-query effect doesn't reset local
+    // filter state between renders.
+    const HYPHEN_COLUMNS = new Set(['service-name']);
+    const MAP_COLUMNS = new Set(['my-map']);
+    const PLAIN_COLUMNS = new Set(['ServiceName']);
+
+    it('keeps the FilterState key clean but emits a quoted key to the URL', () => {
+      const onFilterChange = jest.fn();
+      const { result } = renderHook(() =>
+        useSearchPageFilterState({
+          searchQuery: EMPTY_SEARCH_QUERY,
+          onFilterChange,
+          knownColumns: HYPHEN_COLUMNS,
+        }),
+      );
+
+      act(() => {
+        result.current.setFilterValue('service-name', 'a');
+      });
+
+      // in-memory: clean
+      expect(Object.keys(result.current.filters)).toEqual(['service-name']);
+      // persisted: canonical/escaped
+      expect(onFilterChange).toHaveBeenLastCalledWith([
+        { type: 'sql', condition: "`service-name` IN ('a')" },
+      ]);
+    });
+
+    it('escapes a Map sub-key (quoted root) for the persisted query only', () => {
+      const onFilterChange = jest.fn();
+      const { result } = renderHook(() =>
+        useSearchPageFilterState({
+          searchQuery: EMPTY_SEARCH_QUERY,
+          onFilterChange,
+          knownColumns: MAP_COLUMNS,
+        }),
+      );
+
+      act(() => {
+        result.current.setFilterValue("my-map['k']", 'v');
+      });
+
+      expect(Object.keys(result.current.filters)).toEqual(["my-map['k']"]);
+      expect(onFilterChange).toHaveBeenLastCalledWith([
+        { type: 'sql', condition: "`my-map`['k'] IN ('v')" },
+      ]);
+    });
+
+    it('leaves a plain column unquoted in both forms', () => {
+      const onFilterChange = jest.fn();
+      const { result } = renderHook(() =>
+        useSearchPageFilterState({
+          searchQuery: EMPTY_SEARCH_QUERY,
+          onFilterChange,
+          knownColumns: PLAIN_COLUMNS,
+        }),
+      );
+
+      act(() => {
+        result.current.setFilterValue('ServiceName', 'a');
+      });
+
+      expect(Object.keys(result.current.filters)).toEqual(['ServiceName']);
+      expect(onFilterChange).toHaveBeenLastCalledWith([
+        { type: 'sql', condition: "ServiceName IN ('a')" },
+      ]);
+    });
+
+    it('unescapes a quoted key loaded from the URL back into clean FilterState', () => {
+      const onFilterChange = jest.fn();
+      const searchQuery: Filter[] = [
+        { type: 'sql', condition: "`service-name` IN ('a')" },
+      ];
+      const { result } = renderHook(() =>
+        useSearchPageFilterState({
+          searchQuery,
+          onFilterChange,
+          knownColumns: HYPHEN_COLUMNS,
+        }),
+      );
+
+      expect(Object.keys(result.current.filters)).toEqual(['service-name']);
+      expect([...result.current.filters['service-name'].included]).toEqual([
+        'a',
+      ]);
+    });
   });
 });

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -6,10 +6,41 @@ import {
 } from '@hyperdx/common-utils/dist/filters';
 import type { Filter } from '@hyperdx/common-utils/dist/types';
 
+import {
+  cleanClickHouseExpression,
+  toQuotedClickHouseKeyExpression,
+} from './components/DBSearchPageFilters/utils';
 import { usePinnedFiltersApi, useUpdatePinnedFilters } from './pinnedFilters';
 import { useLocalStorage } from './utils';
 
 export const IS_ROOT_SPAN_COLUMN_NAME = 'isRootSpan';
+
+// Filter keys live in two forms.
+// 1. In-memory `FilterState`: use the clean/unquoted forms of each key. This is what
+// the UI renders, what test ids are built from, and what every key comparison expects.
+// 2. The persisted `Filter[]`: Uses the quoted/bracketed ClickHouse form so it emits
+// valid SQL verbatim. Persisted in URL params, local storage, and MongoDB for saved searches.
+
+// Convert the clean FilterState keys to valid SQL (quoted/bracket) keys.
+export const escapeFilterStateKeys = (
+  filters: FilterState,
+  knownColumns: Set<string>,
+): FilterState => {
+  const escaped: FilterState = {};
+  for (const [key, value] of Object.entries(filters)) {
+    escaped[toQuotedClickHouseKeyExpression(key, knownColumns)] = value;
+  }
+  return escaped;
+};
+
+// Convert valid SQL/persisted keys to clean FilterState keys.
+const unescapeFilterStateKeys = (filters: FilterState): FilterState => {
+  const cleaned: FilterState = {};
+  for (const [key, value] of Object.entries(filters)) {
+    cleaned[cleanClickHouseExpression(key)] = value;
+  }
+  return cleaned;
+};
 
 export const areFiltersEqual = (a: FilterState, b: FilterState) => {
   const aKeys = Object.keys(a);
@@ -358,13 +389,33 @@ export const parseQuery = (
 export const useSearchPageFilterState = ({
   searchQuery = [],
   onFilterChange,
+  knownColumns,
 }: {
   searchQuery?: Filter[];
   onFilterChange: (filters: Filter[]) => void;
+  /**
+   * Top-level column names on the table, used to quote
+   * column names that contain special characters
+   * (eg. service-name --> `service-name`).
+   **/
+  knownColumns: Set<string>;
 }) => {
+  // Access knownColumns through a ref so the returned mutators (which depend on
+  // updateFilterQuery) keep stable identities across knownColumns reference
+  // changes. The known columns are only used by the mutators, which are called
+  // on user input, not render, so avoid re-render by using a stable ref.
+  const knownColumnsRef = useRef<Set<string>>(knownColumns);
+  useEffect(() => {
+    knownColumnsRef.current = knownColumns;
+  }, [knownColumns]);
+
+  // Persisted filters carry canonical (escaped) keys; convert back to the clean
+  // keys the sidebar/comparisons use as they enter in-memory FilterState.
   const parsedQuery = useMemo(() => {
     try {
-      return parseQuery(searchQuery);
+      return {
+        filters: unescapeFilterStateKeys(parseQuery(searchQuery).filters),
+      };
     } catch (e) {
       console.error(e);
       return { filters: {} };
@@ -383,7 +434,13 @@ export const useSearchPageFilterState = ({
 
   const updateFilterQuery = useCallback(
     (newFilters: FilterState) => {
-      onFilterChange(filtersToQuery(newFilters));
+      // Escape filter keys here prior to saving so the URL / saved
+      // search holds valid-SQL keys while FilterState stays clean.
+      const escapedFilters = escapeFilterStateKeys(
+        newFilters,
+        knownColumnsRef.current,
+      );
+      onFilterChange(filtersToQuery(escapedFilters));
     },
     [onFilterChange],
   );

--- a/packages/app/tests/e2e/components/FilterComponent.ts
+++ b/packages/app/tests/e2e/components/FilterComponent.ts
@@ -2,7 +2,7 @@
  * FilterComponent - Reusable component for search filters
  * Used for applying, excluding, pinning, and searching filters
  */
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 
 export class FilterComponent {
   readonly page: Page;
@@ -70,11 +70,34 @@ export class FilterComponent {
   }
 
   /**
-   * Apply/select a filter value
+   * Apply/select a filter value.
+   *
+   * Click the checkbox *input* rather than the row wrapper. The toggle handler
+   * lives on an inner group that wraps the input, while the `filter-checkbox-*`
+   * wrapper also contains the hover-revealed action overlay (Only/Exclude/Pin).
+   * Clicking the wrapper's center can land in a dead gap once that overlay
+   * expands the row — dropping the toggle and leaving the box unchecked — and is
+   * especially fragile on narrow nested Map/JSON rows. The input sits at the
+   * row's left inside the group, so a click on it bubbles to the toggle handler
+   * regardless of row width or overlay state.
+   *
+   * Facet lists also re-render as lazily-loaded values stream in, which can
+   * remount the checkbox out from under a single click. Retry until the input
+   * actually reflects the checked state so a lost click is recovered rather than
+   * surfacing as a flaky stuck-unchecked timeout.
    */
   async applyFilter(columnName: string, valueName: string) {
-    const checkbox = this.getFilterCheckbox(columnName, valueName);
-    await checkbox.click();
+    const input = this.getFilterCheckboxInput(columnName, valueName);
+    await expect(async () => {
+      if (!(await input.isChecked())) {
+        await input.scrollIntoViewIfNeeded();
+        await input.click();
+      }
+      // Selecting a value flips the checkbox from filter state synchronously, so
+      // a click that registered reflects well within this window; if it doesn't,
+      // the click was dropped by a re-render and the outer retry clicks again.
+      await expect(input).toBeChecked({ timeout: 3000 });
+    }).toPass({ timeout: 20000 });
   }
 
   /**
@@ -265,6 +288,105 @@ export class FilterComponent {
       );
     }
     return visible;
+  }
+
+  /**
+   * Click the "More filters" button to reveal all string columns. High-cardinality
+   * columns (e.g. a plain `service-name` String column) are hidden until this is
+   * clicked; LowCardinality columns and Map/JSON keys show by default. No-op if the
+   * button isn't present (already expanded, or nothing more to show).
+   */
+  async showMoreFilters(): Promise<void> {
+    const btn = this.page.getByRole('button', {
+      name: 'More filters',
+      exact: true,
+    });
+    if (await btn.isVisible().catch(() => false)) {
+      await btn.click();
+      await this.page
+        .getByRole('button', { name: 'Less filters', exact: true })
+        .waitFor({ state: 'visible', timeout: 10000 })
+        .catch(() => {});
+    }
+  }
+
+  /**
+   * Expand a (possibly nested) facet group so its value checkboxes are visible.
+   * `groupTestids` is the ordered chain of group test ids to expand: a single
+   * `filter-group-<name>` for a top-level column, or the `nested-filter-group-*`
+   * chain for Map/JSON keys and dotted column names (which the sidebar renders
+   * as a nested tree). Resolves once the checkbox for `sampleValue` is visible.
+   * Idempotent: a group is only clicked when its child isn't already shown.
+   */
+  async revealColumnValues(
+    groupTestids: readonly string[],
+    columnName: string,
+    sampleValue: string,
+  ): Promise<void> {
+    await this.showMoreFilters();
+    for (let i = 0; i < groupTestids.length; i++) {
+      const childTestid =
+        i < groupTestids.length - 1
+          ? groupTestids[i + 1]
+          : `filter-checkbox-${columnName}-${sampleValue}`;
+      const child = this.page.getByTestId(childTestid);
+      if (!(await child.isVisible().catch(() => false))) {
+        await this.page.getByTestId(groupTestids[i]).click();
+        await child.waitFor({ state: 'visible', timeout: 10000 });
+      }
+    }
+  }
+
+  // ---- Value distributions ----
+
+  /**
+   * The per-group "Show/Hide Distribution" toggle in a filter group header.
+   * `columnName` is the group's display name (a top-level column name, or the
+   * Map/JSON property path for a nested child) — the same value used for the
+   * group's value-checkbox test ids.
+   */
+  getDistributionToggle(columnName: string) {
+    return this.page.getByTestId(`toggle-distribution-button-${columnName}`);
+  }
+
+  /**
+   * Toggle on the value distribution for a column's filter group.
+   */
+  async showDistribution(columnName: string): Promise<void> {
+    const toggle = this.getDistributionToggle(columnName);
+    await toggle.scrollIntoViewIfNeeded();
+    await toggle.click();
+  }
+
+  /**
+   * The distribution percentage label rendered next to a value once
+   * distributions are shown (e.g. "~33%").
+   */
+  getDistributionPercentage(columnName: string, valueName: string) {
+    return this.page.getByTestId(
+      `filter-distribution-${columnName}-${valueName}`,
+    );
+  }
+
+  // ---- Column display ----
+
+  /**
+   * The per-group "Add/Remove Column" toggle in a filter group header.
+   * `columnName` is the group's display name (top-level column, or the Map/JSON
+   * property path for a nested child).
+   */
+  getColumnToggle(columnName: string) {
+    return this.page.getByTestId(`toggle-column-button-${columnName}`);
+  }
+
+  /**
+   * Click the "Add/Remove Column" toggle for a column's filter group. Adds the
+   * column to (or removes it from) the search SELECT and re-runs the query.
+   */
+  async toggleColumn(columnName: string): Promise<void> {
+    const toggle = this.getColumnToggle(columnName);
+    await toggle.scrollIntoViewIfNeeded();
+    await toggle.click();
   }
 
   // ---- Shared Filters ----

--- a/packages/app/tests/e2e/features/filter-key-edge-cases.spec.ts
+++ b/packages/app/tests/e2e/features/filter-key-edge-cases.spec.ts
@@ -1,0 +1,509 @@
+/**
+ * Filter key edge cases
+ *
+ * Exercises identifier escaping for "interesting" filter keys across two
+ * sources, each seeded with 3 rows whose per-column values are distinct so a
+ * single filter value matches exactly one row.
+ *
+ * 1. `otel_logs_interesting_filter_keys` (INTERESTING_FILTER_KEYS_SOURCE_NAME)
+ *    — facet keys/values come straight from the base table. Covers:
+ *      - ServiceName                              — plain LowCardinality column
+ *      - ResourceAttributes['key.subKey.subSubKey'] — Map access with a dotted key
+ *      - ResourceAttributesJSON.key.subKey.subSubKey — JSON nested path (dashboard)
+ *      - `__hdx_materialized_k8s.cluster.name`    — column whose NAME contains dots
+ *      - `service-name`                           — column whose name has a hyphen
+ *      - `Map-Attributes`['pod-name']             — Map column whose NAME has a hyphen
+ *      - `JSON-Attributes`.`key-1`.`key-2`        — JSON column whose name AND nested
+ *                                                   keys have hyphens (dashboard only)
+ *
+ * 2. `e2e_otel_logs_metadata_mv` (METADATA_MV_LOGS_SOURCE_NAME) — a plain
+ *    otel_logs-schema table whose facet keys/values are served from metadata
+ *    materialized views (15-minute key + key/value rollups) registered on the
+ *    source definition. Reruns the filter checks against the rollup-backed facet
+ *    path for:
+ *      - ServiceName                  — native column (ColumnIdentifier=NativeColumn)
+ *      - LogAttributes['requestId']   — Map key (ColumnIdentifier=LogAttributes)
+ *
+ * JSON columns are tested on the dashboard only: JSON nested-path facets are
+ * disabled on the search page (HDX-2480), so they don't surface in the sidebar.
+ *
+ * Search tests verify the sidebar facets resolve and include/exclude correctly.
+ * Dashboard tests verify a Number tile (count) filters to 1 / back to 3, both
+ * when the column expression is typed raw and when it is pre-quoted with
+ * backticks (the app must not double-escape an already-quoted identifier).
+ */
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { SearchPage } from '../page-objects/SearchPage';
+import {
+  INTERESTING_FILTER_KEYS_ROWS,
+  METADATA_MV_LOG_ATTR_KEY,
+  METADATA_MV_ROWS,
+} from '../seed-clickhouse';
+import { expect, test } from '../utils/base-test';
+import {
+  INTERESTING_FILTER_KEYS_SOURCE_NAME,
+  METADATA_MV_LOGS_SOURCE_NAME,
+} from '../utils/constants';
+
+const [ROW1, ROW2, ROW3] = INTERESTING_FILTER_KEYS_ROWS;
+const [MV_ROW1, MV_ROW2, MV_ROW3] = METADATA_MV_ROWS;
+
+// Re-running a ClickHouse query after a filter change (and the table/tile
+// re-render) can take noticeably longer than Playwright's 5s assertion default
+// on slow CI runners. Give count/value assertions extra headroom.
+const QUERY_TIMEOUT = 20_000;
+
+// Each search column: the chain of sidebar group test ids to expand (a single
+// `filter-group-*` for top-level columns, or the nested chain for Map keys and
+// dotted column names), the leaf column name used in the value checkbox test id,
+// and the three seeded values (index 0 corresponds to the source's first row).
+type SearchColumn = {
+  label: string;
+  groupTestids: string[];
+  column: string;
+  values: readonly [string, string, string];
+};
+
+// Each dashboard column: a unique filter name, the raw and/or backtick-quoted
+// forms of the column expression, and the value (from the first row) that should
+// reduce the count to 1. A form left undefined is skipped for that variant.
+type DashboardColumn = {
+  name: string;
+  raw?: string;
+  quoted?: string;
+  value: string;
+};
+
+type Scenario = {
+  source: string;
+  // Body of the index-0 row — the single row a values[0] filter matches.
+  row1Body: string;
+  searchColumns: readonly SearchColumn[];
+  dashboardColumns: readonly DashboardColumn[];
+};
+
+const SCENARIOS: readonly Scenario[] = [
+  {
+    source: INTERESTING_FILTER_KEYS_SOURCE_NAME,
+    row1Body: ROW1.body,
+    searchColumns: [
+      {
+        label: 'ServiceName',
+        groupTestids: ['filter-group-ServiceName'],
+        column: 'ServiceName',
+        values: [ROW1.serviceName, ROW2.serviceName, ROW3.serviceName],
+      },
+      {
+        label: "ResourceAttributes['key.subKey.subSubKey']",
+        groupTestids: [
+          'nested-filter-group-ResourceAttributes',
+          "nested-filter-group-ResourceAttributes['key.subKey.subSubKey']",
+        ],
+        column: 'key.subKey.subSubKey',
+        values: [
+          ROW1.resourceAttrValue,
+          ROW2.resourceAttrValue,
+          ROW3.resourceAttrValue,
+        ],
+      },
+      {
+        label: '__hdx_materialized_k8s.cluster.name',
+        groupTestids: [
+          'nested-filter-group-__hdx_materialized_k8s',
+          'nested-filter-group-__hdx_materialized_k8s.cluster.name',
+        ],
+        column: 'cluster.name',
+        values: [ROW1.clusterName, ROW2.clusterName, ROW3.clusterName],
+      },
+      {
+        label: 'service-name',
+        groupTestids: ['filter-group-service-name'],
+        column: 'service-name',
+        values: [
+          ROW1.serviceNameHyphen,
+          ROW2.serviceNameHyphen,
+          ROW3.serviceNameHyphen,
+        ],
+      },
+      {
+        label: "Map-Attributes['pod-name']",
+        groupTestids: [
+          'nested-filter-group-Map-Attributes',
+          "nested-filter-group-Map-Attributes['pod-name']",
+        ],
+        column: 'pod-name',
+        values: [ROW1.mapHyphenValue, ROW2.mapHyphenValue, ROW3.mapHyphenValue],
+      },
+      // NOTE: A JSON column (e.g. `JSON-Attributes`) is intentionally NOT covered
+      // here — JSON nested-path facets are disabled on the search page (HDX-2480:
+      // getAllFields skips JSON columns), so they never surface in the sidebar. The
+      // JSON hyphen-name + hyphen-key case is exercised on the dashboard instead
+      // (see JsonHyphenFilter below).
+    ],
+    dashboardColumns: [
+      {
+        name: 'ServiceNameFilter',
+        raw: 'ServiceName',
+        quoted: '`ServiceName`',
+        value: ROW1.serviceName,
+      },
+      {
+        name: 'MapKeyFilter',
+        raw: "ResourceAttributes['key.subKey.subSubKey']",
+        quoted: "`ResourceAttributes`['key.subKey.subSubKey']",
+        value: ROW1.resourceAttrValue,
+      },
+      {
+        name: 'JsonPathFilter',
+        raw: 'ResourceAttributesJSON.key.subKey.subSubKey',
+        quoted: '`ResourceAttributesJSON`.`key`.`subKey`.`subSubKey`',
+        value: ROW1.jsonValue,
+      },
+      {
+        name: 'ClusterFilter',
+        // A flat column whose name contains dots is ambiguous verbatim (ClickHouse
+        // parses `a.b.c` as nested access), so the raw form is expected to fail —
+        // dashboard expressions are never auto-quoted. Only the explicitly-quoted
+        // form works. (Search differs: the facet UI owns the key, so it is quoted
+        // schema-awarely there.)
+        raw: undefined,
+        quoted: '`__hdx_materialized_k8s.cluster.name`',
+        value: ROW1.clusterName,
+      },
+      {
+        name: 'ServiceHyphenFilter',
+        raw: undefined, // raw is expected to fail - it will be parsed as subtraction
+        quoted: '`service-name`',
+        value: ROW1.serviceNameHyphen,
+      },
+      {
+        // Verbatim function-call expression. `toString(ServiceName)` resolves to
+        // ServiceName values, so the value to select is ROW1.serviceName (not the
+        // hyphen column's value).
+        name: 'ToStringFilter',
+        raw: 'toString(ServiceName)',
+        quoted: undefined, // toString() is added in the filter query generation, so there's no user-typed raw form to test against
+        value: ROW1.serviceName,
+      },
+      {
+        // Map column whose NAME contains a hyphen. Raw `Map-Attributes['pod-name']`
+        // is parsed as subtraction (`Map` - `Attributes`), so the user must quote it.
+        name: 'MapHyphenFilter',
+        raw: undefined,
+        quoted: "`Map-Attributes`['pod-name']",
+        value: ROW1.mapHyphenValue,
+      },
+      {
+        // JSON column whose name AND nested keys contain hyphens. Raw form parses
+        // incorrectly, so the user must backtick-quote each segment.
+        name: 'JsonHyphenFilter',
+        raw: undefined,
+        quoted: '`JSON-Attributes`.`key-1`.`key-2`',
+        value: ROW1.jsonHyphenValue,
+      },
+    ],
+  },
+  {
+    // Source whose facet keys/values are served by metadata materialized views.
+    // Covers a native column (ServiceName) and a Map key (LogAttributes), both of
+    // which the rollup MVs aggregate (ColumnIdentifier = NativeColumn / LogAttributes).
+    source: METADATA_MV_LOGS_SOURCE_NAME,
+    row1Body: MV_ROW1.body,
+    searchColumns: [
+      {
+        label: 'ServiceName',
+        groupTestids: ['filter-group-ServiceName'],
+        column: 'ServiceName',
+        values: [MV_ROW1.serviceName, MV_ROW2.serviceName, MV_ROW3.serviceName],
+      },
+      {
+        label: `LogAttributes['${METADATA_MV_LOG_ATTR_KEY}']`,
+        groupTestids: [
+          'nested-filter-group-LogAttributes',
+          `nested-filter-group-LogAttributes['${METADATA_MV_LOG_ATTR_KEY}']`,
+        ],
+        column: METADATA_MV_LOG_ATTR_KEY,
+        values: [
+          MV_ROW1.logAttrValue,
+          MV_ROW2.logAttrValue,
+          MV_ROW3.logAttrValue,
+        ],
+      },
+    ],
+    dashboardColumns: [
+      {
+        name: 'ServiceNameFilter',
+        raw: 'ServiceName',
+        quoted: '`ServiceName`',
+        value: MV_ROW1.serviceName,
+      },
+      {
+        name: 'LogAttrFilter',
+        raw: `LogAttributes['${METADATA_MV_LOG_ATTR_KEY}']`,
+        quoted: `\`LogAttributes\`['${METADATA_MV_LOG_ATTR_KEY}']`,
+        value: MV_ROW1.logAttrValue,
+      },
+    ],
+  },
+];
+
+for (const scenario of SCENARIOS) {
+  const SOURCE = scenario.source;
+
+  // -------------------------------------------------------------------------
+  // Search page
+  // -------------------------------------------------------------------------
+  test.describe(
+    `Filter key edge cases — Search [${SOURCE}]`,
+    { tag: ['@search', '@full-stack'] },
+    () => {
+      let searchPage: SearchPage;
+
+      test.beforeEach(async ({ page }) => {
+        searchPage = new SearchPage(page);
+        await searchPage.goto();
+        await searchPage.selectSource(SOURCE);
+        await searchPage.timePicker.selectRelativeTime('Last 1 hour');
+        await searchPage.table.waitForRowsToPopulate();
+      });
+
+      for (const col of scenario.searchColumns) {
+        // The matching value/row is index 0; row1Body uniquely identifies it.
+        const matchValue = col.values[0];
+
+        test(`includes and excludes by ${col.label}`, async () => {
+          const rows = searchPage.table.getRows();
+
+          await test.step('filter options show the seeded values', async () => {
+            await searchPage.filters.revealColumnValues(
+              col.groupTestids,
+              col.column,
+              matchValue,
+            );
+            for (const value of col.values) {
+              await expect(
+                searchPage.filters.getFilterCheckboxInput(col.column, value),
+              ).toBeVisible();
+            }
+          });
+
+          await test.step('value distribution renders when toggled on', async () => {
+            // The distribution query uses the column key as a raw SQL
+            // SELECT/GROUP BY expression, so a key that needs quoting must be
+            // escaped or the query errors and no percentage renders. A visible
+            // percentage proves the distribution query ran and returned a value.
+            await searchPage.filters.showDistribution(col.column);
+            await expect(
+              searchPage.filters.getDistributionPercentage(
+                col.column,
+                matchValue,
+              ),
+            ).toBeVisible({ timeout: QUERY_TIMEOUT });
+            // Toggle back off so later steps start from a clean state.
+            await searchPage.filters.showDistribution(col.column);
+          });
+
+          await test.step('applying a value shows only the matching row', async () => {
+            await searchPage.filters.applyFilter(col.column, matchValue);
+            // Confirm the click registered before asserting on results, so a
+            // missed click is reported as an unchecked box rather than a stale
+            // row count.
+            await expect(
+              searchPage.filters.getFilterCheckboxInput(col.column, matchValue),
+            ).toBeChecked({ timeout: QUERY_TIMEOUT });
+            await expect(searchPage.getTableError()).toHaveCount(0);
+            await expect(rows).toHaveCount(1, { timeout: QUERY_TIMEOUT });
+            await expect(
+              rows.filter({ hasText: scenario.row1Body }),
+            ).toHaveCount(1);
+          });
+
+          await test.step('filter persists across reload', async () => {
+            await searchPage.page.reload();
+            await expect(searchPage.page).toHaveURL(/filters=/);
+            await searchPage.table.waitForRowsToPopulate();
+            await expect(searchPage.getTableError()).toHaveCount(0);
+            await expect(rows).toHaveCount(1, { timeout: QUERY_TIMEOUT });
+            await expect(
+              rows.filter({ hasText: scenario.row1Body }),
+            ).toHaveCount(1);
+          });
+
+          await test.step('excluding the value shows the two other rows', async () => {
+            await searchPage.filters.revealColumnValues(
+              col.groupTestids,
+              col.column,
+              matchValue,
+            );
+            // Move the value straight from included to excluded via the Exclude
+            // button. The exclude action clears the include set and adds the
+            // exclude in a single click, so there's no need to first uncheck the
+            // box (clicking the checkbox to deselect is avoided).
+            await searchPage.filters.excludeFilter(col.column, matchValue);
+            await expect
+              .poll(
+                () =>
+                  searchPage.filters.isFilterExcluded(col.column, matchValue),
+                { timeout: QUERY_TIMEOUT },
+              )
+              .toBe(true);
+            await expect(searchPage.getTableError()).toHaveCount(0);
+            await expect(rows).toHaveCount(2, { timeout: QUERY_TIMEOUT });
+            await expect(
+              rows.filter({ hasText: scenario.row1Body }),
+            ).toHaveCount(0);
+          });
+
+          await test.step('deselecting the excluded value restores all rows', async () => {
+            await searchPage.filters.revealColumnValues(
+              col.groupTestids,
+              col.column,
+              matchValue,
+            );
+            // Deselect by clicking the Exclude button again (toggles the exclude
+            // off), NOT the checkbox — clicking the checkbox of an excluded value
+            // re-includes it rather than clearing it.
+            await searchPage.filters.excludeFilter(col.column, matchValue);
+            await expect
+              .poll(
+                () =>
+                  searchPage.filters.isFilterExcluded(col.column, matchValue),
+                { timeout: QUERY_TIMEOUT },
+              )
+              .toBe(false);
+            await expect(
+              searchPage.filters.getFilterCheckboxInput(col.column, matchValue),
+            ).not.toBeChecked({ timeout: QUERY_TIMEOUT });
+            await expect(searchPage.getTableError()).toHaveCount(0);
+            await expect(rows).toHaveCount(3, { timeout: QUERY_TIMEOUT });
+          });
+
+          // Re-exclude so the persistence step below still verifies a saved
+          // exclusion across reload.
+          await test.step('re-exclude the value', async () => {
+            await searchPage.filters.excludeFilter(col.column, matchValue);
+            await expect
+              .poll(
+                () =>
+                  searchPage.filters.isFilterExcluded(col.column, matchValue),
+                { timeout: QUERY_TIMEOUT },
+              )
+              .toBe(true);
+            await expect(rows).toHaveCount(2, { timeout: QUERY_TIMEOUT });
+          });
+
+          await test.step('exclusion persists across reload', async () => {
+            await searchPage.page.reload();
+            await expect(searchPage.page).toHaveURL(/filters=/);
+            await searchPage.table.waitForRowsToPopulate();
+            await expect(searchPage.getTableError()).toHaveCount(0);
+            await expect(rows).toHaveCount(2, { timeout: QUERY_TIMEOUT });
+            await expect(
+              rows.filter({ hasText: scenario.row1Body }),
+            ).toHaveCount(0);
+          });
+        });
+
+        // Isolated from the include/exclude flow above: adding a column injects
+        // the key into the search SELECT as a raw SQL expression, so a key that
+        // needs quoting must be escaped or the query errors. No table error +
+        // all rows still present proves the generated SELECT is valid.
+        test(`"Add column" builds a valid query for ${col.label}`, async () => {
+          await searchPage.filters.revealColumnValues(
+            col.groupTestids,
+            col.column,
+            matchValue,
+          );
+          await searchPage.filters.toggleColumn(col.column);
+          await searchPage.table.waitForRowsToPopulate();
+          await expect(searchPage.getTableError()).toHaveCount(0);
+          await expect(searchPage.table.getRows()).toHaveCount(3, {
+            timeout: QUERY_TIMEOUT,
+          });
+        });
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Dashboard page
+  // -------------------------------------------------------------------------
+  test.describe(
+    `Filter key edge cases — Dashboard [${SOURCE}]`,
+    { tag: ['@dashboard', '@full-stack'] },
+    () => {
+      // variant = which form of the column expression is typed into the filter
+      // edit modal: 'raw' (no manual quoting) or 'quoted' (explicit backticks).
+      for (const variant of ['raw', 'quoted'] as const) {
+        test(`number tile filters by custom column filters (${variant} column names)`, async ({
+          page,
+        }) => {
+          const dashboardPage = new DashboardPage(page);
+
+          await test.step('create a count Number tile (shows all 3 rows)', async () => {
+            await dashboardPage.goto();
+            await dashboardPage.createNewDashboard();
+            await dashboardPage.timePicker.selectRelativeTime('Last 1 hour');
+            await dashboardPage.addNumberTile('Count tile', SOURCE);
+            await expect(dashboardPage.getNumberTileValue()).toHaveText('3', {
+              timeout: QUERY_TIMEOUT,
+            });
+          });
+
+          await test.step('add a custom filter for each column', async () => {
+            await dashboardPage.openEditFiltersModal();
+            for (const col of scenario.dashboardColumns) {
+              const expression = variant === 'raw' ? col.raw : col.quoted;
+              if (!expression) continue;
+              await dashboardPage.addCustomFilter(col.name, SOURCE, expression);
+            }
+            await dashboardPage.closeFiltersModal();
+            // Reload once so the tile + filter definitions are loaded from the
+            // server; confirms persistence before the per-filter reload checks.
+            await page.reload();
+            await dashboardPage.waitForLoaded();
+            await expect(dashboardPage.getNumberTileValue()).toHaveText('3', {
+              timeout: QUERY_TIMEOUT,
+            });
+            // Every filter created for this variant must render as a selector.
+            // Columns with no expression for the current variant (e.g. raw forms
+            // that are invalid verbatim) are skipped above, so skip them here too.
+            for (const col of scenario.dashboardColumns) {
+              const expression = variant === 'raw' ? col.raw : col.quoted;
+              if (!expression) continue;
+              await expect(
+                dashboardPage.getFilterSelectByName(col.name),
+              ).toBeVisible();
+            }
+          });
+
+          for (const col of scenario.dashboardColumns) {
+            const expression = variant === 'raw' ? col.raw : col.quoted;
+            if (!expression) continue;
+
+            await test.step(`${col.name}: select → 1, reload → 1, deselect → 3`, async () => {
+              await dashboardPage.toggleFilterValue(col.name, col.value);
+              await expect(dashboardPage.getNumberTileValue()).toHaveText('1', {
+                timeout: QUERY_TIMEOUT,
+              });
+              await expect(dashboardPage.getTileError()).toHaveCount(0);
+
+              await page.reload();
+              await dashboardPage.waitForLoaded();
+              await expect(dashboardPage.getNumberTileValue()).toHaveText('1', {
+                timeout: QUERY_TIMEOUT,
+              });
+              await expect(dashboardPage.getTileError()).toHaveCount(0);
+
+              await dashboardPage.toggleFilterValue(col.name, col.value);
+              await expect(dashboardPage.getNumberTileValue()).toHaveText('3', {
+                timeout: QUERY_TIMEOUT,
+              });
+              await expect(dashboardPage.getTileError()).toHaveCount(0);
+            });
+          }
+        });
+      }
+    },
+  );
+}

--- a/packages/app/tests/e2e/fixtures/e2e-fixtures.json
+++ b/packages/app/tests/e2e/fixtures/e2e-fixtures.json
@@ -182,6 +182,50 @@
       "spanIdExpression": "SpanId",
       "implicitColumnExpression": "Body",
       "displayedTimestampValueExpression": "Timestamp"
+    },
+    {
+      "id": "E2E Interesting Filter Keys",
+      "kind": "log",
+      "name": "E2E Interesting Filter Keys",
+      "connection": "local",
+      "from": {
+        "databaseName": "default",
+        "tableName": "otel_logs_interesting_filter_keys"
+      },
+      "timestampValueExpression": "Timestamp",
+      "defaultTableSelectExpression": "Timestamp, ServiceName, Body",
+      "serviceNameExpression": "ServiceName",
+      "severityTextExpression": "SeverityText",
+      "resourceAttributesExpression": "ResourceAttributes",
+      "traceIdExpression": "TraceId",
+      "spanIdExpression": "SpanId",
+      "implicitColumnExpression": "Body",
+      "displayedTimestampValueExpression": "Timestamp"
+    },
+    {
+      "id": "E2E Metadata MV Logs",
+      "kind": "log",
+      "name": "E2E Metadata MV Logs",
+      "connection": "local",
+      "from": {
+        "databaseName": "default",
+        "tableName": "e2e_otel_logs_metadata_mv"
+      },
+      "timestampValueExpression": "Timestamp",
+      "defaultTableSelectExpression": "Timestamp, ServiceName, SeverityText, Body",
+      "serviceNameExpression": "ServiceName",
+      "severityTextExpression": "SeverityText",
+      "eventAttributesExpression": "LogAttributes",
+      "resourceAttributesExpression": "ResourceAttributes",
+      "traceIdExpression": "TraceId",
+      "spanIdExpression": "SpanId",
+      "implicitColumnExpression": "Body",
+      "displayedTimestampValueExpression": "Timestamp",
+      "metadataMaterializedViews": {
+        "keyRollupTable": "e2e_otel_logs_key_rollup_15m",
+        "kvRollupTable": "e2e_otel_logs_kv_rollup_15m",
+        "granularity": "15 minute"
+      }
     }
   ]
 }

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -809,6 +809,87 @@ export class DashboardPage {
     return this.page.getByTestId(`dashboard-filter-select-${name}`);
   }
 
+  /**
+   * Create a Number tile that counts events from `sourceName`. The tile editor's
+   * default aggregation is "Count of Events", so no agg configuration is needed.
+   * Leaves exactly one tile on the dashboard.
+   */
+  async addNumberTile(name: string, sourceName: string) {
+    await this.addTile();
+    await expect(this.chartEditor.nameInput).toBeVisible();
+    await this.chartEditor.waitForDataToLoad();
+    await this.chartEditor.setChartType(DisplayType.Number);
+    await this.chartEditor.setChartName(name);
+    await this.chartEditor.selectSource(sourceName);
+    await this.chartEditor.runQuery(false);
+    await this.chartEditor.save();
+    await expect(this.getTiles()).toHaveCount(1, { timeout: 10000 });
+  }
+
+  /** Locator for the rendered value of a Number tile. */
+  getNumberTileValue(tileIndex = 0): Locator {
+    return this.getTile(tileIndex).getByTestId('number-chart-value');
+  }
+
+  /** Locator for a tile's error state (rendered by ChartErrorState). */
+  getTileError(tileIndex = 0): Locator {
+    return this.getTile(tileIndex).getByText(/Error loading/i);
+  }
+
+  /**
+   * Add a dashboard filter whose key is an arbitrary column expression. Unlike
+   * `fillFilterForm`, the expression is inserted via `insertText` so CodeMirror's
+   * bracket/quote auto-closing does not corrupt expressions containing `[`, `'`,
+   * or backticks. Assumes the Edit Filters modal is already open; leaves it open
+   * (on the filters list) so multiple filters can be added in sequence.
+   */
+  async addCustomFilter(name: string, sourceName: string, expression: string) {
+    await this.addFiltersButton.click();
+    const nameInput = this.page.getByTestId('filter-name-input');
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 });
+    await nameInput.fill(name);
+    await this.filtersSourceSelector.click();
+    await this.page
+      .getByRole('option', { name: sourceName, exact: true })
+      .click();
+    const editor = getSqlEditor(this.page, 'expression');
+    await editor.click();
+    await this.page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+    );
+    await this.page.keyboard.press('Backspace');
+    await this.page.keyboard.insertText(expression);
+    // Blur the SQL editor before saving so its CodeMirror autocomplete tooltip
+    // closes — left open it overlaps the save button and makes the click flake
+    // on "element is not stable".
+    await nameInput.click();
+    const saveButton = this.page.getByTestId('save-filter-button');
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    // Wait for the filter to actually land in the list before returning, so a
+    // slow save doesn't race the next add (which would silently drop a filter).
+    await this.getFilterItemByName(name).waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * Toggle a value in a dashboard filter's multi-select. Selecting an unselected
+   * value applies it; calling again with the same value clears it. Closes the
+   * dropdown afterward so the rest of the dashboard is interactable.
+   */
+  async toggleFilterValue(filterName: string, value: string) {
+    const select = this.getFilterSelectByName(filterName);
+    await select.waitFor({ state: 'visible', timeout: 15000 });
+    await select.scrollIntoViewIfNeeded();
+    await select.click();
+    const option = this.page.getByRole('option', { name: value, exact: true });
+    await option.waitFor({ state: 'visible', timeout: 15000 });
+    await option.click();
+    await this.page.keyboard.press('Escape');
+  }
+
   async clickFilterOption(filterName: string, option: string) {
     const serviceFilter = this.getFilterSelectByName(filterName);
     serviceFilter.click();

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -234,6 +234,15 @@ export class SearchPage {
   }
 
   /**
+   * Locator for the results table's error state (rendered by ChartErrorState
+   * when the underlying ClickHouse query fails). Assert `toHaveCount(0)` to
+   * confirm the results loaded without error.
+   */
+  getTableError() {
+    return this.page.getByText(/Error loading/i);
+  }
+
+  /**
    * Get SELECT editor (CodeMirror)
    */
   getSELECTEditor() {

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -11,7 +11,11 @@
 
 import {
   E2E_CLICKHOUSE_DATABASE,
+  E2E_INTERESTING_FILTER_KEYS_TABLE,
   E2E_LOGS_TABLE,
+  E2E_METADATA_MV_KEY_ROLLUP_TABLE,
+  E2E_METADATA_MV_KV_ROLLUP_TABLE,
+  E2E_METADATA_MV_LOGS_TABLE,
   E2E_METRICS_GAUGE_TABLE,
   E2E_METRICS_SUM_TABLE,
   E2E_SESSIONS_TABLE,
@@ -74,6 +78,68 @@ export const SERVICES = [
   'notification-service',
   'inventory-service',
 ] as const;
+// Rows seeded into `otel_logs_interesting_filter_keys`. Each column has a
+// distinct value per row so a single filter value matches exactly one row.
+// Exported so the filter-key edge case E2E test asserts against the same data.
+export const INTERESTING_FILTER_KEYS_ROWS = [
+  {
+    serviceName: 'service1',
+    resourceAttrValue: 'value1',
+    jsonValue: 'value1',
+    clusterName: 'cluster1',
+    serviceNameHyphen: 'svc-one',
+    mapHyphenValue: 'mapval1',
+    jsonHyphenValue: 'jsonval1',
+    body: 'log body 1',
+  },
+  {
+    serviceName: 'service2',
+    resourceAttrValue: 'value2',
+    jsonValue: 'value2',
+    clusterName: 'cluster2',
+    serviceNameHyphen: 'svc-two',
+    mapHyphenValue: 'mapval2',
+    jsonHyphenValue: 'jsonval2',
+    body: 'log body 2',
+  },
+  {
+    serviceName: 'service3',
+    resourceAttrValue: 'value3',
+    jsonValue: 'value3',
+    clusterName: 'cluster3',
+    serviceNameHyphen: 'svc-three',
+    mapHyphenValue: 'mapval3',
+    jsonHyphenValue: 'jsonval3',
+    body: 'log body 3',
+  },
+] as const;
+
+// LogAttributes map key seeded into the metadata-MV source rows. Exported so
+// the filter-key edge case test references the same key when building filters.
+export const METADATA_MV_LOG_ATTR_KEY = 'requestId';
+// Rows seeded into `e2e_otel_logs_metadata_mv` (the metadata-MV-backed source).
+// Each row has a distinct ServiceName and LogAttributes['requestId'] value so a
+// single filter value matches exactly one row, mirroring the
+// INTERESTING_FILTER_KEYS_ROWS shape. Facet keys/values for this source come
+// from the rollup MVs rather than the base table.
+export const METADATA_MV_ROWS = [
+  {
+    serviceName: 'mv-service-1',
+    logAttrValue: 'mv-req-1',
+    body: 'mv log body 1',
+  },
+  {
+    serviceName: 'mv-service-2',
+    logAttrValue: 'mv-req-2',
+    body: 'mv log body 2',
+  },
+  {
+    serviceName: 'mv-service-3',
+    logAttrValue: 'mv-req-3',
+    body: 'mv log body 3',
+  },
+] as const;
+
 const LOG_MESSAGES = [
   'Request processed successfully',
   'Database connection established',
@@ -593,6 +659,45 @@ function generateK8sEventLogs(
   return rows.join(',\n');
 }
 
+/**
+ * Build the VALUES tuples for `otel_logs_interesting_filter_keys`. Rows are
+ * placed a few seconds before `seedRef` so they fall inside recent relative
+ * time ranges. The map key and JSON path intentionally use a dotted key
+ * ("key.subKey.subSubKey") and the table has dotted/hyphenated column names so
+ * the test exercises identifier escaping in generated filter queries.
+ */
+function generateInterestingFilterKeyLogData(seedRef: number): string {
+  return INTERESTING_FILTER_KEYS_ROWS.map((row, i) => {
+    const timestampNs = (seedRef - (i + 1) * 1000) * 1000000;
+    const json = `{"key": {"subKey": {"subSubKey": "${row.jsonValue}"}}}`;
+    // JSON column with a hyphenated name AND hyphenated nested keys.
+    const jsonHyphen = `{"key-1": {"key-2": "${row.jsonHyphenValue}"}}`;
+    return (
+      `('${timestampNs}', 'trace${i + 1}', 'span${i + 1}', 'INFO', ` +
+      `'${row.serviceName}', '${row.body}', ` +
+      `{'key.subKey.subSubKey':'${row.resourceAttrValue}'}, ` +
+      `'${json}', '${row.clusterName}', '${row.serviceNameHyphen}', ` +
+      `{'pod-name':'${row.mapHyphenValue}'}, '${jsonHyphen}')`
+    );
+  }).join(',\n');
+}
+
+/**
+ * Build the VALUES tuples for `e2e_otel_logs_metadata_mv`. Rows are placed a few
+ * seconds before `seedRef` so they fall inside recent relative time ranges (and
+ * inside the 15-minute rollup bucket the metadata MVs aggregate into). Inserting
+ * here also triggers the key/value rollup MVs that back the source's facets.
+ */
+function generateMetadataMvLogData(seedRef: number): string {
+  return METADATA_MV_ROWS.map((row, i) => {
+    const timestampNs = (seedRef - (i + 1) * 1000) * 1000000;
+    return (
+      `('${timestampNs}', '${row.serviceName}', '${row.body}', ` +
+      `{'${METADATA_MV_LOG_ATTR_KEY}':'${row.logAttrValue}'})`
+    );
+  }).join(',\n');
+}
+
 // CI can be slower, so use a longer timeout
 const CLICKHOUSE_READY_TIMEOUT_SECONDS = parseInt(
   process.env.E2E_CLICKHOUSE_READY_TIMEOUT || '60',
@@ -658,6 +763,20 @@ async function clearTestData(
   );
   await client.query(
     `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METRICS_SUM_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_INTERESTING_FILTER_KEYS_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METADATA_MV_LOGS_TABLE}`,
+  );
+  // The rollup MV targets are not cleared by truncating the base table, so
+  // clear them explicitly to avoid accumulating stale facet rows across re-seeds.
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METADATA_MV_KV_ROLLUP_TABLE}`,
+  );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METADATA_MV_KEY_ROLLUP_TABLE}`,
   );
   console.log('  Existing data cleared');
 }
@@ -772,6 +891,34 @@ export async function seedClickHouse(): Promise<void> {
     ) VALUES ${generateK8sEventLogs(numDataPoints, startMs, endMs)}
   `);
   console.log(`  Inserted ${numDataPoints} Kubernetes event logs`);
+
+  // Insert "interesting filter key" rows (dotted/hyphenated column names, Map
+  // key access, and JSON path access) for the filter-key edge case tests.
+  console.log('  Inserting interesting filter key data...');
+  await client.query(`
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_INTERESTING_FILTER_KEYS_TABLE} (
+      Timestamp, TraceId, SpanId, SeverityText, ServiceName, Body,
+      ResourceAttributes, ResourceAttributesJSON,
+      \`__hdx_materialized_k8s.cluster.name\`, \`service-name\`,
+      \`Map-Attributes\`, \`JSON-Attributes\`
+    ) VALUES ${generateInterestingFilterKeyLogData(seedRef)}
+  `);
+  console.log(
+    `  Inserted ${INTERESTING_FILTER_KEYS_ROWS.length} interesting filter key entries`,
+  );
+
+  // Insert metadata-MV source rows. The insert triggers the key/value rollup
+  // MVs that back this source's facets (ServiceName native column +
+  // LogAttributes['requestId'] map key).
+  console.log('  Inserting metadata-MV source data...');
+  await client.query(`
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_METADATA_MV_LOGS_TABLE} (
+      Timestamp, ServiceName, Body, LogAttributes
+    ) VALUES ${generateMetadataMvLogData(seedRef)}
+  `);
+  console.log(
+    `  Inserted ${METADATA_MV_ROWS.length} metadata-MV source entries`,
+  );
 
   console.log('ClickHouse seeding complete');
 }

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -3,6 +3,18 @@ export const DEFAULT_TRACES_SOURCE_NAME = 'E2E Traces';
 export const DEFAULT_METRICS_SOURCE_NAME = 'E2E Metrics';
 export const DEFAULT_LOGS_SOURCE_NAME = 'E2E Logs';
 
+// Source backed by `otel_logs_interesting_filter_keys`, used by the filter-key
+// edge case tests to exercise identifier escaping (dotted/hyphenated column
+// names, Map keys, and JSON paths) in search and dashboard filters.
+export const INTERESTING_FILTER_KEYS_SOURCE_NAME =
+  'E2E Interesting Filter Keys';
+
+// Log source backed by a plain otel_logs-schema base table whose facet
+// keys/values are served from metadata materialized views (key + key/value
+// 15-minute rollups) registered on the source definition. Used by the
+// filter-key edge case tests to exercise the rollup-backed facet path.
+export const METADATA_MV_LOGS_SOURCE_NAME = 'E2E Metadata MV Logs';
+
 // Trace source pre-configured with a materialized view (e2e_otel_traces_1m),
 // used by the materialized-view acceleration tests.
 export const DEFAULT_TRACES_MV_SOURCE_NAME = 'E2E Traces MV';
@@ -23,3 +35,13 @@ export const E2E_TRACES_MV_TABLE = 'e2e_otel_traces_1m';
 export const E2E_SESSIONS_TABLE = 'e2e_hyperdx_sessions';
 export const E2E_METRICS_GAUGE_TABLE = 'e2e_otel_metrics_gauge';
 export const E2E_METRICS_SUM_TABLE = 'e2e_otel_metrics_sum';
+// Table backing the INTERESTING_FILTER_KEYS_SOURCE_NAME source. Created in
+// `docker/clickhouse/local/init-db-e2e.sh` and seeded in `seed-clickhouse.ts`.
+export const E2E_INTERESTING_FILTER_KEYS_TABLE =
+  'otel_logs_interesting_filter_keys';
+// Base table backing METADATA_MV_LOGS_SOURCE_NAME, plus the key/value rollup
+// tables auto-populated by materialized views on insert. Created in
+// `docker/clickhouse/local/init-db-e2e.sh` and seeded in `seed-clickhouse.ts`.
+export const E2E_METADATA_MV_LOGS_TABLE = 'e2e_otel_logs_metadata_mv';
+export const E2E_METADATA_MV_KV_ROLLUP_TABLE = 'e2e_otel_logs_kv_rollup_15m';
+export const E2E_METADATA_MV_KEY_ROLLUP_TABLE = 'e2e_otel_logs_key_rollup_15m';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [HDX-4585]: Column names containing special characters (e.g. hyphens like `log-status`, `az-id`, `flow-direction`) were interpolated as bare identifiers in filter/key-value queries, causing ClickHouse to misparse them. For example, `log-status` was interpreted as `log` minus `status`.

Expressions are now backtick-quoted using `SqlString.escapeId` prior to being queried as filter keys:

1. LogStatus --> `LogStatus`
2. log-status --> \`log-status\`
3. ResourceAttributes['log.status'] --> \`ResourceAttributes\`['log.status']

This has been fixed both when querying for filter key/values and when generating query conditions based on selected filters.

To ensure that alerts on saved searches work, filter queries are persisted in Mongo with backtick-quoted keys, so that the filter query does not need to be parsed and modified.

## Testing

I've added a fairly comprehensive set of E2E tests testing the following cases

- Search page filters
   - Filter values load for the following columns: `ServiceName`, `ResourceAttributes['key.subKey.subSubKey']`, `__hdx_materialized_k8s.cluster.name`, and `service-name`
   - Filter values can be included and excluded for each of those keys
   - Filter value distributions can be queried for each of those keys
   - The column can be added to the select from the sidebar filter item
- Dashboard filters
   - Filter values load for the following columns: `ServiceName`, `ResourceAttributes['key.subKey.subSubKey']`, `__hdx_materialized_k8s.cluster.name`, `ResourceAttributesJSON.key.subKey.subSubKey` and `service-name`
   - Filter values can be included and excluded for each of those columns
   - Additionally, all of the above filters can be defined by the user using a non-backticked OR pre-backticked expression (i.e. the user types \`service-name\` into the filter expression input, or just service-name).

This can also be tested locally by creating a source with columns that have `-`s in them and testing out the filter functionality. In the preview environment, existing behavior of the filters on dashboards and search page can be regression tested.

Linear Issue: Closes HDX-4585
