### PR TITLE
chore(security): pin @asyncapi/specs to 6.11.1 (Miasma RAT supply-chain compromise)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "diff": "^5.2.2",
     "on-headers": "^1.1.0",
     "fast-xml-parser": "^4.5.6",
-    "systeminformation": "^5.24.0"
+    "systeminformation": "^5.24.0",
+    "@asyncapi/specs": "6.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,7 +172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asyncapi/specs@npm:^6.8.0":
+"@asyncapi/specs@npm:6.11.1":
   version: 6.11.1
   resolution: "@asyncapi/specs@npm:6.11.1"
   dependencies:


### PR DESCRIPTION
Fixes #2641

## Why

On **2026-07-14**, several AsyncAPI npm packages were compromised via malicious commits and CI/CD publication. **`@asyncapi/specs@6.11.2`** was published with obfuscated malware (**Miasma RAT** — a credential stealer targeting browsers, SSH keys, npm tokens, and crypto wallets). `@asyncapi/specs` has ~2.7M weekly downloads.

Reference: https://safedep.io/asyncapi-generator-supply-chain-attack-miasma-rat/

This repo pulls in `@asyncapi/specs` **transitively** (it is not a direct dependency):

```
packages/api  ->  @stoplight/spectral-cli@^6.15.0   (devDependency, used by the `lint:openapi` script)
              ->  @stoplight/spectral-rulesets@>=1
              ->  @asyncapi/specs@^6.8.0
```

The committed `yarn.lock` currently resolves the **safe `6.11.1`**, so existing installs are fine. However, the declared range `^6.8.0` means any fresh resolve / lockfile regeneration could silently pull the compromised `6.11.2`.

## What

- Add `"@asyncapi/specs": "6.11.1"` to the root `resolutions` block.
- `yarn install` updated the lockfile descriptor from `^6.8.0` to a pinned `6.11.1`. The resolved version and checksum are unchanged — same known-safe artifact, just made explicit and immutable.

## Scope

Minimal: `package.json` (+1 resolution) and `yarn.lock` (descriptor key only). No source or runtime behavior change; I did not add a changeset since this only affects dev-tooling dependency resolution — happy to add one if preferred.