### PR TITLE
chore: upgrade TypeScript from 5.9 to 6.0

### DIFF
--- a/.changeset/upgrade-typescript-6.md
+++ b/.changeset/upgrade-typescript-6.md
@@ -1,0 +1,9 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+"@hyperdx/cli": patch
+"@hyperdx/hdx-eval": patch
+---
+
+Upgrade the TypeScript devDependency from 5.9 to 6.0 across all packages.

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,6 +1,12 @@
 const { createJsWithTsPreset } = require('ts-jest');
 
-const tsJestTransformCfg = createJsWithTsPreset();
+const tsJestTransformCfg = createJsWithTsPreset({
+  tsconfig: {
+    // TypeScript 6 requires an explicit rootDir when compiling a subset of
+    // files (ts-jest compiles per-file), otherwise it errors with TS5011.
+    rootDir: './src',
+  },
+});
 
 /** @type {import("jest").Config} **/
 module.exports = {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -76,11 +76,11 @@
     "supertest": "^6.3.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "ts-jest": "^29.4.5",
+    "ts-jest": "^29.4.11",
     "ts-node": "^10.8.1",
     "tsc-alias": "^1.8.8",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "start": "node ./build/index.js",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     },
     "types": ["jest", "node"],
     "outDir": "build",
@@ -12,6 +11,15 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES2022"
+  },
+  "ts-node": {
+    "compilerOptions": {
+      // ts-node compiles single files on demand (e.g. `src/index.ts` for the
+      // dev server), so TypeScript infers the common source dir as `./src`.
+      // TS 6 requires that inferred rootDir to be explicit (TS5011). The full
+      // `tsc` build keeps its implicit root (which spans src/migrations/scripts).
+      "rootDir": "./src"
+    }
   },
   "include": ["src", "migrations", "scripts"],
   "exclude": ["node_modules"]

--- a/packages/app/css.d.ts
+++ b/packages/app/css.d.ts
@@ -1,0 +1,9 @@
+// Ambient declarations for plain (non-module) stylesheet side-effect imports,
+// e.g. `import '@mantine/core/styles.css'`. Next.js only ships ambient types
+// for CSS Modules (`*.module.css`), and TypeScript 6 enforces TS2882 for
+// side-effect imports of otherwise-untyped modules, so declare the plain
+// stylesheet extensions here. CSS Modules keep their typed declarations from
+// Next's `global.d.ts`.
+declare module '*.css';
+declare module '*.scss';
+declare module '*.sass';

--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -3,6 +3,9 @@ const { createJsWithTsPreset } = require('ts-jest');
 const tsJestTransformCfg = createJsWithTsPreset({
   tsconfig: {
     jsx: 'react-jsx',
+    // TypeScript 6 requires an explicit rootDir when compiling a subset of
+    // files (ts-jest compiles per-file), otherwise it errors with TS5011.
+    rootDir: './src',
   },
 });
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -149,8 +149,8 @@
     "stylelint": "^16.26.1",
     "stylelint-config-standard-scss": "^16.0.0",
     "stylelint-prettier": "^5.0.3",
-    "ts-jest": "^29.4.5",
-    "typescript": "^5.9.3"
+    "ts-jest": "^29.4.11",
+    "typescript": "^6.0.3"
   },
   "nx": {
     "targets": {

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -17,10 +17,10 @@
     "useUnknownInCatchVariables": false,
     "jsx": "preserve",
     "types": ["@types/intercom-web", "jest"],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@styles/*": ["styles/*"]
+      "@/*": ["./src/*"],
+      "@styles/*": ["./styles/*"],
+      "tests/*": ["./tests/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,9 +57,9 @@
     "react": "^19.0.0",
     "react-devtools-core": "^7.0.1",
     "sqlstring": "^2.3.3",
-    "ts-jest": "^29.4.5",
+    "ts-jest": "^29.4.11",
     "tsup": "^8.4.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/common-utils/eslint.config.mjs
+++ b/packages/common-utils/eslint.config.mjs
@@ -17,6 +17,7 @@ export default [
       'coverage/**',
       '**/*.config.js',
       '**/*.config.mjs',
+      '**/*.config.ts',
       'jest.config.js',
       'jest.setup.ts',
     ],

--- a/packages/common-utils/package.json
+++ b/packages/common-utils/package.json
@@ -34,9 +34,9 @@
     "dotenv": "^17.2.3",
     "jest": "^30.2.0",
     "nodemon": "^2.0.20",
-    "ts-jest": "^29.4.5",
+    "ts-jest": "^29.4.11",
     "tsup": "^8.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "dev": "nodemon --on-change-only --watch ./src --ext ts --exec \"yarn dev:build\"",

--- a/packages/common-utils/tsconfig.json
+++ b/packages/common-utils/tsconfig.json
@@ -2,12 +2,13 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declarationMap": true,
-    "baseUrl": "./src",
+    "types": ["jest", "node"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     },
     "declaration": true,
     "isolatedModules": true,
+    "rootDir": "./src",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/common-utils/tsup.config.ts
+++ b/packages/common-utils/tsup.config.ts
@@ -3,7 +3,15 @@ import type { Options } from 'tsup';
 export const tsup: Options = {
   splitting: true,
   clean: true, // clean up the dist folder
-  dts: true, // generate dts files
+  dts: {
+    // tsup's DTS bundler (rollup-plugin-dts) unconditionally injects the
+    // `baseUrl` compiler option, which TypeScript 6 reports as deprecated
+    // (TS5101). Acknowledge the deprecation so DTS generation succeeds until
+    // tsup stops forcing baseUrl.
+    compilerOptions: {
+      ignoreDeprecations: '6.0',
+    },
+  }, // generate dts files
   format: ['cjs', 'esm'], // generate cjs and esm files
   minify: true,
   bundle: true,

--- a/packages/hdx-eval/package.json
+++ b/packages/hdx-eval/package.json
@@ -25,10 +25,10 @@
     "@types/node": "^22.15.18",
     "jest": "^30.2.0",
     "rimraf": "^4.4.1",
-    "ts-jest": "^29.4.5",
+    "ts-jest": "^29.4.11",
     "tsc-alias": "^1.8.8",
     "tsx": "^4.19.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "rimraf ./dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",

--- a/packages/hdx-eval/tsconfig.json
+++ b/packages/hdx-eval/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "moduleResolution": "Node",
-    "baseUrl": "./src",
+    "module": "node16",
+    "moduleResolution": "node16",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     },
     "types": ["jest", "node"],
     "outDir": "dist",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,6 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "dom"],
     "allowSyntheticDefaultImports": true,
