### PR TITLE
fix(app): copy css.d.ts into Docker builder stage

### DIFF
--- a/.changeset/docker-copy-css-dts.md
+++ b/.changeset/docker-copy-css-dts.md
@@ -2,4 +2,4 @@
 "@hyperdx/app": patch
 ---
 
-Fix Docker build failure after the TypeScript 6 upgrade. The `css.d.ts` ambient declaration (which types side-effect stylesheet imports like `@mantine/core/styles.css`) was not copied into the builder stage, so the production image build failed type checking with TS2882. The Dockerfile now copies `css.d.ts` alongside `mdx.d.ts`.
+Fix Docker production image build by copying `css.d.ts` into the builder stage so side-effect stylesheet imports type-check under TypeScript 6.

--- a/.changeset/docker-copy-css-dts.md
+++ b/.changeset/docker-copy-css-dts.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix Docker build failure after the TypeScript 6 upgrade. The `css.d.ts` ambient declaration (which types side-effect stylesheet imports like `@mantine/core/styles.css`) was not copied into the builder stage, so the production image build failed type checking with TS2882. The Dockerfile now copies `css.d.ts` alongside `mdx.d.ts`.

--- a/docker/hyperdx/Dockerfile
+++ b/docker/hyperdx/Dockerfile
@@ -52,7 +52,7 @@ COPY .yarnrc.yml yarn.lock package.json nx.json .prettierrc .prettierignore ./ts
 # full source is copied in the build stages that need it.
 COPY ./packages/common-utils/package.json ./packages/common-utils/package.json
 COPY ./packages/api/jest.config.js ./packages/api/tsconfig.json ./packages/api/tsconfig.build.json ./packages/api/package.json ./packages/api/
-COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/mdx.d.ts ./packages/app/eslint.config.mjs ./packages/app/
+COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/css.d.ts ./packages/app/mdx.d.ts ./packages/app/eslint.config.mjs ./packages/app/
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat


### PR DESCRIPTION
The production Docker image failed to build after the TypeScript 6 upgrade (#2617) with `TS2882: Cannot find module or type declarations for side-effect import of '@mantine/core/styles.css'`.

That upgrade added `packages/app/css.d.ts` (the ambient `declare module '*.css'` that types side-effect stylesheet imports) and updated the Dockerfile to copy the new `mdx.d.ts` — but omitted `css.d.ts`. The builder stage assembles app source from selective `COPY` statements (`src`, `pages`, `public`, `styles`, `types`) that don't include package-root `.d.ts` files, so `css.d.ts` never reached the build. Local lint and CI type-checks passed because the file is present there; only the Docker build, with its selective copies, missed it.

Fix: copy `css.d.ts` into the builder stage alongside `mdx.d.ts`.
