### PR TITLE
chore: instrumentation uplift (foundation + docs + pilot)

### DIFF
--- a/.changeset/observability-instrumentation-uplift.md
+++ b/.changeset/observability-instrumentation-uplift.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/api': minor
+---
+
+Improve API observability instrumentation. Add a centralized tracing + metrics
+helper library (`withSpan`, `setBusinessContext`, `getStaticFeatureFlags`,
+memoized `getCounter`/`getHistogram`, `recordDuration`), attach consistent
+team/user/feature-flag context to traces across all auth paths (session,
+access-key, local mode), and add custom metrics for previously log-only hot
+paths: API errors, alert evaluation outcomes/query/process failures, and
+external API search/charts query duration and errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ directory:
 - `agent_docs/development.md` - Development workflows, testing, and common tasks
 - `agent_docs/code_style.md` - Code patterns and best practices (read only when
   actively coding)
+- `agent_docs/observability.md` - Instrumentation standards (tracing, metrics,
+  context) and the shared helpers (read when adding or changing a feature)
 
 **Package-specific guides** (read when working on that package):
 
@@ -86,6 +88,12 @@ before stopping.
    `secondary`, `danger`) - see `agent_docs/code_style.md` for required patterns
 6. **Testing**: Tests live in `__tests__/` directories; use Jest for
    unit/integration tests
+7. **Observability**: This is an observability product - instrument new code as
+   you write it. Every team-scoped operation must carry team/user context
+   (`setBusinessContext`), countable log events should also emit a metric, and
+   spans/metric attributes must stay low-cardinality. Use the shared helpers in
+   `packages/api/src/utils/instrumentation.ts`. See
+   [`agent_docs/observability.md`](agent_docs/observability.md).
 
 ## Running Tests
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -11,7 +11,7 @@ aligned with the
 ## TL;DR (the non-negotiables)
 
 1. **Every team-scoped operation carries team + user context.** Use
-   `setBusinessContext(...)` so `hyperdx.team.id` / `hyperdx.user.id` end up on
+   `setBusinessContext(...)` so `hyperdx.team.id` / `user.id` end up on
    the trace. Auth middleware already does this for HTTP requests; background
    jobs and other entry points must do it themselves.
 2. **If something is worth a log, it's usually worth a metric.** When a log line
@@ -98,8 +98,8 @@ Standard attribute keys:
 | Key                        | Meaning                                                    |
 | -------------------------- | ---------------------------------------------------------- |
 | `hyperdx.team.id`          | Owning team (multi-tenancy boundary). Set this everywhere. |
-| `hyperdx.user.id`          | Acting user.                                               |
-| `hyperdx.user.email`       | Acting user's email.                                       |
+| `user.id`                  | Acting user (OTel `user.*` semconv).                       |
+| `user.email`              | Acting user's email (OTel `user.*` semconv).               |
 | `hyperdx.<domain>.<field>` | Domain IDs, e.g. `hyperdx.alert.id`, `hyperdx.source.id`.  |
 | `feature_flag.<name>`      | Evaluated feature/config flag state.                       |
 
