### PR TITLE
feat: add event patterns as a first-class dashboard tile type

### DIFF
--- a/.changeset/bright-patterns-neab.md
+++ b/.changeset/bright-patterns-neab.md
@@ -1,0 +1,8 @@
+---
+"@hyperdx/app": minor
+"@hyperdx/api": minor
+---
+
+feat: add event patterns as a first-class dashboard tile type
+
+Event patterns can now be created, edited, and saved as dashboard tiles with a dedicated "Pattern Expression" editor. Supported across the UI, MCP server, and External API v2.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1983,6 +1983,47 @@
           }
         }
       },
+      "EventPatternsChartConfig": {
+        "type": "object",
+        "required": [
+          "displayType",
+          "sourceId"
+        ],
+        "description": "Configuration for an event pattern mining tile. Clusters log or trace events by recurring message shapes.",
+        "properties": {
+          "displayType": {
+            "type": "string",
+            "enum": [
+              "event_patterns"
+            ],
+            "description": "Display type discriminator. Must be \"event_patterns\" for pattern mining tiles.",
+            "example": "event_patterns"
+          },
+          "sourceId": {
+            "type": "string",
+            "description": "ID of the data source to mine patterns from.",
+            "example": "65f5e4a3b9e77c001a111111"
+          },
+          "select": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Column or expression to mine patterns from. Leave empty to use the source default (Body for logs, SpanName for traces).",
+            "default": "",
+            "example": "Body"
+          },
+          "where": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Filter condition for the pattern mining query (syntax depends on whereLanguage).",
+            "default": "",
+            "example": "level:error"
+          },
+          "whereLanguage": {
+            "$ref": "#/components/schemas/QueryLanguage",
+            "description": "Query language for the where clause."
+          }
+        }
+      },
       "MarkdownChartConfig": {
         "type": "object",
         "required": [
@@ -2495,7 +2536,7 @@
         }
       },
       "TileConfig": {
-        "description": "Tile chart configuration. displayType is the primary discriminant and determines which variant group applies. For displayTypes that support both builder and Raw SQL modes (line, stacked_bar, table, number, pie), configType is the secondary discriminant: omit it for the builder variant or set it to \"sql\" for the Raw SQL variant. The heatmap, search, and markdown displayTypes only have a builder variant.\n",
+        "description": "Tile chart configuration. displayType is the primary discriminant and determines which variant group applies. For displayTypes that support both builder and Raw SQL modes (line, stacked_bar, table, number, pie), configType is the secondary discriminant: omit it for the builder variant or set it to \"sql\" for the Raw SQL variant. The heatmap, search, event_patterns, and markdown displayTypes only have a builder variant.\n",
         "oneOf": [
           {
             "$ref": "#/components/schemas/LineChartConfig"
@@ -2519,6 +2560,9 @@
             "$ref": "#/components/schemas/SearchChartConfig"
           },
           {
+            "$ref": "#/components/schemas/EventPatternsChartConfig"
+          },
+          {
             "$ref": "#/components/schemas/MarkdownChartConfig"
           }
         ],
@@ -2532,6 +2576,7 @@
             "pie": "#/components/schemas/PieChartConfig",
             "heatmap": "#/components/schemas/HeatmapChartConfig",
             "search": "#/components/schemas/SearchChartConfig",
+            "event_patterns": "#/components/schemas/EventPatternsChartConfig",
             "markdown": "#/components/schemas/MarkdownChartConfig"
           }
         }

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -716,6 +716,31 @@ const mcpSearchTileSchema = mcpTileLayoutSchema.extend({
   }),
 });
 
