### PR TITLE
[HDX-4597] feat(otel-collector): add opt-in Datadog receiver for traces, metrics, and logs

### DIFF
--- a/.changeset/add-datadog-receiver.md
+++ b/.changeset/add-datadog-receiver.md
@@ -1,0 +1,11 @@
+---
+"@hyperdx/api": minor
+"@hyperdx/otel-collector": minor
+---
+
+Add an opt-in Datadog receiver (gated behind `ENABLE_DATADOG_RECEIVER`) so a
+Datadog Agent can ship traces, metrics, and logs to HyperDX. The contrib
+`datadogreceiver` is compiled into the collector binary and, when enabled, the
+OpAMP controller attaches it (listening on `0.0.0.0:8126`) to the traces,
+metrics, and logs pipelines. When collector authentication is enforced, the
+receiver validates the `DD-API-KEY` header against team API keys.

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -28,6 +28,11 @@ export const IS_LOCAL_IMAGE = HYPERDX_IMAGE === 'all-in-one-noauth';
 export const IS_INLINE_API = env.HDX_PREVIEW_INLINE_API === 'true';
 export const FRONTEND_REDIRECT_BASE = IS_INLINE_API ? '' : FRONTEND_URL;
 export const INGESTION_API_KEY = env.INGESTION_API_KEY ?? '';
+// Opt-in: emit the contrib `datadogreceiver` on the collector so a
+// Datadog Agent can ship APM traces (DD trace API -> OTLP -> ClickHouse).
+// Off by default because the receiver has no per-team bearer-token auth like
+// `otlp/hyperdx`, so enabling it opens an unauthenticated ingest port (:8126).
+export const ENABLE_DATADOG_RECEIVER = env.ENABLE_DATADOG_RECEIVER === 'true';
 export const HYPERDX_API_KEY = env.HYPERDX_API_KEY as string;
 export const HYPERDX_LOG_LEVEL = env.HYPERDX_LOG_LEVEL as string;
 export const IS_CI = NODE_ENV === 'test';

