### PR TITLE
chore: Add instrumentation to remaining API surfaces

### DIFF
--- a/.changeset/observability-instrumentation-rollout.md
+++ b/.changeset/observability-instrumentation-rollout.md
@@ -1,0 +1,21 @@
+---
+'@hyperdx/api': minor
+---
+
+Extend observability instrumentation to the remaining API surfaces using the
+shared helpers. Add custom metrics and tracing to previously log-only paths:
+OpAMP message handling (message outcomes, agent status reports, remote configs
+sent), the Prometheus proxy router (query duration + swallowed-error counters
+labeled by endpoint and backend), alert webhook/notification delivery (delivery
+attempts and duration labeled by service and outcome), and MongoDB connection
+lifecycle events.
+
+Add a reusable SLO primitive (`withOperationMetrics` / `recordOperationOutcome`)
+that emits standard availability + latency SLIs (`hyperdx.operation.requests`
+and `hyperdx.operation.duration_ms`, labeled by `operation` and `outcome`) so
+SLOs can be defined per piece of application functionality. Apply it to the AI
+assistant generation call, the ClickHouse proxy (query passthrough +
+connection test), and alert processing — both the end-to-end alert evaluation
+(`alerts.evaluate`, excluding scheduling skips) and its ClickHouse data fetch
+(`alerts.query`) — paths whose failures previously surfaced only as logs or
+failures-only counters with no latency or denominator.

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -141,6 +141,36 @@ Metric conventions:
 - **Define instruments at module scope** via `getCounter`/`getHistogram` so they
   are created once and reused.
 
+### SLOs (operation metrics)
+
+To make a piece of functionality SLO-able, wrap it with `withOperationMetrics`
+(or call `recordOperationOutcome` directly when timing is managed manually, e.g.
+a streaming proxy). Both emit a standard pair of SLI signals tagged with a
+stable, low-cardinality `operation` name and `outcome` (`success` | `error`):
+
+| Metric                          | Type      | Use as          |
+| ------------------------------- | --------- | --------------- |
+| `hyperdx.operation.requests`    | counter   | availability SLI |
+| `hyperdx.operation.duration_ms` | histogram | latency SLI     |
+
+```ts
+import { withOperationMetrics } from '@/utils/instrumentation';
+
+const chartConfig = await withOperationMetrics(
+  'ai.assistant',
+  () => generateChart(prompt),
+  { source_kind: source.kind },
+);
+```
+
+Because every operation reports through the same two metrics, an SLO is just a
+filter on `operation` — availability = `outcome:success` / total, latency =
+the duration histogram. Keep `operation` a constant (e.g. `ai.assistant`,
+`clickhouse_proxy.query`); never interpolate IDs or user input into it. Reach
+for this on functionality with real failure modes worth a target (external
+dependencies, query proxies, AI calls) — not on thin CRUD that the HTTP
+auto-instrumentation and error middleware already cover.
+
 ## Where to look for examples
 
 - Generic span + status handling: `packages/api/src/utils/instrumentation.ts`
@@ -153,3 +183,17 @@ Metric conventions:
 - Query duration + error metrics:
   `packages/api/src/routers/external-api/v2/search.ts` and `charts.ts`
 - Scheduled-task metrics pattern: `packages/api/src/tasks/metrics.ts`
+- Outcome counter + span on a non-HTTP entry point:
+  `packages/api/src/opamp/controllers/opampController.ts`
+- Duration + swallowed-error counters where errors never reach the error
+  middleware: `packages/api/src/routers/api/prometheus.ts`
+- Delivery attempt counter + duration around an outbound webhook:
+  `packages/api/src/tasks/checkAlerts/template.ts`
+- Connection lifecycle-event counter: `packages/api/src/models/index.ts`
+- SLO operation metrics (`withOperationMetrics`) on an external dependency:
+  `packages/api/src/routers/api/ai.ts`
+- SLO operation metrics (`recordOperationOutcome`) on a streaming proxy:
+  `packages/api/src/routers/api/clickhouseProxy.ts`
+- End-to-end + sub-operation SLO metrics on a background job (alert evaluation
+  and its data fetch): `packages/api/src/tasks/checkAlerts/index.ts`
+  (`alerts.evaluate`, `alerts.query`)

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -1,9 +1,21 @@
 import mongoose from 'mongoose';
 
 import * as config from '@/config';
+import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 export type ObjectId = mongoose.Types.ObjectId;
+
+// Connection-lifecycle events were log-only. A counter keyed by the (bounded)
+// event name makes flapping/reconnect storms visible on a dashboard and
+// alertable (see agent_docs/observability.md).
+const mongoConnectionEventsCounter = getCounter(
+  'hyperdx.mongodb.connection_events',
+  {
+    description:
+      'Count of MongoDB connection lifecycle events, labeled by event (connected, disconnected, error, reconnected, reconnect_failed).',
+  },
+);
 
 // set flags
 mongoose.set('strictQuery', false);
@@ -15,22 +27,27 @@ mongoose.Schema.Types.String.checkRequired(v => v != null);
 
 // connection events handlers
 mongoose.connection.on('connected', () => {
+  mongoConnectionEventsCounter.add(1, { event: 'connected' });
   logger.info('Connection established to MongoDB');
 });
 
 mongoose.connection.on('disconnected', () => {
+  mongoConnectionEventsCounter.add(1, { event: 'disconnected' });
   logger.info('Lost connection to MongoDB server');
 });
 
 mongoose.connection.on('error', err => {
+  mongoConnectionEventsCounter.add(1, { event: 'error' });
   logger.error({ err }, 'Could not connect to MongoDB');
 });
 
 mongoose.connection.on('reconnected', () => {
+  mongoConnectionEventsCounter.add(1, { event: 'reconnected' });
   logger.warn('Reconnected to MongoDB');
 });
 
 mongoose.connection.on('reconnectFailed', () => {
+  mongoConnectionEventsCounter.add(1, { event: 'reconnect_failed' });
   logger.error('Failed to reconnect to MongoDB');
 });
 

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -10,7 +10,20 @@ import {
   encodeServerToAgent,
   serverCapabilities,
 } from '@/opamp/utils/protobuf';
