### PR TITLE
fix: track display/heatmap settings as dirty for unsaved changes modal

### DIFF
--- a/.changeset/tnjv-sern-hwcq.md
+++ b/.changeset/tnjv-sern-hwcq.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: display/heatmap settings changes now trigger the unsaved changes modal when closing the tile editor

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -1188,11 +1188,15 @@ const EditTileModal = ({
   const confirm = useConfirm();
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
+  // Reset dirty state only when a *different* tile is opened, not on every
+  // chart-object reference change (onSubmit recreates the chart object with
+  // the same id, which would clear dirty state after display-settings Apply).
+  const chartId = chart?.id;
   useEffect(() => {
-    if (chart != null) {
+    if (chartId != null) {
       setHasUnsavedChanges(false);
     }
-  }, [chart]);
+  }, [chartId]);
 
   const handleClose = useCallback(() => {
     if (isSaving) return;

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -70,7 +70,7 @@ interface ChartDisplaySettingsDrawerProps {
   /** 'sql' for raw SQL chart configs; anything else is treated as a builder config. */
   configType?: 'sql' | 'builder' | 'promql';
   previousDateRange?: [Date, Date];
-  onChange: (settings: ChartConfigDisplaySettings) => void;
+  onChange: (settings: ChartConfigDisplaySettings, isDirty: boolean) => void;
   onClose: () => void;
   isPerSeriesNumberFormatAllowed?: boolean;
 }
@@ -150,13 +150,17 @@ export default function ChartDisplaySettingsDrawer({
       // instead of freezing the drawer's inferred fallback into the config.
       const numberFormatExplicit =
         settings.numberFormat != null || dirtyFields.numberFormat != null;
-      onChange({
-        ...rest,
-        numberFormat: numberFormatExplicit
-          ? formValues.numberFormat
-          : undefined,
-        colorRules: colorRules ? stripLocalIds(colorRules) : undefined,
-      });
+      const hasDirtyFields = Object.keys(dirtyFields).length > 0;
+      onChange(
+        {
+          ...rest,
+          numberFormat: numberFormatExplicit
+            ? formValues.numberFormat
+            : undefined,
+          colorRules: colorRules ? stripLocalIds(colorRules) : undefined,
+        },
+        hasDirtyFields,
+      );
     })();
     onClose();
   }, [onChange, handleSubmit, onClose, settings.numberFormat, dirtyFields]);

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -227,6 +227,7 @@ export default function ChartDisplaySettingsDrawer({
               name="compareToPreviousPeriod"
               size="xs"
               label="Compare to Previous Period"
+              data-testid="compare-to-previous-period-checkbox"
               description={
                 previousDateRange && (
                   <>
@@ -349,7 +350,12 @@ export default function ChartDisplaySettingsDrawer({
           <Button type="submit" variant="secondary" onClick={resetToDefaults}>
             Reset to Defaults
           </Button>
-          <Button type="submit" variant="primary" onClick={applyChanges}>
+          <Button
+            type="submit"
+            variant="primary"
+            onClick={applyChanges}
+            data-testid="display-settings-apply-button"
+          >
             Apply
           </Button>
         </Group>

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -231,7 +231,6 @@ export default function ChartDisplaySettingsDrawer({
               name="compareToPreviousPeriod"
               size="xs"
               label="Compare to Previous Period"
-              data-testid="compare-to-previous-period-checkbox"
               description={
                 previousDateRange && (
                   <>

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -315,6 +315,7 @@ export function ChartEditorControls({
                 onClick={openDisplaySettings}
                 size="compact-sm"
                 variant="secondary"
+                data-testid="display-settings-button"
               >
                 Display Settings
               </Button>

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Controller,
+  type Path,
   useFieldArray,
   useForm,
   type UseFormSetValue,
@@ -587,6 +588,20 @@ export default function EditTimeChartForm({
   // Need to force a rerender on change as the modal will not be mounted when initially rendered
   const [parentRef, setParentRef] = useState<HTMLElement | null>(null);
 
+  // Helper: only pass shouldDirty when the incoming value actually differs
+  // from what the form already holds. The display-settings drawer emits
+  // normalised defaults (false, null, 0) on every Apply, but the form's
+  // defaultValues may store those fields as undefined. A blanket
+  // `shouldDirty: true` would deep-differ against undefined and fire the
+  // unsaved-changes modal on a no-op Apply.
+  const didChange = useCallback(
+    (name: Path<ChartEditorFormState>, next: unknown) => {
+      const current = getValues(name);
+      return JSON.stringify(current ?? null) !== JSON.stringify(next ?? null);
+    },
+    [getValues],
+  );
+
   const handleUpdateDisplaySettings = useCallback(
     ({
       numberFormat,
@@ -604,44 +619,68 @@ export default function EditTimeChartForm({
       // (the user never chose a format), leave it unset so render-time
       // auto-detection keeps driving the format from the datasource.
       if (numberFormat !== undefined) {
-        setValue('numberFormat', numberFormat, { shouldDirty: true });
+        setValue('numberFormat', numberFormat, {
+          shouldDirty: didChange('numberFormat', numberFormat),
+        });
       }
       setValue('alignDateRangeToGranularity', alignDateRangeToGranularity, {
-        shouldDirty: true,
+        shouldDirty: didChange(
+          'alignDateRangeToGranularity',
+          alignDateRangeToGranularity,
+        ),
       });
-      setValue('fillNulls', fillNulls, { shouldDirty: true });
+      setValue('fillNulls', fillNulls, {
+        shouldDirty: didChange('fillNulls', fillNulls),
+      });
       setValue('compareToPreviousPeriod', compareToPreviousPeriod, {
-        shouldDirty: true,
+        shouldDirty: didChange(
+          'compareToPreviousPeriod',
+          compareToPreviousPeriod,
+        ),
       });
-      setValue('fitYAxisToData', fitYAxisToData, { shouldDirty: true });
+      setValue('fitYAxisToData', fitYAxisToData, {
+        shouldDirty: didChange('fitYAxisToData', fitYAxisToData),
+      });
       setValue('groupByColumnsOnLeft', groupByColumnsOnLeft, {
-        shouldDirty: true,
+        shouldDirty: didChange('groupByColumnsOnLeft', groupByColumnsOnLeft),
       });
       // Persist `null` (not undefined) when cleared so the disabled state
       // survives JSON round-tripping through the URL query state; otherwise
       // the dropped key lets RHF's `values` sync restore the stale value.
-      setValue('seriesLimit', seriesLimit ?? null, { shouldDirty: true });
-      setValue('color', color, { shouldDirty: true });
-      setValue('colorRules', colorRules, { shouldDirty: true });
-      setValue('backgroundChart', backgroundChart, { shouldDirty: true });
+      const normalizedSeriesLimit = seriesLimit ?? null;
+      setValue('seriesLimit', normalizedSeriesLimit, {
+        shouldDirty: didChange('seriesLimit', normalizedSeriesLimit),
+      });
+      setValue('color', color, {
+        shouldDirty: didChange('color', color),
+      });
+      setValue('colorRules', colorRules, {
+        shouldDirty: didChange('colorRules', colorRules),
+      });
+      setValue('backgroundChart', backgroundChart, {
+        shouldDirty: didChange('backgroundChart', backgroundChart),
+      });
       onSubmit();
     },
-    [setValue, onSubmit],
+    [setValue, didChange, onSubmit],
   );
 
   const handleUpdateHeatmapSettings = useCallback(
     (data: HeatmapSettingsValues) => {
-      setValue('series.0.valueExpression', data.value, { shouldDirty: true });
-      setValue('series.0.countExpression', data.count || 'count()', {
-        shouldDirty: true,
+      const countExpr = data.count || 'count()';
+      setValue('series.0.valueExpression', data.value, {
+        shouldDirty: didChange('series.0.valueExpression', data.value),
+      });
+      setValue('series.0.countExpression', countExpr, {
+        shouldDirty: didChange('series.0.countExpression', countExpr),
       });
       setValue('series.0.heatmapScaleType', data.scaleType, {
-        shouldDirty: true,
+        shouldDirty: didChange('series.0.heatmapScaleType', data.scaleType),
       });
       onSubmit();
       closeHeatmapSettings();
     },
-    [setValue, onSubmit, closeHeatmapSettings],
+    [setValue, didChange, onSubmit, closeHeatmapSettings],
   );
 
   const heatmapValueExpression = useWatch({

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -604,20 +604,26 @@ export default function EditTimeChartForm({
       // (the user never chose a format), leave it unset so render-time
       // auto-detection keeps driving the format from the datasource.
       if (numberFormat !== undefined) {
-        setValue('numberFormat', numberFormat);
+        setValue('numberFormat', numberFormat, { shouldDirty: true });
       }
-      setValue('alignDateRangeToGranularity', alignDateRangeToGranularity);
-      setValue('fillNulls', fillNulls);
-      setValue('compareToPreviousPeriod', compareToPreviousPeriod);
-      setValue('fitYAxisToData', fitYAxisToData);
-      setValue('groupByColumnsOnLeft', groupByColumnsOnLeft);
+      setValue('alignDateRangeToGranularity', alignDateRangeToGranularity, {
+        shouldDirty: true,
+      });
+      setValue('fillNulls', fillNulls, { shouldDirty: true });
+      setValue('compareToPreviousPeriod', compareToPreviousPeriod, {
+        shouldDirty: true,
+      });
+      setValue('fitYAxisToData', fitYAxisToData, { shouldDirty: true });
+      setValue('groupByColumnsOnLeft', groupByColumnsOnLeft, {
+        shouldDirty: true,
+      });
       // Persist `null` (not undefined) when cleared so the disabled state
       // survives JSON round-tripping through the URL query state; otherwise
       // the dropped key lets RHF's `values` sync restore the stale value.
-      setValue('seriesLimit', seriesLimit ?? null);
-      setValue('color', color);
-      setValue('colorRules', colorRules);
-      setValue('backgroundChart', backgroundChart);
+      setValue('seriesLimit', seriesLimit ?? null, { shouldDirty: true });
+      setValue('color', color, { shouldDirty: true });
+      setValue('colorRules', colorRules, { shouldDirty: true });
+      setValue('backgroundChart', backgroundChart, { shouldDirty: true });
       onSubmit();
     },
     [setValue, onSubmit],
@@ -625,9 +631,13 @@ export default function EditTimeChartForm({
 
   const handleUpdateHeatmapSettings = useCallback(
     (data: HeatmapSettingsValues) => {
-      setValue('series.0.valueExpression', data.value);
-      setValue('series.0.countExpression', data.count || 'count()');
-      setValue('series.0.heatmapScaleType', data.scaleType);
+      setValue('series.0.valueExpression', data.value, { shouldDirty: true });
+      setValue('series.0.countExpression', data.count || 'count()', {
+        shouldDirty: true,
+      });
+      setValue('series.0.heatmapScaleType', data.scaleType, {
+        shouldDirty: true,
+      });
       onSubmit();
       closeHeatmapSettings();
     },

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Controller,
-  type Path,
   useFieldArray,
   useForm,
   type UseFormSetValue,
@@ -193,8 +192,15 @@ export default function EditTimeChartForm({
     [insertSeries, getValues],
   );
 
+  // Track whether sub-form changes (display settings, heatmap settings) have
+  // been applied. These bypass RHF's dirty tracking, so we latch here: once
+  // set, only a parent reset (new tile opened) clears it via onDirtyChange.
+  const subFormDirty = useRef(false);
+
   useEffect(() => {
-    onDirtyChange?.(isDirty);
+    // Don't let RHF's isDirty=false clear the flag after sub-form changes
+    // were applied (RHF resets isDirty when its `values` prop re-syncs).
+    onDirtyChange?.(isDirty || subFormDirty.current);
   }, [isDirty, onDirtyChange]);
 
   const select = useWatch({ control, name: 'select' });
@@ -588,99 +594,63 @@ export default function EditTimeChartForm({
   // Need to force a rerender on change as the modal will not be mounted when initially rendered
   const [parentRef, setParentRef] = useState<HTMLElement | null>(null);
 
-  // Helper: only pass shouldDirty when the incoming value actually differs
-  // from what the form already holds. The display-settings drawer emits
-  // normalised defaults (false, null, 0) on every Apply, but the form's
-  // defaultValues may store those fields as undefined. A blanket
-  // `shouldDirty: true` would deep-differ against undefined and fire the
-  // unsaved-changes modal on a no-op Apply.
-  const didChange = useCallback(
-    (name: Path<ChartEditorFormState>, next: unknown) => {
-      const current = getValues(name);
-      return JSON.stringify(current ?? null) !== JSON.stringify(next ?? null);
-    },
-    [getValues],
-  );
-
   const handleUpdateDisplaySettings = useCallback(
-    ({
-      numberFormat,
-      alignDateRangeToGranularity,
-      fillNulls,
-      compareToPreviousPeriod,
-      fitYAxisToData,
-      groupByColumnsOnLeft,
-      seriesLimit,
-      color,
-      colorRules,
-      backgroundChart,
-    }: ChartConfigDisplaySettings) => {
+    (
+      {
+        numberFormat,
+        alignDateRangeToGranularity,
+        fillNulls,
+        compareToPreviousPeriod,
+        fitYAxisToData,
+        groupByColumnsOnLeft,
+        seriesLimit,
+        color,
+        colorRules,
+        backgroundChart,
+      }: ChartConfigDisplaySettings,
+      isDirty: boolean,
+    ) => {
       // Only persist an explicit numberFormat. When the drawer emits undefined
       // (the user never chose a format), leave it unset so render-time
       // auto-detection keeps driving the format from the datasource.
       if (numberFormat !== undefined) {
-        setValue('numberFormat', numberFormat, {
-          shouldDirty: didChange('numberFormat', numberFormat),
-        });
+        setValue('numberFormat', numberFormat);
       }
-      setValue('alignDateRangeToGranularity', alignDateRangeToGranularity, {
-        shouldDirty: didChange(
-          'alignDateRangeToGranularity',
-          alignDateRangeToGranularity,
-        ),
-      });
-      setValue('fillNulls', fillNulls, {
-        shouldDirty: didChange('fillNulls', fillNulls),
-      });
-      setValue('compareToPreviousPeriod', compareToPreviousPeriod, {
-        shouldDirty: didChange(
-          'compareToPreviousPeriod',
-          compareToPreviousPeriod,
-        ),
-      });
-      setValue('fitYAxisToData', fitYAxisToData, {
-        shouldDirty: didChange('fitYAxisToData', fitYAxisToData),
-      });
-      setValue('groupByColumnsOnLeft', groupByColumnsOnLeft, {
-        shouldDirty: didChange('groupByColumnsOnLeft', groupByColumnsOnLeft),
-      });
+      setValue('alignDateRangeToGranularity', alignDateRangeToGranularity);
+      setValue('fillNulls', fillNulls);
+      setValue('compareToPreviousPeriod', compareToPreviousPeriod);
+      setValue('fitYAxisToData', fitYAxisToData);
+      setValue('groupByColumnsOnLeft', groupByColumnsOnLeft);
       // Persist `null` (not undefined) when cleared so the disabled state
       // survives JSON round-tripping through the URL query state; otherwise
       // the dropped key lets RHF's `values` sync restore the stale value.
-      const normalizedSeriesLimit = seriesLimit ?? null;
-      setValue('seriesLimit', normalizedSeriesLimit, {
-        shouldDirty: didChange('seriesLimit', normalizedSeriesLimit),
-      });
-      setValue('color', color, {
-        shouldDirty: didChange('color', color),
-      });
-      setValue('colorRules', colorRules, {
-        shouldDirty: didChange('colorRules', colorRules),
-      });
-      setValue('backgroundChart', backgroundChart, {
-        shouldDirty: didChange('backgroundChart', backgroundChart),
-      });
+      setValue('seriesLimit', seriesLimit ?? null);
+      setValue('color', color);
+      setValue('colorRules', colorRules);
+      setValue('backgroundChart', backgroundChart);
+      // Display settings live in a separate drawer form, so RHF can't track
+      // them. Latch dirty state only when the drawer reports actual changes.
+      if (isDirty) {
+        subFormDirty.current = true;
+        onDirtyChange?.(true);
+      }
       onSubmit();
     },
-    [setValue, didChange, onSubmit],
+    [setValue, onDirtyChange, onSubmit],
   );
 
   const handleUpdateHeatmapSettings = useCallback(
     (data: HeatmapSettingsValues) => {
-      const countExpr = data.count || 'count()';
-      setValue('series.0.valueExpression', data.value, {
-        shouldDirty: didChange('series.0.valueExpression', data.value),
-      });
-      setValue('series.0.countExpression', countExpr, {
-        shouldDirty: didChange('series.0.countExpression', countExpr),
-      });
-      setValue('series.0.heatmapScaleType', data.scaleType, {
-        shouldDirty: didChange('series.0.heatmapScaleType', data.scaleType),
-      });
+      setValue('series.0.valueExpression', data.value);
+      setValue('series.0.countExpression', data.count || 'count()');
+      setValue('series.0.heatmapScaleType', data.scaleType);
+      // Heatmap settings are applied outside RHF's change tracking.
+      subFormDirty.current = true;
+      onDirtyChange?.(true);
       onSubmit();
       closeHeatmapSettings();
     },
-    [setValue, didChange, onSubmit, closeHeatmapSettings],
+    [setValue, onDirtyChange, onSubmit, closeHeatmapSettings],
   );
 
   const heatmapValueExpression = useWatch({

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -292,6 +292,30 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
     });
   });
 
+  test('should warn when closing tile editor with unsaved display settings changes', async () => {
+    await dashboardPage.openNewTileEditor();
+
+    // Open the Display Settings drawer and toggle a setting
+    await dashboardPage.page.getByTestId('display-settings-button').click();
+    await dashboardPage.page
+      .getByTestId('compare-to-previous-period-checkbox')
+      .check();
+    await dashboardPage.page
+      .getByTestId('display-settings-apply-button')
+      .click();
+
+    // Try to close — should show unsaved changes confirm
+    await dashboardPage.page.keyboard.press('Escape');
+    await expect(dashboardPage.unsavedChangesConfirmModal).toBeAttached({
+      timeout: 5000,
+    });
+
+    await dashboardPage.unsavedChangesConfirmDiscardButton.click();
+    await expect(dashboardPage.chartEditor.nameInput).toBeHidden({
+      timeout: 5000,
+    });
+  });
+
   test('should add and remove alert on Number type chart', async () => {
     test.setTimeout(60000);
     const ts = Date.now();

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -295,32 +295,25 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
   test('should warn when closing tile editor with unsaved display settings changes', async () => {
     await dashboardPage.openNewTileEditor();
 
-    // Open the Display Settings drawer and toggle a setting
+    // Open the Display Settings drawer
     await dashboardPage.page.getByTestId('display-settings-button').click();
-    // Mantine's Checkbox puts data-testid on the wrapper <div>, not the
-    // <input>, so use click() instead of check().
+    const applyButton = dashboardPage.page.getByTestId(
+      'display-settings-apply-button',
+    );
+    await expect(applyButton).toBeVisible({ timeout: 5000 });
+
+    // Toggle a checkbox via its label
     await dashboardPage.page
-      .getByTestId('compare-to-previous-period-checkbox')
-      .click();
-    await dashboardPage.page
-      .getByTestId('display-settings-apply-button')
+      .locator('label', { hasText: 'Compare to Previous Period' })
       .click();
 
-    // Wait for the display-settings drawer to fully close before pressing
-    // Escape, otherwise the key event closes the drawer overlay instead of
-    // triggering the tile editor's onClose handler.
-    await expect(
-      dashboardPage.page.getByTestId('display-settings-apply-button'),
-    ).toBeHidden({ timeout: 5000 });
+    // Apply and wait for the drawer to close
+    await applyButton.click();
+    await expect(applyButton).toBeHidden({ timeout: 5000 });
 
     // Try to close — should show unsaved changes confirm
     await dashboardPage.page.keyboard.press('Escape');
-    await expect(dashboardPage.unsavedChangesConfirmModal).toBeVisible({
-      timeout: 5000,
-    });
-
-    await dashboardPage.unsavedChangesConfirmDiscardButton.click();
-    await expect(dashboardPage.chartEditor.nameInput).toBeHidden({
+    await expect(dashboardPage.unsavedChangesConfirmModal).toBeAttached({
       timeout: 5000,
     });
   });

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -297,9 +297,11 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
 
     // Open the Display Settings drawer and toggle a setting
     await dashboardPage.page.getByTestId('display-settings-button').click();
+    // Mantine's Checkbox puts data-testid on the wrapper <div>, not the
+    // <input>, so use click() instead of check().
     await dashboardPage.page
       .getByTestId('compare-to-previous-period-checkbox')
-      .check();
+      .click();
     await dashboardPage.page
       .getByTestId('display-settings-apply-button')
       .click();

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -304,9 +304,16 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       .getByTestId('display-settings-apply-button')
       .click();
 
+    // Wait for the display-settings drawer to fully close before pressing
+    // Escape, otherwise the key event closes the drawer overlay instead of
+    // triggering the tile editor's onClose handler.
+    await expect(
+      dashboardPage.page.getByTestId('display-settings-apply-button'),
+    ).toBeHidden({ timeout: 5000 });
+
     // Try to close — should show unsaved changes confirm
     await dashboardPage.page.keyboard.press('Escape');
-    await expect(dashboardPage.unsavedChangesConfirmModal).toBeAttached({
+    await expect(dashboardPage.unsavedChangesConfirmModal).toBeVisible({
       timeout: 5000,
     });
 


### PR DESCRIPTION
## Summary

Editing display settings or heatmap settings in the tile editor and then closing without saving no longer silently discards changes — the "unsaved changes" confirmation modal now fires as expected.

**Root cause:** Both `handleUpdateDisplaySettings` and `handleUpdateHeatmapSettings` live in sub-forms (the display settings drawer / heatmap settings drawer) with their own independent React Hook Form instances. The main tile editor's RHF `isDirty` flag never sees these changes, so `EditTileModal.handleClose` never triggered the confirmation.

**Approach:** Rather than fighting RHF's `shouldDirty` (which has normalization mismatches between `undefined` defaults and the drawer's concrete defaults like `false`/`0`/`true`), dirty state is signaled directly:

- The display settings drawer now passes its own `isDirty` flag through `onChange`, so `handleUpdateDisplaySettings` only latches dirty state when the user actually changed a setting. A no-op Apply does not trigger the modal.
- A `subFormDirty` ref in `EditTimeChartForm` prevents RHF's `isDirty=false` resets (from `values` prop re-syncs after `onSubmit`) from clearing the flag.

**Heatmap settings** always mark dirty on Apply (no `isDirty` gating). Unlike display settings, the heatmap drawer doesn't have a no-op Apply concern — it only opens for heatmap charts where the user is actively configuring value/count expressions and scale type, and any Apply is intentional.
