### PR TITLE
[HDX] test(otel-collector): add traces, metrics & rrweb routing smoke coverage

### DIFF
--- a/smoke-tests/otel-collector/README.md
+++ b/smoke-tests/otel-collector/README.md
@@ -39,6 +39,28 @@ bats hdx-1453-auto-parse-json.bats
 - `test_helpers/` - Utility functions for the tests
 - `docker-compose.yaml` - Docker Compose configuration for the test environment
 
+### Signals covered
+
+The suite exercises all three OTLP signal types against the standalone
+collector config (`docker/otel-collector/config.standalone.yaml`):
+
+- **logs** - severity inference/normalization, JSON auto-parse, JSON-schema
+  exporter, compat-schema (old ClickHouse), custom-pipeline processor swap, and
+  the `routing/logs` connector that splits rrweb (session replay) logs into
+  `hyperdx_sessions` from ordinary logs in `otel_logs`.
+- **traces** - the `traces` pipeline into `otel_traces` (`traces.bats`).
+- **metrics** - the `metrics` pipeline into `otel_metrics_gauge`
+  (`metrics.bats`).
+
+### Test helpers
+
+- `emit_otel_data <endpoint> <testdir> [signal]` - POSTs `<testdir>/input.json`
+  to `/v1/<signal>`. `signal` is `logs` (default), `traces`, or `metrics`.
+- `wait_for_rows <ch_port> <count_query> [max_attempts]` - polls a ClickHouse
+  count query until it returns a non-zero result (or the attempt budget is
+  exhausted). Prefer this over a fixed `sleep` after emitting data: it is both
+  faster (returns as soon as rows land) and less flaky under load.
+
 The test suite uses Bats' `setup_suite` and `teardown_suite` hooks to initialize
 the environment only once, regardless of how many test files are run. This
 optimizes test execution by:

--- a/smoke-tests/otel-collector/data/metrics/gauge-insert/assert_query.sql
+++ b/smoke-tests/otel-collector/data/metrics/gauge-insert/assert_query.sql
@@ -1,0 +1,10 @@
+SELECT
+    MetricName,
+    ServiceName,
+    toString(Attributes['room']),
+    Value
+FROM otel_metrics_gauge
+WHERE ResourceAttributes['suite-id'] = 'metrics'
+  AND ResourceAttributes['test-id'] = 'gauge-insert'
+ORDER BY TimeUnix
+FORMAT CSV

--- a/smoke-tests/otel-collector/data/metrics/gauge-insert/expected.snap
+++ b/smoke-tests/otel-collector/data/metrics/gauge-insert/expected.snap
@@ -1,0 +1,2 @@
+"smoke.gauge.temperature","metric-test-service","kitchen",21.5
+"smoke.gauge.temperature","metric-test-service","bedroom",19.25

