### PR TITLE
feat: Allow custom order by on categorical (pie/bar) charts

### DIFF
--- a/.changeset/pie-bar-custom-order-by.md
+++ b/.changeset/pie-bar-custom-order-by.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": minor
+"@hyperdx/app": minor
+---
+
+feat: Add a custom ORDER BY input for Bar and Pie charts

--- a/.changeset/pie-bar-custom-order-by.md
+++ b/.changeset/pie-bar-custom-order-by.md
@@ -1,6 +1,7 @@
 ---
 "@hyperdx/common-utils": minor
 "@hyperdx/app": minor
+"@hyperdx/api": minor
 ---
 
 feat: Add a custom ORDER BY input for Bar and Pie charts

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1863,6 +1863,12 @@
             "description": "Field expression to group results by (one slice per group value).",
             "example": "service"
           },
+          "orderBy": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional custom SQL ORDER BY expression (raw SQL). Overrides the default value-descending ordering and, when combined with \"limit\", controls which slices are kept.\n",
+            "example": "\"Count\" DESC"
+          },
           "numberFormat": {
             "$ref": "#/components/schemas/NumberFormat",
             "description": "Number formatting options for displayed values."
@@ -1870,7 +1876,7 @@
           "limit": {
             "type": "integer",
             "minimum": 1,
-            "description": "Maximum number of slices (SQL LIMIT). The query keeps the groups with the largest aggregated values. Omit to fetch all groups.\n",
+            "description": "Maximum number of slices (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first slices in that order. Omit to fetch all groups.\n",
             "example": 10
           }
         }
@@ -1912,6 +1918,12 @@
             "description": "Field expression to group results by (one bar per group value).",
             "example": "service"
           },
+          "orderBy": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Optional custom SQL ORDER BY expression (raw SQL). Overrides the default value-descending ordering and, when combined with \"limit\", controls which bars are kept.\n",
+            "example": "\"Count\" DESC"
+          },
           "numberFormat": {
             "$ref": "#/components/schemas/NumberFormat",
             "description": "Number formatting options for displayed values."
@@ -1919,7 +1931,7 @@
           "limit": {
             "type": "integer",
             "minimum": 1,
-            "description": "Maximum number of bars (SQL LIMIT). The query keeps the groups with the largest aggregated values. Omit to fetch all groups.\n",
+            "description": "Maximum number of bars (SQL LIMIT). Without a custom \"orderBy\" the query keeps the groups with the largest aggregated values; with an \"orderBy\" it keeps the first bars in that order. Omit to fetch all groups.\n",
             "example": 10
           }
         }

--- a/packages/api/src/mcp/__tests__/dashboards/queryTile.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/queryTile.test.ts
@@ -247,21 +247,32 @@ describe('MCP Dashboard Tools - clickstack_query_tile', () => {
       await bulkInsertLogs(logs);
     });
 
-    const saveBarDashboard = async (limit?: number) => {
+    const saveCategoricalDashboard = async ({
+      displayType = 'bar',
+      limit,
+      orderBy,
+    }: {
+      displayType?: 'bar' | 'pie';
+      limit?: number;
+      orderBy?: string;
+    } = {}) => {
       const createResult = await callTool(
         ctx.client!,
         'clickstack_save_dashboard',
         {
-          name: `Bar Limit Dashboard ${limit ?? 'none'}`,
+          name: `Categorical ${displayType} Dashboard ${limit ?? 'none'} ${
+            orderBy ?? 'default-order'
+          }`,
           tiles: [
             {
-              name: 'Bars by service',
+              name: 'Groups by service',
               config: {
-                displayType: 'bar',
+                displayType,
                 sourceId: logSourceId,
                 select: [{ aggFn: 'count' }],
                 groupBy: 'ServiceName',
                 ...(limit != null ? { limit } : {}),
+                ...(orderBy != null ? { orderBy } : {}),
               },
             },
           ],
@@ -284,13 +295,13 @@ describe('MCP Dashboard Tools - clickstack_query_tile', () => {
     };
 
     it('returns every group when no limit is set', async () => {
-      const dashboard = await saveBarDashboard();
+      const dashboard = await saveCategoricalDashboard();
       const rows = await queryTileRows(dashboard);
       expect(rows).toHaveLength(SERVICE_COUNTS.length);
     });
 
     it('caps the bars to the series limit, keeping the largest groups', async () => {
-      const dashboard = await saveBarDashboard(3);
+      const dashboard = await saveCategoricalDashboard({ limit: 3 });
       const rows = await queryTileRows(dashboard);
 
       // The limit must actually reduce the result below the full set.
@@ -300,6 +311,51 @@ describe('MCP Dashboard Tools - clickstack_query_tile', () => {
       // And it must keep the top-3 by count, not an arbitrary subset.
       const services = rows.map(r => r.ServiceName).sort();
       expect(services).toEqual(['svc-a', 'svc-b', 'svc-c']);
+    });
+
+    it('applies a custom orderBy to a bar tile, driving the SQL result order', async () => {
+      const dashboard = await saveCategoricalDashboard({
+        orderBy: 'ServiceName ASC',
+      });
+      const rows = await queryTileRows(dashboard);
+
+      // Every group is returned, ordered ascending by ServiceName rather than
+      // by the aggregated count.
+      expect(rows.map(r => r.ServiceName)).toEqual([
+        'svc-a',
+        'svc-b',
+        'svc-c',
+        'svc-d',
+        'svc-e',
+      ]);
+    });
+
+    it('lets a custom orderBy override the default value-descending ordering when a limit is applied', async () => {
+      // ServiceName DESC + LIMIT 3 keeps the alphabetically-last three
+      // services (svc-e, svc-d, svc-c). The default value-descending ordering
+      // would instead keep the highest-count three (svc-a, svc-b, svc-c), so
+      // the differing result proves the custom orderBy overrides the default
+      // and controls which groups survive the limit.
+      const dashboard = await saveCategoricalDashboard({
+        limit: 3,
+        orderBy: 'ServiceName DESC',
+      });
+      const rows = await queryTileRows(dashboard);
+
+      expect(rows).toHaveLength(3);
+      expect(rows.map(r => r.ServiceName)).toEqual(['svc-e', 'svc-d', 'svc-c']);
+    });
+
+    it('applies a custom orderBy to a pie tile with a limit', async () => {
+      const dashboard = await saveCategoricalDashboard({
+        displayType: 'pie',
+        limit: 3,
+        orderBy: 'ServiceName DESC',
+      });
+      const rows = await queryTileRows(dashboard);
+
+      expect(rows).toHaveLength(3);
+      expect(rows.map(r => r.ServiceName)).toEqual(['svc-e', 'svc-d', 'svc-c']);
     });
   });
 });

--- a/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/saveDashboard.test.ts
@@ -964,6 +964,7 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
         sourceId,
         select: [{ aggFn: 'count' as const, alias: 'Requests' }],
         groupBy: 'SpanName',
+        orderBy: 'SpanName ASC',
         numberFormat,
         limit: 5,
       };
@@ -972,6 +973,7 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
         sourceId,
         select: [{ aggFn: 'count' as const, alias: 'Requests' }],
         groupBy: 'SpanName',
+        orderBy: '"Requests" DESC',
         numberFormat,
         limit: 5,
       };

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -631,6 +631,15 @@ const mcpPieTileSchema = mcpTileLayoutSchema.extend({
         'Column that defines pie slices. Use PascalCase for top-level columns. ' +
           "For attributes: SpanAttributes['key'] or ResourceAttributes['key'].",
       ),
+    orderBy: z
+      .string()
+      .optional()
+      .describe(
+        'Optional custom SQL ORDER BY expression. Overrides the default ' +
+          'value-descending ordering and, combined with `limit`, controls which ' +
+          'slices are kept. When ordering by an alias that contains spaces or ' +
+          `special characters, wrap the alias in quotes: e.g. '"P95 Latency" DESC'.`,
+      ),
     numberFormat: mcpNumberFormatSchema
       .optional()
       .describe(tileLevelNumberFormatDescription),
@@ -640,8 +649,9 @@ const mcpPieTileSchema = mcpTileLayoutSchema.extend({
       .positive()
       .optional()
       .describe(
-        'Maximum number of slices (SQL LIMIT). Keeps the top-N groups by the ' +
-          'aggregated value, descending. Omit to fetch all groups.',
+        'Maximum number of slices (SQL LIMIT). Without a custom `orderBy`, keeps ' +
+          'the top-N groups by the aggregated value, descending; with an `orderBy` ' +
+          'keeps the first N in that order. Omit to fetch all groups.',
       ),
   }),
 });