+const mcpEventPatternsTileSchema = mcpTileLayoutSchema.extend({
+  config: z.object({
+    displayType: z
+      .literal('event_patterns')
+      .describe('Event pattern mining tile'),
+    sourceId: z.string().describe('Source ID – call clickstack_list_sources'),
+    where: z
+      .string()
+      .optional()
+      .default('')
+      .describe('Filter in Lucene syntax. Example: "level:error"'),
+    whereLanguage:
+      SearchConditionTrimmedLanguageSchema.optional().default('lucene'),
+    select: z
+      .string()
+      .optional()
+      .default('')
+      .describe(
+        'Pattern expression — column or expression to mine patterns from. ' +
+          'Leave empty to use the source default (Body for logs, SpanName for traces). ' +
+          'Example: "Body", "SpanName", "SpanAttributes[\'http.url\']"',
+      ),
+  }),
+});
+
 const mcpMarkdownTileSchema = mcpTileLayoutSchema.extend({
   config: z.object({
     displayType: z.literal('markdown').describe('Free-form Markdown text tile'),
@@ -811,6 +836,7 @@ const mcpTileSchema = z.union([
   mcpPieTileSchema,
   mcpHeatmapTileSchema,
   mcpSearchTileSchema,
+  mcpEventPatternsTileSchema,
   mcpMarkdownTileSchema,
   mcpSqlTileSchema,
 ]);
@@ -848,6 +874,9 @@ const mcpPatchTileSchema = z.union([
   }),
   mcpPatchTileLayoutSchema.extend({
     config: mcpSearchTileSchema.shape.config,
+  }),
+  mcpPatchTileLayoutSchema.extend({
+    config: mcpEventPatternsTileSchema.shape.config,
   }),
   mcpPatchTileLayoutSchema.extend({
     config: mcpMarkdownTileSchema.shape.config,

--- a/packages/api/src/mcp/tools/query/helpers.ts
+++ b/packages/api/src/mcp/tools/query/helpers.ts
@@ -33,6 +33,8 @@ import { trimToolResponse } from '@/utils/trimToolResponse';
 import type { ExternalDashboardTileWithId } from '@/utils/zod';
 import { externalDashboardTileSchemaWithId } from '@/utils/zod';
 
+import { runEventPatterns } from './runEventPatterns';
+
 // ─── Source body expression helpers ──────────────────────────────────────────
 
 export interface SourceBodyFields {
@@ -402,6 +404,26 @@ export async function runConfigTile(
           },
         ],
       };
+    }
+
+    // Event-patterns tiles need the Drain pattern-mining pipeline, not the
+    // generic chart-config SQL renderer. Delegate to the same function the
+    // standalone clickstack_event_patterns tool uses.
+    if (builderConfig.displayType === DisplayType.EventPatterns) {
+      const selectStr =
+        typeof builderConfig.select === 'string' ? builderConfig.select : '';
+      return runEventPatterns(
+        teamId,
+        builderConfig.source,
+        startDate,
+        endDate,
+        {
+          where: builderConfig.where ?? '',
+          whereLanguage:
+            (builderConfig.whereLanguage as 'lucene' | 'sql') ?? 'lucene',
+          bodyExpression: selectStr || undefined,
+        },
+      );
     }
 
     const source = await getSource(teamId, builderConfig.source);

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -2413,6 +2413,21 @@ describe('External API v2 Dashboards - new format', () => {
         },
       };
 
+      const eventPatternsChart: ExternalDashboardTile = {
+        name: 'Event Patterns',
+        x: 18,
+        y: 3,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'event_patterns',
+          sourceId: traceSource._id.toString(),
+          select: 'SpanName',
+          where: 'level:error',
+          whereLanguage: 'lucene',
+        },
+      };
+
       // Act
       const response = await authRequest('post', BASE_URL)
         .send({
@@ -2425,6 +2440,7 @@ describe('External API v2 Dashboards - new format', () => {
             markdownChart,
             pieChart,
             heatmapChart,
+            eventPatternsChart,
           ],
           tags: ['round-trip-test'],
         })
@@ -2438,6 +2454,9 @@ describe('External API v2 Dashboards - new format', () => {
       expect(omit(response.body.data.tiles[4], ['id'])).toEqual(markdownChart);
       expect(omit(response.body.data.tiles[5], ['id'])).toEqual(pieChart);
       expect(omit(response.body.data.tiles[6], ['id'])).toEqual(heatmapChart);
+      expect(omit(response.body.data.tiles[7], ['id'])).toEqual(
+        eventPatternsChart,
+      );
     });
 
     // Schema-level rejections that exercise pure Zod constraints
@@ -3976,6 +3995,22 @@ describe('External API v2 Dashboards - new format', () => {
         },
       };
 
+      const eventPatternsChart: ExternalDashboardTileWithId = {
+        id: new ObjectId().toString(),
+        name: 'Event Patterns',
+        x: 12,
+        y: 3,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'event_patterns',
+          sourceId: traceSource._id.toString(),
+          select: 'SpanName',
+          where: 'level:error',
+          whereLanguage: 'lucene',
+        },
+      };
+
       // Create an initial dashboard to update
       const initialDashboard = await createTestDashboard();
 
@@ -3993,6 +4028,7 @@ describe('External API v2 Dashboards - new format', () => {
             numberChart,
             markdownChart,
             heatmapChart,
+            eventPatternsChart,
           ],
           tags: ['round-trip-test'],
         })
@@ -4016,6 +4052,9 @@ describe('External API v2 Dashboards - new format', () => {
       );
       expect(omit(response.body.data.tiles[5], ['id'])).toEqual(
         omit(heatmapChart, ['id']),
+      );
+      expect(omit(response.body.data.tiles[6], ['id'])).toEqual(
+        omit(eventPatternsChart, ['id']),
       );
     });
 

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -922,6 +922,38 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           $ref: '#/components/schemas/QueryLanguage'
  *           description: Query language for the where clause.
  *
+ *     EventPatternsChartConfig:
+ *       type: object
+ *       required:
+ *         - displayType
+ *         - sourceId
+ *       description: Configuration for an event pattern mining tile. Clusters log or trace events by recurring message shapes.
+ *       properties:
+ *         displayType:
+ *           type: string
+ *           enum: [event_patterns]
+ *           description: Display type discriminator. Must be "event_patterns" for pattern mining tiles.
+ *           example: "event_patterns"
+ *         sourceId:
+ *           type: string
+ *           description: ID of the data source to mine patterns from.
+ *           example: "65f5e4a3b9e77c001a111111"
+ *         select:
+ *           type: string
+ *           maxLength: 10000
+ *           description: Column or expression to mine patterns from. Leave empty to use the source default (Body for logs, SpanName for traces).
+ *           default: ""
+ *           example: "Body"
+ *         where:
+ *           type: string
+ *           maxLength: 10000
+ *           description: Filter condition for the pattern mining query (syntax depends on whereLanguage).
+ *           default: ""
+ *           example: "level:error"
+ *         whereLanguage:
+ *           $ref: '#/components/schemas/QueryLanguage'
+ *           description: Query language for the where clause.
+ *
  *     MarkdownChartConfig:
  *       type: object
  *       required:
@@ -1299,7 +1331,7 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *         both builder and Raw SQL modes (line, stacked_bar, table, number, pie),
  *         configType is the secondary discriminant: omit it for the builder
  *         variant or set it to "sql" for the Raw SQL variant. The heatmap,
- *         search, and markdown displayTypes only have a builder variant.
+ *         search, event_patterns, and markdown displayTypes only have a builder variant.
  *       oneOf:
  *         - $ref: '#/components/schemas/LineChartConfig'
  *         - $ref: '#/components/schemas/BarChartConfig'
@@ -1308,6 +1340,7 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *         - $ref: '#/components/schemas/PieChartConfig'
  *         - $ref: '#/components/schemas/HeatmapChartConfig'
  *         - $ref: '#/components/schemas/SearchChartConfig'
+ *         - $ref: '#/components/schemas/EventPatternsChartConfig'
  *         - $ref: '#/components/schemas/MarkdownChartConfig'
  *       discriminator:
  *         propertyName: displayType
@@ -1319,6 +1352,7 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           pie: '#/components/schemas/PieChartConfig'
  *           heatmap: '#/components/schemas/HeatmapChartConfig'
  *           search: '#/components/schemas/SearchChartConfig'
+ *           event_patterns: '#/components/schemas/EventPatternsChartConfig'
  *           markdown: '#/components/schemas/MarkdownChartConfig'
  *
  *     DashboardContainerTab:

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -247,6 +247,7 @@ const convertToExternalTileChartConfig = (
       case DisplayType.Search:
       case DisplayType.Markdown:
       case DisplayType.Heatmap:
+      case DisplayType.EventPatterns:
         logger.error(
           { config },
           'Error converting chart config to external chart - unsupported display type for raw SQL config',
@@ -420,6 +421,14 @@ const convertToExternalTileChartConfig = (
         numberFormat: config.numberFormat,
       };
     }
+    case DisplayType.EventPatterns:
+      return {
+        displayType: config.displayType,
+        sourceId,
+        select: stringValueOrDefault(config.select, ''),
+        where: config.where,
+        whereLanguage: config.whereLanguage ?? 'lucene',
+      };
     case undefined:
       logger.error(
         { config },
@@ -783,6 +792,15 @@ export function convertToInternalTileConfig(
         internalConfig = {
           ...pick(externalConfig, ['select', 'where']),
           displayType: DisplayType.Search,
+          source: externalConfig.sourceId,
+          name,
+          whereLanguage: externalConfig.whereLanguage ?? 'lucene',
+        } satisfies BuilderSavedChartConfig;
+        break;
+      case 'event_patterns':
+        internalConfig = {
+          ...pick(externalConfig, ['select', 'where']),
+          displayType: DisplayType.EventPatterns,
           source: externalConfig.sourceId,
           name,
           whereLanguage: externalConfig.whereLanguage ?? 'lucene',

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -426,7 +426,7 @@ const convertToExternalTileChartConfig = (
         displayType: config.displayType,
         sourceId,
         select: stringValueOrDefault(config.select, ''),
-        where: config.where,
+        where: stringValueOrDefault(config.where, ''),
         whereLanguage: config.whereLanguage ?? 'lucene',
       };
     case undefined:

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -424,6 +424,14 @@ const externalDashboardMarkdownChartConfigSchema = z.object({
   markdown: z.string().max(50000).optional(),
 });
 
+const externalDashboardEventPatternsChartConfigSchema = z.object({
+  displayType: z.literal('event_patterns'),
+  sourceId: objectIdSchema,
+  select: z.string().max(10000).optional().default(''),
+  where: z.string().max(10000).optional().default(''),
+  whereLanguage: whereLanguageSchema,
+});
+
 const externalDashboardBuilderTileConfigSchema = z.discriminatedUnion(
   'displayType',
   [
@@ -435,6 +443,7 @@ const externalDashboardBuilderTileConfigSchema = z.discriminatedUnion(
     externalDashboardHeatmapChartConfigSchema,
     externalDashboardMarkdownChartConfigSchema,
     externalDashboardSearchChartConfigSchema,
+    externalDashboardEventPatternsChartConfigSchema,
   ],
 );
 

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -144,6 +144,7 @@ import DBHeatmapChart, {
 import { DBPieChart } from './components/DBPieChart';
 import DBSqlRowTableWithSideBar from './components/DBSqlRowTableWithSidebar';
 import OnboardingModal from './components/OnboardingModal';
+import PatternTable from './components/PatternTable';
 import SearchWhereInput, {
   getStoredLanguage,
 } from './components/SearchInput/SearchWhereInput';
@@ -170,6 +171,7 @@ import {
 import HDXMarkdownChart from './HDXMarkdownChart';
 import { withAppNav } from './layout';
 import {
+  getEventBody,
   getFirstTimestampValueExpression,
   useSource,
   useSources,
@@ -1045,6 +1047,55 @@ const Tile = forwardRef(
                         queryKeyPrefix={'search'}
                         variant="default"
                         errorVariant="collapsible"
+                      />
+                    </ChartContainer>
+                  )}
+                {effectiveQueriedConfig?.displayType ===
+                  DisplayType.EventPatterns &&
+                  isBuilderChartConfig(effectiveQueriedConfig) &&
+                  isBuilderSavedChartConfig(chart.config) && (
+                    <ChartContainer
+                      title={title}
+                      toolbarItems={toolbar}
+                      disableReactiveContainer
+                    >
+                      <PatternTable
+                        key={`${keyPrefix}-${chart.id}`}
+                        source={source}
+                        config={{
+                          ...effectiveQueriedConfig,
+                          // PatternTable's usePatterns hook overrides `select`
+                          // with pattern-specific columns, so clear the
+                          // defaultTableSelectExpression to prevent
+                          // source-specific columns from leaking through.
+                          select: '',
+                          displayType: DisplayType.Table,
+                          dateRange: effectiveDateRange,
+                          granularity: undefined,
+                        }}
+                        bodyValueExpression={
+                          // Prefer the user's custom pattern expression
+                          // (stored in select) when set. Ignore
+                          // multi-column strings (containing commas) —
+                          // those are stale defaultTableSelectExpression
+                          // values, not a single pattern expression.
+                          (typeof effectiveQueriedConfig.select === 'string' &&
+                          effectiveQueriedConfig.select.length > 0 &&
+                          !effectiveQueriedConfig.select.includes(',')
+                            ? effectiveQueriedConfig.select
+                            : undefined) ??
+                          (source ? (getEventBody(source) ?? '') : '')
+                        }
+                        totalCountConfig={{
+                          ...effectiveQueriedConfig,
+                          displayType: DisplayType.Table,
+                          dateRange: effectiveDateRange,
+                          select: 'count() as total',
+                          groupBy: undefined,
+                          orderBy: undefined,
+                          granularity: undefined,
+                        }}
+                        totalCountQueryKeyPrefix={`dashboard-patterns-${chart.id}`}
                       />
                     </ChartContainer>
                   )}

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -173,6 +173,7 @@ import { withAppNav } from './layout';
 import {
   getEventBody,
   getFirstTimestampValueExpression,
+  isSingleExpression,
   useSource,
   useSources,
 } from './source';
@@ -1075,13 +1076,15 @@ const Tile = forwardRef(
                         }}
                         bodyValueExpression={
                           // Prefer the user's custom pattern expression
-                          // (stored in select) when set. Ignore
-                          // multi-column strings (containing commas) —
-                          // those are stale defaultTableSelectExpression
-                          // values, not a single pattern expression.
+                          // (stored in select) when set. Reject
+                          // multi-column strings — those are stale
+                          // defaultTableSelectExpression values, not a
+                          // single pattern expression. Uses bracket-aware
+                          // splitting so expressions like COALESCE(a, b)
+                          // are correctly treated as single.
                           (typeof effectiveQueriedConfig.select === 'string' &&
                           effectiveQueriedConfig.select.length > 0 &&
-                          !effectiveQueriedConfig.select.includes(',')
+                          isSingleExpression(effectiveQueriedConfig.select)
                             ? effectiveQueriedConfig.select
                             : undefined) ??
                           (source ? (getEventBody(source) ?? '') : '')

--- a/packages/app/src/components/ChartEditor/constants.tsx
+++ b/packages/app/src/components/ChartEditor/constants.tsx
@@ -46,6 +46,7 @@ WHERE TimestampTime >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64})
   [DisplayType.Search]: '',
   [DisplayType.Heatmap]: '',
   [DisplayType.Markdown]: '',
+  [DisplayType.EventPatterns]: '',
 };
 
 const TIMESERIES_INSTRUCTIONS = (

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -69,6 +69,17 @@ export const isRawSqlDisplayType = (
   displayType === DisplayType.Pie ||
   displayType === DisplayType.Number;
 
+/**
+ * Display types that store `select` as a plain string (column expression)
+ * rather than a structured `DerivedColumn[]` series array. These types
+ * don't use the builder series editor and skip series-level validation.
+ */
+export const isStringSelectDisplayType = (
+  displayType: DisplayType | undefined,
+): displayType is DisplayType.Search | DisplayType.EventPatterns =>
+  displayType === DisplayType.Search ||
+  displayType === DisplayType.EventPatterns;
+
 export const isPromqlDisplayType = (
   displayType: DisplayType | undefined,
 ): displayType is
@@ -145,13 +156,11 @@ export function convertFormStateToSavedChartConfig(
     // Merge the series and select fields back together, and prevent the series field from being submitted
     const config: BuilderSavedChartConfig = {
       ...omit(form, ['series', 'configType', 'sqlTemplate']),
-      // If the chart type is search, we need to ensure the select is a string
-      select:
-        form.displayType === DisplayType.Search
-          ? typeof form.select === 'string'
-            ? form.select
-            : ''
-          : form.series,
+      select: isStringSelectDisplayType(form.displayType)
+        ? typeof form.select === 'string'
+          ? form.select
+          : ''
+        : form.series,
       where: form.where ?? '',
       source: source.id,
     };
@@ -225,9 +234,10 @@ export function convertFormStateToChartConfig(
   }
 
   if (source) {
-    // Merge the series and select fields back together, and prevent the series field from being submitted
-    const mergedSelect =
-      form.displayType === DisplayType.Search ? form.select : form.series;
+    // Merge the series and select fields back together, and prevent the series field from being submitted.
+    const mergedSelect = isStringSelectDisplayType(form.displayType)
+      ? form.select
+      : form.series;
     const isSelectEmpty = !mergedSelect || mergedSelect.length === 0;
 
     const newConfig: ChartConfigWithDateRange = {
@@ -249,10 +259,20 @@ export function convertFormStateToChartConfig(
       sampleWeightExpression: getSampleWeightExpression(source),
       metricTables: isMetricSource(source) ? source.metricTables : undefined,
       where: form.where ?? '',
+      // When select is empty, the fallback differs by display type:
+      //   - EventPatterns: keep '' — the pattern-mining code resolves the
+      //     body expression from the source at render time. Using
+      //     defaultTableSelectExpression here would inject multi-column
+      //     search-table columns (e.g. SeverityText) that don't belong in
+      //     a single-expression pattern field.
+      //   - Search: fall back to defaultTableSelectExpression — the
+      //     multi-column list is exactly what the search results table needs.
       select: isSelectEmpty
-        ? ((isLogSource(source) || isTraceSource(source)) &&
-            source.defaultTableSelectExpression) ||
-          ''
+        ? form.displayType === DisplayType.EventPatterns
+          ? ''
+          : ((isLogSource(source) || isTraceSource(source)) &&
+              source.defaultTableSelectExpression) ||
+            ''
         : mergedSelect,
     };
 
@@ -310,13 +330,15 @@ export const validateChartForm = (
     errors.push({ path: `source`, message: 'Source is required' });
   }
 
-  // Validate that valueExpressions are specified for each series
+  // Validate that valueExpressions are specified for each series.
+  // String-select display types (Search, EventPatterns) don't use the
+  // series array, so skip them.
   if (
     !isRawSqlChart &&
     Array.isArray(form.series) &&
     source?.kind !== SourceKind.Metric &&
     form.displayType !== DisplayType.Markdown &&
-    form.displayType !== DisplayType.Search
+    !isStringSelectDisplayType(form.displayType)
   ) {
     form.series.forEach((s, index) => {
       if (s.aggFn && s.aggFn !== 'count' && !s.valueExpression) {

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -32,7 +32,7 @@ import SourceSchemaPreview, {
 import { SourceSelectControlled } from '@/components/SourceSelect';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
 import { IS_LOCAL_MODE } from '@/config';
-import { getEventBody } from '@/source';
+import { getEventBody, isSingleExpression } from '@/source';
 import { DEFAULT_TILE_ALERT } from '@/utils/alerts';
 
 import { OnClickFormButton } from './OnClickForm/OnClickFormButton';
@@ -169,6 +169,15 @@ export function ChartEditorControls({
             onSubmit={onSubmit}
             label="Pattern Expression"
           />
+          {typeof select === 'string' &&
+            select.length > 0 &&
+            !isSingleExpression(select) && (
+              <Text size="xs" c="red">
+                Pattern expression must be a single column or expression —
+                multi-column lists are not supported. The source default will be
+                used instead.
+              </Text>
+            )}
           <SearchWhereInput
             tableConnection={tableConnection}
             control={control}

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -32,6 +32,7 @@ import SourceSchemaPreview, {
 import { SourceSelectControlled } from '@/components/SourceSelect';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
 import { IS_LOCAL_MODE } from '@/config';
+import { getEventBody } from '@/source';
 import { DEFAULT_TILE_ALERT } from '@/utils/alerts';
 
 import { OnClickFormButton } from './OnClickForm/OnClickFormButton';
@@ -136,6 +137,7 @@ export function ChartEditorControls({
           {tableSource &&
             activeTab !== 'search' &&
             activeTab !== 'heatmap' &&
+            activeTab !== 'event_patterns' &&
             chartConfigForExplanations &&
             isBuilderChartConfig(chartConfigForExplanations) && (
               <MVOptimizationIndicator
@@ -153,6 +155,31 @@ export function ChartEditorControls({
           onSubmit={onSubmit}
           onOpenDisplaySettings={openHeatmapSettings}
         />
+      ) : displayType === DisplayType.EventPatterns ? (
+        <Flex gap="xs" direction="column">
+          <SQLInlineEditorControlled
+            tableConnection={tableConnection}
+            control={control}
+            name="select"
+            placeholder={
+              tableSource
+                ? `Default (${getEventBody(tableSource) ?? 'Body'}) — column name or expression`
+                : 'Default — column name or expression'
+            }
+            onSubmit={onSubmit}
+            label="Pattern Expression"
+          />
+          <SearchWhereInput
+            tableConnection={tableConnection}
+            control={control}
+            name="where"
+            onSubmit={onSubmit}
+            onLanguageChange={(lang: 'sql' | 'lucene') =>
+              setValue('whereLanguage', lang)
+            }
+            showLabel={false}
+          />
+        </Flex>
       ) : displayType !== DisplayType.Search && Array.isArray(select) ? (
         <>
           {fields.map((field, index) => (

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -6,6 +6,7 @@ import {
   BuilderChartConfigWithOptTimestamp,
   ChartConfigWithDateRange,
   ChartConfigWithOptTimestamp,
+  DisplayType,
   SourceKind,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
@@ -29,7 +30,8 @@ import DBSqlRowTableWithSideBar from '@/components/DBSqlRowTableWithSidebar';
 import DBTableChart from '@/components/DBTableChart';
 import { DBTimeChart } from '@/components/DBTimeChart';
 import EmptyState from '@/components/EmptyState';
-import { getFirstTimestampValueExpression } from '@/source';
+import PatternTable from '@/components/PatternTable';
+import { getEventBody, getFirstTimestampValueExpression } from '@/source';
 import {
   orderByStringToSortingState,
   sortingStateToOrderByString,
@@ -288,6 +290,64 @@ export function ChartPreviewPanel({
               enabled
               isLive={false}
               queryKeyPrefix={'search'}
+            />
+          </div>
+        )}
+      {queryReady &&
+        tableSource &&
+        queriedConfig != null &&
+        isBuilderChartConfig(queriedConfig) &&
+        activeTab === 'event_patterns' && (
+          <div
+            className="flex-grow-1 d-flex flex-column"
+            style={{ height: 400 }}
+          >
+            <PatternTable
+              source={tableSource}
+              config={{
+                ...queriedConfig,
+                // Override source-specific fields from the live source so
+                // switching sources doesn't query the stale table/connection
+                // or stale defaultTableSelectExpression columns.
+                from: tableSource.from,
+                connection: tableSource.connection,
+                timestampValueExpression: tableSource.timestampValueExpression,
+                // PatternTable's usePatterns hook overrides `select` with
+                // pattern-specific columns, so clear the stale
+                // defaultTableSelectExpression to prevent old-source columns
+                // (e.g. SeverityText from a log source) from leaking through.
+                select: '',
+                displayType: DisplayType.Table,
+                dateRange,
+                granularity: undefined,
+              }}
+              bodyValueExpression={
+                // Prefer the user's custom pattern expression (stored in
+                // queriedConfig.select) when set. Ignore multi-column
+                // strings (containing commas) — those are stale
+                // defaultTableSelectExpression values from pre-fix saved
+                // tiles, not a single pattern expression.
+                (typeof queriedConfig.select === 'string' &&
+                queriedConfig.select.length > 0 &&
+                !queriedConfig.select.includes(',')
+                  ? queriedConfig.select
+                  : undefined) ??
+                getEventBody(tableSource) ??
+                ''
+              }
+              totalCountConfig={{
+                ...queriedConfig,
+                from: tableSource.from,
+                connection: tableSource.connection,
+                timestampValueExpression: tableSource.timestampValueExpression,
+                displayType: DisplayType.Table,
+                dateRange,
+                select: 'count() as total',
+                groupBy: undefined,
+                orderBy: undefined,
+                granularity: undefined,
+              }}
+              totalCountQueryKeyPrefix="chart-editor-patterns"
             />
           </div>
         )}

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -31,7 +31,11 @@ import DBTableChart from '@/components/DBTableChart';
 import { DBTimeChart } from '@/components/DBTimeChart';
 import EmptyState from '@/components/EmptyState';
 import PatternTable from '@/components/PatternTable';
-import { getEventBody, getFirstTimestampValueExpression } from '@/source';
+import {
+  getEventBody,
+  getFirstTimestampValueExpression,
+  isSingleExpression,
+} from '@/source';
 import {
   orderByStringToSortingState,
   sortingStateToOrderByString,
@@ -323,13 +327,14 @@ export function ChartPreviewPanel({
               }}
               bodyValueExpression={
                 // Prefer the user's custom pattern expression (stored in
-                // queriedConfig.select) when set. Ignore multi-column
-                // strings (containing commas) — those are stale
-                // defaultTableSelectExpression values from pre-fix saved
-                // tiles, not a single pattern expression.
+                // queriedConfig.select) when set. Reject multi-column
+                // strings — those are stale defaultTableSelectExpression
+                // values from pre-fix saved tiles, not a single pattern
+                // expression. Uses bracket-aware splitting so expressions
+                // like COALESCE(a, b) are correctly treated as single.
                 (typeof queriedConfig.select === 'string' &&
                 queriedConfig.select.length > 0 &&
-                !queriedConfig.select.includes(',')
+                isSingleExpression(queriedConfig.select)
                   ? queriedConfig.select
                   : undefined) ??
                 getEventBody(tableSource) ??

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -304,7 +304,7 @@ export function ChartPreviewPanel({
         activeTab === 'event_patterns' && (
           <div
             className="flex-grow-1 d-flex flex-column"
-            style={{ height: 400 }}
+            style={{ minHeight: 400 }}
           >
             <PatternTable
               source={tableSource}

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -32,6 +32,7 @@ import {
 import { useDisclosure, usePrevious } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import {
+  IconBracketsContain,
   IconChartLine,
   IconChartPie,
   IconGrid3x3,
@@ -57,6 +58,7 @@ import {
   convertSavedChartConfigToFormState,
   isPromqlDisplayType,
   isRawSqlDisplayType,
+  isStringSelectDisplayType,
   validateChartForm,
 } from '@/components/ChartEditor/utils';
 import type { HeatmapScaleType } from '@/components/DBHeatmapChart';
@@ -488,7 +490,10 @@ export default function EditTimeChartForm({
       prevDisplayTypeRef.current = displayType;
       prevConfigTypeRef.current = configType;
 
-      if (displayType === DisplayType.Search && typeof select !== 'string') {
+      if (
+        isStringSelectDisplayType(displayType) &&
+        typeof select !== 'string'
+      ) {
         setValue('select', '');
         setValue('series', []);
       } else if (displayType === DisplayType.Heatmap) {
@@ -712,6 +717,12 @@ export default function EditTimeChartForm({
                   leftSection={<IconGrid3x3 size={16} />}
                 >
                   Heatmap
+                </Tabs.Tab>
+                <Tabs.Tab
+                  value={DisplayType.EventPatterns}
+                  leftSection={<IconBracketsContain size={16} />}
+                >
+                  Patterns
                 </Tabs.Tab>
                 <Tabs.Tab
                   value={DisplayType.Markdown}

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -101,6 +101,8 @@ export function displayTypeToActiveTab(displayType: DisplayType): string {
       return 'number';
     case DisplayType.Heatmap:
       return 'heatmap';
+    case DisplayType.EventPatterns:
+      return 'event_patterns';
     default:
       return 'time';
   }

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -25,10 +25,10 @@ export default function PatternTable({
   totalCountConfig,
   totalCountQueryKeyPrefix,
   bodyValueExpression,
-  patternColumn,
-  draftPatternColumn,
-  onDraftPatternColumnChange,
-  onSubmit,
+  patternColumn: externalPatternColumn,
+  draftPatternColumn: externalDraftPatternColumn,
+  onDraftPatternColumnChange: externalOnDraftPatternColumnChange,
+  onSubmit: externalOnSubmit,
   source,
 }: {
   config: BuilderChartConfigWithDateRange;
@@ -45,8 +45,16 @@ export default function PatternTable({
 
   const [selectedPattern, setSelectedPattern] = useState<Pattern | null>(null);
 
+  // When external handlers are provided (e.g. search page), the pattern
+  // column selector is shown inline and the user can override the expression
+  // at runtime. For dashboard/preview tiles, the pattern expression is
+  // configured in the tile edit UI (via the config's `select` field) and
+  // the PatternColumnSelector is not shown.
+  const hasExternalPatternColumn =
+    externalOnDraftPatternColumnChange != null && externalOnSubmit != null;
+
   const effectiveBodyValueExpression = buildPatternColumnExpression({
-    patternColumn,
+    patternColumn: externalPatternColumn ?? null,
     fallback: bodyValueExpression,
   });
 
@@ -86,14 +94,16 @@ export default function PatternTable({
 
   return (
     <>
-      <PatternColumnSelector
-        sourceId={source?.id}
-        value={draftPatternColumn ?? ''}
-        onChange={onDraftPatternColumnChange}
-        onSubmit={onSubmit}
-        dateRange={config.dateRange}
-        bodyValueExpression={bodyValueExpression}
-      />
+      {hasExternalPatternColumn && (
+        <PatternColumnSelector
+          sourceId={source?.id}
+          value={externalDraftPatternColumn ?? ''}
+          onChange={externalOnDraftPatternColumnChange}
+          onSubmit={externalOnSubmit}
+          dateRange={config.dateRange}
+          bodyValueExpression={bodyValueExpression}
+        />
+      )}
       {error ? (
         <Container style={{ overflow: 'auto' }}>
           <Box mt="lg">

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -90,6 +90,17 @@ export function getEventBody(eventModel: TSource) {
   return multiExpr.length === 1 ? expression : multiExpr[0];
 }
 
+/**
+ * Check if a select string is a single expression (valid as a pattern body
+ * expression) rather than a multi-column list (stale
+ * `defaultTableSelectExpression`). Uses bracket-aware comma splitting so
+ * expressions like `COALESCE(SpanName, Body)` are correctly treated as a
+ * single expression.
+ */
+export function isSingleExpression(select: string): boolean {
+  return splitAndTrimWithBracket(select).length <= 1;
+}
+
 // This function is for supporting legacy sources, which did not require this field.
 // Will be defaulted to `TimestampTime` when queried, if undefined.
 function addDefaultsToSource(source: TSource): TSource {

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -30,7 +30,14 @@ export type TileConfig = {
   groupBy?: string;
   markdown?: string;
 };
-type SeriesType = 'time' | 'number' | 'table' | 'search' | 'markdown' | 'pie';
+type SeriesType =
+  | 'time'
+  | 'number'
+  | 'table'
+  | 'search'
+  | 'markdown'
+  | 'pie'
+  | 'event_patterns';
 /**
  * Series data structure for chart verification
  * Supports all chart types: time, number, table, search, markdown

--- a/packages/common-utils/src/rawSqlParams.ts
+++ b/packages/common-utils/src/rawSqlParams.ts
@@ -91,6 +91,7 @@ export const QUERY_PARAMS_BY_DISPLAY_TYPE: Record<
   [DisplayType.Search]: [],
   [DisplayType.Heatmap]: [],
   [DisplayType.Markdown]: [],
+  [DisplayType.EventPatterns]: [],
 };
 
 const TIME_CHART_EXAMPLE_SQL = `SELECT
@@ -116,6 +117,7 @@ export const QUERY_PARAM_EXAMPLES: Record<DisplayType, string> = {
   [DisplayType.Search]: '',
   [DisplayType.Heatmap]: '',
   [DisplayType.Markdown]: '',
+  [DisplayType.EventPatterns]: '',
 };
 
 export function renderQueryParam(name: keyof typeof QUERY_PARAMS): string {

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -39,6 +39,7 @@ export enum DisplayType {
   Search = 'search',
   Heatmap = 'heatmap',
   Markdown = 'markdown',
+  EventPatterns = 'event_patterns',
 }
 
 export type KeyValue<Key = string, Value = string> = { key: Key; value: Value };


### PR DESCRIPTION
## Summary

Event patterns can now be created, edited, and saved as dashboard tiles — with full support across the UI, MCP server, and External API v2.

Previously, pattern mining was only available on the search page. Dashboard tiles had no way to persist a custom pattern expression, and the `PatternColumnSelector` used internal component state that was lost on reload. The MCP and External API schemas didn't include `event_patterns` at all, so agents and API consumers couldn't create or round-trip pattern tiles.

### What changed

**Tile edit UI** — EventPatterns gets its own editor section with a "Pattern Expression" input (labeled, with the source's default body expression as placeholder) and a WHERE filter. This replaces the generic SELECT input that Search uses, which was semantically wrong for patterns.

**Config persistence fix** — `convertFormStateToSavedChartConfig` and `convertFormStateToChartConfig` now correctly persist `select` as a string for EventPatterns (it was falling through to the `form.series` array path, discarding the user's input). A new `isStringSelectDisplayType` guard consolidates the repeated `Search || EventPatterns` checks across 4 call sites.

**Source-switching fix** — The preview panel now overrides `from`, `connection`, `timestampValueExpression`, and `select` from the live `tableSource` (matching how the Search preview already works). This prevents stale columns from a previous source (e.g. `SeverityText` from a log source) from leaking into a trace-table query. The `bodyValueExpression` fallback also rejects multi-column strings (containing commas) to guard against pre-fix saved tiles that stored `defaultTableSelectExpression` as the pattern expression.

**MCP** — New `mcpEventPatternsTileSchema` added to both the save and patch tile unions. Agents can create pattern tiles with `displayType: "event_patterns"`, `sourceId`, optional `select` (pattern expression), `where`, and `whereLanguage`.

**External API v2** — New Zod schema + bidirectional conversion. Pattern tiles now round-trip through GET/PUT without being silently downgraded to line charts.

**PatternTable cleanup** — Removed the `variant` prop (parent containers own the background). The `PatternColumnSelector` is now only shown when external handlers are provided (search page); dashboard/preview tiles configure the expression in the edit UI instead.

## Screenshots

<img width="1663" height="819" alt="Screenshot 2026-07-07 at 4 13 42 PM" src="https://github.com/user-attachments/assets/50fdfd63-49aa-4475-a6da-ea91f9e723d2" />
<img width="1583" height="747" alt="Screenshot 2026-07-07 at 4 14 06 PM" src="https://github.com/user-attachments/assets/be2c386a-6ab2-46db-9c13-451b7de29eff" />

