### PR TITLE
Polish dashboard tile styling and header layout

### DIFF
--- a/.changeset/dashboard-tile-visual-polish.md
+++ b/.changeset/dashboard-tile-visual-polish.md
@@ -1,0 +1,9 @@
+---
+"@hyperdx/app": patch
+---
+
+Polish dashboard tiles: white (surface) card backgrounds with a border, a subtle
+muted page background, a modern dotted resize handle, and a compact, consistent
+tile header. Tile actions are consolidated into a right-aligned kebab menu (with
+the alert bell) that sits after each chart's own controls, and a full-bleed
+separator gives every tile a consistent header strip.

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -133,7 +133,9 @@ import useDashboardContainers, {
 } from '@/hooks/useDashboardContainers';
 import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
-import ChartContainer from './components/charts/ChartContainer';
+import ChartContainer, {
+  ChartContainerCardHeaderProvider,
+} from './components/charts/ChartContainer';
 import DBHeatmapChart, {
   toHeatmapChartConfig,
 } from './components/DBHeatmapChart';
@@ -188,7 +190,8 @@ function HeatmapTile({
   keyPrefix,
   chartId,
   title,
-  toolbar,
+  toolbarPrefix,
+  toolbarSuffix,
   queriedConfig,
   source,
   dateRange,
@@ -197,7 +200,8 @@ function HeatmapTile({
   keyPrefix: string;
   chartId: string;
   title: React.ReactNode;
-  toolbar: React.ReactNode[];
+  toolbarPrefix: React.ReactNode[];
+  toolbarSuffix: React.ReactNode[];
   queriedConfig: BuilderChartConfigWithDateRange;
   source: TSource | undefined;
   dateRange: [Date, Date];
@@ -243,7 +247,8 @@ function HeatmapTile({
       <DBHeatmapChart
         key={`${keyPrefix}-${chartId}`}
         title={title}
-        toolbarPrefix={toolbar}
+        toolbarPrefix={toolbarPrefix}
+        toolbarSuffix={toolbarSuffix}
         config={heatmapConfig}
         scaleType={scaleType}
         enabled={enabled}
@@ -658,13 +663,15 @@ const Tile = forwardRef(
         : isPromQL
           ? displayTypeSupportsPromQLAlerts(chart.config.displayType)
           : displayTypeSupportsBuilderAlerts(chart.config.displayType);
+      const canMoveToGroup =
+        onMoveToGroup && moveTargets && moveTargets.length > 0;
       return (
         <Flex
           gap="0px"
+          align="center"
           onMouseDown={e => e.stopPropagation()}
           key="hover-toolbar"
-          my={4} // Margin to ensure that the Alert Indicator doesn't clip on non-Line/Bar display types
-          style={{ visibility: hovered ? 'visible' : 'hidden' }}
+          my={2} // Margin to ensure that the Alert Indicator doesn't clip on non-Line/Bar display types
         >
           {displayTypeSupportsAlerts && (
             <Indicator
@@ -688,113 +695,111 @@ const Tile = forwardRef(
             </Indicator>
           )}
 
-          <ActionIcon
-            data-testid={`tile-duplicate-button-${chart.id}`}
-            variant="subtle"
-            size="sm"
-            onClick={onDuplicateClick}
-            title="Duplicate"
-          >
-            <IconCopy size={14} />
-          </ActionIcon>
-          <ActionIcon
-            data-testid={`tile-fullscreen-button-${chart.id}`}
-            variant="subtle"
-            size="sm"
-            onClick={e => {
-              e.stopPropagation();
-              openFullscreen();
-            }}
-            title="View Fullscreen (f)"
-          >
-            <IconArrowsMaximize size={14} />
-          </ActionIcon>
-          <ActionIcon
-            data-testid={`tile-edit-button-${chart.id}`}
-            variant="subtle"
-            size="sm"
-            onClick={onEditClick}
-            title="Edit"
-          >
-            <IconPencil size={14} />
-          </ActionIcon>
-          {onMoveToGroup && moveTargets && moveTargets.length > 0 && (
-            <Menu width={200} position="bottom-end">
-              <Menu.Target>
-                <Tooltip label="Move to Group" position="top" withArrow>
-                  <ActionIcon
-                    data-testid={`tile-move-group-button-${chart.id}`}
-                    variant="subtle"
-                    size="sm"
-                  >
-                    <IconCornerDownRight size={14} />
-                  </ActionIcon>
-                </Tooltip>
-              </Menu.Target>
-              <Menu.Dropdown>
-                <Menu.Label>Move to Group</Menu.Label>
-                {chart.containerId && (
-                  <Menu.Item onClick={() => onMoveToGroup(undefined)}>
-                    (Ungrouped)
-                  </Menu.Item>
-                )}
-                {moveTargets
-                  .filter(
-                    t =>
-                      !(
-                        t.containerId === chart.containerId &&
-                        t.tabId === chart.tabId
-                      ),
-                  )
-                  .map(t => (
+          <Menu width={220} position="bottom-end">
+            <Menu.Target>
+              <Tooltip label="More actions" position="top" withArrow>
+                <ActionIcon
+                  data-testid={`tile-actions-button-${chart.id}`}
+                  variant="subtle"
+                  size="sm"
+                >
+                  <IconDotsVertical size={16} />
+                </ActionIcon>
+              </Tooltip>
+            </Menu.Target>
+            <Menu.Dropdown onMouseDown={e => e.stopPropagation()}>
+              <Menu.Item
+                data-testid={`tile-duplicate-button-${chart.id}`}
+                leftSection={<IconCopy size={14} />}
+                onClick={onDuplicateClick}
+              >
+                Duplicate
+              </Menu.Item>
+              <Menu.Item
+                data-testid={`tile-fullscreen-button-${chart.id}`}
+                leftSection={<IconArrowsMaximize size={14} />}
+                onClick={() => openFullscreen()}
+              >
+                View fullscreen
+              </Menu.Item>
+              <Menu.Item
+                data-testid={`tile-edit-button-${chart.id}`}
+                leftSection={<IconPencil size={14} />}
+                onClick={onEditClick}
+              >
+                Edit
+              </Menu.Item>
+              {canMoveToGroup && (
+                <>
+                  <Menu.Divider />
+                  <Menu.Label>Move to Group</Menu.Label>
+                  {chart.containerId && (
                     <Menu.Item
-                      key={`${t.containerId}-${t.tabId ?? ''}`}
-                      onClick={() => onMoveToGroup(t.containerId, t.tabId)}
+                      leftSection={<IconCornerDownRight size={14} />}
+                      onClick={() => onMoveToGroup(undefined)}
                     >
-                      {t.allTabs ? (
-                        <span>
-                          {t.allTabs.map((tab, i) => (
-                            <span key={tab.id}>
-                              {i > 0 && (
-                                <span
-                                  style={{
-                                    color: 'var(--mantine-color-dimmed)',
-                                  }}
-                                >
-                                  {' | '}
-                                </span>
-                              )}
-                              <span
-                                style={
-                                  tab.id !== t.tabId
-                                    ? {
-                                        color: 'var(--mantine-color-dimmed)',
-                                      }
-                                    : undefined
-                                }
-                              >
-                                {tab.title}
-                              </span>
-                            </span>
-                          ))}
-                        </span>
-                      ) : (
-                        t.label
-                      )}
+                      (Ungrouped)
                     </Menu.Item>
-                  ))}
-              </Menu.Dropdown>
-            </Menu>
-          )}
-          <ActionIcon
-            data-testid={`tile-delete-button-${chart.id}`}
-            variant="subtle"
-            size="sm"
-            onClick={onDeleteClick}
-            title="Delete"
-          >
-            <IconTrash size={14} />
-          </ActionIcon>
+                  )}
+                  {moveTargets
+                    .filter(
+                      t =>
+                        !(
+                          t.containerId === chart.containerId &&
+                          t.tabId === chart.tabId
+                        ),
+                    )
+                    .map(t => (
+                      <Menu.Item
+                        key={`${t.containerId}-${t.tabId ?? ''}`}
+                        leftSection={<IconCornerDownRight size={14} />}
+                        onClick={() => onMoveToGroup(t.containerId, t.tabId)}
+                      >
+                        {t.allTabs ? (
+                          <span>
+                            {t.allTabs.map((tab, i) => (
+                              <span key={tab.id}>
+                                {i > 0 && (
+                                  <span
+                                    style={{
+                                      color: 'var(--mantine-color-dimmed)',
+                                    }}
+                                  >
+                                    {' | '}
+                                  </span>
+                                )}
+                                <span
+                                  style={
+                                    tab.id !== t.tabId
+                                      ? {
+                                          color: 'var(--mantine-color-dimmed)',
+                                        }
+                                      : undefined
+                                  }
+                                >
+                                  {tab.title}
+                                </span>
+                              </span>
+                            ))}
+                          </span>
+                        ) : (
+                          t.label
+                        )}
+                      </Menu.Item>
+                    ))}
+                </>
+              )}
+              <Menu.Divider />
+              <Menu.Item
+                data-testid={`tile-delete-button-${chart.id}`}
+                color="red"
+                leftSection={<IconTrash size={14} />}
+                onClick={onDeleteClick}
+              >
+                Delete
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
         </Flex>
       );
     }, [
@@ -806,7 +811,6 @@ const Tile = forwardRef(
       chart.id,
       chart.containerId,
       chart.tabId,
-      hovered,
       onDeleteClick,
       onDuplicateClick,
       onEditClick,
@@ -815,20 +819,24 @@ const Tile = forwardRef(
     ]);
 
     const title = useMemo(
-      () => (
-        <Text size="sm" ms="xs">
-          {chart.config.name}
-        </Text>
-      ),
+      () =>
+        chart.config.name ? (
+          <Text size="sm">{chart.config.name}</Text>
+        ) : undefined,
       [chart.config.name],
     );
 
     // Render chart content (used in both tile and fullscreen views)
     const renderChartContent = useCallback(
       (hideToolbar: boolean = false, isFullscreenView: boolean = false) => {
-        const toolbar = hideToolbar
-          ? [filterWarning]
-          : [hoverToolbar, filterWarning];
+        // Tile-level actions (alert bell + kebab) render as a suffix so they
+        // sit to the right of each chart's own controls (display switcher,
+        // granularity, etc.), keeping the kebab at the far right edge.
+        const toolbarPrefixItems = [filterWarning];
+        const toolbarSuffixItems = hideToolbar ? [] : [hoverToolbar];
+        // Combined + ordered for containers that only accept `toolbarItems`
+        // (they have no chart-specific controls to interleave).
+        const toolbar = [...toolbarPrefixItems, ...toolbarSuffixItems];
         const keyPrefix = isFullscreenView ? 'fullscreen' : 'tile';
 
         // The fullscreen view is always visible, so it should always load.
@@ -890,7 +898,8 @@ const Tile = forwardRef(
                   <DBTimeChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
-                    toolbarPrefix={toolbar}
+                    toolbarPrefix={toolbarPrefixItems}
+                    toolbarSuffix={toolbarSuffixItems}
                     sourceId={chart.config.source}
                     showDisplaySwitcher={true}
                     enabled={chartEnabled}
@@ -912,14 +921,15 @@ const Tile = forwardRef(
                   />
                 )}
                 {effectiveQueriedConfig?.displayType === DisplayType.Table && (
-                  <Box p="xs" h="100%">
+                  <Box h="100%">
                     <DBTableChart
                       key={`${keyPrefix}-${chart.id}`}
                       title={title}
-                      toolbarPrefix={toolbar}
+                      toolbarPrefix={toolbarPrefixItems}
+                      toolbarSuffix={toolbarSuffixItems}
                       enabled={chartEnabled}
                       config={effectiveQueriedConfig}
-                      variant="muted"
+                      variant="default"
                       getRowSearchLink={
                         isBuilderChartConfig(effectiveQueriedConfig)
                           ? row =>
@@ -938,7 +948,8 @@ const Tile = forwardRef(
                   <DBNumberChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
-                    toolbarPrefix={toolbar}
+                    toolbarPrefix={toolbarPrefixItems}
+                    toolbarSuffix={toolbarSuffixItems}
                     enabled={chartEnabled}
                     config={effectiveQueriedConfig}
                   />
@@ -947,7 +958,8 @@ const Tile = forwardRef(
                   <DBPieChart
                     key={`${keyPrefix}-${chart.id}`}
                     title={title}
-                    toolbarPrefix={toolbar}
+                    toolbarPrefix={toolbarPrefixItems}
+                    toolbarSuffix={toolbarSuffixItems}
                     enabled={chartEnabled}
                     config={effectiveQueriedConfig}
                   />
@@ -958,7 +970,8 @@ const Tile = forwardRef(
                       keyPrefix={keyPrefix}
                       chartId={chart.id}
                       title={title}
-                      toolbar={toolbar}
+                      toolbarPrefix={toolbarPrefixItems}
+                      toolbarSuffix={toolbarSuffixItems}
                       enabled={chartEnabled}
                       queriedConfig={effectiveQueriedConfig}
                       source={source}
@@ -1010,7 +1023,7 @@ const Tile = forwardRef(
                         }}
                         isLive={false}
                         queryKeyPrefix={'search'}
-                        variant="muted"
+                        variant="default"
                         errorVariant="collapsible"
                       />
                     </ChartContainer>
@@ -1042,7 +1055,9 @@ const Tile = forwardRef(
       <>
         <div
           data-testid={`dashboard-tile-${chart.id}`}
-          className={`p-2 pt-0 ${className} d-flex flex-column bg-muted cursor-grab rounded ${
+          // `dashboard-chart-highlighted` triggers a one-shot flash animation
+          // when the tile is deep-linked via the `highlightedTileId` query param.
+          className={`pt-0 pb-2 ${className} d-flex flex-column bg-surface border cursor-grab rounded ${
             isHighlighted && 'dashboard-chart-highlighted'
           }`}
           id={`chart-${chart.id}`}
@@ -1093,10 +1108,12 @@ const Tile = forwardRef(
           )}
           <div
             ref={inViewportRef}
-            className="fs-7 text-muted flex-grow-1 overflow-hidden cursor-default"
+            className="fs-7 text-muted flex-grow-1 overflow-hidden cursor-default px-2"
             onMouseDown={e => e.stopPropagation()}
           >
-            {renderChartContent()}
+            <ChartContainerCardHeaderProvider>
+              {renderChartContent()}
+            </ChartContainerCardHeaderProvider>
           </div>
           {children}
         </div>
@@ -2824,6 +2841,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
         </PageHeader>
       }
       padded
+      contentClassName="bg-muted-subtle"
       content={dashboardBody}
     />
   );

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -76,6 +76,7 @@ import {
   IconAlertTriangle,
   IconArrowsMaximize,
   IconBell,
+  IconBellPlus,
   IconChartBar,
   IconChevronsDown,
   IconChevronsUp,
@@ -673,27 +674,42 @@ const Tile = forwardRef(
           key="hover-toolbar"
           my={2} // Margin to ensure that the Alert Indicator doesn't clip on non-Line/Bar display types
         >
-          {displayTypeSupportsAlerts && (
-            <Indicator
-              size={alert?.state === AlertState.OK ? 6 : 8}
-              zIndex={1}
-              color={alertIndicatorColor}
-              processing={alert?.state === AlertState.ALERT}
-              label={!alert && <span className="fs-8">+</span>}
-              mr={4}
-            >
+          {displayTypeSupportsAlerts &&
+            (alert ? (
+              // Existing alert: bell with a colored status dot indicator.
+              <Indicator
+                size={alert.state === AlertState.OK ? 6 : 8}
+                zIndex={1}
+                color={alertIndicatorColor}
+                processing={alert.state === AlertState.ALERT}
+                mr={4}
+              >
+                <Tooltip label={alertTooltip} withArrow>
+                  <ActionIcon
+                    data-testid={`tile-alerts-button-${chart.id}`}
+                    variant="subtle"
+                    size="sm"
+                    onClick={onEditClick}
+                  >
+                    <IconBell size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              </Indicator>
+            ) : (
+              // No alert yet: a dedicated "bell +" icon reads clearly on any
+              // background, unlike an overlaid indicator badge.
               <Tooltip label={alertTooltip} withArrow>
                 <ActionIcon
                   data-testid={`tile-alerts-button-${chart.id}`}
                   variant="subtle"
                   size="sm"
                   onClick={onEditClick}
+                  mr={4}
                 >
-                  <IconBell size={16} />
+                  <IconBellPlus size={16} />
                 </ActionIcon>
               </Tooltip>
-            </Indicator>
-          )}
+            ))}
 
           <Menu width={220} position="bottom-end">
             <Menu.Target>
@@ -1057,7 +1073,7 @@ const Tile = forwardRef(
           data-testid={`dashboard-tile-${chart.id}`}
           // `dashboard-chart-highlighted` triggers a one-shot flash animation
           // when the tile is deep-linked via the `highlightedTileId` query param.
-          className={`pt-0 pb-2 ${className} d-flex flex-column bg-surface border cursor-grab rounded ${
+          className={`pt-0 pb-2 ${className} d-flex flex-column bg-body border cursor-grab rounded ${
             isHighlighted && 'dashboard-chart-highlighted'
           }`}
           id={`chart-${chart.id}`}
@@ -2841,7 +2857,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
         </PageHeader>
       }
       padded
-      contentClassName="bg-muted-subtle"
+      contentClassName="bg-sunken"
       content={dashboardBody}
     />
   );

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -136,6 +136,7 @@ import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer, {
   ChartContainerCardHeaderProvider,
+  DASHBOARD_TILE_PADDING_INLINE,
 } from './components/charts/ChartContainer';
 import DBHeatmapChart, {
   toHeatmapChartConfig,
@@ -1127,7 +1128,8 @@ const Tile = forwardRef(
           )}
           <div
             ref={inViewportRef}
-            className="fs-7 text-muted flex-grow-1 overflow-hidden cursor-default px-2"
+            className="fs-7 text-muted flex-grow-1 overflow-hidden cursor-default"
+            style={{ paddingInline: DASHBOARD_TILE_PADDING_INLINE }}
             onMouseDown={e => e.stopPropagation()}
           >
             <ChartContainerCardHeaderProvider>

--- a/packages/app/src/components/DashboardContainer.tsx
+++ b/packages/app/src/components/DashboardContainer.tsx
@@ -252,7 +252,13 @@ export default function DashboardContainer({
           value={resolvedActiveTabId}
           onChange={val => val && onTabChange(val)}
         >
-          <Flex align="center" px="sm" gap={6} mih={headerHeight}>
+          <Flex
+            align="center"
+            px="sm"
+            gap={6}
+            mih={headerHeight}
+            style={{ borderBottom: '1px solid var(--color-border)' }}
+          >
             {dragHandle}
             {chevron}
             <GroupTabBar

--- a/packages/app/src/components/DashboardContainer.tsx
+++ b/packages/app/src/components/DashboardContainer.tsx
@@ -138,8 +138,6 @@ export default function DashboardContainer({
       <ActionIcon
         variant="subtle"
         size="sm"
-        tabIndex={showControls ? 0 : -1}
-        style={hoverControlStyle}
         onClick={onAddTile}
         data-testid={`group-add-tile-${container.id}`}
       >
@@ -154,8 +152,6 @@ export default function DashboardContainer({
         <ActionIcon
           variant="subtle"
           size="sm"
-          tabIndex={showControls ? 0 : -1}
-          style={hoverControlStyle}
           data-testid={`group-menu-${container.id}`}
         >
           <IconDotsVertical size={14} />
@@ -211,8 +207,6 @@ export default function DashboardContainer({
       style={{
         cursor: 'grab',
         flexShrink: 0,
-        opacity: showControls ? 1 : 0,
-        transition: 'opacity 150ms',
       }}
       data-testid={`group-drag-handle-${container.id}`}
     >
@@ -247,6 +241,7 @@ export default function DashboardContainer({
       onMouseLeave={() => setHovered(false)}
       mt={8}
       style={{
+        backgroundColor: 'var(--color-bg-body)',
         border: bordered ? '1px solid var(--color-border)' : undefined,
         borderRadius: bordered ? 4 : undefined,
       }}
@@ -257,13 +252,7 @@ export default function DashboardContainer({
           value={resolvedActiveTabId}
           onChange={val => val && onTabChange(val)}
         >
-          <Flex
-            align="center"
-            px="sm"
-            gap={6}
-            mih={headerHeight}
-            style={{ borderBottom: '1px solid var(--color-border)' }}
-          >
+          <Flex align="center" px="sm" gap={6} mih={headerHeight}>
             {dragHandle}
             {chevron}
             <GroupTabBar
@@ -364,7 +353,16 @@ export default function DashboardContainer({
         </Flex>
       )}
       {!isCollapsed && (
-        <Box>{children(hasTabs ? resolvedActiveTabId : undefined)}</Box>
+        <Box
+          className="bg-sunken"
+          p="xs"
+          style={{
+            borderBottomLeftRadius: bordered ? 4 : undefined,
+            borderBottomRightRadius: bordered ? 4 : undefined,
+          }}
+        >
+          {children(hasTabs ? resolvedActiveTabId : undefined)}
+        </Box>
       )}
       <Modal
         data-testid="group-delete-modal"

--- a/packages/app/src/components/GroupTabBar.tsx
+++ b/packages/app/src/components/GroupTabBar.tsx
@@ -77,7 +77,7 @@ export default function GroupTabBar({
 
   return (
     <>
-      <Tabs.List style={{ flex: 1, border: 'none' }}>
+      <Tabs.List className="dashboard-group-tabs-list" style={{ flex: 1 }}>
         {tabs.map(tab => (
           <Tabs.Tab
             key={tab.id}

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -27,7 +27,13 @@ export function ChartContainerCardHeaderProvider({
   );
 }
 
-const HEADER_SPACING = 'calc(var(--mantine-spacing-md) * 0.5)';
+// Horizontal padding a dashboard tile applies to its content. The card header
+// bleeds its separator to the tile edge by cancelling exactly this inset, so
+// the tile must consume the same value (see DASHBOARD_TILE_PADDING_INLINE usage
+// in DBDashboardPage) instead of a matching `.px-2` utility that could drift.
+export const DASHBOARD_TILE_PADDING_INLINE =
+  'calc(var(--mantine-spacing-md) * 0.5)';
+const HEADER_SPACING = DASHBOARD_TILE_PADDING_INLINE;
 const HEADER_SPACING_SLIM = 'calc(var(--mantine-spacing-md) * 0.25)';
 
 function ChartContainer({

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -1,3 +1,4 @@
+import { createContext, use } from 'react';
 import { Group, Stack } from '@mantine/core';
 
 interface ChartContainerProps {
@@ -7,57 +8,113 @@ interface ChartContainerProps {
   disableReactiveContainer?: boolean;
 }
 
+// When true, ChartContainer renders a "card" style header: an inline header
+// row with top padding so the title/toolbar don't hug the card edge. With a
+// title it also draws a full-bleed separator; without a title it's a slim
+// strip that right-aligns the toolbar (so it never overlaps content).
+// Provided by dashboard tiles; other usages keep the plain, inline header.
+const ChartContainerCardHeaderContext = createContext(false);
+
+export function ChartContainerCardHeaderProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ChartContainerCardHeaderContext value={true}>
+      {children}
+    </ChartContainerCardHeaderContext>
+  );
+}
+
+const HEADER_SPACING = 'calc(var(--mantine-spacing-md) * 0.5)';
+const HEADER_SPACING_SLIM = 'calc(var(--mantine-spacing-md) * 0.25)';
+
 function ChartContainer({
   title,
   toolbarItems,
   children,
   disableReactiveContainer,
 }: ChartContainerProps) {
+  const cardHeader = use(ChartContainerCardHeaderContext);
+  const hasToolbar = !!toolbarItems?.length;
+  const showHeader = !!title || hasToolbar;
+
   return (
-    <Stack h="100%" w="100%" style={{ flexGrow: 1 }}>
-      {(!!title || !!toolbarItems?.length) && (
-        <Group justify="space-between" align="start" wrap="nowrap">
-          <span
-            style={{
-              flex: 1,
-              flexShrink: 1,
-              overflow: 'hidden',
-            }}
+    // Reset the context so nested ChartContainers don't inherit the card
+    // header styling; only the top-most container under a tile gets it.
+    <ChartContainerCardHeaderContext value={false}>
+      <Stack
+        h="100%"
+        w="100%"
+        gap={cardHeader ? 'xs' : undefined}
+        style={{ flexGrow: 1 }}
+      >
+        {showHeader && (
+          <Group
+            justify="space-between"
+            align={cardHeader ? 'center' : 'start'}
+            wrap="nowrap"
+            style={
+              cardHeader
+                ? {
+                    // Full-bleed: cancel the tile's horizontal padding
+                    // (px-2 => spacing-md * 0.5) so the separator reaches the
+                    // card edges, then re-inset the content.
+                    marginInline: `calc(${HEADER_SPACING} * -1)`,
+                    paddingInline: HEADER_SPACING,
+                    // Keep the header strip compact: slim vertical padding for
+                    // both titled and title-less tiles, plus a full-bleed
+                    // separator so every tile has a consistent header.
+                    paddingTop: HEADER_SPACING_SLIM,
+                    paddingBottom: HEADER_SPACING_SLIM,
+                    borderBottom: '1px solid var(--color-border)',
+                  }
+                : undefined
+            }
           >
-            {title}
-          </span>
-          {toolbarItems && (
-            <Group flex={0} wrap="nowrap" gap={5}>
-              {toolbarItems}
-            </Group>
-          )}
-        </Group>
-      )}
-      {disableReactiveContainer ? (
-        children
-      ) : (
-        <div
-          // Hack, recharts will release real fix soon https://github.com/recharts/recharts/issues/172
-          style={{
-            position: 'relative',
-            width: '100%',
-            height: '100%',
-          }}
-        >
+            <span
+              style={{
+                flex: 1,
+                flexShrink: 1,
+                overflow: 'hidden',
+              }}
+            >
+              {title}
+            </span>
+            {toolbarItems && (
+              <Group flex={0} wrap="nowrap" gap={5}>
+                {toolbarItems}
+              </Group>
+            )}
+          </Group>
+        )}
+        {disableReactiveContainer ? (
+          children
+        ) : (
           <div
+            // Hack, recharts will release real fix soon https://github.com/recharts/recharts/issues/172
             style={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              bottom: 0,
-              top: 0,
+              position: 'relative',
+              width: '100%',
+              height: '100%',
             }}
           >
-            {children}
+            <div
+              style={{
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                bottom: 0,
+                top: 0,
+              }}
+            >
+              {children}
+            </div>
           </div>
-        </div>
-      )}
-    </Stack>
+        )}
+      </Stack>
+    </ChartContainerCardHeaderContext>
   );
 }
 

--- a/packages/app/src/theme/themes/clickstack/_tokens.scss
+++ b/packages/app/src/theme/themes/clickstack/_tokens.scss
@@ -110,6 +110,7 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--click-global-color-background-muted);
+
   /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
      the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
      visually pop. It is intentionally darker/greyer than the body itself. */
@@ -310,6 +311,7 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: var(--click-global-color-background-muted);
+
   /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
      the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
      visually pop. It is intentionally slightly darker than the body itself. */

--- a/packages/app/src/theme/themes/clickstack/_tokens.scss
+++ b/packages/app/src/theme/themes/clickstack/_tokens.scss
@@ -110,6 +110,11 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--click-global-color-background-muted);
+  --color-bg-muted-subtle: color-mix(
+    in srgb,
+    var(--click-global-color-background-muted),
+    #fff 6%
+  );
   --color-bg-highlighted: rgb(80 80 80 / 70%);
   --color-bg-sidenav: var(--click-global-color-background-default);
   --color-bg-sidenav-link-active: var(--palette-neutral-712);
@@ -302,6 +307,11 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: var(--click-global-color-background-muted);
+  --color-bg-muted-subtle: color-mix(
+    in srgb,
+    var(--click-global-color-background-muted) 55%,
+    #fff
+  );
   --color-bg-highlighted: rgb(241 243 245 / 80%);
   --color-bg-sidenav: var(--click-global-color-background-default);
   --color-bg-sidenav-link-active: var(--click-global-color-stroke-default);

--- a/packages/app/src/theme/themes/clickstack/_tokens.scss
+++ b/packages/app/src/theme/themes/clickstack/_tokens.scss
@@ -110,10 +110,13 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--click-global-color-background-muted);
-  --color-bg-muted-subtle: color-mix(
+  /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
+     the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
+     visually pop. It is intentionally darker/greyer than the body itself. */
+  --color-bg-sunken: color-mix(
     in srgb,
-    var(--click-global-color-background-muted),
-    #fff 6%
+    var(--click-global-color-background-default),
+    #000 20%
   );
   --color-bg-highlighted: rgb(80 80 80 / 70%);
   --color-bg-sidenav: var(--click-global-color-background-default);
@@ -307,7 +310,10 @@
   --color-bg-surface: var(--click-global-color-background-default);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: var(--click-global-color-background-muted);
-  --color-bg-muted-subtle: color-mix(
+  /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
+     the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
+     visually pop. It is intentionally slightly darker than the body itself. */
+  --color-bg-sunken: color-mix(
     in srgb,
     var(--click-global-color-background-muted) 55%,
     #fff

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -29,7 +29,10 @@
   --color-bg-surface: var(--mantine-color-dark-5);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--mantine-color-dark-7);
-  --color-bg-muted-subtle: var(--mantine-color-dark-6);
+  /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
+     the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
+     visually pop. It is intentionally darker/greyer than the body itself. */
+  --color-bg-sunken: color-mix(in srgb, var(--mantine-color-dark-9), #000 50%);
   --color-bg-highlighted: rgb(55 58 64 / 70%);
   --color-bg-sidenav: var(--mantine-color-dark-9);
   --color-bg-sidenav-link-active: var(--mantine-color-dark-7);
@@ -132,7 +135,10 @@
   --color-bg-surface: var(--mantine-color-white);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: #f6f6fa;
-  --color-bg-muted-subtle: #fafafc;
+  /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
+     the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
+     visually pop. It is intentionally slightly darker than the body itself. */
+  --color-bg-sunken: #fafafc;
   --color-bg-highlighted: rgb(230 232 237 / 70%);
   --color-bg-sidenav: var(--mantine-color-white);
   --color-bg-sidenav-link-active: #ebebef;

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -29,6 +29,7 @@
   --color-bg-surface: var(--mantine-color-dark-5);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--mantine-color-dark-7);
+
   /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
      the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
      visually pop. It is intentionally darker/greyer than the body itself. */
@@ -135,6 +136,7 @@
   --color-bg-surface: var(--mantine-color-white);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: #f6f6fa;
+
   /* "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
      the area behind `--color-bg-body` cards (e.g. dashboard tiles) so the cards
      visually pop. It is intentionally slightly darker than the body itself. */

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -29,6 +29,7 @@
   --color-bg-surface: var(--mantine-color-dark-5);
   --color-bg-inverted: var(--mantine-color-dark-1);
   --color-bg-muted: var(--mantine-color-dark-7);
+  --color-bg-muted-subtle: var(--mantine-color-dark-6);
   --color-bg-highlighted: rgb(55 58 64 / 70%);
   --color-bg-sidenav: var(--mantine-color-dark-9);
   --color-bg-sidenav-link-active: var(--mantine-color-dark-7);
@@ -131,6 +132,7 @@
   --color-bg-surface: var(--mantine-color-white);
   --color-bg-inverted: var(--mantine-color-dark-3);
   --color-bg-muted: #f6f6fa;
+  --color-bg-muted-subtle: #fafafc;
   --color-bg-highlighted: rgb(230 232 237 / 70%);
   --color-bg-sidenav: var(--mantine-color-white);
   --color-bg-sidenav-link-active: #ebebef;

--- a/packages/app/styles/_utilities.scss
+++ b/packages/app/styles/_utilities.scss
@@ -15,6 +15,10 @@
   background-color: var(--color-bg-muted);
 }
 
+.bg-muted-subtle {
+  background-color: var(--color-bg-muted-subtle, var(--color-bg-muted));
+}
+
 .bg-muted-hover {
   &:hover {
     background-color: var(--color-bg-muted);

--- a/packages/app/styles/_utilities.scss
+++ b/packages/app/styles/_utilities.scss
@@ -15,8 +15,11 @@
   background-color: var(--color-bg-muted);
 }
 
-.bg-muted-subtle {
-  background-color: var(--color-bg-muted-subtle, var(--color-bg-muted));
+// "Sunken" = a recessed backdrop that sits *below* raised content. Use it for
+// the area behind `.bg-body` cards (e.g. dashboard tiles / group bodies) so the
+// cards visually pop.
+.bg-sunken {
+  background-color: var(--color-bg-sunken, var(--color-bg-muted));
 }
 
 .bg-muted-hover {

--- a/packages/app/styles/app.scss
+++ b/packages/app/styles/app.scss
@@ -244,6 +244,15 @@ button:focus-visible {
   opacity: 1;
 }
 
+// Mantine's default Tabs variant draws a full-width underline beneath the tab
+// list via a ::before pseudo-element. Dashboard groups already have their own
+// border plus a white-header / muted-body split, so this line is redundant.
+// Scoped to the list's ::before so the active-tab indicator (a separate
+// element that reuses --tab-border-color) is left intact.
+.dashboard-group-tabs-list::before {
+  display: none !important;
+}
+
 // custom overrides for jsontree
 .react-json-tree {
   & > ul {

--- a/packages/app/styles/app.scss
+++ b/packages/app/styles/app.scss
@@ -211,6 +211,9 @@ button:focus-visible {
 
 .react-grid-item > .react-resizable-handle {
   padding: 0;
+  // Drop react-resizable's default corner glyph (a low-opacity SVG angle it
+  // sets via background-image); we render our own grip below instead.
+  background-image: none;
 
   // Modern dotted grip: a triangular cluster of dots tucked into the corner.
   &::after {

--- a/packages/app/styles/app.scss
+++ b/packages/app/styles/app.scss
@@ -209,14 +209,39 @@ button:focus-visible {
   opacity: 0.4 !important;
 }
 
-.react-grid-item > .react-resizable-handle::after {
-  border-color: var(--color-text) !important;
-  right: -4px;
-  bottom: -4px;
-  width: 4px;
-  height: 4px;
-  border-right: 2px solid var(--color-text) !important;
-  border-bottom: 2px solid var(--color-text) !important;
+.react-grid-item > .react-resizable-handle {
+  padding: 0;
+
+  // Modern dotted grip: a triangular cluster of dots tucked into the corner.
+  &::after {
+    content: '';
+    position: absolute;
+    right: 3px;
+    bottom: 3px;
+    width: 12px;
+    height: 12px;
+    border: none !important;
+    background-image: radial-gradient(
+      circle,
+      var(--color-text-muted) 40%,
+      transparent 45%
+    );
+    background-size: 4px 4px;
+    background-position: bottom right;
+
+    // Clip the dot grid into a lower-right triangle for a classic grip look.
+    clip-path: polygon(100% 0, 100% 100%, 0 100%);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+}
+
+.react-grid-item:hover > .react-resizable-handle::after {
+  opacity: 0.65;
+}
+
+.react-grid-item > .react-resizable-handle:hover::after {
+  opacity: 1;
 }
 
 // custom overrides for jsontree

--- a/packages/app/tests/e2e/features/dashboard-external-api-config.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-external-api-config.spec.ts
@@ -181,15 +181,8 @@ test.describe(
         for (let i = 0; i < dashboardPayload.tiles.length; i++) {
           const tileData = dashboardPayload.tiles[i];
 
-          // Hover over tile to reveal edit button
-          await tiles.nth(i).hover();
-
-          // Click edit button for this tile
-          const editButton = page
-            .locator(`[data-testid^="tile-edit-button-"]`)
-            .nth(i);
-          await expect(editButton).toBeVisible();
-          await editButton.click();
+          // Open the tile's actions menu and click Edit
+          await dashboardPage.editTile(i);
 
           // Wait for chart editor modal to open
           const chartNameInput = page.getByTestId('chart-name-input');

--- a/packages/app/tests/e2e/features/dashboard-external-api-series.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-external-api-series.spec.ts
@@ -188,15 +188,8 @@ test.describe(
           const tileData = tilesData[i];
           const series = tileData.series;
 
-          // Hover over tile to reveal edit button
-          await tiles.nth(i).hover();
-
-          // Click edit button for this tile
-          const editButton = page
-            .locator(`[data-testid^="tile-edit-button-"]`)
-            .nth(i);
-          await expect(editButton).toBeVisible();
-          await editButton.click();
+          // Open the tile's actions menu and click Edit
+          await dashboardPage.editTile(i);
 
           // Wait for chart editor modal to open
           const chartNameInput = page.getByTestId('chart-name-input');

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -159,20 +159,23 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       const dashboardTiles = dashboardPage.getTiles();
       await expect(dashboardTiles).toHaveCount(2, { timeout: 10000 });
 
-      // Hover over first tile to reveal action buttons
+      // The alert affordance lives directly in the always-visible tile header.
       await dashboardPage.hoverOverTile(0);
+      await expect(dashboardPage.getTileButton('alerts')).toBeVisible();
 
-      // Verify all action buttons are visible
-      const buttons: Array<'edit' | 'duplicate' | 'delete' | 'alerts'> = [
+      // Edit / duplicate / delete now live inside the tile actions (kebab) menu.
+      await dashboardPage.openTileActionsMenu(0);
+      const menuButtons: Array<'edit' | 'duplicate' | 'delete'> = [
         'edit',
         'duplicate',
         'delete',
-        'alerts',
       ];
-      for (const button of buttons) {
-        const buttonLocator = dashboardPage.getTileButton(button);
-        await expect(buttonLocator).toBeVisible();
+      for (const button of menuButtons) {
+        await expect(dashboardPage.getTileButton(button)).toBeVisible();
       }
+
+      // Close the menu so it doesn't intercept subsequent interactions.
+      await dashboardPage.page.keyboard.press('Escape');
     });
 
     await test.step('Test duplicate tile', async () => {
@@ -338,20 +341,23 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       const dashboardTiles = dashboardPage.getTiles();
       await expect(dashboardTiles).toHaveCount(1, { timeout: 10000 });
 
-      // Hover over first tile to reveal action buttons
+      // The alert affordance lives directly in the always-visible tile header.
       await dashboardPage.hoverOverTile(0);
+      await expect(dashboardPage.getTileButton('alerts')).toBeVisible();
 
-      // Verify all action buttons are visible
-      const buttons: Array<'edit' | 'duplicate' | 'delete' | 'alerts'> = [
+      // Edit / duplicate / delete now live inside the tile actions (kebab) menu.
+      await dashboardPage.openTileActionsMenu(0);
+      const menuButtons: Array<'edit' | 'duplicate' | 'delete'> = [
         'edit',
         'duplicate',
         'delete',
-        'alerts',
       ];
-      for (const button of buttons) {
-        const buttonLocator = dashboardPage.getTileButton(button);
-        await expect(buttonLocator).toBeVisible();
+      for (const button of menuButtons) {
+        await expect(dashboardPage.getTileButton(button)).toBeVisible();
       }
+
+      // Close the menu so it doesn't intercept subsequent interactions.
+      await dashboardPage.page.keyboard.press('Escape');
     });
 
     let dashboardUrl: string;
@@ -991,7 +997,8 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
     });
 
     await test.step('Verify tile can be edited when source is missing', async () => {
-      await dashboardPage.hoverOverTile(0);
+      // Edit now lives inside the tile actions (kebab) menu.
+      await dashboardPage.openTileActionsMenu(0);
 
       const editButton = dashboardPage.getTileButton('edit');
       await expect(editButton).toBeVisible();

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -589,10 +589,22 @@ export class DashboardPage {
   }
 
   /**
+   * Open a tile's actions (kebab) menu, revealing the Duplicate / View
+   * fullscreen / Edit / Delete items (which now live inside the menu).
+   */
+  async openTileActionsMenu(tileIndex: number) {
+    await this.hoverOverTile(tileIndex);
+    await this.page
+      .locator('[data-testid^="tile-actions-button-"]')
+      .nth(tileIndex)
+      .click();
+  }
+
+  /**
    * Edit a tile
    */
   async editTile(tileIndex: number) {
-    await this.hoverOverTile(tileIndex);
+    await this.openTileActionsMenu(tileIndex);
     await this.getTileButton('edit').click();
   }
 
@@ -600,7 +612,7 @@ export class DashboardPage {
    * Duplicate a tile
    */
   async duplicateTile(tileIndex: number) {
-    await this.hoverOverTile(tileIndex);
+    await this.openTileActionsMenu(tileIndex);
     await this.getTileButton('duplicate').click();
 
     const confirmButton = this.page.locator(
@@ -613,7 +625,7 @@ export class DashboardPage {
    * Delete a tile
    */
   async deleteTile(tileIndex: number) {
-    await this.hoverOverTile(tileIndex);
+    await this.openTileActionsMenu(tileIndex);
     await this.getTileButton('delete').click();
 
     const confirmButton = this.page.locator(
@@ -1267,7 +1279,7 @@ export class DashboardPage {
    * Waits for the fullscreen modal's TimePicker to appear before returning.
    */
   async openFullscreenForTile(index: number) {
-    await this.hoverOverTile(index);
+    await this.openTileActionsMenu(index);
     const fullscreenBtn = this.page
       .locator('[data-testid^="tile-fullscreen-button-"]')
       .first();

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -593,7 +593,6 @@ export class DashboardPage {
    * fullscreen / Edit / Delete items (which now live inside the menu).
    */
   async openTileActionsMenu(tileIndex: number) {
-    await this.hoverOverTile(tileIndex);
     await this.page
       .locator('[data-testid^="tile-actions-button-"]')
       .nth(tileIndex)


### PR DESCRIPTION
## Summary

A visual-polish pass on dashboards to make tiles read as distinct cards and give groups a cleaner, more consistent layout. 

### Tiles
- **Card styling**: tiles use a `bg-body` (white in light mode) background with a border, sitting on a recessed "sunken" page background so they read as elevated cards.
- **Compact, consistent header**: every tile has a slim header strip with a full-bleed separator (titled or not), reducing empty space and preventing actions from overlapping content.
- **Right-aligned kebab menu**: tile actions (duplicate, view fullscreen, edit, delete, move-to-group) are consolidated into a `⋮` menu rendered as a toolbar *suffix*, so it sits at the far right after each chart's own controls (display switcher, granularity). The alert affordance stays alongside it and is always visible.
- **Alert affordance**: uses `IconBellPlus` when no alert is configured (reads clearly on the light header) and `IconBell` + a colored status indicator when an alert exists.
- **Non-muted table tiles**: dashboard table tiles use the default (white) table variant so they blend into the card instead of showing a muted panel.
- **Modern resize handle**: replaced the default corner bracket with a subtle, hover-revealed dotted triangular grip.

### Groups
- **Always-visible controls**: the drag handle, add-tile, and `⋮` overflow controls are always visible in the group header (no longer hover-only).
- **Header / body split**: group header uses `bg-body`; the tile area below uses the sunken background with padding around the nested tiles.
- **Removed redundant tab underline**: the group's Mantine tab list no longer draws its default `::before` underline, since the group border + header/body color split already separate the tab row from the content (the active-tab indicator is preserved).

### Theming
- Renamed `--color-bg-muted-subtle` → `--color-bg-sunken` (and `.bg-muted-subtle` → `.bg-sunken`) with explanatory comments, since the token is a recessed backdrop that sits *below* `bg-body` cards rather than a "subtler muted".

### Screenshots

Before

<img width="3456" height="5459" alt="Browser-RUM-–-HyperDX-07-06-2026_11_22_AM (1)" src="https://github.com/user-attachments/assets/27277a03-3227-4912-984d-9a329208a921" />

<img width="1473" height="632" alt="Screenshot 2026-07-06 at 12 35 16" src="https://github.com/user-attachments/assets/b264973e-a2c4-4a1d-a9b4-5ba918dec2dd" />



After

<img width="3456" height="5581" alt="Browser-RUM-–-HyperDX-07-06-2026_11_22_AM" src="https://github.com/user-attachments/assets/c62f51c1-151f-4a4a-8c2b-b2a32e6aac64" />

<img width="1473" height="648" alt="Screenshot 2026-07-06 at 12 34 26" src="https://github.com/user-attachments/assets/ba84a7a1-2e58-44ca-8c1c-2394ae93b1b6" />


### Tests
- Updated dashboard E2E specs/page objects so tile edit/duplicate/delete are exercised through the kebab menu.

## Test plan

- [ ] Tiles render as bordered `bg-body` cards on a sunken page background (light + dark).
- [ ] Tile header is compact and consistent for titled and untitled tiles; separator reaches both card edges.
- [ ] Kebab menu sits at the far right after chart controls; alert bell + all actions (edit/duplicate/delete/fullscreen/move) work.
- [ ] Alert icon shows `bell +` with no alert and a status dot when an alert exists; both visible on light/dark headers.
- [ ] Table tiles no longer show a muted background.
- [ ] Group controls (drag/add/kebab) are always visible; header is `bg-body`, tile area is sunken with padding; no underline under the group tabs (active-tab indicator still shows).
- [ ] Resize handle grip appears on hover and resizing still works.
- [ ] E2E: `make dev-e2e FILE=dashboard`