### PR TITLE
fix(theme): use Mantine's --button-hover-color for primary buttons

### DIFF
--- a/.changeset/fix-primary-button-hover-color.md
+++ b/.changeset/fix-primary-button-hover-color.md
@@ -1,0 +1,8 @@
+---
+'@hyperdx/app': patch
+---
+
+Fix primary button hover text color by using Mantine's `--button-hover-color`
+variable (the theme previously set the non-existent `--button-color-hover`, so
+the hover text color was never applied and could fall through to an inherited
+page color).

--- a/packages/app/src/theme/themes/clickstack/mantineTheme.ts
+++ b/packages/app/src/theme/themes/clickstack/mantineTheme.ts
@@ -251,7 +251,8 @@ const makeTheme = ({
           baseVars['--button-bg'] = 'var(--color-primary-button-bg)';
           baseVars['--button-hover'] = 'var(--color-primary-button-bg-hover)';
           baseVars['--button-color'] = 'var(--color-primary-button-text)';
-          baseVars['--button-color-hover'] = 'var(--color-primary-button-text)';
+          baseVars['--button-hover-color'] =
+            'var(--color-primary-button-text)';
         }
 
         if (props.variant === 'secondary') {

--- a/packages/app/src/theme/themes/clickstack/mantineTheme.ts
+++ b/packages/app/src/theme/themes/clickstack/mantineTheme.ts
@@ -251,8 +251,7 @@ const makeTheme = ({
           baseVars['--button-bg'] = 'var(--color-primary-button-bg)';
           baseVars['--button-hover'] = 'var(--color-primary-button-bg-hover)';
           baseVars['--button-color'] = 'var(--color-primary-button-text)';
-          baseVars['--button-hover-color'] =
-            'var(--color-primary-button-text)';
+          baseVars['--button-hover-color'] = 'var(--color-primary-button-text)';
         }
 
         if (props.variant === 'secondary') {

--- a/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
+++ b/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
@@ -264,8 +264,7 @@ const makeTheme = ({
           baseVars['--button-bg'] = 'var(--color-primary-button-bg)';
           baseVars['--button-hover'] = 'var(--color-primary-button-bg-hover)';
           baseVars['--button-color'] = 'var(--color-primary-button-text)';
-          baseVars['--button-hover-color'] =
-            'var(--color-primary-button-text)';
+          baseVars['--button-hover-color'] = 'var(--color-primary-button-text)';
         }
 
         if (props.variant === 'secondary') {

--- a/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
+++ b/packages/app/src/theme/themes/hyperdx/mantineTheme.ts
@@ -264,7 +264,8 @@ const makeTheme = ({
           baseVars['--button-bg'] = 'var(--color-primary-button-bg)';
           baseVars['--button-hover'] = 'var(--color-primary-button-bg-hover)';
           baseVars['--button-color'] = 'var(--color-primary-button-text)';
-          baseVars['--button-color-hover'] = 'var(--color-primary-button-text)';
+          baseVars['--button-hover-color'] =
+            'var(--color-primary-button-text)';
         }
 
         if (props.variant === 'secondary') {

--- a/packages/app/styles/variants.module.scss
+++ b/packages/app/styles/variants.module.scss
@@ -1,6 +1,6 @@
 // Hover: brighten text to full contrast.
 // Both Button and ActionIcon use SCSS for hover color because
-// Mantine only provides --button-color-hover (no ActionIcon equivalent).
+// Mantine only provides --button-hover-color (no ActionIcon equivalent).
 // Using SCSS for both keeps the approach consistent.
 .buttonLink:hover:not(:disabled, [data-disabled]) {
   --button-color: var(--color-text);


### PR DESCRIPTION
## Summary

The `primary` Button variant sets a CSS variable named `--button-color-hover`, but Mantine's Button component reads `--button-hover-color`. See `@mantine/core` `Button.css`:

```css
.mantine-Button-root:hover {
  color: var(--button-hover-color, var(--button-color));
}
```

Because the variable name doesn't match, the intended hover text color is never applied and the hover `color` silently relies on the `var(--button-color)` fallback. This is a latent bug: if anything overrides the base color on hover (e.g. a global `a:hover` reset for buttons rendered as links via `component={Link}`), the button text can fall through to an inherited page color instead of the button's own text color.

This PR corrects the variable name in both the `clickstack` and `hyperdx` themes so the hover text color is set explicitly, and fixes a stale variable-name reference in a comment.

## Changes

- `packages/app/src/theme/themes/clickstack/mantineTheme.ts` — `--button-color-hover` → `--button-hover-color`
- `packages/app/src/theme/themes/hyperdx/mantineTheme.ts` — same
- `packages/app/styles/variants.module.scss` — fix stale variable-name reference in a comment

## Test plan

- [ ] Hover primary buttons in both `clickstack` and `hyperdx` themes (light and dark) and confirm the text color stays the intended inverted color.
- [ ] Verify no visual regression on primary buttons generally.

Made with [Cursor](https://cursor.com)