@@ -663,6 +673,15 @@ const mcpCategoricalBarTileSchema = mcpTileLayoutSchema.extend({
         'Column(s) that define the bars. Use PascalCase for top-level columns. ' +
           "For attributes: SpanAttributes['key'] or ResourceAttributes['key'].",
       ),
+    orderBy: z
+      .string()
+      .optional()
+      .describe(
+        'Optional custom SQL ORDER BY expression. Overrides the default ' +
+          'value-descending ordering and, combined with `limit`, controls which ' +
+          'bars are kept. When ordering by an alias that contains spaces or ' +
+          `special characters, wrap the alias in quotes: e.g. '"P95 Latency" DESC'.`,
+      ),
     numberFormat: mcpNumberFormatSchema
       .optional()
       .describe(tileLevelNumberFormatDescription),
@@ -672,8 +691,9 @@ const mcpCategoricalBarTileSchema = mcpTileLayoutSchema.extend({
       .positive()
       .optional()
       .describe(
-        'Maximum number of bars (SQL LIMIT). Keeps the top-N groups by the ' +
-          'aggregated value, descending. Omit to fetch all groups.',
+        'Maximum number of bars (SQL LIMIT). Without a custom `orderBy`, keeps ' +
+          'the top-N groups by the aggregated value, descending; with an `orderBy` ' +
+          'keeps the first N in that order. Omit to fetch all groups.',
       ),
   }),
 });

--- a/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.test.ts
@@ -2196,6 +2196,7 @@ describe('External API v2 Dashboards - new format', () => {
             },
           ],
           groupBy: 'service.name',
