### PR TITLE
feat(service-map): metric color toggle and popover polish

### DIFF
--- a/.changeset/service-map-metric-toggle.md
+++ b/.changeset/service-map-metric-toggle.md
@@ -1,0 +1,11 @@
+---
+"@hyperdx/app": patch
+---
+
+Service map: add a dotted canvas background and a metric-mode toggle (Latency /
+Error rate / Throughput) that recolors the graph by the selected dimension, with
+a legend explaining the color scale and that node size encodes throughput. The
+canvas and its controls now follow the app's light/dark color scheme instead of
+being locked to dark. Node colors use a sequential light-to-dark ramp per
+metric, and the node popover is now a raised surface with a service-name header,
+grouped sections, and severity-aware error coloring.

--- a/.changeset/service-map-metric-toggle.md
+++ b/.changeset/service-map-metric-toggle.md
@@ -2,10 +2,10 @@
 "@hyperdx/app": patch
 ---
 
-Service map: add a dotted canvas background and a metric-mode toggle (Latency /
-Error rate / Throughput) that recolors the graph by the selected dimension, with
-a legend explaining the color scale and that node size encodes throughput. The
-canvas and its controls now follow the app's light/dark color scheme instead of
-being locked to dark. Node colors use a sequential light-to-dark ramp per
-metric, and the node popover is now a raised surface with a service-name header,
-grouped sections, and severity-aware error coloring.
+Service map: add a metric-mode toggle (Latency / Error rate / Throughput) that
+recolors the graph by the selected dimension, with a legend explaining the color
+scale and that node size encodes throughput. The canvas and its controls now
+follow the app's light/dark color scheme instead of being locked to dark. Node
+colors use a sequential light-to-dark ramp per metric, and the node popover is
+now a raised surface with a service-name header, grouped sections, and
+severity-aware error coloring.

--- a/packages/app/src/components/ServiceMap/ServiceMap.module.scss
+++ b/packages/app/src/components/ServiceMap/ServiceMap.module.scss
@@ -7,9 +7,33 @@
 
 .toolbar {
   padding: 4px;
-  border-radius: 4px;
-  background-color: var(--color-bg-header);
+  border-radius: 8px;
+
+  // Raised surface: intentionally lighter than the canvas body so the popover reads as floating above the graph.
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-emphasis);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 6px;
+  background-color: var(--color-bg-surface);
   border: 1px solid var(--color-border);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
+}
+
+.legendGradient {
+  width: 132px;
+  height: 10px;
+  border-radius: 5px;
+
+  // Subtle inset hairline instead of a hard 1px border, which looked heavy
+  // around the thin bar (especially at the near-white low end in light mode).
+  box-shadow: inset 0 0 0 1px var(--color-border-muted);
 }
 
 .serviceNode {

--- a/packages/app/src/components/ServiceMap/ServiceMap.module.scss
+++ b/packages/app/src/components/ServiceMap/ServiceMap.module.scss
@@ -27,7 +27,7 @@
 }
 
 .legendGradient {
-  width: 132px;
+  width: 100%;
   height: 10px;
   border-radius: 5px;
 

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -2,17 +2,27 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import dagre from '@dagrejs/dagre';
 import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
 import { TTraceSource } from '@hyperdx/common-utils/dist/types';
-import { Box, Center, Code, Loader, Text } from '@mantine/core';
+import {
+  Box,
+  Center,
+  Code,
+  Loader,
+  SegmentedControl,
+  Text,
+} from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
   applyEdgeChanges,
   applyNodeChanges,
+  Background,
+  BackgroundVariant,
   Controls,
   Edge,
   EdgeChange,
   EdgeTypes,
   Node,
   NodeChange,
+  Panel,
   Position,
   ReactFlow,
   ReactFlowProvider,
@@ -21,9 +31,21 @@ import {
 
 import { SQLPreview } from '@/components/ChartSQLPreview';
 import useServiceMap, { ServiceAggregation } from '@/hooks/useServiceMap';
+import { useResolvedColorScheme } from '@/useUserPreferences';
 
 import ServiceMapEdge, { ServiceMapEdgeData } from './ServiceMapEdge';
+import ServiceMapLegend from './ServiceMapLegend';
+import {
+  ServiceMapMetricContext,
+  ServiceMapMetricMax,
+} from './ServiceMapMetricContext';
 import ServiceMapNode, { ServiceMapNodeData } from './ServiceMapNode';
+import {
+  getServiceMetricValue,
+  SERVICE_MAP_METRIC_LABEL,
+  SERVICE_MAP_METRICS,
+  ServiceMapMetric,
+} from './utils';
 
 import styles from './ServiceMap.module.scss';
 
@@ -91,6 +113,8 @@ function ServiceMapPresentation({
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const { fitView } = useReactFlow();
+  const colorScheme = useResolvedColorScheme();
+  const [metric, setMetric] = useState<ServiceMapMetric>('errorRate');
 
   // Fit the data to the viewport whenever input service information changes
   useEffect(() => {
@@ -109,17 +133,26 @@ function ServiceMapPresentation({
     [],
   );
 
-  const { maxErrorPercentage, maxThroughput } = useMemo(() => {
-    let maxError = 0;
-    let maxTput = 0;
+  // Graph-wide max for each metric, used to normalize per-node color intensity
+  // (and to size nodes by throughput). Recomputed only when the data changes,
+  // never when the user switches the coloring metric.
+  const metricMax = useMemo<ServiceMapMetricMax>(() => {
+    const max: ServiceMapMetricMax = {
+      errorRate: 0,
+      latency: 0,
+      throughput: 0,
+    };
     for (const service of services?.values() ?? []) {
-      maxError = Math.max(service.incomingRequests.errorPercentage, maxError);
-      const throughput =
-        service.incomingRequests.totalRequests + service.outgoingRequests;
-      maxTput = Math.max(throughput, maxTput);
+      for (const m of SERVICE_MAP_METRICS) {
+        max[m] = Math.max(max[m], getServiceMetricValue(service, m));
+      }
     }
-    return { maxErrorPercentage: maxError, maxThroughput: maxTput };
+    return max;
   }, [services]);
+
+  // Latency coloring is only meaningful when the source exposes duration data;
+  // otherwise every node reports 0 and the option is disabled.
+  const hasLatencyData = metricMax.latency > 0;
 
   useEffect(() => {
     const nodes: Node<ServiceMapNodeData>[] =
@@ -129,8 +162,7 @@ function ServiceMapPresentation({
           ...service,
           dateRange,
           source,
-          maxErrorPercentage,
-          maxThroughput,
+          maxThroughput: metricMax.throughput,
           isSingleTrace,
           onFocusService,
         },
@@ -179,8 +211,7 @@ function ServiceMapPresentation({
     services,
     dateRange,
     source,
-    maxErrorPercentage,
-    maxThroughput,
+    metricMax.throughput,
     isSingleTrace,
     onFocusService,
   ]);
@@ -239,21 +270,52 @@ function ServiceMapPresentation({
 
   return (
     <div className={styles.container}>
-      <ReactFlow
-        style={{ backgroundColor: 'inherit' }}
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        fitView
-        colorMode="dark"
-        // TODO: Financially support react-flow if possible
-        proOptions={{ hideAttribution: true }}
-      >
-        <Controls showInteractive={false} />
-      </ReactFlow>
+      <ServiceMapMetricContext.Provider value={{ metric, metricMax }}>
+        <ReactFlow
+          style={{ backgroundColor: 'inherit' }}
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          colorMode={colorScheme}
+          // TODO: Financially support react-flow if possible
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={20}
+            size={1.5}
+            color="var(--color-border-emphasis)"
+          />
+          <Panel position="top-right">
+            <div className={styles.panel}>
+              <SegmentedControl
+                size="xs"
+                value={metric}
+                onChange={value => setMetric(value as ServiceMapMetric)}
+                data={SERVICE_MAP_METRICS.map(m => ({
+                  value: m,
+                  label: SERVICE_MAP_METRIC_LABEL[m],
+                  disabled: m === 'latency' && !hasLatencyData,
+                }))}
+                data-testid="service-map-metric-toggle"
+              />
+              <ServiceMapLegend
+                metric={metric}
+                metricMax={metricMax}
+                source={source}
+                dateRange={dateRange}
+                isSingleTrace={isSingleTrace}
+              />
+            </div>
+          </Panel>
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </ServiceMapMetricContext.Provider>
     </div>
   );
 }

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -98,6 +98,9 @@ interface ServiceMapPresentationProps {
   dateRange: [Date, Date];
   source: TTraceSource;
   isSingleTrace?: boolean;
+  // The single service the map is currently scoped to (via a node's focus
+  // action), or undefined when showing all/multiple services.
+  focusedService?: string;
   onFocusService?: (serviceName: string) => void;
 }
 
@@ -108,6 +111,7 @@ function ServiceMapPresentation({
   dateRange,
   source,
   isSingleTrace,
+  focusedService,
   onFocusService,
 }: ServiceMapPresentationProps) {
   const [nodes, setNodes] = useState<Node[]>([]);
@@ -164,6 +168,7 @@ function ServiceMapPresentation({
           source,
           maxThroughput: metricMax.throughput,
           isSingleTrace,
+          focusedService,
           onFocusService,
         },
         position: { x: index * 150, y: 100 },
@@ -213,6 +218,7 @@ function ServiceMapPresentation({
     source,
     metricMax.throughput,
     isSingleTrace,
+    focusedService,
     onFocusService,
   ]);
 
@@ -369,6 +375,11 @@ export default function ServiceMap({
     }
   }, [error]);
 
+  // A node's focus action scopes the filter to exactly one service, so the map
+  // is "focused" on that service when it is the only one selected.
+  const focusedService =
+    serviceNames?.length === 1 ? serviceNames[0] : undefined;
+
   return (
     <ReactFlowProvider>
       <ServiceMapPresentation
@@ -378,6 +389,7 @@ export default function ServiceMap({
         dateRange={dateRange}
         source={traceTableSource}
         isSingleTrace={isSingleTrace}
+        focusedService={focusedService}
         onFocusService={onFocusService}
       />
     </ReactFlowProvider>

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -14,8 +14,6 @@ import { notifications } from '@mantine/notifications';
 import {
   applyEdgeChanges,
   applyNodeChanges,
-  Background,
-  BackgroundVariant,
   Controls,
   Edge,
   EdgeChange,
@@ -287,7 +285,7 @@ function ServiceMapPresentation({
     <div className={styles.container}>
       <ServiceMapMetricContext.Provider value={{ metric, metricMax }}>
         <ReactFlow
-          style={{ backgroundColor: 'inherit' }}
+          style={{ backgroundColor: 'var(--color-bg-body)' }}
           nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
@@ -300,12 +298,6 @@ function ServiceMapPresentation({
           // TODO: Financially support react-flow if possible
           proOptions={{ hideAttribution: true }}
         >
-          <Background
-            variant={BackgroundVariant.Dots}
-            gap={20}
-            size={1.5}
-            color="var(--color-border-emphasis)"
-          />
           <Panel position="top-right">
             <div className={styles.panel}>
               <SegmentedControl

--- a/packages/app/src/components/ServiceMap/ServiceMap.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMap.tsx
@@ -158,6 +158,15 @@ function ServiceMapPresentation({
   // otherwise every node reports 0 and the option is disabled.
   const hasLatencyData = metricMax.latency > 0;
 
+  // If the active metric loses its data (e.g. time window changes and the new
+  // dataset has no latency), fall back to errorRate so nodes don't all render
+  // at the same zero-intensity color.
+  useEffect(() => {
+    if (metric === 'latency' && !hasLatencyData) {
+      setMetric('errorRate');
+    }
+  }, [metric, hasLatencyData]);
+
   useEffect(() => {
     const nodes: Node<ServiceMapNodeData>[] =
       Array.from(services?.values() ?? []).map((service, index) => ({

--- a/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
@@ -27,14 +27,18 @@ function formatMax(
   dateRange: [Date, Date],
   isSingleTrace?: boolean,
 ): string {
-  if (!(max > 0)) {
+  // Only treat missing/invalid data as "n/a"; a real zero (e.g. a map with no
+  // errors) is meaningful and should render as a formatted 0 for its metric.
+  if (!Number.isFinite(max) || max < 0) {
     return 'n/a';
   }
   switch (metric) {
     case 'errorRate':
-      return `${max.toFixed(max < 10 ? 1 : 0)}%`;
+      return max === 0 ? '0%' : `${max.toFixed(max < 10 ? 1 : 0)}%`;
     case 'latency':
-      return `~${formatDurationMs(rawDurationToMs(max, source.durationPrecision ?? 3))}`;
+      return max === 0
+        ? '0ms'
+        : `~${formatDurationMs(rawDurationToMs(max, source.durationPrecision ?? 3))}`;
     case 'throughput':
       return isSingleTrace
         ? `${max} reqs`
@@ -57,10 +61,17 @@ export default function ServiceMapLegend({
 }) {
   const max = metricMax[metric];
 
+  // Latency is a p95 aggregate; spell that out in the legend (but not the
+  // toggle, which stays compact) so the max value is unambiguous.
+  const label =
+    metric === 'latency'
+      ? `${SERVICE_MAP_METRIC_LABEL[metric]} (p95)`
+      : SERVICE_MAP_METRIC_LABEL[metric];
+
   return (
     <Stack gap={4}>
       <Text size="xxs" c="var(--color-text-muted)">
-        {SERVICE_MAP_METRIC_LABEL[metric]}
+        {label}
       </Text>
       <div
         className={styles.legendGradient}

--- a/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
@@ -36,8 +36,10 @@ function formatMax(
     case 'errorRate':
       return max === 0 ? '0%' : `${max.toFixed(max < 10 ? 1 : 0)}%`;
     case 'latency':
+      // A zero latency max is a "no latency data" sentinel (see
+      // getServiceMetricValue), not a genuine 0ms, so surface it as n/a.
       return max === 0
-        ? '0ms'
+        ? 'n/a'
         : `~${formatDurationMs(rawDurationToMs(max, source.durationPrecision ?? 3))}`;
     case 'throughput':
       return isSingleTrace

--- a/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
@@ -1,0 +1,83 @@
+import { TTraceSource } from '@hyperdx/common-utils/dist/types';
+import { Group, Stack, Text } from '@mantine/core';
+
+import { formatDurationMs } from '@/utils';
+
+import type { ServiceMapMetricMax } from './ServiceMapMetricContext';
+import {
+  formatApproximateNumber,
+  formatRate,
+  getMetricGradientCss,
+  getRequestsPerSecond,
+  rawDurationToMs,
+  SERVICE_MAP_METRIC_LABEL,
+  ServiceMapMetric,
+} from './utils';
+
+import styles from './ServiceMap.module.scss';
+
+/**
+ * Formats the graph-wide max for the active metric into a human label so the
+ * relative (max-normalized) color ramp is interpretable — e.g. the fully
+ * saturated end of the scale corresponds to this value.
+ */
+function formatMax(
+  metric: ServiceMapMetric,
+  max: number,
+  source: TTraceSource,
+  dateRange: [Date, Date],
+  isSingleTrace?: boolean,
+): string {
+  if (!(max > 0)) {
+    return 'n/a';
+  }
+  switch (metric) {
+    case 'errorRate':
+      return `${max.toFixed(max < 10 ? 1 : 0)}%`;
+    case 'latency':
+      return `~${formatDurationMs(rawDurationToMs(max, source.durationPrecision ?? 3))}`;
+    case 'throughput':
+      return isSingleTrace
+        ? `${formatApproximateNumber(max)} reqs`
+        : formatRate(getRequestsPerSecond(max, dateRange));
+  }
+}
+
+export default function ServiceMapLegend({
+  metric,
+  metricMax,
+  source,
+  dateRange,
+  isSingleTrace,
+}: {
+  metric: ServiceMapMetric;
+  metricMax: ServiceMapMetricMax;
+  source: TTraceSource;
+  dateRange: [Date, Date];
+  isSingleTrace?: boolean;
+}) {
+  const max = metricMax[metric];
+
+  return (
+    <Stack gap={4}>
+      <Text size="xxs" c="var(--color-text-muted)">
+        {SERVICE_MAP_METRIC_LABEL[metric]}
+      </Text>
+      <div
+        className={styles.legendGradient}
+        style={{ background: getMetricGradientCss(metric) }}
+      />
+      <Group justify="space-between" gap="xs" wrap="nowrap">
+        <Text size="xxs" c="var(--color-text-muted)">
+          low
+        </Text>
+        <Text size="xxs" c="var(--color-text)">
+          {formatMax(metric, max, source, dateRange, isSingleTrace)}
+        </Text>
+      </Group>
+      <Text size="xxs" c="var(--color-text-muted)">
+        Node size = throughput
+      </Text>
+    </Stack>
+  );
+}

--- a/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapLegend.tsx
@@ -5,7 +5,6 @@ import { formatDurationMs } from '@/utils';
 
 import type { ServiceMapMetricMax } from './ServiceMapMetricContext';
 import {
-  formatApproximateNumber,
   formatRate,
   getMetricGradientCss,
   getRequestsPerSecond,
@@ -38,7 +37,7 @@ function formatMax(
       return `~${formatDurationMs(rawDurationToMs(max, source.durationPrecision ?? 3))}`;
     case 'throughput':
       return isSingleTrace
-        ? `${formatApproximateNumber(max)} reqs`
+        ? `${max} reqs`
         : formatRate(getRequestsPerSecond(max, dateRange));
   }
 }

--- a/packages/app/src/components/ServiceMap/ServiceMapMetricContext.ts
+++ b/packages/app/src/components/ServiceMap/ServiceMapMetricContext.ts
@@ -1,0 +1,20 @@
+import { createContext } from 'react';
+
+import type { ServiceMapMetric } from './utils';
+
+export type ServiceMapMetricMax = Record<ServiceMapMetric, number>;
+
+/**
+ * Provides the currently selected coloring metric and the graph-wide max for
+ * each metric to the custom node components. Passing this via context (rather
+ * than baking it into each node's `data`) lets the user switch metrics and
+ * recolor the graph without rebuilding node objects or re-running the dagre
+ * layout, so manual node positions and zoom are preserved.
+ */
+export const ServiceMapMetricContext = createContext<{
+  metric: ServiceMapMetric;
+  metricMax: ServiceMapMetricMax;
+}>({
+  metric: 'errorRate',
+  metricMax: { errorRate: 0, latency: 0, throughput: 0 },
+});

--- a/packages/app/src/components/ServiceMap/ServiceMapNode.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapNode.tsx
@@ -1,18 +1,24 @@
+import { useContext } from 'react';
 import { TTraceSource } from '@hyperdx/common-utils/dist/types';
 import { Text } from '@mantine/core';
 import { Handle, Node, NodeProps, NodeToolbar, Position } from '@xyflow/react';
 
 import { ServiceAggregation } from '@/hooks/useServiceMap';
 
+import { ServiceMapMetricContext } from './ServiceMapMetricContext';
 import ServiceMapTooltip from './ServiceMapTooltip';
-import { deriveDisplayMetrics, getNodeColors, getNodeSize } from './utils';
+import {
+  deriveDisplayMetrics,
+  getNodeColors,
+  getNodeSize,
+  getServiceMetricValue,
+} from './utils';
 
 import styles from './ServiceMap.module.scss';
 
 export type ServiceMapNodeData = ServiceAggregation & {
   dateRange: [Date, Date];
   source: TTraceSource;
-  maxErrorPercentage: number;
   // Largest total throughput (incoming + outgoing) across all nodes, used to
   // scale node size.
   maxThroughput: number;
@@ -38,16 +44,18 @@ export default function ServiceMapNode(
     outgoingRequests,
     source,
     dateRange,
-    maxErrorPercentage,
     maxThroughput,
     isSingleTrace,
     onFocusService,
   } = data;
 
+  const { metric, metricMax } = useContext(ServiceMapMetricContext);
+
   const { backgroundColor, borderColor } = getNodeColors(
-    errorPercentage,
-    maxErrorPercentage,
+    getServiceMetricValue(data, metric),
+    metricMax[metric],
     props.selected,
+    metric,
   );
 
   // Fallback matches the schema default (3 = ms); in practice the field is

--- a/packages/app/src/components/ServiceMap/ServiceMapNode.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapNode.tsx
@@ -23,6 +23,9 @@ export type ServiceMapNodeData = ServiceAggregation & {
   // scale node size.
   maxThroughput: number;
   isSingleTrace?: boolean;
+  // Name of the service the map is currently focused on (if any), so a node can
+  // tell whether it is the focused one and show the matching CTA.
+  focusedService?: string;
   // When provided, the node's tooltip offers a "Focus" action for this service.
   onFocusService?: (serviceName: string) => void;
 };
@@ -46,6 +49,7 @@ export default function ServiceMapNode(
     dateRange,
     maxThroughput,
     isSingleTrace,
+    focusedService,
     onFocusService,
   } = data;
 
@@ -90,6 +94,7 @@ export default function ServiceMapNode(
           dateRange={dateRange}
           serviceName={serviceName}
           isSingleTrace={isSingleTrace}
+          isFocused={focusedService === serviceName}
           onFocus={
             onFocusService && !isSingleTrace
               ? () => onFocusService(serviceName)

--- a/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
@@ -7,6 +7,7 @@ import {
   IconClock,
   IconSearch,
   IconTarget,
+  IconTargetOff,
 } from '@tabler/icons-react';
 
 import { formatDurationMs } from '@/utils';
@@ -28,6 +29,7 @@ export default function ServiceMapTooltip({
   dateRange,
   serviceName,
   isSingleTrace,
+  isFocused,
   onFocus,
 }: {
   totalRequests: number;
@@ -40,8 +42,11 @@ export default function ServiceMapTooltip({
   dateRange: [Date, Date];
   serviceName: string;
   isSingleTrace?: boolean;
-  // When provided, renders a "Focus" action that filters the map to this
-  // service and its immediate dependencies.
+  // Whether the map is currently scoped to this service (the focus toggle is on)
+  // — flips the focus CTA to a "clear" action.
+  isFocused?: boolean;
+  // When provided, renders an action that scopes the map to this service and its
+  // immediate dependencies (or clears that scope when already focused).
   onFocus?: () => void;
 }) {
   const requestText = `${isSingleTrace ? totalRequests : formatApproximateNumber(totalRequests)} incoming request${
@@ -153,12 +158,13 @@ export default function ServiceMapTooltip({
             onClick={onFocus}
             variant="secondary"
             size="xs"
-            color="gray"
             justify="center"
             fullWidth
-            leftSection={<IconTarget size={14} />}
+            leftSection={
+              isFocused ? <IconTargetOff size={14} /> : <IconTarget size={14} />
+            }
           >
-            Focus
+            {isFocused ? 'Clear focus' : 'Focus on this service'}
           </Button>
         </>
       ) : null}

--- a/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import SqlString from 'sqlstring';
 import { TTraceSource } from '@hyperdx/common-utils/dist/types';
-import { Button, Group, Stack, Text } from '@mantine/core';
+import { Button, Divider, Group, Stack, Text } from '@mantine/core';
 import {
   IconActivity,
   IconClock,
@@ -44,10 +44,16 @@ export default function ServiceMapTooltip({
   // service and its immediate dependencies.
   onFocus?: () => void;
 }) {
-  const requestText = `${isSingleTrace ? totalRequests : formatApproximateNumber(totalRequests)} request${
+  const requestText = `${isSingleTrace ? totalRequests : formatApproximateNumber(totalRequests)} incoming request${
     totalRequests !== 1 ? 's' : ''
   }`;
   const errorsText = `${errorPercentage.toFixed(2)}% errors`;
+  // Only alarm (red) once errors are non-trivial; a fraction of a percent reads
+  // as amber and a clean service stays neutral-danger-free.
+  const errorColor =
+    errorPercentage >= 5
+      ? 'var(--color-text-danger)'
+      : 'var(--color-chart-warning)';
 
   const handleRequestsClick = useCallback(() => {
     navigateToTraceSearch({
@@ -81,7 +87,19 @@ export default function ServiceMapTooltip({
     totalRequests > 0 && (requestsPerSecond != null || latencyMs != null);
 
   return (
-    <Stack className={styles.toolbar} gap={2} align="stretch">
+    <Stack className={styles.toolbar} gap={4} align="stretch" miw={220}>
+      <Text
+        fw={600}
+        size="sm"
+        c="var(--color-text)"
+        px="xs"
+        pt={4}
+        lineClamp={1}
+        title={serviceName}
+      >
+        {serviceName}
+      </Text>
+      <Divider color="var(--color-border)" />
       <Button
         onClick={handleRequestsClick}
         variant="subtle"
@@ -98,7 +116,7 @@ export default function ServiceMapTooltip({
           onClick={handleErrorsClick}
           variant="subtle"
           size="xs"
-          color="var(--color-text-danger)"
+          color={errorColor}
           justify="space-between"
           fullWidth
           rightSection={<IconSearch size={14} />}
@@ -107,7 +125,7 @@ export default function ServiceMapTooltip({
         </Button>
       ) : null}
       {showMetrics ? (
-        <Stack gap={2} px="xs" py={2} c="var(--color-text)">
+        <Stack gap={4} px="xs" py={2} c="var(--color-text)">
           {requestsPerSecond != null ? (
             <Group gap={6} wrap="nowrap">
               <IconActivity size={14} />
@@ -129,17 +147,20 @@ export default function ServiceMapTooltip({
         </Stack>
       ) : null}
       {onFocus ? (
-        <Button
-          onClick={onFocus}
-          variant="subtle"
-          size="xs"
-          color="var(--color-text)"
-          justify="space-between"
-          fullWidth
-          rightSection={<IconTarget size={14} />}
-        >
-          Focus
-        </Button>
+        <>
+          <Divider color="var(--color-border)" />
+          <Button
+            onClick={onFocus}
+            variant="subtle"
+            size="xs"
+            color="var(--color-text)"
+            justify="space-between"
+            fullWidth
+            rightSection={<IconTarget size={14} />}
+          >
+            Focus
+          </Button>
+        </>
       ) : null}
     </Stack>
   );

--- a/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
+++ b/packages/app/src/components/ServiceMap/ServiceMapTooltip.tsx
@@ -151,12 +151,12 @@ export default function ServiceMapTooltip({
           <Divider color="var(--color-border)" />
           <Button
             onClick={onFocus}
-            variant="subtle"
+            variant="secondary"
             size="xs"
-            color="var(--color-text)"
-            justify="space-between"
+            color="gray"
+            justify="center"
             fullWidth
-            rightSection={<IconTarget size={14} />}
+            leftSection={<IconTarget size={14} />}
           >
             Focus
           </Button>

--- a/packages/app/src/components/ServiceMap/__tests__/utils.test.ts
+++ b/packages/app/src/components/ServiceMap/__tests__/utils.test.ts
@@ -5,12 +5,16 @@ import {
   deriveDisplayMetrics,
   formatApproximateNumber,
   formatRate,
+  getMetricGradientCss,
   getNodeColors,
   getNodeSize,
   getRequestsPerSecond,
+  getServiceMetricValue,
   navigateToTraceSearch,
   rawDurationToMs,
+  SERVICE_MAP_METRIC_HUE,
 } from '@/components/ServiceMap/utils';
+import type { ServiceAggregation } from '@/hooks/useServiceMap';
 
 // Mock next/router
 jest.mock('next/router', () => ({
@@ -232,123 +236,171 @@ describe('formatApproximateNumber', () => {
   });
 });
 
+// Parses an `hsl(H S% L%)` string into numeric components for property-based
+// assertions, so tests describe the *shape* of the sequential ramp rather than
+// hardcoding tuned endpoint values.
+function parseHsl(color: string): { h: number; s: number; l: number } {
+  const match = color.match(
+    /^hsl\((\d+(?:\.\d+)?) (\d+(?:\.\d+)?)% (\d+(?:\.\d+)?)%\)$/,
+  );
+  if (!match) {
+    throw new Error(`Not an hsl() color: ${color}`);
+  }
+  return { h: Number(match[1]), s: Number(match[2]), l: Number(match[3]) };
+}
+
 describe('getNodeColors', () => {
-  describe('background color calculation', () => {
-    it('should return light background when error percent is 0', () => {
-      const colors = getNodeColors(0, 20, false);
-      expect(colors.backgroundColor).toBe('hsl(0 0% 80%)');
+  describe('sequential ramp', () => {
+    it('goes from a light tint at zero intensity to a dark shade at max', () => {
+      const low = parseHsl(getNodeColors(0, 20, false).backgroundColor);
+      const high = parseHsl(getNodeColors(20, 20, false).backgroundColor);
+      // Light -> dark: lightness decreases, saturation increases as the metric
+      // value climbs (a proper sequential scale, not a grey->color ramp).
+      expect(high.l).toBeLessThan(low.l);
+      expect(high.s).toBeGreaterThan(low.s);
     });
 
-    it('should calculate background color based on error percentage', () => {
-      const colors = getNodeColors(10, 20, false);
-      // (10 / 20) * 100 = 50% saturation
-      expect(colors.backgroundColor).toBe('hsl(0 50% 80%)');
+    it('increases intensity monotonically with the value', () => {
+      const l0 = parseHsl(getNodeColors(0, 20, false).backgroundColor).l;
+      const l5 = parseHsl(getNodeColors(5, 20, false).backgroundColor).l;
+      const l10 = parseHsl(getNodeColors(10, 20, false).backgroundColor).l;
+      const l20 = parseHsl(getNodeColors(20, 20, false).backgroundColor).l;
+      expect(l0).toBeGreaterThanOrEqual(l5);
+      expect(l5).toBeGreaterThanOrEqual(l10);
+      expect(l10).toBeGreaterThanOrEqual(l20);
     });
 
-    it('should use full saturation when error percent equals max', () => {
-      const colors = getNodeColors(20, 20, false);
-      // (20 / 20) * 100 = 100% saturation
-      expect(colors.backgroundColor).toBe('hsl(0 100% 80%)');
+    it('caps at the max value even when the value is higher', () => {
+      expect(getNodeColors(30, 20, false)).toEqual(
+        getNodeColors(20, 20, false),
+      );
     });
 
-    it('should cap at max error rate even if actual error is higher', () => {
-      const colors = getNodeColors(30, 20, false);
-      // Math.min(20, 30) = 20, (20 / 20) * 100 = 100% saturation
-      expect(colors.backgroundColor).toBe('hsl(0 100% 80%)');
+    it('treats a non-positive max as zero intensity', () => {
+      expect(getNodeColors(5, 0, false)).toEqual(getNodeColors(0, 20, false));
     });
 
-    it('should handle very small error percentages', () => {
-      const colors = getNodeColors(0.1, 20, false);
-      // (0.1 / 20) * 100 = 0.5% saturation
-      expect(colors.backgroundColor).toBe('hsl(0 0.5% 80%)');
-    });
-
-    it('should handle when maxErrorPercent is 0', () => {
-      // This would cause division by zero, but Math results in Infinity
-      const colors = getNodeColors(5, 0, false);
-      expect(colors.backgroundColor).toContain('hsl(0');
-    });
-  });
-
-  describe('border color calculation', () => {
-    it('should return white border when node is selected', () => {
-      const colors = getNodeColors(10, 20, true);
-      expect(colors.borderColor).toBe('white');
-    });
-
-    it('should return calculated border color when not selected', () => {
-      const colors = getNodeColors(10, 20, false);
-      // (10 / 20) * 100 = 50% saturation with 40% lightness
-      expect(colors.borderColor).toBe('hsl(0 50% 40%)');
-    });
-
-    it('should return dark border for high error rates when not selected', () => {
-      const colors = getNodeColors(20, 20, false);
-      expect(colors.borderColor).toBe('hsl(0 100% 40%)');
-    });
-
-    it('should return light border for zero errors when not selected', () => {
-      const colors = getNodeColors(0, 20, false);
-      expect(colors.borderColor).toBe('hsl(0 0% 40%)');
-    });
-
-    it('should cap border color saturation like background', () => {
-      const colors = getNodeColors(30, 20, false);
-      // Should cap at 20% error rate
-      expect(colors.borderColor).toBe('hsl(0 100% 40%)');
+    it('renders the border a fixed step darker than the fill', () => {
+      const { backgroundColor, borderColor } = getNodeColors(10, 20, false);
+      expect(parseHsl(borderColor).l).toBeLessThan(parseHsl(backgroundColor).l);
+      expect(parseHsl(borderColor).h).toBe(parseHsl(backgroundColor).h);
     });
   });
 
   describe('selected state', () => {
-    it('should always use white border when selected regardless of error rate', () => {
+    it('always uses a white border when selected, regardless of value', () => {
       expect(getNodeColors(0, 20, true).borderColor).toBe('white');
-      expect(getNodeColors(5, 20, true).borderColor).toBe('white');
       expect(getNodeColors(10, 20, true).borderColor).toBe('white');
-      expect(getNodeColors(20, 20, true).borderColor).toBe('white');
       expect(getNodeColors(30, 20, true).borderColor).toBe('white');
     });
 
-    it('should still calculate background color correctly when selected', () => {
-      const colors = getNodeColors(10, 20, true);
-      expect(colors.backgroundColor).toBe('hsl(0 50% 80%)');
-      expect(colors.borderColor).toBe('white');
-    });
-  });
-
-  describe('various error percentage scenarios', () => {
-    it('should handle low error rates', () => {
-      const colors = getNodeColors(1, 20, false);
-      expect(colors.backgroundColor).toBe('hsl(0 5% 80%)');
-      expect(colors.borderColor).toBe('hsl(0 5% 40%)');
-    });
-
-    it('should handle medium error rates', () => {
-      const colors = getNodeColors(10, 20, false);
-      expect(colors.backgroundColor).toBe('hsl(0 50% 80%)');
-      expect(colors.borderColor).toBe('hsl(0 50% 40%)');
-    });
-
-    it('should handle high error rates', () => {
-      const colors = getNodeColors(18, 20, false);
-      expect(colors.backgroundColor).toBe('hsl(0 90% 80%)');
-      expect(colors.borderColor).toBe('hsl(0 90% 40%)');
+    it('still computes the fill color when selected', () => {
+      const selected = getNodeColors(10, 20, true);
+      const unselected = getNodeColors(10, 20, false);
+      expect(selected.backgroundColor).toBe(unselected.backgroundColor);
+      expect(selected.borderColor).toBe('white');
     });
   });
 
   describe('return value structure', () => {
-    it('should return an object with backgroundColor and borderColor', () => {
+    it('returns valid hsl() strings for both colors', () => {
       const colors = getNodeColors(10, 20, false);
-      expect(colors).toHaveProperty('backgroundColor');
-      expect(colors).toHaveProperty('borderColor');
-      expect(typeof colors.backgroundColor).toBe('string');
-      expect(typeof colors.borderColor).toBe('string');
+      expect(() => parseHsl(colors.backgroundColor)).not.toThrow();
+      expect(() => parseHsl(colors.borderColor)).not.toThrow();
     });
 
-    it('should return different objects for different inputs', () => {
-      const colors1 = getNodeColors(5, 20, false);
-      const colors2 = getNodeColors(10, 20, false);
-      expect(colors1).not.toEqual(colors2);
+    it('returns different colors for different inputs', () => {
+      expect(getNodeColors(5, 20, false)).not.toEqual(
+        getNodeColors(10, 20, false),
+      );
     });
+  });
+
+  describe('metric hue', () => {
+    it('defaults to the error-rate (red, hue 0) ramp', () => {
+      expect(parseHsl(getNodeColors(10, 20, false).backgroundColor).h).toBe(
+        SERVICE_MAP_METRIC_HUE.errorRate,
+      );
+    });
+
+    it('uses each metric hue for both fill and border', () => {
+      for (const metric of ['errorRate', 'latency', 'throughput'] as const) {
+        const hue = SERVICE_MAP_METRIC_HUE[metric];
+        const colors = getNodeColors(10, 20, false, metric);
+        expect(parseHsl(colors.backgroundColor).h).toBe(hue);
+        expect(parseHsl(colors.borderColor).h).toBe(hue);
+      }
+    });
+  });
+});
+
+describe('getMetricGradientCss', () => {
+  it('builds a left-to-right gradient from the ramp endpoints', () => {
+    const css = getMetricGradientCss('errorRate');
+    const stops = css.match(/hsl\([^)]+\)/g) ?? [];
+    expect(css).toContain('linear-gradient(to right,');
+    expect(stops).toHaveLength(2);
+    // Low stop is lighter than the high stop, matching the node fills.
+    expect(parseHsl(stops[0]).l).toBeGreaterThan(parseHsl(stops[1]).l);
+  });
+
+  it('uses the metric hue for both stops', () => {
+    const stops =
+      getMetricGradientCss('throughput').match(/hsl\([^)]+\)/g) ?? [];
+    expect(parseHsl(stops[0]).h).toBe(SERVICE_MAP_METRIC_HUE.throughput);
+    expect(parseHsl(stops[1]).h).toBe(SERVICE_MAP_METRIC_HUE.throughput);
+  });
+});
+
+describe('getServiceMetricValue', () => {
+  const makeService = (
+    overrides: Partial<ServiceAggregation['incomingRequests']> = {},
+    outgoingRequests = 0,
+  ): ServiceAggregation => ({
+    serviceName: 'svc',
+    incomingRequests: {
+      totalRequests: 100,
+      errorCount: 5,
+      errorPercentage: 5,
+      p50: 10,
+      p95: 40,
+      p99: 90,
+      hasLatency: true,
+      ...overrides,
+    },
+    incomingRequestsByClient: new Map(),
+    outgoingRequests,
+  });
+
+  it('returns the incoming error percentage for errorRate', () => {
+    expect(
+      getServiceMetricValue(
+        makeService({ errorPercentage: 12.5 }),
+        'errorRate',
+      ),
+    ).toBe(12.5);
+  });
+
+  it('returns the p95 latency for latency when available', () => {
+    expect(getServiceMetricValue(makeService({ p95: 42 }), 'latency')).toBe(42);
+  });
+
+  it('returns 0 latency when the source has no duration data', () => {
+    expect(
+      getServiceMetricValue(
+        makeService({ p95: 42, hasLatency: false }),
+        'latency',
+      ),
+    ).toBe(0);
+  });
+
+  it('returns total incoming + outgoing volume for throughput', () => {
+    expect(
+      getServiceMetricValue(
+        makeService({ totalRequests: 100 }, 25),
+        'throughput',
+      ),
+    ).toBe(125);
   });
 });
 

--- a/packages/app/src/components/ServiceMap/__tests__/utils.test.ts
+++ b/packages/app/src/components/ServiceMap/__tests__/utils.test.ts
@@ -239,8 +239,12 @@ describe('formatApproximateNumber', () => {
 // Parses an `hsl(H S% L%)` string into numeric components for property-based
 // assertions, so tests describe the *shape* of the sequential ramp rather than
 // hardcoding tuned endpoint values.
-function parseHsl(color: string): { h: number; s: number; l: number } {
-  const match = color.match(
+function parseHsl(color: string | undefined): {
+  h: number;
+  s: number;
+  l: number;
+} {
+  const match = color?.match(
     /^hsl\((\d+(?:\.\d+)?) (\d+(?:\.\d+)?)% (\d+(?:\.\d+)?)%\)$/,
   );
   if (!match) {

--- a/packages/app/src/components/ServiceMap/utils.ts
+++ b/packages/app/src/components/ServiceMap/utils.ts
@@ -1,6 +1,8 @@
 import router from 'next/router';
 import { TTraceSource } from '@hyperdx/common-utils/dist/types';
 
+import type { ServiceAggregation } from '@/hooks/useServiceMap';
+
 export function navigateToTraceSearch({
   dateRange,
   source,
@@ -43,22 +45,117 @@ export function formatApproximateNumber(num: number): string {
   return `~${Math.round(billions)}B`;
 }
 
+/**
+ * The metric that drives node coloring on the service map. The user switches
+ * between these with the segmented control; each maps to a distinct hue so the
+ * color scale reads as a different dimension (red = errors, amber = latency,
+ * blue = throughput).
+ */
+export type ServiceMapMetric = 'errorRate' | 'latency' | 'throughput';
+
+export const SERVICE_MAP_METRICS: ServiceMapMetric[] = [
+  'latency',
+  'errorRate',
+  'throughput',
+];
+
+export const SERVICE_MAP_METRIC_LABEL: Record<ServiceMapMetric, string> = {
+  errorRate: 'Error rate',
+  latency: 'Latency',
+  throughput: 'Throughput',
+};
+
+// Hue (HSL) used for each metric's color ramp. Saturation encodes intensity.
+export const SERVICE_MAP_METRIC_HUE: Record<ServiceMapMetric, number> = {
+  errorRate: 0, // red
+  latency: 35, // amber
+  throughput: 210, // blue
+};
+
+/**
+ * The comparable scalar used to rank a service for a given metric. This is the
+ * value that gets normalized against the graph-wide max to derive color
+ * intensity, so the same helper drives both the per-node color and the legend's
+ * max label. Latency uses p95 (raw duration units); throughput is total
+ * incoming + outgoing request volume (matching how node size is scaled).
+ */
+export function getServiceMetricValue(
+  service: ServiceAggregation,
+  metric: ServiceMapMetric,
+): number {
+  const { incomingRequests, outgoingRequests } = service;
+  switch (metric) {
+    case 'errorRate':
+      return incomingRequests.errorPercentage;
+    case 'latency':
+      return incomingRequests.hasLatency ? incomingRequests.p95 : 0;
+    case 'throughput':
+      return incomingRequests.totalRequests + outgoingRequests;
+  }
+}
+
+// Sequential color ramp shared by every metric — only the hue differs. As
+// intensity rises the fill goes from a light tint (high lightness, low
+// saturation) to a dark, saturated shade, i.e. a proper light→dark sequential
+// scale rather than a grey→color saturation ramp. Endpoints are tuned to read
+// on both the light and dark canvas.
+const RAMP_SATURATION = { from: 35, to: 72 };
+const RAMP_LIGHTNESS = { from: 90, to: 42 };
+// The border is the same hue/saturation as the fill but a fixed step darker so
+// nodes keep a crisp outline at every intensity (and in light mode).
+const BORDER_LIGHTNESS_STEP = 24;
+const BORDER_MIN_LIGHTNESS = 18;
+
+function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
+}
+
+function clamp01(t: number): number {
+  return Math.max(0, Math.min(1, t));
+}
+
+/**
+ * Background fill for a node/legend stop at a normalized intensity (0..1) on a
+ * metric's ramp. Saturation and lightness are rounded so the emitted HSL string
+ * is stable and free of floating-point noise.
+ */
+function rampFill(hue: number, intensity: number) {
+  const t = clamp01(intensity);
+  const s = Math.round(lerp(RAMP_SATURATION.from, RAMP_SATURATION.to, t));
+  const l = Math.round(lerp(RAMP_LIGHTNESS.from, RAMP_LIGHTNESS.to, t));
+  return { s, l, css: `hsl(${hue} ${s}% ${l}%)` };
+}
+
 export function getNodeColors(
-  errorPercent: number,
-  maxErrorPercent: number,
+  value: number,
+  max: number,
   isSelected: boolean,
+  metric: ServiceMapMetric = 'errorRate',
 ) {
-  const saturation =
-    maxErrorPercent > 0
-      ? (Math.min(errorPercent, maxErrorPercent) / maxErrorPercent) * 100
-      : 0;
-  const backgroundColor = `hsl(0 ${saturation}% 80%)`;
-  const borderColor = isSelected ? 'white' : `hsl(0 ${saturation}% 40%)`;
+  const intensity = max > 0 ? Math.min(value, max) / max : 0;
+  const hue = SERVICE_MAP_METRIC_HUE[metric];
+  const { s, l, css } = rampFill(hue, intensity);
+  const borderLightness = Math.max(
+    l - BORDER_LIGHTNESS_STEP,
+    BORDER_MIN_LIGHTNESS,
+  );
+  const borderColor = isSelected
+    ? 'white'
+    : `hsl(${hue} ${s}% ${borderLightness}%)`;
 
   return {
-    backgroundColor,
+    backgroundColor: css,
     borderColor,
   };
+}
+
+/**
+ * CSS `linear-gradient` for a metric's legend swatch, built from the same ramp
+ * endpoints as the node fills so the legend and the graph always agree.
+ */
+export function getMetricGradientCss(metric: ServiceMapMetric): string {
+  const hue = SERVICE_MAP_METRIC_HUE[metric];
+  return `linear-gradient(to right, ${rampFill(hue, 0).css}, ${rampFill(hue, 1).css})`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Polishes the Service Map page (`@xyflow/react` graph) with a set of related UX improvements:

- **Metric color toggle** — a `Latency / Error rate / Throughput` segmented control that recolors nodes by the selected dimension. The active metric + graph-wide maxes flow through a small React context (`ServiceMapMetricContext`) so switching metrics recolors instantly **without** rebuilding nodes or re-running the dagre layout (preserving zoom/positions). Latency is disabled (and auto-falls back to Error rate) when the dataset has no duration data, so nodes never render at a uniform zero-intensity color.
- **Legend** explaining the color scale (with the real max value formatted per metric) and documenting that node size encodes throughput. The legend swatch and node fills are generated from the **same** ramp endpoints (`getMetricGradientCss`), so they can never drift.
- **Sequential color ramp** — node color now goes light→dark within each metric's hue (red/amber/blue) instead of the previous grey→color saturation ramp.
- **Theme-aware canvas** — the canvas `colorMode`, background, and zoom controls now follow the app's resolved light/dark color scheme (using `--color-bg-body`) instead of being hardcoded to `dark` or React Flow's default background.
- **Popover polish** — the node tooltip is now a raised surface (lighter than the canvas, with elevation) carrying a service-name header, grouped sections (identity → stats → action), an "incoming requests" label, and severity-aware error coloring (amber < 5%, red ≥ 5%).

## Why

The service map lacked single-metric focus common to node-graph tools (Splunk APM, Datadog, ARMS), the node coloring only conveyed error rate and read as washed-out (grey→color), the canvas didn't respect the app theme, and the popover blended into the canvas with no title or hierarchy.

## Screenshots

### Before

<img width="2880" height="2048" alt="Service-Map-ClickStack-07-08-2026_12_16_PM" src="https://github.com/user-attachments/assets/8659da41-7ac5-45e1-8064-9f4b923c8b8d" />


### After

<img width="2880" height="2048" alt="service-map-02" src="https://github.com/user-attachments/assets/839262a3-cb75-4d5c-85a4-84cad286284c" />

<img width="2880" height="2048" alt="service-map-01" src="https://github.com/user-attachments/assets/0166e5c9-88ac-4580-b5be-9595b0326c9a" />

<img width="2880" height="2048" alt="service-map-03" src="https://github.com/user-attachments/assets/361d76b4-3035-40ec-a9af-49c47e4b3bde" />

## Test plan

- [ ] `yarn ci:unit` — `utils.test.ts` covers the sequential ramp (light→dark, monotonic, capping, per-metric hue), `getServiceMetricValue`, and `getMetricGradientCss`.
- [ ] Visual check on `/service-map` in **light** and **dark** mode:
  - [ ] Canvas background matches the app theme.
  - [ ] Toggle recolors nodes; Latency disabled when the source has no duration data.
  - [ ] Legend max value + gradient match the active metric.
  - [ ] Node popover reads as a raised card with a service-name header.

## Notes

- Includes a changeset (`@hyperdx/app` patch).

Made with [Cursor](https://cursor.com)