+import { getCounter, SpanKind, withSpan } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
+
+// OpAMP messages come from collector agents, not authenticated users, so there
+// is no team/user context to attach. We instead track delivery outcomes with a
+// low-cardinality `outcome` enum (see agent_docs/observability.md).
+const opampMessagesCounter = getCounter('hyperdx.opamp.messages', {
+  description:
+    'Count of OpAMP AgentToServer messages handled, labeled by outcome (processed, unsupported_media_type, error).',
+});
+const opampRemoteConfigsCounter = getCounter('hyperdx.opamp.remote_configs', {
+  description:
+    'Count of OpAMP remote collector configs sent back to agents in a ServerToAgent response.',
+});
 
 type CollectorConfig = {
   extensions: Record<string, any>;
@@ -332,73 +345,93 @@ export class OpampController {
    * Handle an OpAMP message from an agent
    */
   public async handleOpampMessage(req: Request, res: Response): Promise<void> {
-    try {
-      // Check content type
-      const contentType = req.get('Content-Type');
-      if (contentType !== 'application/x-protobuf') {
-        res
-          .status(415)
-          .send(
-            'Unsupported Media Type: Content-Type must be application/x-protobuf',
+    return withSpan(
+      'opamp.handle_message',
+      async span => {
+        try {
+          // Check content type
+          const contentType = req.get('Content-Type');
+          if (contentType !== 'application/x-protobuf') {
+            opampMessagesCounter.add(1, { outcome: 'unsupported_media_type' });
+            res
+              .status(415)
+              .send(
+                'Unsupported Media Type: Content-Type must be application/x-protobuf',
+              );
+            return;
+          }
+
+          // Decode the AgentToServer message
+          const agentToServer = decodeAgentToServer(req.body);
+          logger.debug({ agentToServer }, 'agentToServer');
+          logger.debug(
+            // @ts-ignore
+            `Received message from agent: ${agentToServer.instanceUid?.toString(
+              'hex',
+            )}`,
           );
-        return;
-      }
 
-      // Decode the AgentToServer message
-      const agentToServer = decodeAgentToServer(req.body);
-      logger.debug({ agentToServer }, 'agentToServer');
-      logger.debug(
-        // @ts-ignore
-        `Received message from agent: ${agentToServer.instanceUid?.toString(
-          'hex',
-        )}`,
-      );
+          // Process the agent status
+          const agent = agentService.processAgentStatus(agentToServer);
 
-      // Process the agent status
-      const agent = agentService.processAgentStatus(agentToServer);
+          // Prepare the response
+          const serverToAgent: any = {
+            instanceUid: agent.instanceUid,
+            capabilities: serverCapabilities,
+          };
 
-      // Prepare the response
-      const serverToAgent: any = {
-        instanceUid: agent.instanceUid,
-        capabilities: serverCapabilities,
-      };
+          const acceptsRemoteConfig =
+            agentService.agentAcceptsRemoteConfig(agent);
+          span.setAttribute(
+            'opamp.agent.accepts_remote_config',
+            acceptsRemoteConfig,
+          );
 
-      // Check if we should send a remote configuration
-      if (agentService.agentAcceptsRemoteConfig(agent)) {
-        const teams = await getAllTeams([
-          'apiKey',
-          'collectorAuthenticationEnforced',
-        ]);
-        const otelCollectorConfig = buildOtelCollectorConfig(teams);
+          // Check if we should send a remote configuration
+          if (acceptsRemoteConfig) {
+            const teams = await getAllTeams([
+              'apiKey',
+              'collectorAuthenticationEnforced',
+            ]);
+            const otelCollectorConfig = buildOtelCollectorConfig(teams);
 
-        if (config.IS_DEV) {
-          logger.debug(JSON.stringify(otelCollectorConfig, null, 2));
+            if (config.IS_DEV) {
+              logger.debug(JSON.stringify(otelCollectorConfig, null, 2));
+            }
+
+            const remoteConfig = createRemoteConfig(
+              new Map([
+                [
+                  'config.json',
+                  Buffer.from(JSON.stringify(otelCollectorConfig)),
+                ],
+              ]),
+              'application/json',
+            );
+
+            serverToAgent.remoteConfig = remoteConfig;
+            opampRemoteConfigsCounter.add(1);
+            logger.debug(
+              `Sending remote config to agent: ${agent.instanceUid.toString(
+                'hex',
+              )}`,
+            );
+          }
+
+          // Encode and send the response
+          const encodedResponse = encodeServerToAgent(serverToAgent);
+
+          opampMessagesCounter.add(1, { outcome: 'processed' });
+          res.setHeader('Content-Type', 'application/x-protobuf');
+          res.send(encodedResponse);
+        } catch (error) {
+          opampMessagesCounter.add(1, { outcome: 'error' });
+          logger.error({ err: error }, 'Error handling OpAMP message');
+          res.status(500).send('Internal Server Error');
         }
-
-        const remoteConfig = createRemoteConfig(
-          new Map([
-            ['config.json', Buffer.from(JSON.stringify(otelCollectorConfig))],
-          ]),
-          'application/json',
-        );
-
-        serverToAgent.remoteConfig = remoteConfig;
-        logger.debug(
-          `Sending remote config to agent: ${agent.instanceUid.toString(
-            'hex',
-          )}`,
-        );
-      }
-
-      // Encode and send the response
-      const encodedResponse = encodeServerToAgent(serverToAgent);
-
-      res.setHeader('Content-Type', 'application/x-protobuf');
-      res.send(encodedResponse);
-    } catch (error) {
-      logger.error({ err: error }, 'Error handling OpAMP message');
-      res.status(500).send('Internal Server Error');
-    }
+      },
+      { kind: SpanKind.INTERNAL },
+    );
   }
 }
 

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -10,7 +10,12 @@ import {
   encodeServerToAgent,
   serverCapabilities,
 } from '@/opamp/utils/protobuf';
-import { getCounter, SpanKind, withSpan } from '@/utils/instrumentation';
+import {
+  getCounter,
+  SpanKind,
+  SpanStatusCode,
+  withSpan,
+} from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 // OpAMP messages come from collector agents, not authenticated users, so there
@@ -353,6 +358,7 @@ export class OpampController {
           const contentType = req.get('Content-Type');
           if (contentType !== 'application/x-protobuf') {
             opampMessagesCounter.add(1, { outcome: 'unsupported_media_type' });
+            span.setStatus({ code: SpanStatusCode.OK });
             res
               .status(415)
               .send(
@@ -422,15 +428,23 @@ export class OpampController {
           const encodedResponse = encodeServerToAgent(serverToAgent);
 
           opampMessagesCounter.add(1, { outcome: 'processed' });
+          span.setStatus({ code: SpanStatusCode.OK });
           res.setHeader('Content-Type', 'application/x-protobuf');
           res.send(encodedResponse);
         } catch (error) {
           opampMessagesCounter.add(1, { outcome: 'error' });
+          span.recordException(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
           logger.error({ err: error }, 'Error handling OpAMP message');
           res.status(500).send('Internal Server Error');
         }
       },
-      { kind: SpanKind.INTERNAL },
+      { kind: SpanKind.INTERNAL, recordOkStatus: false },
     );
   }
 }

--- a/packages/api/src/opamp/services/agentService.ts
+++ b/packages/api/src/opamp/services/agentService.ts
@@ -1,5 +1,14 @@
 import { Agent, agentStore } from '@/opamp/models/agent';
+import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
+
+// Tracks whether a status report came from an agent we had not seen before
+// (`new`) or an existing one (`updated`). Low-cardinality enum, safe as a
+// metric attribute (see agent_docs/observability.md).
+const agentStatusCounter = getCounter('hyperdx.opamp.agent_status_reports', {
+  description:
+    'Count of processed OpAMP agent status reports, labeled by status (new, updated).',
+});
 
 export class AgentService {
   /**
@@ -19,6 +28,7 @@ export class AgentService {
 
       // Get the existing agent or create a new one
       let agent = agentStore.getAgent(instanceUid);
+      const isNewAgent = !agent;
 
       if (!agent) {
         // New agent, create a new record
@@ -59,6 +69,8 @@ export class AgentService {
 
       // Update the agent in the store
       agentStore.upsertAgent(agent);
+
+      agentStatusCounter.add(1, { status: isNewAgent ? 'new' : 'updated' });
 
       return agent;
     } catch (error) {

--- a/packages/api/src/routers/api/ai.ts
+++ b/packages/api/src/routers/api/ai.ts
@@ -15,6 +15,7 @@ import {
 import { getSource } from '@/controllers/sources';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
 import { Api404Error, Api500Error } from '@/utils/errors';
+import { withOperationMetrics } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 import { objectIdSchema } from '@/utils/zod';
 
@@ -92,30 +93,36 @@ ${JSON.stringify(allFieldsWithKeys.slice(0, 200).map(f => ({ field: f.key, type:
 
       logger.info(prompt);
 
-      try {
-        const result = await generateText({
-          model,
-          output: Output.object({
-            schema: AssistantLineTableConfigSchema,
-          }),
-          experimental_telemetry: { isEnabled: true },
-          prompt,
-        });
+      // The AI generation call is the externally-dependent, latency-defining
+      // part of the assistant, so it carries the SLO signal. Source lookup /
+      // validation above are client-side concerns and intentionally excluded.
+      const chartConfig = await withOperationMetrics(
+        'ai.assistant',
+        async () => {
+          try {
+            const result = await generateText({
+              model,
+              output: Output.object({
+                schema: AssistantLineTableConfigSchema,
+              }),
+              experimental_telemetry: { isEnabled: true },
+              prompt,
+            });
 
-        const chartConfig = getChartConfigFromResolvedConfig(
-          result.output,
-          source,
-        );
+            return getChartConfigFromResolvedConfig(result.output, source);
+          } catch (err) {
+            if (err instanceof APICallError) {
+              throw new Api500Error(
+                `AI Provider Error. Status: ${err.statusCode}. Message: ${err.message}`,
+              );
+            }
+            throw err;
+          }
+        },
+        { source_kind: source.kind },
+      );
 
-        return res.json(chartConfig);
-      } catch (err) {
-        if (err instanceof APICallError) {
-          throw new Api500Error(
-            `AI Provider Error. Status: ${err.statusCode}. Message: ${err.message}`,
-          );
-        }
-        throw err;
-      }
+      return res.json(chartConfig);
     } catch (e) {
       next(e);
     }

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -274,7 +274,6 @@ const proxyMiddleware: RequestHandler =
           outcome: statusCode < 400 ? 'success' : 'error',
           durationMs:
             typeof startedAt === 'number' ? performance.now() - startedAt : 0,
-          attributes: { status_code: statusCode },
         });
 
         // since clickhouse v24, the cors headers * will be attached to the response by default
@@ -303,7 +302,6 @@ const proxyMiddleware: RequestHandler =
           outcome: 'error',
           durationMs:
             typeof startedAt === 'number' ? performance.now() - startedAt : 0,
-          attributes: { status_code: 0 },
         });
         console.error('Proxy error:', err);
         (_res as Response).writeHead(500, {

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -1,6 +1,7 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import express, { RequestHandler, Response } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
+import { performance } from 'perf_hooks';
 import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
 
@@ -8,8 +9,16 @@ import { CODE_VERSION } from '@/config';
 import { getConnectionById } from '@/controllers/connection';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
 import { validateRequestHeaders } from '@/middleware/validation';
+import { recordOperationOutcome } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 import { objectIdSchema } from '@/utils/zod';
+
+// SLO operations for the ClickHouse proxy. Both paths swallow their errors
+// (returning JSON / writing the response directly) so they never reach the API
+// error middleware — they must report their own SLIs. See
+// agent_docs/observability.md.
+const CONNECTION_TEST_OPERATION = 'clickhouse_proxy.connection_test';
+const QUERY_PROXY_OPERATION = 'clickhouse_proxy.query';
 
 /**
  * Validates and sanitizes a URL path to prevent injection attacks.
@@ -83,6 +92,7 @@ router.post(
   }),
   async (req, res) => {
     const { host, username, password } = req.body;
+    const startedAt = performance.now();
     try {
       const result = await fetch(`${host}/?query=SELECT 1`, {
         headers: {
@@ -93,6 +103,11 @@ router.post(
       });
       // For status codes 204-399
       if (!result.ok) {
+        recordOperationOutcome({
+          operation: CONNECTION_TEST_OPERATION,
+          outcome: 'error',
+          durationMs: performance.now() - startedAt,
+        });
         const errorText = await result.text();
         return res.status(result.status).json({
           success: false,
@@ -100,8 +115,18 @@ router.post(
         });
       }
       const data = await result.json();
+      recordOperationOutcome({
+        operation: CONNECTION_TEST_OPERATION,
+        outcome: 'success',
+        durationMs: performance.now() - startedAt,
+      });
       return res.json({ success: data === 1 });
     } catch (e: any) {
+      recordOperationOutcome({
+        operation: CONNECTION_TEST_OPERATION,
+        outcome: 'error',
+        durationMs: performance.now() - startedAt,
+      });
       // fetch returns a 400+ error and throws
       console.error(e);
       const errorMessage =
@@ -240,6 +265,18 @@ const proxyMiddleware: RequestHandler =
         }
       },
       proxyRes: (proxyRes, _req, res) => {
+        const startedAt = (res as Response).locals?.hdxProxyStartedAt;
+        const statusCode = proxyRes.statusCode ?? 0;
+        recordOperationOutcome({
+          operation: QUERY_PROXY_OPERATION,
+          // A response (even a 4xx/5xx from ClickHouse) means the proxy hop
+          // itself worked; outcome reflects whether ClickHouse served it.
+          outcome: statusCode < 400 ? 'success' : 'error',
+          durationMs:
+            typeof startedAt === 'number' ? performance.now() - startedAt : 0,
+          attributes: { status_code: statusCode },
+        });
+
         // since clickhouse v24, the cors headers * will be attached to the response by default
         // which will cause the browser to block the response
         if (_req.headers['access-control-request-method']) {
@@ -258,6 +295,16 @@ const proxyMiddleware: RequestHandler =
         }
       },
       error: (err, _req, _res) => {
+        const startedAt = (_res as Response).locals?.hdxProxyStartedAt;
+        recordOperationOutcome({
+          operation: QUERY_PROXY_OPERATION,
+          // No usable response from ClickHouse (connection refused, timeout,
+          // DNS failure, ...) — a hard availability failure for the proxy.
+          outcome: 'error',
+          durationMs:
+            typeof startedAt === 'number' ? performance.now() - startedAt : 0,
+          attributes: { status_code: 0 },
+        });
         console.error('Proxy error:', err);
         (_res as Response).writeHead(500, {
           'Content-Type': 'application/json',
@@ -275,7 +322,25 @@ const proxyMiddleware: RequestHandler =
     // }),
   });
 
-router.get('/*', hasConnectionId, getConnection, proxyMiddleware);
-router.post('/*', hasConnectionId, getConnection, proxyMiddleware);
+// Stamp a start time so the proxy callbacks can record query SLO latency.
+const markProxyStart: RequestHandler = (_req, res, next) => {
+  res.locals.hdxProxyStartedAt = performance.now();
+  next();
+};
+
+router.get(
+  '/*',
+  hasConnectionId,
+  getConnection,
+  markProxyStart,
+  proxyMiddleware,
+);
+router.post(
+  '/*',
+  hasConnectionId,
+  getConnection,
+  markProxyStart,
+  proxyMiddleware,
+);
 
 export default router;

--- a/packages/api/src/routers/api/prometheus.ts
+++ b/packages/api/src/routers/api/prometheus.ts
@@ -1,11 +1,32 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import express from 'express';
+import { performance } from 'perf_hooks';
 
 import { getConnectionById } from '@/controllers/connection';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
+import { getCounter, getHistogram } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 const router = express.Router();
+
+// The proxy handlers catch their own errors and return Prometheus-shaped 4xx
+// bodies, so failures never reach the API error middleware. Track them here
+// instead. `endpoint` and `backend` are bounded enums (see
+// agent_docs/observability.md), never raw queries.
+type PrometheusBackend = 'prometheus' | 'clickhouse' | 'unknown';
+
+const prometheusQueryDuration = getHistogram(
+  'hyperdx.prometheus.query.duration_ms',
+  {
+    description:
+      'Duration of a Prometheus-compatible proxy request, labeled by endpoint and backend.',
+    unit: 'ms',
+  },
+);
+const prometheusQueryErrors = getCounter('hyperdx.prometheus.query_errors', {
+  description:
+    'Count of Prometheus-compatible proxy requests that failed, labeled by endpoint and backend.',
+});
 
 // Accept URL-encoded form bodies (Prometheus standard) and JSON
 router.use(express.urlencoded({ extended: true }));
@@ -160,6 +181,8 @@ async function proxyToPrometheus(
 // --------------------------
 
 const queryRangeHandler: express.RequestHandler = async (req, res) => {
+  const startedAt = performance.now();
+  let backend: PrometheusBackend = 'unknown';
   try {
     const { teamId } = getNonNullUserWithTeam(req);
     const params = getParams(req);
@@ -198,6 +221,7 @@ const queryRangeHandler: express.RequestHandler = async (req, res) => {
 
     // If connection has a Prometheus endpoint, proxy directly
     if (connection.prometheusEndpoint) {
+      backend = 'prometheus';
       const result = await proxyToPrometheus(
         connection.prometheusEndpoint,
         '/api/v1/query_range',
@@ -207,6 +231,7 @@ const queryRangeHandler: express.RequestHandler = async (req, res) => {
     }
 
     // Otherwise, use ClickHouse prometheusQuery()
+    backend = 'clickhouse';
     const start = parseTimestamp(params.start);
     const end = parseTimestamp(params.end);
     const step = parseDuration(params.step ?? '60s');
@@ -261,11 +286,17 @@ const queryRangeHandler: express.RequestHandler = async (req, res) => {
       },
     });
   } catch (e) {
+    prometheusQueryErrors.add(1, { endpoint: 'query_range', backend });
     logger.error(e, 'Prometheus query_range error');
     return res.status(400).json({
       status: 'error',
       errorType: 'bad_data',
       error: e instanceof Error ? e.message : String(e),
+    });
+  } finally {
+    prometheusQueryDuration.record(performance.now() - startedAt, {
+      endpoint: 'query_range',
+      backend,
     });
   }
 };
@@ -277,6 +308,8 @@ router.post('/query_range', queryRangeHandler);
 // --------------------------
 
 const queryHandler: express.RequestHandler = async (req, res) => {
+  const startedAt = performance.now();
+  let backend: PrometheusBackend = 'unknown';
   try {
     const { teamId } = getNonNullUserWithTeam(req);
     const params = getParams(req);
@@ -313,6 +346,7 @@ const queryHandler: express.RequestHandler = async (req, res) => {
     }
 
     if (connection.prometheusEndpoint) {
+      backend = 'prometheus';
       const result = await proxyToPrometheus(
         connection.prometheusEndpoint,
         '/api/v1/query',
@@ -321,6 +355,7 @@ const queryHandler: express.RequestHandler = async (req, res) => {
       return res.json(result);
     }
 
+    backend = 'clickhouse';
     const time = params.time ? parseTimestamp(params.time) : undefined;
     const database = params.database ?? 'default';
     const table = params.table ?? 'otel_metrics_ts';
@@ -356,11 +391,17 @@ const queryHandler: express.RequestHandler = async (req, res) => {
       },
     });
   } catch (e) {
+    prometheusQueryErrors.add(1, { endpoint: 'query', backend });
     logger.error(e, 'Prometheus query error');
     return res.status(400).json({
       status: 'error',
       errorType: 'bad_data',
       error: e instanceof Error ? e.message : String(e),
+    });
+  } finally {
+    prometheusQueryDuration.record(performance.now() - startedAt, {
+      endpoint: 'query',
+      backend,
     });
   }
 };
@@ -372,6 +413,8 @@ router.post('/query', queryHandler);
 // --------------------------
 
 router.get('/label/:name/values', async (req, res) => {
+  const startedAt = performance.now();
+  let backend: PrometheusBackend = 'unknown';
   try {
     const { teamId } = getNonNullUserWithTeam(req);
     const labelName = req.params.name;
@@ -401,6 +444,7 @@ router.get('/label/:name/values', async (req, res) => {
 
     // Proxy to Prometheus if endpoint is set
     if (connection.prometheusEndpoint) {
+      backend = 'prometheus';
       const result = await proxyToPrometheus(
         connection.prometheusEndpoint,
         `/api/v1/label/${labelName}/values`,
@@ -409,6 +453,7 @@ router.get('/label/:name/values', async (req, res) => {
       return res.json(result);
     }
 
+    backend = 'clickhouse';
     const database = params.database ?? 'default';
     const table = params.table ?? 'otel_metrics_ts';
 
@@ -439,11 +484,17 @@ router.get('/label/:name/values', async (req, res) => {
 
     return res.json({ status: 'success', data: values });
   } catch (e) {
+    prometheusQueryErrors.add(1, { endpoint: 'label_values', backend });
     logger.error(e, 'Prometheus label values error');
     return res.status(400).json({
       status: 'error',
       errorType: 'bad_data',
       error: e instanceof Error ? e.message : String(e),
+    });
+  } finally {
+    prometheusQueryDuration.record(performance.now() - startedAt, {
+      endpoint: 'label_values',
+      backend,
     });
   }
 });

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -46,6 +46,7 @@ import { isString, pick } from 'lodash';
 import { ObjectId } from 'mongoose';
 import mongoose from 'mongoose';
 import ms from 'ms';
+import { performance } from 'perf_hooks';
 import { serializeError } from 'serialize-error';
 
 import { ALERT_HISTORY_QUERY_CONCURRENCY } from '@/controllers/alertHistory';
@@ -75,7 +76,11 @@ import {
   roundDownToXMinutes,
   unflattenObject,
 } from '@/tasks/util';
-import { getCounter } from '@/utils/instrumentation';
+import {
+  getCounter,
+  type OperationOutcome,
+  recordOperationOutcome,
+} from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 // Outcome of a single alert evaluation. Kept low-cardinality (a fixed enum) so
@@ -738,6 +743,12 @@ export const processAlert = async (
   // Errors collected during this execution. Webhook errors accumulate here; query
   // and validation errors are recorded via recordAlertErrors before returning.
   const executionErrors: IAlertError[] = [];
+  // SLO signal for "alerts triggering". Defaults to success; flipped to
+  // 'skipped' on scheduling no-ops (excluded from the SLI) and to 'error' on
+  // any failure path. Recorded once in the finally below so the latency/
+  // availability SLIs cover every real evaluation regardless of exit point.
+  const evalStartedAt = performance.now();
+  let evalOutcome: OperationOutcome | 'skipped' = 'success';
   try {
     const windowSizeInMins = ms(alert.interval) / 60000;
     const scheduleStartAt = normalizeScheduleStartAt({
@@ -745,6 +756,7 @@ export const processAlert = async (
       scheduleStartAt: alert.scheduleStartAt,
     });
     if (scheduleStartAt != null && now < scheduleStartAt) {
+      evalOutcome = 'skipped';
       alertEvaluationsCounter.add(1, { outcome: 'skipped_schedule' });
       logger.info(
         {
@@ -782,6 +794,7 @@ export const processAlert = async (
 
     // Check if we should skip this alert check based on last evaluation time
     if (shouldSkipAlertCheck(details, hasGroupBy, nowInMinsRoundDown)) {
+      evalOutcome = 'skipped';
       alertEvaluationsCounter.add(1, { outcome: 'skipped_window' });
       logger.info(
         {
@@ -806,6 +819,7 @@ export const processAlert = async (
       scheduleStartAt,
     );
     if (dateRange[0].getTime() >= dateRange[1].getTime()) {
+      evalOutcome = 'skipped';
       alertEvaluationsCounter.add(1, { outcome: 'skipped_anchor' });
       logger.info(
         {
@@ -827,6 +841,7 @@ export const processAlert = async (
     );
 
     if (chartConfig == null) {
+      evalOutcome = 'error';
       logger.error(
         {
           chartConfig,
@@ -898,6 +913,7 @@ export const processAlert = async (
     // Query for alert data. If the query fails, record the error and exit
     // without touching alert state or creating an AlertHistory.
     let checksData;
+    const queryStartedAt = performance.now();
     try {
       checksData = await clickhouseClient.queryChartConfig({
         config: optimizedChartConfig,
@@ -905,7 +921,22 @@ export const processAlert = async (
         opts: { clickhouse_settings: clickHouseSettings },
         querySettings: source?.querySettings,
       });
+      // SLO signal for alert data fetching (distinct from the end-to-end
+      // evaluation SLI): did ClickHouse serve the alert query, and how fast.
+      recordOperationOutcome({
+        operation: 'alerts.query',
+        outcome: 'success',
+        durationMs: performance.now() - queryStartedAt,
+        attributes: { alert_source: alert.source },
+      });
     } catch (e) {
+      recordOperationOutcome({
+        operation: 'alerts.query',
+        outcome: 'error',
+        durationMs: performance.now() - queryStartedAt,
+        attributes: { alert_source: alert.source },
+      });
+      evalOutcome = 'error';
       alertQueryFailuresCounter.add(1);
       logger.error(
         {
@@ -1048,6 +1079,7 @@ export const processAlert = async (
 
     const meta = getResponseMetadata(chartConfig, checksData);
     if (!meta) {
+      evalOutcome = 'error';
       logger.error({ alertId: alert.id }, 'Failed to get response metadata');
       return;
     }
@@ -1234,6 +1266,7 @@ export const processAlert = async (
   } catch (e) {
     // Uncomment this for better error messages locally
     // console.error(e);
+    evalOutcome = 'error';
     alertProcessFailuresCounter.add(1);
     logger.error(
       {
@@ -1260,6 +1293,17 @@ export const processAlert = async (
         },
         'Failed to persist alert execution error',
       );
+    }
+  } finally {
+    // Scheduling skips are successful no-ops, not evaluations — exclude them so
+    // the SLI denominator only counts evaluations that actually ran.
+    if (evalOutcome !== 'skipped') {
+      recordOperationOutcome({
+        operation: 'alerts.evaluate',
+        outcome: evalOutcome,
+        durationMs: performance.now() - evalStartedAt,
+        attributes: { alert_source: alert.source },
+      });
     }
   }
 };

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -927,14 +927,14 @@ export const processAlert = async (
         operation: 'alerts.query',
         outcome: 'success',
         durationMs: performance.now() - queryStartedAt,
-        attributes: { alert_source: alert.source },
+        attributes: { alert_source: alert.source ?? 'unknown' },
       });
     } catch (e) {
       recordOperationOutcome({
         operation: 'alerts.query',
         outcome: 'error',
         durationMs: performance.now() - queryStartedAt,
-        attributes: { alert_source: alert.source },
+        attributes: { alert_source: alert.source ?? 'unknown' },
       });
       evalOutcome = 'error';
       alertQueryFailuresCounter.add(1);
@@ -1302,7 +1302,7 @@ export const processAlert = async (
         operation: 'alerts.evaluate',
         outcome: evalOutcome,
         durationMs: performance.now() - evalStartedAt,
-        attributes: { alert_source: alert.source },
+        attributes: { alert_source: alert.source ?? 'unknown' },
       });
     }
   }

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -51,7 +51,7 @@ import * as slack from '@/utils/slack';
 // `service` and `outcome` are bounded enums (see agent_docs/observability.md).
 const webhookDeliveryCounter = getCounter('hyperdx.alerts.webhook_deliveries', {
   description:
-    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, failure).',
+    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, error).',
 });
 const webhookDeliveryDuration = getHistogram(
   'hyperdx.alerts.webhook_delivery.duration_ms',
@@ -304,7 +304,7 @@ export const handleSendSlackWebhook = async (
   } catch (e) {
     webhookDeliveryCounter.add(1, {
       service: WebhookService.Slack,
-      outcome: 'failure',
+      outcome: 'error',
     });
     throw e;
   } finally {
@@ -325,7 +325,7 @@ export const handleSendGenericWebhook = async (
     await sendGenericWebhook(webhook, message);
     webhookDeliveryCounter.add(1, { service, outcome: 'success' });
   } catch (e) {
-    webhookDeliveryCounter.add(1, { service, outcome: 'failure' });
+    webhookDeliveryCounter.add(1, { service, outcome: 'error' });
     throw e;
   } finally {
     webhookDeliveryDuration.record(performance.now() - startedAt, { service });

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -20,6 +20,7 @@ import {
 import { isValidSlackUrl } from '@hyperdx/common-utils/dist/validation';
 import Handlebars, { HelperOptions } from 'handlebars';
 import _ from 'lodash';
+import { performance } from 'perf_hooks';
 import PromisedHandlebars from 'promised-handlebars';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
@@ -41,8 +42,25 @@ import {
 } from '@/tasks/checkAlerts/providers';
 import { escapeJsonString, unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
+import { getCounter, getHistogram } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 import * as slack from '@/utils/slack';
+
+// Webhook delivery is the last (and most failure-prone) hop of an alert. It
+// happens in the background task, so failures only show up in logs today.
+// `service` and `outcome` are bounded enums (see agent_docs/observability.md).
+const webhookDeliveryCounter = getCounter('hyperdx.alerts.webhook_deliveries', {
+  description:
+    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, failure).',
+});
+const webhookDeliveryDuration = getHistogram(
+  'hyperdx.alerts.webhook_delivery.duration_ms',
+  {
+    description:
+      'Duration of an alert webhook delivery attempt, labeled by service.',
+    unit: 'ms',
+  },
+);
 
 const describeThresholdViolation = (
   thresholdType: AlertThresholdType,
@@ -263,26 +281,58 @@ export const handleSendSlackWebhook = async (
   webhook: IWebhook,
   message: Message,
 ) => {
-  validateWebhookUrl(webhook);
+  const startedAt = performance.now();
+  try {
+    validateWebhookUrl(webhook);
 
-  await slack.postMessageToWebhook(webhook.url, {
-    text: message.title,
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
+    await slack.postMessageToWebhook(webhook.url, {
+      text: message.title,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
+          },
         },
-      },
-    ],
-  });
+      ],
+    });
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'success',
+    });
+  } catch (e) {
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'failure',
+    });
+    throw e;
+  } finally {
+    webhookDeliveryDuration.record(performance.now() - startedAt, {
+      service: WebhookService.Slack,
+    });
+  }
 };
 
 export const handleSendGenericWebhook = async (
   webhook: IWebhook,
   message: Message,
 ) => {
+  const startedAt = performance.now();
+  // webhook.service is an enum, so it is safe as a low-cardinality label.
+  const service = webhook.service ?? WebhookService.Generic;
+  try {
+    await sendGenericWebhook(webhook, message);
+    webhookDeliveryCounter.add(1, { service, outcome: 'success' });
+  } catch (e) {
+    webhookDeliveryCounter.add(1, { service, outcome: 'failure' });
+    throw e;
+  } finally {
+    webhookDeliveryDuration.record(performance.now() - startedAt, { service });
+  }
+};
+
+const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
   validateWebhookUrl(webhook);
 
   let url: string;

--- a/packages/api/src/utils/__tests__/instrumentation.test.ts
+++ b/packages/api/src/utils/__tests__/instrumentation.test.ts
@@ -60,8 +60,10 @@ import {
   getHistogram,
   getStaticFeatureFlags,
   recordDuration,
+  recordOperationOutcome,
   setBusinessContext,
   SpanStatusCode,
+  withOperationMetrics,
   withSpan,
 } from '@/utils/instrumentation';
 
@@ -200,6 +202,73 @@ describe('instrumentation', () => {
         expect.any(Number),
         undefined,
       );
+    });
+  });
+
+  describe('recordOperationOutcome', () => {
+    it('emits the request counter and duration histogram with operation + outcome', () => {
+      recordOperationOutcome({
+        operation: 'test.op',
+        outcome: 'success',
+        durationMs: 12,
+        attributes: { extra: 'x' },
+      });
+
+      expect(mockCounter.add).toHaveBeenCalledWith(1, {
+        extra: 'x',
+        operation: 'test.op',
+        outcome: 'success',
+      });
+      expect(mockHistogram.record).toHaveBeenCalledWith(12, {
+        extra: 'x',
+        operation: 'test.op',
+        outcome: 'success',
+      });
+    });
+  });
+
+  describe('withOperationMetrics', () => {
+    it('records a success outcome and returns the result', async () => {
+      const result = await withOperationMetrics('test.op', async () => 'ok');
+
+      expect(result).toBe('ok');
+      expect(mockCounter.add).toHaveBeenCalledWith(1, {
+        operation: 'test.op',
+        outcome: 'success',
+      });
+      expect(mockHistogram.record).toHaveBeenCalledWith(expect.any(Number), {
+        operation: 'test.op',
+        outcome: 'success',
+      });
+    });
+
+    it('records an error outcome and rethrows', async () => {
+      await expect(
+        withOperationMetrics('test.op', async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(mockCounter.add).toHaveBeenCalledWith(1, {
+        operation: 'test.op',
+        outcome: 'error',
+      });
+      expect(mockHistogram.record).toHaveBeenCalledWith(expect.any(Number), {
+        operation: 'test.op',
+        outcome: 'error',
+      });
+    });
+
+    it('merges extra attributes into both signals', async () => {
+      await withOperationMetrics('test.op', async () => undefined, {
+        provider: 'anthropic',
+      });
+
+      expect(mockCounter.add).toHaveBeenCalledWith(1, {
+        provider: 'anthropic',
+        operation: 'test.op',
+        outcome: 'success',
+      });
     });
   });
 });

--- a/packages/api/src/utils/instrumentation.ts
+++ b/packages/api/src/utils/instrumentation.ts
@@ -236,3 +236,83 @@ export async function recordDuration<T>(
     histogram.record(performance.now() - start, attributes);
   }
 }
+
+/**
+ * The outcome of one execution of an instrumented operation. Deliberately a
+ * two-value enum so it maps cleanly onto an SLO "good vs. total" split.
+ */
+export type OperationOutcome = 'success' | 'error';
+
+// Shared SLI instruments. Every instrumented operation reports through the same
+// two metrics, distinguished by the low-cardinality `operation` attribute, so
+// SLO dashboards/queries can be written generically (filter by `operation`)
+// rather than per-metric. See agent_docs/observability.md ("SLOs").
+const operationRequestsCounter = getCounter('hyperdx.operation.requests', {
+  description:
+    'Count of instrumented application operations, labeled by operation and outcome (success, error). Availability SLI for SLOs.',
+});
+const operationDurationHistogram = getHistogram(
+  'hyperdx.operation.duration_ms',
+  {
+    description:
+      'Wall-clock duration of instrumented application operations, labeled by operation and outcome. Latency SLI for SLOs.',
+    unit: 'ms',
+  },
+);
+
+/**
+ * Records the SLI signals for a single execution of a named operation: bumps
+ * `hyperdx.operation.requests` and records `hyperdx.operation.duration_ms`,
+ * both tagged with `operation` + `outcome` (plus any extra `attributes`).
+ *
+ * Prefer {@link withOperationMetrics} for the common async case. Use this
+ * directly only when timing is managed manually and there is no single async
+ * function to wrap (e.g. streaming proxies or event-callback APIs).
+ *
+ * `operation` is a metric attribute, so it must be a stable, low-cardinality
+ * constant (e.g. `ai.assistant`) — never interpolate IDs, queries, or user
+ * input into it.
+ */
+export function recordOperationOutcome(args: {
+  operation: string;
+  outcome: OperationOutcome;
+  durationMs: number;
+  attributes?: Attributes;
+}): void {
+  const { operation, outcome, durationMs, attributes } = args;
+  const attrs: Attributes = { ...attributes, operation, outcome };
+  operationRequestsCounter.add(1, attrs);
+  operationDurationHistogram.record(durationMs, attrs);
+}
+
+/**
+ * Wraps a unit of application functionality so it emits the request-count and
+ * duration SLIs needed to define an SLO. A resolved promise is recorded as
+ * `success`, a thrown error as `error`; the error is always re-raised
+ * unchanged.
+ *
+ * Build an availability SLO from `hyperdx.operation.requests`
+ * (good = `outcome:success`) and a latency SLO from
+ * `hyperdx.operation.duration_ms`, filtering both by the `operation` attribute.
+ */
+export async function withOperationMetrics<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  attributes?: Attributes,
+): Promise<T> {
+  const start = performance.now();
+  let outcome: OperationOutcome = 'success';
+  try {
+    return await fn();
+  } catch (err) {
+    outcome = 'error';
+    throw err;
+  } finally {
+    recordOperationOutcome({
+      operation,
+      outcome,
+      durationMs: performance.now() - start,
+      attributes,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Follow-up to the instrumentation foundation in #2511. That PR added the shared
helper library and instrumented a pilot set of paths; this PR rolls the same
helpers out to the **remaining high-value API surfaces** and adds a reusable
**SLO primitive** so specific pieces of application functionality can have
availability + latency SLOs defined against them.
The motivation is incident-readiness: several critical paths were previously
**log-only** or had **failures-only counters** (no denominator, no latency), and
some swallow their own errors so they never reached the API error middleware.
Those gaps make it impossible to alert on or set SLOs for the features users
depend on most: alert evaluation, query/data fetch, AI assistant, the
ClickHouse proxy, webhook delivery, and the OpAMP control plane.
## What changed
### New reusable SLO primitive (`utils/instrumentation.ts`)
- `withOperationMetrics(operation, fn, attrs?)` and `recordOperationOutcome(...)`
  emit a standard SLI pair tagged with a low-cardinality `operation` +
  `outcome` (`success` | `error`):
  - `hyperdx.operation.requests` (counter) → availability SLI
  - `hyperdx.operation.duration_ms` (histogram) → latency SLI
- Because every operation reports through the same two metrics, an SLO is just a
  filter on `operation`. Unit tests added for both helpers.
### Applied SLO metrics to critical functionality
- **AI assistant** (`routers/api/ai.ts`) — `ai.assistant` wraps the external
  provider generation call (tagged `source_kind`).
- **ClickHouse proxy** (`routers/api/clickhouseProxy.ts`) — `clickhouse_proxy.query`
  (recorded from the proxy `proxyRes`/`error` callbacks, tagged `status_code`)
  and `clickhouse_proxy.connection_test`. Both swallow errors in callbacks today.
- **Alert processing** (`tasks/checkAlerts/index.ts`) — `alerts.evaluate`
  (end-to-end evaluation, recorded once in a `finally`, scheduling skips
  excluded from the denominator) and `alerts.query` (the ClickHouse data fetch,
  previously only a failures-only counter).
### Custom metrics + tracing for previously log-only paths
- **OpAMP** (`opamp/controllers/opampController.ts`, `services/agentService.ts`)
  — wrapped message handling in a span; counters for message outcomes
  (`processed` / `unsupported_media_type` / `error`), agent status reports
  (`new` / `updated`), and remote configs sent.
- **Prometheus proxy** (`routers/api/prometheus.ts`) — query duration histogram
  and swallowed-error counter, labeled by `endpoint` and `backend`.
- **Webhook/notification delivery** (`tasks/checkAlerts/template.ts`) — delivery
  attempt counter + duration, labeled by `service` and `outcome`.
- **MongoDB connection lifecycle** (`models/index.ts`) — counter keyed by event
  (`connected` / `disconnected` / `error` / `reconnected` / `reconnect_failed`).
### Docs
- `agent_docs/observability.md`: new "SLOs (operation metrics)" section plus
  example references for each new pattern.
### New metrics at a glance
| Metric | Type | Key attributes |
| --- | --- | --- |
| `hyperdx.operation.requests` | counter | `operation`, `outcome` |
| `hyperdx.operation.duration_ms` | histogram | `operation`, `outcome` |
| `hyperdx.opamp.messages` | counter | `outcome` |
| `hyperdx.opamp.agent_status_reports` | counter | `status` |
| `hyperdx.opamp.remote_configs` | counter | — |
| `hyperdx.prometheus.query.duration_ms` | histogram | `endpoint`, `backend` |
| `hyperdx.prometheus.query_errors` | counter | `endpoint`, `backend` |
| `hyperdx.alerts.webhook_deliveries` | counter | `service`, `outcome` |
| `hyperdx.alerts.webhook_delivery.duration_ms` | histogram | `service` |
| `hyperdx.mongodb.connection_events` | counter | `event` |
All metric attributes are bounded enums — no IDs, queries, or user input.
## Scope notes
- Paths that already had clean outcome+duration SLIs (external API search/charts,
  MCP tools) were left as-is to avoid redundant metrics.
