### PR TITLE
fix: bring back sessions source validation

### DIFF
--- a/.changeset/hip-kangaroos-deliver.md
+++ b/.changeset/hip-kangaroos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: brings back sessions source validation that was mysteriously deleted

--- a/packages/app/src/components/Sources/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm.tsx
@@ -84,6 +84,7 @@ import { useColumns, useMetadataWithSettings } from '@/hooks/useMetadata';
 import {
   inferTableSourceConfig,
   isValidMetricTable,
+  isValidSessionsTable,
   useCreateSource,
   useDeleteSource,
   useSource,
@@ -1888,6 +1889,37 @@ function SessionTableModelForm({ control }: TableModelProps) {
   });
   const connectionId = useWatch({ control, name: 'connection' });
   const tableName = useWatch({ control, name: 'from.tableName' });
+  const prevTableNameRef = useRef(tableName);
+  const metadata = useMetadataWithSettings();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (tableName && tableName !== prevTableNameRef.current) {
+          prevTableNameRef.current = tableName;
+          const isValid = await isValidSessionsTable({
+            databaseName,
+            tableName,
+            connectionId,
+            metadata,
+          });
+
+          if (!isValid) {
+            notifications.show({
+              color: 'red',
+              message: `${tableName} is not a valid Sessions schema.`,
+            });
+          }
+        }
+      } catch (e) {
+        console.error(e);
+        notifications.show({
+          color: 'red',
+          message: e.message,
+        });
+      }
+    })();
+  }, [tableName, databaseName, connectionId, metadata]);
 
   return (
     <>

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -556,10 +556,6 @@ export function useAllFieldsAndValues(
   });
 }
 
-export function deduplicateArray<T extends object>(array: T[]): T[] {
-  return deduplicate2dArray([array]);
-}
-
 export function deduplicate2dArray<T extends object>(array2d: T[][]): T[] {
   // deduplicate common fields
   const array: T[] = [];

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -48,7 +48,7 @@ export const SESSION_TABLE_EXPRESSIONS = {
   implicitColumnExpression: 'Body',
 } as const;
 
-export const JSON_SESSION_TABLE_EXPRESSIONS = {
+const JSON_SESSION_TABLE_EXPRESSIONS = {
   ...SESSION_TABLE_EXPRESSIONS,
   timestampValueExpression: 'Timestamp',
 } as const;


### PR DESCRIPTION
## Summary

For some reason, the client side validation for sessions was removed and knip started complaining on PRs that had nothing to do with the change. This brings back the validation and fixes a couple of unused export errors knip flagged.