### PR TITLE
chore: upgrade moduleResolution to NodeNext and simplify clickhouseProxy import

### DIFF
--- a/.changeset/nodenext-module-resolution.md
+++ b/.changeset/nodenext-module-resolution.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+chore: upgrade moduleResolution to NodeNext and simplify clickhouseProxy static import

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -15,5 +15,4 @@ module.exports = {
   moduleNameMapper: {
     '@/(.*)$': '<rootDir>/$1',
   },
-
 };

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
   moduleNameMapper: {
     '@/(.*)$': '<rootDir>/$1',
   },
+
 };

--- a/packages/api/jest.setup.ts
+++ b/packages/api/jest.setup.ts
@@ -1,5 +1,11 @@
 jest.retryTimes(1, { logErrorsBeforeRetry: true });
 
+// http-proxy-middleware v4 is ESM-only and Jest's CJS module loader cannot
+// load ESM packages. Auto-mock since no test exercises the proxy directly.
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: jest.fn(() => jest.fn()),
+}));
+
 // Suppress noisy console output during test runs.
 // - debug/info: ClickHouse query logging, server startup messages
 // - warn: expected column-not-found warnings from renderChartConfig on CTE tables

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -272,9 +272,7 @@ const proxyMiddleware: RequestHandler =
           // itself worked; outcome reflects whether ClickHouse served it.
           outcome: statusCode < 400 ? 'success' : 'error',
           durationMs:
-            typeof startedAt === 'number'
-              ? performance.now() - startedAt
-              : 0,
+            typeof startedAt === 'number' ? performance.now() - startedAt : 0,
         });
 
         // since clickhouse v24, the cors headers * will be attached to the response by default
@@ -302,9 +300,7 @@ const proxyMiddleware: RequestHandler =
           // DNS failure, ...) — a hard availability failure for the proxy.
           outcome: 'error',
           durationMs:
-            typeof startedAt === 'number'
-              ? performance.now() - startedAt
-              : 0,
+            typeof startedAt === 'number' ? performance.now() - startedAt : 0,
         });
         console.error('Proxy error:', err);
         (_res as Response).writeHead(500, {

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -1,5 +1,6 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import express, { RequestHandler, Response } from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 import { performance } from 'perf_hooks';
 import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
@@ -188,165 +189,140 @@ const getConnection: RequestHandler =
     }
   };
 
