### PR TITLE
ci: don't flag private org members as external contributors

### DIFF
--- a/.github/workflows/external-contributor-alerts.yml
+++ b/.github/workflows/external-contributor-alerts.yml
@@ -46,17 +46,33 @@ jobs:
             if (item.draft) { core.info(`Skipping draft PR #${item.number}`); return; }
             // Skip bots (Dependabot, etc.).
             if (item.user?.type === 'Bot') { core.info(`Skipping bot ${item.user?.login}`); return; }
-            // External == author has no write association with the repo.
-            const INTERNAL = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-            if (INTERNAL.includes(item.author_association)) {
-              core.info(`#${item.number} by ${item.user?.login} is internal (${item.author_association}); skipping.`);
+            // External == author has no write access to the repo.
+            const { owner, repo } = context.repo;
+            // Fast path (free): public members & direct collaborators.
+            let internal = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(item.author_association);
+            // Slow path: catches PRIVATE org members via their granted repo access.
+            // author_association only reports MEMBER for *public* members, so a
+            // member with concealed membership would otherwise be misflagged as
+            // external. Public repos grant everyone implicit 'read', so require
+            // triage+ (not permission != 'none').
+            if (!internal) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: item.user.login,
+                });
+                const p = data.user?.permissions ?? {};
+                internal = !!(p.admin || p.maintain || p.push || p.triage);
+              } catch (e) {
+                if (e.status !== 404) throw e; // 404 = not a collaborator => external
+              }
+            }
+            if (internal) {
+              core.info(`#${item.number} by ${item.user?.login} is internal; skipping.`);
               return;
             }
             // The `external` label doubles as our "already alerted" marker, so a
             // reopen (label persists) won't post to Slack twice.
             if (item.labels?.some(l => l.name === LABEL)) { core.info(`#${item.number} already handled.`); return; }
-
-            const { owner, repo } = context.repo;
 
             // Deliver the alert FIRST. We only mark the item handled (label it)
             // after a confirmed send, so an unset/failing webhook leaves it


### PR DESCRIPTION
Teammates with **private** (concealed) organization membership are no longer misflagged as external contributors. They previously got a Slack alert and an `external` label on every issue/PR they opened, because `author_association` only reports `MEMBER` for *publicly* visible members — a private member shows up as `CONTRIBUTOR`/`NONE`, which the workflow treated as external. This is what happened on #2545 (author `knudtty` is a private org member).

The internal check now keeps `author_association` as a free fast path, then falls back to resolving the author's actual repository permission via `repos.getCollaboratorPermissionLevel`, which sees access granted through private teams.

Two design points worth noting:

- **Threshold on granted access, not `permission !== 'none'`.** This is a public repo, so GitHub grants *every* user implicit `read`. A naive `!= 'none'` check would mark every genuine external contributor as internal. The check requires `triage`/`push`/`maintain`/`admin` instead.
- **No new secret or permission.** The built-in `GITHUB_TOKEN` can call the endpoint under the existing `issues:write` / `pull-requests:write` scope.

Both behaviors were verified in a throwaway Actions run (in a sibling repo with the identical workflow) before writing this: a private member with `write` access resolved to INTERNAL with no `403`, and a non-collaborator (implicit `read`) correctly resolved to EXTERNAL.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
