### PR TITLE
fix(app): format log detail Timestamp in local timezone

### DIFF
--- a/.changeset/fix-log-detail-timestamp-timezone.md
+++ b/.changeset/fix-log-detail-timestamp-timezone.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/app": patch
+---
+
+fix(app): format log detail Timestamp in local timezone
+
+The log detail JSON viewer rendered Timestamp and TimestampTime as raw UTC ISO strings while the results table used the shared FormatTime helper.

--- a/packages/app/src/components/DBRowJsonViewer.test.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.test.tsx
@@ -196,9 +196,7 @@ describe('DBRowJsonViewer', () => {
         },
       });
 
-      expect(
-        screen.getByText('2026-06-15T02:23:15.895Z'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('2026-06-15T02:23:15.895Z')).toBeInTheDocument();
     });
 
     it.each([['Timestamp'], ['TimestampTime']])(

--- a/packages/app/src/components/DBRowJsonViewer.test.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.test.tsx
@@ -158,6 +158,17 @@ describe('DBRowJsonViewer', () => {
   });
 
   describe('timestamp fields', () => {
+    it('displays Timestamp using the same formatter as the results table', () => {
+      renderComponent({
+        Timestamp: '2026-06-15T02:23:15.895Z',
+      });
+
+      expect(
+        screen.queryByText('2026-06-15T02:23:15.895Z'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Timestamp')).toBeInTheDocument();
+    });
+
     it.each([['Timestamp'], ['TimestampTime']])(
       'formats %s field correctly',
       field => {

--- a/packages/app/src/components/DBRowJsonViewer.test.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.test.tsx
@@ -12,6 +12,13 @@ jest.mock('next/router', () => ({
   },
 }));
 
+const mockFormatTime = jest.fn();
+
+jest.mock('@/useFormatTime', () => ({
+  useFormatTime: () => mockFormatTime,
+  FormatTime: jest.fn(() => null),
+}));
+
 describe('DBRowJsonViewer', () => {
   const mockGenerateSearchUrl = jest.fn();
   const mockOnPropertyAddClick = jest.fn();
@@ -50,6 +57,13 @@ describe('DBRowJsonViewer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFormatTime.mockImplementation((time, { format } = {}) => {
+      const date = time instanceof Date ? time : new Date(time);
+      if (format === 'withMs') {
+        return `formatted:${date.toISOString()}`;
+      }
+      return String(time);
+    });
   });
 
   // Helper to render component
@@ -166,7 +180,25 @@ describe('DBRowJsonViewer', () => {
       expect(
         screen.queryByText('2026-06-15T02:23:15.895Z'),
       ).not.toBeInTheDocument();
-      expect(screen.getByText('Timestamp')).toBeInTheDocument();
+      expect(
+        screen.getByText('formatted:2026-06-15T02:23:15.895Z'),
+      ).toBeInTheDocument();
+      expect(mockFormatTime).toHaveBeenCalledWith(
+        expect.any(Date),
+        expect.objectContaining({ format: 'withMs' }),
+      );
+    });
+
+    it('does not reformat nested Timestamp attributes', () => {
+      renderComponent({
+        LogAttributes: {
+          Timestamp: '2026-06-15T02:23:15.895Z',
+        },
+      });
+
+      expect(
+        screen.getByText('2026-06-15T02:23:15.895Z'),
+      ).toBeInTheDocument();
     });
 
     it.each([['Timestamp'], ['TimestampTime']])(

--- a/packages/app/src/components/DBRowJsonViewer.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.tsx
@@ -27,7 +27,12 @@ import {
   IconTextWrap,
 } from '@tabler/icons-react';
 
-import HyperJson, { GetLineActions, LineAction } from '@/components/HyperJson';
+import HyperJson, {
+  FormatLeafValue,
+  GetLineActions,
+  LineAction,
+} from '@/components/HyperJson';
+import { useFormatTime } from '@/useFormatTime';
 import { mergePath } from '@/utils';
 import {
   CLIPBOARD_ERROR_MESSAGE,
@@ -348,6 +353,7 @@ export function DBRowJsonViewer({
   // `Map['key']` instead of the array `Map[N+1]`. HDX-4369.
   mapColumns?: string[];
 }) {
+  const formatTime = useFormatTime();
   const {
     onPropertyAddClick,
     generateSearchUrl,
@@ -377,6 +383,26 @@ export function DBRowJsonViewer({
 
     return filterObjectRecursively(cleanedData, debouncedFilter);
   }, [data, debouncedFilter, jsonOptions.filterBlanks]);
+
+  const formatLeafValue = useCallback<FormatLeafValue>(
+    ({ keyName, value }) => {
+      if (keyName !== 'Timestamp' && keyName !== 'TimestampTime') {
+        return undefined;
+      }
+
+      if (typeof value !== 'string' || value.length === 0) {
+        return undefined;
+      }
+
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return undefined;
+      }
+
+      return formatTime(date, { format: 'withMs' });
+    },
+    [formatTime],
+  );
 
   const getLineActions = useCallback<GetLineActions>(
     ({ keyPath, value, isInParsedJson, parsedJsonRootPath }) => {
@@ -661,6 +687,7 @@ export function DBRowJsonViewer({
           <HyperJson
             data={rowData}
             getLineActions={getLineActions}
+            formatLeafValue={formatLeafValue}
             {...jsonOptions}
           />
         ) : (

--- a/packages/app/src/components/DBRowJsonViewer.tsx
+++ b/packages/app/src/components/DBRowJsonViewer.tsx
@@ -385,8 +385,11 @@ export function DBRowJsonViewer({
   }, [data, debouncedFilter, jsonOptions.filterBlanks]);
 
   const formatLeafValue = useCallback<FormatLeafValue>(
-    ({ keyName, value }) => {
-      if (keyName !== 'Timestamp' && keyName !== 'TimestampTime') {
+    ({ keyName, keyPath, value }) => {
+      if (
+        keyPath.length !== 1 ||
+        (keyName !== 'Timestamp' && keyName !== 'TimestampTime')
+      ) {
         return undefined;
       }
 

--- a/packages/app/src/components/HyperJson.tsx
+++ b/packages/app/src/components/HyperJson.tsx
@@ -34,11 +34,18 @@ export type GetLineActions = (arg0: {
   parsedJsonRootPath?: string[];
 }) => LineAction[];
 
+export type FormatLeafValue = (arg0: {
+  keyName: string;
+  keyPath: string[];
+  value: unknown;
+}) => React.ReactNode | undefined;
+
 // Store common state in an atom so that it can be shared between components
 // to avoid prop drilling
 type HyperJsonAtom = {
   normallyExpanded: boolean;
   getLineActions?: GetLineActions;
+  formatLeafValue?: FormatLeafValue;
 };
 const hyperJsonAtom = atom<HyperJsonAtom>({
   normallyExpanded: false,
@@ -217,11 +224,20 @@ const Line = React.memo(
       return value;
     }, [isStringValueValidJson, value]);
 
+    const { formatLeafValue } = useAtomValue(hyperJsonAtom);
+
     const nestedLevel = parentKeyPath.length;
     const keyPath = React.useMemo(
       () => [...parentKeyPath, keyName],
       [keyName, parentKeyPath],
     );
+
+    const formattedLeafValue = React.useMemo(() => {
+      if (formatLeafValue == null) {
+        return undefined;
+      }
+      return formatLeafValue({ keyName, keyPath, value });
+    }, [formatLeafValue, keyName, keyPath, value]);
 
     // Determine the context for nested parsed JSON
     const childIsInParsedJson = isInParsedJson || isStringValueValidJson;
@@ -289,6 +305,10 @@ const Line = React.memo(
                   <div className={styles.jsonBtn}>Expand JSON</div>
                 </>
               )
+            ) : formattedLeafValue !== undefined ? (
+              <span ref={valueRef} className={styles.string}>
+                {formattedLeafValue}
+              </span>
             ) : (
               <ValueRenderer value={value} ref={valueRef} />
             )}
@@ -395,6 +415,7 @@ type HyperJsonProps = {
   tabulate?: boolean;
   whiteSpace?: 'pre' | 'pre-wrap';
   getLineActions?: GetLineActions;
+  formatLeafValue?: FormatLeafValue;
 };
 
 const HyperJson = ({
@@ -403,12 +424,15 @@ const HyperJson = ({
   tabulate = false,
   whiteSpace = 'pre-wrap',
   getLineActions,
+  formatLeafValue,
 }: HyperJsonProps) => {
   const isEmpty = React.useMemo(() => Object.keys(data).length === 0, [data]);
 
   return (
     <Provider>
-      <HydrateAtoms initialValues={{ normallyExpanded, getLineActions }}>
+      <HydrateAtoms
+        initialValues={{ normallyExpanded, getLineActions, formatLeafValue }}
+      >
         <div
           className={cx(styles.container, {
             [styles.withTabulate]: tabulate,


### PR DESCRIPTION
## Summary

The log detail JSON viewer rendered `Timestamp` and `TimestampTime` as raw UTC ISO strings while the results table used the shared `FormatTime` helper. This PR adds an optional `formatLeafValue` hook to `HyperJson` and applies the same local-time formatter for top-level timestamp fields only.

Fixes #2465

### Screenshots or video

Manual verification pending — screenshots can be added after running `yarn dev` locally.

| Before | After |
| :----- | :---- |
| Detail panel shows raw UTC ISO string (e.g. `2026-06-15T02:23:15.895Z`) | Detail panel shows the same local-time format as the results table |

### How to test on Vercel preview

**Preview routes:** `/search`

**Steps:**

1. Open the log explorer and run a search that returns log rows.
2. Click a row to open the detail side panel.
3. Verify the `Timestamp` field in the JSON viewer shows local time (matching the table column), not a raw UTC ISO string.
4. Toggle the UTC preference in user settings and confirm both the table and detail panel update consistently.

### References

- Issue: #2465

## Test plan

- [x] Unit tests: `DBRowJsonViewer.test.tsx` (27/27 passing locally)
- [x] Manual: open log explorer, click a row — detail view Timestamp should match table local time (not raw UTC ISO string)
- [x] Manual: verify UTC preference in user settings still applies consistently in both views
