### PR TITLE
[HDX] chore(otel-collector): bump base collector to v0.155.0

### DIFF
--- a/.changeset/bump-otel-collector-0-155-0.md
+++ b/.changeset/bump-otel-collector-0-155-0.md
@@ -1,0 +1,19 @@
+---
+'@hyperdx/otel-collector': minor
+---
+
+chore(otel-collector): bump base collector to v0.155.0
+
+Upgrade the custom OTel Collector base from contrib v0.154.0 (core 1.60.0) to
+v0.155.0 (core 1.61.0). Updates `OTEL_COLLECTOR_VERSION` /
+`OTEL_COLLECTOR_CORE_VERSION` in `.env`, both Dockerfile ARG defaults, and the
+smoke-test compose fallbacks.
+
+Compatibility: no config changes required. Reviewed contrib and core breaking
+changes for v0.155.0 against every component HyperDX uses. The removed
+`telemetry.UseLocalHostAsDefaultMetricsAddress` core gate has no impact because
+the telemetry metrics endpoint is set explicitly (`host: 0.0.0.0`, `port:
+8888`), and the `memory_limiter` metric rename does not affect the smoke tests
+(which assert on the startup log line and the `batch/lowlatency` metric label,
+not memory_limiter metrics). All other breaking changes are in unused components
+or internal feature-gate removals.

--- a/.env
+++ b/.env
@@ -41,8 +41,8 @@ HDX_DEV_OTEL_JSON_HTTP_PORT=14318
 # Otel Collector version (used as Docker build arg for image tags and component versions)
 # When bumping, look up the core version from the upstream manifest:
 # https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/manifest.yaml
-OTEL_COLLECTOR_VERSION=0.154.0
-OTEL_COLLECTOR_CORE_VERSION=1.60.0
+OTEL_COLLECTOR_VERSION=0.155.0
+OTEL_COLLECTOR_CORE_VERSION=1.61.0
 
 # Otel/Clickhouse config
 HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE=default

--- a/docker/hyperdx/Dockerfile
+++ b/docker/hyperdx/Dockerfile
@@ -9,8 +9,8 @@
 
 ARG NODE_VERSION=22.22
 ARG CLICKHOUSE_VERSION=26.5
-ARG OTEL_COLLECTOR_VERSION=0.154.0
-ARG OTEL_COLLECTOR_CORE_VERSION=1.60.0
+ARG OTEL_COLLECTOR_VERSION=0.155.0
+ARG OTEL_COLLECTOR_CORE_VERSION=1.61.0
 
 # base #############################################################################################
 # == Otel Collector Image ==

--- a/docker/otel-collector/Dockerfile
+++ b/docker/otel-collector/Dockerfile
@@ -1,6 +1,6 @@
 ## base #############################################################################################
-ARG OTEL_COLLECTOR_VERSION=0.154.0
-ARG OTEL_COLLECTOR_CORE_VERSION=1.60.0
+ARG OTEL_COLLECTOR_VERSION=0.155.0
+ARG OTEL_COLLECTOR_CORE_VERSION=1.61.0
 
 FROM otel/opentelemetry-collector-opampsupervisor:${OTEL_COLLECTOR_VERSION} AS supervisor
 FROM hairyhenderson/gomplate:v4.3.3-alpine AS gomplate

--- a/smoke-tests/otel-collector/docker-compose.yaml
+++ b/smoke-tests/otel-collector/docker-compose.yaml
@@ -24,8 +24,8 @@ services:
       dockerfile: docker/otel-collector/Dockerfile
       target: dev
       args:
-        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.154.0}
-        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.60.0}
+        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.155.0}
+        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.61.0}
     environment:
       - CLICKHOUSE_ENDPOINT=tcp://ch-server:9000?dial_timeout=10s
       - CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT=ch-server:9363
@@ -55,8 +55,8 @@ services:
       dockerfile: docker/otel-collector/Dockerfile
       target: dev
       args:
-        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.154.0}
-        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.60.0}
+        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.155.0}
+        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.61.0}
     environment:
       - CLICKHOUSE_ENDPOINT=tcp://ch-server:9000?dial_timeout=10s
       - CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT=ch-server:9363
@@ -86,8 +86,8 @@ services:
       dockerfile: docker/otel-collector/Dockerfile
       target: dev
       args:
-        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.154.0}
-        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.60.0}
+        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.155.0}
+        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.61.0}
     environment:
       - CLICKHOUSE_ENDPOINT=tcp://ch-server:9000?dial_timeout=10s
       - CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT=ch-server:9363
@@ -136,8 +136,8 @@ services:
       dockerfile: docker/otel-collector/Dockerfile
       target: dev
       args:
-        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.154.0}
-        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.60.0}
+        OTEL_COLLECTOR_VERSION: ${OTEL_COLLECTOR_VERSION:-0.155.0}
+        OTEL_COLLECTOR_CORE_VERSION: ${OTEL_COLLECTOR_CORE_VERSION:-1.61.0}
     environment:
       - CLICKHOUSE_ENDPOINT=tcp://ch-server-compat:9000?dial_timeout=10s
       - CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT=ch-server-compat:9363


### PR DESCRIPTION
## What

Bumps the custom OTel Collector base from contrib **v0.154.0** (core 1.60.0) to **v0.155.0** (core **1.61.0**).

The core version `1.61.0` comes from the `providers:` section of the [upstream contrib v0.155.0 manifest](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/v0.155.0/distributions/otelcol-contrib/manifest.yaml).

### Files changed
- `.env` — primary source of truth for the build args
- `docker/otel-collector/Dockerfile` — ARG defaults
- `docker/hyperdx/Dockerfile` — ARG defaults
- `smoke-tests/otel-collector/docker-compose.yaml` — 4 fallback default pairs
- `.changeset/` — minor bump for `@hyperdx/otel-collector`

`builder-config.yaml` uses build-time placeholders and the dev/CI compose files read from `.env`, so they need no edits.

## Why

Routine base-version upgrade to pick up upstream fixes and component updates. Follows the v0.154.0 bump (#2512).

## Compatibility

No config changes required. Reviewed **contrib and core** breaking changes for v0.155.0 against every component HyperDX actually uses (`docker/otel-collector/config*.yaml`, `config.standalone.promql.yaml`, and the dynamically-generated config in `opampController.ts`):

| Upstream change | Source | Impact |
|---|---|---|
| Removed `telemetry.UseLocalHostAsDefaultMetricsAddress` gate | core | **None** — `config.yaml` sets telemetry metrics `host: 0.0.0.0` / `port: 8888` explicitly (modern `readers` syntax), so the default address is irrelevant |
| `memory_limiter` metrics renamed to `otelcol_processor_memory_limiter_*` | core | **None** — the custom-pipeline smoke test asserts on the `"Memory limiter configured"` startup log and the `processor="batch/lowlatency"` metric label, not on any `memory_limiter` metric |
| Other core gate removals (confighttp, configoptional, confmap, exporterhelper, xpdata, otelcol) | core | **None** — internal feature-gate cleanups |
| signalfx / datadog / mongodb / oracledb changes | contrib | **None** — components not used |
| k8sattributes / tailsampling / fileconsumer stable-gate removals | contrib | **None** — gates not set; processors not in HyperDX configs |
| `flinkmetrics` / `splunkenterprise` renames (deprecated aliases) | contrib | **None** — not used |

**Prerequisites verified:** Docker base images `opentelemetry-collector-builder:0.155.0` and `opentelemetry-collector-opampsupervisor:0.155.0` both exist; Go 1.26-alpine (already in the Dockerfiles) satisfies the new modules.

## Verify

\`\`\`bash
docker build -f docker/otel-collector/Dockerfile --target dev -t hdx-otel-test .
docker run --rm --entrypoint /otelcontribcol hdx-otel-test --version
docker rmi hdx-otel-test
\`\`\`