### PR TITLE
Fix crash when expanding filter group with empty attribute key

### DIFF
--- a/.changeset/fix-empty-attribute-key-filter-crash.md
+++ b/.changeset/fix-empty-attribute-key-filter-crash.md
@@ -1,0 +1,9 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix "Accordion.Item component was rendered with invalid value or without
+value" error when expanding a map attribute group (e.g. LogAttributes) in the
+search filters sidebar. Telemetry containing an empty attribute key produced a
+filter group with an empty name, which Mantine rejects; such groups now render
+with an `(empty)` placeholder name instead of crashing the panel.

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -962,17 +962,21 @@ export const FilterGroup = ({
 
   const hasOptions = options.length > 0 || totalAppliedFiltersSize > 0;
 
+  // An empty map attribute key (e.g. LogAttributes['']) yields an empty name,
+  // which Mantine rejects as an Accordion.Item value and throws during render.
+  const displayName = name.trim() ? name : '(empty)';
+
   return (
     <Accordion
       variant="unstyled"
       chevronPosition="left"
       classNames={{ chevron: classes.chevron }}
-      value={isExpanded ? name : null}
+      value={isExpanded ? displayName : null}
       onChange={v => {
-        setExpanded(v === name);
+        setExpanded(v === displayName);
       }}
     >
-      <Accordion.Item value={name} data-testid={dataTestId}>
+      <Accordion.Item value={displayName} data-testid={dataTestId}>
         <Stack gap={0}>
           <Center>
             <Accordion.Control
@@ -989,15 +993,15 @@ export const FilterGroup = ({
               className={hasOptions ? '' : 'opacity-50'}
             >
               <Tooltip
-                openDelay={name.length > 26 ? 0 : 1500}
-                label={name}
+                openDelay={displayName.length > 26 ? 0 : 1500}
+                label={displayName}
                 position="top"
                 withArrow
                 fz="xxs"
                 color="gray"
               >
                 <Text size="xs" fw="500" truncate="end">
-                  {name}
+                  {displayName}
                   {showFilterCounts && (
                     <Text
                       component="span"

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -654,6 +654,15 @@ describe('FilterGroup', () => {
 
     expect(screen.getAllByTestId(/filter-checkbox-.+-input/)).toHaveLength(3);
   });
+
+  // https://github.com/hyperdxio/hyperdx/issues/2576 — an empty map attribute
+  // key (e.g. LogAttributes['']) yields an empty name, which Mantine rejects
+  // as an Accordion.Item value and crashes the filter panel.
+  it('should render a placeholder instead of crashing when name is empty', () => {
+    renderWithMantine(<FilterGroup {...defaultProps} name="" />);
+
+    expect(screen.getByText('(empty)')).toBeInTheDocument();
+  });
 });
 
 describe('NestedFilterGroup', () => {


### PR DESCRIPTION
This fixes the "Accordion.Item component was rendered with invalid value or without value" error that occurred when expanding a map attribute group (e.g. LogAttributes) containing an empty key in the search filters sidebar.

Telemetry with an empty attribute key produced a filter group with an empty name, which Mantine rejects as an Accordion.Item value. This PR replaces empty names with an `(empty)` placeholder, preventing the panel from crashing.

Closes #2576