### PR TITLE
feat: trace waterfall redesign

### DIFF
--- a/.changeset/trace-waterfall-redesign.md
+++ b/.changeset/trace-waterfall-redesign.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat: redesign the trace waterfall — per-service span colors, vertical service color bar, child counts, duration outside the bar with the span body on hover, expand/collapse depth controls.

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -14,14 +14,13 @@ import {
   ActionIcon,
   Box,
   Button,
-  Divider,
   Flex,
   Group,
   Stack,
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconPencil, IconX } from '@tabler/icons-react';
+import { IconX } from '@tabler/icons-react';
 
 import { DBTraceWaterfallChartContainer } from '@/components/DBTraceWaterfallChart';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
@@ -266,11 +265,8 @@ export default function DBTracePanel({
     }
   }, [parentSourceData, traceIdSetValue]);
 
-  const [showTraceIdInput, setShowTraceIdInput] = useState(false);
-
-  // Tidy the URL: drop a selection that belongs to a different trace. Purely
-  // cosmetic — the read-time `selectedSpan` gate already prevents a foreign
-  // selection from rendering; this just keeps the param from lingering.
+  // Reset highlighted row when trace ID changes
+  // otherwise we'll show stale span details
   useEffect(() => {
     if (eventRowWhere != null && eventRowWhere.traceId !== traceId) {
       setEventRowWhere(null);
@@ -307,50 +303,11 @@ export default function DBTracePanel({
         minHeight: 0,
       }}
     >
-      <Flex align="center" justify="space-between" mb="sm">
-        <Flex align="center">
-          <Text size="xs" me="xs">
-            {parentSourceData &&
-            (isLogSource(parentSourceData) || isTraceSource(parentSourceData))
-              ? parentSourceData.traceIdExpression
-              : ''}
-            : {traceId || 'No trace id found for event'}
-          </Text>
-          {traceId != null && (
-            <Button
-              variant="subtle"
-              size="xs"
-              onClick={() => setShowTraceIdInput(v => !v)}
-            >
-              <IconPencil size={14} />
-            </Button>
-          )}
-        </Flex>
-        <Group gap="sm">
-          <Text size="sm">
-            {parentSourceData?.kind === SourceKind.Log
-              ? 'Trace Source'
-              : 'Correlated Log Source'}
-          </Text>
-          <SourceSelectControlled
-            control={control}
-            name="source"
-            size="xs"
-            onSchemaPreview={() => setIsSourceSchemaPreviewOpen(true)}
-            isSchemaPreviewEnabled={isSourceSchemaPreviewEnabled(
-              childSourceData,
-            )}
-          />
-          <SourceSchemaPreview
-            source={childSourceData}
-            controlled
-            open={isSourceSchemaPreviewOpen}
-            onClose={() => setIsSourceSchemaPreviewOpen(false)}
-          />
-        </Group>
-      </Flex>
-      {(showTraceIdInput || !traceId) && parentSourceId != null && (
-        <Stack gap="xs">
+      {/* Fallback Trace ID Expression editor: only surfaced when no trace id
+          resolved for the event. The trace id itself now lives in the side
+          panel header (Copy Trace ID), so it's not duplicated here. */}
+      {!traceId && parentSourceId != null && (
+        <Stack gap="xs" mb="sm">
           <Text size="xs">Trace ID Expression</Text>
           <Flex align="center">
             <SQLInlineEditorControlled
@@ -384,18 +341,9 @@ export default function DBTracePanel({
             >
               Save
             </Button>
-            <Button
-              ms="sm"
-              variant="secondary"
-              onClick={() => setShowTraceIdInput(false)}
-              size="xs"
-            >
-              Cancel
-            </Button>
           </Flex>
         </Stack>
       )}
-      <Divider my="sm" />
       {/* Inline resizable split view: waterfall (left) + span detail (right) */}
       <div
         style={{
@@ -425,6 +373,29 @@ export default function DBTracePanel({
               onClick={selectSpan}
               initialRowHighlightHint={initialRowHighlightHint}
               emptyState={emptyState}
+              controlsExtra={
+                <Group gap={4} align="center" wrap="nowrap">
+                  <Text size="xxs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                    Correlated logs
+                  </Text>
+                  <SourceSelectControlled
+                    control={control}
+                    name="source"
+                    size="xs"
+                    w={150}
+                    onSchemaPreview={() => setIsSourceSchemaPreviewOpen(true)}
+                    isSchemaPreviewEnabled={isSourceSchemaPreviewEnabled(
+                      childSourceData,
+                    )}
+                  />
+                  <SourceSchemaPreview
+                    source={childSourceData}
+                    controlled
+                    open={isSourceSchemaPreviewOpen}
+                    onClose={() => setIsSourceSchemaPreviewOpen(false)}
+                  />
+                </Group>
+              }
             />
           )}
         </div>

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -21,25 +21,31 @@ import {
   TTraceSource,
 } from '@hyperdx/common-utils/dist/types';
 import {
+  ActionIcon,
   Anchor,
   Box,
   Center,
   Chip,
   Code,
   Group,
-  Kbd,
   Text,
   Tooltip,
 } from '@mantine/core';
-import { useDisclosure, useElementSize } from '@mantine/hooks';
+import { useElementSize } from '@mantine/hooks';
 import {
+  IconAlertCircleFilled,
+  IconAlertTriangleFilled,
   IconChevronDown,
   IconChevronRight,
+  IconChevronsDown,
+  IconChevronsRight,
   IconLogs,
 } from '@tabler/icons-react';
 
 import { ContactSupportText } from '@/components/ContactSupportText';
-import SearchInputV2 from '@/components/SearchInput/SearchInputV2';
+import SearchWhereInput, {
+  getStoredLanguage,
+} from '@/components/SearchInput/SearchWhereInput';
 import {
   TimelineChart,
   TimelineMinimap,
@@ -56,12 +62,12 @@ import {
 } from '@/source';
 import { useFormatTime } from '@/useFormatTime';
 import {
+  CATEGORICAL_PALETTE_TOKENS,
+  COLORS,
   getChartColorError,
-  getChartColorErrorHighlight,
   getChartColorSuccess,
   getChartColorSuccessHighlight,
   getChartColorWarning,
-  getChartColorWarningHighlight,
   parseTimestampToMs,
 } from '@/utils';
 import {
@@ -97,28 +103,15 @@ type TimestampedRow = {
   Timestamp: string;
 };
 
-function textColor(condition: { isError: boolean; isWarn: boolean }): string {
-  const { isError, isWarn } = condition;
-  if (isError) return 'text-danger';
-  if (isWarn) return 'text-warning';
-  return '';
-}
-
+// Bar background color. Correlated log rows are always green (success), error
+// spans are always red, and every other span takes its per-service color.
 function barColor(condition: {
-  isError: boolean;
-  isWarn: boolean;
   isHighlighted: boolean;
+  isError?: boolean;
   type: string | undefined;
+  serviceColor?: string;
 }) {
-  const { isError, isWarn, isHighlighted, type } = condition;
-
-  if (isError)
-    return isHighlighted ? getChartColorErrorHighlight() : getChartColorError();
-
-  if (isWarn)
-    return isHighlighted
-      ? getChartColorWarningHighlight()
-      : getChartColorWarning();
+  const { isHighlighted, isError, type, serviceColor } = condition;
 
   if (type === SourceKind.Log) {
     return isHighlighted
@@ -126,8 +119,30 @@ function barColor(condition: {
       : getChartColorSuccess();
   }
 
+  if (isError) {
+    return isHighlighted
+      ? `color-mix(in srgb, ${getChartColorError()} 60%, white)`
+      : getChartColorError();
+  }
+
+  if (serviceColor) {
+    return isHighlighted
+      ? `color-mix(in srgb, ${serviceColor} 60%, white)`
+      : serviceColor;
+  }
+
   return isHighlighted ? '#A9AFB7' : '#6A7077';
 }
+
+// Per-service span palette: the full categorical palette minus the two hues we
+// reserve for semantics — green (correlated log rows) and red (error spans) —
+// so a service color is never confused with a log or an error. Index-aligned
+// with CATEGORICAL_PALETTE_TOKENS, so filtering by token survives reordering.
+const SERVICE_COLORS = COLORS.filter(
+  (_color, i) =>
+    CATEGORICAL_PALETTE_TOKENS[i] !== 'chart-green' &&
+    CATEGORICAL_PALETTE_TOKENS[i] !== 'chart-red',
+);
 
 function getTableBody(tableModel: TSource) {
   if (tableModel?.kind === SourceKind.Trace) {
@@ -143,6 +158,7 @@ function getConfig(
   source: TTraceSource | TLogSource,
   traceId: string,
   hiddenRowExpression?: string,
+  hiddenRowExpressionLanguage: 'lucene' | 'sql' = 'lucene',
 ) {
   const alias: Record<string, string> = {
     Body: getTableBody(source),
@@ -208,7 +224,7 @@ function getConfig(
       ? [
           {
             valueExpression: hiddenRowExpression,
-            valueExpressionLanguage: 'lucene' as const,
+            valueExpressionLanguage: hiddenRowExpressionLanguage,
             alias: '__hdx_hidden',
           },
         ]
@@ -318,18 +334,26 @@ export function useEventsAroundFocus({
   traceId,
   enabled,
   hiddenRowExpression,
+  hiddenRowExpressionLanguage = 'lucene',
 }: {
   tableSource: TTraceSource | TLogSource;
   focusDate: Date;
   dateRange: [Date, Date];
   traceId: string;
   enabled: boolean;
-  /** A lucene expression that identifies rows to be hidden. Hidden rows will be returned with a `__hdx_hidden: true` column. */
+  /** An expression (in `hiddenRowExpressionLanguage`) that identifies rows to be hidden. Hidden rows will be returned with a `__hdx_hidden: true` column. */
   hiddenRowExpression?: string;
+  hiddenRowExpressionLanguage?: 'lucene' | 'sql';
 }) {
   const { config, alias, type } = useMemo(
-    () => getConfig(tableSource, traceId, hiddenRowExpression),
-    [tableSource, traceId, hiddenRowExpression],
+    () =>
+      getConfig(
+        tableSource,
+        traceId,
+        hiddenRowExpression,
+        hiddenRowExpressionLanguage,
+      ),
+    [tableSource, traceId, hiddenRowExpression, hiddenRowExpressionLanguage],
   );
 
   const {
@@ -419,14 +443,86 @@ export function getDescendantIds(node: {
   return ids;
 }
 
-function CollapseTooltipLabel({ onShown }: { onShown: () => void }) {
-  useEffect(() => onShown, [onShown]);
+/** "Collapse all": every collapsible parent, at every level, becomes collapsed. */
+export function computeCollapseAll(
+  parentIdsByLevel: Map<number, Set<string>>,
+): Set<string> {
+  const allParentIds = new Set<string>();
+  parentIdsByLevel.forEach(ids => {
+    ids.forEach(id => allParentIds.add(id));
+  });
+  return allParentIds;
+}
 
-  return (
-    <>
-      <Kbd>⌥/Alt</Kbd> + <Kbd>click</Kbd> to collapse children
-    </>
-  );
+/**
+ * "Expand one level": expand the shallowest level that still has any collapsed
+ * parents.
+ */
+export function computeExpandOneLevel(
+  collapsedIds: Set<string>,
+  parentIdsByLevel: Map<number, Set<string>>,
+): Set<string> {
+  if (collapsedIds.size === 0) return collapsedIds;
+  const newSet = new Set(collapsedIds);
+  // Shallowest first: expanding starts at the top of the tree.
+  const sortedLevels = [...parentIdsByLevel.keys()].sort((a, b) => a - b);
+  for (const level of sortedLevels) {
+    const ids = parentIdsByLevel.get(level)!;
+    const collapsedAtLevel = [...ids].filter(id => newSet.has(id));
+    if (collapsedAtLevel.length > 0) {
+      collapsedAtLevel.forEach(id => newSet.delete(id));
+      break;
+    }
+  }
+  return newSet;
+}
+
+export function computeCollapseOneLevel(
+  collapsedIds: Set<string>,
+  parentIdsByLevel: Map<number, Set<string>>,
+): Set<string> {
+  const newSet = new Set(collapsedIds);
+  // Deepest first: collapsing starts at the bottom of the tree.
+  const sortedLevels = [...parentIdsByLevel.keys()].sort((a, b) => b - a);
+  for (const level of sortedLevels) {
+    const ids = parentIdsByLevel.get(level)!;
+    const expandedAtLevel = [...ids].filter(id => !newSet.has(id));
+    if (expandedAtLevel.length > 0) {
+      expandedAtLevel.forEach(id => newSet.add(id));
+      break;
+    }
+  }
+  return newSet;
+}
+
+export function computeToggleCollapse(
+  collapsedIds: Set<string>,
+  id: string,
+  node:
+    | { id?: string; children?: Array<{ id?: string; children?: any[] }> }
+    | undefined,
+  includeDescendants: boolean,
+): Set<string> {
+  const next = new Set(collapsedIds);
+  const wasCollapsed = next.has(id);
+
+  if (wasCollapsed) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+
+  if (includeDescendants && node?.children?.length) {
+    // Match every descendant to the node's new state.
+    const descendantIds = getDescendantIds(node);
+    if (wasCollapsed) {
+      descendantIds.forEach(descId => next.delete(descId));
+    } else {
+      descendantIds.forEach(descId => next.add(descId));
+    }
+  }
+
+  return next;
 }
 
 // TODO: Optimize with ts lookup tables
@@ -440,6 +536,7 @@ export function DBTraceWaterfallChartContainer({
   highlightedRowWhere,
   initialRowHighlightHint,
   emptyState,
+  controlsExtra,
 }: {
   traceTableSource: TTraceSource;
   logTableSource: TLogSource | null;
@@ -458,27 +555,47 @@ export function DBTraceWaterfallChartContainer({
     body: string;
   };
   emptyState?: ReactNode;
+  /** Extra controls rendered in the waterfall controls bar (e.g. the correlated logs source selector). */
+  controlsExtra?: ReactNode;
 }) {
   const formatTime = useFormatTime();
 
   const {
     traceWhere,
     logWhere,
+    whereLanguage,
     clear: clearFilters,
     isFilterActive,
     isFilterExpanded,
     setIsFilterExpanded,
-    onSubmit: onSubmitFilters,
+    onSubmit: submitFilters,
   } = useWaterfallSearchState({
     hasLogSource: !!logTableSource,
   });
+
+  const filterLanguage: 'lucene' | 'sql' =
+    whereLanguage === 'sql' ? 'sql' : 'lucene';
 
   const { control, handleSubmit, setValue } = useForm({
     defaultValues: {
       traceWhere: traceWhere ?? '',
       logWhere: logWhere ?? '',
+      traceWhereLanguage: getStoredLanguage() ?? 'lucene',
     },
   });
+
+  // The combined input writes a single value; apply it to both the trace and
+  // log WHERE clauses, and persist the chosen language for query rebuilds.
+  const onSubmitFilters = useCallback(
+    (data: { traceWhere: string; traceWhereLanguage: string }) => {
+      submitFilters({
+        traceWhere: data.traceWhere,
+        logWhere: data.traceWhere,
+        whereLanguage: data.traceWhereLanguage,
+      });
+    },
+    [submitFilters],
+  );
 
   const onClearFilters = useCallback(() => {
     setValue('traceWhere', '');
@@ -497,6 +614,7 @@ export function DBTraceWaterfallChartContainer({
     dateRange,
     traceId,
     hiddenRowExpression: traceWhere ? `NOT (${traceWhere})` : undefined,
+    hiddenRowExpressionLanguage: filterLanguage,
     enabled: true,
   });
   const {
@@ -512,6 +630,7 @@ export function DBTraceWaterfallChartContainer({
     dateRange: logTableSource ? dateRange : [dateRange[1], dateRange[0]], // different query to prevent cache
     traceId,
     hiddenRowExpression: logWhere ? `NOT (${logWhere})` : undefined,
+    hiddenRowExpressionLanguage: filterLanguage,
     enabled: logTableSource ? true : false, // disable fire query if logSource is not exist
   });
 
@@ -536,6 +655,29 @@ export function DBTraceWaterfallChartContainer({
 
     return nextRows;
   }, [traceRowsData, logRowsData]);
+
+  // Map each distinct span service to a stable color. Sorting the names first
+  // keeps a service's color stable across renders regardless of row ordering.
+  const serviceColorMap = useMemo(() => {
+    const serviceNames = [
+      ...new Set(
+        rows
+          .filter(
+            r =>
+              r.ServiceName &&
+              r.type !== SourceKind.Log &&
+              typeof r.ServiceName === 'string',
+          )
+          .map(r => r.ServiceName),
+      ),
+    ].sort();
+
+    const map = new Map<string, string>();
+    serviceNames.forEach((name, i) => {
+      map.set(name, SERVICE_COLORS[i % SERVICE_COLORS.length]);
+    });
+    return map;
+  }, [rows]);
 
   const highlightedAttributeValues = useMemo(() => {
     const visibleTraceRowsData = traceRowsData?.filter(
@@ -644,7 +786,7 @@ export function DBTraceWaterfallChartContainer({
   const [showSpans, setShowSpans] = useState(true);
   const [showLogs, setShowLogs] = useState(true);
 
-  const { nodesMap, flattenedNodes } = useMemo(() => {
+  const { nodesMap, flattenedNodes, parentIdsByLevel } = useMemo(() => {
     const rootNodes: Node[] = [];
     const nodesMap = new Map(); // Maps result.id (or placeholder id) -> Node
     const spanIdMap = new Map(); // Maps SpanId -> result.id of FIRST node with that SpanId
@@ -712,6 +854,20 @@ export function DBTraceWaterfallChartContainer({
       }
     }
 
+    // Build a map of level → parent node IDs (nodes that have children) so the
+    // depth controls can expand/collapse a whole level at a time.
+    const parentIdsByLevel = new Map<number, Set<string>>();
+    const collectParents = (node: any, level: number) => {
+      if (node.children?.length > 0 && node.id) {
+        if (!parentIdsByLevel.has(level)) {
+          parentIdsByLevel.set(level, new Set());
+        }
+        parentIdsByLevel.get(level)!.add(node.id);
+      }
+      node.children?.forEach((child: any) => collectParents(child, level + 1));
+    };
+    rootNodes.forEach(root => collectParents(root, 0));
+
     type NodeWithLevel = Node & { level: number };
     // flatten the rootnode dag into an array via in-order traversal
     const traverse = (node: Node, arr: NodeWithLevel[], level = 0) => {
@@ -735,40 +891,37 @@ export function DBTraceWaterfallChartContainer({
       rootNodes.forEach(rootNode => traverse(rootNode, flattenedNodes));
     }
 
-    return { nodesMap, flattenedNodes };
+    return { nodesMap, flattenedNodes, parentIdsByLevel };
   }, [collapsedIds, rows, validSpanIDs]);
 
   const toggleCollapse = useCallback(
     (id: string, event: React.MouseEvent) => {
       event.stopPropagation(); // prevent collapsing from selecting row
-
-      setCollapsedIds(prev => {
-        const newSet = new Set(prev);
-        const isCollapsed = newSet.has(id);
-
-        if (isCollapsed) {
-          newSet.delete(id);
-        } else {
-          newSet.add(id);
-        }
-
-        if (event.altKey) {
-          const node = nodesMap.get(id);
-          if (node?.children?.length) {
-            const descendantIds = getDescendantIds(node);
-            if (isCollapsed) {
-              descendantIds.forEach(descId => newSet.delete(descId));
-            } else {
-              descendantIds.forEach(descId => newSet.add(descId));
-            }
-          }
-        }
-
-        return newSet;
-      });
+      // Alt/Option-click toggles the whole subtree along with the node.
+      setCollapsedIds(prev =>
+        computeToggleCollapse(prev, id, nodesMap.get(id), event.altKey),
+      );
     },
     [nodesMap],
   );
+
+  const expandAll = useCallback(() => {
+    setCollapsedIds(new Set());
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    setCollapsedIds(computeCollapseAll(parentIdsByLevel));
+  }, [parentIdsByLevel]);
+
+  const expandOneLevel = useCallback(() => {
+    setCollapsedIds(prev => computeExpandOneLevel(prev, parentIdsByLevel));
+  }, [parentIdsByLevel]);
+
+  const collapseOneLevel = useCallback(() => {
+    setCollapsedIds(prev => computeCollapseOneLevel(prev, parentIdsByLevel));
+  }, [parentIdsByLevel]);
+
+  const hasCollapsibleNodes = parentIdsByLevel.size > 0;
 
   const visibleNodes = useMemo(() => {
     if (showSpans && showLogs) return flattenedNodes;
@@ -810,9 +963,6 @@ export function DBTraceWaterfallChartContainer({
     }, Number.MAX_SAFE_INTEGER) ?? 0;
   const minOffset =
     foundMinOffset === Number.MAX_SAFE_INTEGER ? 0 : foundMinOffset;
-
-  const [collapseTooltipShown, { open: setCollapseTooltipShown }] =
-    useDisclosure(false);
 
   const timelineRows = useMemo(
     () =>
@@ -867,13 +1017,20 @@ export function DBTraceWaterfallChartContainer({
         const isWarn = result.SeverityText === 'warn';
         const isHighlighted = highlightedRowWhere === id;
 
+        const barBackgroundColor =
+          type === SourceKind.Log
+            ? getChartColorSuccess()
+            : serviceName
+              ? (serviceColorMap.get(serviceName) ?? '#6A7077')
+              : '#6A7077';
+
         return {
           id,
           type,
           aliasWith,
           label: (
             <div
-              className={`${textColor({ isError, isWarn })} ${
+              className={`${
                 isHighlighted && styles.traceTimelineLabelHighlighted
               } text-truncate cursor-pointer ps-2 ${styles.traceTimelineLabel}`}
               role="button"
@@ -898,46 +1055,64 @@ export function DBTraceWaterfallChartContainer({
                   ></div>
                 ))}
 
-                <Tooltip
-                  disabled={!result.children.length || collapseTooltipShown}
-                  closeDelay={500}
-                  label={
-                    <CollapseTooltipLabel onShown={setCollapseTooltipShown} />
+                <Center
+                  style={{
+                    opacity: result.children.length > 0 ? 1 : 0,
+                  }}
+                  onClick={
+                    result.children.length > 0
+                      ? e => {
+                          toggleCollapse(id, e);
+                        }
+                      : undefined
                   }
-                  withArrow
                 >
-                  <Center
-                    style={{
-                      opacity: result.children.length > 0 ? 1 : 0,
-                    }}
-                    onClick={
-                      result.children.length > 0
-                        ? e => {
-                            toggleCollapse(id, e);
-                          }
-                        : undefined
-                    }
-                  >
-                    {collapsedIds.has(id) ? (
-                      <IconChevronRight
-                        size={16}
-                        className="me-1 text-muted-hover"
-                      />
-                    ) : (
-                      <IconChevronDown
-                        size={16}
-                        className="me-1 text-muted-hover"
-                      />
-                    )}{' '}
-                  </Center>
-                </Tooltip>
+                  {collapsedIds.has(id) ? (
+                    <IconChevronRight size={16} className="me-1" />
+                  ) : (
+                    <IconChevronDown size={16} className="me-1" />
+                  )}{' '}
+                </Center>
 
-                {!isFilterActive && (
-                  <Text span size="xxs" me="xs" pt="2px">
-                    {result.children.length > 0
-                      ? `(${result.children.length})`
-                      : ''}
+                <div
+                  style={{
+                    width: 3,
+                    minWidth: 3,
+                    height: 14,
+                    backgroundColor: barBackgroundColor,
+                    borderRadius: 1,
+                    flexShrink: 0,
+                    marginRight: 6,
+                  }}
+                />
+
+                {result.children.length > 0 && (
+                  <Text
+                    span
+                    size="xxs"
+                    c="dimmed"
+                    me={4}
+                    style={{ flexShrink: 0 }}
+                  >
+                    ({result.children.length})
                   </Text>
+                )}
+
+                {isError && (
+                  <IconAlertCircleFilled
+                    size={12}
+                    className="me-1 flex-shrink-0"
+                    style={{ color: getChartColorError() }}
+                    aria-label="Error"
+                  />
+                )}
+                {isWarn && !isError && (
+                  <IconAlertTriangleFilled
+                    size={12}
+                    className="me-1 flex-shrink-0"
+                    style={{ color: getChartColorWarning() }}
+                    aria-label="Warning"
+                  />
                 )}
 
                 <Group gap={0} wrap="nowrap">
@@ -952,11 +1127,13 @@ export function DBTraceWaterfallChartContainer({
                     size="xxs"
                     truncate="end"
                     span
-                    title={`${serviceName}${hasHttpAttributes && httpUrl ? ` | ${displayText}` : ''}`}
+                    title={`${serviceName}${hasHttpAttributes && httpUrl ? ` ${displayText}` : ''}`}
                     role="button"
                   >
-                    {serviceName ? `${serviceName} | ` : ''}
-                    {displayText}
+                    {serviceName && <>{serviceName} </>}
+                    <Text span inherit c="dimmed">
+                      {displayText}
+                    </Text>
                   </Text>
                 </Group>
               </div>
@@ -973,10 +1150,12 @@ export function DBTraceWaterfallChartContainer({
               tooltip: `${displayText} ${tookMs >= 0 ? `took ${tookMs.toFixed(4)}ms` : ''} ${status ? `| Status: ${status}` : ''}${!isNaN(startOffset) ? ` | Started at ${formatTime(new Date(startOffset), { format: 'withMs' })}` : ''}`,
               color: 'var(--color-text-inverted)',
               backgroundColor: barColor({
-                isError,
-                isWarn,
                 isHighlighted,
+                isError,
                 type,
+                serviceColor: serviceName
+                  ? serviceColorMap.get(serviceName)
+                  : undefined,
               }),
               body: <span>{displayText}</span>,
               minWidthPx: type === SourceKind.Log ? 10 : 2,
@@ -992,13 +1171,11 @@ export function DBTraceWaterfallChartContainer({
       visibleNodes,
       formatTime,
       highlightedRowWhere,
-      isFilterActive,
       minOffset,
       onClick,
+      serviceColorMap,
       showSpanEvents,
       toggleCollapse,
-      collapseTooltipShown,
-      setCollapseTooltipShown,
     ],
   );
   const initialScrollRowIndex = visibleNodes.findIndex(v => {
@@ -1026,50 +1203,81 @@ export function DBTraceWaterfallChartContainer({
       )}
       {isFilterExpanded && (
         <form onSubmit={handleSubmit(onSubmitFilters)}>
-          <Box
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'auto 1fr',
-              alignItems: 'center',
-              gap: '12px',
-            }}
-          >
-            <Text size="xs">Spans filter</Text>
-            <SearchInputV2
+          <Box mt="xs">
+            <SearchWhereInput
               tableConnection={tcFromSource(traceTableSource)}
-              placeholder={
-                'Search trace spans w/ Lucene ex. StatusCode:"Error"'
-              }
-              language="lucene"
               name="traceWhere"
+              languageName="traceWhereLanguage"
               control={control}
               size="xs"
+              showLabel={false}
+              allowMultiline={false}
               onSubmit={handleSubmit(onSubmitFilters)}
+              onLanguageChange={lang =>
+                setValue('traceWhereLanguage', lang, { shouldDirty: true })
+              }
+              lucenePlaceholder='Filter spans & logs ex. StatusCode:"Error"'
+              sqlPlaceholder="Filter spans & logs ex. StatusCode = 'Error'"
               data-testid="trace-search-input"
+              // The waterfall lives inside an `overflow: hidden` column, which
+              // clips the SQL editor's autocomplete tooltip. Portal it to the
+              // document body so suggestions aren't cut off (Lucene mode already
+              // renders its dropdown in a portal).
+              parentRef={typeof document !== 'undefined' ? document.body : null}
             />
-
-            {logTableSource && (
-              <>
-                <Text size="xs">Logs filter</Text>
-                <SearchInputV2
-                  tableConnection={tcFromSource(logTableSource)}
-                  placeholder={
-                    'Search trace logs w/ Lucene ex. SeverityText:"error"'
-                  }
-                  language="lucene"
-                  name="logWhere"
-                  control={control}
-                  size="xs"
-                  onSubmit={handleSubmit(onSubmitFilters)}
-                  data-testid="log-search-input"
-                />
-              </>
-            )}
           </Box>
         </form>
       )}
       <Group my="xs" justify="space-between">
         <Group gap="md">
+          {hasCollapsibleNodes && (
+            <Group gap={2}>
+              <Tooltip label="Expand +1 level" position="bottom">
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={expandOneLevel}
+                  aria-label="Expand one level"
+                >
+                  <IconChevronDown size={14} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Collapse +1 level" position="bottom">
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={collapseOneLevel}
+                  aria-label="Collapse one level"
+                >
+                  <IconChevronRight size={14} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Expand all" position="bottom">
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={expandAll}
+                  aria-label="Expand all"
+                >
+                  <IconChevronsDown size={14} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Collapse all" position="bottom">
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={collapseAll}
+                  aria-label="Collapse all"
+                >
+                  <IconChevronsRight size={14} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          )}
           <Text size="xs">
             {itemCountString},{' '}
             <span className={errorCount ? 'text-danger' : ''}>
@@ -1123,26 +1331,29 @@ export function DBTraceWaterfallChartContainer({
             </Group>
           </Group>
         </Group>
-        <span>
-          <Anchor
-            underline="always"
-            onClick={() => setIsFilterExpanded(prev => !prev)}
-            size="xs"
-          >
-            {isFilterExpanded ? 'Hide Filters' : 'Show Filters'}{' '}
-            {isFilterActive && '(active)'}
-          </Anchor>
-          {isFilterActive && (
+        <Group gap="sm">
+          {controlsExtra}
+          <span>
             <Anchor
               underline="always"
-              onClick={onClearFilters}
+              onClick={() => setIsFilterExpanded(prev => !prev)}
               size="xs"
-              ms="xs"
             >
-              Clear Filters
+              {isFilterExpanded ? 'Hide Filters' : 'Show Filters'}{' '}
+              {isFilterActive && '(active)'}
             </Anchor>
-          )}
-        </span>
+            {isFilterActive && (
+              <Anchor
+                underline="always"
+                onClick={onClearFilters}
+                size="xs"
+                ms="xs"
+              >
+                Clear Filters
+              </Anchor>
+            )}
+          </span>
+        </Group>
       </Group>
       {!isFetching && !error && highlightedAttributeValues?.length > 0 && (
         <DBHighlightedAttributesList attributes={highlightedAttributeValues} />

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -580,7 +580,12 @@ export function DBTraceWaterfallChartContainer({
     defaultValues: {
       traceWhere: traceWhere ?? '',
       logWhere: logWhere ?? '',
-      traceWhereLanguage: getStoredLanguage() ?? 'lucene',
+      // Prefer the URL's whereLanguage so a shared link / reload shows the same
+      // language the filter runs in; fall back to the stored preference.
+      traceWhereLanguage:
+        whereLanguage === 'sql' || whereLanguage === 'lucene'
+          ? whereLanguage
+          : (getStoredLanguage() ?? 'lucene'),
     },
   });
 
@@ -600,6 +605,9 @@ export function DBTraceWaterfallChartContainer({
   const onClearFilters = useCallback(() => {
     setValue('traceWhere', '');
     setValue('logWhere', '');
+    // Reset the language toggle too, otherwise a stale value gets re-serialized
+    // into the URL on the next submit, undoing the cleared state.
+    setValue('traceWhereLanguage', getStoredLanguage() ?? 'lucene');
     clearFilters();
   }, [clearFilters, setValue]);
 

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -28,6 +28,7 @@ import {
   Chip,
   Code,
   Group,
+  Stack,
   Text,
   Tooltip,
 } from '@mantine/core';
@@ -43,6 +44,7 @@ import {
 } from '@tabler/icons-react';
 
 import { ContactSupportText } from '@/components/ContactSupportText';
+import { ErrorCollapse } from '@/components/Error/ErrorCollapse';
 import SearchWhereInput, {
   getStoredLanguage,
 } from '@/components/SearchInput/SearchWhereInput';
@@ -422,6 +424,39 @@ export function useEventsAroundFocus({
   };
 }
 
+function useFilteredEventsAroundFocus(
+  args: Parameters<typeof useEventsAroundFocus>[0],
+) {
+  const filtered = useEventsAroundFocus(args);
+
+  const filterFailed =
+    args.enabled && !!args.hiddenRowExpression && !!filtered.error;
+
+  const fallback = useEventsAroundFocus({
+    ...args,
+    hiddenRowExpression: undefined,
+    enabled: filterFailed,
+  });
+
+  if (filterFailed) {
+    return {
+      rows: fallback.rows,
+      meta: fallback.meta,
+      isFetching: filtered.isFetching || fallback.isFetching,
+      filterError: fallback.error ? undefined : filtered.error,
+      fatalError: fallback.error,
+    };
+  }
+
+  return {
+    rows: filtered.rows,
+    meta: filtered.meta,
+    isFetching: filtered.isFetching,
+    filterError: undefined,
+    fatalError: filtered.error,
+  };
+}
+
 export function getDescendantIds(node: {
   id?: string;
   children?: Array<{ id?: string; children?: any[] }>;
@@ -563,7 +598,8 @@ export function DBTraceWaterfallChartContainer({
   const {
     traceWhere,
     logWhere,
-    whereLanguage,
+    traceWhereLanguage,
+    logWhereLanguage,
     clear: clearFilters,
     isFilterActive,
     isFilterExpanded,
@@ -573,30 +609,42 @@ export function DBTraceWaterfallChartContainer({
     hasLogSource: !!logTableSource,
   });
 
-  const filterLanguage: 'lucene' | 'sql' =
-    whereLanguage === 'sql' ? 'sql' : 'lucene';
+  // Each filter runs in its own language. Defaults come from the URL (shared
+  // link / reload fidelity), falling back to the stored preference.
+  const traceFilterLanguage: 'lucene' | 'sql' =
+    traceWhereLanguage === 'sql' ? 'sql' : 'lucene';
+  const logFilterLanguage: 'lucene' | 'sql' =
+    logWhereLanguage === 'sql' ? 'sql' : 'lucene';
 
   const { control, handleSubmit, setValue } = useForm({
     defaultValues: {
       traceWhere: traceWhere ?? '',
       logWhere: logWhere ?? '',
-      // Prefer the URL's whereLanguage so a shared link / reload shows the same
-      // language the filter runs in; fall back to the stored preference.
+      // Prefer each input's URL language so a shared link / reload shows the
+      // same language the filter runs in; fall back to the stored preference.
       traceWhereLanguage:
-        whereLanguage === 'sql' || whereLanguage === 'lucene'
-          ? whereLanguage
+        traceWhereLanguage === 'sql' || traceWhereLanguage === 'lucene'
+          ? traceWhereLanguage
+          : (getStoredLanguage() ?? 'lucene'),
+      logWhereLanguage:
+        logWhereLanguage === 'sql' || logWhereLanguage === 'lucene'
+          ? logWhereLanguage
           : (getStoredLanguage() ?? 'lucene'),
     },
   });
 
-  // The combined input writes a single value; apply it to both the trace and
-  // log WHERE clauses, and persist the chosen language for query rebuilds.
   const onSubmitFilters = useCallback(
-    (data: { traceWhere: string; traceWhereLanguage: string }) => {
+    (data: {
+      traceWhere: string;
+      logWhere: string;
+      traceWhereLanguage: string;
+      logWhereLanguage: string;
+    }) => {
       submitFilters({
         traceWhere: data.traceWhere,
-        logWhere: data.traceWhere,
-        whereLanguage: data.traceWhereLanguage,
+        logWhere: data.logWhere,
+        traceWhereLanguage: data.traceWhereLanguage,
+        logWhereLanguage: data.logWhereLanguage,
       });
     },
     [submitFilters],
@@ -605,9 +653,10 @@ export function DBTraceWaterfallChartContainer({
   const onClearFilters = useCallback(() => {
     setValue('traceWhere', '');
     setValue('logWhere', '');
-    // Reset the language toggle too, otherwise a stale value gets re-serialized
+    // Reset the language toggles too, otherwise stale values get re-serialized
     // into the URL on the next submit, undoing the cleared state.
     setValue('traceWhereLanguage', getStoredLanguage() ?? 'lucene');
+    setValue('logWhereLanguage', getStoredLanguage() ?? 'lucene');
     clearFilters();
   }, [clearFilters, setValue]);
 
@@ -615,22 +664,24 @@ export function DBTraceWaterfallChartContainer({
     rows: traceRowsData,
     isFetching: traceIsFetching,
     meta: traceRowsMeta,
-    error: traceError,
-  } = useEventsAroundFocus({
+    filterError: traceFilterError,
+    fatalError: traceError,
+  } = useFilteredEventsAroundFocus({
     tableSource: traceTableSource,
     focusDate,
     dateRange,
     traceId,
     hiddenRowExpression: traceWhere ? `NOT (${traceWhere})` : undefined,
-    hiddenRowExpressionLanguage: filterLanguage,
+    hiddenRowExpressionLanguage: traceFilterLanguage,
     enabled: true,
   });
   const {
     rows: logRowsData,
     isFetching: logIsFetching,
     meta: logRowsMeta,
-    error: logError,
-  } = useEventsAroundFocus({
+    filterError: logFilterError,
+    fatalError: logFatalError,
+  } = useFilteredEventsAroundFocus({
     // search data if logTableModel exist
     // search invalid date range if no logTableModel(react hook need execute no matter what)
     tableSource: logTableSource ? logTableSource : traceTableSource,
@@ -638,12 +689,20 @@ export function DBTraceWaterfallChartContainer({
     dateRange: logTableSource ? dateRange : [dateRange[1], dateRange[0]], // different query to prevent cache
     traceId,
     hiddenRowExpression: logWhere ? `NOT (${logWhere})` : undefined,
-    hiddenRowExpressionLanguage: filterLanguage,
+    hiddenRowExpressionLanguage: logFilterLanguage,
     enabled: logTableSource ? true : false, // disable fire query if logSource is not exist
   });
 
   const isFetching = traceIsFetching || logIsFetching;
-  const error = traceError || logError;
+  // Only a fatal trace failure (bad source / connection) blanks the waterfall.
+  // A *filter* error on either side is non-fatal: the offending query falls back
+  // to unfiltered data and the error is surfaced inline next to its input, so a
+  // bad filter can never hide valid spans or logs. The correlated-log source is
+  // secondary, so even a fatal log failure only drops logs — never the chart.
+  const error = traceError;
+  // Log-side error to surface inline: prefer the filter error (fallback data is
+  // shown), otherwise the fatal error (no logs could be loaded at all).
+  const logError = logFilterError ?? logFatalError;
 
   const rows: any[] = useMemo(() => {
     const nextRows: Array<(typeof traceRowsData)[number] & TimestampedRow> = [
@@ -1211,29 +1270,82 @@ export function DBTraceWaterfallChartContainer({
       )}
       {isFilterExpanded && (
         <form onSubmit={handleSubmit(onSubmitFilters)}>
-          <Box mt="xs">
-            <SearchWhereInput
-              tableConnection={tcFromSource(traceTableSource)}
-              name="traceWhere"
-              languageName="traceWhereLanguage"
-              control={control}
-              size="xs"
-              showLabel={false}
-              allowMultiline={false}
-              onSubmit={handleSubmit(onSubmitFilters)}
-              onLanguageChange={lang =>
-                setValue('traceWhereLanguage', lang, { shouldDirty: true })
-              }
-              lucenePlaceholder='Filter spans & logs ex. StatusCode:"Error"'
-              sqlPlaceholder="Filter spans & logs ex. StatusCode = 'Error'"
-              data-testid="trace-search-input"
-              // The waterfall lives inside an `overflow: hidden` column, which
-              // clips the SQL editor's autocomplete tooltip. Portal it to the
-              // document body so suggestions aren't cut off (Lucene mode already
-              // renders its dropdown in a portal).
-              parentRef={typeof document !== 'undefined' ? document.body : null}
-            />
-          </Box>
+          <Stack gap="xs" mt="xs">
+            <Box>
+              <Text size="xxs" c="dimmed" mb={2}>
+                Spans filter
+              </Text>
+              <SearchWhereInput
+                tableConnection={tcFromSource(traceTableSource)}
+                name="traceWhere"
+                languageName="traceWhereLanguage"
+                control={control}
+                size="xs"
+                showLabel={false}
+                allowMultiline={false}
+                onSubmit={handleSubmit(onSubmitFilters)}
+                onLanguageChange={lang =>
+                  setValue('traceWhereLanguage', lang, { shouldDirty: true })
+                }
+                lucenePlaceholder='Filter spans ex. StatusCode:"Error"'
+                sqlPlaceholder="Filter spans ex. StatusCode = 'Error'"
+                data-testid="trace-search-input"
+                // The waterfall lives inside an `overflow: hidden` column, which
+                // clips the SQL editor's autocomplete tooltip. Portal it to the
+                // document body so suggestions aren't cut off (Lucene mode
+                // already renders its dropdown in a portal).
+                parentRef={
+                  typeof document !== 'undefined' ? document.body : null
+                }
+              />
+              {traceFilterError && (
+                <Box mt={4} data-testid="trace-filter-error">
+                  <ErrorCollapse
+                    summary="Couldn't apply spans filter (showing all spans)"
+                    details={traceFilterError.message}
+                  />
+                </Box>
+              )}
+            </Box>
+            {logTableSource && (
+              <Box>
+                <Text size="xxs" c="dimmed" mb={2}>
+                  Logs filter
+                </Text>
+                <SearchWhereInput
+                  tableConnection={tcFromSource(logTableSource)}
+                  name="logWhere"
+                  languageName="logWhereLanguage"
+                  control={control}
+                  size="xs"
+                  showLabel={false}
+                  allowMultiline={false}
+                  onSubmit={handleSubmit(onSubmitFilters)}
+                  onLanguageChange={lang =>
+                    setValue('logWhereLanguage', lang, { shouldDirty: true })
+                  }
+                  lucenePlaceholder='Filter logs ex. SeverityText:"error"'
+                  sqlPlaceholder="Filter logs ex. SeverityText = 'error'"
+                  data-testid="log-search-input"
+                  parentRef={
+                    typeof document !== 'undefined' ? document.body : null
+                  }
+                />
+                {logError && (
+                  <Box mt={4} data-testid="log-filter-error">
+                    <ErrorCollapse
+                      summary={
+                        logFilterError
+                          ? "Couldn't apply logs filter (showing all logs)"
+                          : "Couldn't load correlated logs"
+                      }
+                      details={logError.message}
+                    />
+                  </Box>
+                )}
+              </Box>
+            )}
+          </Stack>
         </form>
       )}
       <Group my="xs" justify="space-between">

--- a/packages/app/src/components/SearchInput/SearchWhereInput.tsx
+++ b/packages/app/src/components/SearchInput/SearchWhereInput.tsx
@@ -119,6 +119,7 @@ export type SearchWhereInputProps = {
    * Source id used in various queries
    */
   sourceId?: string;
+  parentRef?: HTMLElement | null;
 } & TableConnectionChoice &
   UseControllerProps<any>;
 
@@ -166,6 +167,7 @@ export default function SearchWhereInput({
   dateRange,
   languageName = `${name}Language`,
   sourceId,
+  parentRef,
 }: SearchWhereInputProps) {
   const [syntaxRefOpened, { open: openSyntaxRef, close: closeSyntaxRef }] =
     useDisclosure(false);
@@ -240,6 +242,7 @@ export default function SearchWhereInput({
               additionalSuggestions={additionalSuggestions}
               dateRange={dateRange}
               sourceId={sourceId}
+              parentRef={parentRef}
             />
           ) : (
             <SearchInputV2

--- a/packages/app/src/components/TimelineChart/TimelineChart.module.scss
+++ b/packages/app/src/components/TimelineChart/TimelineChart.module.scss
@@ -74,6 +74,11 @@
 .eventsContainer {
   flex: 1;
   position: relative;
+
+  // Own stacking context so a span-event marker's high z-index (the diamonds)
+  // stays contained within the events column and cannot paint over the sticky
+  // label column (which sits above this column at z-index 2).
+  isolation: isolate;
 }
 
 // Duration (+ span body on hover) rendered just outside the bar. Positioned by

--- a/packages/app/src/components/TimelineChart/TimelineChart.module.scss
+++ b/packages/app/src/components/TimelineChart/TimelineChart.module.scss
@@ -76,6 +76,30 @@
   position: relative;
 }
 
+// Duration (+ span body on hover) rendered just outside the bar. Positioned by
+// TimelineChartRowEvents on whichever side has more room.
+.barDetail {
+  position: absolute;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+// Span body text is hidden by default and only revealed while the row is
+// hovered or active, so it never competes with the always-on duration label.
+.barDetailBody {
+  display: none;
+  color: var(--color-text-muted);
+}
+
+.timelineRow:hover .barDetailBody,
+.timelineRowActive .barDetailBody {
+  display: inline;
+}
+
 .resizeHandleContainer {
   position: absolute;
   left: 0;
@@ -102,9 +126,26 @@
   background: var(--color-bg-body);
 }
 
+// Full-height grid lines layer. Zero-height + sticky top so the lines track the
+// viewport (matching the label header), with no z-index so they paint behind
+// the rows while the header (z-index: 1) stays above them.
+.xAxisGrid {
+  position: sticky;
+  top: 0;
+  height: 0;
+  pointer-events: none;
+}
+
 .xAxisInner {
   display: flex;
   align-items: center;
+}
+
+// Top-align the grid lines so they start at the viewport top and extend down,
+// rather than being vertically centered in the zero-height grid layer.
+.xAxisGridInner {
+  display: flex;
+  align-items: flex-start;
 }
 
 // Tick children are created/measured imperatively by TimelineXAxis.tsx

--- a/packages/app/src/components/TimelineChart/TimelineChart.module.scss
+++ b/packages/app/src/components/TimelineChart/TimelineChart.module.scss
@@ -120,7 +120,6 @@
   position: sticky;
   top: 0;
   height: 24px;
-  padding-top: 4px;
   z-index: 1;
   pointer-events: none;
   background: var(--color-bg-body);

--- a/packages/app/src/components/TimelineChart/TimelineChart.stories.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineChart.stories.tsx
@@ -4,6 +4,7 @@ import { IconChevronDown } from '@tabler/icons-react';
 
 import { TimelineChart } from './TimelineChart';
 import type { TTimelineEvent } from './TimelineChartRowEvents';
+import type { TTimelineSpanEventMarker } from './TimelineSpanEventMarker';
 
 import styles from '@/../styles/LogSidePanel.module.scss';
 
@@ -15,6 +16,7 @@ function makeRow(
   duration: number,
   level = 0,
   childCount = 0,
+  markers?: TTimelineSpanEventMarker[],
 ) {
   const event: TTimelineEvent = {
     id,
@@ -26,6 +28,7 @@ function makeRow(
     body: <span>{body}</span>,
     minWidthPx: 2,
     showDuration: true,
+    markers,
   };
 
   return {
@@ -208,6 +211,49 @@ type Story = StoryObj<typeof TimelineChart>;
 export const Default: Story = {
   args: {
     rows: sampleRows,
+    rowHeight: 24,
+    labelWidth: 300,
+    maxHeight: 800,
+    initialScrollRowIndex: 0,
+  },
+};
+
+// Variant with span-event markers (the green diamonds) clustered near the
+// timeline start. Use this to verify diamonds paint above their bar but never
+// over the sticky left-hand label column — scroll the chart vertically so a
+// marked span sits behind the labels and confirm the labels stay on top.
+const markedRows = (() => {
+  const makeMarkers = (base: number): TTimelineSpanEventMarker[] =>
+    [0, 20, 45, 80].map((offset, idx) => ({
+      timestamp: base + offset,
+      name: `span.event.${idx}`,
+      attributes: {
+        'event.index': idx,
+        'exception.type': idx % 2 === 0 ? 'RetryableError' : 'Timeout',
+        'exception.message': `sample span event detail #${idx}`,
+      },
+    }));
+
+  return sampleRows.map((row, idx) => {
+    // Add markers to the first few spans (which start near t=0) so they land
+    // under the label column once the list is scrolled.
+    if (idx > 4) return row;
+    const event = row.events[0];
+    return {
+      ...row,
+      events: [
+        {
+          ...event,
+          markers: makeMarkers(event.start),
+        },
+      ],
+    };
+  });
+})();
+
+export const WithSpanEvents: Story = {
+  args: {
+    rows: markedRows,
     rowHeight: 24,
     labelWidth: 300,
     maxHeight: 800,

--- a/packages/app/src/components/TimelineChart/TimelineChart.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineChart.tsx
@@ -403,7 +403,7 @@ export const TimelineChart = memo(function (props: TimelineChartProps) {
   );
 
   return (
-    <Flex mah={maxHeight} direction="column">
+    <Flex h={maxHeight} mah={maxHeight} direction="column">
       <Flex justify="end" mb="sm">
         <Text>
           <Kbd>⌘/Ctrl</Kbd> + <Kbd>scroll</Kbd> to zoom

--- a/packages/app/src/components/TimelineChart/TimelineChart.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineChart.tsx
@@ -431,8 +431,8 @@ export const TimelineChart = memo(function (props: TimelineChartProps) {
               className={styles.timelineCorner}
               style={{
                 width: labelWidth,
-                height: `${axisHeight}px`,
-                marginTop: `-${axisHeight}px`,
+                height: `${axisHeight + rowsMarginTop}px`,
+                marginTop: `-${axisHeight + rowsMarginTop}px`,
               }}
             />
 

--- a/packages/app/src/components/TimelineChart/TimelineChartRowEvents.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineChartRowEvents.tsx
@@ -7,6 +7,8 @@ import {
 } from './TimelineSpanEventMarker';
 import { renderMs } from './utils';
 
+import styles from './TimelineChart.module.scss';
+
 export type TTimelineEvent = {
   id: string;
   start: number;
@@ -43,8 +45,9 @@ export const TimelineChartRowEvents = memo(function (
     const durationMs = event.end - event.start;
     const barCenter = (event.start + event.end) / 2;
     const timelineMidpoint = maxVal / 2;
-    // Duration on left when majority of bar is past halfway, otherwise on right
-    const durationOnRight = barCenter <= timelineMidpoint;
+    // Render the detail on whichever side has more room: to the right when the
+    // bar's center sits in the left half of the timeline, otherwise to the left.
+    const onRight = barCenter <= timelineMidpoint;
 
     return (
       <div
@@ -71,20 +74,16 @@ export const TimelineChartRowEvents = memo(function (
           }}
         >
           <div
-            className="d-flex align-items-center h-100 cursor-pointer text-truncate hover-opacity"
+            className="d-flex align-items-center h-100 cursor-pointer hover-opacity"
             style={{
               userSelect: 'none',
               width: '100%',
               position: 'relative',
               borderRadius: 2,
               fontSize: height * 0.5,
-              color: event.color,
               backgroundColor: event.backgroundColor,
             }}
           >
-            <div style={{ margin: 'auto' }} className="px-2">
-              {event.body}
-            </div>
             {event.markers?.map((marker, idx) => (
               <TimelineSpanEventMarker
                 key={`${event.id}-marker-${idx}`}
@@ -98,22 +97,23 @@ export const TimelineChartRowEvents = memo(function (
         </Tooltip>
         {!!event.showDuration && (
           <span
+            className={styles.barDetail}
             style={{
-              position: 'absolute',
-              top: 0,
               height: '100%',
-              display: 'flex',
-              alignItems: 'center',
               fontSize: height * 0.5,
-              color: 'var(--color-text)',
-              whiteSpace: 'nowrap',
-              pointerEvents: 'none',
-              ...(durationOnRight
-                ? { left: '100%', marginLeft: 4 }
-                : { right: '100%', marginRight: 4 }),
+              ...(onRight
+                ? { left: '100%', paddingLeft: 4 }
+                : {
+                    right: '100%',
+                    paddingRight: 4,
+                    flexDirection: 'row-reverse',
+                  }),
             }}
           >
-            {renderMs(durationMs)}
+            <span style={{ color: 'var(--color-text-muted)' }}>
+              {renderMs(durationMs)}
+            </span>
+            <span className={styles.barDetailBody}>{event.body}</span>
           </span>
         )}
       </div>

--- a/packages/app/src/components/TimelineChart/TimelineXAxis.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineXAxis.tsx
@@ -31,7 +31,12 @@ export function TimelineXAxis({
   heightRef: RefObject<number>;
   ref: Ref<TimelineXAxisHandle>;
 }) {
-  const ticksContainerRef = useRef<HTMLDivElement>(null);
+  // Two tick containers laid out from the same spacing computation so their
+  // children stay column-aligned: the grid container holds the full-height
+  // vertical lines (painted behind rows), the label container holds the time
+  // labels (painted above rows in the sticky header).
+  const gridTicksRef = useRef<HTMLDivElement>(null);
+  const labelTicksRef = useRef<HTMLDivElement>(null);
 
   // Mirrored synchronously during render so recompute (called imperatively
   // from the parent's wheel/resize handlers) cannot read a stale maxVal in
@@ -42,9 +47,10 @@ export function TimelineXAxis({
   maxValRef.current = maxVal;
 
   const recompute = useCallback(() => {
-    const container = ticksContainerRef.current;
+    const gridContainer = gridTicksRef.current;
+    const labelContainer = labelTicksRef.current;
 
-    if (container == null) {
+    if (gridContainer == null || labelContainer == null) {
       return;
     }
 
@@ -55,36 +61,56 @@ export function TimelineXAxis({
     // the (zoom-scaled) events area, so dividing its width by a minimum label
     // width gives how many labels fit without overlapping. Measuring here keeps
     // the axis correct on both panel resize and zoom, since both re-invoke
-    // recompute after the layout/scale has changed.
-    const ticksWidthPx = container.getBoundingClientRect().width;
+    // recompute after the layout/scale has changed. Both containers span the
+    // same width, so measure one and drive both from the same spacing.
+    const ticksWidthPx = gridContainer.getBoundingClientRect().width;
     const maxTicks = Math.max(1, Math.floor(ticksWidthPx / MIN_TICK_PX));
     const interval = calculateInterval(max, maxTicks);
     const numTicks = Math.floor(max / interval);
     const percSpacing = (interval / max) * 100;
+    const marginLeft = (i: number) =>
+      i === 0 ? '0' : `${percSpacing.toFixed(6)}%`;
 
-    while (container.children.length > numTicks) {
-      container.removeChild(container.lastChild!);
+    // Grid layer: full-height vertical lines only, painted behind the rows.
+    while (gridContainer.children.length > numTicks) {
+      gridContainer.removeChild(gridContainer.lastChild!);
+    }
+    while (gridContainer.children.length < numTicks) {
+      const line = document.createElement('div');
+      line.style.width = '1px';
+      line.style.marginRight = '-1px';
+      line.style.background = 'var(--color-border-muted)';
+      gridContainer.appendChild(line);
+    }
+    for (let i = 0; i < numTicks; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const line = gridContainer.children[i] as HTMLDivElement;
+      line.style.height = `${height}px`;
+      line.style.marginLeft = marginLeft(i);
     }
 
-    while (container.children.length < numTicks) {
+    // Header layer: time labels only, painted above the rows. Each entry is a
+    // 1px-wide spacer div (no background line) so it column-aligns with the
+    // matching grid line while leaving the vertical line to the grid layer.
+    while (labelContainer.children.length > numTicks) {
+      labelContainer.removeChild(labelContainer.lastChild!);
+    }
+    while (labelContainer.children.length < numTicks) {
       const tick = document.createElement('div');
       tick.style.width = '1px';
       tick.style.marginRight = '-1px';
-      tick.style.background = 'var(--color-border-muted)';
       const label = document.createElement('div');
       label.className = styles.xAxisTickLabel;
       tick.appendChild(label);
-      container.appendChild(tick);
+      labelContainer.appendChild(tick);
     }
-
     // Children are always the tick <div><div /></div> pairs we created above.
     for (let i = 0; i < numTicks; i++) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const tick = container.children[i] as HTMLDivElement;
+      const tick = labelContainer.children[i] as HTMLDivElement;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const label = tick.firstElementChild as HTMLDivElement;
-      tick.style.height = `${height}px`;
-      tick.style.marginLeft = i === 0 ? '0' : `${percSpacing.toFixed(6)}%`;
+      tick.style.marginLeft = marginLeft(i);
       label.textContent = renderMs(i * interval);
     }
   }, [maxValRef, heightRef]);
@@ -98,11 +124,25 @@ export function TimelineXAxis({
   }, [maxVal, recompute]);
 
   return (
-    <div className={styles.xAxis}>
-      <div className={styles.xAxisInner}>
-        <div style={{ width: labelWidth, minWidth: labelWidth }}></div>
-        <div ref={ticksContainerRef} className={styles.xAxisTicks}></div>
+    <>
+      {/* Full-height vertical grid lines. No z-index + rendered before the
+          rows so the rows paint on top, keeping the lines behind row bars,
+          duration labels, and span-body text. */}
+      <div className={styles.xAxisGrid}>
+        <div className={styles.xAxisGridInner}>
+          <div style={{ width: labelWidth, minWidth: labelWidth }}></div>
+          <div ref={gridTicksRef} className={styles.xAxisTicks}></div>
+        </div>
       </div>
-    </div>
+
+      {/* Sticky header with the time labels. z-index keeps it above the rows
+          so labels stay visible while rows scroll underneath. */}
+      <div className={styles.xAxis}>
+        <div className={styles.xAxisInner}>
+          <div style={{ width: labelWidth, minWidth: labelWidth }}></div>
+          <div ref={labelTicksRef} className={styles.xAxisTicks}></div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/packages/app/src/components/__tests__/DBTracePanel.test.tsx
+++ b/packages/app/src/components/__tests__/DBTracePanel.test.tsx
@@ -27,9 +27,16 @@ jest.mock('@/source', () => ({
 jest.mock('@/components/DBTraceWaterfallChart', () => ({
   DBTraceWaterfallChartContainer: ({
     emptyState,
+    controlsExtra,
   }: {
     emptyState?: React.ReactNode;
-  }) => <div>{emptyState ?? 'waterfall'}</div>,
+    controlsExtra?: React.ReactNode;
+  }) => (
+    <div>
+      {controlsExtra}
+      {emptyState ?? 'waterfall'}
+    </div>
+  ),
 }));
 
 jest.mock('../SourceSelect', () => ({
@@ -85,5 +92,36 @@ describe('DBTracePanel', () => {
     );
 
     expect(screen.getByText('Trace not found')).toBeInTheDocument();
+  });
+
+  it('moves the correlated logs source selector into the waterfall controls', () => {
+    renderWithMantine(
+      <DBTracePanel
+        traceId="trace-123"
+        parentSourceId="trace-source"
+        childSourceId="log-source"
+        dateRange={[new Date(0), new Date(1000)]}
+        focusDate={new Date(500)}
+      />,
+    );
+
+    // The selector (mocked) now renders inside the waterfall controls bar.
+    expect(screen.getByText('source select')).toBeInTheDocument();
+    expect(screen.getByText('Correlated logs')).toBeInTheDocument();
+  });
+
+  it('does not duplicate the trace id in the panel body', () => {
+    renderWithMantine(
+      <DBTracePanel
+        traceId="trace-123"
+        parentSourceId="trace-source"
+        childSourceId="log-source"
+        dateRange={[new Date(0), new Date(1000)]}
+        focusDate={new Date(500)}
+      />,
+    );
+
+    // Trace id lives in the side-panel header now, not the trace panel body.
+    expect(screen.queryByText(/trace-123/)).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/__tests__/DBTraceWaterfallChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBTraceWaterfallChart.test.tsx
@@ -75,18 +75,37 @@ jest.mock('../DBRowDataPanel', () => ({
   getJSONColumnNames: jest.fn().mockReturnValue([]),
 }));
 
+// Lightweight stub: the real SearchWhereInput renders SearchInputV2, which
+// pulls in useMe()/metadata hooks that require a QueryClientProvider not present
+// in this harness. We only care that the right inputs render, so stub it to a
+// plain element carrying the data-testid.
+jest.mock('@/components/SearchInput/SearchWhereInput', () => ({
+  __esModule: true,
+  default: ({ 'data-testid': dataTestId, name }: any) => (
+    <div data-testid={dataTestId ?? `${name}-input`}>{name}</div>
+  ),
+  getStoredLanguage: () => 'lucene',
+}));
+
+const makeWaterfallSearchState = () => ({
+  traceWhere: '',
+  logWhere: '',
+  traceWhereLanguage: '',
+  logWhereLanguage: '',
+  clear: jest.fn(),
+  isFilterActive: false,
+  isFilterExpanded: false,
+  setIsFilterExpanded: jest.fn(),
+  onSubmit: jest.fn(),
+});
+
+const mockUseWaterfallSearchState: jest.Mock = jest.fn(
+  makeWaterfallSearchState,
+);
+
 jest.mock('@/hooks/useWaterfallSearchState', () => ({
   __esModule: true,
-  default: () => ({
-    traceWhere: '',
-    logWhere: '',
-    whereLanguage: '',
-    clear: jest.fn(),
-    isFilterActive: false,
-    isFilterExpanded: false,
-    setIsFilterExpanded: jest.fn(),
-    onSubmit: jest.fn(),
-  }),
+  default: (...args: any[]) => mockUseWaterfallSearchState(...args),
 }));
 
 const mockUseOffsetPaginatedQuery = useOffsetPaginatedQuery as jest.Mock;
@@ -172,6 +191,7 @@ describe('DBTraceWaterfallChartContainer', () => {
     jest.clearAllMocks();
     mockUseRowWhere.mockReturnValue(() => ({ where: 'row-id', aliasWith: [] }));
     MockTimelineChart.latestProps = {};
+    mockUseWaterfallSearchState.mockReturnValue(makeWaterfallSearchState());
   });
 
   // Helper functions
@@ -198,31 +218,62 @@ describe('DBTraceWaterfallChartContainer', () => {
     });
   };
 
+  // Content-based query mock. The waterfall runs, per source, a filtered query
+  // (with a computed `__hdx_hidden` column) plus an unfiltered fallback query
+  // that only fires when the filtered query errors. Keying responses off the
+  // query shape (table, before/after window, presence of the filter column,
+  // enabled flag) rather than call order keeps the mock stable as the number of
+  // queries changes.
+  //
+  // - `traceError`/`logError`: fatal — every query for that source fails.
+  // - `traceFilterError`/`logFilterError`: only the *filtered* query fails, so
+  //   the unfiltered fallback still returns data.
   const setupQueryMocks = (options: {
     traceData?: typeof mockTraceData | typeof emptyData;
     logData?: typeof mockLogData | typeof emptyData;
+    traceError?: Error;
+    logError?: Error;
+    traceFilterError?: Error;
+    logFilterError?: Error;
     isFetching?: boolean;
   }) => {
     const {
       traceData = emptyData,
       logData = emptyData,
+      traceError,
+      logError,
+      traceFilterError,
+      logFilterError,
       isFetching = false,
     } = options;
 
     mockUseOffsetPaginatedQuery.mockReset();
+    mockUseOffsetPaginatedQuery.mockImplementation((query: any, opts: any) => {
+      // Disabled queries never fire (mirrors react-query).
+      if (opts?.enabled === false) {
+        return { data: undefined, isFetching: false, error: undefined };
+      }
+      const isLog = query?.from?.tableName === 'log_table';
+      const isBefore = query?.dateRangeStartInclusive === true;
+      const isFiltered =
+        Array.isArray(query?.select) &&
+        query.select.some((s: any) => s?.alias === '__hdx_hidden');
 
-    // Use mockImplementation to handle all calls consistently
-    let callCount = 0;
-    mockUseOffsetPaginatedQuery.mockImplementation(() => {
-      const responses = [
-        { data: traceData, isFetching, error: undefined }, // trace before
-        { data: emptyData, isFetching, error: undefined }, // trace after
-        { data: logData, isFetching, error: undefined }, // log before
-        { data: emptyData, isFetching, error: undefined }, // log after
-      ];
-      const response = responses[callCount % responses.length];
-      callCount++;
-      return response;
+      const fatal = isLog ? logError : traceError;
+      if (fatal) {
+        return { data: undefined, isFetching, error: fatal };
+      }
+      const filterErr = isLog ? logFilterError : traceFilterError;
+      if (filterErr && isFiltered) {
+        return { data: undefined, isFetching, error: filterErr };
+      }
+
+      const data = isLog ? logData : traceData;
+      return {
+        data: isBefore ? data : emptyData,
+        isFetching,
+        error: undefined,
+      };
     });
   };
 
@@ -424,6 +475,105 @@ describe('DBTraceWaterfallChartContainer', () => {
 
     expect(screen.queryByLabelText('Expand all')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Collapse all')).not.toBeInTheDocument();
+  });
+
+  it('keeps rendering spans when the correlated-log filter errors', async () => {
+    // A log filter that references a column the log table lacks is the trigger.
+    mockUseWaterfallSearchState.mockReturnValue({
+      ...makeWaterfallSearchState(),
+      isFilterActive: true,
+      isFilterExpanded: true,
+      logWhere: "StatusCode = 'Error'",
+    });
+    setupQueryMocks({
+      traceData: mockTraceData,
+      logFilterError: new Error('Missing columns: StatusCode'),
+    });
+
+    renderComponent(); // with log source
+    await waitForLoading();
+
+    // Valid spans still render — the log failure did not blank the chart.
+    expect(MockTimelineChart.latestProps.rows.length).toBe(1);
+    // The full-chart error block is NOT shown.
+    expect(
+      screen.queryByText('An error occurred while fetching trace data:'),
+    ).not.toBeInTheDocument();
+    // The log failure is surfaced inline under the logs filter instead.
+    expect(screen.getByTestId('log-filter-error')).toBeInTheDocument();
+  });
+
+  it('keeps rendering spans (unfiltered) when the spans filter errors', async () => {
+    // A spans filter is a computed column inside the trace query, so an invalid
+    // one fails the query. We fall back to unfiltered spans instead of blanking.
+    mockUseWaterfallSearchState.mockReturnValue({
+      ...makeWaterfallSearchState(),
+      isFilterActive: true,
+      isFilterExpanded: true,
+      traceWhere: "StatusCode = 'Error'",
+    });
+    setupQueryMocks({
+      traceData: mockTraceData,
+      traceFilterError: new Error('Missing column: Nope'),
+    });
+
+    renderComponent(null); // no log source, to isolate the spans path
+    await waitForLoading();
+
+    // Spans still render (unfiltered fallback) — chart is not blanked.
+    expect(MockTimelineChart.latestProps.rows.length).toBe(1);
+    expect(
+      screen.queryByText('An error occurred while fetching trace data:'),
+    ).not.toBeInTheDocument();
+    // The span filter failure is surfaced inline under the spans filter.
+    expect(screen.getByTestId('trace-filter-error')).toBeInTheDocument();
+  });
+
+  it('renders the full-chart error block when the base trace query errors', async () => {
+    // No filter active, so a trace query error is fatal (nothing to show).
+    setupQueryMocks({
+      traceError: new Error('Trace query boom'),
+      logData: mockLogData,
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('An error occurred while fetching trace data:'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText('Trace query boom')).toBeInTheDocument();
+    // The chart itself is replaced by the error block.
+    expect(screen.queryByTestId('timeline-chart')).not.toBeInTheDocument();
+  });
+
+  it('renders separate span and log filter inputs when a log source exists', async () => {
+    mockUseWaterfallSearchState.mockReturnValue({
+      ...makeWaterfallSearchState(),
+      isFilterExpanded: true,
+    });
+    setupQueryMocks({ traceData: mockTraceData, logData: mockLogData });
+
+    renderComponent(); // with log source
+    await waitForLoading();
+
+    expect(screen.getByTestId('trace-search-input')).toBeInTheDocument();
+    expect(screen.getByTestId('log-search-input')).toBeInTheDocument();
+  });
+
+  it('renders only the span filter input when there is no log source', async () => {
+    mockUseWaterfallSearchState.mockReturnValue({
+      ...makeWaterfallSearchState(),
+      isFilterExpanded: true,
+    });
+    setupQueryMocks({ traceData: mockTraceData });
+
+    renderComponent(null); // no log source
+    await waitForLoading();
+
+    expect(screen.getByTestId('trace-search-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('log-search-input')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/app/src/components/__tests__/DBTraceWaterfallChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBTraceWaterfallChart.test.tsx
@@ -10,6 +10,10 @@ import userEvent from '@testing-library/user-event';
 
 import { RowSidePanelContext } from '@/components/DBRowSidePanel';
 import {
+  computeCollapseAll,
+  computeCollapseOneLevel,
+  computeExpandOneLevel,
+  computeToggleCollapse,
   DBTraceWaterfallChartContainer,
   getDescendantIds,
   SpanRow,
@@ -76,6 +80,7 @@ jest.mock('@/hooks/useWaterfallSearchState', () => ({
   default: () => ({
     traceWhere: '',
     logWhere: '',
+    whereLanguage: '',
     clear: jest.fn(),
     isFilterActive: false,
     isFilterExpanded: false,
@@ -367,6 +372,59 @@ describe('DBTraceWaterfallChartContainer', () => {
       expect(MockTimelineChart.latestProps.rows.length).toBe(1);
     });
   });
+
+  it('renders depth controls when the trace has collapsible spans', async () => {
+    // Distinct row ids per span so the parent/child tree is preserved (the
+    // default mock collapses every row onto the same id).
+    mockUseRowWhere.mockReturnValue((row: any) => ({
+      where: `where-${row?.SpanId ?? 'x'}`,
+      aliasWith: [],
+    }));
+
+    const nestedTraceData = {
+      data: [
+        {
+          Body: 'parent span',
+          Timestamp: '2024-01-01T06:00:00.000000000Z',
+          Duration: 0.2,
+          SpanId: 'span-1',
+          ParentSpanId: '',
+          ServiceName: 'svc-a',
+          HyperDXEventType: 'span' as const,
+          type: 'trace',
+        } as SpanRow,
+        {
+          Body: 'child span',
+          Timestamp: '2024-01-01T06:00:00.050000000Z',
+          Duration: 0.1,
+          SpanId: 'span-2',
+          ParentSpanId: 'span-1',
+          ServiceName: 'svc-b',
+          HyperDXEventType: 'span' as const,
+          type: 'trace',
+        } as SpanRow,
+      ],
+      meta: [{ totalCount: 2 }],
+    };
+
+    setupQueryMocks({ traceData: nestedTraceData });
+    renderComponent(null);
+    await waitForLoading();
+
+    expect(screen.getByLabelText('Expand all')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse all')).toBeInTheDocument();
+    expect(screen.getByLabelText('Expand one level')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse one level')).toBeInTheDocument();
+  });
+
+  it('does not render depth controls for a flat trace', async () => {
+    setupQueryMocks({ traceData: mockTraceData });
+    renderComponent(null);
+    await waitForLoading();
+
+    expect(screen.queryByLabelText('Expand all')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse all')).not.toBeInTheDocument();
+  });
 });
 
 describe('useEventsAroundFocus', () => {
@@ -539,5 +597,195 @@ describe('getDescendantIds', () => {
       children: [{ id: 'only', children: [] }],
     };
     expect(getDescendantIds(node)).toEqual(['only']);
+  });
+});
+
+describe('depth control helpers', () => {
+  // Build a level -> parent-ids map. Keys are intentionally passed out of order
+  // in some tests to prove the helpers sort levels themselves.
+  const makeLevels = (entries: Array<[number, string[]]>) =>
+    new Map<number, Set<string>>(
+      entries.map(([level, ids]) => [level, new Set(ids)]),
+    );
+
+  // A 3-deep tree of collapsible parents:
+  //   level 0: root
+  //   level 1: a, b
+  //   level 2: a1
+  const threeLevels = () =>
+    makeLevels([
+      [2, ['a1']],
+      [0, ['root']],
+      [1, ['a', 'b']],
+    ]);
+
+  const asSorted = (set: Set<string>) => [...set].sort();
+
+  describe('computeCollapseAll', () => {
+    it('returns an empty set for a trace with no collapsible parents', () => {
+      expect(computeCollapseAll(new Map())).toEqual(new Set());
+    });
+
+    it('flattens every parent id from every level into one set', () => {
+      expect(asSorted(computeCollapseAll(threeLevels()))).toEqual([
+        'a',
+        'a1',
+        'b',
+        'root',
+      ]);
+    });
+  });
+
+  describe('computeExpandOneLevel', () => {
+    it('returns the same set reference when nothing is collapsed', () => {
+      const collapsed = new Set<string>();
+      const result = computeExpandOneLevel(collapsed, threeLevels());
+      // Identity is relied on by the caller to skip a redundant state update.
+      expect(result).toBe(collapsed);
+    });
+
+    it('expands the shallowest collapsed level first', () => {
+      const levels = threeLevels();
+      const fullyCollapsed = new Set(['root', 'a', 'b', 'a1']);
+
+      // level 0 (root) is shallowest -> expanded first.
+      const afterOne = computeExpandOneLevel(fullyCollapsed, levels);
+      expect(asSorted(afterOne)).toEqual(['a', 'a1', 'b']);
+
+      // next shallowest collapsed level is level 1 (a, b).
+      const afterTwo = computeExpandOneLevel(afterOne, levels);
+      expect(asSorted(afterTwo)).toEqual(['a1']);
+
+      // finally level 2 (a1).
+      const afterThree = computeExpandOneLevel(afterTwo, levels);
+      expect(asSorted(afterThree)).toEqual([]);
+    });
+
+    it('skips already-expanded shallow levels', () => {
+      // Only the deepest level remains collapsed.
+      const result = computeExpandOneLevel(new Set(['a1']), threeLevels());
+      expect(asSorted(result)).toEqual([]);
+    });
+
+    it('does not mutate the input set', () => {
+      const collapsed = new Set(['root', 'a', 'b', 'a1']);
+      computeExpandOneLevel(collapsed, threeLevels());
+      expect(asSorted(collapsed)).toEqual(['a', 'a1', 'b', 'root']);
+    });
+  });
+
+  describe('computeCollapseOneLevel', () => {
+    it('collapses the deepest expanded level first', () => {
+      const levels = threeLevels();
+
+      // Nothing collapsed -> deepest level (a1) collapses first.
+      const afterOne = computeCollapseOneLevel(new Set<string>(), levels);
+      expect(asSorted(afterOne)).toEqual(['a1']);
+
+      // next deepest expanded level is level 1 (a, b).
+      const afterTwo = computeCollapseOneLevel(afterOne, levels);
+      expect(asSorted(afterTwo)).toEqual(['a', 'a1', 'b']);
+
+      // finally level 0 (root).
+      const afterThree = computeCollapseOneLevel(afterTwo, levels);
+      expect(asSorted(afterThree)).toEqual(['a', 'a1', 'b', 'root']);
+    });
+
+    it('skips already-collapsed deep levels', () => {
+      // Deepest level already collapsed -> collapse level 1 next.
+      const result = computeCollapseOneLevel(new Set(['a1']), threeLevels());
+      expect(asSorted(result)).toEqual(['a', 'a1', 'b']);
+    });
+
+    it('returns an equivalent set when everything is already collapsed', () => {
+      const fullyCollapsed = new Set(['root', 'a', 'b', 'a1']);
+      const result = computeCollapseOneLevel(fullyCollapsed, threeLevels());
+      expect(asSorted(result)).toEqual(['a', 'a1', 'b', 'root']);
+    });
+
+    it('does not mutate the input set', () => {
+      const collapsed = new Set(['a1']);
+      computeCollapseOneLevel(collapsed, threeLevels());
+      expect(asSorted(collapsed)).toEqual(['a1']);
+    });
+  });
+
+  it('expand and collapse one level are inverse across a full tree', () => {
+    const levels = threeLevels();
+
+    // Collapse everything one level at a time.
+    let state = new Set<string>();
+    state = computeCollapseOneLevel(state, levels); // a1
+    state = computeCollapseOneLevel(state, levels); // + a, b
+    state = computeCollapseOneLevel(state, levels); // + root
+    expect(asSorted(state)).toEqual(['a', 'a1', 'b', 'root']);
+
+    // Expand everything one level at a time back to empty.
+    state = computeExpandOneLevel(state, levels); // - root
+    state = computeExpandOneLevel(state, levels); // - a, b
+    state = computeExpandOneLevel(state, levels); // - a1
+    expect(asSorted(state)).toEqual([]);
+  });
+
+  describe('computeToggleCollapse', () => {
+    // A parent `p` with a nested subtree: descendants are c1, c1a, c2.
+    const node = () => ({
+      id: 'p',
+      children: [
+        { id: 'c1', children: [{ id: 'c1a', children: [] }] },
+        { id: 'c2', children: [] },
+      ],
+    });
+
+    it('collapses an expanded node (adds its id)', () => {
+      expect(
+        asSorted(computeToggleCollapse(new Set(), 'p', node(), false)),
+      ).toEqual(['p']);
+    });
+
+    it('expands a collapsed node (removes its id)', () => {
+      expect(
+        asSorted(computeToggleCollapse(new Set(['p']), 'p', node(), false)),
+      ).toEqual([]);
+    });
+
+    it('collapses the whole subtree when includeDescendants is true', () => {
+      expect(
+        asSorted(computeToggleCollapse(new Set(), 'p', node(), true)),
+      ).toEqual(['c1', 'c1a', 'c2', 'p']);
+    });
+
+    it('expands the whole subtree when includeDescendants is true', () => {
+      const collapsed = new Set(['p', 'c1', 'c1a', 'c2']);
+      expect(
+        asSorted(computeToggleCollapse(collapsed, 'p', node(), true)),
+      ).toEqual([]);
+    });
+
+    it('leaves descendants untouched when includeDescendants is false', () => {
+      // c1 stays collapsed even though the parent is toggled.
+      expect(
+        asSorted(computeToggleCollapse(new Set(['c1']), 'p', node(), false)),
+      ).toEqual(['c1', 'p']);
+    });
+
+    it('toggles only the id when the node is not found', () => {
+      expect(
+        asSorted(computeToggleCollapse(new Set(), 'missing', undefined, true)),
+      ).toEqual(['missing']);
+    });
+
+    it('toggles only the id for a leaf node with no children', () => {
+      const leaf = { id: 'leaf', children: [] };
+      expect(
+        asSorted(computeToggleCollapse(new Set(), 'leaf', leaf, true)),
+      ).toEqual(['leaf']);
+    });
+
+    it('does not mutate the input set', () => {
+      const collapsed = new Set(['other']);
+      computeToggleCollapse(collapsed, 'p', node(), true);
+      expect(asSorted(collapsed)).toEqual(['other']);
+    });
   });
 });

--- a/packages/app/src/hooks/useWaterfallSearchState.tsx
+++ b/packages/app/src/hooks/useWaterfallSearchState.tsx
@@ -8,9 +8,10 @@ export default function useWaterfallSearchState({
 }) {
   const [traceWhere, setTraceWhere] = useQueryState('traceWhere');
   const [logWhere, setLogWhere] = useQueryState('logWhere');
-  // Persisted alongside the WHERE values so a shared link / reload rebuilds the
-  // query with the same language the filter was written in (lucene vs sql).
-  const [whereLanguage, setWhereLanguage] = useQueryState('whereLanguage');
+  const [traceWhereLanguage, setTraceWhereLanguage] =
+    useQueryState('traceWhereLanguage');
+  const [logWhereLanguage, setLogWhereLanguage] =
+    useQueryState('logWhereLanguage');
 
   const isFilterActive = !!traceWhere || !!(hasLogSource && logWhere);
 
@@ -20,27 +21,33 @@ export default function useWaterfallSearchState({
     (data: {
       traceWhere: string;
       logWhere: string;
-      whereLanguage?: string;
+      traceWhereLanguage?: string;
+      logWhereLanguage?: string;
     }) => {
       setTraceWhere(data.traceWhere || null);
       setLogWhere(data.logWhere || null);
-      if (data.whereLanguage !== undefined) {
-        setWhereLanguage(data.whereLanguage || null);
+      if (data.traceWhereLanguage !== undefined) {
+        setTraceWhereLanguage(data.traceWhereLanguage || null);
+      }
+      if (data.logWhereLanguage !== undefined) {
+        setLogWhereLanguage(data.logWhereLanguage || null);
       }
     },
-    [setTraceWhere, setLogWhere, setWhereLanguage],
+    [setTraceWhere, setLogWhere, setTraceWhereLanguage, setLogWhereLanguage],
   );
 
   const clear = useCallback(() => {
     setTraceWhere(null);
     setLogWhere(null);
-    setWhereLanguage(null);
-  }, [setTraceWhere, setLogWhere, setWhereLanguage]);
+    setTraceWhereLanguage(null);
+    setLogWhereLanguage(null);
+  }, [setTraceWhere, setLogWhere, setTraceWhereLanguage, setLogWhereLanguage]);
 
   return {
     traceWhere,
     logWhere,
-    whereLanguage,
+    traceWhereLanguage,
+    logWhereLanguage,
     isFilterActive,
     isFilterExpanded,
     setIsFilterExpanded,

--- a/packages/app/src/hooks/useWaterfallSearchState.tsx
+++ b/packages/app/src/hooks/useWaterfallSearchState.tsx
@@ -8,27 +8,39 @@ export default function useWaterfallSearchState({
 }) {
   const [traceWhere, setTraceWhere] = useQueryState('traceWhere');
   const [logWhere, setLogWhere] = useQueryState('logWhere');
+  // Persisted alongside the WHERE values so a shared link / reload rebuilds the
+  // query with the same language the filter was written in (lucene vs sql).
+  const [whereLanguage, setWhereLanguage] = useQueryState('whereLanguage');
 
   const isFilterActive = !!traceWhere || !!(hasLogSource && logWhere);
 
   const [isFilterExpanded, setIsFilterExpanded] = useState(isFilterActive);
 
   const onSubmit = useCallback(
-    (data: { traceWhere: string; logWhere: string }) => {
+    (data: {
+      traceWhere: string;
+      logWhere: string;
+      whereLanguage?: string;
+    }) => {
       setTraceWhere(data.traceWhere || null);
       setLogWhere(data.logWhere || null);
+      if (data.whereLanguage !== undefined) {
+        setWhereLanguage(data.whereLanguage || null);
+      }
     },
-    [setTraceWhere, setLogWhere],
+    [setTraceWhere, setLogWhere, setWhereLanguage],
   );
 
   const clear = useCallback(() => {
     setTraceWhere(null);
     setLogWhere(null);
-  }, [setTraceWhere, setLogWhere]);
+    setWhereLanguage(null);
+  }, [setTraceWhere, setLogWhere, setWhereLanguage]);
 
   return {
     traceWhere,
     logWhere,
+    whereLanguage,
     isFilterActive,
     isFilterExpanded,
     setIsFilterExpanded,

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -762,20 +762,6 @@ export function getChartColorSuccessHighlight(): string {
   );
 }
 
-export function getChartColorErrorHighlight(): string {
-  return getSemanticChartColor(
-    '--color-chart-error-highlight',
-    'errorHighlight',
-  );
-}
-
-export function getChartColorWarningHighlight(): string {
-  return getSemanticChartColor(
-    '--color-chart-warning-highlight',
-    'warningHighlight',
-  );
-}
-
 // Try to match log levels to colors
 export const semanticKeyedColor = (
   key: string | number | undefined,


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Redesigns the trace waterfall chart and cleans up the surrounding trace panel layout.

### Waterfall redesign (HDX-3945)
- **Per-service colors**: each service gets a stable color (sorted for render-order stability). Green is reserved for correlated log rows and red for error spans, so a service color is never confused with a log or error.
- **Bar & label layout**: no text inside bars — the operation/service label sits beside a vertical service color bar, with the span duration shown as muted text and the span body revealed on hover, placed on whichever side has more room.
- **Depth controls**: expand/collapse one level and expand/collapse all, only shown when the trace has collapsible nodes.

### Trace panel layout (HDX-3952)
- Removed the duplicated Trace ID from the panel body (it lives in the side panel header). The Trace ID Expression editor now only appears as a fallback when no trace id resolves for the event.
- Moved the Correlated Logs source selector into the waterfall controls bar as a compact selector.

### Collapse hint bug (HDX-4444)
- Removed the flaky tooltip-based Alt+click collapse hint (`CollapseTooltipLabel` / `useDisclosure`) that could render multiple times when chevrons were highlighted in quick succession. Collapse is now an always-present chevron control.

### Supporting changes
- `useWaterfallSearchState` now persists the filter language (`whereLanguage`) in the URL so shared links / reloads rebuild the query in the language it was written in.
- `SearchWhereInput` accepts a `parentRef` for popover positioning.

## Testing
- Added `DBTraceWaterfallChart.test.tsx` covering the depth-control logic.
- Updated `DBTracePanel.test.tsx` for the new layout.
 
### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->

<img width="1685" height="1011" alt="Screenshot 2026-07-01 at 17 12 42" src="https://github.com/user-attachments/assets/a626f16b-60c0-4864-adc3-900e3ddf2a15" />

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/search`

**Steps:**

1. Open the trace timeline and explore the new features described above.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-3945, HDX-3952, HDX-4443, and HDX-4444.
- Related PRs: https://github.com/hyperdxio/hyperdx/pull/1970