--- a/packages/api/src/opamp/controllers/__tests__/opampController.test.ts
+++ b/packages/api/src/opamp/controllers/__tests__/opampController.test.ts
@@ -1,0 +1,124 @@
+// Use mutable object so individual tests can flip flags. The values here are
+// the defaults used by every test unless explicitly overridden.
+const configState = {
+  IS_ALL_IN_ONE_IMAGE: false,
+  IS_LOCAL_APP_MODE: false,
+  IS_DEV: false,
+  INGESTION_API_KEY: '' as string,
+  IS_PROMQL_ENABLED: false,
+  ENABLE_DATADOG_RECEIVER: false,
+};
+
+jest.mock('@/config', () => ({
+  get IS_ALL_IN_ONE_IMAGE() {
+    return configState.IS_ALL_IN_ONE_IMAGE;
+  },
+  get IS_LOCAL_APP_MODE() {
+    return configState.IS_LOCAL_APP_MODE;
+  },
+  get IS_DEV() {
+    return configState.IS_DEV;
+  },
+  get INGESTION_API_KEY() {
+    return configState.INGESTION_API_KEY;
+  },
+  get IS_PROMQL_ENABLED() {
+    return configState.IS_PROMQL_ENABLED;
+  },
+  get ENABLE_DATADOG_RECEIVER() {
+    return configState.ENABLE_DATADOG_RECEIVER;
+  },
+}));
+
+import { buildOtelCollectorConfig } from '@/opamp/controllers/opampController';
+
+const resetConfig = () => {
+  configState.IS_ALL_IN_ONE_IMAGE = false;
+  configState.IS_LOCAL_APP_MODE = false;
+  configState.IS_DEV = false;
+  configState.INGESTION_API_KEY = '';
+  configState.IS_PROMQL_ENABLED = false;
+  configState.ENABLE_DATADOG_RECEIVER = false;
+};
+
+describe('opampController', () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  describe('buildOtelCollectorConfig datadog receiver', () => {
+    it('omits the datadog receiver when the flag is off (default)', () => {
+      configState.ENABLE_DATADOG_RECEIVER = false;
+
+      const cfg = buildOtelCollectorConfig([]);
+
+      expect(cfg.receivers.datadog).toBeUndefined();
+      expect(cfg.service.pipelines.traces.receivers).not.toContain('datadog');
+    });
+
+    it('attaches the datadog receiver to the traces pipeline when the flag is on', () => {
+      configState.ENABLE_DATADOG_RECEIVER = true;
+
+      const cfg = buildOtelCollectorConfig([]);
+
+      expect(cfg.receivers.datadog).toMatchObject({
+        endpoint: '0.0.0.0:8126',
+        read_timeout: '60s',
+      });
+      expect(cfg.service.pipelines.traces.receivers).toContain('datadog');
+      // Traces-only: the receiver must not leak into metrics/logs pipelines.
+      expect(cfg.service.pipelines.metrics.receivers).not.toContain('datadog');
+      expect(cfg.service.pipelines['logs/in'].receivers).not.toContain(
+        'datadog',
+      );
+    });
+
+    it('leaves the datadog receiver unauthenticated when no team API keys exist', () => {
+      configState.ENABLE_DATADOG_RECEIVER = true;
+
+      const cfg = buildOtelCollectorConfig([]);
+
+      // No API keys -> no auth wiring, mirroring otlp/hyperdx.
+      expect(cfg.receivers.datadog?.auth).toBeUndefined();
+      expect(cfg.extensions['bearertokenauth/datadog']).toBeUndefined();
+      expect(cfg.service.extensions).not.toContain('bearertokenauth/datadog');
+    });
+
+    it('leaves the datadog receiver unauthenticated when collector authentication is not enforced', () => {
+      configState.ENABLE_DATADOG_RECEIVER = true;
+
+      const cfg = buildOtelCollectorConfig([
+        { apiKey: 'k1', collectorAuthenticationEnforced: false },
+      ]);
+
+      // Keys exist but auth is not enforced -> no auth wiring, mirroring
+      // otlp/hyperdx.
+      expect(cfg.receivers.datadog?.auth).toBeUndefined();
+      expect(cfg.extensions['bearertokenauth/datadog']).toBeUndefined();
+      expect(cfg.service.extensions).not.toContain('bearertokenauth/datadog');
+    });
+
+    it('authenticates the datadog receiver with team API keys via the DD-API-KEY header', () => {
+      configState.ENABLE_DATADOG_RECEIVER = true;
+
+      const cfg = buildOtelCollectorConfig([
+        { apiKey: 'k1', collectorAuthenticationEnforced: true },
+        { apiKey: 'k2', collectorAuthenticationEnforced: true },
+      ]);
+
+      // Bearer-token extension keyed on DD-API-KEY with the team API keys.
+      expect(cfg.extensions['bearertokenauth/datadog']).toEqual({
+        header: 'DD-API-KEY',
+        scheme: '',
+        tokens: ['k1', 'k2'],
+      });
+      // Receiver references the authenticator and the extension is enabled.
+      expect(cfg.receivers.datadog?.auth).toEqual({
+        authenticator: 'bearertokenauth/datadog',
+      });
+      expect(cfg.service.extensions).toContain('bearertokenauth/datadog');
+      // The otlp/hyperdx auth extension stays intact alongside it.
+      expect(cfg.service.extensions).toContain('bearertokenauth/hyperdx');
+    });
+  });
+});

--- a/packages/api/src/opamp/controllers/__tests__/opampController.test.ts
+++ b/packages/api/src/opamp/controllers/__tests__/opampController.test.ts
@@ -54,9 +54,13 @@ describe('opampController', () => {
 
       expect(cfg.receivers.datadog).toBeUndefined();
       expect(cfg.service.pipelines.traces.receivers).not.toContain('datadog');
+      expect(cfg.service.pipelines.metrics.receivers).not.toContain('datadog');
+      expect(cfg.service.pipelines['logs/in'].receivers).not.toContain(
+        'datadog',
+      );
     });
 