--- a/smoke-tests/otel-collector/data/metrics/gauge-insert/input.json
+++ b/smoke-tests/otel-collector/data/metrics/gauge-insert/input.json
@@ -1,0 +1,67 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "metrics"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "gauge-insert"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "metric-test-service"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "smoke.gauge.temperature",
+              "unit": "Cel",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1901999590000000000",
+                    "asDouble": 21.5,
+                    "attributes": [
+                      {
+                        "key": "room",
+                        "value": {
+                          "stringValue": "kitchen"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "timeUnixNano": "1901999590000000001",
+                    "asDouble": 19.25,
+                    "attributes": [
+                      {
+                        "key": "room",
+                        "value": {
+                          "stringValue": "bedroom"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/assert_query.sql
+++ b/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/assert_query.sql
@@ -1,0 +1,13 @@
+SELECT table, Body FROM (
+    SELECT 'hyperdx_sessions' AS table, Body, Timestamp
+    FROM hyperdx_sessions
+    WHERE ResourceAttributes['suite-id'] = 'rrweb-routing'
+      AND ResourceAttributes['test-id'] = 'route-to-sessions'
+    UNION ALL
+    SELECT 'otel_logs' AS table, Body, Timestamp
+    FROM otel_logs
+    WHERE ResourceAttributes['suite-id'] = 'rrweb-routing'
+      AND ResourceAttributes['test-id'] = 'route-to-sessions'
+)
+ORDER BY table, Timestamp
+FORMAT CSV

--- a/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/expected.snap
+++ b/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/expected.snap
@@ -1,0 +1,2 @@
+"hyperdx_sessions","session replay event"
+"otel_logs","ordinary application log"

--- a/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/input.json
+++ b/smoke-tests/otel-collector/data/rrweb-routing/route-to-sessions/input.json
@@ -1,0 +1,63 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "rrweb-routing"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "route-to-sessions"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "rrweb-test-service"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1901999590000000000",
+              "body": {
+                "stringValue": "session replay event"
+              },
+              "attributes": [
+                {
+                  "key": "rr-web.event",
+                  "value": {
+                    "stringValue": "2"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1901999590000000001",
+              "body": {
+                "stringValue": "ordinary application log"
+              },
+              "attributes": [
+                {
+                  "key": "request.id",
+                  "value": {
+                    "stringValue": "req-789"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/data/traces/basic-insert/assert_query.sql
+++ b/smoke-tests/otel-collector/data/traces/basic-insert/assert_query.sql
@@ -1,0 +1,11 @@
+SELECT
+    SpanName,
+    ServiceName,
+    ParentSpanId = '' AS is_root,
+    toString(SpanAttributes['http.method']),
+    toString(SpanAttributes['db.system'])
+FROM otel_traces
+WHERE ResourceAttributes['suite-id'] = 'traces'
+  AND ResourceAttributes['test-id'] = 'basic-insert'
+ORDER BY Timestamp
+FORMAT CSV

--- a/smoke-tests/otel-collector/data/traces/basic-insert/expected.snap
+++ b/smoke-tests/otel-collector/data/traces/basic-insert/expected.snap
@@ -1,0 +1,2 @@
+"root-operation","trace-test-service",1,"GET",""
+"child-operation","trace-test-service",0,"","clickhouse"

--- a/smoke-tests/otel-collector/data/traces/basic-insert/input.json
+++ b/smoke-tests/otel-collector/data/traces/basic-insert/input.json
@@ -1,0 +1,75 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "suite-id",
+            "value": {
+              "stringValue": "traces"
+            }
+          },
+          {
+            "key": "test-id",
+            "value": {
+              "stringValue": "basic-insert"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "trace-test-service"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {},
+          "spans": [
+            {
+              "traceId": "5b8efff798038103d269b633813fc60c",
+              "spanId": "eee19b7ec3c1b174",
+              "parentSpanId": "",
+              "name": "root-operation",
+              "kind": 2,
+              "startTimeUnixNano": "1901999590000000000",
+              "endTimeUnixNano": "1901999590000123000",
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "traceId": "5b8efff798038103d269b633813fc60c",
+              "spanId": "f1f2f3f4f5f6f7f8",
+              "parentSpanId": "eee19b7ec3c1b174",
+              "name": "child-operation",
+              "kind": 3,
+              "startTimeUnixNano": "1901999590000010000",
+              "endTimeUnixNano": "1901999590000099000",
+              "attributes": [
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "clickhouse"
+                  }
+                }
+              ],
+              "status": {
+                "code": 2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/smoke-tests/otel-collector/metrics.bats
+++ b/smoke-tests/otel-collector/metrics.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+# Exercises the `metrics` pipeline (otlp/hyperdx -> clickhouse exporter ->
+# otel_metrics_gauge). Prior to this the smoke suite only emitted logs, so the
+# metric ingest path and otel_metrics_* schema were never verified end-to-end.
+
+load 'test_helpers/utilities.bash'
+load 'test_helpers/assertions.bash'
+
+@test "metrics: gauge data points are ingested into otel_metrics_gauge with attributes and values" {
+    emit_otel_data "http://localhost:4318" "data/metrics/gauge-insert" "metrics"
+    wait_for_rows 9000 "SELECT count() FROM otel_metrics_gauge WHERE ResourceAttributes['suite-id'] = 'metrics' AND ResourceAttributes['test-id'] = 'gauge-insert'"
+    assert_test_data "data/metrics/gauge-insert"
+}

--- a/smoke-tests/otel-collector/metrics.bats
+++ b/smoke-tests/otel-collector/metrics.bats
@@ -9,6 +9,8 @@ load 'test_helpers/assertions.bash'
 
 @test "metrics: gauge data points are ingested into otel_metrics_gauge with attributes and values" {
     emit_otel_data "http://localhost:4318" "data/metrics/gauge-insert" "metrics"
-    wait_for_rows 9000 "SELECT count() FROM otel_metrics_gauge WHERE ResourceAttributes['suite-id'] = 'metrics' AND ResourceAttributes['test-id'] = 'gauge-insert'"
+    # The fixture sends 2 gauge data points; wait for both so the snapshot
+    # assertion never runs against a partially-flushed batch.
+    wait_for_rows 9000 "SELECT count() FROM otel_metrics_gauge WHERE ResourceAttributes['suite-id'] = 'metrics' AND ResourceAttributes['test-id'] = 'gauge-insert'" 2
     assert_test_data "data/metrics/gauge-insert"
 }

--- a/smoke-tests/otel-collector/rrweb-routing.bats
+++ b/smoke-tests/otel-collector/rrweb-routing.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+# Exercises the routing/logs connector that splits the logs pipeline:
+# log records carrying an `rr-web.event` attribute are routed to
+# logs/out-rrweb -> clickhouse/rrweb (the hyperdx_sessions table), while all
+# other logs fall through to logs/out-default -> clickhouse (otel_logs).
+#
+# Prior to this the routing connector and the rrweb (session replay) exporter
+# path were never exercised by the smoke suite.
+
+load 'test_helpers/utilities.bash'
+load 'test_helpers/assertions.bash'
+
+@test "rrweb routing: rr-web.event logs go to hyperdx_sessions, others go to otel_logs" {
+    emit_otel_data "http://localhost:4318" "data/rrweb-routing/route-to-sessions"
+
+    # One record routes to hyperdx_sessions, the other to otel_logs. Wait for
+    # both to land before asserting the combined snapshot.
+    wait_for_rows 9000 "SELECT count() FROM hyperdx_sessions WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'"
+    wait_for_rows 9000 "SELECT count() FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'"
+
+    assert_test_data "data/rrweb-routing/route-to-sessions"
+}

--- a/smoke-tests/otel-collector/rrweb-routing.bats
+++ b/smoke-tests/otel-collector/rrweb-routing.bats
@@ -15,9 +15,9 @@ load 'test_helpers/assertions.bash'
     emit_otel_data "http://localhost:4318" "data/rrweb-routing/route-to-sessions"
 
     # One record routes to hyperdx_sessions, the other to otel_logs. Wait for
-    # both to land before asserting the combined snapshot.
-    wait_for_rows 9000 "SELECT count() FROM hyperdx_sessions WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'"
-    wait_for_rows 9000 "SELECT count() FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'"
+    # the expected row in each table before asserting the combined snapshot.
+    wait_for_rows 9000 "SELECT count() FROM hyperdx_sessions WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'" 1
+    wait_for_rows 9000 "SELECT count() FROM otel_logs WHERE ResourceAttributes['suite-id'] = 'rrweb-routing' AND ResourceAttributes['test-id'] = 'route-to-sessions'" 1
 
     assert_test_data "data/rrweb-routing/route-to-sessions"
 }

--- a/smoke-tests/otel-collector/test_helpers/utilities.bash
+++ b/smoke-tests/otel-collector/test_helpers/utilities.bash
@@ -75,31 +75,56 @@ emit_otel_data() {
     return 0
 }
 
-# Poll a ClickHouse count query until it returns a non-zero result or the
-# attempt budget is exhausted. This replaces fixed `sleep` calls after emitting
-# data: the collector's batch timeout is short (100ms in the smoke env), but the
-# round trip through the exporter into ClickHouse is not instantaneous, and a
-# fixed sleep is both slower (always waits the full duration) and flakier (may
-# wait too little under load). Returns 0 as soon as rows are visible.
+# Poll a ClickHouse count query until at least `expected_count` rows are present
+# or the attempt budget is exhausted. This replaces fixed `sleep` calls after
+# emitting data: the collector's batch timeout is short (100ms in the smoke
+# env), but the round trip through the exporter into ClickHouse is not
+# instantaneous, and a fixed sleep is both slower (always waits the full
+# duration) and flakier (may wait too little under load).
 #
-# Usage: wait_for_rows <clickhouse_port> <count_query> [max_attempts]
+# IMPORTANT: pass the FULL number of rows the subsequent snapshot assertion
+# expects, not 1. The collector's batch exporter may flush a multi-record
+# payload across several micro-batches, so the first rows can land before the
+# rest. Unblocking on the first row would let assert_test_data run against a
+# partial result and fail intermittently. Waiting for the full count makes the
+# assertion deterministic.
+#
+# Usage: wait_for_rows <clickhouse_port> <count_query> <expected_count> [max_attempts]
 wait_for_rows() {
     local port=$1
     local count_query=$2
-    local max_attempts=${3:-30}
+    local expected_count=$3
+    local max_attempts=${4:-30}
     local attempt=0
+    # Captures the most recent clickhouse-client stderr so it can be surfaced on
+    # timeout instead of being silently swallowed (e.g. ClickHouse not yet
+    # listening, or a typo in a column name that makes the query always error).
+    local last_err=""
+    local err_file
+    err_file=$(mktemp "${TMPDIR:-/tmp}/wait_for_rows.XXXXXX")
 
     while [ "$attempt" -lt "$max_attempts" ]; do
         local count
-        count=$(clickhouse-client --port="$port" --query="$count_query" 2>/dev/null)
-        if [ -n "$count" ] && [ "$count" != "0" ]; then
+        count=$(clickhouse-client --port="$port" --query="$count_query" 2>"$err_file")
+        last_err=$(cat "$err_file")
+        # The `2>/dev/null` guards the integer comparison against a non-numeric
+        # `count` (e.g. empty stdout when the query errored), which would
+        # otherwise emit a bash "integer expression expected" error.
+        if [ -n "$count" ] && [ "$count" -ge "$expected_count" ] 2>/dev/null; then
+            rm -f "$err_file"
             return 0
         fi
         attempt=$((attempt + 1))
         sleep 0.5
     done
 
-    echo "❌ Error: rows did not arrive within $((max_attempts / 2))s for query: $count_query" >&3
+    rm -f "$err_file"
+
+    echo "❌ Error: expected >= $expected_count row(s) within $((max_attempts / 2))s for query: $count_query" >&3
+    echo "   last observed count: '${count:-<empty>}'" >&3
+    if [ -n "$last_err" ]; then
+        echo "   last clickhouse-client error: $last_err" >&3
+    fi
     return 1
 }
 

--- a/smoke-tests/otel-collector/test_helpers/utilities.bash
+++ b/smoke-tests/otel-collector/test_helpers/utilities.bash
@@ -46,6 +46,9 @@ wait_for_ready() {
 emit_otel_data() {
     local endpoint=$1
     local testdir=$2
+    # Optional third argument selects the OTLP signal: logs (default), traces,
+    # or metrics. It maps to the matching /v1/<signal> ingest path.
+    local signal=${3:-logs}
     local datafile="${testdir}/input.json"
 
     # Check if the data file exists and is readable
@@ -60,7 +63,7 @@ emit_otel_data() {
     fi
 
     # Send the JSON file as a single request
-    curl -s -X POST "$endpoint/v1/logs" \
+    curl -s -X POST "$endpoint/v1/${signal}" \
         -H "Content-Type: application/json" \
         --data @"$datafile"
 
@@ -70,6 +73,34 @@ emit_otel_data() {
         return 1
     fi
     return 0
+}
+
+# Poll a ClickHouse count query until it returns a non-zero result or the
+# attempt budget is exhausted. This replaces fixed `sleep` calls after emitting
+# data: the collector's batch timeout is short (100ms in the smoke env), but the
+# round trip through the exporter into ClickHouse is not instantaneous, and a
+# fixed sleep is both slower (always waits the full duration) and flakier (may
+# wait too little under load). Returns 0 as soon as rows are visible.
+#
+# Usage: wait_for_rows <clickhouse_port> <count_query> [max_attempts]
+wait_for_rows() {
+    local port=$1
+    local count_query=$2
+    local max_attempts=${3:-30}
+    local attempt=0
+
+    while [ "$attempt" -lt "$max_attempts" ]; do
+        local count
+        count=$(clickhouse-client --port="$port" --query="$count_query" 2>/dev/null)
+        if [ -n "$count" ] && [ "$count" != "0" ]; then
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 0.5
+    done
+
+    echo "❌ Error: rows did not arrive within $((max_attempts / 2))s for query: $count_query" >&3
+    return 1
 }
 
 attempt_env_cleanup() {

--- a/smoke-tests/otel-collector/traces.bats
+++ b/smoke-tests/otel-collector/traces.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+# Exercises the `traces` pipeline (otlp/hyperdx -> clickhouse exporter ->
+# otel_traces). Prior to this the smoke suite only emitted logs, so the trace
+# ingest path and otel_traces schema were never verified end-to-end.
+
+load 'test_helpers/utilities.bash'
+load 'test_helpers/assertions.bash'
+
+@test "traces: spans are ingested into otel_traces with attributes and parent/child linkage" {
+    emit_otel_data "http://localhost:4318" "data/traces/basic-insert" "traces"
+    wait_for_rows 9000 "SELECT count() FROM otel_traces WHERE ResourceAttributes['suite-id'] = 'traces' AND ResourceAttributes['test-id'] = 'basic-insert'"
+    assert_test_data "data/traces/basic-insert"
+}

--- a/smoke-tests/otel-collector/traces.bats
+++ b/smoke-tests/otel-collector/traces.bats
@@ -9,6 +9,8 @@ load 'test_helpers/assertions.bash'
 
 @test "traces: spans are ingested into otel_traces with attributes and parent/child linkage" {
     emit_otel_data "http://localhost:4318" "data/traces/basic-insert" "traces"
-    wait_for_rows 9000 "SELECT count() FROM otel_traces WHERE ResourceAttributes['suite-id'] = 'traces' AND ResourceAttributes['test-id'] = 'basic-insert'"
+    # The fixture sends 2 spans (root + child); wait for both so the snapshot
+    # assertion never runs against a partially-flushed batch.
+    wait_for_rows 9000 "SELECT count() FROM otel_traces WHERE ResourceAttributes['suite-id'] = 'traces' AND ResourceAttributes['test-id'] = 'basic-insert'" 2
     assert_test_data "data/traces/basic-insert"
 }


### PR DESCRIPTION
## What

Broadens the OTel Collector smoke suite from **logs-only** to cover the **traces** and **metrics** pipelines and the **rrweb routing connector**, plus a small harness improvement.

### New tests
| File | Covers | Asserts |
|---|---|---|
| `traces.bats` | `traces` pipeline → `clickhouse` exporter → `otel_traces` | span name, service name, parent/child linkage (`ParentSpanId = ''`), span attributes |
| `metrics.bats` | `metrics` pipeline → `clickhouse` exporter → `otel_metrics_gauge` | metric name, service name, datapoint attribute, value |
| `rrweb-routing.bats` | `routing/logs` connector split | `rr-web.event` logs land in `hyperdx_sessions`; ordinary logs land in `otel_logs` (combined UNION snapshot) |

### Harness changes
- `emit_otel_data` gains an optional third arg `signal` (`logs` default / `traces` / `metrics`) mapping to `/v1/<signal>`. Existing 2-arg log callers are unchanged.
- New `wait_for_rows <ch_port> <count_query> [max_attempts]` helper polls ClickHouse until rows arrive, used by the new tests instead of a fixed `sleep` — returns as soon as data lands (faster) and is bounded/retried (less flaky under load).
- README updated to document signals covered and the helpers.

## Why

The smoke suite only ever POSTed to `/v1/logs`, so the trace and metric ingest paths, the `otel_traces` / `otel_metrics_*` schemas, and the session-replay routing connector had **zero** end-to-end coverage. These are exactly the paths most exposed when bumping the collector base version (see the v0.154.0 bump in #2512, where the deprecated-alias risks fell into uncovered areas). This closes the highest-value Tier-1 gaps from the coverage review.

## Assertion design

Snapshots avoid columns whose exact string form is environment/version-sensitive (e.g. `SpanKind`/`StatusCode` enum spellings). Instead they assert on values the exporter stores verbatim — names, `service.name`, attributes, `Value`, and a derived `is_root` boolean — so the snapshots stay stable across collector versions and ClickHouse builds.

## Notes / follow-ups (not in this PR)

- `smoke-tests/otel-collector/receiver-config.yaml` appears **orphaned** (not mounted or copied by any compose file / Dockerfile). Left as-is here; worth removing in a dedicated cleanup.
- Existing log tests still use fixed `sleep`; left untouched to keep this PR additive. They can migrate to `wait_for_rows` incrementally.
- Tier-2/3 ideas (default Map-schema `otel_logs` column-types assertion, prometheusremotewrite/promql path, bearertokenauth startup) remain open.

## Verification

Bats files parse-validated locally (`bats --count`), bash helpers `bash -n` clean, and all JSON fixtures validated. Full execution runs in CI via the `otel-smoke-test` job (`bats .`), which is gated on `smoke-tests/otel-collector/**` changes. Docker was unavailable locally so the suite itself runs in CI.