### PR TITLE
fix(table): keep sticky table header above body cells when scrolling

### DIFF
--- a/.changeset/fix-table-header-overlap.md
+++ b/.changeset/fix-table-header-overlap.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Prevent table content from overlapping table headers

--- a/packages/app/src/HDXMultiSeriesTableChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTableChart.tsx
@@ -349,6 +349,12 @@ export const Table = ({
           style={{
             position: 'sticky',
             top: 0,
+            // Body cells include positioned elements (e.g. the
+            // position: relative `.lastCell`), which otherwise paint on
+            // top of the sticky header as rows scroll underneath it.
+            // A stacking context above those cells keeps the header on
+            // top. Mirrors the log table's sticky head (LogTable.module.scss).
+            zIndex: 2,
             background:
               variant === 'muted'
                 ? 'var(--color-bg-muted)'


### PR DESCRIPTION
## Summary

Fixes a bug causing text content from the rightmost column in the HDXMultiSeriesTableChart overlapping the table header text. The `.lastCell` class [associated with table onClick action tooltips](https://github.com/hyperdxio/hyperdx/pull/2380/changes#diff-134df20f2798566e6a607358f3d2c12f7b5560c331004d4aec24a02cf502477dR30) applies relative positioning, which creates a new stacking context for the rightmost cell, above the header.

The `z-index: 2` now applied to the header ensures that the header is positioned above the cell content. This mirrors the solution used for the existing logs table.

### Screenshots or video

#### Before

https://github.com/user-attachments/assets/855477fe-dc15-4a26-8f7b-4d2cfc803dab

#### After

https://github.com/user-attachments/assets/5ae4fdbc-6679-4913-ac06-3a9c0407e9e3

### How to test on Vercel preview

- Create a table with a few columns and enough rows to trigger scrolling
- Confirm that none of the content overlaps the headers

### References

- Linear Issue: Closes HDX-4657
- Related PRs:
