### PR TITLE
feat: expose window alerting on the external API

### DIFF
--- a/.changeset/external-api-consecutive-window-alerts.md
+++ b/.changeset/external-api-consecutive-window-alerts.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+Expose consecutive-window alerting on the external API.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -102,7 +102,8 @@
           "ALERT",
           "OK",
           "INSUFFICIENT_DATA",
-          "DISABLED"
+          "DISABLED",
+          "PENDING"
         ],
         "description": "Current alert state."
       },
@@ -292,6 +293,13 @@
             "minLength": 1,
             "maxLength": 4096,
             "example": "Threshold raised from 50 to 100 on 2026-01-15. See [runbook](https://wiki.example.com/runbook)."
+          },
+          "numConsecutiveWindows": {
+            "type": "integer",
+            "minimum": 1,
+            "nullable": true,
+            "description": "Fire the alert only after its condition has been met for this many consecutive evaluation windows. While the condition is met but fewer than this many consecutive windows have violated, the alert is in the PENDING state.",
+            "example": 3
           }
         }
       },
@@ -4293,6 +4301,7 @@
                         "teamId": "65f5e4a3b9e77c001a345678",
                         "tileId": "65f5e4a3b9e77c001a901234",
                         "dashboardId": "65f5e4a3b9e77c001a567890",
+                        "numConsecutiveWindows": 3,
                         "createdAt": "2023-03-15T10:20:30.000Z",
                         "updatedAt": "2023-03-15T14:25:10.000Z"
                       }
@@ -4558,7 +4567,8 @@
                       "webhookId": "65f5e4a3b9e77c001a789012"
                     },
                     "name": "Error Spike Alert",
-                    "message": "Error rate has exceeded 100 in the last hour"
+                    "message": "Error rate has exceeded 100 in the last hour",
+                    "numConsecutiveWindows": 3
                   }
                 }
               }

--- a/packages/api/src/routers/external-api/__tests__/alerts.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.test.ts
@@ -223,6 +223,7 @@ describe('External API Alerts', () => {
           name: 'Format Test Alert',
           message: 'This is a test alert for format verification',
           note: null,
+          numConsecutiveWindows: null,
           threshold: 123,
           interval: '15m',
           source: AlertSource.TILE,
@@ -1230,6 +1231,106 @@ describe('External API Alerts', () => {
       expect(match.executionErrors).toHaveLength(1);
       expect(match.executionErrors[0].type).toBe(AlertErrorType.WEBHOOK_ERROR);
       expect(match.executionErrors[0].message).toBe('webhook delivery failed');
+    });
+  });
+
+  describe('Consecutive-window alerting (numConsecutiveWindows)', () => {
+    it('should create an alert with numConsecutiveWindows and return it', async () => {
+      const { alert } = await createTestAlert({ numConsecutiveWindows: 3 });
+
+      expect(alert.numConsecutiveWindows).toBe(3);
+    });
+
+    it('should default numConsecutiveWindows to null when not provided', async () => {
+      const { alert } = await createTestAlert();
+
+      expect(alert.numConsecutiveWindows).toBeNull();
+    });
+
+    it('should reject numConsecutiveWindows below 1', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const dashboard = await createTestDashboard();
+      const webhook = await createTestWebhook();
+
+      await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          dashboardId: dashboard._id.toString(),
+          tileId: dashboard.tiles[0].id,
+          threshold: 100,
+          interval: '1h',
+          source: AlertSource.TILE,
+          thresholdType: AlertThresholdType.ABOVE,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          numConsecutiveWindows: 0,
+        })
+        .expect(400);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should return numConsecutiveWindows on GET by id', async () => {
+      const { alert } = await createTestAlert({ numConsecutiveWindows: 5 });
+
+      const getResponse = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${alert.id}`,
+      ).expect(200);
+
+      expect(getResponse.body.data.numConsecutiveWindows).toBe(5);
+    });
+
+    it('should return numConsecutiveWindows on the list endpoint', async () => {
+      const { alert } = await createTestAlert({ numConsecutiveWindows: 4 });
+
+      const listResponse = await authRequest('get', ALERTS_BASE_URL).expect(
+        200,
+      );
+
+      const match = listResponse.body.data.find((a: any) => a.id === alert.id);
+      expect(match).toBeDefined();
+      expect(match.numConsecutiveWindows).toBe(4);
+    });
+
+    it('should update an alert to set numConsecutiveWindows', async () => {
+      const { alert, alertInput } = await createTestAlert();
+
+      expect(alert.numConsecutiveWindows).toBeNull();
+
+      await authRequest('put', `${ALERTS_BASE_URL}/${alert.id}`)
+        .send({ ...alertInput, numConsecutiveWindows: 2 })
+        .expect(200);
+
+      const getResponse = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${alert.id}`,
+      ).expect(200);
+
+      expect(getResponse.body.data.numConsecutiveWindows).toBe(2);
+    });
+
+    it('should update an alert to clear numConsecutiveWindows (null)', async () => {
+      const { alert, alertInput } = await createTestAlert({
+        numConsecutiveWindows: 3,
+      });
+
+      expect(alert.numConsecutiveWindows).toBe(3);
+
+      await authRequest('put', `${ALERTS_BASE_URL}/${alert.id}`)
+        .send({ ...alertInput, numConsecutiveWindows: null })
+        .expect(200);
+
+      const getResponse = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${alert.id}`,
+      ).expect(200);
+
+      expect(getResponse.body.data.numConsecutiveWindows).toBeNull();
     });
   });
 });

--- a/packages/api/src/routers/external-api/v2/alerts.ts
+++ b/packages/api/src/routers/external-api/v2/alerts.ts
@@ -42,7 +42,7 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *       description: Alert source type.
  *     AlertState:
  *       type: string
- *       enum: [ALERT, OK, INSUFFICIENT_DATA, DISABLED]
+ *       enum: [ALERT, OK, INSUFFICIENT_DATA, DISABLED, PENDING]
  *       description: Current alert state.
  *     AlertChannelType:
  *       type: string
@@ -186,6 +186,12 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *           minLength: 1
  *           maxLength: 4096
  *           example: "Threshold raised from 50 to 100 on 2026-01-15. See [runbook](https://wiki.example.com/runbook)."
+ *         numConsecutiveWindows:
+ *           type: integer
+ *           minimum: 1
+ *           nullable: true
+ *           description: Fire the alert only after its condition has been met for this many consecutive evaluation windows. While the condition is met but fewer than this many consecutive windows have violated, the alert is in the PENDING state.
+ *           example: 3
  *
  *     AlertResponse:
  *       allOf:
@@ -310,6 +316,7 @@ const router = express.Router();
  *                     teamId: "65f5e4a3b9e77c001a345678"
  *                     tileId: "65f5e4a3b9e77c001a901234"
  *                     dashboardId: "65f5e4a3b9e77c001a567890"
+ *                     numConsecutiveWindows: 3
  *                     createdAt: "2023-03-15T10:20:30.000Z"
  *                     updatedAt: "2023-03-15T14:25:10.000Z"
  *       '401':
@@ -443,6 +450,7 @@ router.get('/', async (req, res, next) => {
  *                   webhookId: "65f5e4a3b9e77c001a789012"
  *                 name: "Error Spike Alert"
  *                 message: "Error rate has exceeded 100 in the last hour"
+ *                 numConsecutiveWindows: 3
  *     responses:
  *       '200':
  *         description: Successfully created alert

--- a/packages/api/src/utils/__tests__/externalApi.test.ts
+++ b/packages/api/src/utils/__tests__/externalApi.test.ts
@@ -71,4 +71,30 @@ describe('utils/externalApi', () => {
       expect(translated.note).toBe('threshold raised to 100');
     });
   });
+
+  describe('numConsecutiveWindows handling', () => {
+    it('returns numConsecutiveWindows as null when the value is null', () => {
+      const alert = createAlertDocument({ numConsecutiveWindows: null });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.numConsecutiveWindows).toBeNull();
+    });
+
+    it('returns numConsecutiveWindows as null when the value is undefined', () => {
+      const alert = createAlertDocument({ numConsecutiveWindows: undefined });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.numConsecutiveWindows).toBeNull();
+    });
+
+    it('returns numConsecutiveWindows when the value is a positive integer', () => {
+      const alert = createAlertDocument({ numConsecutiveWindows: 3 });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.numConsecutiveWindows).toBe(3);
+    });
+  });
 });

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -237,6 +237,7 @@ export type ExternalAlert = {
   interval: AlertInterval;
   scheduleOffsetMinutes?: number;
   scheduleStartAt?: string | null;
+  numConsecutiveWindows?: number | null;
   thresholdType: AlertThresholdType;
   source?: string;
   state: AlertState;
@@ -338,6 +339,7 @@ export function translateAlertDocumentToExternalAlert(
       scheduleOffsetMinutes: alertObj.scheduleOffsetMinutes,
     }),
     scheduleStartAt: transformScheduleStartAt(alertObj.scheduleStartAt),
+    numConsecutiveWindows: alertObj.numConsecutiveWindows ?? null,
     thresholdType: alertObj.thresholdType,
     source: alertObj.source,
     state: alertObj.state,


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Follow up to https://github.com/hyperdxio/hyperdx/pull/2472 to expose the `numConsecutiveWindows` field on the external API.

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> N/A

**Steps:**

1. Test via external API

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Related PRs: https://github.com/hyperdxio/hyperdx/pull/2472