@@ -117,7 +117,7 @@ import {
 } from '@/utils/instrumentation';
 
 const queryErrors = getCounter('hyperdx.search.query_errors', {
-  description: 'Search query failures, labeled by ClickHouse error type.',
+  description: 'Search query failures, labeled by error type.',
 });
 const queryDuration = getHistogram('hyperdx.search.query.duration_ms', {
   description: 'Search query duration.',
@@ -126,7 +126,7 @@ const queryDuration = getHistogram('hyperdx.search.query.duration_ms', {
 
 const result = await recordDuration(queryDuration, () => runQuery(cfg));
 // ...on a known error:
-queryErrors.add(1, { ch_error_type: chType });
+queryErrors.add(1, { error_type: chType });
 ```
 
 Metric conventions:

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -1,0 +1,155 @@
+# Observability & Instrumentation
+
+HyperDX is an observability product, so our own code should be a shining example
+of well-instrumented software. When you add or change a feature, instrument it
+as part of the change - not as an afterthought.
+
+This guide covers the conventions and the shared helpers. The principles are
+aligned with the
+[Instrumentation Score specification](https://github.com/instrumentation-score/spec/tree/main/rules).
+
+## TL;DR (the non-negotiables)
+
+1. **Every team-scoped operation carries team + user context.** Use
+   `setBusinessContext(...)` so `hyperdx.team.id` / `hyperdx.user.id` end up on
+   the trace. Auth middleware already does this for HTTP requests; background
+   jobs and other entry points must do it themselves.
+2. **If something is worth a log, it's usually worth a metric.** When a log line
+   marks a countable event (an error, a skip, a fired alert, a query), emit a
+   counter or histogram alongside it.
+3. **Spans and metric attributes must be low-cardinality.** Never put raw
+   queries, user input, IDs, or error messages into a span _name_ or a metric
+   _attribute key/value enum_. IDs belong in span _attributes_, not names.
+4. **Use the shared helpers** in
+   [`packages/api/src/utils/instrumentation.ts`](../packages/api/src/utils/instrumentation.ts).
+   Don't hand-roll tracer/meter lifecycle.
+
+## The shared helper library
+
+All manual instrumentation in `packages/api` goes through
+`@/utils/instrumentation`:
+
+| Helper                                                    | Purpose                                                                                                      |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `withSpan(name, fn, opts?)`                               | Run an async unit of work in an active span. Records exceptions, sets OK/ERROR status, always ends the span. |
+| `setBusinessContext({ teamId, userId, email, ...extra })` | Attach standardized incident-remediation context to the trace + active span.                                 |
+| `getStaticFeatureFlags()`                                 | Returns the static (env/compile-time) feature-flag states as `feature_flag.*` attributes.                    |
+| `getCounter(name, opts?)` / `getHistogram(name, opts?)`   | Memoized OTel instrument accessors. Always use these instead of `meter.create*`.                             |
+| `recordDuration(histogram, fn, attrs?)`                   | Run `fn`, recording its wall-clock duration on a histogram (even on throw).                                  |
+
+The module also re-exports `SpanKind`, `SpanStatusCode`, and the relevant OTel
+types, so a single import is usually enough.
+
+### Tracing
+
+Rely on the HyperDX SDK auto-instrumentation (HTTP, Express, Mongo, etc.) for
+the common path. Add a **manual span only for a meaningful unit of work** that
+auto-instrumentation can't see - a background job step, a fan-out, an expensive
+computation, an external tool invocation.
+
+```ts
+import { withSpan } from '@/utils/instrumentation';
+
+await withSpan(
+  'alerts.process_batch',
+  async span => {
+    span.setAttribute('hyperdx.alerts.batch.size', alerts.length);
+    return processBatch(alerts);
+  },
+  { attributes: { 'hyperdx.team.id': teamId } },
+);
+```
+
+Span rules to follow (from the Instrumentation Score spec):
+
+- **Bound span-name cardinality** (SPA-003): span names are constants or use
+  route templates - never interpolate IDs, queries, or URLs into the name. Put
+  those in attributes instead.
+- **Don't over-span** (SPA-001, SPA-005): keep `INTERNAL` spans limited and
+  meaningful. Never create a span per loop iteration or per trivial sub-call -
+  it bloats traces and hurts performance.
+- **Root spans are not `CLIENT`** (SPA-004): an entry point (HTTP handler, job
+  tick) should open a `SERVER`/`INTERNAL` span before issuing outbound `CLIENT`
+  calls. Auto-instrumentation handles this for HTTP; for headless workloads
+  (cron tasks), wrap the work in a top-level span.
+
+### Business context
+
+Attach team/user context as early as possible (at the auth boundary or the top
+of a job). `setBusinessContext` writes both to the whole trace (via the HyperDX
+SDK, requires `HDX_NODE_BETA_MODE=1`) and to the active span.
+
+```ts
+import {
+  getStaticFeatureFlags,
+  setBusinessContext,
+} from '@/utils/instrumentation';
+
+setBusinessContext({
+  teamId: user.team?.toString(),
+  userId: user._id?.toString(),
+  email: user.email,
+  ...getStaticFeatureFlags(),
+});
+```
+
+Standard attribute keys:
+
+| Key                        | Meaning                                                    |
+| -------------------------- | ---------------------------------------------------------- |
+| `hyperdx.team.id`          | Owning team (multi-tenancy boundary). Set this everywhere. |
+| `hyperdx.user.id`          | Acting user.                                               |
+| `hyperdx.user.email`       | Acting user's email.                                       |
+| `hyperdx.<domain>.<field>` | Domain IDs, e.g. `hyperdx.alert.id`, `hyperdx.source.id`.  |
+| `feature_flag.<name>`      | Evaluated feature/config flag state.                       |
+
+### Metrics
+
+When you write a log line that marks a countable event, add a metric too.
+Counters for occurrences, histograms for durations/sizes. Prefer counters and
+histograms over gauges.
+
+```ts
+import {
+  getCounter,
+  getHistogram,
+  recordDuration,
+} from '@/utils/instrumentation';
+
+const queryErrors = getCounter('hyperdx.search.query_errors', {
+  description: 'Search query failures, labeled by ClickHouse error type.',
+});
+const queryDuration = getHistogram('hyperdx.search.query.duration_ms', {
+  description: 'Search query duration.',
+  unit: 'ms',
+});
+
+const result = await recordDuration(queryDuration, () => runQuery(cfg));
+// ...on a known error:
+queryErrors.add(1, { ch_error_type: chType });
+```
+
+Metric conventions:
+
+- **Naming**: `hyperdx.<domain>.<event>` (snake_case event), e.g.
+  `hyperdx.alerts.evaluations`, `hyperdx.api.errors`.
+- **Attributes are low-cardinality** (MET-001): use fixed enums
+  (`{ outcome: 'fired' | 'resolved' | 'skipped_silenced' }`), status codes, or
+  bounded error-type strings. Never user IDs, team IDs, raw messages, or query
+  text.
+- **Always pass a `description`** (and `unit` for histograms).
+- **Define instruments at module scope** via `getCounter`/`getHistogram` so they
+  are created once and reused.
+
+## Where to look for examples
+
+- Generic span + status handling: `packages/api/src/utils/instrumentation.ts`
+- Span + metrics wrapper around a unit of work:
+  `packages/api/src/mcp/utils/tracing.ts`
+- Context at the auth boundary: `packages/api/src/middleware/auth.ts`
+- Error counter: `packages/api/src/middleware/error.ts`
+- Outcome counters in a background job:
+  `packages/api/src/tasks/checkAlerts/index.ts`
+- Query duration + error metrics:
+  `packages/api/src/routers/external-api/v2/search.ts` and `charts.ts`
+- Scheduled-task metrics pattern: `packages/api/src/tasks/metrics.ts`

--- a/packages/api/src/mcp/__tests__/tracing.test.ts
+++ b/packages/api/src/mcp/__tests__/tracing.test.ts
@@ -3,6 +3,7 @@
 
 const mockSpan = {
   setAttribute: jest.fn(),
+  setAttributes: jest.fn(),
   setStatus: jest.fn(),
   recordException: jest.fn(),
   end: jest.fn(),
@@ -11,8 +12,21 @@ const mockSpan = {
 const mockTracer = {
   startActiveSpan: (
     _name: string,
-    fn: (span: typeof mockSpan) => Promise<unknown>,
-  ) => fn(mockSpan),
+    _optionsOrFn: unknown,
+    maybeFn?: (span: typeof mockSpan) => Promise<unknown>,
+  ) => {
+    const fn = (
+      typeof _optionsOrFn === 'function' ? _optionsOrFn : maybeFn
+    ) as (span: typeof mockSpan) => Promise<unknown>;
+    return fn(mockSpan);
+  },
+};
+
+const mockCounter = { add: jest.fn() };
+const mockHistogram = { record: jest.fn() };
+const mockMeter = {
+  createCounter: jest.fn(() => mockCounter),
+  createHistogram: jest.fn(() => mockHistogram),
 };
 
 jest.mock('@opentelemetry/api', () => ({
@@ -20,12 +34,28 @@ jest.mock('@opentelemetry/api', () => ({
   default: {
     trace: {
       getTracer: () => mockTracer,
+      getActiveSpan: () => mockSpan,
+    },
+    metrics: {
+      getMeter: () => mockMeter,
     },
   },
   SpanStatusCode: {
     OK: 1,
     ERROR: 2,
   },
+  SpanKind: {
+    INTERNAL: 0,
+    SERVER: 1,
+    CLIENT: 2,
+    PRODUCER: 3,
+    CONSUMER: 4,
+  },
+}));
+
+jest.mock('@hyperdx/node-opentelemetry', () => ({
+  __esModule: true,
+  setTraceAttributes: jest.fn(),
 }));
 
 jest.mock('@/config', () => ({
@@ -141,5 +171,44 @@ describe('withToolTracing', () => {
       'mcp.tool.duration_ms',
       expect.any(Number),
     );
+  });
+
+  it('should record duration metric on success', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+
+    const traced = withToolTracing('my_tool', context, handler);
+    await traced({});
+
+    expect(mockHistogram.record).toHaveBeenCalledWith(expect.any(Number), {
+      tool: 'my_tool',
+    });
+    expect(mockCounter.add).not.toHaveBeenCalled();
+  });
+
+  it('should increment the error counter for isError results', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      isError: true,
+      content: [{ type: 'text', text: 'nope' }],
+    });
+
+    const traced = withToolTracing('my_tool', context, handler);
+    await traced({});
+
+    expect(mockCounter.add).toHaveBeenCalledWith(1, { tool: 'my_tool' });
+  });
+
+  it('should increment the error counter on a thrown exception', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const traced = withToolTracing('my_tool', context, handler);
+
+    await expect(traced({})).rejects.toThrow('boom');
+
+    expect(mockCounter.add).toHaveBeenCalledWith(1, { tool: 'my_tool' });
+    expect(mockHistogram.record).toHaveBeenCalledWith(expect.any(Number), {
+      tool: 'my_tool',
+    });
   });
 });

--- a/packages/api/src/mcp/utils/tracing.ts
+++ b/packages/api/src/mcp/utils/tracing.ts
@@ -1,19 +1,30 @@
-import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
-
-import { CODE_VERSION } from '@/config';
+import {
+  getCounter,
+  getHistogram,
+  SpanStatusCode,
+  withSpan,
+} from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 import type { McpContext } from '../tools/types';
-
-const mcpTracer = opentelemetry.trace.getTracer('clickstack-mcp', CODE_VERSION);
 
 type ToolResult = {
   content: { type: 'text'; text: string }[];
   isError?: boolean;
 };
 
+const toolDurationHistogram = getHistogram('hyperdx.mcp.tool.duration_ms', {
+  description: 'Wall-clock duration of an MCP tool invocation.',
+  unit: 'ms',
+});
+
+const toolErrorCounter = getCounter('hyperdx.mcp.tool.errors', {
+  description:
+    'Count of MCP tool invocations that returned an error or threw an exception.',
+});
+
 /**
- * Wraps an MCP tool handler with tracing and structured logging.
+ * Wraps an MCP tool handler with tracing, metrics, and structured logging.
  * Creates a span for each tool invocation and logs start/end with duration.
  */
 export function withToolTracing<TArgs>(
@@ -22,60 +33,62 @@ export function withToolTracing<TArgs>(
   handler: (args: TArgs) => Promise<ToolResult>,
 ): (args: TArgs) => Promise<ToolResult> {
   return async (args: TArgs) => {
-    return mcpTracer.startActiveSpan(`mcp.tool.${toolName}`, async span => {
-      const startTime = Date.now();
-      const logContext = {
-        tool: toolName,
-        teamId: context.teamId,
-        userId: context.userId,
-      };
+    const logContext = {
+      tool: toolName,
+      teamId: context.teamId,
+      userId: context.userId,
+    };
 
-      span.setAttribute('mcp.tool.name', toolName);
-      span.setAttribute('mcp.team.id', context.teamId);
-      span.setAttribute('mcp.user.id', context.userId);
+    return withSpan(
+      `mcp.tool.${toolName}`,
+      async span => {
+        const startTime = Date.now();
+        span.setAttribute('mcp.tool.name', toolName);
+        span.setAttribute('mcp.team.id', context.teamId);
+        span.setAttribute('mcp.user.id', context.userId);
 
-      logger.info(logContext, `MCP tool invoked: ${toolName}`);
+        logger.info(logContext, `MCP tool invoked: ${toolName}`);
 
-      try {
-        const result = await handler(args);
-        const durationMs = Date.now() - startTime;
+        try {
+          const result = await handler(args);
+          const durationMs = Date.now() - startTime;
 
-        if (result.isError) {
-          span.setStatus({ code: SpanStatusCode.ERROR });
-          span.setAttribute('mcp.tool.error', true);
-          logger.warn(
-            { ...logContext, durationMs },
-            `MCP tool error: ${toolName}`,
+          if (result.isError) {
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            span.setAttribute('mcp.tool.error', true);
+            toolErrorCounter.add(1, { tool: toolName });
+            logger.warn(
+              { ...logContext, durationMs },
+              `MCP tool error: ${toolName}`,
+            );
+          } else {
+            span.setStatus({ code: SpanStatusCode.OK });
+            logger.info(
+              { ...logContext, durationMs },
+              `MCP tool completed: ${toolName}`,
+            );
+          }
+
+          span.setAttribute('mcp.tool.duration_ms', durationMs);
+          toolDurationHistogram.record(durationMs, { tool: toolName });
+          return result;
+        } catch (err) {
+          const durationMs = Date.now() - startTime;
+          span.setAttribute('mcp.tool.duration_ms', durationMs);
+          toolDurationHistogram.record(durationMs, { tool: toolName });
+          toolErrorCounter.add(1, { tool: toolName });
+
+          logger.error(
+            { ...logContext, durationMs, error: err },
+            `MCP tool failed: ${toolName}`,
           );
-        } else {
-          span.setStatus({ code: SpanStatusCode.OK });
-          logger.info(
-            { ...logContext, durationMs },
-            `MCP tool completed: ${toolName}`,
-          );
+          throw err;
         }
-
-        span.setAttribute('mcp.tool.duration_ms', durationMs);
-        span.end();
-        return result;
-      } catch (err) {
-        const durationMs = Date.now() - startTime;
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err instanceof Error ? err.message : String(err),
-        });
-        span.recordException(
-          err instanceof Error ? err : new Error(String(err)),
-        );
-        span.setAttribute('mcp.tool.duration_ms', durationMs);
-        span.end();
-
-        logger.error(
-          { ...logContext, durationMs, error: err },
-          `MCP tool failed: ${toolName}`,
-        );
-        throw err;
-      }
-    });
+      },
+      // The span status is managed inside the handler (OK vs ERROR for
+      // non-throwing error results); withSpan still records exceptions and ends
+      // the span on a thrown error.
+      { recordOkStatus: false },
+    );
   };
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,11 +1,14 @@
 import { Connection } from '@hyperdx/common-utils/dist/types';
-import { setTraceAttributes } from '@hyperdx/node-opentelemetry';
 import type { NextFunction, Request, Response } from 'express';
 import { serializeError } from 'serialize-error';
 
 import * as config from '@/config';
 import { findUserByAccessKey } from '@/controllers/user';
 import type { UserDocument } from '@/models/user';
+import {
+  getStaticFeatureFlags,
+  setBusinessContext,
+} from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 declare global {
@@ -95,6 +98,15 @@ export async function validateUserAccessKey(
 
   req.user = user;
 
+  // Attribute access-key authenticated requests (external API v2 + MCP HTTP)
+  // with team/user context so their traces are searchable during incidents.
+  setBusinessContext({
+    teamId: user.team?.toString(),
+    userId: user._id?.toString(),
+    email: user.email,
+    ...getStaticFeatureFlags(),
+  });
+
   next();
 }
 
@@ -113,14 +125,22 @@ export function isUserAuthenticated(
       // @ts-ignore
       team: '_local_team_',
     };
+    setBusinessContext({
+      teamId: '_local_team_',
+      userId: '_local_user_',
+      'hyperdx.local_mode': true,
+      ...getStaticFeatureFlags(),
+    });
     return next();
   }
 
   if (req.isAuthenticated()) {
-    // set user id as trace attribute
-    setTraceAttributes({
-      userId: req.user?._id.toString(),
-      userEmail: req.user?.email,
+    // Attach incident-remediation context to the trace and active span.
+    setBusinessContext({
+      teamId: req.user?.team?.toString(),
+      userId: req.user?._id?.toString(),
+      email: req.user?.email,
+      ...getStaticFeatureFlags(),
     });
 
     return next();

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -3,7 +3,13 @@ import type { NextFunction, Request, Response } from 'express';
 
 import { IS_PROD } from '@/config';
 import { BaseError, isOperationalError, StatusCode } from '@/utils/errors';
+import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
+
+const apiErrorCounter = getCounter('hyperdx.api.errors', {
+  description:
+    'Count of errors handled by the API error middleware, labeled by operational flag and HTTP status code.',
+});
 
 // WARNING: need to keep the 4th arg for express to identify it as an error-handling middleware function
 export const appErrorHandler = (
@@ -12,13 +18,20 @@ export const appErrorHandler = (
   res: Response,
   next: NextFunction,
 ) => {
-  if (isOperationalError(err)) {
+  const operational = isOperationalError(err);
+  const statusCode = err.statusCode ?? StatusCode.INTERNAL_SERVER;
+  apiErrorCounter.add(1, {
+    operational,
+    status_code: statusCode,
+  });
+
+  if (operational) {
     logger.warn({ err }, err.message);
   } else {
     logger.error({ err }, err.message);
   }
 
-  const userFacingErrorMessage = isOperationalError(err)
+  const userFacingErrorMessage = operational
     ? err.name || err.message
     : err instanceof SyntaxError && err.message.includes('JSON')
       ? 'Invalid JSON payload'
@@ -32,7 +45,7 @@ export const appErrorHandler = (
   });
 
   if (!res.headersSent) {
-    res.status(err.statusCode ?? StatusCode.INTERNAL_SERVER).json({
+    res.status(statusCode).json({
       message: userFacingErrorMessage,
     });
   }

--- a/packages/api/src/routers/external-api/v2/charts.ts
+++ b/packages/api/src/routers/external-api/v2/charts.ts
@@ -7,7 +7,6 @@ import {
   pickSampleWeightExpressionProps,
   SourceKind,
 } from '@hyperdx/common-utils/dist/types';
-import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
 import express from 'express';
 import _ from 'lodash';
 import { z } from 'zod';
@@ -18,7 +17,22 @@ import { getTeam } from '@/controllers/team';
 import { IConnection } from '@/models/connection';
 import { ISource } from '@/models/source';
 import { validateRequestWithEnhancedErrors as validateRequest } from '@/utils/enhancedErrors';
+import {
+  getCounter,
+  getHistogram,
+  SpanStatusCode,
+  withSpan,
+} from '@/utils/instrumentation';
 import { externalQueryChartSeriesSchema } from '@/utils/zod';
+
+const chartsSeriesDuration = getHistogram('hyperdx.charts.series.duration_ms', {
+  description:
+    'Duration of external API v2 chart /series requests (across all series).',
+  unit: 'ms',
+});
+const chartsSeriesErrors = getCounter('hyperdx.charts.series.errors', {
+  description: 'Count of external API v2 chart /series request failures.',
+});
 
 /**
  * @openapi
@@ -539,129 +553,147 @@ router.post(
     }),
   }),
   async (req, res) => {
-    const span = opentelemetry.trace.getActiveSpan();
-    try {
-      const teamId = req.user?.team;
-      if (!teamId) {
-        return res.status(403).send({ error: 'Team context missing' });
-      }
-      const team = await getTeam(teamId);
-      if (!team) {
-        return res.status(403).send({ error: 'Team not found' });
-      }
-
-      const {
-        endTime,
-        granularity,
-        startTime,
-        seriesReturnType,
-        series: externalSeries,
-      } = req.body;
-
-      const allResults = await Promise.all(
-        externalSeries.map(async (series, index) => {
-          try {
-            const source = await getSource(teamId.toString(), series.sourceId);
-            if (!source || !source.connection) {
-              // Return a structured error object instead of throwing
-              return {
-                error: {
-                  status: 404,
-                  message: `Source not found for series ${index}`,
-                },
-              } as SeriesResult;
-            }
-
-            const connection = await getConnectionById(
-              teamId.toString(),
-              source.connection.toString(),
-              true, // Decrypt password
-            );
-
-            if (!connection) {
-              return {
-                error: {
-                  status: 404,
-                  message: `Connection not found for series ${index}`,
-                },
-              } as SeriesResult;
-            }
-
-            const { chartConfig, groupByFields } =
-              await buildChartConfigFromRequest(
-                {
-                  externalSeries: series,
-                  sourceId: series.sourceId,
-                  seriesIndex: index,
-                  startTime,
-                  endTime,
-                  granularity,
-                  seriesReturnType,
-                  teamId: teamId.toString(),
-                },
-                source,
-                connection,
-              );
-
-            const clickhouseClient = new ClickhouseClient({
-              host: connection.host,
-              username: connection.username,
-              password: connection.password,
-            });
-
-            const metadata = getMetadata(clickhouseClient);
-            const result = await clickhouseClient.queryChartConfig({
-              config: chartConfig,
-              metadata,
-              querySettings: source.querySettings,
-            });
-
-            return {
-              data: result.data || [],
-              groupByFields,
-            } as SeriesResult;
-          } catch (err) {
-            console.error(`Error processing series ${index}:`, err);
-            throw err;
+    const requestStartedAt = Date.now();
+    // The span status/exception is managed inside the handler (errors are mapped
+    // to HTTP responses rather than thrown), so disable the default OK status.
+    await withSpan(
+      'external_api.charts.series',
+      async span => {
+        try {
+          const teamId = req.user?.team;
+          if (!teamId) {
+            return res.status(403).send({ error: 'Team context missing' });
           }
-        }),
-      );
+          const team = await getTeam(teamId);
+          if (!team) {
+            return res.status(403).send({ error: 'Team not found' });
+          }
 
-      // Check if any results contain errors
-      const errorResult = allResults.find(
-        result => 'error' in result && result.error,
-      ) as SeriesResult | undefined;
-      if (errorResult && errorResult.error) {
-        const { status, message } = errorResult.error;
-        return res.status(status).json({ error: message });
-      }
+          const {
+            endTime,
+            granularity,
+            startTime,
+            seriesReturnType,
+            series: externalSeries,
+          } = req.body;
 
-      // Combine all data rows across all series
-      const combinedResults = allResults.flatMap(
-        result => result.data || [],
-      ) as Record<string, unknown>[];
+          const allResults = await Promise.all(
+            externalSeries.map(async (series, index) => {
+              try {
+                const source = await getSource(
+                  teamId.toString(),
+                  series.sourceId,
+                );
+                if (!source || !source.connection) {
+                  // Return a structured error object instead of throwing
+                  return {
+                    error: {
+                      status: 404,
+                      message: `Source not found for series ${index}`,
+                    },
+                  } as SeriesResult;
+                }
 
-      // Format based on requested type
-      let responseData;
-      if (seriesReturnType === 'column') {
-        responseData = combinedResults;
-      } else {
-        const primaryGroupByFields = allResults.find(
-          r => r.groupByFields,
-        )?.groupByFields;
-        responseData = formatCHResult(combinedResults, primaryGroupByFields);
-      }
+                const connection = await getConnectionById(
+                  teamId.toString(),
+                  source.connection.toString(),
+                  true, // Decrypt password
+                );
 
-      res.json({ data: responseData });
-    } catch (e) {
-      span?.recordException(e as Error);
-      span?.setStatus({ code: SpanStatusCode.ERROR });
-      console.error('Error in /series endpoint:', e);
+                if (!connection) {
+                  return {
+                    error: {
+                      status: 404,
+                      message: `Connection not found for series ${index}`,
+                    },
+                  } as SeriesResult;
+                }
 
-      const errMsg = e instanceof Error ? e.message : 'Internal server error';
-      const statusCode = (e as any).statusCode || 500;
-      res.status(statusCode).json({ error: errMsg });
-    }
+                const { chartConfig, groupByFields } =
+                  await buildChartConfigFromRequest(
+                    {
+                      externalSeries: series,
+                      sourceId: series.sourceId,
+                      seriesIndex: index,
+                      startTime,
+                      endTime,
+                      granularity,
+                      seriesReturnType,
+                      teamId: teamId.toString(),
+                    },
+                    source,
+                    connection,
+                  );
+
+                const clickhouseClient = new ClickhouseClient({
+                  host: connection.host,
+                  username: connection.username,
+                  password: connection.password,
+                });
+
+                const metadata = getMetadata(clickhouseClient);
+                const result = await clickhouseClient.queryChartConfig({
+                  config: chartConfig,
+                  metadata,
+                  querySettings: source.querySettings,
+                });
+
+                return {
+                  data: result.data || [],
+                  groupByFields,
+                } as SeriesResult;
+              } catch (err) {
+                console.error(`Error processing series ${index}:`, err);
+                throw err;
+              }
+            }),
+          );
+
+          // Check if any results contain errors
+          const errorResult = allResults.find(
+            result => 'error' in result && result.error,
+          ) as SeriesResult | undefined;
+          if (errorResult && errorResult.error) {
+            const { status, message } = errorResult.error;
+            return res.status(status).json({ error: message });
+          }
+
+          // Combine all data rows across all series
+          const combinedResults = allResults.flatMap(
+            result => result.data || [],
+          ) as Record<string, unknown>[];
+
+          // Format based on requested type
+          let responseData;
+          if (seriesReturnType === 'column') {
+            responseData = combinedResults;
+          } else {
+            const primaryGroupByFields = allResults.find(
+              r => r.groupByFields,
+            )?.groupByFields;
+            responseData = formatCHResult(
+              combinedResults,
+              primaryGroupByFields,
+            );
+          }
+
+          span.setStatus({ code: SpanStatusCode.OK });
+          res.json({ data: responseData });
+        } catch (e) {
+          chartsSeriesErrors.add(1);
+          span.recordException(e as Error);
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          console.error('Error in /series endpoint:', e);
+
+          const errMsg =
+            e instanceof Error ? e.message : 'Internal server error';
+          const statusCode = (e as any).statusCode || 500;
+          res.status(statusCode).json({ error: errMsg });
+        }
+      },
+      { recordOkStatus: false },
+    );
+    chartsSeriesDuration.record(Date.now() - requestStartedAt);
   },
 );
 

--- a/packages/api/src/routers/external-api/v2/charts.ts
+++ b/packages/api/src/routers/external-api/v2/charts.ts
@@ -31,7 +31,10 @@ const chartsSeriesDuration = getHistogram('hyperdx.charts.series.duration_ms', {
   unit: 'ms',
 });
 const chartsSeriesErrors = getCounter('hyperdx.charts.series.errors', {
-  description: 'Count of external API v2 chart /series request failures.',
+  description:
+    'Count of external API v2 chart /series request failures, labeled by ' +
+    'error type (e.g. TEAM_MISSING, TEAM_NOT_FOUND, SOURCE_NOT_FOUND, ' +
+    'CONNECTION_NOT_FOUND, UNHANDLED).',
 });
 
 /**
@@ -365,6 +368,7 @@ type SeriesResult = {
   error?: {
     status: number;
     message: string;
+    code: string;
   };
 };
 
@@ -562,10 +566,12 @@ router.post(
         try {
           const teamId = req.user?.team;
           if (!teamId) {
+            chartsSeriesErrors.add(1, { error_type: 'TEAM_MISSING' });
             return res.status(403).send({ error: 'Team context missing' });
           }
           const team = await getTeam(teamId);
           if (!team) {
+            chartsSeriesErrors.add(1, { error_type: 'TEAM_NOT_FOUND' });
             return res.status(403).send({ error: 'Team not found' });
           }
 
@@ -590,6 +596,7 @@ router.post(
                     error: {
                       status: 404,
                       message: `Source not found for series ${index}`,
+                      code: 'SOURCE_NOT_FOUND',
                     },
                   } as SeriesResult;
                 }
@@ -605,6 +612,7 @@ router.post(
                     error: {
                       status: 404,
                       message: `Connection not found for series ${index}`,
+                      code: 'CONNECTION_NOT_FOUND',
                     },
                   } as SeriesResult;
                 }
@@ -654,7 +662,8 @@ router.post(
             result => 'error' in result && result.error,
           ) as SeriesResult | undefined;
           if (errorResult && errorResult.error) {
-            const { status, message } = errorResult.error;
+            const { status, message, code } = errorResult.error;
+            chartsSeriesErrors.add(1, { error_type: code });
             return res.status(status).json({ error: message });
           }
 
@@ -680,7 +689,7 @@ router.post(
           span.setStatus({ code: SpanStatusCode.OK });
           res.json({ data: responseData });
         } catch (e) {
-          chartsSeriesErrors.add(1);
+          chartsSeriesErrors.add(1, { error_type: 'UNHANDLED' });
           span.recordException(e as Error);
           span.setStatus({ code: SpanStatusCode.ERROR });
           console.error('Error in /series endpoint:', e);

--- a/packages/api/src/routers/external-api/v2/search.ts
+++ b/packages/api/src/routers/external-api/v2/search.ts
@@ -6,10 +6,24 @@ import { z } from 'zod';
 import { parseTimeRange } from '@/mcp/tools/query/helpers';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
 import { processRequestWithEnhancedErrors as validateRequest } from '@/utils/enhancedErrors';
+import {
+  getCounter,
+  getHistogram,
+  recordDuration,
+} from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 import { externalDashboardSearchRequestSchema } from '@/utils/zod';
 
 import { runSearchConfig, type SearchErrorCode } from './utils/search';
+
+const searchQueryDuration = getHistogram('hyperdx.search.query.duration_ms', {
+  description: 'Duration of external API v2 search queries against ClickHouse.',
+  unit: 'ms',
+});
+const searchQueryErrors = getCounter('hyperdx.search.query_errors', {
+  description:
+    'Count of external API v2 search query failures, labeled by ClickHouse error type.',
+});
 
 // CH error types caused by user-supplied query content — map to 400.
 const CH_USER_INPUT_ERRORS = new Set([
@@ -379,14 +393,16 @@ router.post(
         orderBy,
       });
 
-      const result = await runSearchConfig({
-        teamId: teamId.toString(),
-        config,
-        startDate,
-        endDate,
-        maxResults,
-        offset,
-      });
+      const result = await recordDuration(searchQueryDuration, () =>
+        runSearchConfig({
+          teamId: teamId.toString(),
+          config,
+          startDate,
+          endDate,
+          maxResults,
+          offset,
+        }),
+      );
 
       if (result.isError) {
         return res
@@ -401,6 +417,7 @@ router.post(
           ?.type ?? 'UNKNOWN') as string;
         const safeMsg =
           (err.message.split('\n')[0] ?? '').slice(0, 300) || 'Query error';
+        searchQueryErrors.add(1, { ch_error_type: chType });
         logger.error({ chType, safeMsg }, '[search] ClickHouse query error');
 
         if (CH_USER_INPUT_ERRORS.has(chType)) {

--- a/packages/api/src/routers/external-api/v2/search.ts
+++ b/packages/api/src/routers/external-api/v2/search.ts
@@ -22,7 +22,8 @@ const searchQueryDuration = getHistogram('hyperdx.search.query.duration_ms', {
 });
 const searchQueryErrors = getCounter('hyperdx.search.query_errors', {
   description:
-    'Count of external API v2 search query failures, labeled by ClickHouse error type.',
+    'Count of external API v2 search query failures, labeled by error type ' +
+    '(semantic error codes like SOURCE_NOT_FOUND, or ClickHouse error types).',
 });
 
 // CH error types caused by user-supplied query content — map to 400.
@@ -405,6 +406,7 @@ router.post(
       );
 
       if (result.isError) {
+        searchQueryErrors.add(1, { error_type: result.code });
         return res
           .status(codeToStatus(result.code))
           .json({ message: result.message });
@@ -417,7 +419,7 @@ router.post(
           ?.type ?? 'UNKNOWN') as string;
         const safeMsg =
           (err.message.split('\n')[0] ?? '').slice(0, 300) || 'Query error';
-        searchQueryErrors.add(1, { ch_error_type: chType });
+        searchQueryErrors.add(1, { error_type: chType });
         logger.error({ chType, safeMsg }, '[search] ClickHouse query error');
 
         if (CH_USER_INPUT_ERRORS.has(chType)) {

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -359,23 +359,6 @@ const fireChannelEvent = async ({
     throw new Error('Team not found');
   }
 
-  // KNOWN LIMITATION: Alert data (including silenced state) is fetched when the
-  // task is queued via AlertProvider, not when it processes. If a user silences
-  // an alert after it's queued but before it processes, this execution may still
-  // send a notification. Subsequent alert checks will respect the silenced state.
-  // This trade-off maintains architectural separation from direct database access.
-  if ((alert.silenced?.until?.getTime() ?? 0) > Date.now()) {
-    alertEvaluationsCounter.add(1, { outcome: 'skipped_silenced' });
-    logger.info(
-      {
-        alertId: alert.id,
-        silenced: alert.silenced,
-      },
-      'Skipped firing alert due to silence',
-    );
-    return;
-  }
-
   const attributesNested = unflattenObject(attributes);
   const templateView: AlertMessageTemplateDefaultView = {
     alert: {
@@ -981,6 +964,24 @@ export const processAlert = async (
       startTime?: Date;
       attributes?: Record<string, string>;
     }) => {
+      // KNOWN LIMITATION: Alert data (including silenced state) is fetched when
+      // the task is queued via AlertProvider, not when it processes. If a user
+      // silences an alert after it's queued but before it processes, this
+      // execution may still send a notification. Subsequent alert checks will
+      // respect the silenced state. This trade-off maintains architectural
+      // separation from direct database access.
+      if ((alert.silenced?.until?.getTime() ?? 0) > Date.now()) {
+        alertEvaluationsCounter.add(1, { outcome: 'skipped_silenced' });
+        logger.info(
+          {
+            alertId: alert.id,
+            silenced: alert.silenced,
+          },
+          'Skipped firing alert due to silence',
+        );
+        return;
+      }
+
       alertEvaluationsCounter.add(1, {
         outcome: state === AlertState.ALERT ? 'fired' : 'resolved',
       });

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -75,7 +75,26 @@ import {
   roundDownToXMinutes,
   unflattenObject,
 } from '@/tasks/util';
+import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
+
+// Outcome of a single alert evaluation. Kept low-cardinality (a fixed enum) so
+// it is safe to use as a metric attribute (see agent_docs/observability.md).
+const alertEvaluationsCounter = getCounter('hyperdx.alerts.evaluations', {
+  description:
+    'Count of alert evaluations, labeled by outcome (fired, resolved, or the reason it was skipped).',
+});
+const alertQueryFailuresCounter = getCounter('hyperdx.alerts.query_failures', {
+  description:
+    'Count of alert evaluations where the ClickHouse query failed, skipping the state/history update.',
+});
+const alertProcessFailuresCounter = getCounter(
+  'hyperdx.alerts.process_failures',
+  {
+    description:
+      'Count of alert evaluations that threw an unexpected error during processing.',
+  },
+);
 
 /**
  * Determine if an alert has group-by behavior.
@@ -346,6 +365,7 @@ const fireChannelEvent = async ({
   // send a notification. Subsequent alert checks will respect the silenced state.
   // This trade-off maintains architectural separation from direct database access.
   if ((alert.silenced?.until?.getTime() ?? 0) > Date.now()) {
+    alertEvaluationsCounter.add(1, { outcome: 'skipped_silenced' });
     logger.info(
       {
         alertId: alert.id,
@@ -742,6 +762,7 @@ export const processAlert = async (
       scheduleStartAt: alert.scheduleStartAt,
     });
     if (scheduleStartAt != null && now < scheduleStartAt) {
+      alertEvaluationsCounter.add(1, { outcome: 'skipped_schedule' });
       logger.info(
         {
           alertId: alert.id,
@@ -778,6 +799,7 @@ export const processAlert = async (
 
     // Check if we should skip this alert check based on last evaluation time
     if (shouldSkipAlertCheck(details, hasGroupBy, nowInMinsRoundDown)) {
+      alertEvaluationsCounter.add(1, { outcome: 'skipped_window' });
       logger.info(
         {
           windowSizeInMins,
@@ -801,6 +823,7 @@ export const processAlert = async (
       scheduleStartAt,
     );
     if (dateRange[0].getTime() >= dateRange[1].getTime()) {
+      alertEvaluationsCounter.add(1, { outcome: 'skipped_anchor' });
       logger.info(
         {
           alertId: alert.id,
@@ -900,6 +923,7 @@ export const processAlert = async (
         querySettings: source?.querySettings,
       });
     } catch (e) {
+      alertQueryFailuresCounter.add(1);
       logger.error(
         {
           alertId: alert.id,
@@ -957,6 +981,9 @@ export const processAlert = async (
       startTime?: Date;
       attributes?: Record<string, string>;
     }) => {
+      alertEvaluationsCounter.add(1, {
+        outcome: state === AlertState.ALERT ? 'fired' : 'resolved',
+      });
       logger.info(
         { alertId: alert.id, group, totalCount },
         state === AlertState.ALERT
@@ -1091,6 +1118,7 @@ export const processAlert = async (
       // Handle case where no data is available for this bucket
       const bucketHasData = dataForBucket && dataForBucket.length > 0;
       if (!bucketHasData) {
+        alertEvaluationsCounter.add(1, { outcome: 'empty_bucket' });
         logger.info(
           { alertId: alert.id, bucketStart },
           'No data returned from ClickHouse for time bucket',
@@ -1205,6 +1233,7 @@ export const processAlert = async (
   } catch (e) {
     // Uncomment this for better error messages locally
     // console.error(e);
+    alertProcessFailuresCounter.add(1);
     logger.error(
       {
         alertId: alert.id,
@@ -1348,6 +1377,7 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
         alertTask.conn.team.toString(),
       );
       span.setAttribute('hyperdx.alerts.connection.id', alertTask.conn.id);
+      span.setAttribute('hyperdx.alerts.batch.size', alertTask.alerts.length);
 
       try {
         const { alerts, conn } = alertTask;

--- a/packages/api/src/utils/__tests__/instrumentation.test.ts
+++ b/packages/api/src/utils/__tests__/instrumentation.test.ts
@@ -1,0 +1,205 @@
+// Mock OpenTelemetry + the HyperDX SDK before importing the module under test.
+
+const mockSpan = {
+  setAttribute: jest.fn(),
+  setAttributes: jest.fn(),
+  setStatus: jest.fn(),
+  recordException: jest.fn(),
+  end: jest.fn(),
+};
+
+const mockTracer = {
+  startActiveSpan: (
+    _name: string,
+    _options: unknown,
+    fn: (span: typeof mockSpan) => Promise<unknown>,
+  ) => fn(mockSpan),
+};
+
+const mockCounter = { add: jest.fn() };
+const mockHistogram = { record: jest.fn() };
+const mockMeter = {
+  createCounter: jest.fn(() => mockCounter),
+  createHistogram: jest.fn(() => mockHistogram),
+};
+
+const mockSetTraceAttributes = jest.fn();
+
+jest.mock('@opentelemetry/api', () => ({
+  __esModule: true,
+  default: {
+    trace: {
+      getTracer: () => mockTracer,
+      getActiveSpan: () => mockSpan,
+    },
+    metrics: {
+      getMeter: () => mockMeter,
+    },
+  },
+  SpanStatusCode: { OK: 1, ERROR: 2 },
+  SpanKind: { INTERNAL: 0, SERVER: 1, CLIENT: 2, PRODUCER: 3, CONSUMER: 4 },
+}));
+
+jest.mock('@hyperdx/node-opentelemetry', () => ({
+  __esModule: true,
+  setTraceAttributes: (...args: unknown[]) => mockSetTraceAttributes(...args),
+}));
+
+jest.mock('@/config', () => ({
+  CODE_VERSION: 'test-version',
+  IS_LOCAL_APP_MODE: false,
+  IS_PROMQL_ENABLED: true,
+  USAGE_STATS_ENABLED: false,
+  RUN_SCHEDULED_TASKS_EXTERNALLY: false,
+  AI_API_KEY: '',
+  ANTHROPIC_API_KEY: 'present',
+}));
+
+import {
+  getCounter,
+  getHistogram,
+  getStaticFeatureFlags,
+  recordDuration,
+  setBusinessContext,
+  SpanStatusCode,
+  withSpan,
+} from '../instrumentation';
+
+describe('instrumentation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('withSpan', () => {
+    it('runs the handler, sets OK status, and ends the span', async () => {
+      const result = await withSpan('op', async () => 'value');
+
+      expect(result).toBe('value');
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.OK,
+      });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not set OK status when recordOkStatus is false', async () => {
+      await withSpan('op', async () => 'value', { recordOkStatus: false });
+
+      expect(mockSpan.setStatus).not.toHaveBeenCalled();
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('records exceptions, sets ERROR status, ends the span, and rethrows', async () => {
+      const error = new Error('boom');
+
+      await expect(
+        withSpan('op', async () => {
+          throw error;
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: 'boom',
+      });
+      expect(mockSpan.recordException).toHaveBeenCalledWith(error);
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setBusinessContext', () => {
+    it('maps team/user/email to standardized keys on trace and span', () => {
+      setBusinessContext({
+        teamId: 'team-1',
+        userId: 'user-1',
+        email: 'a@b.com',
+      });
+
+      const expected = {
+        'hyperdx.team.id': 'team-1',
+        'hyperdx.user.id': 'user-1',
+        'hyperdx.user.email': 'a@b.com',
+      };
+      expect(mockSetTraceAttributes).toHaveBeenCalledWith(expected);
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith(expected);
+    });
+
+    it('passes through extra attributes and skips nullish values', () => {
+      setBusinessContext({
+        teamId: 'team-1',
+        userId: null,
+        'feature_flag.local_app_mode': true,
+      });
+
+      expect(mockSetTraceAttributes).toHaveBeenCalledWith({
+        'hyperdx.team.id': 'team-1',
+        'feature_flag.local_app_mode': true,
+      });
+    });
+
+    it('is a no-op when there is nothing to set', () => {
+      setBusinessContext({});
+
+      expect(mockSetTraceAttributes).not.toHaveBeenCalled();
+      expect(mockSpan.setAttributes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getStaticFeatureFlags', () => {
+    it('reflects config-derived flag states', () => {
+      expect(getStaticFeatureFlags()).toEqual({
+        'feature_flag.local_app_mode': false,
+        'feature_flag.promql_enabled': true,
+        'feature_flag.usage_stats_enabled': false,
+        'feature_flag.ai_assistant_enabled': true,
+        'feature_flag.scheduled_tasks_external': false,
+      });
+    });
+  });
+
+  describe('metric accessors', () => {
+    it('memoizes counters by name', () => {
+      const a = getCounter('hyperdx.test.counter');
+      const b = getCounter('hyperdx.test.counter');
+
+      expect(a).toBe(b);
+      expect(mockMeter.createCounter).toHaveBeenCalledTimes(1);
+    });
+
+    it('memoizes histograms by name', () => {
+      const a = getHistogram('hyperdx.test.histogram');
+      const b = getHistogram('hyperdx.test.histogram');
+
+      expect(a).toBe(b);
+      expect(mockMeter.createHistogram).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('recordDuration', () => {
+    it('records duration and returns the result on success', async () => {
+      const histogram = getHistogram('hyperdx.test.duration');
+      const result = await recordDuration(histogram, async () => 42, {
+        op: 'x',
+      });
+
+      expect(result).toBe(42);
+      expect(mockHistogram.record).toHaveBeenCalledWith(expect.any(Number), {
+        op: 'x',
+      });
+    });
+
+    it('records duration even when the function throws', async () => {
+      const histogram = getHistogram('hyperdx.test.duration');
+
+      await expect(
+        recordDuration(histogram, async () => {
+          throw new Error('nope');
+        }),
+      ).rejects.toThrow('nope');
+
+      expect(mockHistogram.record).toHaveBeenCalledWith(
+        expect.any(Number),
+        undefined,
+      );
+    });
+  });
+});

--- a/packages/api/src/utils/__tests__/instrumentation.test.ts
+++ b/packages/api/src/utils/__tests__/instrumentation.test.ts
@@ -63,7 +63,7 @@ import {
   setBusinessContext,
   SpanStatusCode,
   withSpan,
-} from '../instrumentation';
+} from '@/utils/instrumentation';
 
 describe('instrumentation', () => {
   beforeEach(() => {

--- a/packages/api/src/utils/__tests__/instrumentation.test.ts
+++ b/packages/api/src/utils/__tests__/instrumentation.test.ts
@@ -116,8 +116,8 @@ describe('instrumentation', () => {
 
       const expected = {
         'hyperdx.team.id': 'team-1',
-        'hyperdx.user.id': 'user-1',
-        'hyperdx.user.email': 'a@b.com',
+        'user.id': 'user-1',
+        'user.email': 'a@b.com',
       };
       expect(mockSetTraceAttributes).toHaveBeenCalledWith(expected);
       expect(mockSpan.setAttributes).toHaveBeenCalledWith(expected);

--- a/packages/api/src/utils/instrumentation.ts
+++ b/packages/api/src/utils/instrumentation.ts
@@ -15,11 +15,14 @@ import {
   AI_API_KEY,
   ANTHROPIC_API_KEY,
   CODE_VERSION,
+  IS_CI,
+  IS_DEV,
   IS_LOCAL_APP_MODE,
   IS_PROMQL_ENABLED,
   RUN_SCHEDULED_TASKS_EXTERNALLY,
   USAGE_STATS_ENABLED,
 } from '@/config';
+import logger from '@/utils/logger';
 
 /**
  * Centralized tracing + metrics helpers for the API.
@@ -104,6 +107,11 @@ export type BusinessContext = {
  * SDK) and to the active span. Standardizes the attribute keys so team/user
  * context is consistent across every code path.
  *
+ * User attributes follow the OTel `user.*` semantic conventions (currently
+ * experimental). Team has no OTel equivalent, so it stays under the `hyperdx.*`
+ * namespace. Note these are the server-side API trace attributes and are
+ * distinct from the browser-RUM session attributes (`userEmail`, `userName`).
+ *
  * NOTE: trace-wide attributes require `HDX_NODE_BETA_MODE=1`.
  */
 export function setBusinessContext(context: BusinessContext): void {
@@ -114,10 +122,10 @@ export function setBusinessContext(context: BusinessContext): void {
     attributes['hyperdx.team.id'] = String(teamId);
   }
   if (userId != null) {
-    attributes['hyperdx.user.id'] = String(userId);
+    attributes['user.id'] = String(userId);
   }
   if (email != null) {
-    attributes['hyperdx.user.email'] = String(email);
+    attributes['user.email'] = String(email);
   }
   for (const [key, value] of Object.entries(extra)) {
     if (value != null) {
@@ -148,30 +156,68 @@ export function getStaticFeatureFlags(): Attributes {
   };
 }
 
-const counters = new Map<string, Counter>();
-const histograms = new Map<string, Histogram>();
+type CachedInstrument<T> = { instrument: T; options?: MetricOptions };
+
+const counters = new Map<string, CachedInstrument<Counter>>();
+const histograms = new Map<string, CachedInstrument<Histogram>>();
+
+/**
+ * Warns (in dev/CI only) when a cached instrument is re-requested with options
+ * that differ from the ones it was first registered with. The first registration
+ * wins, so a mismatch means the new description/unit/etc. is silently dropped —
+ * usually a typo or a duplicate name defined in another module.
+ */
+function warnOnOptionsMismatch(
+  kind: string,
+  name: string,
+  existing: MetricOptions | undefined,
+  next: MetricOptions | undefined,
+): void {
+  if (!IS_DEV && !IS_CI) {
+    return;
+  }
+  // Only flag when the caller actually passed options to compare against.
+  if (next == null) {
+    return;
+  }
+  if (JSON.stringify(existing) !== JSON.stringify(next)) {
+    logger.warn(
+      {
+        metric: name,
+        registeredOptions: existing,
+        ignoredOptions: next,
+      },
+      `${kind} "${name}" is already registered with different options; ` +
+        `the original definition is kept and the new options are ignored.`,
+    );
+  }
+}
 
 /**
  * Returns a memoized counter for `name`, creating it on first use. Always use
  * this instead of `meter.createCounter` so instruments are shared across calls.
  */
 export function getCounter(name: string, options?: MetricOptions): Counter {
-  let counter = counters.get(name);
-  if (!counter) {
-    counter = meter.createCounter(name, options);
-    counters.set(name, counter);
+  const cached = counters.get(name);
+  if (cached) {
+    warnOnOptionsMismatch('Counter', name, cached.options, options);
+    return cached.instrument;
   }
-  return counter;
+  const instrument = meter.createCounter(name, options);
+  counters.set(name, { instrument, options });
+  return instrument;
 }
 
 /** Memoized histogram accessor. See {@link getCounter}. */
 export function getHistogram(name: string, options?: MetricOptions): Histogram {
-  let histogram = histograms.get(name);
-  if (!histogram) {
-    histogram = meter.createHistogram(name, options);
-    histograms.set(name, histogram);
+  const cached = histograms.get(name);
+  if (cached) {
+    warnOnOptionsMismatch('Histogram', name, cached.options, options);
+    return cached.instrument;
   }
-  return histogram;
+  const instrument = meter.createHistogram(name, options);
+  histograms.set(name, { instrument, options });
+  return instrument;
 }
 
 /**

--- a/packages/api/src/utils/instrumentation.ts
+++ b/packages/api/src/utils/instrumentation.ts
@@ -1,0 +1,192 @@
+import { setTraceAttributes } from '@hyperdx/node-opentelemetry';
+import opentelemetry, {
+  Attributes,
+  AttributeValue,
+  Counter,
+  Histogram,
+  MetricOptions,
+  Span,
+  SpanKind,
+  SpanStatusCode,
+} from '@opentelemetry/api';
+import { performance } from 'perf_hooks';
+
+import {
+  AI_API_KEY,
+  ANTHROPIC_API_KEY,
+  CODE_VERSION,
+  IS_LOCAL_APP_MODE,
+  IS_PROMQL_ENABLED,
+  RUN_SCHEDULED_TASKS_EXTERNALLY,
+  USAGE_STATS_ENABLED,
+} from '@/config';
+
+/**
+ * Centralized tracing + metrics helpers for the API.
+ *
+ * This module is the single import surface for manual instrumentation so that
+ * call sites don't manage tracer/meter lifecycle or duplicate span boilerplate.
+ * See `agent_docs/observability.md` for conventions and usage examples.
+ */
+
+const INSTRUMENTATION_SCOPE = 'hyperdx-api';
+
+const tracer = opentelemetry.trace.getTracer(
+  INSTRUMENTATION_SCOPE,
+  CODE_VERSION,
+);
+const meter = opentelemetry.metrics.getMeter(
+  INSTRUMENTATION_SCOPE,
+  CODE_VERSION,
+);
+
+// Re-export the OTel primitives most call sites need, so a single import from
+// `@/utils/instrumentation` is enough for typical instrumentation work.
+export {
+  type Attributes,
+  type Counter,
+  type Histogram,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+};
+
+export type WithSpanOptions = {
+  attributes?: Attributes;
+  kind?: SpanKind;
+  /**
+   * Whether to set an OK status on the span when the handler resolves without
+   * throwing. Defaults to true. Set to false when the caller wants to manage
+   * the span status itself (e.g. mapping a non-throwing error result to ERROR).
+   */
+  recordOkStatus?: boolean;
+};
+
+/**
+ * Wraps an async unit of work in an active span. Records exceptions, sets span
+ * status, and always ends the span. The thrown error is re-raised unchanged.
+ */
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  options: WithSpanOptions = {},
+): Promise<T> {
+  const { attributes, kind, recordOkStatus = true } = options;
+  return tracer.startActiveSpan(name, { attributes, kind }, async span => {
+    try {
+      const result = await fn(span);
+      if (recordOkStatus) {
+        span.setStatus({ code: SpanStatusCode.OK });
+      }
+      return result;
+    } catch (err) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export type BusinessContext = {
+  teamId?: string | null;
+  userId?: string | null;
+  email?: string | null;
+  [key: string]: AttributeValue | null | undefined;
+};
+
+/**
+ * Attaches incident-remediation context to the whole trace (via the HyperDX
+ * SDK) and to the active span. Standardizes the attribute keys so team/user
+ * context is consistent across every code path.
+ *
+ * NOTE: trace-wide attributes require `HDX_NODE_BETA_MODE=1`.
+ */
+export function setBusinessContext(context: BusinessContext): void {
+  const { teamId, userId, email, ...extra } = context;
+
+  const attributes: Attributes = {};
+  if (teamId != null) {
+    attributes['hyperdx.team.id'] = String(teamId);
+  }
+  if (userId != null) {
+    attributes['hyperdx.user.id'] = String(userId);
+  }
+  if (email != null) {
+    attributes['hyperdx.user.email'] = String(email);
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value != null) {
+      attributes[key] = value;
+    }
+  }
+
+  if (Object.keys(attributes).length === 0) {
+    return;
+  }
+
+  setTraceAttributes(attributes);
+  opentelemetry.trace.getActiveSpan()?.setAttributes(attributes);
+}
+
+/**
+ * Returns the static (env / compile-time) feature flag states as span/trace
+ * attributes. The repo has no dynamic flag service, so these are the toggles
+ * that actually change behavior and are useful during incident remediation.
+ */
+export function getStaticFeatureFlags(): Attributes {
+  return {
+    'feature_flag.local_app_mode': IS_LOCAL_APP_MODE,
+    'feature_flag.promql_enabled': IS_PROMQL_ENABLED,
+    'feature_flag.usage_stats_enabled': USAGE_STATS_ENABLED,
+    'feature_flag.ai_assistant_enabled': !!(AI_API_KEY || ANTHROPIC_API_KEY),
+    'feature_flag.scheduled_tasks_external': RUN_SCHEDULED_TASKS_EXTERNALLY,
+  };
+}
+
+const counters = new Map<string, Counter>();
+const histograms = new Map<string, Histogram>();
+
+/**
+ * Returns a memoized counter for `name`, creating it on first use. Always use
+ * this instead of `meter.createCounter` so instruments are shared across calls.
+ */
+export function getCounter(name: string, options?: MetricOptions): Counter {
+  let counter = counters.get(name);
+  if (!counter) {
+    counter = meter.createCounter(name, options);
+    counters.set(name, counter);
+  }
+  return counter;
+}
+
+/** Memoized histogram accessor. See {@link getCounter}. */
+export function getHistogram(name: string, options?: MetricOptions): Histogram {
+  let histogram = histograms.get(name);
+  if (!histogram) {
+    histogram = meter.createHistogram(name, options);
+    histograms.set(name, histogram);
+  }
+  return histogram;
+}
+
+/**
+ * Runs `fn`, recording its wall-clock duration (ms) on `histogram` regardless
+ * of whether it resolves or rejects.
+ */
+export async function recordDuration<T>(
+  histogram: Histogram,
+  fn: () => Promise<T>,
+  attributes?: Attributes,
+): Promise<T> {
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    histogram.record(performance.now() - start, attributes);
+  }
+}


### PR DESCRIPTION
## Summary

### Why

Incident remediation is harder than it should be because span context is inconsistent: session routes set `userId`/`userEmail` but not `teamId`, access-key (external API + MCP) requests set no trace attributes at all, and many hot paths (alerts, search, charts, errors) only log — they never emit metrics. There was also no shared instrumentation helper, so the few manual spans duplicated boilerplate.

This PR establishes an observability foundation so future features are instrumented by default, then pilots the pattern on the highest-value paths. Principles are aligned with the [Instrumentation Score spec](https://github.com/instrumentation-score/spec/tree/main/rules).

This is intentionally scoped as **foundation + docs + a pilot** rather than a repo-wide rollout, to keep the PR reviewable (see Next steps).

### What changed

**Docs / standards**
- New `agent_docs/observability.md`: instrumentation conventions (low-cardinality span names & metric attributes, limited `INTERNAL` spans, non-`CLIENT` root spans, standardized `hyperdx.*` / `feature_flag.*` keys) with copy-paste helper examples.
- New "Observability" key principle in `AGENTS.md` linking to the guide.

**Centralized helper library** — `packages/api/src/utils/instrumentation.ts` (new)
- `withSpan(name, fn, opts?)` — active-span wrapper that records exceptions, sets OK/ERROR status, and always ends the span.
- `setBusinessContext({ teamId, userId, email, ...extra })` — standardized incident context applied to the whole trace and the active span.
- `getStaticFeatureFlags()` — static env/compile-time flag states as `feature_flag.*` attributes (there is no dynamic flag service).
- Memoized `getCounter` / `getHistogram` accessors + `recordDuration`.

**Universal context** — `middleware/auth.ts`
- `isUserAuthenticated` now attaches `teamId` (previously missing) + feature flags.
- `validateUserAccessKey` (external API / MCP) now attaches team/user context (previously none).
- Local app mode tags `hyperdx.local_mode` instead of silently dropping context.

**Pilot metrics on log-only hot paths**
- `middleware/error.ts`: `hyperdx.api.errors` counter `{ operational, status_code }`.
- `tasks/checkAlerts/index.ts`: `hyperdx.alerts.evaluations{outcome}` (fired/resolved/skipped_silenced/skipped_schedule/skipped_window/skipped_anchor/empty_bucket), `hyperdx.alerts.query_failures`, `hyperdx.alerts.process_failures`, and `hyperdx.alerts.batch.size` on the batch span.
- `external-api/v2/search.ts`: `hyperdx.search.query.duration_ms` histogram + `hyperdx.search.query_errors{ch_error_type}` counter.
- `external-api/v2/charts.ts`: replaced the ad-hoc `getActiveSpan()` block with a named `withSpan`; added `hyperdx.charts.series.duration_ms` histogram + `hyperdx.charts.series.errors` counter.

**Refactor**
- `mcp/utils/tracing.ts`: `withToolTracing` reimplemented on `withSpan`, plus `hyperdx.mcp.tool.duration_ms` histogram and `hyperdx.mcp.tool.errors` counter.

All new metric attributes are deliberately low-cardinality (no raw queries, IDs, or messages).

### New telemetry reference

| Metric | Type | Key attributes |
| --- | --- | --- |
| `hyperdx.api.errors` | counter | `operational`, `status_code` |
| `hyperdx.alerts.evaluations` | counter | `outcome` |
| `hyperdx.alerts.query_failures` | counter | — |
| `hyperdx.alerts.process_failures` | counter | — |
| `hyperdx.search.query.duration_ms` | histogram | — |
| `hyperdx.search.query_errors` | counter | `ch_error_type` |
| `hyperdx.charts.series.duration_ms` | histogram | — |
| `hyperdx.charts.series.errors` | counter | — |
| `hyperdx.mcp.tool.duration_ms` | histogram | `tool` |
| `hyperdx.mcp.tool.errors` | counter | `tool` |

Span/trace attributes now consistently include `hyperdx.team.id`, `hyperdx.user.id`, `hyperdx.user.email`, and `feature_flag.*` across session, access-key, and MCP auth paths.

### Testing

- New `packages/api/src/utils/__tests__/instrumentation.test.ts` (11 tests) and expanded MCP tracing test (9 tests) — 20 passing.
- `tsc --noEmit` clean; `eslint --quiet` 0 errors; `lint:openapi` 0 errors with no `openapi.json` drift.

### Notes for reviewers

- `charts.ts` has a large line delta that is mostly re-indentation from wrapping the handler in `withSpan`. Review with whitespace ignored (`git diff -w`) for the real change.
- Trace-wide attributes via `setBusinessContext` require `HDX_NODE_BETA_MODE=1` (already set in the API dev env).
- Changeset: `@hyperdx/api` minor.

### Next steps (after merge)

These were intentionally left out to keep this PR scoped; each is a good follow-up:

1. **Roll out context + metrics to the remaining API surfaces** using the same helpers: OpAMP controllers/services, the Prometheus proxy router, webhook/notification delivery (`checkAlerts/template.ts`), MongoDB connection-event counters, and the broader set of routers/controllers.
2. **App (browser + Next.js) context uplift**: add `teamId`/`userId` to the browser RUM global attributes (currently only `userEmail`/`teamName`) and to the Next.js server `instrumentation.ts`, plus client-side custom metrics worth capturing.
3. **Enable host/runtime metrics in production** (currently dev-only in `index.ts`) so the new counters/histograms ship from real deployments.
4. **Build dashboards + alerts** on the new metrics (error rate by route/status, alert evaluation outcomes, search/chart query latency, MCP tool latency/errors) and wire them into the default provisioned dashboards.
5. **Add a lint/convention check** (or extend the eslint config) to nudge new manual spans/metrics toward the helpers and low-cardinality naming, enforcing `agent_docs/observability.md` over time.