### PR TITLE
fix(charts): add Reset zoom button to time-series charts

### DIFF
--- a/.changeset/line-chart-reset-zoom.md
+++ b/.changeset/line-chart-reset-zoom.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix(charts): add a "Reset zoom" button to time-series charts so a brush-zoom can be undone back to the pre-zoom time range

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useId, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import cx from 'classnames';
 import { add, isSameSecond, sub } from 'date-fns';
 import { withErrorBoundary } from 'react-error-boundary';
@@ -20,7 +28,8 @@ import {
 import { AxisDomain } from 'recharts/types/util/types';
 import { convertGranularityToSeconds } from '@hyperdx/common-utils/dist/core/utils';
 import { DisplayType } from '@hyperdx/common-utils/dist/types';
-import { Popover } from '@mantine/core';
+import { Button, Popover, Tooltip as MantineTooltip } from '@mantine/core';
+import { IconZoomReset } from '@tabler/icons-react';
 
 import type { NumberFormat } from '@/types';
 import { COLORS, formatNumber, truncateMiddle } from '@/utils';
@@ -713,6 +722,46 @@ export const MemoChart = memo(function MemoChart({
   const [highlightEnd, setHighlightEnd] = useState<string | undefined>();
   const mouseDownPosRef = useRef<number | null>(null);
 
+  // Tracks the time range that was displayed before the user brushed to zoom
+  // in, so a "Reset zoom" control can restore it (mirrors Highcharts). It holds
+  // the earliest pre-zoom range across consecutive zoom-ins so resetting jumps
+  // all the way back to where zooming started.
+  const [zoomOrigin, setZoomOrigin] = useState<[Date, Date] | null>(null);
+  // Set right before we trigger our own brush-zoom so the dateRange effect can
+  // tell an internal zoom apart from an external time-range change.
+  const justZoomedRef = useRef(false);
+  const prevDateRangeRef = useRef<[number, number] | null>(null);
+
+  // Clear the reset-zoom affordance whenever the time range changes for a
+  // reason other than our own brush-zoom (e.g. the time picker or live tail),
+  // so the button never restores a stale range. Compared by value because
+  // `dateRange` can be a fresh array reference even when unchanged.
+  useEffect(() => {
+    const from = dateRange[0].getTime();
+    const to = dateRange[1].getTime();
+    const prev = prevDateRangeRef.current;
+    const changed = prev == null || prev[0] !== from || prev[1] !== to;
+    prevDateRangeRef.current = [from, to];
+
+    if (!changed) {
+      return;
+    }
+    if (justZoomedRef.current) {
+      justZoomedRef.current = false;
+      return;
+    }
+    setZoomOrigin(null);
+  }, [dateRange]);
+
+  const handleResetZoom = useCallback(() => {
+    if (zoomOrigin == null) {
+      return;
+    }
+    const [start, end] = zoomOrigin;
+    setZoomOrigin(null);
+    onTimeRangeSelect?.(new Date(start.getTime()), new Date(end.getTime()));
+  }, [zoomOrigin, onTimeRangeSelect]);
+
   const lineDataMap = useMemo(() => {
     const map: { [key: string]: LineData } = {};
     lineData.forEach(ld => {
@@ -744,147 +793,172 @@ export const MemoChart = memo(function MemoChart({
   }, [dateRange, granularity, dateRangeEndInclusive, displayType]);
 
   return (
-    <ResponsiveContainer
-      width="100%"
-      height="100%"
-      minWidth={0}
-      onResize={(width, height) => {
-        const w = width ?? 1;
-        sizeRef.current = [w, height ?? 1];
-        setContainerWidth(prev => (prev === w ? prev : w));
-      }}
-      className={isLoading ? 'effect-pulse' : ''}
-    >
-      <ChartComponent
-        width={500}
-        height={300}
-        data={graphResults}
-        syncId="hdx"
-        syncMethod="value"
-        barSize={singlePointBarSize}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => {
-          setIsHovered(false);
-          setNearestSeriesKey(undefined);
-
-          setHighlightStart(undefined);
-          setHighlightEnd(undefined);
-          mouseDownPosRef.current = null;
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {onTimeRangeSelect != null && zoomOrigin != null ? (
+        <MantineTooltip label="Reset to the range before zooming in" withArrow>
+          <Button
+            variant="secondary"
+            size="compact-xs"
+            leftSection={<IconZoomReset size={14} />}
+            onClick={handleResetZoom}
+            style={{
+              position: 'absolute',
+              top: 4,
+              right: 8,
+              zIndex: 2,
+            }}
+          >
+            Reset zoom
+          </Button>
+        </MantineTooltip>
+      ) : null}
+      <ResponsiveContainer
+        width="100%"
+        height="100%"
+        minWidth={0}
+        onResize={(width, height) => {
+          const w = width ?? 1;
+          sizeRef.current = [w, height ?? 1];
+          setContainerWidth(prev => (prev === w ? prev : w));
         }}
-        onMouseDown={e => {
-          if (e != null && e.chartX != null && e.chartY != null) {
-            setHighlightStart(e.activeLabel);
-            mouseDownPosRef.current = e.chartX;
-          }
-        }}
-        onMouseMove={e => {
-          setIsHovered(true);
-
-          // Track which series' line is nearest the cursor so the lines can
-          // emphasize it. The active dots captured their pixel Y on the prior
-          // frame; comparing the pointer's chartY picks the nearest line. Skip
-          // while a click-frozen tooltip is shown, matching the tooltip, and
-          // only set state when the key changes to keep re-renders rare.
-          const activePointYByKey = activePointYByKeyRef.current;
-          const nextNearest =
-            isClickActive == null &&
-            activePointYByKey.size > 1 &&
-            e?.chartY != null
-              ? findNearestSeriesKey(
-                  activePointYByKey,
-                  Array.from(activePointYByKey.keys()),
-                  e.chartY,
-                  NEAREST_SERIES_MAX_DISTANCE_PX,
-                )
-              : undefined;
-          setNearestSeriesKey(prev =>
-            prev === nextNearest ? prev : nextNearest,
-          );
-
-          if (highlightStart != null) {
-            setHighlightEnd(e.activeLabel);
-            setIsClickActive(undefined); // Clear out any click state as we're highlighting
-          }
-        }}
-        onMouseUp={e => {
-          const MIN_DRAG_DISTANCE = 20; // Minimum horizontal drag distance in pixels
-          let dragDistance = 0;
-
-          if (mouseDownPosRef.current != null && e?.chartX != null) {
-            dragDistance = Math.abs(e.chartX - mouseDownPosRef.current);
-          }
-
-          if (e?.activeLabel != null && highlightStart === e.activeLabel) {
-            // If it's just a click, don't zoom
-            setHighlightStart(undefined);
-            setHighlightEnd(undefined);
-            mouseDownPosRef.current = null;
-          } else if (
-            highlightStart != null &&
-            highlightEnd != null &&
-            dragDistance >= MIN_DRAG_DISTANCE
-          ) {
-            try {
-              onTimeRangeSelect?.(
-                new Date(
-                  Number.parseInt(
-                    highlightStart <= highlightEnd
-                      ? highlightStart
-                      : highlightEnd,
-                  ) * 1000,
-                ),
-                new Date(
-                  Number.parseInt(
-                    highlightEnd >= highlightStart
-                      ? highlightEnd
-                      : highlightStart,
-                  ) * 1000,
-                ),
-              );
-            } catch (e) {
-              console.error('failed to highlight range', e);
-            }
-            setHighlightStart(undefined);
-            setHighlightEnd(undefined);
-            mouseDownPosRef.current = null;
-          } else {
-            // Drag was too short, clear the highlight
-            setHighlightStart(undefined);
-            setHighlightEnd(undefined);
-            mouseDownPosRef.current = null;
-          }
-        }}
-        onClick={(state, e) => {
-          if (
-            state != null &&
-            state.chartX != null &&
-            state.chartY != null &&
-            state.activeLabel != null &&
-            // If we didn't drag and highlight yet
-            highlightStart == null
-          ) {
-            setIsClickActive({
-              x: state.chartX,
-              y: state.chartY,
-              activeLabel: state.activeLabel,
-              xPerc: state.chartX / sizeRef.current[0],
-              yPerc: state.chartY / sizeRef.current[1],
-              activePayload: state.activePayload,
-            });
-            // The click-frozen tooltip hides the live tooltip, so drop any
-            // line emphasis to match.
-            setNearestSeriesKey(undefined);
-          } else {
-            // We clicked on the chart but outside of a line
-            setIsClickActive(undefined);
-          }
-
-          // TODO: Properly detect clicks outside of the fake tooltip
-          e.stopPropagation();
-        }}
+        className={isLoading ? 'effect-pulse' : ''}
       >
-        <defs>
-          {/* Gradient defs cover every hex that any <Area> fill may reference.
+        <ChartComponent
+          width={500}
+          height={300}
+          data={graphResults}
+          syncId="hdx"
+          syncMethod="value"
+          barSize={singlePointBarSize}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => {
+            setIsHovered(false);
+            setNearestSeriesKey(undefined);
+
+            setHighlightStart(undefined);
+            setHighlightEnd(undefined);
+            mouseDownPosRef.current = null;
+          }}
+          onMouseDown={e => {
+            if (e != null && e.chartX != null && e.chartY != null) {
+              setHighlightStart(e.activeLabel);
+              mouseDownPosRef.current = e.chartX;
+            }
+          }}
+          onMouseMove={e => {
+            setIsHovered(true);
+
+            // Track which series' line is nearest the cursor so the lines can
+            // emphasize it. The active dots captured their pixel Y on the prior
+            // frame; comparing the pointer's chartY picks the nearest line. Skip
+            // while a click-frozen tooltip is shown, matching the tooltip, and
+            // only set state when the key changes to keep re-renders rare.
+            const activePointYByKey = activePointYByKeyRef.current;
+            const nextNearest =
+              isClickActive == null &&
+              activePointYByKey.size > 1 &&
+              e?.chartY != null
+                ? findNearestSeriesKey(
+                    activePointYByKey,
+                    Array.from(activePointYByKey.keys()),
+                    e.chartY,
+                    NEAREST_SERIES_MAX_DISTANCE_PX,
+                  )
+                : undefined;
+            setNearestSeriesKey(prev =>
+              prev === nextNearest ? prev : nextNearest,
+            );
+
+            if (highlightStart != null) {
+              setHighlightEnd(e.activeLabel);
+              setIsClickActive(undefined); // Clear out any click state as we're highlighting
+            }
+          }}
+          onMouseUp={e => {
+            const MIN_DRAG_DISTANCE = 20; // Minimum horizontal drag distance in pixels
+            let dragDistance = 0;
+
+            if (mouseDownPosRef.current != null && e?.chartX != null) {
+              dragDistance = Math.abs(e.chartX - mouseDownPosRef.current);
+            }
+
+            if (e?.activeLabel != null && highlightStart === e.activeLabel) {
+              // If it's just a click, don't zoom
+              setHighlightStart(undefined);
+              setHighlightEnd(undefined);
+              mouseDownPosRef.current = null;
+            } else if (
+              highlightStart != null &&
+              highlightEnd != null &&
+              dragDistance >= MIN_DRAG_DISTANCE
+            ) {
+              try {
+                // Remember the range we're zooming away from so "Reset zoom" can
+                // restore it. Keep the earliest origin across consecutive zooms.
+                const originStart = dateRange[0];
+                const originEnd = dateRange[1];
+                setZoomOrigin(prev => prev ?? [originStart, originEnd]);
+                justZoomedRef.current = true;
+                onTimeRangeSelect?.(
+                  new Date(
+                    Number.parseInt(
+                      highlightStart <= highlightEnd
+                        ? highlightStart
+                        : highlightEnd,
+                    ) * 1000,
+                  ),
+                  new Date(
+                    Number.parseInt(
+                      highlightEnd >= highlightStart
+                        ? highlightEnd
+                        : highlightStart,
+                    ) * 1000,
+                  ),
+                );
+              } catch (e) {
+                console.error('failed to highlight range', e);
+              }
+              setHighlightStart(undefined);
+              setHighlightEnd(undefined);
+              mouseDownPosRef.current = null;
+            } else {
+              // Drag was too short, clear the highlight
+              setHighlightStart(undefined);
+              setHighlightEnd(undefined);
+              mouseDownPosRef.current = null;
+            }
+          }}
+          onClick={(state, e) => {
+            if (
+              state != null &&
+              state.chartX != null &&
+              state.chartY != null &&
+              state.activeLabel != null &&
+              // If we didn't drag and highlight yet
+              highlightStart == null
+            ) {
+              setIsClickActive({
+                x: state.chartX,
+                y: state.chartY,
+                activeLabel: state.activeLabel,
+                xPerc: state.chartX / sizeRef.current[0],
+                yPerc: state.chartY / sizeRef.current[1],
+                activePayload: state.activePayload,
+              });
+              // The click-frozen tooltip hides the live tooltip, so drop any
+              // line emphasis to match.
+              setNearestSeriesKey(undefined);
+            } else {
+              // We clicked on the chart but outside of a line
+              setIsClickActive(undefined);
+            }
+
+            // TODO: Properly detect clicks outside of the fake tooltip
+            e.stopPropagation();
+          }}
+        >
+          <defs>
+            {/* Gradient defs cover every hex that any <Area> fill may reference.
               `COLORS` (the unified categorical palette) is included up-front
               as a baseline; semantic colors returned by the
               `getChartColor{Info,Success,Warning,Error}` helpers can also
@@ -892,96 +966,97 @@ export const MemoChart = memo(function MemoChart({
               resolve to `--color-chart-info`, chart blue `#437eef`, on both
               brands, which matches categorical slot 0). Union them here so the
               referenced `url(#time-chart-lin-grad-…)` always exists. */}
-          {collectMemoChartGradientHexes(lineData).map(c => {
-            return (
-              <linearGradient
-                key={c}
-                id={`time-chart-lin-grad-${id}-${c.replace('#', '').toLowerCase()}`}
-                x1="0"
-                y1="0"
-                x2="0"
-                y2="1"
-              >
-                <stop offset="0%" stopColor={c} stopOpacity={0.15} />
-                <stop offset="10%" stopColor={c} stopOpacity={0.003} />
-              </linearGradient>
-            );
-          })}
-        </defs>
-        {isHovered && (
-          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-        )}
-        <XAxis
-          dataKey={timestampKey ?? 'ts_bucket'}
-          domain={xAxisDomain}
-          interval="preserveStartEnd"
-          scale="time"
-          type="number"
-          tickFormatter={xTickFormatter}
-          minTickGap={100}
-          tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
-        />
-        <YAxis
-          width={Y_AXIS_WIDTH}
-          minTickGap={25}
-          tickFormatter={tickFormatter}
-          tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
-          domain={yAxisDomain}
-        />
-        {lines}
-        {isClickActive == null && (
-          <Tooltip
-            content={
-              <HDXLineChartTooltip
-                numberFormat={fallbackNumberFormat}
-                numberFormatByKey={tooltipNumberFormatsByKey}
-                lineDataMap={lineDataMap}
-                previousPeriodOffsetSeconds={previousPeriodOffsetSeconds}
-                activePointYByKeyRef={activePointYByKeyRef}
-              />
-            }
-            wrapperStyle={{
-              zIndex: 1,
-            }}
+            {collectMemoChartGradientHexes(lineData).map(c => {
+              return (
+                <linearGradient
+                  key={c}
+                  id={`time-chart-lin-grad-${id}-${c.replace('#', '').toLowerCase()}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="0%" stopColor={c} stopOpacity={0.15} />
+                  <stop offset="10%" stopColor={c} stopOpacity={0.003} />
+                </linearGradient>
+              );
+            })}
+          </defs>
+          {isHovered && (
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          )}
+          <XAxis
+            dataKey={timestampKey ?? 'ts_bucket'}
+            domain={xAxisDomain}
+            interval="preserveStartEnd"
+            scale="time"
+            type="number"
+            tickFormatter={xTickFormatter}
+            minTickGap={100}
+            tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
           />
-        )}
-        {referenceLines}
-        {highlightStart && highlightEnd ? (
-          <ReferenceArea
-            // yAxisId="1"
-            x1={highlightStart}
-            x2={highlightEnd}
-            strokeOpacity={0.3}
+          <YAxis
+            width={Y_AXIS_WIDTH}
+            minTickGap={25}
+            tickFormatter={tickFormatter}
+            tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
+            domain={yAxisDomain}
           />
-        ) : null}
-        {showLegend && (
-          <Legend
-            iconSize={10}
-            verticalAlign="bottom"
-            content={
-              <LegendRenderer
-                lineDataMap={lineDataMap}
-                allLineData={lineData}
-                selectedSeries={selectedSeriesNames || new Set()}
-                onToggleSeries={onToggleSeries}
-              />
-            }
-            offset={-100}
-          />
-        )}
-        {/** Needs to be at the bottom to prevent re-rendering */}
-        {isClickActive != null ? (
-          <ReferenceLine x={isClickActive.activeLabel} stroke="#ccc" />
-        ) : null}
-        {logReferenceTimestamp != null ? (
-          <ReferenceLine
-            x={logReferenceTimestamp}
-            stroke="#ff5d5b"
-            strokeDasharray="3 3"
-            label="Event"
-          />
-        ) : null}
-      </ChartComponent>
-    </ResponsiveContainer>
+          {lines}
+          {isClickActive == null && (
+            <Tooltip
+              content={
+                <HDXLineChartTooltip
+                  numberFormat={fallbackNumberFormat}
+                  numberFormatByKey={tooltipNumberFormatsByKey}
+                  lineDataMap={lineDataMap}
+                  previousPeriodOffsetSeconds={previousPeriodOffsetSeconds}
+                  activePointYByKeyRef={activePointYByKeyRef}
+                />
+              }
+              wrapperStyle={{
+                zIndex: 1,
+              }}
+            />
+          )}
+          {referenceLines}
+          {highlightStart && highlightEnd ? (
+            <ReferenceArea
+              // yAxisId="1"
+              x1={highlightStart}
+              x2={highlightEnd}
+              strokeOpacity={0.3}
+            />
+          ) : null}
+          {showLegend && (
+            <Legend
+              iconSize={10}
+              verticalAlign="bottom"
+              content={
+                <LegendRenderer
+                  lineDataMap={lineDataMap}
+                  allLineData={lineData}
+                  selectedSeries={selectedSeriesNames || new Set()}
+                  onToggleSeries={onToggleSeries}
+                />
+              }
+              offset={-100}
+            />
+          )}
+          {/** Needs to be at the bottom to prevent re-rendering */}
+          {isClickActive != null ? (
+            <ReferenceLine x={isClickActive.activeLabel} stroke="#ccc" />
+          ) : null}
+          {logReferenceTimestamp != null ? (
+            <ReferenceLine
+              x={logReferenceTimestamp}
+              stroke="#ff5d5b"
+              strokeDasharray="3 3"
+              label="Event"
+            />
+          ) : null}
+        </ChartComponent>
+      </ResponsiveContainer>
+    </div>
   );
 });

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -917,6 +917,8 @@ export const MemoChart = memo(function MemoChart({
                 );
               } catch (e) {
                 console.error('failed to highlight range', e);
+                justZoomedRef.current = false;
+                setZoomOrigin(null);
               }
               setHighlightStart(undefined);
               setHighlightEnd(undefined);


### PR DESCRIPTION
## Summary

Brush-zooming a time-series line chart narrows the global time range, but there was previously **no way to zoom back out** — you had to manually reopen the time picker. This adds a **Reset zoom** button (mirroring [Highcharts](https://www.highcharts.com/demo/highcharts/line-time-series)) that restores the time range shown before you zoomed in.

- The button lives in the shared `MemoChart` (`HDXMultiSeriesTimeChart.tsx`), so every surface that wires up `onTimeRangeSelect` (Search histogram, Dashboards, Chart Explorer, ClickHouse page) gets it automatically.
- It appears **only after a brush-zoom** and sits in the top-right corner of the chart.
- It **auto-hides** when the time range changes for any other reason (time picker, live tail), so it never restores a stale range.
- Consecutive zoom-ins keep the *earliest* pre-zoom range, so one click returns you all the way back (matching Highcharts).

> Note: the diff looks large but is almost entirely whitespace — wrapping the chart in a positioned `<div>` caused Prettier to re-indent the existing JSX. Review with "hide whitespace" for the real change.

<img width="943" height="419" alt="Screenshot 2026-07-02 at 20 20 59" src="https://github.com/user-attachments/assets/20c1441e-2844-4a54-8c17-e09d26167c20" />


## Test plan

1. Go to the **ClickHouse dashboard** page.
2. Find the **"Query Count by Table"** chart.
3. **Brush-zoom in**: click and drag horizontally across a portion of the chart to select a narrower time window — the chart (and page time range) zooms into that window.
4. Confirm a **"Reset zoom"** button appears in the top-right of the chart.
5. Click **Reset zoom** and confirm the time range returns to what it was before you zoomed in.
6. Zoom in again, then instead of clicking Reset, change the time range via the time picker → confirm the Reset zoom button disappears (no stale range).


Made with [Cursor](https://cursor.com)