### PR TITLE
fix(app): fix flaky ActiveFilterPills popover tests

### DIFF
--- a/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
+++ b/packages/app/src/components/__tests__/ActiveFilterPills.test.tsx
@@ -372,8 +372,8 @@ describe('ActiveFilterPills', () => {
     await user.click(screen.getByTestId('active-filter-pill-status'));
 
     const [copyButton, excludeButton] = await Promise.all([
-      screen.findByRole('button', { name: 'Copy value' }),
-      screen.findByRole('button', { name: 'Exclude' }),
+      screen.findByRole('button', { name: 'Copy value', hidden: true }),
+      screen.findByRole('button', { name: 'Exclude', hidden: true }),
     ]);
     expect(copyButton).toBeInTheDocument();
     expect(excludeButton).toBeInTheDocument();
@@ -391,7 +391,9 @@ describe('ActiveFilterPills', () => {
     renderPills(searchFilters);
 
     await user.click(screen.getByTestId('active-filter-pill-status'));
-    await user.click(await screen.findByRole('button', { name: 'Exclude' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Exclude', hidden: true }),
+    );
 
     expect(searchFilters.setFilterValue).toHaveBeenCalledWith(
       'status',
@@ -412,7 +414,9 @@ describe('ActiveFilterPills', () => {
     renderPills(searchFilters);
 
     await user.click(screen.getByTestId('active-filter-pill-status'));
-    await user.click(await screen.findByRole('button', { name: 'Include' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Include', hidden: true }),
+    );
 
     expect(searchFilters.setFilterValue).toHaveBeenCalledWith(
       'status',
@@ -433,7 +437,9 @@ describe('ActiveFilterPills', () => {
     renderPills(searchFilters);
 
     await user.click(screen.getByTestId('active-filter-pill-status'));
-    await user.click(await screen.findByRole('button', { name: 'Copy value' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Copy value', hidden: true }),
+    );
 
     expect(copyTextToClipboard).toHaveBeenCalledWith('200');
   });


### PR DESCRIPTION
The `ActiveFilterPills` popover action-menu tests (`"opens the action menu"`, `"excludes an included value"`, `"includes an excluded value"`, `"copies the value"`) fail intermittently because Mantine's `Popover` uses a 150ms CSS transition that jsdom never completes — `transitionend` events don't fire, so `Popover.Dropdown` retains `display: none` even after React state says `opened=true`. `findByRole('button', ...)` then can't locate the action buttons inside the hidden container.

Added `hidden: true` to all `findByRole` calls targeting popover content, matching the pattern already used in the same file for `Select` combobox options (line 526).
