### PR TITLE
chore(worktrees): use install instead of symlink 

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -5,11 +5,9 @@
 # hooks that run when creating/switching/removing worktrees via `wt`.
 
 # ---------------------------------------------------------------------------
-# pre-start: blocking — symlink node_modules from primary worktree for
-# instant dependency access. If the branch needs different deps:
-#   rm node_modules && yarn install
+# pre-start: install dependencies so app is ready to run
 # ---------------------------------------------------------------------------
-pre-start = "ln -sf {{ primary_worktree_path }}/node_modules {{ worktree_path }}/node_modules"
+pre-start = "yarn install"
 
 # ---------------------------------------------------------------------------
 # post-start: background tasks


### PR DESCRIPTION
turbopack does not support symlinks for node_modules, so any new worktrunk worktrees will fail until you manually fix the problem

link: https://nextjs.org/docs/app/api-reference/turbopack#filesystem-root