+          orderBy: '"Median Duration" ASC',
           numberFormat: {
             output: 'number',
             mantissa: 2,
@@ -2224,6 +2225,7 @@ describe('External API v2 Dashboards - new format', () => {
             },
           ],
           groupBy: 'service.name',
+          orderBy: '"Median Duration" ASC',
           numberFormat: {
             output: 'number',
             mantissa: 2,
@@ -2511,6 +2513,116 @@ describe('External API v2 Dashboards - new format', () => {
       expect(omit(response.body.data.tiles[8], ['id'])).toEqual(
         categoricalBarChart,
       );
+    });
+
+    it('persists a custom orderBy on pie and categorical bar tiles through create and get', async () => {
+      // Arrange: pie and bar tiles carrying a custom ORDER BY that differs from
+      // the default value-descending ordering the charts apply client-side.
+      const pieChart: ExternalDashboardTile = {
+        name: 'Pie with custom order',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'pie',
+          sourceId: traceSource._id.toString(),
+          select: [
+            {
+              aggFn: 'count',
+              alias: 'Count',
+              where: '',
+              whereLanguage: 'sql',
+            },
+          ],
+          groupBy: 'ServiceName',
+          orderBy: 'ServiceName ASC',
+          limit: 5,
+        },
+      };
+
+      const barChart: ExternalDashboardTile = {
+        name: 'Bar with custom order',
+        x: 6,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'bar',
+          sourceId: traceSource._id.toString(),
+          select: [
+            {
+              aggFn: 'count',
+              alias: 'Count',
+              where: '',
+              whereLanguage: 'sql',
+            },
+          ],
+          groupBy: 'ServiceName',
+          orderBy: '"Count" DESC',
+          limit: 5,
+        },
+      };
+
+      // Act: create the dashboard
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard with custom categorical ordering',
+          tiles: [pieChart, barChart],
+        })
+        .expect(200);
+
+      // Assert: create response echoes the custom orderBy back
+      expect(createResponse.body.data.tiles[0].config.orderBy).toBe(
+        'ServiceName ASC',
+      );
+      expect(createResponse.body.data.tiles[1].config.orderBy).toBe(
+        '"Count" DESC',
+      );
+
+      // Assert: the orderBy survives a round-trip through persistence (GET)
+      const { id } = createResponse.body.data;
+      const getResponse = await authRequest('get', `${BASE_URL}/${id}`).expect(
+        200,
+      );
+      expect(getResponse.body.data.tiles[0].config.orderBy).toBe(
+        'ServiceName ASC',
+      );
+      expect(getResponse.body.data.tiles[1].config.orderBy).toBe(
+        '"Count" DESC',
+      );
+    });
+
+    it('omits orderBy on pie/bar tiles when it is not provided', async () => {
+      const pieChart: ExternalDashboardTile = {
+        name: 'Pie without order',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 3,
+        config: {
+          displayType: 'pie',
+          sourceId: traceSource._id.toString(),
+          select: [
+            {
+              aggFn: 'count',
+              alias: 'Count',
+              where: '',
+              whereLanguage: 'sql',
+            },
+          ],
+          groupBy: 'ServiceName',
+        },
+      };
+
+      const response = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard without categorical ordering',
+          tiles: [pieChart],
+        })
+        .expect(200);
+
+      expect(response.body.data.tiles[0].config).not.toHaveProperty('orderBy');
     });
 
     // Schema-level rejections that exercise pure Zod constraints

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -809,6 +809,14 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           maxLength: 10000
  *           description: Field expression to group results by (one slice per group value).
  *           example: "service"
+ *         orderBy:
+ *           type: string
+ *           maxLength: 10000
+ *           description: >
+ *             Optional custom SQL ORDER BY expression (raw SQL). Overrides the
+ *             default value-descending ordering and, when combined with
+ *             "limit", controls which slices are kept.
+ *           example: "\"Count\" DESC"
  *         numberFormat:
  *           $ref: '#/components/schemas/NumberFormat'
  *           description: Number formatting options for displayed values.
@@ -816,9 +824,10 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           type: integer
  *           minimum: 1
  *           description: >
- *             Maximum number of slices (SQL LIMIT). The query keeps the
- *             groups with the largest aggregated values. Omit to fetch all
- *             groups.
+ *             Maximum number of slices (SQL LIMIT). Without a custom "orderBy"
+ *             the query keeps the groups with the largest aggregated values;
+ *             with an "orderBy" it keeps the first slices in that order. Omit
+ *             to fetch all groups.
  *           example: 10
  *
  *     CategoricalBarBuilderChartConfig:
@@ -853,6 +862,14 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           maxLength: 10000
  *           description: Field expression to group results by (one bar per group value).
  *           example: "service"
+ *         orderBy:
+ *           type: string
+ *           maxLength: 10000
+ *           description: >
+ *             Optional custom SQL ORDER BY expression (raw SQL). Overrides the
+ *             default value-descending ordering and, when combined with
+ *             "limit", controls which bars are kept.
+ *           example: "\"Count\" DESC"
  *         numberFormat:
  *           $ref: '#/components/schemas/NumberFormat'
  *           description: Number formatting options for displayed values.
@@ -860,8 +877,10 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           type: integer
  *           minimum: 1
  *           description: >
- *             Maximum number of bars (SQL LIMIT). The query keeps the groups
- *             with the largest aggregated values. Omit to fetch all groups.
+ *             Maximum number of bars (SQL LIMIT). Without a custom "orderBy"
+ *             the query keeps the groups with the largest aggregated values;
+ *             with an "orderBy" it keeps the first bars in that order. Omit to
+ *             fetch all groups.
  *           example: 10
  *
  *     HeatmapSelectItem:

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -350,6 +350,7 @@ const convertToExternalTileChartConfig = (
           ? [convertToExternalSelectItem(config.select[0])]
           : [DEFAULT_SELECT_ITEM],
         groupBy: stringValueOrDefault(config.groupBy, undefined),
+        orderBy: stringValueOrDefault(config.orderBy, undefined),
         numberFormat: config.numberFormat,
         limit: config.seriesLimit ?? undefined,
       };
@@ -361,6 +362,7 @@ const convertToExternalTileChartConfig = (
           ? [convertToExternalSelectItem(config.select[0])]
           : [DEFAULT_SELECT_ITEM],
         groupBy: stringValueOrDefault(config.groupBy, undefined),
+        orderBy: stringValueOrDefault(config.orderBy, undefined),
         numberFormat: config.numberFormat,
         limit: config.seriesLimit ?? undefined,
       };
