### PR TITLE
feat: add ability to connect to external prometheus datastore

### DIFF
--- a/.changeset/connection-prometheus-endpoint-ui.md
+++ b/.changeset/connection-prometheus-endpoint-ui.md
@@ -1,0 +1,9 @@
+---
+'@hyperdx/app': minor
+'@hyperdx/api': minor
+'@hyperdx/common-utils': minor
+---
+
+Add UI support for configuring an external Prometheus-compatible endpoint on a
+connection. Modify Connections model to now have a boolean
+`isPrometheusEndpoint` field and use host for storing the host.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -620,11 +620,10 @@
             "nullable": true,
             "example": "hyperdx_"
           },
-          "prometheusEndpoint": {
-            "type": "string",
-            "description": "Optional Prometheus-compatible API endpoint. When set, PromQL queries are proxied to this endpoint.",
-            "nullable": true,
-            "example": "http://prometheus:9090"
+          "isPrometheusEndpoint": {
+            "type": "boolean",
+            "description": "Optional. When true, `host` is treated as a Prometheus-compatible API endpoint (e.g. Prometheus or Thanos) and PromQL queries are proxied to it. When false or omitted, `host` is a ClickHouse HTTP endpoint.",
+            "example": false
           },
           "createdAt": {
             "type": "string",
@@ -675,10 +674,10 @@
             "nullable": true,
             "example": "hyperdx_"
           },
-          "prometheusEndpoint": {
-            "type": "string",
-            "description": "Optional Prometheus-compatible API endpoint. When set, PromQL queries are proxied to this endpoint.",
-            "example": "http://prometheus:9090"
+          "isPrometheusEndpoint": {
+            "type": "boolean",
+            "description": "Optional. When true, `host` is treated as a Prometheus-compatible API endpoint (e.g. Prometheus or Thanos) and PromQL queries are proxied to it. When false or omitted, `host` is a ClickHouse HTTP endpoint.",
+            "example": false
           }
         }
       },
@@ -717,11 +716,10 @@
             "nullable": true,
             "example": "hyperdx_"
           },
-          "prometheusEndpoint": {
-            "type": "string",
-            "description": "Optional Prometheus-compatible API endpoint. Set to null to clear the existing value. If omitted, the existing value is kept.",
-            "nullable": true,
-            "example": "http://prometheus:9090"
+          "isPrometheusEndpoint": {
+            "type": "boolean",
+            "description": "Optional. When true, `host` is treated as a Prometheus-compatible API endpoint. When false or omitted, `host` is a ClickHouse HTTP endpoint. Omit to keep the existing value unchanged.",
+            "example": false
           }
         }
       },

--- a/packages/api/src/models/connection.ts
+++ b/packages/api/src/models/connection.ts
@@ -12,10 +12,11 @@ export interface IConnection {
   username: string;
   team: ObjectId;
   hyperdxSettingPrefix?: string;
-  /** Optional Prometheus-compatible API endpoint (e.g. http://prometheus:9090).
-   *  When set, PromQL queries are proxied to this endpoint instead of using
-   *  ClickHouse's prometheusQuery() function. */
-  prometheusEndpoint?: string;
+  /** When true, `host` is treated as a Prometheus-compatible API endpoint
+   *  (e.g. Prometheus or Thanos) and PromQL queries are proxied directly to
+   *  it. When false/unset, `host` is a ClickHouse HTTP endpoint and PromQL
+   *  queries use ClickHouse's prometheusQuery() function. */
+  isPrometheusEndpoint?: boolean;
 }
 
 export type ConnectionDocument = mongoose.HydratedDocument<IConnection>;
@@ -37,7 +38,7 @@ export default mongoose.model<IConnection>(
         select: false,
       },
       hyperdxSettingPrefix: String,
