### PR TITLE
Hide feedback control when left nav is collapsed

### DIFF
--- a/.changeset/hide-feedback-when-nav-collapsed.md
+++ b/.changeset/hide-feedback-when-nav-collapsed.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Hide the left nav feedback control entirely when the nav is collapsed, since the thumbs up/down icons were not usable in that state.

--- a/packages/app/src/components/AppNav/AppNavFeedback.tsx
+++ b/packages/app/src/components/AppNav/AppNavFeedback.tsx
@@ -1,15 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useRouter } from 'next/router';
 import HyperDX from '@hyperdx/browser';
-import {
-  ActionIcon,
-  Box,
-  Button,
-  Group,
-  Text,
-  Textarea,
-  Tooltip,
-} from '@mantine/core';
+import { ActionIcon, Box, Button, Group, Text, Textarea } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import {
   IconThumbDown,
@@ -114,40 +106,9 @@ const AppNavFeedbackInner = () => {
     }, 1500);
   }, [vote, comment, pageContext, reset]);
 
-  if (!sdkEnabled || hidden || dismissed) return null;
-
-  if (isCollapsed) {
-    return (
-      <Tooltip label="Feedback" position="right">
-        <Group
-          data-testid="feedback-inline"
-          gap={0}
-          justify="center"
-          py={4}
-          wrap="nowrap"
-        >
-          <ActionIcon
-            data-testid="feedback-thumbs-up"
-            variant="subtle"
-            size="sm"
-            onClick={() => handleVote('up')}
-            title="Thumbs up"
-          >
-            <IconThumbUp size={14} />
-          </ActionIcon>
-          <ActionIcon
-            data-testid="feedback-thumbs-down"
-            variant="subtle"
-            size="sm"
-            onClick={() => handleVote('down')}
-            title="Thumbs down"
-          >
-            <IconThumbDown size={14} />
-          </ActionIcon>
-        </Group>
-      </Tooltip>
-    );
-  }
+  // Hide the feedback control entirely when the nav is collapsed, since it is
+  // not usable in that state.
+  if (!sdkEnabled || hidden || dismissed || isCollapsed) return null;
 
   return (
     <Box data-testid="feedback-inline">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

When the left nav is collapsed, the feedback control (thumbs up/down) is not usable — the collapsed variant rendered bare thumbs icons with no way to leave a comment or meaningfully interact. Linear issue HDX-4686 requests hiding the control entirely in this state.

## What changed

- `AppNavFeedback` now returns `null` when `isCollapsed` is true, removing the compact collapsed thumbs up/down variant entirely.
- Removed the now-unused collapsed-state JSX and the unused `Tooltip` import.
- Added a changeset (`@hyperdx/app` patch).

The expanded (non-collapsed) feedback UI is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4686](https://linear.app/clickhouse/issue/HDX-4686/hide-this-control-when-the-left-nav-is-collapsed)

<div><a href="https://cursor.com/agents/bc-6ed2bc83-5d34-4952-b6be-fa2c116b3ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ed2bc83-5d34-4952-b6be-fa2c116b3ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

