### PR TITLE
fix(api): allow creating and editing Sources in Local App Mode

### DIFF
--- a/.changeset/fix-sources-local-app-mode.md
+++ b/.changeset/fix-sources-local-app-mode.md
@@ -1,0 +1,12 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: allow creating and editing Sources in Local App Mode
+
+In Local App Mode (`IS_LOCAL_APP_MODE`) the auth middleware injects a plain
+string team id onto the request instead of a Mongoose `ObjectId`. The sources
+router's create/update handlers called `teamId.toJSON()`, which only exists on
+`ObjectId`, causing an HTTP 500 (`TypeError: teamId.toJSON is not a function`)
+when saving a Source. Use `teamId.toString()` instead, which works for both
+string and `ObjectId` team ids.

--- a/packages/api/src/routers/api/__tests__/sources.test.ts
+++ b/packages/api/src/routers/api/__tests__/sources.test.ts
@@ -3,10 +3,14 @@ import {
   TSource,
   UseTextIndex,
 } from '@hyperdx/common-utils/dist/types';
+import express from 'express';
 import { Types } from 'mongoose';
+import request from 'supertest';
 
 import { getLoggedInAgent, getServer } from '@/fixtures';
+import { appErrorHandler } from '@/middleware/error';
 import { Source } from '@/models/source';
+import sourcesRouter from '@/routers/api/sources';
 
 const MOCK_SOURCE: Omit<Extract<TSource, { kind: 'log' }>, 'id'> = {
   kind: SourceKind.Log,
@@ -687,6 +691,73 @@ describe('sources router', () => {
       expect(sources[1].kind).toBe(SourceKind.Metric);
       expect(sources[2].kind).toBe(SourceKind.Session);
       expect(sources[3].kind).toBe(SourceKind.Trace);
+    });
+  });
+
+  describe('local app mode (string team id)', () => {
+    // In Local App Mode (IS_LOCAL_APP_MODE) the auth middleware injects a
+    // plain string team id ("_local_team_") onto req.user instead of a
+    // Mongoose ObjectId. Regression test for HDX-4713 where the POST/PUT
+    // handlers called teamId.toJSON() — a method that only exists on
+    // ObjectId, not on strings — producing an HTTP 500
+    // "TypeError: teamId.toJSON is not a function".
+    const LOCAL_APP_TEAM_ID = '_local_team_';
+
+    // Build a minimal Express app that mirrors how api-app.ts mounts the
+    // sources router, but with a middleware that emulates the Local App Mode
+    // branch of isUserAuthenticated (string team id).
+    const getLocalAppModeApp = () => {
+      const app = express();
+      app.use(express.json());
+      app.use((req, _res, next) => {
+        req.user = {
+          _id: '_local_user_',
+          email: 'local-user@hyperdx.io',
+          team: LOCAL_APP_TEAM_ID,
+        } as unknown as Express.User;
+        next();
+      });
+      app.use('/sources', sourcesRouter);
+      app.use(appErrorHandler);
+      return app;
+    };
+
+    it('POST / - creates a source when team id is a string', async () => {
+      const app = getLocalAppModeApp();
+
+      const response = await request(app)
+        .post('/sources')
+        .send(MOCK_SOURCE)
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        kind: MOCK_SOURCE.kind,
+        name: MOCK_SOURCE.name,
+      });
+
+      const sources = await Source.find({ team: LOCAL_APP_TEAM_ID });
+      expect(sources).toHaveLength(1);
+    });
+
+    it('PUT /:id - updates a source when team id is a string', async () => {
+      const app = getLocalAppModeApp();
+
+      const source = await Source.create({
+        ...MOCK_SOURCE,
+        team: LOCAL_APP_TEAM_ID,
+      });
+
+      await request(app)
+        .put(`/sources/${source._id}`)
+        .send({
+          ...MOCK_SOURCE,
+          id: source._id.toString(),
+          name: 'Updated In Local App Mode',
+        })
+        .expect(200);
+
+      const updated = await Source.findById(source._id);
+      expect(updated?.name).toBe('Updated In Local App Mode');
     });
   });
 

--- a/packages/api/src/routers/api/sources.ts
+++ b/packages/api/src/routers/api/sources.ts
@@ -45,7 +45,7 @@ router.post(
 
       const source = await createSource(teamId.toString(), {
         ...req.body,
-        team: teamId.toJSON(),
+        team: teamId.toString(),
       });
 
       res.json(source);
@@ -69,7 +69,7 @@ router.put(
 
       const source = await updateSource(teamId.toString(), req.params.id, {
         ...req.body,
-        team: teamId.toJSON(),
+        team: teamId.toString(),
       });
 
       if (!source) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Since `@hyperdx/app@v2.22.0`, creating or editing a Source from **Team Settings → Data → Sources** fails with `HTTP 500 "Failed to update source"` when running HyperDX in Local App Mode (`IS_LOCAL_APP_MODE="DANGEROUSLY_is_local_app_mode💀"`).

**Root cause:** In Local App Mode, the auth middleware (`isUserAuthenticated`) injects a plain **string** team id (`"_local_team_"`) onto `req.user.team` instead of a Mongoose `ObjectId`. The `POST /sources` and `PUT /sources/:id` handlers built the request body with `team: teamId.toJSON()`. `.toJSON()` only exists on `ObjectId`, not on strings, so the handler threw:

```
TypeError: teamId.toJSON is not a function
    at .../routers/api/sources.js:49
```

`GET /sources` was unaffected because it already used `teamId.toString()`, which is why listing sources worked but saving them did not.

**Fix:** Use `teamId.toString()` in both the create and update handlers. It returns the correct value for both a `string` team id (Local App Mode) and an `ObjectId` (normal auth). The `team` value in the body is also overridden downstream by the controllers, so this is safe.

### How to test on Vercel preview

N/A — non-UI change (API-only bug fix).

### Testing

Added two regression tests in `packages/api/src/routers/api/__tests__/sources.test.ts` that mount the sources router with a middleware emulating the Local App Mode string team id and exercise `POST /` and `PUT /:id`.

- With the pre-fix `teamId.toJSON()` code, both tests fail with the exact error from the issue (`TypeError: teamId.toJSON is not a function`).
- With the fix, both tests pass, and the full sources integration suite (34 tests) passes.

### References

- Linear Issue: HDX-4713
- Fixes #2600
- Upstream PR: https://github.com/hyperdxio/hyperdx/pull/1895/changes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4713](https://linear.app/clickhouse/issue/HDX-4713/http-500-failed-to-update-source-when-creating-or-editing-sources-in)

<div><a href="https://cursor.com/agents/bc-f172af28-94ed-49c9-9e91-85e7ada5a34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f172af28-94ed-49c9-9e91-85e7ada5a34b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

