### PR TITLE
fix: bug preventing deletion of metadataMVs from source

### DIFF
--- a/.changeset/wise-jobs-relax.md
+++ b/.changeset/wise-jobs-relax.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+---
+
+fix: bug preventing deletion of nested subdocuments like metadataMVs

--- a/packages/api/src/controllers/sources.ts
+++ b/packages/api/src/controllers/sources.ts
@@ -61,8 +61,8 @@ export async function updateSource(
 
   // Same kind: simple update through the discriminator model
   if (existing.kind === source.kind) {
-    // @ts-expect-error The findOneAndUpdate method has incompatible type signatures but is actually safe
-    return getModelForKind(source.kind)?.findOneAndUpdate(
+    // @ts-expect-error The findOneAndReplace method has incompatible type signatures but is actually safe
+    return getModelForKind(source.kind)?.findOneAndReplace(
       { _id: sourceId, team },
       source,
       { new: true },

--- a/packages/api/src/routers/api/__tests__/sources.test.ts
+++ b/packages/api/src/routers/api/__tests__/sources.test.ts
@@ -690,6 +690,88 @@ describe('sources router', () => {
     });
   });
 
+  describe('metadataMaterializedViews field', () => {
+    // Regression test for a bug where clearing the Metadata Materialized
+    // Views in the source form did not persist. The UI sets the field to
+    // undefined, JSON serialization drops it from the PUT payload, and the
+    // previous findOneAndUpdate-based controller silently preserved the
+    // old value because partial updates don't unset absent fields.
+    it('PUT /:id - removes metadataMaterializedViews when omitted from the payload', async () => {
+      const { agent, team } = await getLoggedInAgent(server);
+
+      const source = await Source.create({
+        ...MOCK_SOURCE,
+        team: team._id,
+        metadataMaterializedViews: {
+          keyRollupTable: 'test_table_key_rollup_15m',
+          kvRollupTable: 'test_table_kv_rollup_15m',
+          granularity: '15 minute',
+        },
+      });
+
+      const created = await Source.findById(source._id).lean();
+      if (created?.kind !== SourceKind.Log) {
+        throw new Error(`expected Log source, got ${created?.kind}`);
+      }
+      expect(created.metadataMaterializedViews).toMatchObject({
+        keyRollupTable: 'test_table_key_rollup_15m',
+        kvRollupTable: 'test_table_kv_rollup_15m',
+        granularity: '15 minute',
+      });
+
+      await agent
+        .put(`/sources/${source._id}`)
+        .send({
+          ...MOCK_SOURCE,
+          id: source._id.toString(),
+        })
+        .expect(200);
+
+      const updated = await Source.findById(source._id).lean();
+      if (updated?.kind !== SourceKind.Log) {
+        throw new Error(`expected Log source, got ${updated?.kind}`);
+      }
+      expect(updated.metadataMaterializedViews).toBeUndefined();
+    });
+
+    it('PUT /:id - updates metadataMaterializedViews when included in the payload', async () => {
+      const { agent, team } = await getLoggedInAgent(server);
+
+      const source = await Source.create({
+        ...MOCK_SOURCE,
+        team: team._id,
+        metadataMaterializedViews: {
+          keyRollupTable: 'old_key_rollup',
+          kvRollupTable: 'old_kv_rollup',
+          granularity: '15 minute',
+        },
+      });
+
+      await agent
+        .put(`/sources/${source._id}`)
+        .send({
+          ...MOCK_SOURCE,
+          id: source._id.toString(),
+          metadataMaterializedViews: {
+            keyRollupTable: 'new_key_rollup',
+            kvRollupTable: 'new_kv_rollup',
+            granularity: '1 hour',
+          },
+        })
+        .expect(200);
+
+      const updated = await Source.findById(source._id).lean();
+      if (updated?.kind !== SourceKind.Log) {
+        throw new Error(`expected Log source, got ${updated?.kind}`);
+      }
+      expect(updated.metadataMaterializedViews).toMatchObject({
+        keyRollupTable: 'new_key_rollup',
+        kvRollupTable: 'new_kv_rollup',
+        granularity: '1 hour',
+      });
+    });
+  });
+
   describe('useTextIndexForImplicitColumn field', () => {
     it('POST / - persists useTextIndexForImplicitColumn on a Log source and returns it', async () => {
       const { agent } = await getLoggedInAgent(server);

--- a/packages/app/tests/e2e/features/sources.spec.ts
+++ b/packages/app/tests/e2e/features/sources.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_METRICS_SOURCE_NAME,
   DEFAULT_SESSIONS_SOURCE_NAME,
   DEFAULT_TRACES_SOURCE_NAME,
+  METADATA_MV_LOGS_SOURCE_NAME,
 } from '../utils/constants';
 
 const COMMON_FIELDS = [
@@ -229,6 +230,88 @@ test.describe('Sources Functionality', { tag: ['@sources'] }, () => {
             orderByExpression: '',
           },
         });
+      }
+    },
+  );
+
+  test(
+    'source form sends the complete source on update (no field omission)',
+    { tag: ['@full-stack'] },
+    async ({ page }) => {
+      // Pins the contract that updateSource relies on: saving from the
+      // source form must not drop any populated field. The controller
+      // uses findOneAndReplace, so any field omitted from the PUT body
+      // is silently deleted from MongoDB. If the frontend ever moves
+      // to a partial/PATCH-style payload, this test will fail because
+      // the before/after diff will show fields disappearing.
+      //
+      // METADATA_MV_LOGS has the broadest field coverage in fixtures,
+      // including metadataMaterializedViews — the field whose deletion
+      // bug motivated the controller change.
+      const logSources = await getSources(page, 'log');
+      const sourceBefore = logSources.find(
+        (s: any) => s.name === METADATA_MV_LOGS_SOURCE_NAME,
+      );
+      expect(sourceBefore).toBeDefined();
+      expect(sourceBefore.metadataMaterializedViews).toBeDefined();
+      const sourceId = sourceBefore._id;
+
+      await searchPage.selectSource(METADATA_MV_LOGS_SOURCE_NAME);
+      await searchPage.openEditSourceModal();
+
+      // Gate on form hydration to avoid racing Save against
+      // react-hook-form's `values` reset. In full-stack mode "Edit
+      // source" navigates to /team and expands the source's
+      // TableSourceForm inline (no modal), so we scope by input name.
+      await expect(page.locator('input[name="name"]')).toHaveValue(
+        METADATA_MV_LOGS_SOURCE_NAME,
+      );
+
+      const putResponsePromise = page.waitForResponse(
+        res =>
+          res.url().includes(`/sources/${sourceId}`) &&
+          res.request().method() === 'PUT',
+      );
+      await searchPage.saveSourceForm();
+
+      // The seeded source sets implicitColumnExpression without
+      // bodyExpression, which triggers the pairing-warnings dialog.
+      // The PUT only fires after the user confirms via "Save anyway".
+      await page.getByRole('button', { name: 'Save anyway' }).click();
+
+      const putResponse = await putResponsePromise;
+      expect(putResponse.ok()).toBeTruthy();
+
+      const sourcesAfter = await getSources(page, 'log');
+      const sourceAfter = sourcesAfter.find((s: any) => s._id === sourceId);
+      expect(sourceAfter).toBeDefined();
+
+      // Specific regression: metadataMaterializedViews survived the
+      // form roundtrip with its user-meaningful fields intact. The
+      // embedded sub-document gets a fresh Mongoose-minted _id on
+      // each findOneAndReplace, which is fine — we only care that
+      // the rollup config the user configured is preserved.
+      expect(sourceAfter.metadataMaterializedViews).toMatchObject({
+        keyRollupTable: sourceBefore.metadataMaterializedViews.keyRollupTable,
+        kvRollupTable: sourceBefore.metadataMaterializedViews.kvRollupTable,
+        granularity: sourceBefore.metadataMaterializedViews.granularity,
+      });
+
+      // Broader contract: every populated field present before the save
+      // is still present after the save. Server-managed bookkeeping
+      // fields are expected to differ (timestamps, version) or stay
+      // pinned (_id, team) on their own schedule.
+      const serverManagedKeys = new Set([
+        '_id',
+        '__v',
+        'team',
+        'createdAt',
+        'updatedAt',
+      ]);
+      for (const key of Object.keys(sourceBefore)) {
+        if (serverManagedKeys.has(key)) continue;
+        if (sourceBefore[key] == null) continue;
+        expect(sourceAfter).toHaveProperty(key);
       }
     },
   );

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -123,6 +123,10 @@ export class SearchPage {
     }
   }
 
+  async saveSourceForm() {
+    await this.page.getByRole('button', { name: 'Save Source' }).click();
+  }
+
   /**
    * Perform a search with the given query
    */


### PR DESCRIPTION
## Summary

Fixes a bug that prevented deleting some fields from a Source. Adds a regression test for the main interesting one, metadataMVs.

### References

- Linear Issue: Closes HDX-4645