### PR TITLE
fix(docker): copy css.d.ts into app build stage to fix nightly build

### DIFF
--- a/.changeset/fix-nightly-css-dts-docker.md
+++ b/.changeset/fix-nightly-css-dts-docker.md
@@ -1,0 +1,9 @@
+---
+'@hyperdx/app': patch
+---
+
+Copy `css.d.ts` into the Docker build stage so the app image compiles. The
+TypeScript 6 upgrade added ambient `declare module '*.css'` declarations in
+`css.d.ts` to satisfy TS2882 for side-effect stylesheet imports, but the
+Dockerfiles only copied `mdx.d.ts`, so `next build` failed inside the
+container.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,147 @@
+name: Docker Build
+# Verifies the release Docker images actually build on PRs, without pushing.
+# A source-level type check (`make ci-lint`) cannot catch build failures that
+# only surface inside the image — e.g. a declaration file that exists in the
+# repo but was never COPYed into the Docker build stage. Each image is built
+# only when files that affect it change, so unrelated PRs stay fast.
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  # OTel Collector image (Go build via OCB) — docker/otel-collector/Dockerfile.
+  otel-collector-image:
+    name: Build OTel Collector Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            docker/otel-collector/**
+            packages/otel-collector/**
+      - name: Setup Docker Buildx
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/otel-collector/Dockerfile
+          target: prod
+          platforms: linux/amd64
+          push: false
+          cache-from: |
+            type=gha,scope=otel-collector-nightly-amd64
+            type=gha,scope=docker-build-pr-otel-collector
+          cache-to: type=gha,mode=max,scope=docker-build-pr-otel-collector
+
+  # App/prod image (API + App + common-utils Node build) — docker/hyperdx target prod.
+  # This is the image the nightly css.d.ts failure surfaced in; the same builder
+  # stage backs the all-in-one targets below.
+  app-image:
+    name: Build App Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            packages/api/**
+            packages/app/**
+            packages/common-utils/**
+            docker/hyperdx/**
+            package.json
+            yarn.lock
+            .yarn/**
+            tsconfig.base.json
+            nx.json
+      - name: Setup Docker Buildx
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/hyperdx/Dockerfile
+          target: prod
+          platforms: linux/amd64
+          push: false
+          build-contexts: |
+            hyperdx=./docker/hyperdx
+            api=./packages/api
+            app=./packages/app
+          build-args: |
+            CODE_VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: |
+            type=gha,scope=app-nightly-amd64
+            type=gha,scope=docker-build-pr-app
+          cache-to: type=gha,mode=max,scope=docker-build-pr-app
+
+  # All-in-one image (adds ClickHouse, MongoDB, OTel Collector to the app build)
+  # — docker/hyperdx target all-in-one-auth. Building the auth target also
+  # exercises the shared all-in-one-base, so no-auth need not be built
+  # separately. Gated on the app inputs plus the bundled-service inputs.
+  all-in-one-image:
+    name: Build All-in-One Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            packages/api/**
+            packages/app/**
+            packages/common-utils/**
+            packages/otel-collector/**
+            docker/hyperdx/**
+            docker/clickhouse/**
+            docker/otel-collector/**
+            package.json
+            yarn.lock
+            .yarn/**
+            tsconfig.base.json
+            nx.json
+      - name: Setup Docker Buildx
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/hyperdx/Dockerfile
+          target: all-in-one-auth
+          platforms: linux/amd64
+          push: false
+          build-contexts: |
+            clickhouse=./docker/clickhouse
+            otel-collector=./docker/otel-collector
+            hyperdx=./docker/hyperdx
+            api=./packages/api
+            app=./packages/app
+          build-args: |
+            CODE_VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: |
+            type=gha,scope=all-in-one-nightly-amd64
+            type=gha,scope=docker-build-pr-all-in-one
+          cache-to: type=gha,mode=max,scope=docker-build-pr-all-in-one

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -96,7 +96,14 @@ jobs:
   # All-in-one image (adds ClickHouse, MongoDB, OTel Collector to the app build)
   # — docker/hyperdx target all-in-one-auth. Building the auth target also
   # exercises the shared all-in-one-base, so no-auth need not be built
-  # separately. Gated on the app inputs plus the bundled-service inputs.
+  # separately.
+  #
+  # This target's base does `COPY --from=prod /app /app`, so it already
+  # rebuilds the entire App/prod image. To avoid duplicating that ~8-minute
+  # Node build on every app change, this job is gated ONLY on the incremental
+  # bundling inputs (ClickHouse / OTel / the shared Dockerfile) — NOT on
+  # api/app/common-utils/deps. Those are covered by the App Image job above,
+  # and they can't break the bundling layers, which only COPY the prod output.
   all-in-one-image:
     name: Build All-in-One Image
     runs-on: ubuntu-24.04
@@ -109,18 +116,10 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-            packages/api/**
-            packages/app/**
-            packages/common-utils/**
             packages/otel-collector/**
             docker/hyperdx/**
             docker/clickhouse/**
             docker/otel-collector/**
-            package.json
-            yarn.lock
-            .yarn/**
-            tsconfig.base.json
-            nx.json
       - name: Setup Docker Buildx
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@v3

--- a/docker/hyperdx/Dockerfile
+++ b/docker/hyperdx/Dockerfile
@@ -52,7 +52,7 @@ COPY .yarnrc.yml yarn.lock package.json nx.json .prettierrc .prettierignore ./ts
 # full source is copied in the build stages that need it.
 COPY ./packages/common-utils/package.json ./packages/common-utils/package.json
 COPY ./packages/api/jest.config.js ./packages/api/tsconfig.json ./packages/api/tsconfig.build.json ./packages/api/package.json ./packages/api/
-COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/mdx.d.ts ./packages/app/eslint.config.mjs ./packages/app/
+COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/mdx.d.ts ./packages/app/css.d.ts ./packages/app/eslint.config.mjs ./packages/app/
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -330,7 +330,7 @@ export const getScheduledWindowStart = (
  * that history fetched up-front (see getConsecutiveWindowHistories) lines up
  * exactly with the window processAlert evaluates.
  */
-export const getAlertWindowStart = (alert: IAlert, now: Date): Date => {
+const getAlertWindowStart = (alert: IAlert, now: Date): Date => {
   const windowSizeInMins = ms(alert.interval) / 60000;
   const scheduleStartAt = normalizeScheduleStartAt({
     alertId: alert.id,

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -9,7 +9,7 @@ COPY .yarnrc.yml yarn.lock package.json nx.json .prettierrc .prettierignore ./ts
 # Only copy package.json for workspace resolution during yarn install;
 # full source is copied in the build stages that need it.
 COPY ./packages/common-utils/package.json ./packages/common-utils/package.json
-COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/mdx.d.ts ./packages/app/eslint.config.mjs ./packages/app/
+COPY ./packages/app/jest.config.js ./packages/app/tsconfig.json ./packages/app/tsconfig.build.json ./packages/app/package.json ./packages/app/next.config.mjs ./packages/app/mdx.d.ts ./packages/app/css.d.ts ./packages/app/eslint.config.mjs ./packages/app/
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,id=yarn-cache \
     yarn install --mode=skip-build && yarn cache clean
 


### PR DESCRIPTION
## Why

The nightly release ([run 29215841780](https://github.com/hyperdxio/hyperdx/actions/runs/29215841780)) has been failing across the **App**, **All-in-One**, and **Local** image builds with:

```
Type error: Cannot find module or type declarations for side-effect import of '@mantine/core/styles.css'.
```

The TypeScript 6 upgrade (#2617) introduced the stricter TS2882 check for side-effect imports of otherwise-untyped modules. To satisfy it, that PR added `packages/app/css.d.ts` with ambient `declare module '*.css'` (and `.scss`/`.sass`) declarations, which cover the stylesheet imports in `pages/_app.tsx`.

This works locally, but **both Dockerfiles only copy `mdx.d.ts` into the build stage, not `css.d.ts`**. Inside the container the ambient declaration is missing, so `next build` fails type-checking. Local `tsc`/CI passed because `css.d.ts` is present on disk there — a source-level type check fundamentally cannot catch a file that exists in the repo but was never `COPY`ed into the image.

## What

**The fix**
- Add `css.d.ts` to the `COPY` line in `docker/hyperdx/Dockerfile` (App / All-in-One / Local nightly + release images) and `packages/app/Dockerfile` (standalone app image), right alongside the existing `mdx.d.ts`.
- Drop a stray `export` on `getAlertWindowStart` (`packages/api/src/tasks/checkAlerts/index.ts`) — only used within its own file. Pre-existing dead export flagged by the pre-commit `knip` check, which was blocking commits through the hook.
- Patch changeset for `@hyperdx/app`.

**Prevention** — new `Docker Build` workflow (`.github/workflows/docker-build.yml`)
- Builds each released image on PRs with `push: false`, so image-only build failures are caught in review instead of the nightly.
- **Conditional on changed paths** (via `tj-actions/changed-files`, matching the existing otel-collector gating in `main.yml`) so unrelated PRs skip the builds:
  - OTel Collector image → `docker/otel-collector/**`, `packages/otel-collector/**`
  - App/prod image → `packages/{api,app,common-utils}/**`, `docker/hyperdx/**`, root deps
  - All-in-one image → the above plus `docker/clickhouse/**`, `docker/otel-collector/**`
- Single-arch (amd64), warmed from the nightly gha cache scopes, to keep PR runtimes low. Build errors here are arch-independent.

## Verification

Ran the `docker/hyperdx` `builder` target locally (the stage that runs `next build`) with the fix:

```
#34 [builder 10/11] RUN yarn workspace @hyperdx/api run build && yarn workspace @hyperdx/app run build
#34   Running TypeScript ...
#34 ✓ Compiled successfully in 25.7s
...
#36 DONE   (exit 0)
```

The TS2882 error is gone and the image builds cleanly.