-    "downlevelIteration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,11 +4503,11 @@ __metadata:
     supertest: "npm:^6.3.1"
     swagger-jsdoc: "npm:^6.2.8"
     swagger-ui-express: "npm:^5.0.1"
-    ts-jest: "npm:^29.4.5"
+    ts-jest: "npm:^29.4.11"
     ts-node: "npm:^10.8.1"
     tsc-alias: "npm:^1.8.8"
     tsconfig-paths: "npm:^4.2.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     uuid: "npm:^8.3.2"
     zod: "npm:3.25"
     zod-express-middleware: "npm:^1.4.0"
@@ -4636,8 +4636,8 @@ __metadata:
     stylelint-config-standard-scss: "npm:^16.0.0"
     stylelint-prettier: "npm:^5.0.3"
     timestamp-nano: "npm:^1.0.1"
-    ts-jest: "npm:^29.4.5"
-    typescript: "npm:^5.9.3"
+    ts-jest: "npm:^29.4.11"
+    typescript: "npm:^6.0.3"
     uplot: "npm:^1.6.31"
     uplot-react: "npm:^1.2.2"
     zod: "npm:3.25"
@@ -4676,10 +4676,10 @@ __metadata:
     react: "npm:^19.0.0"
     react-devtools-core: "npm:^7.0.1"
     sqlstring: "npm:^2.3.3"
-    ts-jest: "npm:^29.4.5"
+    ts-jest: "npm:^29.4.11"
     tsup: "npm:^8.4.0"
     tsx: "npm:^4.19.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   bin:
     hdx: dist/cli.js
   languageName: unknown
@@ -4709,9 +4709,9 @@ __metadata:
     object-hash: "npm:^3.0.0"
     sql-formatter: "npm:^15.7.2"
     sqlstring: "npm:^2.3.3"
-    ts-jest: "npm:^29.4.5"
+    ts-jest: "npm:^29.4.11"
     tsup: "npm:^8.4.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     zod: "npm:3.25"
   languageName: unknown
   linkType: soft
@@ -4730,10 +4730,10 @@ __metadata:
     jest: "npm:^30.2.0"
     ms: "npm:^2.1.3"
     rimraf: "npm:^4.4.1"
-    ts-jest: "npm:^29.4.5"
+    ts-jest: "npm:^29.4.11"
     tsc-alias: "npm:^1.8.8"
     tsx: "npm:^4.19.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   bin:
     hdx-eval: ./dist/cli.js
   languageName: unknown
@@ -17351,7 +17351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.8, handlebars@npm:^4.7.9":
+"handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -25395,6 +25395,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.8.0":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
 "semver@npm:~7.0.0":
   version: 7.0.0
   resolution: "semver@npm:7.0.0"
@@ -27377,17 +27386,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.4.5":
-  version: 29.4.5
-  resolution: "ts-jest@npm:29.4.5"
+"ts-jest@npm:^29.4.11":
+  version: 29.4.11
+  resolution: "ts-jest@npm:29.4.11"
   dependencies:
     bs-logger: "npm:^0.2.6"
     fast-json-stable-stringify: "npm:^2.1.0"
-    handlebars: "npm:^4.7.8"
+    handlebars: "npm:^4.7.9"
     json5: "npm:^2.2.3"
     lodash.memoize: "npm:^4.1.2"
     make-error: "npm:^1.3.6"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.8.0"
     type-fest: "npm:^4.41.0"
     yargs-parser: "npm:^21.1.1"
   peerDependencies:
@@ -27397,7 +27406,7 @@ __metadata:
     babel-jest: ^29.0.0 || ^30.0.0
     jest: ^29.0.0 || ^30.0.0
     jest-util: ^29.0.0 || ^30.0.0
-    typescript: ">=4.3 <6"
+    typescript: ">=4.3 <7"
   peerDependenciesMeta:
     "@babel/core":
       optional: true
@@ -27413,7 +27422,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 10c0/789f00666ba785ac425606d42601cbdc03015e46f228a0b333f06c6658d80865819bae0ddd59c762285352d2b14d0aa50912574ec699ba6369ddb0d400a49ac0
+  checksum: 10c0/f9e6ab3235f33088c4d6441da97d4b03b1fe9c21f4d859d7acf3f325ea36471a6c1ea9301f445b2670efa1a391dcddc31ecd8641a2d673752d074136311b8480
   languageName: node
   linkType: hard
 
@@ -27816,23 +27825,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Move the monorepo onto TypeScript 6 (latest stable, `6.0.3`) from `5.9`. TS 6 is
the transition release before TS 7 — it converts several soon-to-be-removed
compiler options into **deprecation errors**, so upgrading now surfaces and
lets us fix those ahead of the (breaking) TS 7 release. Staying on v6 for now,
not v7.

TypeScript is a `devDependency` in every package (build-time only, not shipped),
so there is no runtime behavior change for users.

## What changed

**Dependency**
- `typescript` → `^6.0.3` in all 5 packages.
- `ts-jest` → `^29.4.11` (its peer range now allows TS 6, and it no longer
  forces `node10` module resolution).

**TS 6 deprecations fixed at the source (not just silenced)**
- Removed no-op `downlevelIteration` from `tsconfig.base.json` (target is ES2022).
- Removed deprecated `baseUrl`; rewrote `paths` mappings to be relative to each
  tsconfig (api, app, common-utils, hdx-eval).
- Switched `hdx-eval` off deprecated `node10` resolution → `node16`.

**New TS 6 requirements**
- Added explicit `types: ["jest","node"]` + `rootDir` to `common-utils`
  (TS 6 changed auto-`@types` inclusion; hoisted root `@types` no longer
  auto-resolve).
- Added `tests/*` path mapping and a `css.d.ts` ambient shim for plain
  `.css`/`.scss` side-effect imports — Next 16 only ships `*.module.css` types
  and TS 6 now enforces `TS2882` for untyped side-effect imports.

**Tooling workarounds (scoped, documented)**
- `ts-jest` transforms (api, app): explicit `rootDir` — TS 6 requires it when
  compiling a file subset per-file (`TS5011`).
- api dev/e2e server runs via `ts-node`, which also hit `TS5011`; added a
  `ts-node.compilerOptions.rootDir` override (scoped to ts-node; the full `tsc`
  build keeps its multi-dir root).
- `tsup` still hardcodes the now-deprecated `baseUrl` in its DTS build
  ([egoist/tsup#1388](https://github.com/egoist/tsup/issues/1388), fix PR
  [#1390](https://github.com/egoist/tsup/pull/1390) still open), so its DTS
  transform sets `ignoreDeprecations: "6.0"`.
- `common-utils` eslint now ignores `*.config.ts` (parity with the existing
  `*.config.js`/`.mjs` ignores).

Relevant upstream: TS 6 deprecation list
[microsoft/TypeScript#54500](https://github.com/microsoft/TypeScript/issues/54500),
ts-jest TS 6 support
[kulshekhar/ts-jest#4198](https://github.com/kulshekhar/ts-jest/issues/4198)
(shipped in 29.4.11).

## Verification

- `make ci-lint` — ✅ 5 projects (lint + `tsc --noEmit`, 0 errors)
- `make ci-unit` — ✅ common-utils (1406), cli (8), app (2272), hdx-eval (211)
- Integration — ✅ api (`make dev-int`, 1716), common-utils (51)
- E2E (`make e2e`) — ✅ 223 passed; the ts-node `TS5011` was caught and fixed
  here. Remaining failures were all pre-existing flaky timeouts (unrelated to
  TS) that pass in isolation.
- Dev-mode dry run (`yarn dev`) — ✅ api (ts-node) `/health` 200, app (Next 16)
  ready, no TS errors.

## Notes

- Branch prefix is `brandon/` rather than `claude/`/`agent/` because the
  worktree/branch was set up ahead of time; happy to rename if triage prefers.