@@ -744,7 +746,7 @@ export function convertToInternalTileConfig(
       case 'pie':
       case 'bar':
         internalConfig = {
-          ...pick(externalConfig, ['groupBy', 'numberFormat']),
+          ...pick(externalConfig, ['groupBy', 'numberFormat', 'orderBy']),
           displayType:
             externalConfig.displayType === 'bar'
               ? DisplayType.Bar

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -371,6 +371,7 @@ const externalDashboardPieChartConfigSchema = z.object({
   sourceId: objectIdSchema,
   select: z.array(externalDashboardSelectItemSchema).length(1),
   groupBy: z.string().max(10000).optional(),
+  orderBy: z.string().max(10000).optional(),
   numberFormat: NumberFormatSchema.optional(),
   limit: z.number().int().positive().optional(),
 });
@@ -380,6 +381,7 @@ const externalDashboardCategoricalBarChartConfigSchema = z.object({
   sourceId: objectIdSchema,
   select: z.array(externalDashboardSelectItemSchema).length(1),
   groupBy: z.string().max(10000).optional(),
+  orderBy: z.string().max(10000).optional(),
   numberFormat: NumberFormatSchema.optional(),
   limit: z.number().int().positive().optional(),
 });

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -422,9 +422,12 @@ function inferGroupColumns(meta: Array<{ name: string; type: string }>) {
   ]);
 }
 
