### PR TITLE
fix(api): resolve TS5011 in Docker build after TypeScript 6 upgrade

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "dev": "DOTENV_CONFIG_PATH=.env.development nodemon --exec 'ts-node' --transpile-only -r tsconfig-paths/register -r dotenv-expand/config -r '@hyperdx/node-opentelemetry/build/src/tracing' ./src/index.ts",
     "dev:mcp": "npx @modelcontextprotocol/inspector",
     "dev-task": "DOTENV_CONFIG_PATH=.env.development nodemon --exec 'ts-node' --transpile-only -r tsconfig-paths/register -r dotenv-expand/config -r '@hyperdx/node-opentelemetry/build/src/tracing' ./src/tasks/index.ts",
-    "build": "rimraf ./build && tsc && tsc-alias && cp -r ./src/opamp/proto ./build/opamp/",
+    "build": "rimraf ./build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && cp -r ./src/opamp/proto ./build/opamp/",
     "build:vercel": "rimraf ./build && tsc -p tsconfig.vercel.json && tsc-alias -p tsconfig.vercel.json && cp -r ./src/opamp/proto ./build/opamp/",
     "lint": "npx eslint --quiet . --ext .ts",
     "lint:fix": "npx eslint . --ext .ts --fix",

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,12 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "src",
-    "migrations",
-    "scripts"
-  ],
-  "exclude": [
-    "node_modules",
-    "**/*.test.ts"
-  ]
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -16,8 +16,7 @@
     "compilerOptions": {
       // ts-node compiles single files on demand (e.g. `src/index.ts` for the
       // dev server), so TypeScript infers the common source dir as `./src`.
-      // TS 6 requires that inferred rootDir to be explicit (TS5011). The full
-      // `tsc` build keeps its implicit root (which spans src/migrations/scripts).
+      // TS 6 requires that inferred rootDir to be explicit (TS5011).
       "rootDir": "./src"
     }
   },


### PR DESCRIPTION
## Summary

Fixes a build failure surfaced by the TypeScript 6 upgrade (#2617) when building the API Docker image:

```
tsconfig.json(8,5): error TS5011: The common source directory of 'tsconfig.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
```

## Why it happens

The API Docker build stage copies only `packages/api/src` into the builder image — it does **not** copy `migrations/` or `scripts/`. The default `build` script runs a bare `tsc`, which uses `tsconfig.json` with `include: ["src", "migrations", "scripts"]`.

- Locally / in CI, all three directories exist, so `tsc` infers a common source dir that spans them and doesn't complain.
- In the Docker image, only `src` is present, so the `include` glob resolves to `src/**` and the common source dir collapses to `./src`. TypeScript 6 now requires that inferred `rootDir` to be explicit, and fails with `TS5011`.

`migrations/` ships to the runtime image as raw source (not compiled output) and `scripts/` is dev-only, so neither belongs in the compiled `build/` output — they only need to exist for lint/typecheck.

## Fix

- Point the `build` script at `tsconfig.build.json`, which is now `src`-only with an explicit `rootDir: "./src"` (mirroring the existing `tsconfig.vercel.json`). This makes the build match what actually ships in the image.
- `tsconfig.json` stays broad (`include: ["src", "migrations", "scripts"]`) so lint, `tsc --noEmit` typecheck, and `ts-node` continue to cover `migrations/` and `scripts/`.
- Trimmed a now-inaccurate comment in `tsconfig.json`.

## Verification

- Reproduced the exact `TS5011` locally by running the old build command against a `src`-only tree (matching the Docker builder), in the same `node:22-alpine` base image.
- Confirmed the new `build` command succeeds in that same `src`-only environment, with `migrations/` correctly excluded from the compiled output.
- `yarn build` (full tree) and `yarn ci:lint` pass; `make ci-lint` passes across all projects.

Follow-up to #2617.