-    it('attaches the datadog receiver to the traces pipeline when the flag is on', () => {
+    it('attaches the datadog receiver to the traces, metrics, and logs pipelines when the flag is on', () => {
       configState.ENABLE_DATADOG_RECEIVER = true;
 
       const cfg = buildOtelCollectorConfig([]);
@@ -65,12 +69,10 @@ describe('opampController', () => {
         endpoint: '0.0.0.0:8126',
         read_timeout: '60s',
       });
+      // The single DD receiver serves all three signals; attach it to each.
       expect(cfg.service.pipelines.traces.receivers).toContain('datadog');
-      // Traces-only: the receiver must not leak into metrics/logs pipelines.
-      expect(cfg.service.pipelines.metrics.receivers).not.toContain('datadog');
-      expect(cfg.service.pipelines['logs/in'].receivers).not.toContain(
-        'datadog',
-      );
+      expect(cfg.service.pipelines.metrics.receivers).toContain('datadog');
+      expect(cfg.service.pipelines['logs/in'].receivers).toContain('datadog');
     });
 
     it('leaves the datadog receiver unauthenticated when no team API keys exist', () => {

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -349,18 +349,20 @@ export const buildOtelCollectorConfig = (
     }
   }
 
-  // Opt-in Datadog receiver: lets a Datadog Agent ship APM traces to HyperDX.
-  // The contrib `datadogreceiver` runs its own HTTP server (the DD trace
-  // intake API) and translates DD traces into OTLP, which then flow through
-  // the existing `traces` pipeline to ClickHouse. Traces only — metrics/logs
-  // from DD are intentionally not wired. It is gated behind
-  // ENABLE_DATADOG_RECEIVER because it opens an extra ingest port (:8126).
+  // Opt-in Datadog receiver: lets a Datadog Agent ship traces, metrics, and
+  // logs to HyperDX. The contrib `datadogreceiver` runs a single HTTP server
+  // (the DD intake API on :8126) that serves all three signals and translates
+  // them into OTLP, which then flow through the existing traces/metrics/logs
+  // pipelines to ClickHouse. It is gated behind ENABLE_DATADOG_RECEIVER
+  // because it opens an extra ingest port (:8126).
   if (config.ENABLE_DATADOG_RECEIVER) {
     otelCollectorConfig.receivers.datadog = {
       endpoint: '0.0.0.0:8126',
       read_timeout: '60s',
     };
     otelCollectorConfig.service.pipelines.traces.receivers.push('datadog');
+    otelCollectorConfig.service.pipelines.metrics.receivers.push('datadog');
+    otelCollectorConfig.service.pipelines['logs/in'].receivers.push('datadog');
 
     // Authenticate Datadog agents with the same per-team API keys as
     // otlp/hyperdx. DD agents send their key in the `DD-API-KEY` header

--- a/packages/api/src/opamp/controllers/opampController.ts
+++ b/packages/api/src/opamp/controllers/opampController.ts
@@ -71,6 +71,13 @@ type CollectorConfig = {
     };
     nop?: null;
     'routing/logs'?: string[];
+    datadog?: {
+      endpoint: string;
+      read_timeout: string;
+      auth?: {
+        authenticator: string;
+      };
+    };
   };
   connectors?: {
     'routing/logs'?: {
@@ -339,6 +346,39 @@ export const buildOtelCollectorConfig = (
         authenticator: 'bearertokenauth/hyperdx',
       };
       otelCollectorConfig.service.extensions = ['bearertokenauth/hyperdx'];
+    }
+  }
+
+  // Opt-in Datadog receiver: lets a Datadog Agent ship APM traces to HyperDX.
+  // The contrib `datadogreceiver` runs its own HTTP server (the DD trace
+  // intake API) and translates DD traces into OTLP, which then flow through
+  // the existing `traces` pipeline to ClickHouse. Traces only — metrics/logs
+  // from DD are intentionally not wired. It is gated behind
+  // ENABLE_DATADOG_RECEIVER because it opens an extra ingest port (:8126).
+  if (config.ENABLE_DATADOG_RECEIVER) {
+    otelCollectorConfig.receivers.datadog = {
+      endpoint: '0.0.0.0:8126',
+      read_timeout: '60s',
+    };
+    otelCollectorConfig.service.pipelines.traces.receivers.push('datadog');
+
+    // Authenticate Datadog agents with the same per-team API keys as
+    // otlp/hyperdx. DD agents send their key in the `DD-API-KEY` header
+    // (set via DD_API_KEY on the agent), so the bearer-token extension is
+    // configured to validate that header instead of `Authorization`. Only
+    // attached when team API keys exist and collector authentication is
+    // enforced, mirroring otlp/hyperdx — otherwise the receiver stays
+    // unauthenticated.
+    if (apiKeys && apiKeys.length > 0 && collectorAuthenticationEnforced) {
+      otelCollectorConfig.extensions['bearertokenauth/datadog'] = {
+        header: 'DD-API-KEY',
+        scheme: '',
+        tokens: apiKeys,
+      };
+      otelCollectorConfig.receivers.datadog.auth = {
+        authenticator: 'bearertokenauth/datadog',
+      };
+      otelCollectorConfig.service.extensions.push('bearertokenauth/datadog');
     }
   }
 

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -56,17 +56,18 @@ custom OTel configurations without rebuilding the collector.
 
 ### Receivers
 
-| Component        | Module  | Used in                                           |
-| ---------------- | ------- | ------------------------------------------------- |
-| `nop`            | core    | OpAMP controller                                  |
-| `otlp`           | core    | standalone configs, OpAMP controller, smoke tests |
-| `dockerstats`    | contrib | user configs                                      |
-| `filelog`        | contrib | user configs                                      |
-| `fluentforward`  | contrib | standalone configs, OpAMP controller, smoke tests |
-| `hostmetrics`    | contrib | custom.config.yaml                                |
-| `k8scluster`     | contrib | user configs                                      |
-| `kubeletstats`   | contrib | user configs                                      |
-| `prometheus`     | contrib | OpAMP controller, smoke tests                     |
+| Component       | Module  | Used in                                                 |
+| --------------- | ------- | ------------------------------------------------------- |
+| `nop`           | core    | OpAMP controller                                        |
+| `otlp`          | core    | standalone configs, OpAMP controller, smoke tests       |
+| `datadog`       | contrib | OpAMP controller (opt-in via `ENABLE_DATADOG_RECEIVER`) |
+| `dockerstats`   | contrib | user configs                                            |
+| `filelog`       | contrib | user configs                                            |
+| `fluentforward` | contrib | standalone configs, OpAMP controller, smoke tests       |
+| `hostmetrics`   | contrib | custom.config.yaml                                      |
+| `k8scluster`    | contrib | user configs                                            |
+| `kubeletstats`  | contrib | user configs                                            |
+| `prometheus`    | contrib | OpAMP controller, smoke tests                           |
 
 ### Processors
 
@@ -127,6 +128,31 @@ custom OTel configurations without rebuilding the collector.
 | `http`   | core   |
 | `https`  | core   |
 | `yaml`   | core   |
+
+## Ingesting Datadog APM traces
+
+The `datadogreceiver` contrib component is compiled into the binary so a
+Datadog Agent can ship **APM traces** to HyperDX (the receiver translates the
+Datadog trace API into OTLP, which flows through the existing `traces`
+pipeline into ClickHouse). It is **opt-in and traces-only**:
+
+- In OpAMP supervisor mode, set `ENABLE_DATADOG_RECEIVER=true` on the API/
+  OpAMP process. `buildOtelCollectorConfig()` then emits the `datadog`
+  receiver (listening on `0.0.0.0:8126`) and attaches it to the `traces`
+  pipeline.
+- In standalone mode, add a `datadog` receiver block to your collector config
+  and add `datadog` to the `traces` pipeline receivers.
+
+Point the Datadog Agent's trace intake at the collector's `:8126` endpoint
+(e.g. `DD_APM_DD_URL` / agent `apm_config.apm_dd_url`). Only metrics and logs
+are **not** wired — Datadog metrics/logs ingestion is out of scope.
+
+### Authentication
+
+In OpAMP supervisor mode, when collector authentication is enforced the
+receiver authenticates against the team API keys (same as `otlp/hyperdx`) via
+the `DD-API-KEY` header. Set the Datadog Agent's `DD_API_KEY` to a HyperDX
+team ingestion API key.
 
 ## Overriding base components via `CUSTOM_OTELCOL_CONFIG_FILE`
 

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -129,23 +129,26 @@ custom OTel configurations without rebuilding the collector.
 | `https`  | core   |
 | `yaml`   | core   |
 
-## Ingesting Datadog APM traces
+## Ingesting Datadog traces, metrics, and logs
 
 The `datadogreceiver` contrib component is compiled into the binary so a
-Datadog Agent can ship **APM traces** to HyperDX (the receiver translates the
-Datadog trace API into OTLP, which flows through the existing `traces`
-pipeline into ClickHouse). It is **opt-in and traces-only**:
+Datadog Agent can ship **traces, metrics, and logs** to HyperDX. The receiver
+runs a single HTTP server on `:8126` that serves the Datadog intake API for
+all three signals and translates them into OTLP, which flows through the
+existing `traces`, `metrics`, and `logs` pipelines into ClickHouse. It is
+**opt-in**:
 
 - In OpAMP supervisor mode, set `ENABLE_DATADOG_RECEIVER=true` on the API/
   OpAMP process. `buildOtelCollectorConfig()` then emits the `datadog`
-  receiver (listening on `0.0.0.0:8126`) and attaches it to the `traces`
-  pipeline.
+  receiver (listening on `0.0.0.0:8126`) and attaches it to the `traces`,
+  `metrics`, and `logs/in` pipelines.
 - In standalone mode, add a `datadog` receiver block to your collector config
-  and add `datadog` to the `traces` pipeline receivers.
+  and add `datadog` to the `traces`, `metrics`, and `logs/in` pipeline
+  receivers.
 
-Point the Datadog Agent's trace intake at the collector's `:8126` endpoint
-(e.g. `DD_APM_DD_URL` / agent `apm_config.apm_dd_url`). Only metrics and logs
-are **not** wired — Datadog metrics/logs ingestion is out of scope.
+Point the Datadog Agent at the collector's `:8126` endpoint (e.g.
+`DD_APM_DD_URL` for traces, `DD_DD_URL` for metrics, and the logs endpoint
+config for logs).
 
 ### Authentication
 

--- a/packages/otel-collector/builder-config.yaml
+++ b/packages/otel-collector/builder-config.yaml
@@ -28,6 +28,9 @@ receivers:
       v__OTEL_COLLECTOR_VERSION__
   # Contrib
   - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
+      v__OTEL_COLLECTOR_VERSION__
+  - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
       v__OTEL_COLLECTOR_VERSION__
   - gomod:


### PR DESCRIPTION
## Summary

Cherry-picks the opt-in Datadog receiver from the EE repo into OSS, adapted for the OSS OpAMP controller:

- [`ff7e5ca`](https://github.com/DeploySentinel/hyperdx-ee/commit/ff7e5ca9dc182d5142920874753fb8f2208df5e7) — [HDX-4597] add opt-in Datadog receiver for APM traces
- [`e8dd564`](https://github.com/DeploySentinel/hyperdx-ee/commit/e8dd5643e09060d2e886dfedbe5b976c50cd81c5) — support Datadog metrics and logs ingestion

**Linear:** [HDX-4597](https://linear.app/hyperdx/issue/HDX-4597)

## What it does

- Compiles the contrib `datadogreceiver` into the collector binary (`builder-config.yaml`).
- Adds an `ENABLE_DATADOG_RECEIVER` flag (off by default). When enabled, the OpAMP controller emits a `datadog` receiver on `0.0.0.0:8126` and attaches it to the `traces`, `metrics`, and `logs/in` pipelines — a Datadog Agent can point its intake at `:8126` and ship all three signals (DD intake API → OTLP → ClickHouse).
- Authenticates DD agents via a `bearertokenauth/datadog` extension keyed on the `DD-API-KEY` header, validated against team API keys.

## OSS adaptations (why this isn't a clean cherry-pick)

The OSS `opampController.ts` has no ClickStack Cloud S3-overflow rewrite, no main/catchup collector roles, and gates receiver auth on `collectorAuthenticationEnforced`:

- The DD auth wiring is gated on `apiKeys.length > 0 && collectorAuthenticationEnforced`, mirroring how OSS gates the `otlp/hyperdx` auth (EE attaches auth whenever keys exist).
- Cloud/catchup-specific code paths, comments, tests, and README references were dropped or reworded.
- The test file was adapted to the OSS `buildOtelCollectorConfig(teams)` signature and config keys; cloud rewrite/catchup test cases removed, and a case asserting no auth when `collectorAuthenticationEnforced` is false was added.

## Testing

- `make ci-lint` — passes
- `yarn workspace @hyperdx/api run ci:int --testPathPatterns=opampController` — 5/5 pass

## Ref
HDX-4687