-      prometheusEndpoint: String,
+      isPrometheusEndpoint: Boolean,
     },
     {
       timestamps: true,

--- a/packages/api/src/routers/api/__tests__/connections.test.ts
+++ b/packages/api/src/routers/api/__tests__/connections.test.ts
@@ -43,42 +43,26 @@ describe('connections router', () => {
     expect(res.body[0].name).toBe('My Team Connection');
   });
 
-  it('persists prometheusEndpoint through POST /connections', async () => {
+  it('persists isPrometheusEndpoint through POST /connections', async () => {
     const { agent } = await getLoggedInAgent(server);
 
     const res = await agent
       .post('/connections')
       .send({
         name: 'Prom-enabled',
-        host: config.CLICKHOUSE_HOST,
-        username: 'default',
+        host: 'http://thanos:10902',
+        username: '',
         password: '',
-        prometheusEndpoint: 'http://prom.example.com',
+        isPrometheusEndpoint: true,
       })
       .expect(200);
 
-    const stored = await Connection.findById(res.body.id).select(
-      '+prometheusEndpoint',
-    );
-    expect(stored?.prometheusEndpoint).toBe('http://prom.example.com');
+    const stored = await Connection.findById(res.body.id);
+    expect(stored?.host).toBe('http://thanos:10902');
+    expect(stored?.isPrometheusEndpoint).toBe(true);
   });
 
-  it('rejects invalid prometheusEndpoint URLs with 400', async () => {
-    const { agent } = await getLoggedInAgent(server);
-
-    await agent
-      .post('/connections')
-      .send({
-        name: 'Bad-URL',
-        host: config.CLICKHOUSE_HOST,
-        username: 'default',
-        password: '',
-        prometheusEndpoint: 'not-a-url',
-      })
-      .expect(400);
-  });
-
-  it('persists prometheusEndpoint through PUT /connections/:id', async () => {
+  it('persists isPrometheusEndpoint through PUT /connections/:id', async () => {
     const { agent, team } = await getLoggedInAgent(server);
 
     const created = await Connection.create({
@@ -94,16 +78,44 @@ describe('connections router', () => {
       .send({
         id: created._id.toString(),
         name: 'No-prom',
-        host: config.CLICKHOUSE_HOST,
-        username: 'default',
+        host: 'http://thanos:10902',
+        username: '',
         password: '',
-        prometheusEndpoint: 'http://prom-new.example.com',
+        isPrometheusEndpoint: true,
       })
       .expect(200);
 
-    const stored = await Connection.findById(created._id).select(
-      '+prometheusEndpoint',
-    );
-    expect(stored?.prometheusEndpoint).toBe('http://prom-new.example.com');
+    const stored = await Connection.findById(created._id);
+    expect(stored?.host).toBe('http://thanos:10902');
+    expect(stored?.isPrometheusEndpoint).toBe(true);
+  });
+
+  it('toggles isPrometheusEndpoint back to false through PUT', async () => {
+    const { agent, team } = await getLoggedInAgent(server);
+
+    const created = await Connection.create({
+      team: team._id,
+      name: 'Prom',
+      host: 'http://thanos:10902',
+      username: '',
+      password: '',
+      isPrometheusEndpoint: true,
+    });
+
+    await agent
+      .put(`/connections/${created._id.toString()}`)
+      .send({
+        id: created._id.toString(),
+        name: 'Prom',
+        host: config.CLICKHOUSE_HOST,
+        username: 'default',
+        password: '',
+        isPrometheusEndpoint: false,
+      })
+      .expect(200);
+
+    const stored = await Connection.findById(created._id);
+    expect(stored?.host).toBe(config.CLICKHOUSE_HOST);
+    expect(stored?.isPrometheusEndpoint).toBe(false);
   });
 });

--- a/packages/api/src/routers/api/__tests__/prometheus.integration.test.ts
+++ b/packages/api/src/routers/api/__tests__/prometheus.integration.test.ts
@@ -31,10 +31,10 @@ describe('prometheus router', () => {
     return Connection.create({
       team: teamId,
       name: 'Prom',
-      host: 'http://ch-server:8123',
-      username: 'default',
+      host: 'http://prom.example.com',
+      username: '',
       password: '',
-      prometheusEndpoint: 'http://prom.example.com',
+      isPrometheusEndpoint: true,
     });
   };
 
@@ -95,7 +95,7 @@ describe('prometheus router', () => {
       });
     });
 
-    it('proxies to upstream Prometheus when connection has prometheusEndpoint', async () => {
+    it('proxies to upstream Prometheus when connection isPrometheusEndpoint', async () => {
       const { agent, team } = await getLoggedInAgent(server);
       const conn = await seedPrometheusConnection(team._id);
 
@@ -129,7 +129,7 @@ describe('prometheus router', () => {
       expect(calledUrl).not.toContain('connectionId');
     });
 
-    it('does NOT proxy to Prometheus when connection has no prometheusEndpoint', async () => {
+    it('does NOT proxy to Prometheus when connection is not isPrometheusEndpoint', async () => {
       const { agent, team } = await getLoggedInAgent(server);
       const conn = await seedClickHouseConnection(team._id);
 
@@ -197,7 +197,7 @@ describe('prometheus router', () => {
         .expect(404);
     });
 
-    it('proxies to upstream Prometheus when connection has prometheusEndpoint', async () => {
+    it('proxies to upstream Prometheus when connection isPrometheusEndpoint', async () => {
       const { agent, team } = await getLoggedInAgent(server);
       const conn = await seedPrometheusConnection(team._id);
 
@@ -238,7 +238,7 @@ describe('prometheus router', () => {
         .expect(404);
     });
 
-    it('proxies to upstream Prometheus when connection has prometheusEndpoint', async () => {
+    it('proxies to upstream Prometheus when connection isPrometheusEndpoint', async () => {
       const { agent, team } = await getLoggedInAgent(server);
       const conn = await seedPrometheusConnection(team._id);
 

--- a/packages/api/src/routers/api/__tests__/prometheus.integration.test.ts
+++ b/packages/api/src/routers/api/__tests__/prometheus.integration.test.ts
@@ -6,6 +6,26 @@ import Connection from '@/models/connection';
 
 const mockFetch = global.fetch as jest.Mock;
 
+// The proxy now streams the upstream response straight through (no
+// `await resp.json()`), so test mocks must expose the fields the pipeline
+// actually reads: `status`, `headers.get()`, and a web `ReadableStream` body.
+function fakeUpstreamResponse(payload: unknown, status = 200) {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+      controller.close();
+    },
+  });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body,
+    text: jest.fn().mockResolvedValue(JSON.stringify(payload)),
+    json: jest.fn().mockResolvedValue(payload),
+  };
+}
+
 describe('prometheus router', () => {
   const server = getServer();
 
@@ -16,11 +36,7 @@ describe('prometheus router', () => {
   afterEach(async () => {
     await server.clearDBs();
     mockFetch.mockReset();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      text: jest.fn().mockResolvedValue(''),
-      json: jest.fn().mockResolvedValue({}),
-    } as any);
+    mockFetch.mockResolvedValue(fakeUpstreamResponse({}) as any);
   });
 
   afterAll(async () => {
@@ -103,11 +119,9 @@ describe('prometheus router', () => {
         status: 'success',
         data: { resultType: 'matrix', result: [] },
       };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: jest.fn().mockResolvedValue(''),
-        json: jest.fn().mockResolvedValue(promResponse),
-      } as any);
+      mockFetch.mockResolvedValueOnce(
+        fakeUpstreamResponse(promResponse) as any,
+      );
 
       const res = await agent
         .get('/v1/prometheus/query_range')
@@ -205,11 +219,9 @@ describe('prometheus router', () => {
         status: 'success',
         data: { resultType: 'vector', result: [] },
       };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: jest.fn().mockResolvedValue(''),
-        json: jest.fn().mockResolvedValue(promResponse),
-      } as any);
+      mockFetch.mockResolvedValueOnce(
+        fakeUpstreamResponse(promResponse) as any,
+      );
 
       const res = await agent
         .get('/v1/prometheus/query')
@@ -243,11 +255,9 @@ describe('prometheus router', () => {
       const conn = await seedPrometheusConnection(team._id);
 
       const promResponse = { status: 'success', data: ['up', 'requests'] };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: jest.fn().mockResolvedValue(''),
-        json: jest.fn().mockResolvedValue(promResponse),
-      } as any);
+      mockFetch.mockResolvedValueOnce(
+        fakeUpstreamResponse(promResponse) as any,
+      );
 
       const res = await agent
         .get('/v1/prometheus/label/__name__/values')

--- a/packages/api/src/routers/api/connections.ts
+++ b/packages/api/src/routers/api/connections.ts
@@ -67,7 +67,6 @@ router.put(
         return;
       }
 
-      // Build the base connection update
       const shouldUnsetPrefix =
         req.body.hyperdxSettingPrefix === null ||
         req.body.hyperdxSettingPrefix === '';
@@ -82,7 +81,6 @@ router.put(
           : {
               password: connection.password,
             }),
-        // Only include hyperdxSettingPrefix if it's a valid string
         ...(!shouldUnsetPrefix && hyperdxSettingPrefix
           ? { hyperdxSettingPrefix }
           : {}),

--- a/packages/api/src/routers/api/prometheus.ts
+++ b/packages/api/src/routers/api/prometheus.ts
@@ -427,10 +427,23 @@ router.post('/query', queryHandler);
 // GET /label/:name/values
 // --------------------------
 
+// Prometheus label-name grammar — used to reject anything that could
+// influence the upstream URL we're about to construct (e.g. embedded `?`,
+// `#`, or percent-encoded slashes that Express's param decoder lets through).
+// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+const PROMETHEUS_LABEL_NAME = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
+
 router.get('/label/:name/values', async (req, res) => {
   try {
     const { teamId } = getNonNullUserWithTeam(req);
     const labelName = req.params.name;
+    if (!PROMETHEUS_LABEL_NAME.test(labelName)) {
+      return res.status(400).json({
+        status: 'error',
+        errorType: 'bad_data',
+        error: 'Invalid label name',
+      });
+    }
     const params = req.query as Record<string, string>;
 
     const connectionId = params.connectionId;

--- a/packages/api/src/routers/api/prometheus.ts
+++ b/packages/api/src/routers/api/prometheus.ts
@@ -1,8 +1,8 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import express from 'express';
+import { performance } from 'perf_hooks';
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
-import { performance } from 'perf_hooks';
 
 import { getConnectionById } from '@/controllers/connection';
 import { getNonNullUserWithTeam } from '@/middleware/auth';

--- a/packages/api/src/routers/api/prometheus.ts
+++ b/packages/api/src/routers/api/prometheus.ts
@@ -1,5 +1,7 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import express from 'express';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 
 import { getConnectionById } from '@/controllers/connection';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
@@ -119,40 +121,96 @@ export function formatVectorResponse(
 // Prometheus proxy (for real Prometheus backends)
 // --------------------------
 
-const PROMETHEUS_PROXY_TIMEOUT_MS = 30_000;
+const PROMETHEUS_PROXY_TIMEOUT_MS = 90_000;
 const PROMETHEUS_CH_TIMEOUT_MS = 30_000;
 const PROMETHEUS_MAX_EXECUTION_SEC = 30;
 const PROMETHEUS_MAX_RESULT_ROWS = '100000';
 const PROMETHEUS_MAX_RESOLUTION = 11_000;
 
+// Forwards the response straight from the upstream Prometheus to the
+// HyperDX client. The response can be multi-megabyte (e.g. `/label/__name__/
+// values` on a large Prometheus), so we avoid `await resp.json()` +
+// `res.json(...)` which would parse + re-serialize the whole body in memory.
+// Prometheus's native response shape (`{status, data}` / `{status, errorType,
+// error}`) is already what HyperDX clients expect, so we forward the status
+// code and content-type as-is.
 async function proxyToPrometheus(
-  prometheusEndpoint: string,
+  upstreamHost: string,
   path: string,
   params: Record<string, string>,
-): Promise<any> {
-  const url = new URL(path, prometheusEndpoint);
+  res: express.Response,
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(path, upstreamHost);
+  } catch {
+    res.status(400).json({
+      status: 'error',
+      errorType: 'bad_data',
+      error: `Connection host is not a valid URL: ${JSON.stringify(upstreamHost)}`,
+    });
+    return;
+  }
   for (const [k, v] of Object.entries(params)) {
     if (['connectionId', 'database', 'table'].includes(k)) continue;
     if (v != null) url.searchParams.set(k, v);
   }
-  let resp: Response;
+  const target = url.toString();
+
+  let upstreamResp: Response;
   try {
-    resp = await fetch(url.toString(), {
+    upstreamResp = await fetch(target, {
       signal: AbortSignal.timeout(PROMETHEUS_PROXY_TIMEOUT_MS),
     });
   } catch (err) {
     if (err instanceof Error && err.name === 'TimeoutError') {
-      throw new Error(
-        `Prometheus request timed out after ${PROMETHEUS_PROXY_TIMEOUT_MS}ms`,
-      );
+      res.status(504).json({
+        status: 'error',
+        errorType: 'timeout',
+        error: `Prometheus request to ${target} timed out after ${PROMETHEUS_PROXY_TIMEOUT_MS}ms`,
+      });
+      return;
     }
-    throw err;
+    // Node's fetch wraps the real network error (ECONNREFUSED, ENOTFOUND, TLS,
+    // …) in `.cause`. Without unwrapping it the client only sees a useless
+    // `"fetch failed"`.
+    const cause = err instanceof Error ? (err.cause ?? err) : err;
+    let detail: string;
+    if (cause && typeof cause === 'object' && 'code' in cause) {
+      const c = cause as { code: string; message?: string };
+      detail = c.message ? `${c.code}: ${c.message}` : c.code;
+    } else if (cause instanceof Error) {
+      detail = cause.message;
+    } else {
+      detail = String(cause);
+    }
+    res.status(502).json({
+      status: 'error',
+      errorType: 'unavailable',
+      error: `Failed to reach Prometheus at ${target} (${detail})`,
+    });
+    return;
   }
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Prometheus returned ${resp.status}: ${text}`);
+
+  res.status(upstreamResp.status);
+  const contentType = upstreamResp.headers.get('content-type');
+  if (contentType) res.setHeader('content-type', contentType);
+
+  if (!upstreamResp.body) {
+    res.end();
+    return;
   }
-  return resp.json();
+
+  try {
+    await pipeline(Readable.fromWeb(upstreamResp.body as any), res);
+  } catch (err) {
+    // Headers are already sent at this point — best we can do is destroy the
+    // socket so the client sees a truncated response instead of a hung
+    // connection.
+    if (!res.writableEnded) {
+      res.destroy(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
 }
 
 // --------------------------
@@ -196,14 +254,16 @@ const queryRangeHandler: express.RequestHandler = async (req, res) => {
       });
     }
 
-    // If connection has a Prometheus endpoint, proxy directly
-    if (connection.prometheusEndpoint) {
-      const result = await proxyToPrometheus(
-        connection.prometheusEndpoint,
+    // If the connection points at a Prometheus-compatible endpoint, proxy
+    // directly to connection.host instead of running a ClickHouse query.
+    if (connection.isPrometheusEndpoint) {
+      await proxyToPrometheus(
+        connection.host,
         '/api/v1/query_range',
         params,
+        res,
       );
-      return res.json(result);
+      return;
     }
 
     // Otherwise, use ClickHouse prometheusQuery()
@@ -312,13 +372,9 @@ const queryHandler: express.RequestHandler = async (req, res) => {
       });
     }
 
-    if (connection.prometheusEndpoint) {
-      const result = await proxyToPrometheus(
-        connection.prometheusEndpoint,
-        '/api/v1/query',
-        params,
-      );
-      return res.json(result);
+    if (connection.isPrometheusEndpoint) {
+      await proxyToPrometheus(connection.host, '/api/v1/query', params, res);
+      return;
     }
 
     const time = params.time ? parseTimestamp(params.time) : undefined;
@@ -400,13 +456,14 @@ router.get('/label/:name/values', async (req, res) => {
     }
 
     // Proxy to Prometheus if endpoint is set
-    if (connection.prometheusEndpoint) {
-      const result = await proxyToPrometheus(
-        connection.prometheusEndpoint,
+    if (connection.isPrometheusEndpoint) {
+      await proxyToPrometheus(
+        connection.host,
         `/api/v1/label/${labelName}/values`,
         params,
+        res,
       );
-      return res.json(result);
+      return;
     }
 
     const database = params.database ?? 'default';

--- a/packages/api/src/routers/external-api/__tests__/connections.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/connections.test.ts
@@ -193,13 +193,11 @@ describe('External API v2 Connections', () => {
         .send({
           ...MOCK_CONNECTION,
           hyperdxSettingPrefix: 'hyperdx_',
-          prometheusEndpoint: 'http://prometheus:9090',
         })
         .expect(200);
 
       expect(response.body.data).toMatchObject({
         hyperdxSettingPrefix: 'hyperdx_',
-        prometheusEndpoint: 'http://prometheus:9090',
       });
     });
 
@@ -209,10 +207,22 @@ describe('External API v2 Connections', () => {
         .expect(400);
     });
 
-    it('should reject an invalid prometheusEndpoint', async () => {
-      await authRequest('post', CONNECTIONS_BASE_URL)
-        .send({ ...MOCK_CONNECTION, prometheusEndpoint: 'not-a-url' })
-        .expect(400);
+    it('should create a Prometheus-compatible connection', async () => {
+      const response = await authRequest('post', CONNECTIONS_BASE_URL)
+        .send({
+          name: 'Thanos',
+          host: 'http://thanos:10902',
+          username: '',
+          password: '',
+          isPrometheusEndpoint: true,
+        })
+        .expect(200);
+
+      expect(response.body.data).toMatchObject({
+        name: 'Thanos',
+        host: 'http://thanos:10902',
+        isPrometheusEndpoint: true,
+      });
     });
 
     it('should require authentication', async () => {
@@ -316,26 +326,29 @@ describe('External API v2 Connections', () => {
       expect(stored?.hyperdxSettingPrefix).toBeUndefined();
     });
 
-    it('should clear prometheusEndpoint when set to null', async () => {
+    it('should toggle isPrometheusEndpoint', async () => {
       const connection = await Connection.create({
         ...MOCK_CONNECTION,
-        prometheusEndpoint: 'http://prometheus:9090',
         team: team._id,
       });
 
       await authRequest('put', `${CONNECTIONS_BASE_URL}/${connection._id}`)
-        .send({ ...MOCK_CONNECTION, prometheusEndpoint: null })
+        .send({
+          ...MOCK_CONNECTION,
+          host: 'http://thanos:10902',
+          isPrometheusEndpoint: true,
+        })
         .expect(200);
 
       const stored = await Connection.findById(connection._id);
-      expect(stored?.prometheusEndpoint).toBeUndefined();
+      expect(stored?.host).toBe('http://thanos:10902');
+      expect(stored?.isPrometheusEndpoint).toBe(true);
     });
 
-    it('should keep optional fields unchanged when omitted', async () => {
+    it('should keep hyperdxSettingPrefix unchanged when omitted', async () => {
       const connection = await Connection.create({
         ...MOCK_CONNECTION,
         hyperdxSettingPrefix: 'hyperdx_',
-        prometheusEndpoint: 'http://prometheus:9090',
         team: team._id,
       });
 
@@ -349,7 +362,6 @@ describe('External API v2 Connections', () => {
 
       const stored = await Connection.findById(connection._id);
       expect(stored?.hyperdxSettingPrefix).toBe('hyperdx_');
-      expect(stored?.prometheusEndpoint).toBe('http://prometheus:9090');
     });
 
     it('should return 404 for a non-existent connection', async () => {

--- a/packages/api/src/routers/external-api/v2/connections.ts
+++ b/packages/api/src/routers/external-api/v2/connections.ts
@@ -25,9 +25,9 @@ const externalConnectionSchema = ConnectionSchema.omit({
 
 const createConnectionBodySchema = ConnectionSchema.omit({ id: true });
 
-// On update, hyperdxSettingPrefix additionally accepts '' and
-// prometheusEndpoint additionally accepts null, both meaning "clear the
-// existing value". The base ConnectionSchema rejects both.
+// On update, hyperdxSettingPrefix additionally accepts '' meaning "clear the
+// existing value". The base ConnectionSchema rejects '' because the prefix
+// regex requires 1+ chars.
 const updateConnectionBodySchema = ConnectionSchema.omit({ id: true }).extend({
   hyperdxSettingPrefix: z
     .string()
@@ -35,7 +35,6 @@ const updateConnectionBodySchema = ConnectionSchema.omit({ id: true }).extend({
     .or(z.literal(''))
     .optional()
     .nullable(),
-  prometheusEndpoint: z.string().url().optional().nullable(),
 });
 
 function formatExternalConnection(connection: ConnectionDocument) {
@@ -94,11 +93,10 @@ function formatExternalConnection(connection: ConnectionDocument) {
  *           description: Optional prefix for HyperDX-specific ClickHouse settings. Must only contain alphanumeric characters and underscores.
  *           nullable: true
  *           example: hyperdx_
- *         prometheusEndpoint:
- *           type: string
- *           description: Optional Prometheus-compatible API endpoint. When set, PromQL queries are proxied to this endpoint.
- *           nullable: true
- *           example: http://prometheus:9090
+ *         isPrometheusEndpoint:
+ *           type: boolean
+ *           description: Optional. When true, `host` is treated as a Prometheus-compatible API endpoint (e.g. Prometheus or Thanos) and PromQL queries are proxied to it. When false or omitted, `host` is a ClickHouse HTTP endpoint.
+ *           example: false
  *         createdAt:
  *           type: string
  *           format: date-time
@@ -138,10 +136,10 @@ function formatExternalConnection(connection: ConnectionDocument) {
  *           description: Optional prefix for HyperDX-specific ClickHouse settings. Must only contain alphanumeric characters and underscores.
  *           nullable: true
  *           example: hyperdx_
- *         prometheusEndpoint:
- *           type: string
- *           description: Optional Prometheus-compatible API endpoint. When set, PromQL queries are proxied to this endpoint.
- *           example: http://prometheus:9090
+ *         isPrometheusEndpoint:
+ *           type: boolean
+ *           description: Optional. When true, `host` is treated as a Prometheus-compatible API endpoint (e.g. Prometheus or Thanos) and PromQL queries are proxied to it. When false or omitted, `host` is a ClickHouse HTTP endpoint.
+ *           example: false
  *     UpdateConnectionRequest:
  *       type: object
  *       required:
@@ -171,11 +169,10 @@ function formatExternalConnection(connection: ConnectionDocument) {
  *           description: Optional prefix for HyperDX-specific ClickHouse settings. Set to null or an empty string to clear the existing value. If omitted, the existing value is kept.
  *           nullable: true
  *           example: hyperdx_
- *         prometheusEndpoint:
- *           type: string
- *           description: Optional Prometheus-compatible API endpoint. Set to null to clear the existing value. If omitted, the existing value is kept.
- *           nullable: true
- *           example: http://prometheus:9090
+ *         isPrometheusEndpoint:
+ *           type: boolean
+ *           description: Optional. When true, `host` is treated as a Prometheus-compatible API endpoint. When false or omitted, `host` is a ClickHouse HTTP endpoint. Omit to keep the existing value unchanged.
+ *           example: false
  *     ConnectionResponseEnvelope:
  *       type: object
  *       properties:
@@ -504,15 +501,11 @@ router.put(
         return res.sendStatus(404);
       }
 
-      const { hyperdxSettingPrefix, prometheusEndpoint, ...restBody } =
-        req.body;
+      const { hyperdxSettingPrefix, ...restBody } = req.body;
 
       const unsetFields: string[] = [];
       if (hyperdxSettingPrefix === null || hyperdxSettingPrefix === '') {
         unsetFields.push('hyperdxSettingPrefix');
-      }
-      if (prometheusEndpoint === null) {
-        unsetFields.push('prometheusEndpoint');
       }
 
       const updatedConnection = await updateConnection(
@@ -526,7 +519,6 @@ router.put(
             ? req.body.password
             : existingConnection.password,
           ...(hyperdxSettingPrefix ? { hyperdxSettingPrefix } : {}),
-          ...(prometheusEndpoint ? { prometheusEndpoint } : {}),
         },
         unsetFields,
       );

--- a/packages/app/src/components/ConnectionForm.tsx
+++ b/packages/app/src/components/ConnectionForm.tsx
@@ -389,36 +389,31 @@ export function ConnectionForm({
                   control={control}
                   name="isPrometheusEndpoint"
                   render={({ field: { value, onChange } }) => (
-                    <Switch
-                      data-testid="connection-prometheus-compatible-switch"
-                      checked={!!value}
-                      onChange={e => {
-                        onChange(e.currentTarget.checked);
-                        if (
-                          formState.isSubmitted ||
-                          formState.touchedFields.host
-                        ) {
-                          void trigger('host');
-                        }
-                      }}
-                      label={
-                        <Group gap="xs">
-                          <Text size="sm">Prometheus compatible</Text>
-                          <Tooltip
-                            label="Treat the Host as a Prometheus-compatible API endpoint (e.g. Thanos). PromQL queries are proxied here. ClickHouse-backed sources (logs, traces, OTel metrics) are not available on this connection."
-                            color="dark"
-                            c="white"
-                            multiline
-                            maw={400}
-                          >
-                            <IconHelpCircle
-                              size={16}
-                              className="cursor-pointer"
-                            />
-                          </Tooltip>
-                        </Group>
-                      }
-                    />
+                    <Group gap="xs">
+                      <Switch
+                        data-testid="connection-prometheus-compatible-switch"
+                        checked={!!value}
+                        onChange={e => {
+                          onChange(e.currentTarget.checked);
+                          if (
+                            formState.isSubmitted ||
+                            formState.touchedFields.host
+                          ) {
+                            void trigger('host');
+                          }
+                        }}
+                      />
+                      <Text size="sm">Prometheus compatible</Text>
+                      <Tooltip
+                        label="Treat the Host as a Prometheus-compatible API endpoint (e.g. Thanos). PromQL queries are proxied here. ClickHouse-backed sources (logs, traces, OTel metrics) are not available on this connection."
+                        color="dark"
+                        c="white"
+                        multiline
+                        maw={400}
+                      >
+                        <IconHelpCircle size={16} className="cursor-pointer" />
+                      </Tooltip>
+                    </Group>
                   )}
                 />
               </Box>

--- a/packages/app/src/components/ConnectionForm.tsx
+++ b/packages/app/src/components/ConnectionForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { omit } from 'lodash';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { testLocalConnection } from '@hyperdx/common-utils/dist/clickhouse/browser';
 import { Connection } from '@hyperdx/common-utils/dist/types';
 import {
@@ -10,6 +10,7 @@ import {
   Flex,
   Group,
   Stack,
+  Switch,
   Text,
   Tooltip,
 } from '@mantine/core';
@@ -20,8 +21,13 @@ import api from '@/api';
 import {
   InputControlled,
   PasswordInputControlled,
+  TextInputControlled,
 } from '@/components/InputControlled';
-import { IS_CLICKHOUSE_BUILD, IS_LOCAL_MODE } from '@/config';
+import {
+  IS_CLICKHOUSE_BUILD,
+  IS_LOCAL_MODE,
+  IS_PROMQL_ENABLED,
+} from '@/config';
 import {
   useCreateConnection,
   useDeleteConnection,
@@ -134,31 +140,43 @@ export function ConnectionForm({
   showCancelButton?: boolean;
   showDeleteButton?: boolean;
 }) {
-  const { control, handleSubmit, resetField, getValues, formState } =
+  const { control, handleSubmit, resetField, getValues, formState, trigger } =
     useForm<Connection>({
       defaultValues: {
         id: connection.id,
         name: connection.name,
-        host: connection.host,
+        host: connection.host ?? '',
         username: connection.username,
         password: connection.password,
         hyperdxSettingPrefix: connection.hyperdxSettingPrefix,
+        isPrometheusEndpoint: connection.isPrometheusEndpoint,
       },
     });
+
+  const watchedHost = useWatch({ control, name: 'host' });
+  const isPrometheusEndpoint = useWatch({
+    control,
+    name: 'isPrometheusEndpoint',
+  });
 
   const createConnection = useCreateConnection();
   const updateConnection = useUpdateConnection();
   const deleteConnection = useDeleteConnection();
 
   const onSubmit = (data: Connection) => {
-    // Make sure we don't save a trailing slash in the host
-    // Convert empty hyperdxSettingPrefix to null to signal clearing the field
-    // (undefined gets stripped from JSON, null is preserved and handled by API)
-    const normalizedData = {
-      ...data,
-      host: stripTrailingSlash(data.host),
-      hyperdxSettingPrefix: data.hyperdxSettingPrefix || null,
-    };
+    const stripped = data.host ? stripTrailingSlash(data.host) : '';
+    const normalizedData: Connection = data.isPrometheusEndpoint
+      ? {
+          ...data,
+          host: stripped,
+          username: '',
+          hyperdxSettingPrefix: null,
+        }
+      : {
+          ...data,
+          host: stripped,
+          hyperdxSettingPrefix: data.hyperdxSettingPrefix || null,
+        };
 
     if (isNew) {
       const connection = omit(normalizedData, ['id']);
@@ -237,71 +255,105 @@ export function ConnectionForm({
           />
         </Box>
         <Box>
-          <Text size="xs" mb="xs">
-            Host
-          </Text>
-          <InputControlled
+          <Group gap="xs" mb="xs">
+            <Text size="xs">Host</Text>
+            <Tooltip
+              label={
+                isPrometheusEndpoint
+                  ? 'Prometheus-compatible API endpoint. PromQL queries are proxied to this URL.'
+                  : 'ClickHouse HTTP endpoint URL.'
+              }
+              color="dark"
+              c="white"
+              multiline
+              maw={400}
+            >
+              <IconHelpCircle size={16} className="cursor-pointer" />
+            </Tooltip>
+          </Group>
+          <TextInputControlled
             data-testid="connection-host-input"
             name="host"
             control={control}
             placeholder={
-              IS_CLICKHOUSE_BUILD
-                ? window.location.origin
-                : 'http://localhost:8123'
+              isPrometheusEndpoint
+                ? 'http://thanos-querier:10902'
+                : IS_CLICKHOUSE_BUILD
+                  ? window.location.origin
+                  : 'http://localhost:8123'
             }
-            rules={{ required: 'Host is required' }}
+            rules={{
+              validate: value => {
+                if (typeof value !== 'string' || !value) {
+                  return 'Host is required';
+                }
+                if (isPrometheusEndpoint) {
+                  try {
+                    new URL(value);
+                    return true;
+                  } catch {
+                    return 'Must be a valid URL';
+                  }
+                }
+                return true;
+              },
+            }}
           />
         </Box>
-        <Box>
-          <Text size="xs" mb="xs">
-            Username
-          </Text>
-          <InputControlled
-            data-testid="connection-username-input"
-            name="username"
-            control={control}
-            placeholder="Username (default: default)"
-          />
-        </Box>
-        <Box>
-          <Text size="xs" mb="xs">
-            Password
-          </Text>
-          {!showUpdatePassword && !isNew && (
-            <Button
-              data-testid="update-password-button"
-              variant="secondary"
-              onClick={() => {
-                setShowUpdatePassword(true);
-              }}
-            >
-              Update Password
-            </Button>
-          )}
-          {(showUpdatePassword || isNew) && (
-            <Flex align="center" gap="sm">
-              <PasswordInputControlled
-                data-testid="connection-password-input"
-                style={{ flexGrow: 1 }}
-                name="password"
+        {!isPrometheusEndpoint && (
+          <>
+            <Box>
+              <Text size="xs" mb="xs">
+                Username
+              </Text>
+              <InputControlled
+                data-testid="connection-username-input"
+                name="username"
                 control={control}
-                placeholder="Password (default: blank)"
+                placeholder="Username (default: default)"
               />
-              {!isNew && (
+            </Box>
+            <Box>
+              <Text size="xs" mb="xs">
+                Password
+              </Text>
+              {!showUpdatePassword && !isNew && (
                 <Button
-                  data-testid="cancel-password-button"
+                  data-testid="update-password-button"
                   variant="secondary"
                   onClick={() => {
-                    setShowUpdatePassword(false);
-                    resetField('password');
+                    setShowUpdatePassword(true);
                   }}
                 >
-                  Cancel
+                  Update Password
                 </Button>
               )}
-            </Flex>
-          )}
-        </Box>
+              {(showUpdatePassword || isNew) && (
+                <Flex align="center" gap="sm">
+                  <PasswordInputControlled
+                    data-testid="connection-password-input"
+                    style={{ flexGrow: 1 }}
+                    name="password"
+                    control={control}
+                    placeholder="Password (default: blank)"
+                  />
+                  {!isNew && (
+                    <Button
+                      data-testid="cancel-password-button"
+                      variant="secondary"
+                      onClick={() => {
+                        setShowUpdatePassword(false);
+                        resetField('password');
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  )}
+                </Flex>
+              )}
+            </Box>
+          </>
+        )}
         <Box>
           {!showAdvancedSettings && (
             <Anchor
@@ -330,34 +382,88 @@ export function ConnectionForm({
             display: showAdvancedSettings ? 'block' : 'none',
           }}
         >
-          <Group gap="xs" mb="xs">
-            <Text size="xs">Query Log Setting Prefix</Text>
-            <Tooltip
-              label="Tracks query origins by adding the current user's email to ClickHouse queries (as {prefix}_user in system.query_log). Requires 'custom_settings_prefixes' in your ClickHouse config.xml to include this exact value, otherwise queries will be rejected."
-              color="dark"
-              c="white"
-              multiline
-              maw={400}
-            >
-              <IconHelpCircle size={16} className="cursor-pointer" />
-            </Tooltip>
-          </Group>
-          <InputControlled
-            data-testid="connection-setting-prefix-input"
-            name="hyperdxSettingPrefix"
-            control={control}
-            placeholder="hyperdx"
-          />
+          <Stack gap="md">
+            {IS_PROMQL_ENABLED && (
+              <Box>
+                <Controller
+                  control={control}
+                  name="isPrometheusEndpoint"
+                  render={({ field: { value, onChange } }) => (
+                    <Switch
+                      data-testid="connection-prometheus-compatible-switch"
+                      checked={!!value}
+                      onChange={e => {
+                        onChange(e.currentTarget.checked);
+                        if (
+                          formState.isSubmitted ||
+                          formState.touchedFields.host
+                        ) {
+                          void trigger('host');
+                        }
+                      }}
+                      label={
+                        <Group gap="xs">
+                          <Text size="sm">Prometheus compatible</Text>
+                          <Tooltip
+                            label="Treat the Host as a Prometheus-compatible API endpoint (e.g. Thanos). PromQL queries are proxied here. ClickHouse-backed sources (logs, traces, OTel metrics) are not available on this connection."
+                            color="dark"
+                            c="white"
+                            multiline
+                            maw={400}
+                          >
+                            <IconHelpCircle
+                              size={16}
+                              className="cursor-pointer"
+                            />
+                          </Tooltip>
+                        </Group>
+                      }
+                    />
+                  )}
+                />
+              </Box>
+            )}
+            {!isPrometheusEndpoint && (
+              <Box>
+                <Group gap="xs" mb="xs">
+                  <Text size="xs">Query Log Setting Prefix</Text>
+                  <Tooltip
+                    label="Tracks query origins by adding the current user's email to ClickHouse queries (as {prefix}_user in system.query_log). Requires 'custom_settings_prefixes' in your ClickHouse config.xml to include this exact value, otherwise queries will be rejected."
+                    color="dark"
+                    c="white"
+                    multiline
+                    maw={400}
+                  >
+                    <IconHelpCircle size={16} className="cursor-pointer" />
+                  </Tooltip>
+                </Group>
+                <InputControlled
+                  data-testid="connection-setting-prefix-input"
+                  name="hyperdxSettingPrefix"
+                  control={control}
+                  placeholder="hyperdx"
+                />
+              </Box>
+            )}
+          </Stack>
         </Box>
         <Group justify="space-between">
           <Tooltip
-            label="🔒 Password re-entry required for security"
+            label={
+              isPrometheusEndpoint
+                ? 'Test Connection only verifies ClickHouse hosts; Prometheus-compatible endpoints have no equivalent probe.'
+                : !watchedHost
+                  ? 'Enter a ClickHouse host to test the connection.'
+                  : '🔒 Password re-entry required for security'
+            }
             position="right"
-            disabled={isNew}
+            disabled={isNew && !!watchedHost && !isPrometheusEndpoint}
             withArrow
           >
             <Button
-              disabled={!formState.isValid}
+              disabled={
+                !formState.isValid || !watchedHost || isPrometheusEndpoint
+              }
               variant={
                 testConnectionState === TestConnectionState.Invalid
                   ? 'danger'

--- a/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
@@ -4,7 +4,7 @@ import {
   acceptCompletion,
   autocompletion,
   Completion,
-  CompletionResult,
+  CompletionSource,
   startCompletion,
 } from '@codemirror/autocomplete';
 import { Paper, useMantineColorScheme } from '@mantine/core';
@@ -47,6 +47,50 @@ const COMPLETION_LIMIT = 500;
 // any in-flight scan from a previous burst short-circuits and returns null.
 const COMPLETION_DEBOUNCE_MS = 150;
 
+const debounceAndPruneAutocompleteResults: (
+  metricNames: string[],
+) => CompletionSource = metricNames => {
+  return async context => {
+    const word = context.matchBefore(/[\w.:]+/);
+    if (!word && !context.explicit) return null;
+
+    if (!context.explicit) {
+      // debounce so we don't do this expensive operation on every keystroke
+      await new Promise(r => setTimeout(r, COMPLETION_DEBOUNCE_MS));
+      if (context.aborted) return null;
+    }
+
+    const prefix = (word?.text ?? '').toLowerCase();
+    // matches is a list with a max length of COMPLETION_LIMIT of search terms that match.
+    // For large metrics deployments, this is necessary
+    const matches: Completion[] = [];
+    if (prefix === '') {
+      for (
+        let i = 0;
+        i < metricNames.length && matches.length < COMPLETION_LIMIT;
+        i++
+      ) {
+        matches.push({ label: metricNames[i], type: 'variable' });
+      }
+    } else {
+      for (
+        let i = 0;
+        i < metricNames.length && matches.length < COMPLETION_LIMIT;
+        i++
+      ) {
+        if (metricNames[i].toLowerCase().startsWith(prefix)) {
+          matches.push({ label: metricNames[i], type: 'variable' });
+        }
+      }
+    }
+
+    return {
+      from: word?.from ?? context.pos,
+      options: matches,
+    };
+  };
+};
+
 export default function PromQLEditor({
   value,
   onChange,
@@ -61,51 +105,12 @@ export default function PromQLEditor({
 
   const updateAutocomplete = useCallback(
     (viewRef: EditorView) => {
-      const all = metricNames ?? [];
-      if (all.length === 0) return;
+      if (!metricNames || metricNames.length === 0) return;
 
       viewRef.dispatch({
         effects: compartmentRef.current.reconfigure(
           autocompletion({
-            override: [
-              async (context): Promise<CompletionResult | null> => {
-                const word = context.matchBefore(/[\w.:]+/);
-                if (!word && !context.explicit) return null;
-
-                if (!context.explicit) {
-                  // debounce so we don't do this expensive operation on every keystroke
-                  await new Promise(r => setTimeout(r, COMPLETION_DEBOUNCE_MS));
-                  if (context.aborted) return null;
-                }
-
-                const prefix = (word?.text ?? '').toLowerCase();
-                const matches: Completion[] = [];
-                if (prefix === '') {
-                  for (
-                    let i = 0;
-                    i < all.length && matches.length < COMPLETION_LIMIT;
-                    i++
-                  ) {
-                    matches.push({ label: all[i], type: 'variable' });
-                  }
-                } else {
-                  for (
-                    let i = 0;
-                    i < all.length && matches.length < COMPLETION_LIMIT;
-                    i++
-                  ) {
-                    if (all[i].toLowerCase().startsWith(prefix)) {
-                      matches.push({ label: all[i], type: 'variable' });
-                    }
-                  }
-                }
-
-                return {
-                  from: word?.from ?? context.pos,
-                  options: matches,
-                };
-              },
-            ],
+            override: [debounceAndPruneAutocompleteResults(metricNames)],
           }),
         ),
       });

--- a/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
@@ -4,6 +4,7 @@ import {
   acceptCompletion,
   autocompletion,
   Completion,
+  CompletionResult,
   startCompletion,
 } from '@codemirror/autocomplete';
 import { Paper, useMantineColorScheme } from '@mantine/core';
@@ -35,6 +36,17 @@ type PromQLEditorProps = {
 
 const MAX_EDITOR_HEIGHT = '150px';
 
+// Cap the number of completion options returned per query. With large
+// Prometheus instances `metricNames` can be 1M+ entries; passing the whole
+// list to CodeMirror's fuzzy filter on every keystroke causes severe typing
+// latency.
+const COMPLETION_LIMIT = 500;
+
+// Wait this long after the last keystroke before scanning `metricNames`.
+// `context.aborted` flips to true when CodeMirror starts a newer request, so
+// any in-flight scan from a previous burst short-circuits and returns null.
+const COMPLETION_DEBOUNCE_MS = 150;
+
 export default function PromQLEditor({
   value,
   onChange,
@@ -47,37 +59,58 @@ export default function PromQLEditor({
   const compartmentRef = useRef<Compartment>(new Compartment());
   const [isFocused, setIsFocused] = useState(false);
 
-  const metricCompletions = useMemo<Completion[]>(
-    () =>
-      (metricNames ?? []).map(name => ({
-        label: name,
-        type: 'variable' as const,
-      })),
-    [metricNames],
-  );
-
   const updateAutocomplete = useCallback(
     (viewRef: EditorView) => {
-      if (metricCompletions.length > 0) {
-        viewRef.dispatch({
-          effects: compartmentRef.current.reconfigure(
-            autocompletion({
-              override: [
-                context => {
-                  const word = context.matchBefore(/[\w.:]+/);
-                  if (!word && !context.explicit) return null;
-                  return {
-                    from: word?.from ?? context.pos,
-                    options: metricCompletions,
-                  };
-                },
-              ],
-            }),
-          ),
-        });
-      }
+      const all = metricNames ?? [];
+      if (all.length === 0) return;
+
+      viewRef.dispatch({
+        effects: compartmentRef.current.reconfigure(
+          autocompletion({
+            override: [
+              async (context): Promise<CompletionResult | null> => {
+                const word = context.matchBefore(/[\w.:]+/);
+                if (!word && !context.explicit) return null;
+
+                if (!context.explicit) {
+                  // debounce so we don't do this expensive operation on every keystroke
+                  await new Promise(r => setTimeout(r, COMPLETION_DEBOUNCE_MS));
+                  if (context.aborted) return null;
+                }
+
+                const prefix = (word?.text ?? '').toLowerCase();
+                const matches: Completion[] = [];
+                if (prefix === '') {
+                  for (
+                    let i = 0;
+                    i < all.length && matches.length < COMPLETION_LIMIT;
+                    i++
+                  ) {
+                    matches.push({ label: all[i], type: 'variable' });
+                  }
+                } else {
+                  for (
+                    let i = 0;
+                    i < all.length && matches.length < COMPLETION_LIMIT;
+                    i++
+                  ) {
+                    if (all[i].toLowerCase().startsWith(prefix)) {
+                      matches.push({ label: all[i], type: 'variable' });
+                    }
+                  }
+                }
+
+                return {
+                  from: word?.from ?? context.pos,
+                  options: matches,
+                };
+              },
+            ],
+          }),
+        ),
+      });
     },
-    [metricCompletions],
+    [metricNames],
   );
 
   useEffect(() => {

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -178,6 +178,10 @@ function setCorrelationFieldValue(
 
 const DEFAULT_DATABASE = 'default';
 
+// Placeholder written into from.databaseName / from.tableName when the
+// selected connection is Prometheus-only.
+const PROMETHEUS_PLACEHOLDER = 'prometheus';
+
 const MV_AGGREGATE_FUNCTION_OPTIONS = MV_AGGREGATE_FUNCTIONS.map(fn => ({
   value: fn,
   label: fn,
@@ -2083,6 +2087,33 @@ export function TableSourceForm({
   });
   const prevTableNameRef = useRef(watchedTableName);
 
+  const selectedConnection = useMemo(
+    () => connections?.find(c => c.id === watchedConnection),
+    [connections, watchedConnection],
+  );
+  const isPrometheusOnlyConnection = Boolean(
+    selectedConnection?.isPrometheusEndpoint,
+  );
+
+  useEffect(() => {
+    if (!isPrometheusOnlyConnection) return;
+    if (watchedDatabaseName !== PROMETHEUS_PLACEHOLDER) {
+      setValue('from.databaseName', PROMETHEUS_PLACEHOLDER, {
+        shouldDirty: true,
+      });
+    }
+    if (watchedTableName !== PROMETHEUS_PLACEHOLDER) {
+      setValue('from.tableName', PROMETHEUS_PLACEHOLDER, {
+        shouldDirty: true,
+      });
+    }
+  }, [
+    isPrometheusOnlyConnection,
+    setValue,
+    watchedDatabaseName,
+    watchedTableName,
+  ]);
+
   const metadata = useMetadataWithSettings();
 
   useEffect(() => {
@@ -2090,6 +2121,10 @@ export function TableSourceForm({
       try {
         if (watchedTableName !== prevTableNameRef.current) {
           prevTableNameRef.current = watchedTableName;
+
+          if (isPrometheusOnlyConnection) {
+            return;
+          }
 
           if (
             watchedConnection != null &&
@@ -2135,6 +2170,7 @@ export function TableSourceForm({
     resetField,
     metadata,
     setValue,
+    isPrometheusOnlyConnection,
   ]);
 
   // Sets the default connection field to the first connection after the
@@ -2566,23 +2602,27 @@ export function TableSourceForm({
         <FormRow label={'Server Connection'}>
           <ConnectionSelectControlled control={control} name={`connection`} />
         </FormRow>
-        <FormRow label={'Database'}>
-          <DatabaseSelectControlled
-            control={control}
-            name={`from.databaseName`}
-            connectionId={connectionId}
-          />
-        </FormRow>
-        {kind !== SourceKind.Metric && (
-          <FormRow label={'Table'}>
-            <DBTableSelectControlled
-              database={databaseName}
-              control={control}
-              name={`from.tableName`}
-              connectionId={connectionId}
-              rules={{ required: 'Table is required' }}
-            />
-          </FormRow>
+        {!isPrometheusOnlyConnection && (
+          <>
+            <FormRow label={'Database'}>
+              <DatabaseSelectControlled
+                control={control}
+                name={`from.databaseName`}
+                connectionId={connectionId}
+              />
+            </FormRow>
+            {kind !== SourceKind.Metric && (
+              <FormRow label={'Table'}>
+                <DBTableSelectControlled
+                  database={databaseName}
+                  control={control}
+                  name={`from.tableName`}
+                  connectionId={connectionId}
+                  rules={{ required: 'Table is required' }}
+                />
+              </FormRow>
+            )}
+          </>
         )}
         <FormRow
           label={

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1579,7 +1579,7 @@ export const ConnectionSchema = z.object({
     .regex(/^[a-z0-9_]+$/i)
     .optional()
     .nullable(),
-  prometheusEndpoint: z.string().url().optional(),
+  isPrometheusEndpoint: z.boolean().optional(),
 });
 
 export type Connection = z.infer<typeof ConnectionSchema>;


### PR DESCRIPTION
## Summary

Builds on the existing PromQL functionality. Now, ClickStack can support querying via PromQL from a prometheus compatible API.

Note: Although the connections model was changed, there was no place in the UI to set up an external Prometheus connection, so migrations shouldn't be an issue. This is highly experimental still.

### Screenshots or video

<img width="1091" height="423" alt="image" src="https://github.com/user-attachments/assets/fbc03033-d29e-4265-9fab-81b3468aff99" />

<img width="1221" height="562" alt="image" src="https://github.com/user-attachments/assets/8a46cb85-e47f-4e19-b560-2ee6b7f04992" />

### References

- Linear Issue: HDX-4600