+const DEFAULT_MAX_CATEGORICAL_GROUPS = 500;
+
 export function formatResponseForCategoricalChart(
   data: ResponseJSON<Record<string, unknown>>,
   getColor: (index: number, label: string) => string,
+  applyDefaultOrder: boolean = true,
 ): Array<{ label: string; value: number; color: string }> {
   if (data.meta == null) {
     throw new Error('No meta data found in response');
@@ -442,27 +445,31 @@ export function formatResponseForCategoricalChart(
 
   const groupByColumns = inferGroupColumns(data.meta);
 
-  return (
-    data.data
-      .map(row => {
-        const label = groupByColumns?.length
-          ? groupByColumns.map(({ name }) => row[name]).join(' - ')
-          : valueColumn;
-        const rawValue = row[valueColumn];
-        const value =
-          typeof rawValue === 'number'
-            ? rawValue
-            : Number.parseFloat(`${rawValue}`);
-        return { label, value };
-      })
-      .filter(entry => !isNaN(entry.value) && isFinite(entry.value))
-      // Sort in descending order so the largest entry is always first and gets the first color in the palette
-      .sort((a, b) => b.value - a.value)
-      .map((entry, index) => ({
-        ...entry,
-        color: getColor(index, entry.label),
-      }))
-  );
+  const labelsAndValues = data.data
+    .map(row => {
+      const label = groupByColumns?.length
+        ? groupByColumns.map(({ name }) => row[name]).join(' - ')
+        : valueColumn;
+      const rawValue = row[valueColumn];
+      const value =
+        typeof rawValue === 'number'
+          ? rawValue
+          : Number.parseFloat(`${rawValue}`);
+      return { label, value };
+    })
+    .filter(entry => !isNaN(entry.value) && isFinite(entry.value));
+
+  if (applyDefaultOrder) {
+    // Sort in descending order so the largest entry is always first and gets the first color in the palette
+    labelsAndValues.sort((a, b) => b.value - a.value);
+  }
+
+  return labelsAndValues
+    .slice(0, DEFAULT_MAX_CATEGORICAL_GROUPS)
+    .map((entry, index) => ({
+      ...entry,
+      color: getColor(index, entry.label),
+    }));
 }
 
 export function getPreviousDateRange(currentRange: [Date, Date]): [Date, Date] {

--- a/packages/app/src/__tests__/ChartUtils.test.ts
+++ b/packages/app/src/__tests__/ChartUtils.test.ts
@@ -1045,6 +1045,59 @@ describe('ChartUtils', () => {
       expect(result[1]).toMatchObject({ label: 'b', color: 'color-1-b' });
     });
 
+    it('preserves the input row order and index-based colors when applyDefaultOrder is false', () => {
+      // Rows are intentionally NOT in descending-by-value order. With
+      // applyDefaultOrder=false (the custom ORDER BY render path), the server
+      // has already ordered the rows, so the function must not re-sort them and
+      // must assign palette colors by the incoming row index.
+      const result = formatResponseForCategoricalChart(
+        {
+          data: [
+            { 'count()': 3, ServiceName: 'c' },
+            { 'count()': 10, ServiceName: 'a' },
+            { 'count()': 1, ServiceName: 'b' },
+          ],
+          meta: [
+            { name: 'count()', type: 'UInt64' },
+            { name: 'ServiceName', type: 'LowCardinality(String)' },
+          ],
+        },
+        getColor,
+        false,
+      );
+
+      // Row order is preserved exactly as provided (no descending re-sort).
+      expect(result).toEqual([
+        { label: 'c', value: 3, color: 'color-0-c' },
+        { label: 'a', value: 10, color: 'color-1-a' },
+        { label: 'b', value: 1, color: 'color-2-b' },
+      ]);
+    });
+
+    it('still sorts descending when applyDefaultOrder is explicitly true', () => {
+      const result = formatResponseForCategoricalChart(
+        {
+          data: [
+            { 'count()': 3, ServiceName: 'c' },
+            { 'count()': 10, ServiceName: 'a' },
+            { 'count()': 1, ServiceName: 'b' },
+          ],
+          meta: [
+            { name: 'count()', type: 'UInt64' },
+            { name: 'ServiceName', type: 'LowCardinality(String)' },
+          ],
+        },
+        getColor,
+        true,
+      );
+
+      expect(result).toEqual([
+        { label: 'a', value: 10, color: 'color-0-a' },
+        { label: 'c', value: 3, color: 'color-1-c' },
+        { label: 'b', value: 1, color: 'color-2-b' },
+      ]);
+    });
+
     it('uses only the first numeric column as the value column', () => {
       const result = formatResponseForCategoricalChart(
         {

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -46,8 +46,9 @@ function normalizeChartConfig<
     // Order By and Having can only be set by the user for table charts
     having:
       config.displayType === DisplayType.Table ? config.having : undefined,
-    orderBy:
-      config.displayType === DisplayType.Table ? config.orderBy : undefined,
+    orderBy: isCustomOrderByDisplayType(config.displayType)
+      ? config.orderBy
+      : undefined,
     onClick:
       config.onClick && config.displayType === DisplayType.Table
         ? config.onClick
@@ -97,6 +98,13 @@ export const isPromqlDisplayType = (
   displayType === DisplayType.Pie ||
   displayType === DisplayType.Bar ||
   displayType === DisplayType.Number;
+
+const isCustomOrderByDisplayType = (
+  displayType: DisplayType | undefined,
+): displayType is DisplayType.Table | DisplayType.Bar | DisplayType.Pie =>
+  displayType === DisplayType.Table ||
+  displayType === DisplayType.Bar ||
+  displayType === DisplayType.Pie;
 
 export function convertFormStateToSavedChartConfig(
   form: ChartEditorFormState,

--- a/packages/app/src/components/DBEditTimeChartForm/ChartActionBar.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartActionBar.tsx
@@ -78,21 +78,24 @@ export function ChartActionBar({
         )}
       </Flex>
       <Flex gap="sm" mb="sm" align="center" justify="end">
-        {activeTab === 'table' && !isRawSqlInput && (
-          <div style={{ width: 400 }}>
-            <SQLInlineEditorControlled
-              parentRef={parentRef}
-              tableConnection={tableConnection}
-              // The default order by is the current group by value
-              placeholder={typeof groupBy === 'string' ? groupBy : ''}
-              control={control}
-              name={`orderBy`}
-              disableKeywordAutocomplete
-              onSubmit={onSubmit}
-              label="ORDER BY"
-            />
-          </div>
-        )}
+        {(activeTab === 'table' ||
+          activeTab === 'pie' ||
+          activeTab === 'bar') &&
+          !isRawSqlInput && (
+            <div style={{ width: 400 }} data-testid="order-by-input">
+              <SQLInlineEditorControlled
+                parentRef={parentRef}
+                tableConnection={tableConnection}
+                // The default order by is the current group by value
+                placeholder={typeof groupBy === 'string' ? groupBy : ''}
+                control={control}
+                name={`orderBy`}
+                disableKeywordAutocomplete
+                onSubmit={onSubmit}
+                label="ORDER BY"
+              />
+            </div>
+          )}
         {activeTab !== 'markdown' &&
           setDisplayedTimeInputValue != null &&
           displayedTimeInputValue != null &&

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartActionBar.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartActionBar.test.tsx
@@ -185,6 +185,30 @@ describe('ChartActionBar', () => {
     expect(screen.queryByTestId('sql-editor-order-by')).not.toBeInTheDocument();
   });
 
+  it('should render ORDER BY editor for pie tab when not raw SQL', () => {
+    renderActionBar({ activeTab: 'pie', isRawSqlInput: false });
+
+    expect(screen.getByTestId('sql-editor-order-by')).toBeInTheDocument();
+  });
+
+  it('should render ORDER BY editor for bar tab when not raw SQL', () => {
+    renderActionBar({ activeTab: 'bar', isRawSqlInput: false });
+
+    expect(screen.getByTestId('sql-editor-order-by')).toBeInTheDocument();
+  });
+
+  it('should not render ORDER BY editor for pie tab when raw SQL', () => {
+    renderActionBar({ activeTab: 'pie', isRawSqlInput: true });
+
+    expect(screen.queryByTestId('sql-editor-order-by')).not.toBeInTheDocument();
+  });
+
+  it('should not render ORDER BY editor for time tab', () => {
+    renderActionBar({ activeTab: 'time' });
+
+    expect(screen.queryByTestId('sql-editor-order-by')).not.toBeInTheDocument();
+  });
+
   it('should render TimePicker when time range props are provided', () => {
     renderActionBar({
       displayedTimeInputValue: 'Last 24h',

--- a/packages/app/src/components/charts/CategoricalChart.tsx
+++ b/packages/app/src/components/charts/CategoricalChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { hasNonEmptyOrderBy } from '@hyperdx/common-utils/dist/core/utils';
 import { isBuilderChartConfig } from '@hyperdx/common-utils/dist/guards';
 import { ChartConfigWithOptTimestamp } from '@hyperdx/common-utils/dist/types';
 
@@ -113,8 +114,7 @@ export function useCategoricalChart({
     try {
       const hasOrderBy =
         isBuilderChartConfig(queriedConfig) &&
-        typeof queriedConfig.orderBy === 'string' &&
-        !!queriedConfig.orderBy?.trim();
+        hasNonEmptyOrderBy(queriedConfig.orderBy);
 
       return [
         formatResponseForCategoricalChart(data, getColorProps, !hasOrderBy),

--- a/packages/app/src/components/charts/CategoricalChart.tsx
+++ b/packages/app/src/components/charts/CategoricalChart.tsx
@@ -111,11 +111,19 @@ export function useCategoricalChart({
   >(() => {
     if (!data) return [[], null];
     try {
-      return [formatResponseForCategoricalChart(data, getColorProps), null];
+      const hasOrderBy =
+        isBuilderChartConfig(queriedConfig) &&
+        typeof queriedConfig.orderBy === 'string' &&
+        !!queriedConfig.orderBy?.trim();
+
+      return [
+        formatResponseForCategoricalChart(data, getColorProps, !hasOrderBy),
+        null,
+      ];
     } catch (error) {
       return [[], error instanceof Error ? error : new Error(String(error))];
     }
-  }, [data]);
+  }, [data, queriedConfig]);
 
   return {
     resolvedNumberFormat,

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -71,6 +71,25 @@ export class ChartEditorComponent {
   }
 
   /**
+   * Set a custom ORDER BY expression in the chart editor's ORDER BY input.
+   * Available on the Table, Pie, and Bar display types. Clears any existing
+   * value first, then types the new expression and dismisses the autocomplete
+   * popup so it doesn't swallow the following interaction.
+   */
+  async setOrderBy(expression: string) {
+    const editor = this.page
+      .getByTestId('order-by-input')
+      .locator('.cm-content');
+    await editor.click();
+    // Clear any existing content before typing the new expression.
+    await this.page.keyboard.press('ControlOrMeta+A');
+    await this.page.keyboard.press('Delete');
+    await this.page.keyboard.type(expression);
+    // Dismiss the autocomplete dropdown so it doesn't intercept the next click.
+    await this.page.keyboard.press('Escape');
+  }
+
+  /**
    * Select a data source
    */
   async selectSource(sourceName: string) {

--- a/packages/app/tests/e2e/features/chart-explorer.spec.ts
+++ b/packages/app/tests/e2e/features/chart-explorer.spec.ts
@@ -97,4 +97,119 @@ test.describe('Chart Explorer Functionality', { tag: ['@charts'] }, () => {
       expect(seriesLimit).toBeLessThan(totalBars);
     });
   });
+
+  test('should apply a custom ORDER BY on a categorical bar chart', async () => {
+    let ascendingLabels: string[] = [];
+    let descendingLabels: string[] = [];
+
+    await test.step('Verify chart configuration form is accessible', async () => {
+      await expect(chartExplorerPage.form).toBeVisible();
+      await chartExplorerPage.page.waitForLoadState('networkidle');
+    });
+
+    await test.step('Select the Bar chart type and group by ServiceName', async () => {
+      await chartExplorerPage.chartEditor.setChartType(DisplayType.Bar);
+      await chartExplorerPage.chartEditor.setGroupBy('ServiceName');
+    });
+
+    await test.step('Order by ServiceName ascending and capture the bar order', async () => {
+      await chartExplorerPage.chartEditor.setOrderBy('ServiceName ASC');
+      await chartExplorerPage.chartEditor.runQuery();
+      await expect(chartExplorerPage.getBars().first()).toBeVisible({
+        timeout: 15000,
+      });
+
+      ascendingLabels = await chartExplorerPage.getBarLabels();
+      // Need at least two distinct bars for the ordering to be observable.
+      expect(ascendingLabels.length).toBeGreaterThan(1);
+    });
+
+    await test.step('Order by ServiceName descending and verify the order is reversed', async () => {
+      await chartExplorerPage.chartEditor.setOrderBy('ServiceName DESC');
+      await chartExplorerPage.chartEditor.runQuery();
+
+      // The descending result must be the exact reverse of the ascending one,
+      // proving the custom ORDER BY is driving the SQL query ordering.
+      await expect
+        .poll(async () => chartExplorerPage.getBarLabels(), { timeout: 10000 })
+        .toEqual([...ascendingLabels].reverse());
+
+      descendingLabels = await chartExplorerPage.getBarLabels();
+    });
+
+    await test.step('Apply a series limit and confirm the custom order still drives which bars are kept', async () => {
+      const seriesLimit = 3;
+      await chartExplorerPage.chartEditor.setSeriesLimit(seriesLimit);
+      await chartExplorerPage.chartEditor.runQuery();
+
+      await expect
+        .poll(async () => chartExplorerPage.getBars().count(), {
+          timeout: 10000,
+        })
+        .toBe(seriesLimit);
+
+      // With ServiceName DESC + LIMIT 3, the kept bars must be the first three
+      // of the descending order — not the three largest by value. This proves
+      // the custom ORDER BY overrides the default value-descending ordering and
+      // is honored alongside the series limit.
+      await expect
+        .poll(async () => chartExplorerPage.getBarLabels(), { timeout: 10000 })
+        .toEqual(descendingLabels.slice(0, seriesLimit));
+    });
+  });
+
+  test('should apply a custom ORDER BY on a categorical pie chart', async () => {
+    let ascendingLabels: string[] = [];
+    let descendingLabels: string[] = [];
+
+    await test.step('Verify chart configuration form is accessible', async () => {
+      await expect(chartExplorerPage.form).toBeVisible();
+      await chartExplorerPage.page.waitForLoadState('networkidle');
+    });
+
+    await test.step('Select the Pie chart type and group by ServiceName', async () => {
+      await chartExplorerPage.chartEditor.setChartType(DisplayType.Pie);
+      await chartExplorerPage.chartEditor.setGroupBy('ServiceName');
+    });
+
+    await test.step('Order by ServiceName ascending and capture the legend order', async () => {
+      await chartExplorerPage.chartEditor.setOrderBy('ServiceName ASC');
+      await chartExplorerPage.chartEditor.runQuery();
+
+      ascendingLabels = await chartExplorerPage.getPieLegendLabels();
+      // Need at least two distinct slices for the ordering to be observable.
+      expect(ascendingLabels.length).toBeGreaterThan(1);
+    });
+
+    await test.step('Order by ServiceName descending and verify the order is reversed', async () => {
+      await chartExplorerPage.chartEditor.setOrderBy('ServiceName DESC');
+      await chartExplorerPage.chartEditor.runQuery();
+
+      // The descending result must be the exact reverse of the ascending one,
+      // proving the custom ORDER BY is driving the SQL query ordering.
+      await expect
+        .poll(async () => chartExplorerPage.getPieLegendLabels(), {
+          timeout: 10000,
+        })
+        .toEqual([...ascendingLabels].reverse());
+
+      descendingLabels = await chartExplorerPage.getPieLegendLabels();
+    });
+
+    await test.step('Apply a series limit and confirm the custom order still drives which slices are kept', async () => {
+      const seriesLimit = 3;
+      await chartExplorerPage.chartEditor.setSeriesLimit(seriesLimit);
+      await chartExplorerPage.chartEditor.runQuery();
+
+      // With ServiceName DESC + LIMIT 3, the kept slices must be the first
+      // three of the descending order — not the three largest by value. This
+      // proves the custom ORDER BY overrides the default value-descending
+      // ordering and is honored alongside the series limit.
+      await expect
+        .poll(async () => chartExplorerPage.getPieLegendLabels(), {
+          timeout: 10000,
+        })
+        .toEqual(descendingLabels.slice(0, seriesLimit));
+    });
+  });
 });

--- a/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
+++ b/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
@@ -48,6 +48,37 @@ export class ChartExplorerPage {
     );
   }
 
+  /**
+   * Read the x-axis category labels of the bar chart in the order they are
+   * rendered (left to right), which reflects the order of the underlying
+   * query result. Labels may be truncated with an ellipsis by the chart.
+   */
+  async getBarLabels(): Promise<string[]> {
+    const ticks = this.page.locator(
+      '[data-testid="bar-chart-container"] .recharts-xAxis .recharts-cartesian-axis-tick-value',
+    );
+    await ticks.first().waitFor({ state: 'visible', timeout: 15000 });
+    const labels = await ticks.allTextContents();
+    return labels.map(l => l.trim());
+  }
+
+  /**
+   * Read the legend labels of the pie chart in the order they are rendered
+   * (top to bottom), which reflects the order of the underlying query result.
+   */
+  async getPieLegendLabels(): Promise<string[]> {
+    const legend = this.page.locator('[data-testid="pie-chart-legend"]');
+    await legend.waitFor({ state: 'visible', timeout: 15000 });
+    // Each legend row renders its label in a <p> (Mantine Text) that carries a
+    // `title` attribute equal to the full, untruncated label.
+    const titles = await legend
+      .locator('[title]')
+      .evaluateAll(nodes =>
+        nodes.map(n => (n.getAttribute('title') ?? '').trim()),
+      );
+    return titles.filter(t => t.length > 0);
+  }
+
   // Getters for assertions
 
   get form() {

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -337,7 +337,7 @@ describe('utils', () => {
       expect(convertedConfig.limit).toEqual({ limit: 3 });
     });
 
-    it('should override an explicit orderBy with the value-descending default when a limit is set', () => {
+    it('should preserve a user-supplied string orderBy over the value-descending default when a limit is set', () => {
       const config = {
         select: [{ aggFn: 'count', valueExpression: '' }],
         groupBy: 'ServiceName',
@@ -348,14 +348,64 @@ describe('utils', () => {
 
       const convertedConfig = convertToCategoricalChartConfig(config);
 
-      // A limit forces the value-descending ordering so the kept bars/slices
-      // are deterministically the largest, regardless of any prior orderBy.
+      // The user's explicit ORDER BY wins; the limit then keeps the top rows
+      // according to that ordering rather than the value-descending default.
+      expect(convertedConfig.orderBy).toEqual('ServiceName ASC');
+      expect(convertedConfig.limit).toEqual({ limit: 5 });
+      // The default value alias is only injected when we synthesize an
+      // ordering, so an untouched series keeps no alias.
+      expect(convertedConfig.select[0]).not.toHaveProperty('alias');
+    });
+
+    it('should preserve a user-supplied array orderBy over the value-descending default when a limit is set', () => {
+      const config = {
+        select: [{ aggFn: 'count', valueExpression: '' }],
+        groupBy: 'ServiceName',
+        seriesLimit: 5,
+        orderBy: [
+          { valueExpression: 'ServiceName', ordering: 'DESC' as const },
+        ],
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      const convertedConfig = convertToCategoricalChartConfig(config);
+
+      expect(convertedConfig.orderBy).toEqual([
+        { valueExpression: 'ServiceName', ordering: 'DESC' },
+      ]);
+      expect(convertedConfig.limit).toEqual({ limit: 5 });
+    });
+
+    it('should preserve a user-supplied orderBy even when no limit is set', () => {
+      const config = {
+        select: [{ aggFn: 'count', valueExpression: '' }],
+        groupBy: 'ServiceName',
+        orderBy: 'ServiceName ASC',
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      const convertedConfig = convertToCategoricalChartConfig(config);
+
+      expect(convertedConfig.orderBy).toEqual('ServiceName ASC');
+      expect(convertedConfig.limit).toBeUndefined();
+    });
+
+    it('should inject the value-descending default when the user orderBy is an empty string', () => {
+      const config = {
+        select: [{ aggFn: 'count', valueExpression: '' }],
+        groupBy: 'ServiceName',
+        seriesLimit: 5,
+        orderBy: '',
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      const convertedConfig = convertToCategoricalChartConfig(config);
+
       expect(convertedConfig.orderBy).toEqual([
         { valueExpression: '"Value"', ordering: 'DESC' },
         { valueExpression: 'ServiceName', ordering: 'ASC' },
       ]);
       expect(convertedConfig.limit).toEqual({ limit: 5 });
-      expect(convertedConfig.select[0]).toMatchObject({ alias: 'Value' });
     });
 
     it('should inject the value-descending ordering for ratio configs too', () => {

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getAlignedDateRange,
   getDistributedTableArgs,
   getFirstOrderingItem,
+  hasNonEmptyOrderBy,
   isFirstOrderByAscending,
   isJsonExpression,
   isTimestampExpressionInFirstOrderBy,
@@ -465,6 +466,40 @@ describe('utils', () => {
       expect(config.select[0]).not.toHaveProperty('alias');
       expect(config.orderBy).toBeUndefined();
       expect(config.limit).toBeUndefined();
+    });
+  });
+
+  describe('hasCategoricalUserOrderBy', () => {
+    it('returns false for undefined', () => {
+      expect(hasNonEmptyOrderBy(undefined)).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(hasNonEmptyOrderBy(null)).toBe(false);
+    });
+
+    it('returns false for an empty string', () => {
+      expect(hasNonEmptyOrderBy('')).toBe(false);
+    });
+
+    it('returns false for a whitespace-only string', () => {
+      expect(hasNonEmptyOrderBy('   ')).toBe(false);
+    });
+
+    it('returns true for a non-empty string', () => {
+      expect(hasNonEmptyOrderBy('ServiceName ASC')).toBe(true);
+    });
+
+    it('returns false for an empty array', () => {
+      expect(hasNonEmptyOrderBy([])).toBe(false);
+    });
+
+    it('returns true for a non-empty array of sort specifications', () => {
+      expect(
+        hasNonEmptyOrderBy([
+          { valueExpression: 'ServiceName', ordering: 'DESC' },
+        ]),
+      ).toBe(true);
     });
   });
 

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -23,6 +23,7 @@ import {
   QuerySettings,
   RawSqlChartConfig,
   SavedChartConfig,
+  SortSpecificationList,
   SQLInterval,
   TileTemplateSchema,
   TSource,
@@ -734,6 +735,17 @@ export function convertToDashboardDocument(
   return output;
 }
 
+export function hasNonEmptyOrderBy(
+  orderBy: SortSpecificationList | undefined | null,
+): boolean {
+  if (orderBy == null) {
+    return false;
+  }
+  return typeof orderBy === 'string'
+    ? orderBy.trim().length > 0
+    : orderBy.length > 0;
+}
+
 /**
  * Normalize a builder chart config for categorical (pie/bar) rendering.
  *
@@ -770,17 +782,11 @@ export function convertToCategoricalChartConfig(
 
   // A user-supplied ORDER BY takes precedence over the default value-descending
   // ordering, so only inject the default when the user has not set one.
-  const userOrderBy = convertedConfig.orderBy;
-  const hasUserOrderBy =
-    typeof userOrderBy === 'string'
-      ? userOrderBy.trim().length > 0
-      : Array.isArray(userOrderBy) && userOrderBy.length > 0;
-
   // When a series limit is set and the user has not supplied an ordering, order
   // by the first aggregated value descending (with the group as a stable
   // tiebreak) so the limit deterministically keeps the largest slices/bars.
   if (
-    !hasUserOrderBy &&
+    !hasNonEmptyOrderBy(convertedConfig.orderBy) &&
     convertedConfig.limit?.limit != null &&
     Array.isArray(convertedConfig.select) &&
     convertedConfig.select.length > 0 &&

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -741,8 +741,14 @@ export function convertToDashboardDocument(
  * the per-tile `seriesLimit` is reinterpreted as a plain SQL `LIMIT` on the
  * number of slices/bars (the `__hdx_series_limit` ranking CTE it drives on time
  * charts is gated on granularity, which categorical charts never set — see
- * `renderSeriesLimitCte`). When a limit is present we also inject a
- * value-descending ordering so the kept slices/bars are the largest ones.
+ * `renderSeriesLimitCte`).
+ *
+ * Ordering precedence:
+ *  - A user-supplied `orderBy` (from the chart editor's ORDER BY input) always
+ *    wins and is pushed down to SQL as-is. When combined with a limit, the
+ *    limit keeps the top rows according to that ordering.
+ *  - Otherwise, when a limit is present we inject a value-descending ordering
+ *    so the kept slices/bars are the largest ones by default.
  *
  * Shared by the in-app renderers (DBPieChart/DBBarChart) and the server-side
  * MCP tile-query path so every surface applies the limit identically.
@@ -762,10 +768,19 @@ export function convertToCategoricalChartConfig(
     delete convertedConfig.seriesLimit;
   }
 
-  // When a series limit is set, order by the first aggregated value
-  // descending (with the group as a stable tiebreak) so the limit
-  // deterministically keeps the largest slices/bars.
+  // A user-supplied ORDER BY takes precedence over the default value-descending
+  // ordering, so only inject the default when the user has not set one.
+  const userOrderBy = convertedConfig.orderBy;
+  const hasUserOrderBy =
+    typeof userOrderBy === 'string'
+      ? userOrderBy.trim().length > 0
+      : Array.isArray(userOrderBy) && userOrderBy.length > 0;
+
+  // When a series limit is set and the user has not supplied an ordering, order
+  // by the first aggregated value descending (with the group as a stable
+  // tiebreak) so the limit deterministically keeps the largest slices/bars.
   if (
+    !hasUserOrderBy &&
     convertedConfig.limit?.limit != null &&
     Array.isArray(convertedConfig.select) &&
     convertedConfig.select.length > 0 &&


### PR DESCRIPTION
## Summary

This PR adds support for custom order-by values on categorical charts. Previously, these charts were ordered by value descending by default. Now the user can specify a SQL expression to order by. The ordering is pushed down to the query, so it works with the existing seriesLimit functionality. The default remains a sort by value descending.

This PR also sets a max of 500 groups displayed in the pie/bar charts, to reduce the chances of OOM and render timeouts due to too many groups being rendered, if the user does not set a seriesLimit. This is similar to what we do for other chart types.

Note: SQL-based pie chart slices used to be ordered by value via a client-side sort, and are now rendered in the order they are returned by the query. 

### Screenshots or video

<img width="2091" height="912" alt="Screenshot 2026-07-10 at 8 33 30 AM" src="https://github.com/user-attachments/assets/2b7575c7-58fe-4be8-935c-5b7032a3c6b1" />
<img width="2096" height="913" alt="Screenshot 2026-07-10 at 8 33 52 AM" src="https://github.com/user-attachments/assets/1fc7bb8f-a66e-4f0e-afd1-0e9d15e0d15d" />
<img width="2095" height="917" alt="Screenshot 2026-07-10 at 8 33 44 AM" src="https://github.com/user-attachments/assets/f6fa09bb-aca2-4511-b0da-287cca476ee3" />

### How to test on Vercel preview

This can be tested in the preview environment by creating bar and pie charts in chart explorer and dashboards. The MCP and external API can be tested locally.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4749
- Related PRs:
