### PR TITLE
fix(dashboards): keep auto-detected number format on display settings apply

### DIFF
--- a/.changeset/number-tile-format-survives-apply.md
+++ b/.changeset/number-tile-format-survives-apply.md
@@ -1,0 +1,12 @@
+---
+"@hyperdx/app": patch
+---
+
+fix(dashboards): keep the auto-detected number format when applying display settings
+
+Opening Display Settings on a number tile that auto-detects its format from the
+datasource (for example p95 of a trace Duration column) and clicking Apply no
+longer rewrites the format to Number. The drawer now reflects the
+datasource-derived format, and Apply persists `numberFormat` only when the user
+explicitly changes it; otherwise it stays unset so render-time auto-detection
+keeps driving the format.

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -117,7 +117,13 @@ export default function ChartDisplaySettingsDrawer({
     [settings, defaultNumberFormat],
   );
 
-  const { control, handleSubmit, reset, setValue } = useForm<DrawerFormValues>({
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    formState: { dirtyFields },
+  } = useForm<DrawerFormValues>({
     defaultValues: appliedDefaults,
   });
 
@@ -137,13 +143,23 @@ export default function ChartDisplaySettingsDrawer({
     handleSubmit(formValues => {
       // Strip client-side localIds before passing rules to the config.
       const { colorRules, ...rest } = formValues;
+      // Persist numberFormat only when the user actually chose one: either the
+      // tile already had an explicit override (settings.numberFormat) or the
+      // user changed the format control in this session (dirtyFields). Otherwise
+      // emit undefined so the datasource-derived format keeps driving render
+      // instead of freezing the drawer's inferred fallback into the config.
+      const numberFormatExplicit =
+        settings.numberFormat != null || dirtyFields.numberFormat != null;
       onChange({
         ...rest,
+        numberFormat: numberFormatExplicit
+          ? formValues.numberFormat
+          : undefined,
         colorRules: colorRules ? stripLocalIds(colorRules) : undefined,
       });
     })();
     onClose();
-  }, [onChange, handleSubmit, onClose]);
+  }, [onChange, handleSubmit, onClose, settings.numberFormat, dirtyFields]);
 
   const resetToDefaults = useCallback(() => {
     reset(

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -196,6 +196,7 @@ export default function EditTimeChartForm({
   }, [isDirty, onDirtyChange]);
 
   const select = useWatch({ control, name: 'select' });
+  const series = useWatch({ control, name: 'series' });
   const sourceId = useWatch({ control, name: 'source' });
   const alert = useWatch({ control, name: 'alert' });
   const seriesReturnType = useWatch({ control, name: 'seriesReturnType' });
@@ -263,13 +264,18 @@ export default function EditTimeChartForm({
     ],
   });
 
+  // Format auto-detected purely from the datasource (e.g. duration for a trace
+  // Duration column), used as the drawer's fallback when no explicit
+  // numberFormat is set. Reads the live `series`, the field the builder edits;
+  // `select` is only synced from `series` on submit and on display-type / source
+  // resets, so it goes stale after an aggregation edit and resolves undefined.
+  // The drawer prioritizes an explicit `numberFormat` over this fallback.
   const autoDetectedNumberFormat = useMemo(
     () =>
-      numberFormat ??
-      (Array.isArray(select)
-        ? getFirstSeriesNumberFormat(select, tableSource)
-        : undefined),
-    [numberFormat, select, tableSource],
+      Array.isArray(series)
+        ? getFirstSeriesNumberFormat(series, tableSource)
+        : undefined,
+    [series, tableSource],
   );
 
   const displaySettings: ChartConfigDisplaySettings = useMemo(
@@ -592,7 +598,12 @@ export default function EditTimeChartForm({
       colorRules,
       backgroundChart,
     }: ChartConfigDisplaySettings) => {
-      setValue('numberFormat', numberFormat);
+      // Only persist an explicit numberFormat. When the drawer emits undefined
+      // (the user never chose a format), leave it unset so render-time
+      // auto-detection keeps driving the format from the datasource.
+      if (numberFormat !== undefined) {
+        setValue('numberFormat', numberFormat);
+      }
       setValue('alignDateRangeToGranularity', alignDateRangeToGranularity);
       setValue('fillNulls', fillNulls);
       setValue('compareToPreviousPeriod', compareToPreviousPeriod);

--- a/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
+++ b/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
@@ -263,4 +263,89 @@ describe('ChartDisplaySettingsDrawer', () => {
       expect(onChange.mock.calls[0][0].seriesLimit).toBeNull();
     });
   });
+
+  describe('number format persistence', () => {
+    // A duration number tile (e.g. p95 Duration from a trace source) auto-detects
+    // a duration format from the datasource; the drawer receives it as
+    // `defaultNumberFormat` and shows it as the fallback when no explicit
+    // numberFormat is set.
+    const durationFormat = { output: 'duration' as const, factor: 1e-9 };
+    const numberBuilderProps = {
+      ...baseProps,
+      configType: 'builder' as const,
+      displayType: DisplayType.Number,
+    };
+
+    it('does not persist the auto-detected format when Apply is clicked without changing it', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...numberBuilderProps}
+          defaultNumberFormat={durationFormat}
+          onChange={onChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].numberFormat).toBeUndefined();
+    });
+
+    it('persists the format when the user changes the output format', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...numberBuilderProps}
+          defaultNumberFormat={durationFormat}
+          onChange={onChange}
+        />,
+      );
+
+      await user.selectOptions(
+        screen.getByRole('combobox', { name: /output format/i }),
+        'number',
+      );
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].numberFormat).toMatchObject({
+        output: 'number',
+      });
+    });
+
+    it('preserves an existing explicit format when only another setting changes', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...numberBuilderProps}
+          settings={
+            {
+              numberFormat: { output: 'currency', currencySymbol: '$' },
+            } as ChartConfigDisplaySettings
+          }
+          onChange={onChange}
+        />,
+      );
+
+      // Change the tile color, not the format.
+      await user.click(screen.getByTestId('color-swatch-input-trigger'));
+      await user.click(
+        await screen.findByTestId('color-swatch-option-chart-blue'),
+      );
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toMatchObject({
+        color: 'chart-blue',
+        numberFormat: { output: 'currency' },
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fix a number tile losing its auto-detected format when Display Settings is applied.

On a builder number tile that shows p95 of a trace `Duration` column, the value auto-detects a duration format (for example `367.7ms`). Opening **Display Settings** and clicking **Apply** without touching the format flipped it to plain Number, so the value then rendered as a raw nanosecond integer. This was a latent bug; #2489 surfaced it by adding the background-chart control, which is a new reason to open that drawer on a number tile.

## Summary

Two things were wrong, both fixed here:

- The drawer's auto-detected fallback (`defaultNumberFormat`) read the form's `select` field. `select` is only synced from `series` on submit and on display-type / source resets, so after the user edits the aggregation in the builder it goes stale, `getFirstSeriesNumberFormat` resolves `undefined`, and the drawer falls through to the Number default. It now reads the live `series` (the field the builder actually edits), so the drawer reflects the datasource format.
- **Apply** unconditionally wrote `numberFormat` into the config, freezing whatever the drawer happened to show (an inferred value the user never chose). It now persists `numberFormat` only on an explicit override: either the tile already had a saved format, or the user changed the format control in this session. Otherwise it stays unset and render-time auto-detection keeps driving the format.

This matches the contract render already uses (`useSingleSeriesNumberFormat`): an explicit `numberFormat` wins, otherwise the datasource-derived format applies.

## Changes

- `EditTimeChartForm.tsx`: source `autoDetectedNumberFormat` from the live `series` watch instead of the stale `select`, and persist the drawer's `numberFormat` only when it is defined.
- `ChartDisplaySettingsDrawer.tsx`: on Apply, emit `numberFormat` only when it is an explicit override (an existing saved format, or a field the user changed this session), otherwise emit `undefined`.

## Test plan

- [x] `make ci-lint` (eslint + tsc + stylelint, app package)
- [x] `make ci-unit` (app package, 2081 passed)
- [x] New drawer tests in `ChartDisplaySettingsDrawer.test.tsx`:
  - Apply without touching the format emits `numberFormat: undefined` (does not clobber the auto-detected format).
  - Changing the output format and applying persists the chosen format.
  - Editing only another setting (color) preserves an existing explicit format.

### UI verification

This is a persistence-logic fix with no styling or layout change. The visible effect (the tile value staying duration-formatted, and the drawer showing Duration rather than Number) depends on a trace source with a `Duration` column and seeded data, which the fresh local dev stack does not have. The behavior is covered by the new drawer tests, which drive the real Apply pipeline and assert exactly what gets persisted; the render path that formats the value is unchanged. [ui-check: allow]

### What's not in this PR (follow-up)

Switching the output format to Duration or Time still keeps the previous factor (for example Seconds), so a nanosecond value can be misread as seconds. A follow-up will seed the factor from the source's duration precision when the output switches to a time-based format. It stacks on this change.
