### PR TITLE
feat: support external links via dashboard table on-click behavior

### DIFF
--- a/.changeset/onclick-external-link-variant.md
+++ b/.changeset/onclick-external-link-variant.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": minor
+"@hyperdx/api": minor
+---
+
+feat: Add an "external link" row-click action for dashboard table tiles

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -2391,6 +2391,30 @@
           }
         }
       },
+      "OnClickExternal": {
+        "type": "object",
+        "required": [
+          "type",
+          "urlTemplate"
+        ],
+        "description": "Link-out that navigates to an arbitrary external URL (e.g. a Grafana or Langfuse dashboard). The rendered URL must be an absolute http(s) URL.\n",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "external"
+            ],
+            "description": "OnClick variant discriminator. Must be \"external\" for external link-outs.",
+            "example": "external"
+          },
+          "urlTemplate": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Handlebars template rendered against the clicked row; supports `{{column}}` variables. The rendered value must be an absolute http(s) URL.\n",
+            "example": "https://example.com/d/abc?var-service={{ServiceName}}"
+          }
+        }
+      },
       "OnClick": {
         "description": "Link-out configuration applied when a user clicks a row of a table tile. Only table tiles (builder or raw SQL) currently support onClick. When target.mode is \"id\", the referenced source (type=search) or dashboard (type=dashboard) must already exist for the team.\n",
         "oneOf": [
@@ -2399,13 +2423,17 @@
           },
           {
             "$ref": "#/components/schemas/OnClickDashboard"
+          },
+          {
+            "$ref": "#/components/schemas/OnClickExternal"
           }
         ],
         "discriminator": {
           "propertyName": "type",
           "mapping": {
             "search": "#/components/schemas/OnClickSearch",
-            "dashboard": "#/components/schemas/OnClickDashboard"
+            "dashboard": "#/components/schemas/OnClickDashboard",
+            "external": "#/components/schemas/OnClickExternal"
           }
         }
       },

--- a/packages/api/src/mcp/__tests__/dashboards/prompts.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/prompts.test.ts
@@ -81,9 +81,11 @@ describe('MCP Dashboard Prompts', () => {
       const next = prompt.indexOf('\n== ', idx + 1);
       const section = prompt.slice(idx, next === -1 ? prompt.length : next);
 
-      // Both destination types are mentioned.
+      // All destination types are mentioned.
       expect(section).toContain('type: "search"');
       expect(section).toContain('type: "dashboard"');
+      expect(section).toContain('type: "external"');
+      expect(section).toContain('urlTemplate');
       // Both target modes are mentioned.
       expect(section).toContain('mode: "id"');
       expect(section).toContain('mode: "template"');

--- a/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
@@ -2093,6 +2093,53 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
       });
     });
 
+    it('should round-trip a table tile with an external onClick link', async () => {
+      const sourceId = ctx.traceSource._id.toString();
+      const result = await callTool(ctx.client!, 'clickstack_save_dashboard', {
+        name: 'OnClick external link',
+        tiles: [
+          {
+            name: 'Top Services',
+            x: 0,
+            y: 0,
+            w: 12,
+            h: 6,
+            config: {
+              displayType: 'table',
+              sourceId,
+              groupBy: "ResourceAttributes['service.name']",
+              select: [{ aggFn: 'count' }],
+              onClick: {
+                type: 'external',
+                urlTemplate:
+                  'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+              },
+            },
+          },
+        ],
+      });
+
+      expect(result.isError).toBeFalsy();
+      const output = JSON.parse(getFirstText(result));
+      expect(output.tiles[0].config.onClick).toEqual({
+        type: 'external',
+        urlTemplate:
+          'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+      });
+
+      const getResult = await callTool(
+        ctx.client!,
+        'clickstack_get_dashboard',
+        {
+          id: output.id,
+        },
+      );
+      const fetched = JSON.parse(getFirstText(getResult));
+      expect(fetched.tiles[0].config.onClick).toEqual(
+        output.tiles[0].config.onClick,
+      );
+    });
+
     it('should round-trip a templated dashboard onClick (mode=template)', async () => {
       const sourceId = ctx.traceSource._id.toString();
       const result = await callTool(ctx.client!, 'clickstack_save_dashboard', {

--- a/packages/api/src/mcp/prompts/dashboards/content.ts
+++ b/packages/api/src/mcp/prompts/dashboards/content.ts
@@ -1056,6 +1056,8 @@ Destination types:
     Opens the /search page for a log or trace source. Metric and session sources are rejected by the server (the /search page does not render those kinds).
   { type: "dashboard", target, whereLanguage, whereTemplate?, filters? }
     Opens another ClickStack dashboard owned by the same team.
+  { type: "external",  urlTemplate }
+    Opens an arbitrary external URL in a new tab (e.g. a Grafana or Langfuse dashboard, a runbook). The urlTemplate is rendered against the clicked row and the rendered value must be an absolute http(s) URL. It takes no target, whereLanguage, whereTemplate, or filters, and references no ClickStack source or dashboard.
 
 Target shape, how the destination is identified:
   target: { mode: "id", id: "<object-id>" }
@@ -1115,6 +1117,12 @@ Example, destination chosen by the clicked row (rare; prefer mode="id"):
     "type": "dashboard",
     "target": { "mode": "template", "template": "{{TargetDashboardName}}" },
     "whereLanguage": "lucene"
+  }
+
+Example, link out to an external tool:
+  "onClick": {
+    "type": "external",
+    "urlTemplate": "https://grafana.example.com/d/abc?var-service={{ServiceName}}"
   }
 
 Validation rules the server enforces:

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -314,18 +314,42 @@ const mcpOnClickDashboardSchema = z
       'high-level overview table down to a per-service or per-endpoint dashboard.',
   );
 
+const mcpOnClickExternalSchema = z
+  .object({
+    type: z
+      .literal('external')
+      .describe('Link to an arbitrary external URL (e.g. Grafana, Langfuse).'),
+    urlTemplate: z
+      .string()
+      .min(1)
+      .max(10000)
+      .describe(
+        'Handlebars-style template rendered against the clicked row, e.g. ' +
+          '"https://example.com/d/abc?var-service={{ServiceName}}". ' +
+          'The rendered value MUST be an absolute http(s) URL; relative URLs and ' +
+          'non-http(s) schemes (javascript:, data:, etc.) are rejected at click time. ' +
+          'This variant references no HyperDX source or dashboard.',
+      ),
+  })
+  .describe(
+    'Row-click handler that opens an external URL in a new tab. Use this to ' +
+      'link out to a third-party tool (Grafana, Langfuse, runbooks, etc.).',
+  );
+
 const mcpOnClickSchema = z
   .discriminatedUnion('type', [
     mcpOnClickSearchSchema,
     mcpOnClickDashboardSchema,
+    mcpOnClickExternalSchema,
   ])
   .describe(
     'Row-click navigation for tiles that render as tables (Table tiles always; ' +
       'SQL tiles only when displayType is "table"). ' +
       'type="search" links to the /search page for a log/trace source; ' +
-      'type="dashboard" links to another dashboard. ' +
-      'Both support Handlebars `{{column}}` templating against the clicked row ' +
-      'for the target, whereTemplate, and filter values.\n\n' +
+      'type="dashboard" links to another dashboard; ' +
+      'type="external" links to an arbitrary external http(s) URL. ' +
+      'All support Handlebars `{{column}}` templating against the clicked row ' +
+      'for the target/url, whereTemplate, and filter values.\n\n' +
       'Examples:\n' +
       '1. Drill into search for the clicked service: \n' +
       '   { "type": "search", "target": { "mode": "id", "id": "<trace-source-id>" }, ' +
@@ -339,7 +363,10 @@ const mcpOnClickSchema = z
       '"template": "{{ServiceName}}" }] }\n' +
       '3. Resolve the destination from the row (rare; prefer mode="id"): \n' +
       '   { "type": "dashboard", "target": { "mode": "template", "template": ' +
-      '"{{TargetDashboardName}}" }, "whereLanguage": "lucene" }',
+      '"{{TargetDashboardName}}" }, "whereLanguage": "lucene" }\n' +
+      '4. Link out to an external tool: \n' +
+      '   { "type": "external", "urlTemplate": ' +
+      '"https://grafana.example.com/d/abc?var-service={{ServiceName}}" }',
   );
 
 const mcpTileLayoutSchema = z.object({

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -3182,6 +3182,39 @@ describe('External API v2 Dashboards - new format', () => {
       });
     });
 
+    it('should accept and round-trip a table tile external onClick link', async () => {
+      const response = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard with external onClick',
+          tiles: [
+            {
+              name: 'External Link Table',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'table',
+                sourceId: traceSource._id.toString(),
+                select: [{ aggFn: 'count' }],
+                onClick: {
+                  type: 'external',
+                  urlTemplate:
+                    'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+                },
+              },
+            },
+          ],
+        })
+        .expect(200);
+
+      expect(response.body.data.tiles[0].config.onClick).toEqual({
+        type: 'external',
+        urlTemplate:
+          'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+      });
+    });
+
     it('should return 400 when a table tile onClick target.id is not a valid ObjectId', async () => {
       const response = await authRequest('post', BASE_URL)
         .send({

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1215,6 +1215,27 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           items:
  *             $ref: '#/components/schemas/OnClickFilterTemplate'
  *
+ *     OnClickExternal:
+ *       type: object
+ *       required: [type, urlTemplate]
+ *       description: >
+ *         Link-out that navigates to an arbitrary external URL (e.g. a Grafana
+ *         or Langfuse dashboard). The rendered URL must be an absolute http(s) URL.
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [external]
+ *           description: OnClick variant discriminator. Must be "external" for external link-outs.
+ *           example: "external"
+ *         urlTemplate:
+ *           type: string
+ *           minLength: 1
+ *           description: >
+ *             Handlebars template rendered against the clicked row; supports
+ *             `{{column}}` variables. The rendered value must be an absolute
+ *             http(s) URL.
+ *           example: "https://example.com/d/abc?var-service={{ServiceName}}"
+ *
  *     OnClick:
  *       description: >
  *         Link-out configuration applied when a user clicks a row of a table tile.
@@ -1224,11 +1245,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *       oneOf:
  *         - $ref: '#/components/schemas/OnClickSearch'
  *         - $ref: '#/components/schemas/OnClickDashboard'
+ *         - $ref: '#/components/schemas/OnClickExternal'
  *       discriminator:
  *         propertyName: type
  *         mapping:
  *           search: '#/components/schemas/OnClickSearch'
  *           dashboard: '#/components/schemas/OnClickDashboard'
+ *           external: '#/components/schemas/OnClickExternal'
  *
  *     TableChartConfig:
  *       description: >

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -12,6 +12,7 @@ import {
   NumberFormatSchema,
   NumberTileColorConditionSchema,
   OnClickDashboardSchema,
+  OnClickExternalSchema,
   OnClickSearchSchema,
   scheduleStartAtSchema,
   SearchConditionLanguageSchema as whereLanguageSchema,
@@ -188,9 +189,12 @@ const externalOnClickDashboardSchema = OnClickDashboardSchema.extend({
   target: externalOnClickTargetSchema,
 });
 
+const externalOnClickExternalSchema = OnClickExternalSchema;
+
 const externalOnClickSchema = z.discriminatedUnion('type', [
   externalOnClickSearchSchema,
   externalOnClickDashboardSchema,
+  externalOnClickExternalSchema,
 ]);
 
 const externalDashboardSelectItemSchema = z

--- a/packages/app/src/DBDashboardImportPage.tsx
+++ b/packages/app/src/DBDashboardImportPage.tsx
@@ -759,7 +759,14 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
 
         const inputOnClick = tile.config.onClick;
         const applyOnClick = (config: SavedChartConfig): SavedChartConfig => {
-          if (!inputOnClick || inputOnClick.target.mode !== 'id') return config;
+          // The external variant references no source/dashboard, so there is no mapping to apply.
+          if (
+            !inputOnClick ||
+            inputOnClick.type === 'external' ||
+            inputOnClick.target.mode !== 'id'
+          ) {
+            return config;
+          }
           const mappedId =
             inputOnClick.type === 'search'
               ? data.onClickSourceMappings?.[idx]

--- a/packages/app/src/HDXMultiSeriesTableChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTableChart.tsx
@@ -183,6 +183,20 @@ export const Table = ({
                 // in the <tbody> loop below sees the same identity.
                 const action = getRowAction(row.original);
                 if (action.url) {
+                  if (action.external) {
+                    return (
+                      <a
+                        href={action.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={interactiveClassName}
+                        data-testid="dashboard-table-row-action"
+                        data-shape="external-link"
+                      >
+                        {formattedValue}
+                      </a>
+                    );
+                  }
                   // Use prefetch={false} so virtualization scroll doesn't
                   // trigger an N-row prefetch storm against /search? and
                   // /dashboards/ routes the user usually never opens.
@@ -451,16 +465,30 @@ export const Table = ({
                           closeDelay={100}
                           fz="xs"
                         >
-                          <Link
-                            href={actionUrl}
-                            prefetch={false}
-                            tabIndex={-1}
-                            aria-hidden="true"
-                            className={styles.rowActionHint}
-                            data-testid="row-action-hint"
-                          >
-                            <IconArrowUpRight size={14} />
-                          </Link>
+                          {rowAction.external ? (
+                            <a
+                              href={actionUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              tabIndex={-1}
+                              aria-hidden="true"
+                              className={styles.rowActionHint}
+                              data-testid="row-action-hint"
+                            >
+                              <IconArrowUpRight size={14} />
+                            </a>
+                          ) : (
+                            <Link
+                              href={actionUrl}
+                              prefetch={false}
+                              tabIndex={-1}
+                              aria-hidden="true"
+                              className={styles.rowActionHint}
+                              data-testid="row-action-hint"
+                            >
+                              <IconArrowUpRight size={14} />
+                            </Link>
+                          )}
                         </Tooltip>
                       )}
                     </td>

--- a/packages/app/src/__tests__/HDXMultiSeriesTableChart.test.tsx
+++ b/packages/app/src/__tests__/HDXMultiSeriesTableChart.test.tsx
@@ -193,6 +193,64 @@ describe('HDXMultiSeriesTableChart <Table>', () => {
     });
   });
 
+  describe('external link path', () => {
+    it('renders the cell as a plain <a target="_blank"> for external actions', () => {
+      const getRowAction = jest.fn().mockReturnValue({
+        url: 'https://grafana.example.com/d/abc?svc=web',
+        description: 'https://grafana.example.com/d/abc?svc=web',
+        external: true,
+      });
+
+      renderWithMantine(
+        <Table
+          data={baseData}
+          columns={baseColumns}
+          getRowAction={getRowAction}
+          sorting={[]}
+          onSortingChange={() => {}}
+        />,
+      );
+
+      const links = screen.getAllByTestId('dashboard-table-row-action');
+      expect(links.length).toBeGreaterThan(0);
+      links.forEach(link => {
+        expect(link.tagName).toBe('A');
+        expect(link.getAttribute('data-shape')).toBe('external-link');
+        expect(link.getAttribute('href')).toBe(
+          'https://grafana.example.com/d/abc?svc=web',
+        );
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+      });
+    });
+
+    it('renders the trailing arrow hint as an external anchor opening in a new tab', () => {
+      const getRowAction = jest.fn().mockReturnValue({
+        url: 'https://grafana.example.com/d/abc?svc=web',
+        description: 'https://grafana.example.com/d/abc?svc=web',
+        external: true,
+      });
+
+      renderWithMantine(
+        <Table
+          data={baseData}
+          columns={baseColumns}
+          getRowAction={getRowAction}
+          sorting={[]}
+          onSortingChange={() => {}}
+        />,
+      );
+
+      const hint = screen.getByTestId('row-action-hint');
+      expect(hint.tagName).toBe('A');
+      expect(hint.getAttribute('target')).toBe('_blank');
+      expect(hint.getAttribute('rel')).toBe('noopener noreferrer');
+      expect(hint.getAttribute('href')).toBe(
+        'https://grafana.example.com/d/abc?svc=web',
+      );
+    });
+  });
+
   describe('getRowAction failure path', () => {
     it('renders the cell as a <button> when the row resolution failed and wires onClickError', async () => {
       const user = userEvent.setup();

--- a/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickDrawer.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickDrawer.tsx
@@ -168,6 +168,11 @@ function ExternalOnClickFields({ control }: { control: DrawerControl }) {
     <Stack gap="xs">
       <Text size="xs" c="dimmed">
         {TEMPLATE_HELP_TEXT} The rendered value must be an absolute http(s) URL.
+        <br />
+        <br />
+        <b>Caution:</b> this may navigate to an external site and include
+        information from your data. Make sure the template does not contain any
+        sensitive information, and that the external site is trusted.
       </Text>
 
       <Box>

--- a/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickDrawer.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickDrawer.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 
+import { TextInputControlled } from '@/components/InputControlled';
 import { InputLabelWithTooltip } from '@/components/InputLabelWithTooltip';
 import SearchWhereInput from '@/components/SearchInput/SearchWhereInput';
 import { useDashboards } from '@/dashboard';
@@ -37,6 +38,7 @@ import {
   DrawerFormValues,
   DrawerSchema,
   emptyDashboardOnClick,
+  emptyExternalOnClick,
   emptySearchOnClick,
 } from './utils';
 
@@ -161,6 +163,29 @@ function DashboardOnClickFields({
   );
 }
 
+function ExternalOnClickFields({ control }: { control: DrawerControl }) {
+  return (
+    <Stack gap="xs">
+      <Text size="xs" c="dimmed">
+        {TEMPLATE_HELP_TEXT} The rendered value must be an absolute http(s) URL.
+      </Text>
+
+      <Box>
+        <InputLabelWithTooltip
+          label="URL"
+          tooltip="Handlebars template that resolves to an external URL. It is opened in a new tab when a row is clicked."
+        />
+        <TextInputControlled
+          control={control}
+          name="onClick.urlTemplate"
+          placeholder="https://example.com/abc?service={{ServiceName}}"
+          data-testid="onclick-external-url-input"
+        />
+      </Box>
+    </Stack>
+  );
+}
+
 function ModeFields({
   control,
   setValue,
@@ -182,6 +207,8 @@ function ModeFields({
         getValues={getValues}
       />
     );
+  } else if (onClick?.type === 'external') {
+    return <ExternalOnClickFields control={control} />;
   }
 
   return (
@@ -228,7 +255,13 @@ export default function OnClickDrawer({
   const watchedOnClick = useWatch({ control, name: 'onClick' });
 
   const isTargetMissing = useMemo(() => {
-    if (!watchedOnClick || watchedOnClick.target.mode !== 'id') return false;
+    if (
+      !watchedOnClick ||
+      watchedOnClick.type === 'external' ||
+      watchedOnClick.target.mode !== 'id'
+    ) {
+      return false;
+    }
 
     const validTargetIds =
       watchedOnClick.type === 'dashboard'
@@ -287,6 +320,7 @@ export default function OnClickDrawer({
                 { label: 'Default', value: 'default' },
                 { label: 'Search', value: 'search' },
                 { label: 'Dashboard', value: 'dashboard' },
+                { label: 'External', value: 'external' },
               ]}
               value={onClickValue?.type ?? 'default'}
               onChange={value => {
@@ -295,7 +329,9 @@ export default function OnClickDrawer({
                     ? emptySearchOnClick()
                     : value === 'dashboard'
                       ? emptyDashboardOnClick()
-                      : null;
+                      : value === 'external'
+                        ? emptyExternalOnClick()
+                        : null;
                 setValue('onClick', formValue);
               }}
               fullWidth

--- a/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickFormButton.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/OnClickForm/OnClickFormButton.tsx
@@ -28,7 +28,9 @@ export function OnClickFormButton({
       ? 'Search'
       : onClickValue?.type === 'dashboard'
         ? 'Dashboard'
-        : 'Default';
+        : onClickValue?.type === 'external'
+          ? 'External'
+          : 'Default';
 
   return (
     <>

--- a/packages/app/src/components/DBEditTimeChartForm/OnClickForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/OnClickForm/utils.ts
@@ -21,3 +21,10 @@ export function emptyDashboardOnClick(): OnClick {
     whereLanguage: 'sql',
   };
 }
+
+export function emptyExternalOnClick(): OnClick {
+  return {
+    type: 'external',
+    urlTemplate: '',
+  };
+}

--- a/packages/app/src/hooks/__tests__/useOnClickLinkBuilder.test.tsx
+++ b/packages/app/src/hooks/__tests__/useOnClickLinkBuilder.test.tsx
@@ -1,5 +1,6 @@
 import type {
   OnClickDashboard,
+  OnClickExternal,
   OnClickSearch,
 } from '@hyperdx/common-utils/dist/types';
 import { notifications } from '@mantine/notifications';
@@ -83,6 +84,42 @@ describe('useOnClickLinkBuilder', () => {
     const action = result.current!({});
     expect(action.description).toBe('Open dashboard "API Latency Drilldown"');
     expect(action.url!.startsWith('/dashboards/dash_1?')).toBe(true);
+  });
+
+  it('resolves an external link to an absolute URL marked external', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate:
+        'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+    };
+    const { result } = renderHook(() =>
+      useOnClickLinkBuilder({ onClick, dateRange }),
+    );
+    const action = result.current!({ ServiceName: 'checkout' });
+    // The resolved destination URL is surfaced as the hover hint so the
+    // user can see exactly where an external link points.
+    expect(action.description).toBe(
+      'https://grafana.example.com/d/abc?var-service=checkout',
+    );
+    expect(action.url).toBe(
+      'https://grafana.example.com/d/abc?var-service=checkout',
+    );
+    expect(action.external).toBe(true);
+    expect(action.onClickError).toBeUndefined();
+  });
+
+  it('encodes an invalid external URL as url: null with an error handler', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: '/dashboards/{{Id}}',
+    };
+    const { result } = renderHook(() =>
+      useOnClickLinkBuilder({ onClick, dateRange }),
+    );
+    const action = result.current!({ Id: '123' });
+    expect(action.url).toBeNull();
+    expect(action.description).toBe('Open external link');
+    expect(action.onClickError).toBeInstanceOf(Function);
   });
 
   it('caches results per row reference so repeated calls share the same RowAction', () => {

--- a/packages/app/src/hooks/useOnClickLinkBuilder.ts
+++ b/packages/app/src/hooks/useOnClickLinkBuilder.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import {
   describeOnClick,
   renderOnClickDashboard,
+  renderOnClickExternal,
   renderOnClickSearch,
 } from '@hyperdx/common-utils/dist/core/linkUrlBuilder';
 import { isSearchableSource, OnClick } from '@hyperdx/common-utils/dist/types';
@@ -25,6 +26,8 @@ import { useSources } from '@/source';
 export type RowAction = {
   url: string | null;
   description: string;
+  /** True when `url` points to an arbitrary external destination (the `external` onClick variant) */
+  external?: boolean;
   onClickError?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
@@ -97,6 +100,8 @@ export function useOnClickLinkBuilder({
     // memo (different onClick / sources / dashboards) starts fresh.
     const cache = new WeakMap<Record<string, unknown>, RowAction>();
 
+    const isExternal = onClick.type === 'external';
+
     const compute = (row: Record<string, unknown>): RowAction => {
       const renderResult =
         onClick.type === 'search'
@@ -107,16 +112,22 @@ export function useOnClickLinkBuilder({
               sourceIdsByName,
               dateRange,
             })
-          : renderOnClickDashboard({
-              onClick,
-              row,
-              dashboardIds,
-              dashboardIdsByName,
-              dateRange,
-            });
+          : onClick.type === 'dashboard'
+            ? renderOnClickDashboard({
+                onClick,
+                row,
+                dashboardIds,
+                dashboardIdsByName,
+                dateRange,
+              })
+            : renderOnClickExternal({ onClick, row });
 
       if (renderResult.ok) {
-        return { url: renderResult.url, description };
+        return {
+          url: renderResult.url,
+          description: isExternal ? renderResult.url : description,
+          external: isExternal,
+        };
       }
 
       const errorMessage = renderResult.error;

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -331,11 +331,19 @@ export class ChartEditorComponent {
   /**
    * Switch the Row Click Action mode (SegmentedControl).
    */
-  async setRowClickMode(mode: 'Default' | 'Search' | 'Dashboard') {
+  async setRowClickMode(mode: 'Default' | 'Search' | 'Dashboard' | 'External') {
     await this.page
       .getByTestId('onclick-mode-segmented')
       .getByText(mode, { exact: true })
       .click();
+  }
+
+  /**
+   * Fill the External URL template input in the drawer. Call
+   * setRowClickMode('External') first to make the input visible.
+   */
+  async fillRowClickExternalUrl(urlTemplate: string) {
+    await this.page.getByTestId('onclick-external-url-input').fill(urlTemplate);
   }
 
   /**

--- a/packages/app/tests/e2e/features/dashboard-table-linking.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-table-linking.spec.ts
@@ -752,6 +752,82 @@ test.describe(
       });
     });
 
+    test('External mode: row renders an absolute http(s) link opening in a new tab', async () => {
+      const ts = Date.now();
+
+      await test.step('Configure External-mode row click with a templated URL', async () => {
+        await addTableTile(`E2E External Link ${ts}`);
+        await dashboardPage.chartEditor.openRowClickDrawer();
+        await dashboardPage.chartEditor.setRowClickMode('External');
+        await dashboardPage.chartEditor.fillRowClickExternalUrl(
+          'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+        );
+        await dashboardPage.chartEditor.applyRowClickDrawer();
+        await dashboardPage.saveTile();
+      });
+
+      await test.step('Set dashboard time range to Last 6 hours', async () => {
+        await dashboardPage.timePicker.selectRelativeTime('Last 6 hours');
+      });
+
+      await dashboardPage.waitForTableTileRows(0);
+      // ServiceName is the second column in the rendered table (count is col 0).
+      const serviceName = await dashboardPage.getFirstTableRowValue(0, 1);
+      expect(serviceName.length).toBeGreaterThan(0);
+
+      await test.step('Verify the row renders a plain external anchor with the rendered URL', async () => {
+        const link = dashboardPage.getFirstRowActionLink(0);
+        await expect(link).toHaveAttribute('data-shape', 'external-link');
+        await expect(link).toHaveAttribute('target', '_blank');
+        await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        await expect(link).toHaveAttribute(
+          'href',
+          `https://grafana.example.com/d/abc?var-service=${encodeURIComponent(
+            serviceName,
+          )}`,
+        );
+      });
+
+      await test.step('Verify no Link error notification appeared', async () => {
+        await expect(dashboardPage.getLinkErrorNotification()).toBeHidden();
+      });
+    });
+
+    test('External mode: a non-http(s) URL shows a Link error notification on click', async ({
+      page,
+    }) => {
+      const ts = Date.now();
+
+      await test.step('Configure External-mode row click with a relative URL', async () => {
+        await addTableTile(`E2E Bad External ${ts}`);
+        await dashboardPage.chartEditor.openRowClickDrawer();
+        await dashboardPage.chartEditor.setRowClickMode('External');
+        await dashboardPage.chartEditor.fillRowClickExternalUrl(
+          '/dashboards/{{ServiceName}}',
+        );
+        await dashboardPage.chartEditor.applyRowClickDrawer();
+        await dashboardPage.saveTile();
+      });
+
+      await test.step('Set dashboard time range to Last 6 hours', async () => {
+        await dashboardPage.timePicker.selectRelativeTime('Last 6 hours');
+      });
+
+      await dashboardPage.waitForTableTileRows(0);
+
+      await test.step('Click first row and verify Link error appears', async () => {
+        const dashboardUrlBefore = page.url();
+        await dashboardPage.clickFirstTableRow(0);
+        const notification = dashboardPage.getLinkErrorNotification();
+        await expect(notification).toBeVisible({ timeout: 5000 });
+        await expect(notification).toContainText(
+          /must be an absolute http\(s\) URL/,
+        );
+        // Should not have navigated away.
+        expect(page.url()).toBe(dashboardUrlBefore);
+      });
+    });
+
     test('Trailing arrow hint appears on row hover and navigates to the action URL (HDX-4405)', async ({
       page,
     }) => {

--- a/packages/app/tests/e2e/features/dashboard-template-import.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-template-import.spec.ts
@@ -787,6 +787,72 @@ test.describe('Dashboard Template Import', { tag: ['@dashboard'] }, () => {
   );
 
   test(
+    'should preserve an external onClick through import with no source mapping',
+    { tag: '@full-stack' },
+    async ({ page }) => {
+      const ts = Date.now();
+      const dashboardName = `E2E Import OnClick External ${ts}`;
+      const tileName = `External Link Tile ${ts}`;
+      const urlTemplate =
+        'https://grafana.example.com/d/abc?var-service={{ServiceName}}';
+
+      const templatePath = writeTempTemplate(
+        makeTemplateWithOnClick({
+          dashboardName,
+          tileName,
+          // Use the workspace logs source name so the tile source mapping
+          // auto-resolves and the import can finish without manual mapping.
+          tileSourceName: DEFAULT_LOGS_SOURCE_NAME,
+          onClick: {
+            type: 'external',
+            urlTemplate,
+          },
+        }),
+      );
+
+      await test.step('Upload the template and wait for mapping step', async () => {
+        await dashboardImportPage.gotoImport();
+        await dashboardImportPage.uploadTemplateFile(templatePath);
+        await expect(dashboardImportPage.mappingStepHeading).toBeVisible();
+        await expect(dashboardImportPage.dashboardNameInput).toHaveValue(
+          dashboardName,
+        );
+      });
+
+      await test.step('Verify no onClick mapping rows are rendered (external has none)', async () => {
+        await expect(
+          dashboardImportPage.getMappingRow(
+            tileName,
+            'On Click - Search Source',
+          ),
+        ).toBeHidden();
+        await expect(
+          dashboardImportPage.getMappingRow(tileName, 'On Click - Dashboard'),
+        ).toBeHidden();
+      });
+
+      await test.step('Finish import (tile source auto-resolves)', async () => {
+        await dashboardImportPage.finishImportButton.click();
+        await expect(
+          dashboardImportPage.getImportSuccessNotification(),
+        ).toBeVisible();
+        await page.waitForURL(/\/dashboards\/[a-f0-9]{24}/);
+      });
+
+      await test.step('Verify the external onClick survived import unchanged', async () => {
+        const dashboardId = dashboardPage.getCurrentDashboardId();
+        const dashboard = await fetchDashboardById(page, dashboardId);
+        expect(dashboard.name).toBe(dashboardName);
+        expect(dashboard.tiles).toHaveLength(1);
+        expect(dashboard.tiles[0].config.onClick).toEqual({
+          type: 'external',
+          urlTemplate,
+        });
+      });
+    },
+  );
+
+  test(
     'should drop an unmapped onClick from the imported tile',
     { tag: '@full-stack' },
     async ({ page }) => {

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -1100,6 +1100,20 @@ export class DashboardPage {
   }
 
   /**
+   * Return the first row's action element (anchor or button) of a table
+   * tile. Carries `data-testid="dashboard-table-row-action"`. Useful for
+   * asserting on rendered link attributes (href / target / rel / data-shape)
+   * without triggering navigation — e.g. external links open a new tab.
+   */
+  getFirstRowActionLink(tileIndex = 0): Locator {
+    return this.getTile(tileIndex)
+      .locator('table tbody tr')
+      .first()
+      .locator('[data-testid="dashboard-table-row-action"]')
+      .first();
+  }
+
+  /**
    * Return the first data row (<tr data-index>) of the table in the
    * given tile. Used for hover-based interactions (e.g. tooltip tests).
    */

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -1360,6 +1360,23 @@ describe('utils', () => {
         });
       });
 
+      it('leaves an external onClick untouched (no source mapping)', () => {
+        const dashboard = makeDashboard({
+          type: 'external',
+          urlTemplate: 'https://grafana.example.com/d/abc?svc={{ServiceName}}',
+        });
+
+        const template = convertToDashboardTemplate(dashboard, [source]);
+
+        expect(template.tiles[0].config).toMatchObject({
+          onClick: {
+            type: 'external',
+            urlTemplate:
+              'https://grafana.example.com/d/abc?svc={{ServiceName}}',
+          },
+        });
+      });
+
       it('drops a search onClick whose source was deleted', () => {
         const dashboard = makeDashboard({
           type: 'search',

--- a/packages/common-utils/src/core/__tests__/linkUrlBuilder.test.ts
+++ b/packages/common-utils/src/core/__tests__/linkUrlBuilder.test.ts
@@ -1,10 +1,11 @@
 import {
   describeOnClick,
   renderOnClickDashboard,
+  renderOnClickExternal,
   renderOnClickSearch,
   validateOnClickTemplate,
 } from '@/core/linkUrlBuilder';
-import type { OnClickDashboard, OnClickSearch } from '@/types';
+import type { OnClickDashboard, OnClickExternal, OnClickSearch } from '@/types';
 
 const dateRange: [Date, Date] = [
   new Date('2026-01-01T00:00:00Z'),
@@ -871,6 +872,183 @@ describe('renderOnClickDashboard', () => {
   });
 });
 
+describe('renderOnClickExternal', () => {
+  it('renders a static absolute https URL', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://grafana.example.com/d/abc',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe('https://grafana.example.com/d/abc');
+    }
+  });
+
+  it('renders a templated URL from row columns', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate:
+        'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { ServiceName: 'checkout' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe(
+        'https://grafana.example.com/d/abc?var-service=checkout',
+      );
+    }
+  });
+
+  it('allows http URLs', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'http://internal-tool.local/runbook',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(true);
+  });
+
+  it('trims surrounding whitespace from the rendered URL', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: '  https://example.com/{{Path}}  ',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { Path: 'page' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe('https://example.com/page');
+    }
+  });
+
+  it('errors when the template references a missing column', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/{{MissingColumn}}',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toBe("Row has no column 'MissingColumn'");
+  });
+
+  it('errors when the rendered URL is empty', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: '{{Blank}}',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { Blank: '' },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('External link URL is empty');
+  });
+
+  it('percent-encodes a column value so it cannot inject extra query params', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate:
+        'https://grafana.example.com/d/abc?var-service={{ServiceName}}',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { ServiceName: 'checkout&admin=true' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe(
+        'https://grafana.example.com/d/abc?var-service=checkout%26admin%3Dtrue',
+      );
+      // The injected "&admin=true" must NOT become a separate query param.
+      const parsed = new URL(result.url);
+      expect(parsed.searchParams.get('var-service')).toBe(
+        'checkout&admin=true',
+      );
+      expect(parsed.searchParams.has('admin')).toBe(false);
+    }
+  });
+
+  it('percent-encodes path-traversal and fragment characters in a column value', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/service/{{ServiceName}}',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { ServiceName: '../../etc/passwd#frag' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe(
+        'https://example.com/service/..%2F..%2Fetc%2Fpasswd%23frag',
+      );
+      const parsed = new URL(result.url);
+      expect(parsed.pathname).toBe('/service/..%2F..%2Fetc%2Fpasswd%23frag');
+      expect(parsed.hash).toBe('');
+    }
+  });
+
+  it('does not encode the template author\u2019s own URL structure', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/d/abc?a={{A}}&b={{B}}#section={{C}}',
+    };
+    const result = renderOnClickExternal({
+      onClick,
+      row: { A: 'x y', B: 'p/q', C: 'z' },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url).toBe(
+        'https://example.com/d/abc?a=x%20y&b=p%2Fq#section=z',
+      );
+      const parsed = new URL(result.url);
+      expect(parsed.searchParams.get('a')).toBe('x y');
+      expect(parsed.searchParams.get('b')).toBe('p/q');
+      expect(parsed.hash).toBe('#section=z');
+    }
+  });
+
+  it('rejects a javascript: scheme to prevent XSS', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+
+      urlTemplate: 'javascript:alert(1)',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toContain('must be an absolute http(s) URL');
+  });
+
+  it('rejects relative URLs', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: '/dashboards/123',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toContain('must be an absolute http(s) URL');
+  });
+
+  it('rejects non-http(s) schemes like data:', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'data:text/html,<script>alert(1)</script>',
+    };
+    const result = renderOnClickExternal({ onClick, row: {} });
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe('validateOnClickTemplate', () => {
   it('accepts a valid target template with no where template', () => {
     const onClick: OnClickSearch = {
@@ -949,6 +1127,22 @@ describe('validateOnClickTemplate', () => {
     };
     expect(() => validateOnClickTemplate(onClick)).not.toThrow();
   });
+
+  it('accepts a valid external url template', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/{{ServiceName}}',
+    };
+    expect(() => validateOnClickTemplate(onClick)).not.toThrow();
+  });
+
+  it('throws when the external url template has invalid syntax', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/{{#if',
+    };
+    expect(() => validateOnClickTemplate(onClick)).toThrow();
+  });
 });
 
 describe('describeOnClick', () => {
@@ -1021,5 +1215,15 @@ describe('describeOnClick', () => {
     expect(
       describeOnClick({ onClick, sourceNamesById, dashboardNamesById }),
     ).toBe('Open dashboard');
+  });
+
+  it('describes an external link action', () => {
+    const onClick: OnClickExternal = {
+      type: 'external',
+      urlTemplate: 'https://example.com/{{ServiceName}}',
+    };
+    expect(
+      describeOnClick({ onClick, sourceNamesById, dashboardNamesById }),
+    ).toBe('Open external link');
   });
 });

--- a/packages/common-utils/src/core/linkTemplate.ts
+++ b/packages/common-utils/src/core/linkTemplate.ts
@@ -76,6 +76,35 @@ export function renderLinkTemplate(
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function stringifyAndEncode(value: unknown): unknown {
+  if (typeof value === 'string') return encodeURIComponent(value);
+  if (Array.isArray(value) || isPlainObject(value)) {
+    return encodeURIComponent(JSON.stringify(value));
+  }
+  return value;
+}
+
+/**
+ * Render a template that produces a URL. Identical to {@link renderLinkTemplate}
+ * except that interpolated context (column) values are URL-encoded.
+ */
+export function renderUrlTemplate(
+  template: string,
+  ctx: Record<string, unknown>,
+): string {
+  const encoded: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(ctx)) {
+    encoded[key] = stringifyAndEncode(value);
+  }
+  return renderLinkTemplate(template, encoded);
+}
+
 export const clearLinkTemplateCache = () => {
   compiledTemplateCache.clear();
 };

--- a/packages/common-utils/src/core/linkUrlBuilder.ts
+++ b/packages/common-utils/src/core/linkUrlBuilder.ts
@@ -3,6 +3,7 @@ import type {
   Filter,
   OnClick,
   OnClickDashboard,
+  OnClickExternal,
   OnClickFilterTemplate,
   OnClickSearch,
 } from '@/types';
@@ -11,6 +12,7 @@ import {
   LinkTemplateError,
   MissingTemplateVariableError,
   renderLinkTemplate,
+  renderUrlTemplate,
   validateTemplate,
 } from './linkTemplate';
 
@@ -21,9 +23,13 @@ export type LinkBuildResult =
 function renderOrError(
   template: string,
   rowData: Record<string, unknown>,
+  options?: { encodeValues?: boolean },
 ): { ok: true; value: string } | { ok: false; error: string } {
   try {
-    return { ok: true, value: renderLinkTemplate(template, rowData) };
+    const value = options?.encodeValues
+      ? renderUrlTemplate(template, rowData)
+      : renderLinkTemplate(template, rowData);
+    return { ok: true, value };
   } catch (err) {
     const message =
       err instanceof MissingTemplateVariableError
@@ -240,6 +246,53 @@ export function renderOnClickDashboard({
 }
 
 /**
+ * Only absolute http(s) URLs are allowed for external link-outs. This blocks
+ * dangerous schemes (e.g. `javascript:`, `data:`, `vbscript:`) that could
+ * execute when rendered into an anchor's `href`, and rejects relative URLs
+ * that would resolve against the HyperDX origin (those should use the search /
+ * dashboard variants instead).
+ */
+function isAllowedExternalUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
+
+/**
+ * Render an OnClickExternal to an absolute external URL, or return an error if
+ * rendering fails or the rendered value is not a safe http(s) URL.
+ */
+export function renderOnClickExternal({
+  onClick,
+  row,
+}: {
+  onClick: OnClickExternal;
+  row: Record<string, unknown>;
+}): LinkBuildResult {
+  const rendered = renderOrError(onClick.urlTemplate, row, {
+    encodeValues: true,
+  });
+  if (!rendered.ok) return rendered;
+
+  const url = rendered.value.trim();
+  if (url === '') {
+    return { ok: false, error: 'External link URL is empty' };
+  }
+  if (!isAllowedExternalUrl(url)) {
+    return {
+      ok: false,
+      error: `External link must be an absolute http(s) URL, got '${url}'`,
+    };
+  }
+
+  return { ok: true, url };
+}
+
+/**
  * Build a one-line, row-independent description of an OnClick action,
  * suitable for a hover hint shown before the user commits to the click.
  *
@@ -279,6 +332,9 @@ export function describeOnClick({
     }
     return 'Open dashboard';
   }
+  if (onClick.type === 'external') {
+    return 'Open external link';
+  }
   // Exhaustiveness check: adding a new OnClickSchema variant must
   // also extend describeOnClick.
   const _exhaustive: never = onClick;
@@ -287,6 +343,11 @@ export function describeOnClick({
 
 /** Throws if the given OnClick includes a template with invalid syntax */
 export function validateOnClickTemplate(onClick: OnClick) {
+  if (onClick.type === 'external') {
+    validateTemplate(onClick.urlTemplate);
+    return;
+  }
+
   if (onClick.target.mode === 'template') {
     validateTemplate(onClick.target.template);
   }

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -595,7 +595,8 @@ export function convertToDashboardTemplate(
   // OnClickTargetSchema requires id.min(1), so we can't emit an empty string.
   const convertOnClickTargetIdToName = (config: SavedChartConfig) => {
     const onClick = config.onClick;
-    if (!onClick || onClick.target.mode !== 'id') return;
+    if (!onClick || onClick.type === 'external' || onClick.target.mode !== 'id')
+      return;
     const targetId = onClick.target.id;
     const name =
       onClick.type === 'search'

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -757,9 +757,16 @@ export const OnClickDashboardSchema = z.object({
 });
 export type OnClickDashboard = z.infer<typeof OnClickDashboardSchema>;
 
+export const OnClickExternalSchema = z.object({
+  type: z.literal('external'),
+  urlTemplate: z.string().min(1).max(10000),
+});
+export type OnClickExternal = z.infer<typeof OnClickExternalSchema>;
+
 export const OnClickSchema = z.discriminatedUnion('type', [
   OnClickSearchSchema,
   OnClickDashboardSchema,
+  OnClickExternalSchema,
 ]);
 export type OnClick = z.infer<typeof OnClickSchema>;
 


### PR DESCRIPTION
## Summary

Dashboard table tiles already support two row-click drill-down actions: linking to the **Search** page or to another **Dashboard**. This PR adds a third variant — **External** — that links out to an arbitrary external URL (e.g. a Grafana, Langfuse, or runbook page), generated from a user-provided Handlebars template that can reference the clicked row's column values.

The motivation is to let teams compose navigation flows that extend beyond HyperDX itself, wiring dashboard rows to the external tools they already use.

### Screenshots or video

<img width="621" height="337" alt="Screenshot 2026-06-25 at 4 23 12 PM" src="https://github.com/user-attachments/assets/4e379a4c-769c-4500-8a2b-4b22e5505ba0" />

<img width="506" height="157" alt="Screenshot 2026-06-25 at 4 23 25 PM" src="https://github.com/user-attachments/assets/3d26a8e0-807f-4290-a5f8-4ed671d919b5" />

<img width="892" height="513" alt="Screenshot 2026-06-25 at 4 23 30 PM" src="https://github.com/user-attachments/assets/32e4616f-b5a2-4c4e-ae18-21d06ef93719" />

### How to test on Vercel preview

This can be tested in the preview environment by adding a dashboard table tile and setting an on-click link with an external target.

### References

- Linear Issue: Closes HDX-4370
- Related PRs:
