### PR TITLE
feat(app): support ratio mode on number chart tiles

### DIFF
--- a/.changeset/ratio-number-tiles.md
+++ b/.changeset/ratio-number-tiles.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": minor
+---
+
+Number chart tiles now support a second series with the "As Ratio" toggle (`series[0] / series[1]`), matching line and bar charts. Combined with a `percent` number format, this renders a percentage (e.g. success/error rate) as a single big number with the trend sparkline behind it.

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -1036,12 +1036,13 @@ describe('validateChartForm', () => {
 
   // ── Number / Pie single-series validation ────────────────────────────
 
-  it('allows a Number chart with two series (ratio mode)', () => {
+  it('allows a Number chart with two series in ratio mode', () => {
     const setError = jest.fn();
     const errors = validateChartForm(
       makeForm({
         displayType: DisplayType.Number,
         source: 'source-log',
+        seriesReturnType: 'ratio',
         series: [seriesItem, seriesItem],
       }),
       logSource,
@@ -1052,12 +1053,54 @@ describe('validateChartForm', () => {
     );
   });
 
-  it('errors when Number chart has more than two series', () => {
+  it('errors when Number chart has two series without ratio mode', () => {
     const setError = jest.fn();
     const errors = validateChartForm(
       makeForm({
         displayType: DisplayType.Number,
         source: 'source-log',
+        seriesReturnType: 'column',
+        series: [seriesItem, seriesItem],
+      }),
+      logSource,
+      setError,
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        path: 'series',
+        message:
+          'Number charts support a single series unless ratio mode (As Ratio) is enabled',
+      }),
+    );
+  });
+
+  it('errors when Number chart has two series and seriesReturnType is unset', () => {
+    const setError = jest.fn();
+    const errors = validateChartForm(
+      makeForm({
+        displayType: DisplayType.Number,
+        source: 'source-log',
+        series: [seriesItem, seriesItem],
+      }),
+      logSource,
+      setError,
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        path: 'series',
+        message:
+          'Number charts support a single series unless ratio mode (As Ratio) is enabled',
+      }),
+    );
+  });
+
+  it('errors when Number chart has more than two series in ratio mode', () => {
+    const setError = jest.fn();
+    const errors = validateChartForm(
+      makeForm({
+        displayType: DisplayType.Number,
+        source: 'source-log',
+        seriesReturnType: 'ratio',
         series: [seriesItem, seriesItem, seriesItem],
       }),
       logSource,

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -1036,7 +1036,7 @@ describe('validateChartForm', () => {
 
   // ── Number / Pie single-series validation ────────────────────────────
 
-  it('errors when Number chart has more than one series', () => {
+  it('allows a Number chart with two series (ratio mode)', () => {
     const setError = jest.fn();
     const errors = validateChartForm(
       makeForm({
@@ -1047,10 +1047,26 @@ describe('validateChartForm', () => {
       logSource,
       setError,
     );
+    expect(errors).not.toContainEqual(
+      expect.objectContaining({ path: 'series' }),
+    );
+  });
+
+  it('errors when Number chart has more than two series', () => {
+    const setError = jest.fn();
+    const errors = validateChartForm(
+      makeForm({
+        displayType: DisplayType.Number,
+        source: 'source-log',
+        series: [seriesItem, seriesItem, seriesItem],
+      }),
+      logSource,
+      setError,
+    );
     expect(errors).toContainEqual(
       expect.objectContaining({
         path: 'series',
-        message: `Only one series is allowed for ${DisplayType.Number} charts`,
+        message: 'Number charts support at most two series (ratio mode)',
       }),
     );
   });
@@ -1271,12 +1287,14 @@ describe('validateChartForm', () => {
         series: [
           { ...seriesItem, aggFn: 'sum', valueExpression: '' },
           { ...seriesItem, aggFn: 'avg', valueExpression: '' },
+          { ...seriesItem, aggFn: 'avg', valueExpression: '' },
         ],
       }),
       logSource,
       setError,
     );
-    // Should have: source error + 2 valueExpression errors + series count error
+    // Should have: source error + 3 valueExpression errors + series count error
+    // (Number charts allow up to two series, so three trips the count rule)
     expect(errors).toContainEqual(expect.objectContaining({ path: 'source' }));
     expect(errors).toContainEqual(
       expect.objectContaining({ path: 'series.0.valueExpression' }),
@@ -1284,8 +1302,11 @@ describe('validateChartForm', () => {
     expect(errors).toContainEqual(
       expect.objectContaining({ path: 'series.1.valueExpression' }),
     );
+    expect(errors).toContainEqual(
+      expect.objectContaining({ path: 'series.2.valueExpression' }),
+    );
     expect(errors).toContainEqual(expect.objectContaining({ path: 'series' }));
-    expect(errors).toHaveLength(4);
+    expect(errors).toHaveLength(5);
   });
 
   it('calls setError for every accumulated error', () => {

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -402,11 +402,14 @@ export const validateChartForm = (
     !isRawSqlChart &&
     Array.isArray(form.series) &&
     form.displayType === DisplayType.Number &&
-    form.series.length > 2
+    form.series.length > (form.seriesReturnType === 'ratio' ? 2 : 1)
   ) {
     errors.push({
       path: `series`,
-      message: 'Number charts support at most two series (ratio mode)',
+      message:
+        form.seriesReturnType === 'ratio'
+          ? 'Number charts support at most two series (ratio mode)'
+          : 'Number charts support a single series unless ratio mode (As Ratio) is enabled',
     });
   }
 

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -381,18 +381,32 @@ export const validateChartForm = (
     }
   }
 
-  // Validate number, pie, and heatmap charts only have one series
+  // Validate pie and heatmap charts only have one series
   if (
     !isRawSqlChart &&
     Array.isArray(form.series) &&
-    (form.displayType === DisplayType.Number ||
-      form.displayType === DisplayType.Pie ||
+    (form.displayType === DisplayType.Pie ||
       form.displayType === DisplayType.Heatmap) &&
     form.series.length > 1
   ) {
     errors.push({
       path: `series`,
       message: `Only one series is allowed for ${form.displayType} charts`,
+    });
+  }
+
+  // Number charts allow a second series only for ratio mode (numerator /
+  // denominator, which can be shown as a percentage via the number format);
+  // otherwise they show a single value.
+  if (
+    !isRawSqlChart &&
+    Array.isArray(form.series) &&
+    form.displayType === DisplayType.Number &&
+    form.series.length > 2
+  ) {
+    errors.push({
+      path: `series`,
+      message: 'Number charts support at most two series (ratio mode)',
     });
   }
 

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -267,25 +267,25 @@ export function ChartEditorControls({
                   Add Series
                 </Button>
               )}
-              {fields.length === 2 &&
-                (displayType === DisplayType.Line ||
-                  displayType === DisplayType.StackedBar ||
-                  displayType === DisplayType.Number) && (
-                  <Switch
-                    label="As Ratio"
-                    size="sm"
-                    color="gray"
-                    variant="subtle"
-                    onClick={() => {
-                      setValue(
-                        'seriesReturnType',
-                        seriesReturnType === 'ratio' ? 'column' : 'ratio',
-                      );
-                      onSubmit();
-                    }}
-                    checked={seriesReturnType === 'ratio'}
-                  />
-                )}
+              {/* Ratio merges exactly two series via divide(); only
+                  Line/StackedBar/Table/Number can reach two series, so gating
+                  on the count alone covers them all (Number included). */}
+              {fields.length === 2 && (
+                <Switch
+                  label="As Ratio"
+                  size="sm"
+                  color="gray"
+                  variant="subtle"
+                  onClick={() => {
+                    setValue(
+                      'seriesReturnType',
+                      seriesReturnType === 'ratio' ? 'column' : 'ratio',
+                    );
+                    onSubmit();
+                  }}
+                  checked={seriesReturnType === 'ratio'}
+                />
+              )}
               {(displayType === DisplayType.Line ||
                 displayType === DisplayType.StackedBar ||
                 displayType === DisplayType.Number) &&

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -97,9 +97,11 @@ export function ChartEditorControls({
   openHeatmapSettings,
 }: ChartEditorControlsProps) {
   const canAddSeries =
-    displayType !== DisplayType.Number &&
     displayType !== DisplayType.Pie &&
-    displayType !== DisplayType.Heatmap;
+    displayType !== DisplayType.Heatmap &&
+    // Number tiles support up to two series (numerator + denominator for
+    // ratio mode); Line/Table types remain unbounded.
+    !(displayType === DisplayType.Number && fields.length >= 2);
   const [isSourceSchemaPreviewOpen, setIsSourceSchemaPreviewOpen] =
     useState(false);
 
@@ -265,22 +267,25 @@ export function ChartEditorControls({
                   Add Series
                 </Button>
               )}
-              {fields.length == 2 && displayType !== DisplayType.Number && (
-                <Switch
-                  label="As Ratio"
-                  size="sm"
-                  color="gray"
-                  variant="subtle"
-                  onClick={() => {
-                    setValue(
-                      'seriesReturnType',
-                      seriesReturnType === 'ratio' ? 'column' : 'ratio',
-                    );
-                    onSubmit();
-                  }}
-                  checked={seriesReturnType === 'ratio'}
-                />
-              )}
+              {fields.length === 2 &&
+                (displayType === DisplayType.Line ||
+                  displayType === DisplayType.StackedBar ||
+                  displayType === DisplayType.Number) && (
+                  <Switch
+                    label="As Ratio"
+                    size="sm"
+                    color="gray"
+                    variant="subtle"
+                    onClick={() => {
+                      setValue(
+                        'seriesReturnType',
+                        seriesReturnType === 'ratio' ? 'column' : 'ratio',
+                      );
+                      onSubmit();
+                    }}
+                    checked={seriesReturnType === 'ratio'}
+                  />
+                )}
               {(displayType === DisplayType.Line ||
                 displayType === DisplayType.StackedBar ||
                 displayType === DisplayType.Number) &&


### PR DESCRIPTION
## Why

Number chart tiles only supported a single series, so there was no way to show a percentage (e.g. success/error rate, SLO compliance) as a single big number. Line and bar charts could already combine two series with the "As Ratio" toggle (`series[0] / series[1]`) and render the result as a percentage via a `percent` number format, number tiles could not.

This brings number tiles to parity with the smallest possible change.

## What

- **`ChartEditorControls`** — the "As Ratio" toggle is now shown for Number tiles (in addition to line/bar), and a Number tile can add a second series (capped at two).
- **`ChartEditor/utils.ts`** — form validation now allows up to two series for number charts instead of hard-capping at one. Pie and heatmap remain single-series.
- Tests updated accordingly.

<img width="1080" height="696" alt="CleanShot 2026-06-28 at 19 03 25@2x" src="https://github.com/user-attachments/assets/84fae57f-0bdb-4f40-8c54-c6c2828fa368" />


No new query semantics: ratio on a number tile reuses the existing `divide(a, b)` rendering path and the existing background sparkline, both of which already handle ratio configs generically. To display the value as a percentage, set the tile's output format to **Percentage** in display settings.

## How to use

1. Add a Number tile, add a second series (numerator, then denominator).
2. Enable **As Ratio**.
3. In display settings, set the output format to **Percentage**.

The big number shows e.g. `99.95%`, with the trend sparkline behind it.

## Testing

- `make ci-lint` — passes across all packages.
- `packages/app` unit tests for `validateChartForm` updated and passing (80/80).
