### PR TITLE
feat: Add Known Columns List setting for distributed tables

### DIFF
--- a/.changeset/spotty-roses-cheer.md
+++ b/.changeset/spotty-roses-cheer.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+feat: Add Known Columns List setting for distributed tables

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3480,6 +3480,12 @@
             "nullable": true,
             "example": "Body"
           },
+          "knownColumnsListExpression": {
+            "type": "string",
+            "description": "For Distributed table sources whose target tables have non-matching column sets. A list of columns supported across all target tables, used instead of SELECT * when fetching full row data. Leave blank to select all columns.",
+            "nullable": true,
+            "example": "Timestamp, Body, ServiceName"
+          },
           "useTextIndexForImplicitColumn": {
             "type": "string",
             "enum": [
@@ -3705,6 +3711,12 @@
             "description": "Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log.",
             "nullable": true,
             "example": "SpanName"
+          },
+          "knownColumnsListExpression": {
+            "type": "string",
+            "description": "For Distributed table sources whose target tables have non-matching column sets. A list of columns supported across all target tables, used instead of SELECT * when fetching full row data. Leave blank to select all columns.",
+            "nullable": true,
+            "example": "Timestamp, Body, ServiceName"
           },
           "useTextIndexForImplicitColumn": {
             "type": "string",

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -144,6 +144,7 @@ export const LogSource = Source.discriminator<ILogSource>(
     traceIdExpression: String,
     spanIdExpression: String,
     implicitColumnExpression: String,
+    knownColumnsListExpression: String,
     useTextIndexForImplicitColumn: {
       type: String,
       enum: Object.values(UseTextIndex),
@@ -197,6 +198,7 @@ export const TraceSource = Source.discriminator<ITraceSource>(
     eventAttributesExpression: String,
     spanEventsValueExpression: String,
     implicitColumnExpression: String,
+    knownColumnsListExpression: String,
     useTextIndexForImplicitColumn: {
       type: String,
       enum: Object.values(UseTextIndex),

--- a/packages/api/src/routers/external-api/v2/sources.ts
+++ b/packages/api/src/routers/external-api/v2/sources.ts
@@ -360,6 +360,11 @@ function formatExternalSource(source: SourceDocument) {
  *           description: Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log.
  *           nullable: true
  *           example: Body
+ *         knownColumnsListExpression:
+ *           type: string
+ *           description: For Distributed table sources whose target tables have non-matching column sets. A list of columns supported across all target tables, used instead of SELECT * when fetching full row data. Leave blank to select all columns.
+ *           nullable: true
+ *           example: Timestamp, Body, ServiceName
  *         useTextIndexForImplicitColumn:
  *           type: string
  *           enum: [auto, enabled, disabled]
@@ -538,6 +543,11 @@ function formatExternalSource(source: SourceDocument) {
  *           description: Column used for full text search if no property is specified in a Lucene-based search. Typically the message body of a log.
  *           nullable: true
  *           example: SpanName
+ *         knownColumnsListExpression:
+ *           type: string
+ *           description: For Distributed table sources whose target tables have non-matching column sets. A list of columns supported across all target tables, used instead of SELECT * when fetching full row data. Leave blank to select all columns.
+ *           nullable: true
+ *           example: Timestamp, Body, ServiceName
  *         useTextIndexForImplicitColumn:
  *           type: string
  *           enum: [auto, enabled, disabled]

--- a/packages/app/src/components/DBRowDataPanel.tsx
+++ b/packages/app/src/components/DBRowDataPanel.tsx
@@ -63,12 +63,21 @@ export function useRowData({
         )
       : [];
 
+  // `SELECT *` can fail against a Distributed/Merge table whose underlying
+  // target tables declare different column sets. When the source declares a
+  // "known columns" list (columns known to exist across all target tables) we
+  // select that instead of `*` when fetching full row data.
+  const knownColumns =
+    isLogSource(source) || isTraceSource(source)
+      ? source.knownColumnsListExpression?.trim()
+      : undefined;
+
   const queryResult = useQueriedChartConfig(
     {
       connection: source.connection,
       select: [
         {
-          valueExpression: '*',
+          valueExpression: knownColumns || '*',
         },
         {
           valueExpression: getDisplayedTimestampValueExpression(source),

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -42,6 +42,7 @@ import ContextSubpanel from './ContextSidePanel';
 import DBInfraPanel from './DBInfraPanel';
 import { RowDataPanel, rowHasK8sContext, useRowData } from './DBRowDataPanel';
 import { RowOverviewPanel } from './DBRowOverviewPanel';
+import { DBRowSidePanelErrorState } from './DBRowSidePanelErrorState';
 import { DBSessionPanel, useSessionId } from './DBSessionPanel';
 import DBTracePanel from './DBTracePanel';
 import { INITIAL_DRAWER_WIDTH_PERCENT } from './DrawerUtils';
@@ -120,6 +121,8 @@ const DBRowSidePanel = ({
     data: rowData,
     isLoading: isRowLoading,
     isSuccess: isRowSuccess,
+    isError: isRowError,
+    error: rowError,
   } = useRowData({
     source,
     rowId,
@@ -308,6 +311,13 @@ const DBRowSidePanel = ({
   }
 
   if (!isRowSuccess) {
+    if (isRowError && rowError) {
+      return (
+        <Box p="sm" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+          <DBRowSidePanelErrorState error={rowError} source={source} />
+        </Box>
+      );
+    }
     return <div className={styles.loadingState}>Error loading row data</div>;
   }
 

--- a/packages/app/src/components/DBRowSidePanelErrorState.tsx
+++ b/packages/app/src/components/DBRowSidePanelErrorState.tsx
@@ -1,0 +1,138 @@
+import Link from 'next/link';
+import {
+  ClickHouseQueryError,
+  isMissingColumnError,
+} from '@hyperdx/common-utils/dist/clickhouse';
+import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
+import {
+  isLogSource,
+  isTraceSource,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
+import { Alert, Anchor, Button, Code, Modal, Stack, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+import { IS_LOCAL_MODE } from '@/config';
+import { useTableMetadata } from '@/hooks/useMetadata';
+
+import { TableSourceForm } from './Sources/SourceForm';
+import { SQLPreview } from './ChartSQLPreview';
+
+/** A hint to the user that setting the Known Columns List may resolve SELECT * failures on Distributed or Merge tables */
+function KnownColumnsListHint({
+  onEditClick,
+  source,
+}: {
+  onEditClick?: () => void;
+  source: TSource;
+}) {
+  const hasKnownColumnsList =
+    (isLogSource(source) || isTraceSource(source)) &&
+    !!source.knownColumnsListExpression;
+
+  const message = hasKnownColumnsList ? (
+    <>
+      This query may have failed due to an invalid <b>Known Columns List</b>{' '}
+      configuration. Check the <b>Known Columns List</b> for this source and
+      ensure that it references valid columns that exist in all target tables of
+      the Distributed or Merge table.
+    </>
+  ) : (
+    <>
+      This query may have failed due to a{' '}
+      <Text span ff="monospace">
+        SELECT *
+      </Text>{' '}
+      query on a Distributed table that declares columns missing in one or more
+      of its target tables. If this is the case, the{' '}
+      <Text span ff="monospace">
+        SELECT *
+      </Text>{' '}
+      can be overridden by setting a <b>Known Columns List</b> for this source.
+    </>
+  );
+
+  return (
+    <Alert
+      color="yellow"
+      icon={<IconAlertTriangle size={16} />}
+      title="SELECT * failure on Distributed or Merge table"
+    >
+      <Stack gap="xs" align="start">
+        <Text size="sm">{message}</Text>
+        {IS_LOCAL_MODE ? (
+          <Button size="xs" variant="subtle" onClick={onEditClick}>
+            Edit source settings
+          </Button>
+        ) : (
+          <Anchor
+            component={Link}
+            href={`/team?source=${source.id}#sources`}
+            size="sm"
+          >
+            Edit source settings
+          </Anchor>
+        )}
+      </Stack>
+    </Alert>
+  );
+}
+
+export function DBRowSidePanelErrorState({
+  error,
+  source,
+}: {
+  error: Error | ClickHouseQueryError;
+  source: TSource;
+}) {
+  const [editOpened, editModal] = useDisclosure(false);
+  const { data: tableMetadata } = useTableMetadata(tcFromSource(source));
+
+  const showHint =
+    isMissingColumnError(error) && !!tableMetadata?.isPointerTable;
+
+  return (
+    <Stack gap="sm">
+      <Text>Error loading row data</Text>
+
+      {showHint && (
+        <KnownColumnsListHint onEditClick={editModal.open} source={source} />
+      )}
+
+      <Stack align="start">
+        <Text size="sm" mt={10}>
+          Error Message:
+        </Text>
+        <Code
+          flex={1}
+          block
+          style={{
+            whiteSpace: 'pre-wrap',
+            maxWidth: '100%',
+          }}
+        >
+          {error.message}
+        </Code>
+        {error instanceof ClickHouseQueryError && (
+          <>
+            <Text size="sm" ta="center">
+              Sent Query:
+            </Text>
+            <SQLPreview data={error?.query} enableLineWrapping enableCopy />
+          </>
+        )}
+      </Stack>
+      {IS_LOCAL_MODE && (
+        <Modal
+          opened={editOpened}
+          onClose={editModal.close}
+          title="Edit Source"
+          size="xl"
+        >
+          <TableSourceForm sourceId={source.id} onSave={editModal.close} />
+        </Modal>
+      )}
+    </Stack>
+  );
+}

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -1458,6 +1458,22 @@ function LogTableModelForm(props: TableModelProps) {
           sourceKind={SourceKind.Log}
           tableConnection={tableConnection}
         />
+        <FormRow
+          label={'Known Columns List'}
+          helpText="For Distributed table sources whose target tables have non-matching column sets. Provide a list of columns supported across all target tables; it is used instead of SELECT * when fetching full row data (e.g. the row side panel). Leave blank to select all columns. This should be a comma-separated list of column names - do not include non-column expressions or aliases."
+        >
+          <SQLInlineEditorControlled
+            tableConnection={{
+              databaseName,
+              tableName,
+              connectionId,
+            }}
+            control={control}
+            name="knownColumnsListExpression"
+            placeholder="Timestamp, Body, ServiceName"
+            disableKeywordAutocomplete
+          />
+        </FormRow>
         <UseTextIndexFormRow control={control} />
         <Divider />
         <HighlightedAttributeExpressionsFormRow
@@ -1801,6 +1817,22 @@ function TraceTableModelForm(props: TableModelProps) {
         sourceKind={SourceKind.Trace}
         tableConnection={tableConnection}
       />
+      <FormRow
+        label={'Known Columns List'}
+        helpText="For Distributed table sources whose target tables have non-matching column sets. Provide a list of columns supported across all target tables; it is used instead of SELECT * when fetching full row data (e.g. the row side panel). Leave blank to select all columns. This should be a comma-separated list of column names - do not include non-column expressions or aliases."
+      >
+        <SQLInlineEditorControlled
+          tableConnection={{
+            databaseName,
+            tableName,
+            connectionId,
+          }}
+          control={control}
+          name="knownColumnsListExpression"
+          placeholder="Timestamp, Body, ServiceName"
+          disableKeywordAutocomplete
+        />
+      </FormRow>
       <UseTextIndexFormRow control={control} />
       <FormRow
         label={'Displayed Timestamp Column'}

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -179,6 +179,8 @@ function setCorrelationFieldValue(
 }
 
 const DEFAULT_DATABASE = 'default';
+const KNOWN_COLUMNS_EXPRESSION_HELP_TEXT =
+  'For Distributed table sources whose target tables have non-matching column sets. Provide a list of columns supported across all target tables; it is used instead of SELECT * when fetching full row data (e.g. the row side panel). Leave blank to select all columns. This should be a comma-separated list of column names - do not include non-column expressions or aliases.';
 
 // Placeholder written into from.databaseName / from.tableName when the
 // selected connection is Prometheus-only.
@@ -1460,7 +1462,7 @@ function LogTableModelForm(props: TableModelProps) {
         />
         <FormRow
           label={'Known Columns List'}
-          helpText="For Distributed table sources whose target tables have non-matching column sets. Provide a list of columns supported across all target tables; it is used instead of SELECT * when fetching full row data (e.g. the row side panel). Leave blank to select all columns. This should be a comma-separated list of column names - do not include non-column expressions or aliases."
+          helpText={KNOWN_COLUMNS_EXPRESSION_HELP_TEXT}
         >
           <SQLInlineEditorControlled
             tableConnection={{
@@ -1819,7 +1821,7 @@ function TraceTableModelForm(props: TableModelProps) {
       />
       <FormRow
         label={'Known Columns List'}
-        helpText="For Distributed table sources whose target tables have non-matching column sets. Provide a list of columns supported across all target tables; it is used instead of SELECT * when fetching full row data (e.g. the row side panel). Leave blank to select all columns. This should be a comma-separated list of column names - do not include non-column expressions or aliases."
+        helpText={KNOWN_COLUMNS_EXPRESSION_HELP_TEXT}
       >
         <SQLInlineEditorControlled
           tableConnection={{

--- a/packages/app/src/components/__tests__/DBRowDataPanel.test.ts
+++ b/packages/app/src/components/__tests__/DBRowDataPanel.test.ts
@@ -1,9 +1,46 @@
+import { SourceKind, TLogSource } from '@hyperdx/common-utils/dist/types';
+import { renderHook } from '@testing-library/react';
+
 import {
   getJSONColumnNames,
   getMapColumnNames,
+  useRowData,
 } from '@/components/DBRowDataPanel';
+import { useQueriedChartConfig } from '@/hooks/useChartConfig';
+
+jest.mock('@/hooks/useChartConfig', () => ({
+  useQueriedChartConfig: jest.fn(),
+}));
+
+const mockUseQueriedChartConfig = useQueriedChartConfig as jest.Mock;
 
 describe('DBRowDataPanel', () => {
+  const source: TLogSource = {
+    id: 'source-id',
+    kind: SourceKind.Log,
+    name: 'logs',
+    connection: 'conn-id',
+    from: { databaseName: 'default', tableName: 'logs' },
+    timestampValueExpression: 'Timestamp',
+    defaultTableSelectExpression: 'Timestamp, Body',
+    bodyExpression: 'Body',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQueriedChartConfig.mockReturnValue({
+      data: {
+        data: [],
+        meta: [],
+        rows: 0,
+        isComplete: true,
+      },
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+    });
+  });
+
   describe('getJSONColumnNames', () => {
     it('should return JSON column names', () => {
       const meta = [
@@ -14,6 +51,30 @@ describe('DBRowDataPanel', () => {
       const result = getJSONColumnNames(meta);
       expect(result).toEqual(['col2', 'col3']);
     });
+  });
+
+  it('selects `*` when the source has no Known Columns List', () => {
+    renderHook(() => useRowData({ source, rowId: "id='abc123'" }));
+
+    const [config] = mockUseQueriedChartConfig.mock.calls[0];
+    expect(config.select[0]).toEqual({ valueExpression: '*' });
+  });
+
+  it('selects the Known Columns List instead of `*` when set', () => {
+    const sourceWithKnownColumns: TLogSource = {
+      ...source,
+      knownColumnsListExpression: 'Timestamp, Body, ServiceName',
+    };
+
+    renderHook(() =>
+      useRowData({ source: sourceWithKnownColumns, rowId: "id='abc123'" }),
+    );
+
+    const [config] = mockUseQueriedChartConfig.mock.calls[0];
+    expect(config.select[0]).toEqual({
+      valueExpression: 'Timestamp, Body, ServiceName',
+    });
+    expect(config.select).not.toContainEqual({ valueExpression: '*' });
   });
 
   // Regression test for the OSS #2357 conflict-resolution merge. The

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -89,7 +89,10 @@ export function useColumns(
 ) {
   const metadata = useMetadataWithSettings();
   return useQuery<ColumnMeta[]>({
-    queryKey: ['useMetadata.useColumns', { databaseName, tableName }],
+    queryKey: [
+      'useMetadata.useColumns',
+      { connectionId, databaseName, tableName },
+    ],
     queryFn: async () => {
       return metadata.getColumns({
         databaseName,
@@ -297,7 +300,10 @@ export function useTableMetadata(
 ) {
   const metadata = useMetadataWithSettings();
   return useQuery<TableMetadata | undefined>({
-    queryKey: ['useMetadata.useTableMetadata', { databaseName, tableName }],
+    queryKey: [
+      'useMetadata.useTableMetadata',
+      { connectionId, databaseName, tableName },
+    ],
     queryFn: async () => {
       return await metadata.getTableMetadata({
         databaseName,

--- a/packages/common-utils/src/__tests__/metadata.test.ts
+++ b/packages/common-utils/src/__tests__/metadata.test.ts
@@ -213,6 +213,58 @@ describe('Metadata', () => {
       expect(result!.partition_key).toEqual('column1');
     });
 
+    it('does not set isPointerTable for tables that hold their own data', async () => {
+      const mockTableMetadata = {
+        database: 'test_db',
+        name: 'test_table',
+        engine: 'MergeTree',
+        engine_full: 'MergeTree() ORDER BY id',
+        partition_key: 'column1',
+        sorting_key: 'column2',
+        primary_key: 'column3',
+      };
+
+      (mockClickhouseClient.query as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          data: [mockTableMetadata],
+        }),
+      });
+
+      const result = await metadata.getTableMetadata({
+        databaseName: 'test_db',
+        tableName: 'test_table',
+        connectionId: 'test_connection',
+      });
+
+      expect(result!.isPointerTable).toBeFalsy();
+    });
+
+    it('sets isPointerTable for a Merge table', async () => {
+      const mockTableMetadata = {
+        database: 'test_db',
+        name: 'merge_table',
+        engine: 'Merge',
+        engine_full: "Merge('test_db', '^events_')",
+        partition_key: '',
+        sorting_key: '',
+        primary_key: '',
+      };
+
+      (mockClickhouseClient.query as jest.Mock).mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          data: [mockTableMetadata],
+        }),
+      });
+
+      const result = await metadata.getTableMetadata({
+        databaseName: 'test_db',
+        tableName: 'merge_table',
+        connectionId: 'test_connection',
+      });
+
+      expect(result!.isPointerTable).toBe(true);
+    });
+
     it('should query via cluster() for Distributed table underlying metadata', async () => {
       const distributedMetadata = {
         database: 'test_db',

--- a/packages/common-utils/src/clickhouse/__tests__/index.test.ts
+++ b/packages/common-utils/src/clickhouse/__tests__/index.test.ts
@@ -1,8 +1,47 @@
 import {
+  ClickHouseQueryError,
   convertCHDataTypeToJSType,
   extractColumnReferencesFromKey,
+  isMissingColumnError,
   JSDataType,
 } from '@/clickhouse';
+
+describe('isMissingColumnError', () => {
+  it.each([
+    'Code: 47. DB::Exception: Unknown identifier: foo',
+    'DB::Exception: Unknown expression identifier `bar`',
+    'UNKNOWN_IDENTIFIER',
+    'Missing columns: baz while processing query',
+    'Code: 16. NO_SUCH_COLUMN_IN_TABLE',
+    'There is no column with name qux',
+    'There is no column with name qux',
+    "Identifier '__table1.skip_indices' cannot be resolved from table with name __table1.",
+  ])('returns true for missing-column error: %s', msg => {
+    expect(isMissingColumnError(new Error(msg))).toBe(true);
+  });
+
+  it('detects the error via a ClickHouseQueryError instance', () => {
+    expect(
+      isMissingColumnError(
+        new ClickHouseQueryError('Missing columns: foo', 'SELECT * FROM t'),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    'Code: 60. DB::Exception: Table default.foo does not exist',
+    'Syntax error: failed at position 10',
+    'Timeout exceeded',
+    '',
+  ])('returns false for unrelated error: %s', msg => {
+    expect(isMissingColumnError(new Error(msg))).toBe(false);
+  });
+
+  it('handles non-Error inputs', () => {
+    expect(isMissingColumnError(undefined)).toBe(false);
+    expect(isMissingColumnError('Unknown identifier: x')).toBe(true);
+  });
+});
 
 describe('extractColumnReferencesFromKey', () => {
   // Suppress expected console.error from parse failures in edge-case tests

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -300,6 +300,19 @@ export class ClickHouseQueryError extends Error {
 }
 
 /**
+ * Heuristically detects whether a query error is a ClickHouse "missing/unknown
+ * column" error. Useful for surfacing actionable hints (e.g. when a `SELECT *`
+ * against a Distributed/Merge table references a column absent from some target
+ * tables).
+ */
+export function isMissingColumnError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error ?? '');
+  return /Unknown (expression|identifier)|UNKNOWN_IDENTIFIER|Missing columns|NO_SUCH_COLUMN_IN_TABLE|There is no column|cannot be resolved/i.test(
+    msg,
+  );
+}
+
+/**
  * Returns columns referenced in given expression, where the expression is a comma-separated list of SQL expressions
  * E.g. "id, toStartOfInterval(timestamp, toIntervalDay(3)), user_id, json.a.b".
  */

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -154,6 +154,12 @@ export type TableMetadata = {
   create_table_query: string;
   /** DDL for the local (non-distributed) table, when the table is Distributed */
   create_local_table_query?: string;
+  /**
+   * True when the queried table routes to other tables rather than holding its
+   * own data — i.e. a Distributed or Merge table (whose underlying target
+   * tables may declare differing column sets).
+   **/
+  isPointerTable?: boolean;
   /** Note: This will contain the engine_full of the local table, when the table is Distributed */
   engine_full: string;
   as_select: string;
@@ -979,6 +985,7 @@ export class Metadata {
 
     // For Distributed tables, fetch metadata of the underlying local table to get correct partition key, sorting key, etc.
     if (tableMetadata?.engine === 'Distributed') {
+      tableMetadata.isPointerTable = true;
       try {
         const { cluster, database, table } =
           getDistributedTableArgs(tableMetadata) ?? {};
@@ -1026,6 +1033,12 @@ export class Metadata {
           e,
         );
       }
+    }
+
+    // Merge tables (including a Distributed table whose local table is a Merge
+    // table) also route to other tables rather than holding their own data.
+    if (tableMetadata?.engine === 'Merge') {
+      tableMetadata.isPointerTable = true;
     }
 
     // partition_key which includes parenthesis, unlike other keys such as 'primary_key' or 'sorting_key'

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1745,6 +1745,7 @@ export const LogSourceSchema = BaseSourceSchema.extend({
   traceIdExpression: z.string().optional(),
   spanIdExpression: z.string().optional(),
   implicitColumnExpression: z.string().optional(),
+  knownColumnsListExpression: z.string().optional(),
   /**
    * @deprecated Application-side SQL predicate AND'd into every query against
    * the source. Not a security boundary; bypassable by direct table SELECT.
@@ -1795,6 +1796,7 @@ export const TraceSourceSchema = BaseSourceSchema.extend({
   eventAttributesExpression: z.string().optional(),
   spanEventsValueExpression: z.string().optional(),
   implicitColumnExpression: z.string().optional(),
+  knownColumnsListExpression: z.string().optional(),
   displayedTimestampValueExpression: z.string().optional(),
   highlightedTraceAttributeExpressions:
     HighlightedAttributeExpressionsSchema.optional(),


### PR DESCRIPTION
## Summary

This PR adds a new source configuration setting for log and trace tables, intended to improve support for sources based on distributed tables which reference local tables with non-uniform column lists.

### The Problem

Distributed tables may point to "local" tables with non-matching sets of columns. When this is the case, `SELECT *` queries request the list of columns declared by the distributed table from each local table. This causes errors when a local table is missing one of the declared columns.

### The Solution

The solution in this PR is a new setting at the source level which allows the user to specify a list of "Known Columns" which exist on every local table. When this setting is provided, it is used instead of `*` when opening the side panel.

To aid the user in diagnosing the failure when this setting is not provided:

- The side panel error state has been updated from a vague `Error loading row details` to the ClickHouse query error and the query that was sent to ClickHouse
- When the error indicates a referenced column could not be found AND when the source references a Distributed or Merge table, then the UI will also display an Alert hinting to the user that they might be able to solve it by setting a Known Columns List in source settings.

### Screenshots or video


https://github.com/user-attachments/assets/26b04cd9-86f1-46d9-880a-b1ac6f4f5a87



### How to test on Vercel preview

This is tough to test on the preview environment because it requires a distributed table with non-matching columns to trigger the exact error.

You could set this up locally by updating the development environment docker config to spin up a second ClickHouse node in the hdx_cluster (Claude is good at this) and creating the following tables + source:

<details>
<summary>DDL</summary>

```sql
-- Local Table (Node 1)
CREATE TABLE default.otel_logs_local (
  `Timestamp` DateTime64(9) CODEC (Delta (8), ZSTD (1)),
  `TraceId` String CODEC (ZSTD (1)),
  `SpanId` String CODEC (ZSTD (1)),
  `TraceFlags` UInt8,
  `SeverityText` LowCardinality(String) CODEC (ZSTD (1)),
  `SeverityNumber` UInt8,
  `ServiceName` LowCardinality(String) CODEC (ZSTD (1)),
  `Body` String CODEC (ZSTD (1)),
  `ResourceSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ResourceAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `ScopeSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeName` String CODEC (ZSTD (1)),
  `ScopeVersion` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `LogAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `EventName` String CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.cluster.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.cluster.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.container.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.container.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.deployment.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.deployment.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.namespace.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.namespace.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.node.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.node.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.pod.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.pod.uid` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.uid'] CODEC (ZSTD (1)),
  `__hdx_materialized_deployment.environment.name` LowCardinality(String) MATERIALIZED ResourceAttributes['deployment.environment.name'] CODEC (ZSTD (1)),
  `ResourceAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(
      ResourceAttributes,
      'Array(Tuple(String, String))'
    )
  ),
  `ScopeAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(ScopeAttributes, 'Array(Tuple(String, String))')
  ),
  `LogAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(LogAttributes, 'Array(Tuple(String, String))')
  ),
  INDEX idx_trace_id TraceId
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_res_attr_key mapKeys(ResourceAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_res_attr_items ResourceAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_scope_attr_key mapKeys(ScopeAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_scope_attr_items ScopeAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_log_attr_key mapKeys(LogAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_log_attr_items LogAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_lower_body lower(Body)
  TYPE
    text(tokenizer = 'splitByNonAlpha')
  GRANULARITY 100000000
) ENGINE = MergeTree
PARTITION BY
  toDate(Timestamp)
ORDER BY
  (
    toStartOfFiveMinutes(Timestamp),
    ServiceName,
    Timestamp
  ) TTL toDateTime(Timestamp) + toIntervalDay(1)
SETTINGS
  index_granularity = 8192,
  ttl_only_drop_parts = 1,
  enable_block_number_column = 1,
  enable_block_offset_column = 1;

-- Local Table (Node 2, missing SeverityNumber column)
CREATE TABLE default.otel_logs_local (
  `Timestamp` DateTime64(9) CODEC (Delta (8), ZSTD (1)),
  `TraceId` String CODEC (ZSTD (1)),
  `SpanId` String CODEC (ZSTD (1)),
  `TraceFlags` UInt8,
  `SeverityText` LowCardinality(String) CODEC (ZSTD (1)),
  `ServiceName` LowCardinality(String) CODEC (ZSTD (1)),
  `Body` String CODEC (ZSTD (1)),
  `ResourceSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ResourceAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `ScopeSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeName` String CODEC (ZSTD (1)),
  `ScopeVersion` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `LogAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `EventName` String CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.cluster.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.cluster.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.container.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.container.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.deployment.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.deployment.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.namespace.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.namespace.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.node.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.node.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.pod.name` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.name'] CODEC (ZSTD (1)),
  `__hdx_materialized_k8s.pod.uid` LowCardinality(String) MATERIALIZED ResourceAttributes['k8s.pod.uid'] CODEC (ZSTD (1)),
  `__hdx_materialized_deployment.environment.name` LowCardinality(String) MATERIALIZED ResourceAttributes['deployment.environment.name'] CODEC (ZSTD (1)),
  `ResourceAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(
      ResourceAttributes,
      'Array(Tuple(String, String))'
    )
  ),
  `ScopeAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(ScopeAttributes, 'Array(Tuple(String, String))')
  ),
  `LogAttributeItems` Array(String) ALIAS arrayMap(
    arr -> concat(arr .1, '=', arr .2),
    CAST(LogAttributes, 'Array(Tuple(String, String))')
  ),
  INDEX idx_trace_id TraceId
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_res_attr_key mapKeys(ResourceAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_res_attr_items ResourceAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_scope_attr_key mapKeys(ScopeAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_scope_attr_items ScopeAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_log_attr_key mapKeys(LogAttributes)
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_log_attr_items LogAttributeItems
  TYPE
    text(tokenizer = 'array')
  GRANULARITY 100000000,
  INDEX idx_lower_body lower(Body)
  TYPE
    text(tokenizer = 'splitByNonAlpha')
  GRANULARITY 100000000
) ENGINE = MergeTree
PARTITION BY
  toDate(Timestamp)
ORDER BY
  (
    toStartOfFiveMinutes(Timestamp),
    ServiceName,
    Timestamp
  ) TTL toDateTime(Timestamp) + toIntervalDay(1)
SETTINGS
  index_granularity = 8192,
  ttl_only_drop_parts = 1,
  enable_block_number_column = 1,
  enable_block_offset_column = 1;

-- Distributed Table (Both Nodes)
CREATE TABLE default.otel_logs_distributed_mismatch (
  `Timestamp` DateTime64(9) CODEC (Delta (8), ZSTD (1)),
  `TraceId` String CODEC (ZSTD (1)),
  `SpanId` String CODEC (ZSTD (1)),
  `TraceFlags` UInt8,
  `SeverityText` LowCardinality(String) CODEC (ZSTD (1)),
  `ServiceName` LowCardinality(String) CODEC (ZSTD (1)),
  `SeverityNumber` UInt8, -- Includes the SeverityNumber column
  `Body` String CODEC (ZSTD (1)),
  `ResourceSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ResourceAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `ScopeSchemaUrl` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeName` String CODEC (ZSTD (1)),
  `ScopeVersion` LowCardinality(String) CODEC (ZSTD (1)),
  `ScopeAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `LogAttributes` Map(LowCardinality(String), String) CODEC (ZSTD (1)),
  `EventName` String CODEC (ZSTD (1))
) ENGINE Distributed('hdx_cluster', 'default', 'otel_logs_local', rand());

-- Populate the local table with some data from the original otel_logs table
INSERT INTO otel_logs_local SELECT *
FROM otel_logs;
```

</details>

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4588
- Related PRs:
