### PR TITLE
feat(api): add POST /api/v2/dashboards/validate

### DIFF
--- a/.changeset/gold-lions-marry.md
+++ b/.changeset/gold-lions-marry.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": minor
+---
+
+Adds a POST /api/v2/dashboards/validate endpoint to the external v2 API. It

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -5779,6 +5779,111 @@
         }
       }
     },
+    "/api/v2/dashboards/validate": {
+      "post": {
+        "summary": "Validate Dashboard",
+        "description": "Validates a dashboard body against the same schema and tile rules used\nby POST /api/v2/dashboards. The dashboard is **never persisted**. Use\nthis endpoint at plan time (e.g. from a Terraform provider) to check\nthat a dashboard configuration is valid before applying it.\n",
+        "operationId": "validateDashboard",
+        "tags": [
+          "Dashboards"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDashboardRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation result. HTTP 200 is always returned for valid **and**\ninvalid bodies — a non-200 response means the request itself\nfailed (auth, server error, etc.).\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "valid",
+                    "errors",
+                    "normalized"
+                  ],
+                  "properties": {
+                    "valid": {
+                      "type": "boolean",
+                      "description": "True when the body passes all validation rules."
+                    },
+                    "errors": {
+                      "type": "array",
+                      "description": "Validation errors. Empty when valid is true.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "message"
+                        ],
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "description": "Dot-separated field path, or empty string for top-level errors."
+                          },
+                          "message": {
+                            "type": "string",
+                            "description": "Human-readable error description."
+                          }
+                        }
+                      }
+                    },
+                    "normalized": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Reserved for Task 2 — always null in this version."
+                    }
+                  }
+                },
+                "examples": {
+                  "valid": {
+                    "summary": "Valid dashboard body",
+                    "value": {
+                      "valid": true,
+                      "errors": [],
+                      "normalized": null
+                    }
+                  },
+                  "invalid": {
+                    "summary": "Invalid dashboard body",
+                    "value": {
+                      "valid": false,
+                      "errors": [
+                        {
+                          "path": "name",
+                          "message": "Required"
+                        }
+                      ],
+                      "normalized": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Unauthorized access. API key is missing or invalid."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/search": {
       "post": {
         "summary": "Search Raw Logs and Traces",

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -5838,7 +5838,7 @@
                     "normalized": {
                       "type": "object",
                       "nullable": true,
-                      "description": "Reserved for Task 2 — always null in this version."
+                      "description": "The parsed dashboard body with defaults applied (no\npersistence, so no server-assigned tile IDs). Populated\nwhen valid is true, null when valid is false.\n"
                     }
                   }
                 },
@@ -5848,7 +5848,10 @@
                     "value": {
                       "valid": true,
                       "errors": [],
-                      "normalized": null
+                      "normalized": {
+                        "name": "My Dashboard",
+                        "tiles": []
+                      }
                     }
                   },
                   "invalid": {

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -5893,11 +5893,51 @@ describe('External API v2 Dashboards - new format', () => {
         { method: 'post', path: BASE_URL },
         { method: 'put', path: `${BASE_URL}/${testId}` },
         { method: 'delete', path: `${BASE_URL}/${testId}` },
+        { method: 'post', path: `${BASE_URL}/validate` },
       ];
 
       for (const { method, path } of routes) {
         await unauthenticatedAgent[method](path).expect(401);
       }
+    });
+  });
+
+  describe('POST /api/v2/dashboards/validate', () => {
+    it('returns valid:true for a well-formed builder dashboard', async () => {
+      const res = await authRequest('post', `${BASE_URL}/validate`).send({
+        name: 'D',
+        tiles: [],
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(true);
+      expect(res.body.errors).toEqual([]);
+    });
+
+    it('returns valid:false with errors for a malformed body', async () => {
+      const res = await authRequest('post', `${BASE_URL}/validate`).send({
+        tiles: 'nope',
+      }); // name missing, tiles wrong type
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(false);
+      expect(res.body.errors.length).toBeGreaterThan(0);
+    });
+
+    it('returns a normalized body with zod defaults applied when valid', async () => {
+      const res = await authRequest('post', `${BASE_URL}/validate`).send({
+        name: 'D',
+        tiles: [],
+      });
+      expect(res.body.valid).toBe(true);
+      expect(res.body.normalized).toMatchObject({ name: 'D', tiles: [] });
+    });
+
+    it('does not persist (dashboard count unchanged)', async () => {
+      const before = await Dashboard.countDocuments({});
+      await authRequest('post', `${BASE_URL}/validate`).send({
+        name: 'D',
+        tiles: [],
+      });
+      expect(await Dashboard.countDocuments({})).toBe(before);
     });
   });
 });

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1931,6 +1931,122 @@ router.get(
 
 /**
  * @openapi
+ * /api/v2/dashboards/validate:
+ *   post:
+ *     summary: Validate Dashboard
+ *     description: |
+ *       Validates a dashboard body against the same schema and tile rules used
+ *       by POST /api/v2/dashboards. The dashboard is **never persisted**. Use
+ *       this endpoint at plan time (e.g. from a Terraform provider) to check
+ *       that a dashboard configuration is valid before applying it.
+ *     operationId: validateDashboard
+ *     tags: [Dashboards]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateDashboardRequest'
+ *     responses:
+ *       '200':
+ *         description: |
+ *           Validation result. HTTP 200 is always returned for valid **and**
+ *           invalid bodies — a non-200 response means the request itself
+ *           failed (auth, server error, etc.).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [valid, errors, normalized]
+ *               properties:
+ *                 valid:
+ *                   type: boolean
+ *                   description: True when the body passes all validation rules.
+ *                 errors:
+ *                   type: array
+ *                   description: Validation errors. Empty when valid is true.
+ *                   items:
+ *                     type: object
+ *                     required: [path, message]
+ *                     properties:
+ *                       path:
+ *                         type: string
+ *                         description: Dot-separated field path, or empty string for top-level errors.
+ *                       message:
+ *                         type: string
+ *                         description: Human-readable error description.
+ *                 normalized:
+ *                   type: object
+ *                   nullable: true
+ *                   description: Reserved for Task 2 — always null in this version.
+ *             examples:
+ *               valid:
+ *                 summary: Valid dashboard body
+ *                 value:
+ *                   valid: true
+ *                   errors: []
+ *                   normalized: null
+ *               invalid:
+ *                 summary: Invalid dashboard body
+ *                 value:
+ *                   valid: false
+ *                   errors:
+ *                     - path: "name"
+ *                       message: "Required"
+ *                   normalized: null
+ *       '401':
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *             example:
+ *               message: "Unauthorized access. API key is missing or invalid."
+ */
+router.post('/validate', async (req, res, next) => {
+  try {
+    const teamId = req.user?.team;
+    if (teamId == null) {
+      return res.sendStatus(403);
+    }
+
+    const parsed = createDashboardBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.json({
+        valid: false,
+        errors: parsed.error.issues.map(i => ({
+          path: i.path.join('.'),
+          message: i.message,
+        })),
+        normalized: null,
+      });
+    }
+
+    const { tiles, filters, containers } = parsed.data;
+    // Cast: createDashboardBodySchema tiles have optional `id`; the validator
+    // only reads sourceId/config — the cast is safe for a no-persist call.
+    const validationError = await validateDashboardTiles({
+      teamId: teamId.toString(),
+      tiles: tiles as ExternalDashboardTileWithId[],
+      filters,
+      containers: containers ?? [],
+    });
+    if (validationError) {
+      return res.json({
+        valid: false,
+        errors: [{ path: '', message: validationError }],
+        normalized: null,
+      });
+    }
+
+    return res.json({ valid: true, errors: [], normalized: parsed.data });
+  } catch (e) {
+    next(e);
+  }
+});
+
+/**
+ * @openapi
  * /api/v2/dashboards:
  *   post:
  *     summary: Create Dashboard

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1978,14 +1978,19 @@ router.get(
  *                 normalized:
  *                   type: object
  *                   nullable: true
- *                   description: Reserved for Task 2 — always null in this version.
+ *                   description: |
+ *                     The parsed dashboard body with defaults applied (no
+ *                     persistence, so no server-assigned tile IDs). Populated
+ *                     when valid is true, null when valid is false.
  *             examples:
  *               valid:
  *                 summary: Valid dashboard body
  *                 value:
  *                   valid: true
  *                   errors: []
- *                   normalized: null
+ *                   normalized:
+ *                     name: "My Dashboard"
+ *                     tiles: []
  *               invalid:
  *                 summary: Invalid dashboard body
  *                 value:


### PR DESCRIPTION
## What

Adds a `POST /api/v2/dashboards/validate` endpoint to the external v2 API. It
validates a dashboard body **without persisting anything** and returns a
structured result, so external clients can check a dashboard before writing it.

## Why

The ClickStack Terraform provider (`clickstack_dashboard`) manages dashboards as
a JSON body it sends verbatim to `POST/PUT /api/v2/dashboards`. Without a
validate endpoint, the only way to surface a bad dashboard is at apply time
(mid-`terraform apply`), after other resources may have changed. This endpoint
lets the provider validate at **plan** time and show precise errors before any
mutation. It is generally useful to any API consumer that wants a dry-run check.

## Contract

`POST /api/v2/dashboards/validate` (Bearer auth, team-scoped, rate-limited like
the other v2 routes). Always returns **HTTP 200** for both valid and invalid
bodies:

```json
{ "valid": true|false,
  "errors": [{ "path": "tiles.0.config", "message": "..." }],
  "normalized": { ...defaults-applied body... } | null }
```

- 200 always (not 400 on invalid) so callers can distinguish "validation ran
and found problems" from "the request itself failed" (auth/5xx).
- errors aggregates all zod issues; a validateDashboardTiles failure is
returned as a single {path:"", message}.
- normalized echoes the zod-parsed body with defaults applied (no persistence,
so no server-assigned tile IDs) for consumers that want a canonical form.

Implementation

- Reuses the exact createDashboardBodySchema and validateDashboardTiles
the create path uses, so validation cannot drift from what create enforces
(FK existence for sources/connections, container/tab refs, PromQL rejection).
- No DB writes / no side effects; safe to call repeatedly (e.g. on every plan).
- OpenAPI annotation added; /validate added to the auth-coverage test list.

Testing

packages/api/src/routers/external-api/__tests__/dashboards.test.ts: valid body
→ valid:true; malformed body → valid:false with errors; no-persist assertion
(dashboard count unchanged); normalized-body-on-valid. Requires MongoDB +
ClickHouse (run in CI / docker-compose.ci.yml); tsc --noEmit is clean.

Notes

PromQL tiles are rejected here (as on create) — not yet supported in the
external API. Paired with the provider PR: <link to provider PR>.

contributes to HDX-4671