-// http-proxy-middleware v4 is ESM-only, so we use a dynamic import with a
-// cached promise to keep this CJS module compatible and avoid concurrent-init races.
-let _proxyPromise: Promise<RequestHandler> | undefined;
+const proxyMiddleware: RequestHandler =
+  // prettier-ignore-next-line
+  createProxyMiddleware({
+    target: '', // doesn't matter. it should be overridden by the router
+    changeOrigin: true,
+    pathFilter: (path, _req) => {
+      return _req.method === 'GET' || _req.method === 'POST';
+    },
+    pathRewrite: function (path, req) {
+      const sanitizedPath = validateAndSanitizePath(
+        path.replace(/^\/clickhouse-proxy/, ''),
+      );
 
-function getProxyMiddleware(): Promise<RequestHandler> {
-  if (_proxyPromise) return _proxyPromise;
+      const parsedUrl = new URL(sanitizedPath, 'http://localhost');
+      const { searchParams, pathname } = parsedUrl;
 
-  _proxyPromise = import('http-proxy-middleware').then(
-    ({ createProxyMiddleware }) =>
-      createProxyMiddleware({
-        target: '', // doesn't matter. it should be overridden by the router
-        changeOrigin: true,
-        pathFilter: (path, _req) => {
-          return _req.method === 'GET' || _req.method === 'POST';
-        },
-        pathRewrite: function (path, req) {
-          const sanitizedPath = validateAndSanitizePath(
-            path.replace(/^\/clickhouse-proxy/, ''),
+      // Append user email as custom ClickHouse setting for query log annotation if the prefix was set
+      const hyperdxSettingPrefix = req._hdx_connection?.hyperdxSettingPrefix;
+      if (hyperdxSettingPrefix) {
+        const userEmail = req.user?.email;
+        if (userEmail) {
+          const userSettingKey = `${hyperdxSettingPrefix}${CUSTOM_SETTING_KEY_SEP}${CUSTOM_SETTING_KEY_USER_SUFFIX}`;
+          searchParams.set(userSettingKey, userEmail);
+        } else {
+          logger.debug('hyperdxSettingPrefix set, no session user found');
+        }
+      }
+
+      return `${pathname}?${searchParams.toString()}`;
+    },
+    router: _req => {
+      if (!_req._hdx_connection?.host) {
+        throw new Error('[createProxyMiddleware] Connection not found');
+      }
+      return _req._hdx_connection.host;
+    },
+    on: {
+      proxyReq: (proxyReq, _req, res) => {
+        // set user-agent to the hyperdx version identifier
+        proxyReq.setHeader('user-agent', `hyperdx ${CODE_VERSION}`);
+
+        if (_req._hdx_connection?.username) {
+          proxyReq.setHeader(
+            'X-ClickHouse-User',
+            _req._hdx_connection.username,
           );
+        }
+        // Passwords can be empty
+        if (_req._hdx_connection?.password) {
+          proxyReq.setHeader('X-ClickHouse-Key', _req._hdx_connection.password);
+        }
 
-          const parsedUrl = new URL(sanitizedPath, 'http://localhost');
-          const { searchParams, pathname } = parsedUrl;
+        if (_req.method !== 'POST') {
+          console.error(`Unsupported method ${_req.method}`);
+          return res.sendStatus(405);
+        }
 
-          // Append user email as custom ClickHouse setting for query log annotation if the prefix was set
-          const hyperdxSettingPrefix =
-            req._hdx_connection?.hyperdxSettingPrefix;
-          if (hyperdxSettingPrefix) {
-            const userEmail = req.user?.email;
-            if (userEmail) {
-              const userSettingKey = `${hyperdxSettingPrefix}${CUSTOM_SETTING_KEY_SEP}${CUSTOM_SETTING_KEY_USER_SUFFIX}`;
-              searchParams.set(userSettingKey, userEmail);
-            } else {
-              logger.debug('hyperdxSettingPrefix set, no session user found');
-            }
+        let body = _req.body;
+        if (_req.headers['content-type'] === 'application/json') {
+          try {
+            body = JSON.stringify(body);
+          } catch (e) {
+            console.error(e);
           }
+        }
 
-          return `${pathname}?${searchParams.toString()}`;
-        },
-        router: _req => {
-          if (!_req._hdx_connection?.host) {
-            throw new Error('[createProxyMiddleware] Connection not found');
-          }
-          return _req._hdx_connection.host;
-        },
-        on: {
-          proxyReq: (proxyReq, _req, res) => {
-            // set user-agent to the hyperdx version identifier
-            proxyReq.setHeader('user-agent', `hyperdx ${CODE_VERSION}`);
+        try {
+          proxyReq.write(body);
+        } catch (e) {
+          console.error(
+            `clickhouseProxy error writing body, body is type ${typeof body}`,
+          );
+        }
+      },
+      proxyRes: (proxyRes, _req, res) => {
+        const startedAt = (res as Response).locals?.hdxProxyStartedAt;
+        const statusCode = proxyRes.statusCode ?? 0;
+        recordOperationOutcome({
+          operation: QUERY_PROXY_OPERATION,
+          // A response (even a 4xx/5xx from ClickHouse) means the proxy hop
+          // itself worked; outcome reflects whether ClickHouse served it.
+          outcome: statusCode < 400 ? 'success' : 'error',
+          durationMs:
+            typeof startedAt === 'number'
+              ? performance.now() - startedAt
+              : 0,
+        });
 
-            if (_req._hdx_connection?.username) {
-              proxyReq.setHeader(
-                'X-ClickHouse-User',
-                _req._hdx_connection.username,
-              );
-            }
-            // Passwords can be empty
-            if (_req._hdx_connection?.password) {
-              proxyReq.setHeader(
-                'X-ClickHouse-Key',
-                _req._hdx_connection.password,
-              );
-            }
+        // since clickhouse v24, the cors headers * will be attached to the response by default
+        // which will cause the browser to block the response
+        if (_req.headers['access-control-request-method']) {
+          proxyRes.headers['access-control-allow-methods'] =
+            _req.headers['access-control-request-method'];
+        }
 
-            if (_req.method !== 'POST') {
-              console.error(`Unsupported method ${_req.method}`);
-              return res.sendStatus(405);
-            }
+        if (_req.headers['access-control-request-headers']) {
+          proxyRes.headers['access-control-allow-headers'] =
+            _req.headers['access-control-request-headers'];
+        }
 
-            let body = _req.body;
-            if (_req.headers['content-type'] === 'application/json') {
-              try {
-                body = JSON.stringify(body);
-              } catch (e) {
-                console.error(e);
-              }
-            }
-
-            try {
-              // TODO: Use fixRequestBody after this issue is resolved: https://github.com/chimurai/http-proxy-middleware/issues/1102
-              proxyReq.write(body);
-            } catch (e) {
-              console.error(
-                `clickhouseProxy error writing body, body is type ${typeof body}`,
-              );
-            }
-          },
-          proxyRes: (proxyRes, _req, res) => {
-            const startedAt = (res as Response).locals?.hdxProxyStartedAt;
-            const statusCode = proxyRes.statusCode ?? 0;
-            recordOperationOutcome({
-              operation: QUERY_PROXY_OPERATION,
-              // A response (even a 4xx/5xx from ClickHouse) means the proxy hop
-              // itself worked; outcome reflects whether ClickHouse served it.
-              outcome: statusCode < 400 ? 'success' : 'error',
-              durationMs:
-                typeof startedAt === 'number'
-                  ? performance.now() - startedAt
-                  : 0,
-            });
-
-            // since clickhouse v24, the cors headers * will be attached to the response by default
-            // which will cause the browser to block the response
-            if (_req.headers['access-control-request-method']) {
-              proxyRes.headers['access-control-allow-methods'] =
-                _req.headers['access-control-request-method'];
-            }
-
-            if (_req.headers['access-control-request-headers']) {
-              proxyRes.headers['access-control-allow-headers'] =
-                _req.headers['access-control-request-headers'];
-            }
-
-            if (_req.headers.origin) {
-              proxyRes.headers['access-control-allow-origin'] =
-                _req.headers.origin;
-              proxyRes.headers['access-control-allow-credentials'] = 'true';
-            }
-          },
-          error: (err, _req, _res) => {
-            const startedAt = (_res as Response).locals?.hdxProxyStartedAt;
-            recordOperationOutcome({
-              operation: QUERY_PROXY_OPERATION,
-              // No usable response from ClickHouse (connection refused, timeout,
-              // DNS failure, ...) — a hard availability failure for the proxy.
-              outcome: 'error',
-              durationMs:
-                typeof startedAt === 'number'
-                  ? performance.now() - startedAt
-                  : 0,
-            });
-            console.error('Proxy error:', err);
-            (_res as Response).writeHead(500, {
-              'Content-Type': 'application/json',
-            });
-            _res.end(
-              JSON.stringify({
-                success: false,
-                error: err.message || 'Failed to connect to ClickHouse server',
-              }),
-            );
-          },
-        },
-        // ...(config.IS_DEV && {
-        //   logger: console,
-        // }),
-      }),
-  );
-
-  return _proxyPromise;
-}
-
-const proxyMiddleware: RequestHandler = async (req, res, next) => {
-  try {
-    const middleware = await getProxyMiddleware();
-    middleware(req, res, next);
-  } catch (e) {
-    next(e);
-  }
-};
+        if (_req.headers.origin) {
+          proxyRes.headers['access-control-allow-origin'] =
+            _req.headers.origin;
+          proxyRes.headers['access-control-allow-credentials'] = 'true';
+        }
+      },
+      error: (err, _req, _res) => {
+        const startedAt = (_res as Response).locals?.hdxProxyStartedAt;
+        recordOperationOutcome({
+          operation: QUERY_PROXY_OPERATION,
+          // No usable response from ClickHouse (connection refused, timeout,
+          // DNS failure, ...) — a hard availability failure for the proxy.
+          outcome: 'error',
+          durationMs:
+            typeof startedAt === 'number'
+              ? performance.now() - startedAt
+              : 0,
+        });
+        console.error('Proxy error:', err);
+        (_res as Response).writeHead(500, {
+          'Content-Type': 'application/json',
+        });
+        _res.end(
+          JSON.stringify({
+            success: false,
+            error: err.message || 'Failed to connect to ClickHouse server',
+          }),
+        );
+      },
+    },
+    // ...(config.IS_DEV && {
+    //   logger: console,
+    // }),
+  });
 
 // Stamp a start time so the proxy callbacks can record query SLO latency.
 const markProxyStart: RequestHandler = (_req, res, next) => {

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -290,8 +290,7 @@ const proxyMiddleware: RequestHandler =
         }
 
         if (_req.headers.origin) {
-          proxyRes.headers['access-control-allow-origin'] =
-            _req.headers.origin;
+          proxyRes.headers['access-control-allow-origin'] = _req.headers.origin;
           proxyRes.headers['access-control-allow-credentials'] = 'true';
         }
       },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022", "dom"],
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,


### PR DESCRIPTION
## Summary

Upgrades the base `tsconfig.json` from `Node16` to `NodeNext` module resolution and reverts the `http-proxy-middleware` import in `clickhouseProxy.ts` from a lazy dynamic `import()` back to a static top-level import.

## Motivation

After bumping `http-proxy-middleware` to v4 (ESM-only) in #2461, a dynamic import with a cached promise was used to keep CJS compatibility. With `moduleResolution: "NodeNext"`, TypeScript can resolve ESM packages via static imports, eliminating the need for the async wrapper pattern.

Ref: https://github.com/hyperdxio/hyperdx/pull/2461#discussion_r3429496145

## Changes

- **`tsconfig.base.json`** — `module` and `moduleResolution` from `Node16` → `NodeNext`
- **`clickhouseProxy.ts`** — Replace lazy `import()` + cached promise + async wrapper with a direct static `import { createProxyMiddleware }`. No functional behavior change — path rewriting, header injection, CORS handling, and error handling are identical.
- **`jest.setup.ts`** — Add global `jest.mock('http-proxy-middleware')` since the ESM-only package can't be loaded by Jest's CJS module loader. No test exercises the proxy directly.

## Testing

- `make ci-lint` — pass
- `make ci-unit` — pass (all packages)
- `make dev-int` — pass (61 suites, 1,387 tests)