### PR TITLE
fix(charts): use multi-line ellipsis for dashboard tile titles

### DIFF
--- a/.changeset/tile-title-ellipsis.md
+++ b/.changeset/tile-title-ellipsis.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix dashboard tile titles getting clipped unpredictably when tiles are resized small by applying multi-line ellipsis truncation.

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -136,6 +136,7 @@ import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer, {
   ChartContainerCardHeaderProvider,
+  CollapsedToolbarProvider,
   DASHBOARD_TILE_PADDING_INLINE,
 } from './components/charts/ChartContainer';
 import DBHeatmapChart, {
@@ -838,6 +839,136 @@ const Tile = forwardRef(
       openFullscreen,
     ]);
 
+    // Flat Menu.Item list for the collapsed (narrow-tile) toolbar.
+    // Merges the alert action + all kebab items into a single flat list
+    // so ChartContainer can render them without nested menus.
+    const collapsedMenuItems = useMemo(() => {
+      const isRawSql = isRawSqlSavedChartConfig(chart.config);
+      const isPromQL = isPromqlSavedChartConfig(chart.config);
+      const showAlerts = isRawSql
+        ? displayTypeSupportsRawSqlAlerts(chart.config.displayType)
+        : isPromQL
+          ? displayTypeSupportsPromQLAlerts(chart.config.displayType)
+          : displayTypeSupportsBuilderAlerts(chart.config.displayType);
+      const canMoveToGroup =
+        onMoveToGroup && moveTargets && moveTargets.length > 0;
+      return (
+        <>
+          {showAlerts && (
+            <>
+              <Menu.Item
+                leftSection={
+                  alert ? <IconBell size={14} /> : <IconBellPlus size={14} />
+                }
+                onClick={onEditClick}
+              >
+                {alertTooltip}
+              </Menu.Item>
+              <Menu.Divider />
+            </>
+          )}
+          <Menu.Item
+            leftSection={<IconCopy size={14} />}
+            onClick={onDuplicateClick}
+          >
+            Duplicate
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<IconArrowsMaximize size={14} />}
+            onClick={() => openFullscreen()}
+          >
+            View fullscreen
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<IconPencil size={14} />}
+            onClick={onEditClick}
+          >
+            Edit
+          </Menu.Item>
+          {canMoveToGroup && (
+            <>
+              <Menu.Divider />
+              <Menu.Label>Move to Group</Menu.Label>
+              {chart.containerId && (
+                <Menu.Item
+                  leftSection={<IconCornerDownRight size={14} />}
+                  onClick={() => onMoveToGroup(undefined)}
+                >
+                  (Ungrouped)
+                </Menu.Item>
+              )}
+              {moveTargets
+                .filter(
+                  t =>
+                    !(
+                      t.containerId === chart.containerId &&
+                      t.tabId === chart.tabId
+                    ),
+                )
+                .map(t => (
+                  <Menu.Item
+                    key={`collapsed-${t.containerId}-${t.tabId ?? ''}`}
+                    leftSection={<IconCornerDownRight size={14} />}
+                    onClick={() => onMoveToGroup(t.containerId, t.tabId)}
+                  >
+                    {t.allTabs ? (
+                      <span>
+                        {t.allTabs.map((tab, i) => (
+                          <span key={tab.id}>
+                            {i > 0 && (
+                              <span
+                                style={{
+                                  color: 'var(--mantine-color-dimmed)',
+                                }}
+                              >
+                                {' | '}
+                              </span>
+                            )}
+                            <span
+                              style={
+                                tab.id !== t.tabId
+                                  ? {
+                                      color: 'var(--mantine-color-dimmed)',
+                                    }
+                                  : undefined
+                              }
+                            >
+                              {tab.title}
+                            </span>
+                          </span>
+                        ))}
+                      </span>
+                    ) : (
+                      t.label
+                    )}
+                  </Menu.Item>
+                ))}
+            </>
+          )}
+          <Menu.Divider />
+          <Menu.Item
+            color="red"
+            leftSection={<IconTrash size={14} />}
+            onClick={onDeleteClick}
+          >
+            Delete
+          </Menu.Item>
+        </>
+      );
+    }, [
+      alert,
+      alertTooltip,
+      moveTargets,
+      chart.config,
+      chart.containerId,
+      chart.tabId,
+      onDeleteClick,
+      onDuplicateClick,
+      onEditClick,
+      onMoveToGroup,
+      openFullscreen,
+    ]);
+
     const title = useMemo(
       () =>
         chart.config.name ? (
@@ -1132,9 +1263,14 @@ const Tile = forwardRef(
             style={{ paddingInline: DASHBOARD_TILE_PADDING_INLINE }}
             onMouseDown={e => e.stopPropagation()}
           >
-            <ChartContainerCardHeaderProvider>
-              {renderChartContent()}
-            </ChartContainerCardHeaderProvider>
+            <CollapsedToolbarProvider
+              menuItems={collapsedMenuItems}
+              suffixCount={1}
+            >
+              <ChartContainerCardHeaderProvider>
+                {renderChartContent()}
+              </ChartContainerCardHeaderProvider>
+            </CollapsedToolbarProvider>
           </div>
           {children}
         </div>

--- a/packages/app/src/components/DBSearchPageFilters/hooks.ts
+++ b/packages/app/src/components/DBSearchPageFilters/hooks.ts
@@ -397,7 +397,7 @@ export function useFetchFacets({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setExtraFacets(null);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+
     setExtraFacetKeys(new Set());
   }, [
     sourceId,

--- a/packages/app/src/components/charts/ChartContainer.module.scss
+++ b/packages/app/src/components/charts/ChartContainer.module.scss
@@ -12,6 +12,21 @@
   display: none;
 }
 
+/* Hide the inline section (row + divider) when the row has no visible
+   child elements — e.g. Number/Table tiles where all prefix items are
+   null and no chart-specific indicators apply. */
+.inlineSection:not(:has(.inlineRow > *)) {
+  display: none;
+}
+
+/* Inline row inside the collapsed dropdown: indicators stay compact,
+   the last child (typically the DisplaySwitcher toggle group) stretches
+   to fill remaining width with icons spread evenly. */
+.inlineRow > :last-child {
+  flex: 1;
+  justify-content: space-evenly;
+}
+
 @container (max-width: 200px) {
   .toolbarNormal {
     display: none;

--- a/packages/app/src/components/charts/ChartContainer.module.scss
+++ b/packages/app/src/components/charts/ChartContainer.module.scss
@@ -1,0 +1,23 @@
+.root {
+  container-type: inline-size;
+}
+
+/* Normal toolbar: visible by default, hidden when narrow */
+.toolbarNormal {
+  display: flex;
+}
+
+/* Collapsed toolbar: hidden by default, shown when narrow */
+.toolbarCollapsed {
+  display: none;
+}
+
+@container (max-width: 200px) {
+  .toolbarNormal {
+    display: none;
+  }
+
+  .toolbarCollapsed {
+    display: flex;
+  }
+}

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -85,7 +85,7 @@ function ChartContainer({
                 flexShrink: 1,
                 overflow: 'hidden',
                 display: '-webkit-box',
-                WebkitLineClamp: 2,
+                WebkitLineClamp: 4,
                 WebkitBoxOrient: 'vertical',
                 overflowWrap: 'break-word',
               }}

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -1,5 +1,5 @@
 import { createContext, use } from 'react';
-import { ActionIcon, Group, Popover, Stack, Tooltip } from '@mantine/core';
+import { ActionIcon, Group, Menu, Stack, Tooltip } from '@mantine/core';
 import { IconDotsVertical } from '@tabler/icons-react';
 
 import styles from './ChartContainer.module.scss';
@@ -30,6 +30,33 @@ export function ChartContainerCardHeaderProvider({
   );
 }
 
+// Collapsed toolbar context for narrow dashboard tiles.
+// `menuItems` contains pre-built Menu.Item elements (alert + kebab actions)
+// that render as a flat list in the collapsed dropdown. `suffixCount` tells
+// ChartContainer how many items at the end of toolbarItems[] are "suffix"
+// (i.e. the hoverToolbar) and should be excluded from the inline row in the
+// collapsed view — they are replaced by the flat menuItems instead.
+interface CollapsedToolbarData {
+  menuItems: React.ReactNode;
+  suffixCount: number;
+}
+
+const CollapsedToolbarContext = createContext<CollapsedToolbarData | null>(
+  null,
+);
+
+export function CollapsedToolbarProvider({
+  menuItems,
+  suffixCount,
+  children,
+}: CollapsedToolbarData & { children: React.ReactNode }) {
+  return (
+    <CollapsedToolbarContext value={{ menuItems, suffixCount }}>
+      {children}
+    </CollapsedToolbarContext>
+  );
+}
+
 // Horizontal padding a dashboard tile applies to its content. The card header
 // bleeds its separator to the tile edge by cancelling exactly this inset, so
 // the tile must consume the same value (see DASHBOARD_TILE_PADDING_INLINE usage
@@ -46,8 +73,20 @@ function ChartContainer({
   disableReactiveContainer,
 }: ChartContainerProps) {
   const cardHeader = use(ChartContainerCardHeaderContext);
+  const collapsedToolbar = use(CollapsedToolbarContext);
   const hasToolbar = !!toolbarItems?.length;
   const showHeader = !!title || hasToolbar;
+
+  // In the collapsed view, split toolbarItems into inline items (indicators,
+  // toggles) and suffix items (hoverToolbar) which get replaced by flat
+  // Menu.Items from context. Filter out null/undefined entries (e.g.
+  // filterWarning is null when no warning applies).
+  const inlineItems = collapsedToolbar
+    ? toolbarItems
+        ?.slice(0, -collapsedToolbar.suffixCount || undefined)
+        .filter(Boolean)
+    : undefined;
+  const hasInlineItems = !!inlineItems?.length;
 
   return (
     // Reset the context so nested ChartContainers don't inherit the card
@@ -103,33 +142,51 @@ function ChartContainer({
                   flex={0}
                   wrap="nowrap"
                   gap={5}
-                  className={styles.toolbarNormal}
+                  className={
+                    collapsedToolbar ? styles.toolbarNormal : undefined
+                  }
                 >
                   {toolbarItems}
                 </Group>
-                {/* Collapsed toolbar: single ⋮ icon at narrow sizes */}
-                <div className={styles.toolbarCollapsed}>
-                  <Popover width={200} position="bottom-end">
-                    <Popover.Target>
-                      <Tooltip
-                        label="Tile actions"
-                        position="top"
-                        withArrow
+                {/* Collapsed toolbar: single ⋮ dropdown at narrow sizes.
+                    Row 1 shows inline items (indicators, toggles) as-is,
+                    then a divider, then flattened action Menu.Items. */}
+                {collapsedToolbar && (
+                  <div className={styles.toolbarCollapsed}>
+                    <Menu width={220} position="bottom-end">
+                      <Menu.Target>
+                        <Tooltip
+                          label="Tile actions"
+                          position="top"
+                          withArrow
+                        >
+                          <ActionIcon variant="subtle" size="sm">
+                            <IconDotsVertical size={16} />
+                          </ActionIcon>
+                        </Tooltip>
+                      </Menu.Target>
+                      <Menu.Dropdown
+                        onMouseDown={e => e.stopPropagation()}
                       >
-                        <ActionIcon variant="subtle" size="sm">
-                          <IconDotsVertical size={16} />
-                        </ActionIcon>
-                      </Tooltip>
-                    </Popover.Target>
-                    <Popover.Dropdown
-                      onMouseDown={e => e.stopPropagation()}
-                    >
-                      <Group gap={5} justify="center">
-                        {toolbarItems}
-                      </Group>
-                    </Popover.Dropdown>
-                  </Popover>
-                </div>
+                        {hasInlineItems && (
+                          <div className={styles.inlineSection}>
+                            <Group
+                              gap="sm"
+                              wrap="nowrap"
+                              px="sm"
+                              py="xs"
+                              className={styles.inlineRow}
+                            >
+                              {inlineItems}
+                            </Group>
+                            <Menu.Divider />
+                          </div>
+                        )}
+                        {collapsedToolbar.menuItems}
+                      </Menu.Dropdown>
+                    </Menu>
+                  </div>
+                )}
               </>
             )}
           </Group>

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -155,19 +155,13 @@ function ChartContainer({
                   <div className={styles.toolbarCollapsed}>
                     <Menu width={220} position="bottom-end">
                       <Menu.Target>
-                        <Tooltip
-                          label="Tile actions"
-                          position="top"
-                          withArrow
-                        >
+                        <Tooltip label="Tile actions" position="top" withArrow>
                           <ActionIcon variant="subtle" size="sm">
                             <IconDotsVertical size={16} />
                           </ActionIcon>
                         </Tooltip>
                       </Menu.Target>
-                      <Menu.Dropdown
-                        onMouseDown={e => e.stopPropagation()}
-                      >
+                      <Menu.Dropdown onMouseDown={e => e.stopPropagation()}>
                         {hasInlineItems && (
                           <div className={styles.inlineSection}>
                             <Group

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -1,5 +1,8 @@
 import { createContext, use } from 'react';
-import { Group, Stack } from '@mantine/core';
+import { ActionIcon, Group, Popover, Stack, Tooltip } from '@mantine/core';
+import { IconDotsVertical } from '@tabler/icons-react';
+
+import styles from './ChartContainer.module.scss';
 
 interface ChartContainerProps {
   title?: React.ReactNode;
@@ -55,6 +58,7 @@ function ChartContainer({
         w="100%"
         gap={cardHeader ? 'xs' : undefined}
         style={{ flexGrow: 1 }}
+        className={styles.root}
       >
         {showHeader && (
           <Group
@@ -93,9 +97,40 @@ function ChartContainer({
               {title}
             </span>
             {toolbarItems && (
-              <Group flex={0} wrap="nowrap" gap={5}>
-                {toolbarItems}
-              </Group>
+              <>
+                {/* Normal toolbar: visible at wider sizes */}
+                <Group
+                  flex={0}
+                  wrap="nowrap"
+                  gap={5}
+                  className={styles.toolbarNormal}
+                >
+                  {toolbarItems}
+                </Group>
+                {/* Collapsed toolbar: single ⋮ icon at narrow sizes */}
+                <div className={styles.toolbarCollapsed}>
+                  <Popover width={200} position="bottom-end">
+                    <Popover.Target>
+                      <Tooltip
+                        label="Tile actions"
+                        position="top"
+                        withArrow
+                      >
+                        <ActionIcon variant="subtle" size="sm">
+                          <IconDotsVertical size={16} />
+                        </ActionIcon>
+                      </Tooltip>
+                    </Popover.Target>
+                    <Popover.Dropdown
+                      onMouseDown={e => e.stopPropagation()}
+                    >
+                      <Group gap={5} justify="center">
+                        {toolbarItems}
+                      </Group>
+                    </Popover.Dropdown>
+                  </Popover>
+                </div>
+              </>
             )}
           </Group>
         )}

--- a/packages/app/src/components/charts/ChartContainer.tsx
+++ b/packages/app/src/components/charts/ChartContainer.tsx
@@ -84,6 +84,10 @@ function ChartContainer({
                 flex: 1,
                 flexShrink: 1,
                 overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflowWrap: 'break-word',
               }}
             >
               {title}


### PR DESCRIPTION
## Summary

Fixes dashboard tile titles getting clipped unpredictably when tiles are resized small, and collapses toolbar actions into a compact popover at narrow widths.

## Changes

**Title truncation** — Apply `-webkit-line-clamp: 4` with `overflow-wrap: break-word` to the tile title wrapper so titles wrap naturally across up to 4 lines, truncate cleanly with "..." if needed, and only break mid-word when a single word is wider than the tile.

**Toolbar collapse** — Use a CSS container query (`@container (max-width: 200px)`) to detect narrow tiles. At that breakpoint the normal toolbar icons are hidden and replaced with a single ⋮ icon that opens a popover containing the same toolbar actions.
