### PR TITLE
fix: Save Alert does nothing when editing an existing saved-search alert

### DIFF
--- a/.changeset/fix-save-alert-edit.md
+++ b/.changeset/fix-save-alert-edit.md
@@ -1,0 +1,9 @@
+---
+"@hyperdx/app": patch
+---
+
+Fix "Save Alert" doing nothing when editing an existing saved-search alert. The
+alert form schema now accepts the persisted `numConsecutiveWindows: null` value
+(so form validation no longer silently blocks submission), and the update
+request resolves the alert id from the selected tab instead of an unregistered
+form field.

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -173,12 +173,20 @@ const AlertForm = ({
     <form
       onSubmit={handleSubmit(data =>
         onSubmit(
-          normalizeNoOpAlertScheduleFields(data, defaultValues, {
-            preserveExplicitScheduleOffsetMinutes:
-              dirtyFields.scheduleOffsetMinutes === true,
-            preserveExplicitScheduleStartAt:
-              dirtyFields.scheduleStartAt === true,
-          }),
+          normalizeNoOpAlertScheduleFields(
+            // `id` is not a registered form field, so carry it from the alert
+            // this form was opened with. This binds the submission to the
+            // originally-edited alert rather than whatever the parent's alerts
+            // list happens to index at submit time.
+            { ...data, id: defaultValues?.id },
+            defaultValues,
+            {
+              preserveExplicitScheduleOffsetMinutes:
+                dirtyFields.scheduleOffsetMinutes === true,
+              preserveExplicitScheduleStartAt:
+                dirtyFields.scheduleStartAt === true,
+            },
+          ),
         ),
       )}
     >
@@ -487,19 +495,19 @@ export const DBSearchPageAlertModal = ({
             source: AlertSource.SAVED_SEARCH,
             savedSearchId: id,
           });
-        } else {
-          // Update existing alert. `id` is not a registered form field, so
-          // resolve it from the active tab rather than the form payload.
-          const existingAlert = savedSearch?.alerts?.[parseInt(activeIndex)];
-          if (!existingAlert?.id) {
-            return;
-          }
+        } else if (data.id) {
+          // Update existing alert. `data.id` is the id of the alert the form
+          // was opened with (carried through by AlertForm), not a live
+          // re-index of the alerts list, so edits always target the intended
+          // alert even if the list changes while the modal is open.
           await updateAlert.mutateAsync({
             ...data,
-            id: existingAlert.id,
+            id: data.id,
             source: AlertSource.SAVED_SEARCH,
             savedSearchId: id,
           });
+        } else {
+          return;
         }
         notifications.show({
           color: 'green',

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -77,7 +77,9 @@ const SavedSearchAlertFormSchema = z
     scheduleStartAt: scheduleStartAtSchema,
     thresholdType: z.nativeEnum(AlertThresholdType),
     channel: zAlertChannel,
-    numConsecutiveWindows: z.number().int().min(1).optional(),
+    // nullish() (not optional()): persisted alerts store this as null, which
+    // optional() would reject.
+    numConsecutiveWindows: z.number().int().min(1).nullish(),
   })
   .passthrough()
   .superRefine(validateAlertScheduleOffsetMinutes)
@@ -123,6 +125,9 @@ const AlertForm = ({
           ...defaultValues,
           scheduleOffsetMinutes: defaultValues.scheduleOffsetMinutes ?? 0,
           scheduleStartAt: defaultValues.scheduleStartAt ?? null,
+          // Persisted null -> undefined for the NumberInput.
+          numConsecutiveWindows:
+            defaultValues.numConsecutiveWindows ?? undefined,
         }
       : {
           interval: '5m',
@@ -467,7 +472,7 @@ export const DBSearchPageAlertModal = ({
           filters: searchedConfig.filters ?? [],
           tags: [],
         });
-        await createAlert.mutate({
+        await createAlert.mutateAsync({
           ...data,
           source: AlertSource.SAVED_SEARCH,
           savedSearchId: result.id,
@@ -477,21 +482,24 @@ export const DBSearchPageAlertModal = ({
       } else if (id) {
         // Create new alert
         if (activeIndex === 'stage') {
-          await createAlert.mutate({
+          await createAlert.mutateAsync({
             ...data,
-            source: AlertSource.SAVED_SEARCH,
-            savedSearchId: id,
-          });
-        } else if (data.id) {
-          // Update existing alert
-          await updateAlert.mutate({
-            ...data,
-            id: data.id,
             source: AlertSource.SAVED_SEARCH,
             savedSearchId: id,
           });
         } else {
-          return;
+          // Update existing alert. `id` is not a registered form field, so
+          // resolve it from the active tab rather than the form payload.
+          const existingAlert = savedSearch?.alerts?.[parseInt(activeIndex)];
+          if (!existingAlert?.id) {
+            return;
+          }
+          await updateAlert.mutateAsync({
+            ...data,
+            id: existingAlert.id,
+            source: AlertSource.SAVED_SEARCH,
+            savedSearchId: id,
+          });
         }
         notifications.show({
           color: 'green',
@@ -513,7 +521,7 @@ export const DBSearchPageAlertModal = ({
 
   const onDelete = async (id: string) => {
     try {
-      await deleteAlert.mutate(id);
+      await deleteAlert.mutateAsync(id);
       notifications.show({
         color: 'green',
         message: 'Alert deleted!',

--- a/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
@@ -1,0 +1,154 @@
+import {
+  AlertSource,
+  AlertThresholdType,
+} from '@hyperdx/common-utils/dist/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { DBSearchPageAlertModal } from '@/DBSearchPageAlertModal';
+
+// --- Mutation spies ------------------------------------------------------
+const createAlertMutateAsync = jest.fn().mockResolvedValue({ data: {} });
+const updateAlertMutateAsync = jest.fn().mockResolvedValue({ data: {} });
+const deleteAlertMutateAsync = jest.fn().mockResolvedValue(undefined);
+
+// Two alerts so the test can edit the second tab and confirm the PUT targets
+// the right id.
+const makeAlert = (id: string) => ({
+  id,
+  interval: '1m' as const,
+  threshold: 1,
+  thresholdType: AlertThresholdType.ABOVE,
+  source: AlertSource.SAVED_SEARCH,
+  savedSearchId: 'saved-search-id',
+  channel: { type: 'webhook' as const, webhookId: 'webhook-id' },
+  note: null,
+  // Match the persisted alert shape (both stored as null), which the form
+  // schema must accept.
+  numConsecutiveWindows: null,
+  scheduleStartAt: null,
+});
+
+const firstAlert = makeAlert('6a5163af632ecadec80ec00e');
+const secondAlert = makeAlert('aaaa1111bbbb2222cccc3333');
+
+const savedSearch = {
+  _id: 'saved-search-id',
+  name: 'My Search',
+  where: 'level:error',
+  whereLanguage: 'lucene',
+  select: '',
+  source: 'source-id',
+  orderBy: '',
+  tags: [],
+  alerts: [firstAlert, secondAlert],
+};
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useCreateAlert: () => ({
+      mutateAsync: createAlertMutateAsync,
+      isPending: false,
+    }),
+    useUpdateAlert: () => ({
+      mutateAsync: updateAlertMutateAsync,
+      isPending: false,
+    }),
+    useDeleteAlert: () => ({
+      mutateAsync: deleteAlertMutateAsync,
+      isPending: false,
+    }),
+    useAlert: (id?: string) => ({
+      data: {
+        data: [firstAlert, secondAlert].find(a => a.id === id) ?? firstAlert,
+      },
+    }),
+  },
+}));
+
+jest.mock('@/savedSearch', () => ({
+  __esModule: true,
+  useSavedSearch: () => ({ data: savedSearch, isLoading: false }),
+  useCreateSavedSearch: () => ({ mutateAsync: jest.fn() }),
+}));
+
+jest.mock('@/source', () => ({
+  __esModule: true,
+  useSource: () => ({ data: undefined }),
+}));
+
+jest.mock('@/theme/ThemeProvider', () => ({
+  __esModule: true,
+  useBrandDisplayName: () => 'HyperDX',
+}));
+
+// Heavy / visual child components are stubbed so the form still renders and
+// its submit handler runs. The alert channel form must register the
+// `channel.type` field so form validation passes.
+jest.mock('@/components/alerts/AlertHistoryCards', () => ({
+  __esModule: true,
+  AlertHistoryCardList: () => <div data-testid="alert-history" />,
+}));
+jest.mock('@/components/alerts/AckAlert', () => ({
+  __esModule: true,
+  AckAlert: () => <div data-testid="ack-alert" />,
+}));
+jest.mock('@/components/AlertPreviewChart', () => ({
+  __esModule: true,
+  AlertPreviewChart: () => <div data-testid="alert-preview-chart" />,
+}));
+jest.mock('@/components/Alerts', () => ({
+  __esModule: true,
+  AlertChannelForm: () => <div data-testid="alert-channel-form" />,
+}));
+jest.mock('@/components/SQLEditor/SQLInlineEditor', () => ({
+  __esModule: true,
+  SQLInlineEditorControlled: () => <div data-testid="sql-inline-editor" />,
+}));
+
+const renderModal = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderWithMantine(
+    <QueryClientProvider client={queryClient}>
+      <DBSearchPageAlertModal id="saved-search-id" open onClose={jest.fn()} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('DBSearchPageAlertModal', () => {
+  beforeEach(() => {
+    createAlertMutateAsync.mockClear();
+    updateAlertMutateAsync.mockClear();
+    deleteAlertMutateAsync.mockClear();
+  });
+
+  it('dispatches an update (PUT) with the id resolved from the selected alert tab', async () => {
+    renderModal();
+
+    // Modal opens on the "New Alert" tab; select the second existing alert so
+    // it renders in edit mode. Using the second (not first) tab confirms the
+    // update id is resolved by tab index.
+    const alertTab = await screen.findByRole('tab', { name: /Alert 2/ });
+    fireEvent.click(alertTab);
+
+    const saveButton = await screen.findByText('Save Alert');
+    fireEvent.click(saveButton.closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(updateAlertMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    // The id must come from the selected alert so the PUT targets it.
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: secondAlert.id,
+        source: AlertSource.SAVED_SEARCH,
+        savedSearchId: 'saved-search-id',
+      }),
+    );
+    expect(createAlertMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/tests/e2e/components/SearchPageAlertModalComponent.ts
+++ b/packages/app/tests/e2e/components/SearchPageAlertModalComponent.ts
@@ -12,6 +12,8 @@ export class SearchPageAlertModalComponent {
   private readonly addNewWebhookButtonLocator: Locator;
   private readonly createAlertButtonLocator: Locator;
   private readonly webhookSelector: Locator;
+  private readonly saveAlertButtonLocator: Locator;
+  private readonly deleteAlertButtonLocator: Locator;
   readonly webhookAlertModal: WebhookAlertModalComponent;
 
   constructor(page: Page) {
@@ -22,6 +24,12 @@ export class SearchPageAlertModalComponent {
     );
     this.createAlertButtonLocator = page.getByRole('button', {
       name: 'Create Alert',
+    });
+    this.saveAlertButtonLocator = page.getByRole('button', {
+      name: 'Save Alert',
+    });
+    this.deleteAlertButtonLocator = page.getByRole('button', {
+      name: 'Delete Alert',
     });
     this.webhookSelector = page.getByTestId('select-webhook');
     this.webhookAlertModal = new WebhookAlertModalComponent(page);
@@ -121,6 +129,65 @@ export class SearchPageAlertModalComponent {
    */
   async createAlert() {
     await this.createAlertButtonLocator.click();
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Select an existing alert's tab by its zero-based index. Existing alerts
+   * render as tabs labeled "Alert 1", "Alert 2", ... in the order returned by
+   * the saved search. The "New Alert" tab is separate.
+   */
+  async selectExistingAlertTab(index: number) {
+    await this.modal.getByRole('tab', { name: `Alert ${index + 1}` }).click();
+  }
+
+  /** Locator for the interval NativeSelect (2nd <select> in a threshold alert form). */
+  private get intervalSelect() {
+    return this.modal.locator('select').nth(1);
+  }
+
+  /**
+   * Change the alert check interval. Pass the interval key (e.g. '1m', '5m').
+   */
+  async selectInterval(value: string) {
+    await this.intervalSelect.selectOption(value);
+  }
+
+  /** Read the currently selected interval value (e.g. '1m', '5m'). */
+  async getSelectedInterval() {
+    return this.intervalSelect.inputValue();
+  }
+
+  /**
+   * Submit edits to an existing alert via "Save Alert". Waits for the
+   * PUT /api/alerts/:id so the test fails if the request is never sent, then
+   * waits for the modal to close.
+   */
+  async saveAlert() {
+    const updateResponse = this.page.waitForResponse(
+      resp =>
+        /\/api\/alerts\/[^/]+$/.test(resp.url()) &&
+        resp.request().method() === 'PUT',
+      { timeout: 10000 },
+    );
+    await this.saveAlertButtonLocator.click();
+    await updateResponse;
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Delete the currently open existing alert via "Delete Alert". Waits for the
+   * DELETE request and the modal to close.
+   */
+  async deleteAlert() {
+    const deleteResponse = this.page.waitForResponse(
+      resp =>
+        /\/api\/alerts\/[^/]+$/.test(resp.url()) &&
+        resp.request().method() === 'DELETE',
+      { timeout: 10000 },
+    );
+    await this.deleteAlertButtonLocator.click();
+    await deleteResponse;
     await this.modal.waitFor({ state: 'hidden' });
   }
 }

--- a/packages/app/tests/e2e/features/alerts.spec.ts
+++ b/packages/app/tests/e2e/features/alerts.spec.ts
@@ -449,6 +449,81 @@ test.describe('Alert Creation', { tag: ['@alerts', '@full-stack'] }, () => {
   );
 });
 
+test.describe(
+  'Alert Lifecycle (create/update/delete)',
+  { tag: ['@alerts', '@full-stack'] },
+  () => {
+    let searchPage: SearchPage;
+    let alertsPage: AlertsPage;
+
+    test.beforeEach(async ({ page }) => {
+      searchPage = new SearchPage(page);
+      alertsPage = new AlertsPage(page);
+    });
+
+    test(
+      'should create, then update the interval of, then delete a saved-search alert',
+      { tag: '@full-stack' },
+      async () => {
+        const ts = Date.now();
+        const savedSearchName = `E2E Lifecycle Alert ${ts}`;
+        const webhookName = `E2E Webhook Lifecycle ${ts}`;
+        const webhookUrl = `https://example.com/lifecycle-${ts}`;
+
+        await test.step('Create a saved search', async () => {
+          await searchPage.goto();
+          await searchPage.openSaveSearchModal();
+          await searchPage.savedSearchModal.saveSearchAndWaitForNavigation(
+            savedSearchName,
+          );
+        });
+
+        await test.step('Create an alert with a 1 minute interval', async () => {
+          await searchPage.openAlertsModal();
+          await searchPage.alertModal.addWebhookAndWait(
+            'Generic',
+            webhookName,
+            webhookUrl,
+          );
+          await searchPage.alertModal.selectWebhook(webhookName);
+          // Start on a 1-minute cadence so the update below is observable.
+          await searchPage.alertModal.selectInterval('1m');
+          await searchPage.alertModal.createAlert();
+        });
+
+        await test.step('Reopen the alert and confirm the 1 minute interval persisted', async () => {
+          await searchPage.openAlertsModal();
+          await searchPage.alertModal.selectExistingAlertTab(0);
+          expect(await searchPage.alertModal.getSelectedInterval()).toBe('1m');
+        });
+
+        await test.step('Change the interval to 5 minute and Save Alert (dispatches PUT)', async () => {
+          await searchPage.alertModal.selectInterval('5m');
+          await searchPage.alertModal.saveAlert();
+        });
+
+        await test.step('Reopen the alert and confirm the interval update was persisted', async () => {
+          await searchPage.openAlertsModal();
+          await searchPage.alertModal.selectExistingAlertTab(0);
+          expect(await searchPage.alertModal.getSelectedInterval()).toBe('5m');
+        });
+
+        await test.step('Delete the alert', async () => {
+          await searchPage.alertModal.deleteAlert();
+        });
+
+        await test.step('Verify the alert no longer appears on the alerts page', async () => {
+          await alertsPage.goto();
+          await expect(alertsPage.pageContainer).toBeVisible();
+          await expect(
+            alertsPage.getAlertCardByName(savedSearchName),
+          ).toBeHidden({ timeout: 10000 });
+        });
+      },
+    );
+  },
+);
+
 test.describe('Alert Notes', { tag: ['@alerts', '@full-stack'] }, () => {
   let searchPage: SearchPage;
   let dashboardPage: DashboardPage;


### PR DESCRIPTION
## Problem
In the saved-search alert editor, clicking "Save Alert" on an existing alert did nothing — no update request was dispatched, so edits (e.g. changing the check interval) could never be saved. The only workaround was to delete and recreate the alert.

## Root cause
Two issues on the edit path:

1. The alert form's Zod schema declared `numConsecutiveWindows` as `.optional()`, which rejects `null`. Persisted alerts store this field as `null`, so `zodResolver` validation threw on submit and react-hook-form silently blocked `handleSubmit` — no request, no error, no feedback.
2. Even past validation, the update branch keyed off `data.id`, but `id` is not a registered form field, so it was `undefined` at submit time and the handler fell through to a silent no-op.

## Fix
- Accept the persisted shape: `numConsecutiveWindows` is now `.nullish()`, and the value is normalized (`null` → `undefined`) in the form defaults.
- Resolve the alert id from the selected tab (the saved search's alerts) rather than the form payload, so the update always targets the right alert.
- Await the create/update/delete mutations with `mutateAsync` so success and error handling behave as intended.

## Tests
- Unit test asserting an edit dispatches the update with the id from the selected tab (fails without the fix).
- E2E test covering the full create → update interval → delete lifecycle, asserting the update request is actually sent and persisted.