### PR TITLE
fix: render side panel controls in error state

### DIFF
--- a/.changeset/fix-side-drawer-error-close.md
+++ b/.changeset/fix-side-drawer-error-close.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: render side panel controls in error state

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -628,6 +628,20 @@ export const DBRowSidePanelInner = ({
 
   const displayedTab = reconcileTab(persistedTab, availableTabs, defaultTab);
 
+  const controls = useMemo(
+    () => (
+      <Flex align="center" justify="space-between" gap="sm" mb={8}>
+        <SidePanelBreadcrumbs items={allBreadcrumbs} onBack={handlePanelBack} />
+        <SidePanelHeaderActions
+          onClose={onClose}
+          isFullWidth={isFullWidth}
+          onToggleFullWidth={onToggleFullWidth}
+        />
+      </Flex>
+    ),
+    [allBreadcrumbs, handlePanelBack, onClose, isFullWidth, onToggleFullWidth],
+  );
+
   if (isRowLoading || isResolvingSource) {
     return <div className={styles.loadingState}>Loading...</div>;
   }
@@ -640,17 +654,7 @@ export const DBRowSidePanelInner = ({
     return (
       <>
         <Box px="sm" pt="sm" pb="xs">
-          <Flex align="center" justify="space-between" gap="sm" mb={8}>
-            <SidePanelBreadcrumbs
-              items={allBreadcrumbs}
-              onBack={handlePanelBack}
-            />
-            <SidePanelHeaderActions
-              onClose={onClose}
-              isFullWidth={isFullWidth}
-              onToggleFullWidth={onToggleFullWidth}
-            />
-          </Flex>
+          {controls}
         </Box>
         <Box p="sm" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
           <Text size="sm" c="dimmed">
@@ -666,12 +670,24 @@ export const DBRowSidePanelInner = ({
   if (!isRowSuccess) {
     if (isRowError && rowError) {
       return (
-        <Box p="sm" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
-          <DBRowSidePanelErrorState error={rowError} source={source} />
-        </Box>
+        <>
+          <Box px="sm" pt="sm" pb="xs">
+            {controls}
+          </Box>
+          <Box p="sm" style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+            <DBRowSidePanelErrorState error={rowError} source={source} />
+          </Box>
+        </>
       );
     }
-    return <div className={styles.loadingState}>Error loading row data</div>;
+    return (
+      <>
+        <Box px="sm" pt="sm" pb="xs">
+          {controls}
+        </Box>
+        <div className={styles.loadingState}>Error loading row data</div>
+      </>
+    );
   }
 
   const showLogTraceActions = !sourceIsTrace && traceId && traceSourceId;
@@ -679,17 +695,7 @@ export const DBRowSidePanelInner = ({
   return (
     <>
       <Box px="sm" pt="sm" pb="xs">
-        <Flex align="center" justify="space-between" gap="sm" mb={8}>
-          <SidePanelBreadcrumbs
-            items={allBreadcrumbs}
-            onBack={handlePanelBack}
-          />
-          <SidePanelHeaderActions
-            onClose={onClose}
-            isFullWidth={isFullWidth}
-            onToggleFullWidth={onToggleFullWidth}
-          />
-        </Flex>
+        {controls}
         <Group gap="xs" wrap="wrap">
           {!sourceIsTrace && severityText && <LogLevel level={severityText} />}
           {timestampDate && !isNaN(timestampDate.getTime()) && (


### PR DESCRIPTION
## Summary

When a search-page row triggers a side-panel error ("Error loading row data"), the drawer became difficult to close: there was no close button, clicking outside did nothing (the drawer intentionally disables its overlay). Escape key worked, but was non-obvious.

The root cause is in `DBRowSidePanel.tsx` (`DBRowSidePanelInner`): the `!isRowSuccess` branches rendered only the error/loading body inside a `Box`, with **no header**.

This PR renders that same header in both `!isRowSuccess` branches (the `ClickHouseQueryError`/`Error` state and the generic fallback), so the user can always close the panel or navigate back via the breadcrumbs.

### Screenshots or video

Before:

<img width="1484" height="768" alt="Screenshot 2026-07-14 at 10 24 13 AM" src="https://github.com/user-attachments/assets/8e78c4cd-4644-47fc-a1be-80bfe76b4e75" />

After:

<img width="1485" height="732" alt="Screenshot 2026-07-14 at 10 23 39 AM" src="https://github.com/user-attachments/assets/982774e2-0b33-4492-bd91-166726c45a47" />

### References

- Linear Issue: HDX-4774
- Related PRs:
