### PR TITLE
feat(evals): support metric types and seeding

### DIFF
--- a/.changeset/small-taxis-speak.md
+++ b/.changeset/small-taxis-speak.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/hdx-eval": patch
+---
+
+feat(evals): support metric types and seeding

--- a/packages/hdx-eval/src/__tests__/metrics.test.ts
+++ b/packages/hdx-eval/src/__tests__/metrics.test.ts
@@ -1,0 +1,370 @@
+import { __metricMappers } from '@/clickhouse/insert';
+import { scenarioTables } from '@/clickhouse/schema';
+import {
+  bucketize,
+  makeExponentialHistogram,
+  makeGauge,
+  makeHistogram,
+  makeSum,
+  makeSummary,
+} from '@/generators/metrics';
+import type { GaugeMetricRow, SumMetricRow } from '@/generators/types';
+import { mulberry32 } from '@/rng/seeded';
+import {
+  collectScenario,
+  type MetricBatch,
+  type ScenarioBatch,
+} from '@/scenarios/types';
+
+const NOW_MS = Date.parse('2026-05-10T20:00:00.000Z');
+const DATETIME_SEC = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+describe('scenarioTables metric names', () => {
+  it('derives the five eval metric table names from the slug', () => {
+    const t = scenarioTables('metric-saturation');
+    expect(t.metricsGauge).toBe('eval_metric_saturation_otel_metrics_gauge');
+    expect(t.metricsSum).toBe('eval_metric_saturation_otel_metrics_sum');
+    expect(t.metricsHistogram).toBe(
+      'eval_metric_saturation_otel_metrics_histogram',
+    );
+    expect(t.metricsExponentialHistogram).toBe(
+      'eval_metric_saturation_otel_metrics_exponential_histogram',
+    );
+    expect(t.metricsSummary).toBe(
+      'eval_metric_saturation_otel_metrics_summary',
+    );
+  });
+});
+
+describe('metric factories', () => {
+  it('makeGauge fills defaults and injects service.name', () => {
+    const g = makeGauge({
+      timeUnixMs: NOW_MS,
+      serviceName: 'checkout',
+      metricName: 'queue.depth',
+      value: 7,
+    });
+    expect(g.startTimeUnixMs).toBe(NOW_MS);
+    expect(g.metricDescription).toBe('');
+    expect(g.metricUnit).toBe('');
+    expect(g.attributes).toEqual({});
+    expect(g.resourceAttributes).toEqual({ 'service.name': 'checkout' });
+    expect(g.value).toBe(7);
+  });
+
+  it('makeGauge merges caller resourceAttributes over the service.name default', () => {
+    const g = makeGauge({
+      timeUnixMs: NOW_MS,
+      serviceName: 'checkout',
+      metricName: 'queue.depth',
+      value: 1,
+      resourceAttributes: { 'k8s.namespace.name': 'prod' },
+    });
+    expect(g.resourceAttributes).toEqual({
+      'service.name': 'checkout',
+      'k8s.namespace.name': 'prod',
+    });
+  });
+
+  it('makeSum defaults to cumulative + monotonic', () => {
+    const s = makeSum({
+      timeUnixMs: NOW_MS,
+      serviceName: 'api',
+      metricName: 'http.requests',
+      value: 42,
+    });
+    expect(s.aggregationTemporality).toBe(2);
+    expect(s.isMonotonic).toBe(true);
+  });
+
+  it('makeSum respects explicit temporality/monotonicity', () => {
+    const s = makeSum({
+      timeUnixMs: NOW_MS,
+      serviceName: 'api',
+      metricName: 'http.active',
+      value: 3,
+      aggregationTemporality: 1,
+      isMonotonic: false,
+    });
+    expect(s.aggregationTemporality).toBe(1);
+    expect(s.isMonotonic).toBe(false);
+  });
+
+  it('makeHistogram carries buckets and defaults temporality', () => {
+    const h = makeHistogram({
+      timeUnixMs: NOW_MS,
+      serviceName: 'api',
+      metricName: 'http.duration',
+      count: 3,
+      sum: 12,
+      bucketCounts: [1, 1, 1],
+      explicitBounds: [5, 10],
+      min: 1,
+      max: 9,
+    });
+    expect(h.aggregationTemporality).toBe(2);
+    expect(h.bucketCounts).toEqual([1, 1, 1]);
+    expect(h.explicitBounds).toEqual([5, 10]);
+  });
+
+  it('makeExponentialHistogram fills bucket defaults', () => {
+    const e = makeExponentialHistogram({
+      timeUnixMs: NOW_MS,
+      serviceName: 'api',
+      metricName: 'http.duration.exp',
+      count: 10,
+      sum: 100,
+      scale: 3,
+    });
+    expect(e.zeroCount).toBe(0);
+    expect(e.positiveOffset).toBe(0);
+    expect(e.positiveBucketCounts).toEqual([]);
+    expect(e.negativeOffset).toBe(0);
+    expect(e.negativeBucketCounts).toEqual([]);
+    expect(e.aggregationTemporality).toBe(2);
+  });
+
+  it('makeSummary carries quantiles', () => {
+    const s = makeSummary({
+      timeUnixMs: NOW_MS,
+      serviceName: 'api',
+      metricName: 'rpc.latency',
+      count: 100,
+      sum: 5000,
+      quantiles: [
+        { quantile: 0.5, value: 40 },
+        { quantile: 0.99, value: 120 },
+      ],
+    });
+    expect(s.quantiles).toHaveLength(2);
+    expect(s.quantiles[1]).toEqual({ quantile: 0.99, value: 120 });
+  });
+});
+
+describe('bucketize', () => {
+  it('places samples into cumulative explicit buckets (+Inf overflow)', () => {
+    const { bucketCounts, count, sum, min, max } = bucketize(
+      [1, 4, 6, 9, 100],
+      [5, 10],
+    );
+    // bounds [5,10] → 3 buckets: (<=5), (<=10), (+Inf)
+    expect(bucketCounts).toEqual([2, 2, 1]);
+    expect(count).toBe(5);
+    expect(sum).toBe(120);
+    expect(min).toBe(1);
+    expect(max).toBe(100);
+  });
+
+  it('returns zeroed stats for an empty sample set', () => {
+    const { bucketCounts, count, sum, min, max } = bucketize([], [5, 10]);
+    expect(bucketCounts).toEqual([0, 0, 0]);
+    expect(count).toBe(0);
+    expect(sum).toBe(0);
+    expect(min).toBe(0);
+    expect(max).toBe(0);
+  });
+});
+
+// A tiny deterministic metric generator used to exercise determinism,
+// nowMs-anchoring, and collectScenario merging without a real scenario.
+function* generateMetrics(
+  rng: ReturnType<typeof mulberry32>,
+  nowMs: number,
+): Generator<ScenarioBatch, void, void> {
+  const windowMs = 10 * 60 * 1000;
+  const gauge: GaugeMetricRow[] = [];
+  const sum: SumMetricRow[] = [];
+  for (let i = 0; i < 20; i++) {
+    const t = nowMs - Math.floor(rng.next() * windowMs);
+    gauge.push(
+      makeGauge({
+        timeUnixMs: t,
+        serviceName: 'svc',
+        metricName: 'cpu.util',
+        value: rng.range(0, 100),
+        attributes: { pod: `pod-${rng.intRange(0, 5)}` },
+      }),
+    );
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: 'svc',
+        metricName: 'req.total',
+        value: rng.intRange(0, 1000),
+      }),
+    );
+  }
+  yield { traces: [], logs: [], metrics: { gauge, sum } };
+}
+
+describe('metric generation determinism + anchoring', () => {
+  it('produces an identical metric stream for the same seed', () => {
+    const a = collectScenario(generateMetrics(mulberry32(42), NOW_MS));
+    const b = collectScenario(generateMetrics(mulberry32(42), NOW_MS));
+    expect(a.metrics).toEqual(b.metrics);
+  });
+
+  it('anchors all points at or before nowMs, within the window', () => {
+    const { metrics } = collectScenario(generateMetrics(mulberry32(7), NOW_MS));
+    const all = [...(metrics?.gauge ?? []), ...(metrics?.sum ?? [])];
+    expect(all.length).toBe(40);
+    for (const m of all) {
+      expect(m.timeUnixMs).toBeLessThanOrEqual(NOW_MS);
+      expect(m.timeUnixMs).toBeGreaterThanOrEqual(NOW_MS - 10 * 60 * 1000);
+    }
+  });
+
+  it('collectScenario merges per-type arrays across batches', () => {
+    function* twoBatches(): Generator<ScenarioBatch, void, void> {
+      const base: MetricBatch = {
+        gauge: [
+          makeGauge({
+            timeUnixMs: NOW_MS,
+            serviceName: 's',
+            metricName: 'g',
+            value: 1,
+          }),
+        ],
+      };
+      yield { traces: [], logs: [], metrics: base };
+      yield {
+        traces: [],
+        logs: [],
+        metrics: {
+          summary: [
+            makeSummary({
+              timeUnixMs: NOW_MS,
+              serviceName: 's',
+              metricName: 'q',
+              count: 1,
+              sum: 1,
+              quantiles: [{ quantile: 0.5, value: 1 }],
+            }),
+          ],
+        },
+      };
+    }
+    const { metrics } = collectScenario(twoBatches());
+    expect(metrics?.gauge).toHaveLength(1);
+    expect(metrics?.summary).toHaveLength(1);
+    expect(metrics?.histogram).toEqual([]);
+  });
+
+  it('omits metrics entirely when no batch carries any', () => {
+    function* noMetrics(): Generator<ScenarioBatch, void, void> {
+      yield { traces: [], logs: [] };
+    }
+    const collected = collectScenario(noMetrics());
+    expect(collected.metrics).toBeUndefined();
+  });
+});
+
+describe('metric → ClickHouse row mappers', () => {
+  it('gauge maps to a second-resolution DateTime + empty exemplars', () => {
+    const row = __metricMappers.gauge(
+      makeGauge({
+        timeUnixMs: NOW_MS,
+        serviceName: 'svc',
+        metricName: 'cpu.util',
+        value: 55.5,
+        attributes: { pod: 'pod-1' },
+      }),
+    );
+    expect(row.ServiceName).toBe('svc');
+    expect(row.MetricName).toBe('cpu.util');
+    expect(row.Value).toBe(55.5);
+    expect(row.Flags).toBe(0);
+    expect(row.Attributes).toEqual({ pod: 'pod-1' });
+    expect(row.ResourceAttributes).toEqual({ 'service.name': 'svc' });
+    expect(String(row.TimeUnix)).toMatch(DATETIME_SEC);
+    expect(String(row.StartTimeUnix)).toMatch(DATETIME_SEC);
+    expect(row.TimeUnix).toBe('2026-05-10 20:00:00');
+    expect(row['Exemplars.TimeUnix']).toEqual([]);
+    expect(row['Exemplars.Value']).toEqual([]);
+    expect(row['Exemplars.FilteredAttributes']).toEqual([]);
+  });
+
+  it('sum maps counter columns', () => {
+    const row = __metricMappers.sum(
+      makeSum({
+        timeUnixMs: NOW_MS,
+        serviceName: 'svc',
+        metricName: 'req.total',
+        value: 10,
+      }),
+    );
+    expect(row.Value).toBe(10);
+    expect(row.AggregationTemporality).toBe(2);
+    expect(row.IsMonotonic).toBe(true);
+  });
+
+  it('histogram maps UInt64 counts as strings and keeps bounds numeric', () => {
+    const row = __metricMappers.histogram(
+      makeHistogram({
+        timeUnixMs: NOW_MS,
+        serviceName: 'svc',
+        metricName: 'http.duration',
+        count: 3,
+        sum: 12,
+        bucketCounts: [2, 1, 0],
+        explicitBounds: [5, 10],
+        min: 1,
+        max: 9,
+      }),
+    );
+    expect(row.Count).toBe('3');
+    expect(row.Sum).toBe(12);
+    expect(row.BucketCounts).toEqual(['2', '1', '0']);
+    expect(row.ExplicitBounds).toEqual([5, 10]);
+    expect(row.Min).toBe(1);
+    expect(row.Max).toBe(9);
+    expect(row.AggregationTemporality).toBe(2);
+  });
+
+  it('exponential histogram maps positive/negative bucket arrays', () => {
+    const row = __metricMappers.exponentialHistogram(
+      makeExponentialHistogram({
+        timeUnixMs: NOW_MS,
+        serviceName: 'svc',
+        metricName: 'http.duration.exp',
+        count: 5,
+        sum: 50,
+        scale: 2,
+        zeroCount: 1,
+        positiveOffset: 3,
+        positiveBucketCounts: [1, 2],
+        negativeOffset: 0,
+        negativeBucketCounts: [],
+        min: 2,
+        max: 20,
+      }),
+    );
+    expect(row.Count).toBe('5');
+    expect(row.Scale).toBe(2);
+    expect(row.ZeroCount).toBe('1');
+    expect(row.PositiveOffset).toBe(3);
+    expect(row.PositiveBucketCounts).toEqual(['1', '2']);
+    expect(row.NegativeBucketCounts).toEqual([]);
+    expect(row.AggregationTemporality).toBe(2);
+  });
+
+  it('summary maps parallel quantile arrays', () => {
+    const row = __metricMappers.summary(
+      makeSummary({
+        timeUnixMs: NOW_MS,
+        serviceName: 'svc',
+        metricName: 'rpc.latency',
+        count: 100,
+        sum: 5000,
+        quantiles: [
+          { quantile: 0.5, value: 40 },
+          { quantile: 0.99, value: 120 },
+        ],
+      }),
+    );
+    expect(row.Count).toBe('100');
+    expect(row.Sum).toBe(5000);
+    expect(row['ValueAtQuantiles.Quantile']).toEqual([0.5, 0.99]);
+    expect(row['ValueAtQuantiles.Value']).toEqual([40, 120]);
+  });
+});

--- a/packages/hdx-eval/src/cli.ts
+++ b/packages/hdx-eval/src/cli.ts
@@ -7,6 +7,7 @@ import { createEvalClient, defaultClickHouseUrl } from './clickhouse/client';
 import {
   dropScenarioTables,
   scenarioIsSeeded,
+  scenarioSlug,
   scenarioTables,
 } from './clickhouse/schema';
 import { buildBlindingEntries } from './grading/blind';
@@ -37,7 +38,11 @@ import { batchDirName } from './runs/path';
 import { writeRun } from './runs/store';
 import { listBatches, listRunsInBatch, readRun } from './runs/store';
 import { getScenario, SCENARIO_NAMES, SCENARIOS } from './scenarios';
-import { type SeedProgress, seedScenario } from './scenarios/seedScenario';
+import {
+  getTotalMetrics,
+  type SeedProgress,
+  seedScenario,
+} from './scenarios/seedScenario';
 
 if (!process.env.ANTHROPIC_API_KEY && process.env.AI_API_KEY) {
   process.env.ANTHROPIC_API_KEY = process.env.AI_API_KEY;
@@ -52,9 +57,16 @@ function formatCount(n: number): string {
 function logSeedProgress(prefix: string, startMs: number) {
   return (p: SeedProgress) => {
     const elapsed = ((Date.now() - startMs) / 1000).toFixed(0);
-    const total = p.tracesInserted + p.logsInserted;
+    const totalMetrics = getTotalMetrics(p.metricsInserted);
+    const total = p.tracesInserted + p.logsInserted + totalMetrics;
+
+    const totalRows = `${formatCount(total)} rows`;
+    const tracesRows = `${formatCount(p.tracesInserted)} traces`;
+    const logsRows = `${formatCount(p.logsInserted)} logs`;
+    const metricsRows = `${formatCount(totalMetrics)} metrics`;
+
     process.stdout.write(
-      `\r${prefix}${formatCount(total)} rows (${formatCount(p.tracesInserted)} traces, ${formatCount(p.logsInserted)} logs) · ${elapsed}s`,
+      `\r${prefix}${totalRows} (${tracesRows}, ${logsRows}, ${metricsRows}) · ${elapsed}s`,
     );
   };
 }
@@ -210,6 +222,15 @@ program
         console.log(
           `Inserted ${result.logsInserted} log rows    → default.${result.tables.logs}`,
         );
+        const totalMetrics = getTotalMetrics(result.metricsInserted);
+        if (totalMetrics > 0) {
+          const m = result.metricsInserted;
+          console.log(
+            `Inserted ${totalMetrics} metric rows → default.eval_${scenarioSlug(scenario.name)}_otel_metrics_* ` +
+              `(gauge ${m.gauge}, sum ${m.sum}, histogram ${m.histogram}, ` +
+              `exp-histogram ${m.exponentialHistogram}, summary ${m.summary})`,
+          );
+        }
         console.log(`Done in ${seedSecs}s`);
       } finally {
         await client.close();
@@ -595,8 +616,11 @@ program
           });
           const seedSecs = ((Date.now() - seedStart) / 1000).toFixed(1);
           process.stdout.write('\n');
+          const metricTotal = getTotalMetrics(r.metricsInserted);
+          const metricsPart =
+            metricTotal > 0 ? `, ${formatCount(metricTotal)} metrics` : '';
           console.log(
-            `Seeded ${scenario.name}: ${formatCount(r.tracesInserted)} traces, ${formatCount(r.logsInserted)} logs in ${seedSecs}s`,
+            `Seeded ${scenario.name}: ${formatCount(r.tracesInserted)} traces, ${formatCount(r.logsInserted)} logs${metricsPart} in ${seedSecs}s`,
           );
         } finally {
           await client.close();

--- a/packages/hdx-eval/src/clickhouse/insert.ts
+++ b/packages/hdx-eval/src/clickhouse/insert.ts
@@ -1,6 +1,14 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 
-import type { LogRow, TraceRow } from '@/generators/types';
+import type {
+  ExponentialHistogramMetricRow,
+  GaugeMetricRow,
+  HistogramMetricRow,
+  LogRow,
+  SummaryMetricRow,
+  SumMetricRow,
+  TraceRow,
+} from '@/generators/types';
 
 import { EVAL_DATABASE } from './schema';
 
@@ -14,12 +22,35 @@ function msToDateTime64(ms: number): string {
   return `${base}.${msPart}000000`;
 }
 
+function msToDateTime(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 19).replace('T', ' ');
+}
+
 function chunk<T>(rows: T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < rows.length; i += size) {
     out.push(rows.slice(i, i + size));
   }
   return out;
+}
+
+async function insertMappedRows<T>(
+  client: ClickHouseClient,
+  table: string,
+  rows: T[],
+  mapper: (row: T) => Record<string, unknown>,
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  let inserted = 0;
+  for (const batch of chunk(rows, BATCH_SIZE)) {
+    await client.insert({
+      table: `${EVAL_DATABASE}.${table}`,
+      values: batch.map(mapper),
+      format: 'JSONEachRow',
+    });
+    inserted += batch.length;
+  }
+  return inserted;
 }
 
 function traceRowToCHObject(r: TraceRow): Record<string, unknown> {
@@ -70,38 +101,174 @@ function logRowToCHObject(r: LogRow): Record<string, unknown> {
   };
 }
 
-export async function insertTraceRows(
+export function insertTraceRows(
   client: ClickHouseClient,
   table: string,
   rows: TraceRow[],
 ): Promise<number> {
-  if (rows.length === 0) return 0;
-  let inserted = 0;
-  for (const batch of chunk(rows, BATCH_SIZE)) {
-    await client.insert({
-      table: `${EVAL_DATABASE}.${table}`,
-      values: batch.map(traceRowToCHObject),
-      format: 'JSONEachRow',
-    });
-    inserted += batch.length;
-  }
-  return inserted;
+  return insertMappedRows(client, table, rows, traceRowToCHObject);
 }
 
-export async function insertLogRows(
+export function insertLogRows(
   client: ClickHouseClient,
   table: string,
   rows: LogRow[],
 ): Promise<number> {
-  if (rows.length === 0) return 0;
-  let inserted = 0;
-  for (const batch of chunk(rows, BATCH_SIZE)) {
-    await client.insert({
-      table: `${EVAL_DATABASE}.${table}`,
-      values: batch.map(logRowToCHObject),
-      format: 'JSONEachRow',
-    });
-    inserted += batch.length;
-  }
-  return inserted;
+  return insertMappedRows(client, table, rows, logRowToCHObject);
 }
+
+const EMPTY_EXEMPLARS = {
+  'Exemplars.FilteredAttributes': [],
+  'Exemplars.TimeUnix': [],
+  'Exemplars.Value': [],
+  'Exemplars.SpanId': [],
+  'Exemplars.TraceId': [],
+} as const;
+
+function metricCommon(r: {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+}): Record<string, unknown> {
+  return {
+    ResourceAttributes: r.resourceAttributes ?? {},
+    ResourceSchemaUrl: '',
+    ScopeName: '',
+    ScopeVersion: '',
+    ScopeAttributes: {},
+    ScopeDroppedAttrCount: 0,
+    ScopeSchemaUrl: '',
+    ServiceName: r.serviceName,
+    MetricName: r.metricName,
+    MetricDescription: r.metricDescription ?? '',
+    MetricUnit: r.metricUnit ?? '',
+    Attributes: r.attributes ?? {},
+    StartTimeUnix: msToDateTime(r.startTimeUnixMs ?? r.timeUnixMs),
+    TimeUnix: msToDateTime(r.timeUnixMs),
+    Flags: 0,
+  };
+}
+
+function gaugeRowToCHObject(r: GaugeMetricRow): Record<string, unknown> {
+  return {
+    ...metricCommon(r),
+    Value: r.value,
+    ...EMPTY_EXEMPLARS,
+  };
+}
+
+function sumRowToCHObject(r: SumMetricRow): Record<string, unknown> {
+  return {
+    ...metricCommon(r),
+    Value: r.value,
+    ...EMPTY_EXEMPLARS,
+    AggregationTemporality: r.aggregationTemporality ?? 2,
+    IsMonotonic: r.isMonotonic ?? true,
+  };
+}
+
+function histogramRowToCHObject(
+  r: HistogramMetricRow,
+): Record<string, unknown> {
+  return {
+    ...metricCommon(r),
+    Count: String(r.count),
+    Sum: r.sum,
+    BucketCounts: r.bucketCounts.map(String),
+    ExplicitBounds: r.explicitBounds,
+    ...EMPTY_EXEMPLARS,
+    Min: r.min ?? 0,
+    Max: r.max ?? 0,
+    AggregationTemporality: r.aggregationTemporality ?? 2,
+  };
+}
+
+function exponentialHistogramRowToCHObject(
+  r: ExponentialHistogramMetricRow,
+): Record<string, unknown> {
+  return {
+    ...metricCommon(r),
+    Count: String(r.count),
+    Sum: r.sum,
+    Scale: r.scale,
+    ZeroCount: String(r.zeroCount),
+    PositiveOffset: r.positiveOffset,
+    PositiveBucketCounts: r.positiveBucketCounts.map(String),
+    NegativeOffset: r.negativeOffset,
+    NegativeBucketCounts: r.negativeBucketCounts.map(String),
+    ...EMPTY_EXEMPLARS,
+    Min: r.min ?? 0,
+    Max: r.max ?? 0,
+    AggregationTemporality: r.aggregationTemporality ?? 2,
+  };
+}
+
+function summaryRowToCHObject(r: SummaryMetricRow): Record<string, unknown> {
+  return {
+    ...metricCommon(r),
+    Count: String(r.count),
+    Sum: r.sum,
+    'ValueAtQuantiles.Quantile': r.quantiles.map(q => q.quantile),
+    'ValueAtQuantiles.Value': r.quantiles.map(q => q.value),
+  };
+}
+
+export function insertGaugeMetricRows(
+  client: ClickHouseClient,
+  table: string,
+  rows: GaugeMetricRow[],
+): Promise<number> {
+  return insertMappedRows(client, table, rows, gaugeRowToCHObject);
+}
+
+export function insertSumMetricRows(
+  client: ClickHouseClient,
+  table: string,
+  rows: SumMetricRow[],
+): Promise<number> {
+  return insertMappedRows(client, table, rows, sumRowToCHObject);
+}
+
+export function insertHistogramMetricRows(
+  client: ClickHouseClient,
+  table: string,
+  rows: HistogramMetricRow[],
+): Promise<number> {
+  return insertMappedRows(client, table, rows, histogramRowToCHObject);
+}
+
+export function insertExponentialHistogramMetricRows(
+  client: ClickHouseClient,
+  table: string,
+  rows: ExponentialHistogramMetricRow[],
+): Promise<number> {
+  return insertMappedRows(
+    client,
+    table,
+    rows,
+    exponentialHistogramRowToCHObject,
+  );
+}
+
+export function insertSummaryMetricRows(
+  client: ClickHouseClient,
+  table: string,
+  rows: SummaryMetricRow[],
+): Promise<number> {
+  return insertMappedRows(client, table, rows, summaryRowToCHObject);
+}
+
+// Exported for unit tests so the CH row shape can be asserted without a live
+// ClickHouse. Not part of the public seeding API.
+export const __metricMappers = {
+  gauge: gaugeRowToCHObject,
+  sum: sumRowToCHObject,
+  histogram: histogramRowToCHObject,
+  exponentialHistogram: exponentialHistogramRowToCHObject,
+  summary: summaryRowToCHObject,
+};

--- a/packages/hdx-eval/src/clickhouse/schema.ts
+++ b/packages/hdx-eval/src/clickhouse/schema.ts
@@ -4,6 +4,31 @@ export const EVAL_DATABASE = 'default';
 const SOURCE_TRACES_TABLE = 'otel_traces';
 const SOURCE_LOGS_TABLE = 'otel_logs';
 
+const METRIC_TABLES = [
+  {
+    field: 'metricsGauge',
+    source: 'otel_metrics_gauge',
+  },
+  {
+    field: 'metricsSum',
+    source: 'otel_metrics_sum',
+  },
+  {
+    field: 'metricsHistogram',
+    source: 'otel_metrics_histogram',
+  },
+  {
+    field: 'metricsExponentialHistogram',
+    source: 'otel_metrics_exponential_histogram',
+  },
+  {
+    field: 'metricsSummary',
+    source: 'otel_metrics_summary',
+  },
+] as const;
+
+type MetricTableField = (typeof METRIC_TABLES)[number]['field'];
+
 export type ScenarioTables = {
   traces: string;
   logs: string;
@@ -11,9 +36,9 @@ export type ScenarioTables = {
   tracesKeyRollup: string;
   logsKvRollup: string;
   logsKeyRollup: string;
-};
+} & Record<MetricTableField, string>;
 
-function scenarioSlug(scenario: string): string {
+export function scenarioSlug(scenario: string): string {
   if (!/^[a-z0-9_-]+$/.test(scenario)) {
     throw new Error(
       `Invalid scenario name "${scenario}": must match /^[a-z0-9_-]+$/`,
@@ -24,6 +49,9 @@ function scenarioSlug(scenario: string): string {
 
 export function scenarioTables(scenario: string): ScenarioTables {
   const slug = scenarioSlug(scenario);
+  const metricTables = Object.fromEntries(
+    METRIC_TABLES.map(({ field, source }) => [field, `eval_${slug}_${source}`]),
+  ) as Record<MetricTableField, string>;
   return {
     traces: `eval_${slug}_otel_traces`,
     logs: `eval_${slug}_otel_logs`,
@@ -31,6 +59,7 @@ export function scenarioTables(scenario: string): ScenarioTables {
     tracesKeyRollup: `eval_${slug}_otel_traces_key_rollup_15m`,
     logsKvRollup: `eval_${slug}_otel_logs_kv_rollup_15m`,
     logsKeyRollup: `eval_${slug}_otel_logs_key_rollup_15m`,
+    ...metricTables,
   };
 }
 
@@ -51,7 +80,12 @@ async function tableExists(
 async function assertSourceTablesExist(
   client: ClickHouseClient,
 ): Promise<void> {
-  for (const t of [SOURCE_TRACES_TABLE, SOURCE_LOGS_TABLE]) {
+  const required = [
+    SOURCE_TRACES_TABLE,
+    SOURCE_LOGS_TABLE,
+    ...METRIC_TABLES.map(({ source }) => source),
+  ];
+  for (const t of required) {
     if (!(await tableExists(client, EVAL_DATABASE, t))) {
       throw new Error(
         `Required source table ${EVAL_DATABASE}.${t} does not exist. ` +
@@ -83,6 +117,14 @@ export async function ensureScenarioTables(
   // Idempotent: subsequent runs error with "no TTL to remove" — ignore.
   await removeTtlIfPresent(client, tables.traces);
   await removeTtlIfPresent(client, tables.logs);
+
+  for (const { field, source } of METRIC_TABLES) {
+    const metricTable = tables[field];
+    await client.command({
+      query: `CREATE TABLE IF NOT EXISTS ${EVAL_DATABASE}.${metricTable} AS ${EVAL_DATABASE}.${source}`,
+    });
+    await removeTtlIfPresent(client, metricTable);
+  }
 
   // Create KV/Key rollup tables and materialized views so the HyperDX MCP
   // can use fast metadata discovery instead of scanning the full raw tables.
@@ -152,6 +194,11 @@ export async function truncateScenarioTables(
   await client.command({
     query: `TRUNCATE TABLE IF EXISTS ${EVAL_DATABASE}.${tables.logs}`,
   });
+  for (const { field } of METRIC_TABLES) {
+    await client.command({
+      query: `TRUNCATE TABLE IF EXISTS ${EVAL_DATABASE}.${tables[field]}`,
+    });
+  }
 }
 
 export async function dropScenarioTables(
@@ -167,6 +214,11 @@ export async function dropScenarioTables(
   await client.command({
     query: `DROP TABLE IF EXISTS ${EVAL_DATABASE}.${tables.logs}`,
   });
+  for (const { field } of METRIC_TABLES) {
+    await client.command({
+      query: `DROP TABLE IF EXISTS ${EVAL_DATABASE}.${tables[field]}`,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/hdx-eval/src/generators/metrics.ts
+++ b/packages/hdx-eval/src/generators/metrics.ts
@@ -1,0 +1,244 @@
+import type { SeededRng } from '@/rng/seeded';
+
+import type {
+  AggregationTemporality,
+  ExponentialHistogramMetricRow,
+  GaugeMetricRow,
+  HistogramMetricRow,
+  SummaryMetricRow,
+  SumMetricRow,
+} from './types';
+
+const CUMULATIVE: AggregationTemporality = 2;
+
+function withServiceName(
+  serviceName: string,
+  resourceAttributes?: Record<string, string>,
+): Record<string, string> {
+  return {
+    'service.name': serviceName,
+    ...(resourceAttributes ?? {}),
+  };
+}
+
+export type GaugeInput = {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  value: number;
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+};
+
+export function makeGauge(input: GaugeInput): GaugeMetricRow {
+  return {
+    timeUnixMs: input.timeUnixMs,
+    startTimeUnixMs: input.startTimeUnixMs ?? input.timeUnixMs,
+    serviceName: input.serviceName,
+    metricName: input.metricName,
+    metricDescription: input.metricDescription ?? '',
+    metricUnit: input.metricUnit ?? '',
+    value: input.value,
+    resourceAttributes: withServiceName(
+      input.serviceName,
+      input.resourceAttributes,
+    ),
+    attributes: input.attributes ?? {},
+  };
+}
+
+export type SumInput = GaugeInput & {
+  aggregationTemporality?: AggregationTemporality;
+  isMonotonic?: boolean;
+};
+
+export function makeSum(input: SumInput): SumMetricRow {
+  return {
+    timeUnixMs: input.timeUnixMs,
+    startTimeUnixMs: input.startTimeUnixMs ?? input.timeUnixMs,
+    serviceName: input.serviceName,
+    metricName: input.metricName,
+    metricDescription: input.metricDescription ?? '',
+    metricUnit: input.metricUnit ?? '',
+    value: input.value,
+    aggregationTemporality: input.aggregationTemporality ?? CUMULATIVE,
+    isMonotonic: input.isMonotonic ?? true,
+    resourceAttributes: withServiceName(
+      input.serviceName,
+      input.resourceAttributes,
+    ),
+    attributes: input.attributes ?? {},
+  };
+}
+
+export type HistogramInput = {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  count: number;
+  sum: number;
+  bucketCounts: number[];
+  explicitBounds: number[];
+  min?: number;
+  max?: number;
+  aggregationTemporality?: AggregationTemporality;
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+};
+
+export function makeHistogram(input: HistogramInput): HistogramMetricRow {
+  return {
+    timeUnixMs: input.timeUnixMs,
+    startTimeUnixMs: input.startTimeUnixMs ?? input.timeUnixMs,
+    serviceName: input.serviceName,
+    metricName: input.metricName,
+    metricDescription: input.metricDescription ?? '',
+    metricUnit: input.metricUnit ?? '',
+    count: input.count,
+    sum: input.sum,
+    bucketCounts: input.bucketCounts,
+    explicitBounds: input.explicitBounds,
+    min: input.min,
+    max: input.max,
+    aggregationTemporality: input.aggregationTemporality ?? CUMULATIVE,
+    resourceAttributes: withServiceName(
+      input.serviceName,
+      input.resourceAttributes,
+    ),
+    attributes: input.attributes ?? {},
+  };
+}
+
+export type ExponentialHistogramInput = {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  count: number;
+  sum: number;
+  scale: number;
+  zeroCount?: number;
+  positiveOffset?: number;
+  positiveBucketCounts?: number[];
+  negativeOffset?: number;
+  negativeBucketCounts?: number[];
+  min?: number;
+  max?: number;
+  aggregationTemporality?: AggregationTemporality;
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+};
+
+export function makeExponentialHistogram(
+  input: ExponentialHistogramInput,
+): ExponentialHistogramMetricRow {
+  return {
+    timeUnixMs: input.timeUnixMs,
+    startTimeUnixMs: input.startTimeUnixMs ?? input.timeUnixMs,
+    serviceName: input.serviceName,
+    metricName: input.metricName,
+    metricDescription: input.metricDescription ?? '',
+    metricUnit: input.metricUnit ?? '',
+    count: input.count,
+    sum: input.sum,
+    scale: input.scale,
+    zeroCount: input.zeroCount ?? 0,
+    positiveOffset: input.positiveOffset ?? 0,
+    positiveBucketCounts: input.positiveBucketCounts ?? [],
+    negativeOffset: input.negativeOffset ?? 0,
+    negativeBucketCounts: input.negativeBucketCounts ?? [],
+    min: input.min,
+    max: input.max,
+    aggregationTemporality: input.aggregationTemporality ?? CUMULATIVE,
+    resourceAttributes: withServiceName(
+      input.serviceName,
+      input.resourceAttributes,
+    ),
+    attributes: input.attributes ?? {},
+  };
+}
+
+export type SummaryInput = {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  count: number;
+  sum: number;
+  quantiles: { quantile: number; value: number }[];
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+};
+
+export function makeSummary(input: SummaryInput): SummaryMetricRow {
+  return {
+    timeUnixMs: input.timeUnixMs,
+    startTimeUnixMs: input.startTimeUnixMs ?? input.timeUnixMs,
+    serviceName: input.serviceName,
+    metricName: input.metricName,
+    metricDescription: input.metricDescription ?? '',
+    metricUnit: input.metricUnit ?? '',
+    count: input.count,
+    sum: input.sum,
+    quantiles: input.quantiles,
+    resourceAttributes: withServiceName(
+      input.serviceName,
+      input.resourceAttributes,
+    ),
+    attributes: input.attributes ?? {},
+  };
+}
+
+/**
+ * Build cumulative histogram bucket counts from raw samples given explicit
+ * upper bounds. Returns `{ bucketCounts, count, sum, min, max }`. The returned
+ * `bucketCounts` has `bounds.length + 1` entries (final entry is the +Inf
+ * overflow bucket), matching the OTel/ClickHouse layout. Deterministic — a
+ * pure function of its inputs.
+ */
+export function bucketize(
+  samples: readonly number[],
+  bounds: readonly number[],
+): {
+  bucketCounts: number[];
+  count: number;
+  sum: number;
+  min: number;
+  max: number;
+} {
+  const bucketCounts = new Array<number>(bounds.length + 1).fill(0);
+  let sum = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const s of samples) {
+    sum += s;
+    if (s < min) min = s;
+    if (s > max) max = s;
+    let placed = false;
+    for (let b = 0; b < bounds.length; b++) {
+      if (s <= bounds[b]) {
+        bucketCounts[b]++;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) bucketCounts[bounds.length]++;
+  }
+  return {
+    bucketCounts,
+    count: samples.length,
+    sum,
+    min: samples.length ? min : 0,
+    max: samples.length ? max : 0,
+  };
+}

--- a/packages/hdx-eval/src/generators/types.ts
+++ b/packages/hdx-eval/src/generators/types.ts
@@ -49,3 +49,65 @@ export const SEVERITY_NUMBER: Record<CanonicalSeverity, number> = {
   WARN: 13,
   ERROR: 17,
 };
+
+export type AggregationTemporality = 1 | 2;
+
+export type BaseMetricRow = {
+  timeUnixMs: number;
+  startTimeUnixMs?: number;
+  serviceName: string;
+  metricName: string;
+  metricDescription?: string;
+  metricUnit?: string;
+  resourceAttributes?: Record<string, string>;
+  attributes?: Record<string, string>;
+};
+
+export type GaugeMetricRow = BaseMetricRow & {
+  value: number;
+};
+
+export type SumMetricRow = BaseMetricRow & {
+  value: number;
+  aggregationTemporality?: AggregationTemporality;
+  isMonotonic?: boolean;
+};
+
+export type HistogramMetricRow = BaseMetricRow & {
+  count: number;
+  sum: number;
+  /** Per-bucket counts. Length must be `explicitBounds.length + 1`. */
+  bucketCounts: number[];
+  /** Upper bounds of each bucket (exclusive of the final +Inf bucket). */
+  explicitBounds: number[];
+  min?: number;
+  max?: number;
+  aggregationTemporality?: AggregationTemporality;
+};
+
+export type ExponentialHistogramMetricRow = BaseMetricRow & {
+  count: number;
+  sum: number;
+  scale: number;
+  zeroCount: number;
+  positiveOffset: number;
+  positiveBucketCounts: number[];
+  negativeOffset: number;
+  negativeBucketCounts: number[];
+  min?: number;
+  max?: number;
+  aggregationTemporality?: AggregationTemporality;
+};
+
+export type SummaryMetricRow = BaseMetricRow & {
+  count: number;
+  sum: number;
+  quantiles: { quantile: number; value: number }[];
+};
+
+export type MetricRow =
+  | GaugeMetricRow
+  | SumMetricRow
+  | HistogramMetricRow
+  | ExponentialHistogramMetricRow
+  | SummaryMetricRow;

--- a/packages/hdx-eval/src/hyperdx/config.ts
+++ b/packages/hdx-eval/src/hyperdx/config.ts
@@ -11,6 +11,7 @@ import {
 type ScenarioSourceIds = {
   tracesSourceId: string;
   logsSourceId: string;
+  metricsSourceId?: string;
 };
 
 /**

--- a/packages/hdx-eval/src/hyperdx/setup.ts
+++ b/packages/hdx-eval/src/hyperdx/setup.ts
@@ -1,5 +1,3 @@
-import { MetricsDataType } from '@hyperdx/common-utils/dist/types';
-
 import { scenarioTables } from '@/clickhouse/schema';
 import { QUERY_TIMEOUT_SECONDS } from '@/harness/mcpConfig';
 import type { McpDefinition } from '@/harness/types';
@@ -282,7 +280,7 @@ function buildMetricSourceBody(
       histogram: metricTables.histogram,
       'exponential histogram': metricTables.exponentialHistogram,
       summary: metricTables.summary,
-    } satisfies Record<MetricsDataType, string>,
+    },
     logSourceId,
     querySettings: EVAL_QUERY_SETTINGS,
   };

--- a/packages/hdx-eval/src/hyperdx/setup.ts
+++ b/packages/hdx-eval/src/hyperdx/setup.ts
@@ -1,3 +1,5 @@
+import { MetricsDataType } from '@hyperdx/common-utils/dist/types';
+
 import { scenarioTables } from '@/clickhouse/schema';
 import { QUERY_TIMEOUT_SECONDS } from '@/harness/mcpConfig';
 import type { McpDefinition } from '@/harness/types';
@@ -79,13 +81,14 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
   const created: string[] = [];
   const scenarioIds: Record<
     string,
-    { tracesSourceId: string; logsSourceId: string }
+    { tracesSourceId: string; logsSourceId: string; metricsSourceId: string }
   > = {};
 
   for (const name of SCENARIO_NAMES) {
     const tables = scenarioTables(name);
     const traceName = `eval-${name}-traces`;
     const logName = `eval-${name}-logs`;
+    const metricName = `eval-${name}-metrics`;
 
     let traceSource = sourcesByName.get(traceName);
     if (!traceSource) {
@@ -109,9 +112,29 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
       created.push(logName);
     }
 
+    let metricSource = sourcesByName.get(metricName);
+    if (!metricSource) {
+      metricSource = await api.createSource(
+        buildMetricSourceBody(
+          metricName,
+          connection._id,
+          {
+            gauge: tables.metricsGauge,
+            sum: tables.metricsSum,
+            histogram: tables.metricsHistogram,
+            exponentialHistogram: tables.metricsExponentialHistogram,
+            summary: tables.metricsSummary,
+          },
+          sourceId(logSource),
+        ),
+      );
+      created.push(metricName);
+    }
+
     scenarioIds[name] = {
       tracesSourceId: sourceId(traceSource),
       logsSourceId: sourceId(logSource),
+      metricsSourceId: sourceId(metricSource),
     };
   }
 
@@ -230,6 +253,38 @@ function buildTraceSourceBody(
       kvRollupTable: rollup.kvRollupTable,
       granularity: '15 minute',
     },
+  };
+}
+
+function buildMetricSourceBody(
+  name: string,
+  connectionId: string,
+  metricTables: {
+    gauge: string;
+    sum: string;
+    histogram: string;
+    exponentialHistogram: string;
+    summary: string;
+  },
+  logSourceId: string,
+): Record<string, unknown> {
+  return {
+    name,
+    kind: 'metric',
+    connection: connectionId,
+    from: { databaseName: 'default', tableName: '' },
+    timestampValueExpression: 'TimeUnix',
+    serviceNameExpression: 'ServiceName',
+    resourceAttributesExpression: 'ResourceAttributes',
+    metricTables: {
+      gauge: metricTables.gauge,
+      sum: metricTables.sum,
+      histogram: metricTables.histogram,
+      'exponential histogram': metricTables.exponentialHistogram,
+      summary: metricTables.summary,
+    } satisfies Record<MetricsDataType, string>,
+    logSourceId,
+    querySettings: EVAL_QUERY_SETTINGS,
   };
 }
 

--- a/packages/hdx-eval/src/index.ts
+++ b/packages/hdx-eval/src/index.ts
@@ -1,10 +1,29 @@
 export { scenarioTables } from './clickhouse/schema';
-export type { LogRow, TraceRow } from './generators/types';
+export {
+  makeExponentialHistogram,
+  makeGauge,
+  makeHistogram,
+  makeSum,
+  makeSummary,
+} from './generators/metrics';
+export type {
+  AggregationTemporality,
+  BaseMetricRow,
+  ExponentialHistogramMetricRow,
+  GaugeMetricRow,
+  HistogramMetricRow,
+  LogRow,
+  MetricRow,
+  SummaryMetricRow,
+  SumMetricRow,
+  TraceRow,
+} from './generators/types';
 export type { SeededRng } from './rng/seeded';
 export { mulberry32 } from './rng/seeded';
 export { getScenario, SCENARIO_NAMES, SCENARIOS } from './scenarios';
 export type {
   GenerateContext,
+  MetricBatch,
   Scenario,
   ScenarioBatch,
 } from './scenarios/types';

--- a/packages/hdx-eval/src/scenarios/seedScenario.ts
+++ b/packages/hdx-eval/src/scenarios/seedScenario.ts
@@ -1,23 +1,61 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 
-import { insertLogRows, insertTraceRows } from '@/clickhouse/insert';
+import {
+  insertExponentialHistogramMetricRows,
+  insertGaugeMetricRows,
+  insertHistogramMetricRows,
+  insertLogRows,
+  insertSummaryMetricRows,
+  insertSumMetricRows,
+  insertTraceRows,
+} from '@/clickhouse/insert';
 import {
   ensureScenarioTables,
+  type ScenarioTables,
   truncateScenarioTables,
 } from '@/clickhouse/schema';
 import { mulberry32 } from '@/rng/seeded';
 
 import { getScenario } from './index';
+import type { MetricBatch } from './types';
+
+export type MetricInsertCounts = {
+  gauge: number;
+  sum: number;
+  histogram: number;
+  exponentialHistogram: number;
+  summary: number;
+};
+
+const ZERO_METRIC_COUNTS: MetricInsertCounts = {
+  gauge: 0,
+  sum: 0,
+  histogram: 0,
+  exponentialHistogram: 0,
+  summary: 0,
+};
+
+export function getTotalMetrics(counts: MetricInsertCounts): number {
+  return (
+    counts.gauge +
+    counts.sum +
+    counts.histogram +
+    counts.exponentialHistogram +
+    counts.summary
+  );
+}
 
 export type SeedProgress = {
   tracesInserted: number;
   logsInserted: number;
+  metricsInserted: MetricInsertCounts;
   batchesCompleted: number;
 };
 
 export type SeedResult = {
   tracesInserted: number;
   logsInserted: number;
+  metricsInserted: MetricInsertCounts;
   tables: { traces: string; logs: string };
 };
 
@@ -36,6 +74,7 @@ export async function seedScenario(args: {
 
   let tracesInserted = 0;
   let logsInserted = 0;
+  const metricsInserted: MetricInsertCounts = { ...ZERO_METRIC_COUNTS };
   let batchesCompleted = 0;
   for (const batch of scenario.generate({
     rng,
@@ -52,8 +91,65 @@ export async function seedScenario(args: {
     if (batch.logs.length > 0) {
       logsInserted += await insertLogRows(args.client, tables.logs, batch.logs);
     }
+    if (batch.metrics) {
+      await insertMetricBatch(
+        args.client,
+        tables,
+        batch.metrics,
+        metricsInserted,
+      );
+    }
+
     batchesCompleted++;
-    args.onProgress?.({ tracesInserted, logsInserted, batchesCompleted });
+    args.onProgress?.({
+      tracesInserted,
+      logsInserted,
+      metricsInserted,
+      batchesCompleted,
+    });
   }
-  return { tracesInserted, logsInserted, tables };
+  return { tracesInserted, logsInserted, metricsInserted, tables };
+}
+
+async function insertMetricBatch(
+  client: ClickHouseClient,
+  tables: ScenarioTables,
+  metrics: MetricBatch,
+  counts: MetricInsertCounts,
+): Promise<void> {
+  if (metrics.gauge?.length) {
+    counts.gauge += await insertGaugeMetricRows(
+      client,
+      tables.metricsGauge,
+      metrics.gauge,
+    );
+  }
+  if (metrics.sum?.length) {
+    counts.sum += await insertSumMetricRows(
+      client,
+      tables.metricsSum,
+      metrics.sum,
+    );
+  }
+  if (metrics.histogram?.length) {
+    counts.histogram += await insertHistogramMetricRows(
+      client,
+      tables.metricsHistogram,
+      metrics.histogram,
+    );
+  }
+  if (metrics.exponentialHistogram?.length) {
+    counts.exponentialHistogram += await insertExponentialHistogramMetricRows(
+      client,
+      tables.metricsExponentialHistogram,
+      metrics.exponentialHistogram,
+    );
+  }
+  if (metrics.summary?.length) {
+    counts.summary += await insertSummaryMetricRows(
+      client,
+      tables.metricsSummary,
+      metrics.summary,
+    );
+  }
 }

--- a/packages/hdx-eval/src/scenarios/seedScenario.ts
+++ b/packages/hdx-eval/src/scenarios/seedScenario.ts
@@ -56,7 +56,7 @@ export type SeedResult = {
   tracesInserted: number;
   logsInserted: number;
   metricsInserted: MetricInsertCounts;
-  tables: { traces: string; logs: string };
+  tables: ScenarioTables;
 };
 
 export async function seedScenario(args: {
@@ -117,39 +117,40 @@ async function insertMetricBatch(
   metrics: MetricBatch,
   counts: MetricInsertCounts,
 ): Promise<void> {
-  if (metrics.gauge?.length) {
-    counts.gauge += await insertGaugeMetricRows(
-      client,
-      tables.metricsGauge,
-      metrics.gauge,
-    );
-  }
-  if (metrics.sum?.length) {
-    counts.sum += await insertSumMetricRows(
-      client,
-      tables.metricsSum,
-      metrics.sum,
-    );
-  }
-  if (metrics.histogram?.length) {
-    counts.histogram += await insertHistogramMetricRows(
-      client,
-      tables.metricsHistogram,
-      metrics.histogram,
-    );
-  }
-  if (metrics.exponentialHistogram?.length) {
-    counts.exponentialHistogram += await insertExponentialHistogramMetricRows(
-      client,
-      tables.metricsExponentialHistogram,
-      metrics.exponentialHistogram,
-    );
-  }
-  if (metrics.summary?.length) {
-    counts.summary += await insertSummaryMetricRows(
-      client,
-      tables.metricsSummary,
-      metrics.summary,
-    );
-  }
+  const [gauge, sum, histogram, exponentialHistogram, summary] =
+    await Promise.all([
+      metrics.gauge?.length
+        ? insertGaugeMetricRows(client, tables.metricsGauge, metrics.gauge)
+        : 0,
+      metrics.sum?.length
+        ? insertSumMetricRows(client, tables.metricsSum, metrics.sum)
+        : 0,
+      metrics.histogram?.length
+        ? insertHistogramMetricRows(
+            client,
+            tables.metricsHistogram,
+            metrics.histogram,
+          )
+        : 0,
+      metrics.exponentialHistogram?.length
+        ? insertExponentialHistogramMetricRows(
+            client,
+            tables.metricsExponentialHistogram,
+            metrics.exponentialHistogram,
+          )
+        : 0,
+      metrics.summary?.length
+        ? insertSummaryMetricRows(
+            client,
+            tables.metricsSummary,
+            metrics.summary,
+          )
+        : 0,
+    ]);
+
+  counts.gauge += gauge;
+  counts.sum += sum;
+  counts.histogram += histogram;
+  counts.exponentialHistogram += exponentialHistogram;
+  counts.summary += summary;
 }

--- a/packages/hdx-eval/src/scenarios/types.ts
+++ b/packages/hdx-eval/src/scenarios/types.ts
@@ -1,4 +1,12 @@
-import type { LogRow, TraceRow } from '@/generators/types';
+import type {
+  ExponentialHistogramMetricRow,
+  GaugeMetricRow,
+  HistogramMetricRow,
+  LogRow,
+  SummaryMetricRow,
+  SumMetricRow,
+  TraceRow,
+} from '@/generators/types';
 import type { PromptVariant, ToolCallRecord } from '@/harness/types';
 import type { SeededRng } from '@/rng/seeded';
 
@@ -18,9 +26,22 @@ export type GenerateContext = {
   batchSize?: number;
 };
 
+export type MetricBatch = {
+  gauge?: GaugeMetricRow[];
+  sum?: SumMetricRow[];
+  histogram?: HistogramMetricRow[];
+  exponentialHistogram?: ExponentialHistogramMetricRow[];
+  summary?: SummaryMetricRow[];
+};
+
 export type ScenarioBatch = {
   traces: TraceRow[];
   logs: LogRow[];
+  /**
+   * Optional metric rows. Omitted (or empty) for scenarios that don't emit
+   * metrics — the metric tables/source still exist but stay empty.
+   */
+  metrics?: MetricBatch;
 };
 
 // ─── Scenario hooks ──────────────────────────────────────────────────────────
@@ -133,9 +154,27 @@ export type Scenario = {
 export function collectScenario(iter: Iterable<ScenarioBatch>): ScenarioBatch {
   const traces: TraceRow[] = [];
   const logs: LogRow[] = [];
+  const metrics: Required<MetricBatch> = {
+    gauge: [],
+    sum: [],
+    histogram: [],
+    exponentialHistogram: [],
+    summary: [],
+  };
+  let sawMetrics = false;
   for (const b of iter) {
     if (b.traces.length) traces.push(...b.traces);
     if (b.logs.length) logs.push(...b.logs);
+    if (b.metrics) {
+      sawMetrics = true;
+      if (b.metrics.gauge?.length) metrics.gauge.push(...b.metrics.gauge);
+      if (b.metrics.sum?.length) metrics.sum.push(...b.metrics.sum);
+      if (b.metrics.histogram?.length)
+        metrics.histogram.push(...b.metrics.histogram);
+      if (b.metrics.exponentialHistogram?.length)
+        metrics.exponentialHistogram.push(...b.metrics.exponentialHistogram);
+      if (b.metrics.summary?.length) metrics.summary.push(...b.metrics.summary);
+    }
   }
-  return { traces, logs };
+  return sawMetrics ? { traces, logs, metrics } : { traces, logs };
 }


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Adds metrics type support to the `hdx-eval` tool.

- **Metric row types** (`generators/types.ts`): Added a shared `BaseMetricRow` plus five concrete row types — gauge, sum, histogram, exponential histogram, and summary (ms-based timestamps, converted at insert time).

- **Deterministic generators** (`generators/metrics.ts`, new): Added `makeGauge` / `makeSum` / `makeHistogram` / `makeExponentialHistogram` / `makeSummary` factories mirroring `makeSpan` / `makeLog`, with seeded-RNG determinism, `nowMs` anchoring, and sensible defaults (start time, `service.name` resource attr, cumulative temporality).

- **Batch plumbing** (`scenarios/types.ts`): Extended `ScenarioBatch` with an optional `metrics: MetricBatch` (per-type arrays) and updated `collectScenario` to merge them across yielded batches — backward-compatible, so existing scenarios/tests are untouched.

- **ClickHouse inserts** (`clickhouse/insert.ts`): Added a CH-object mapper + chunked `insert*MetricRows` per type, mapping nested columns (`Exemplars.*`, `ValueAtQuantiles.*`, exp-histogram positive/negative bucket arrays) as dotted keys, plus second-resolution `DateTime` handling for `TimeUnix` / `StartTimeUnix`.

- **Schema cloning** (`clickhouse/schema.ts`): Refactored the five metric tables into a `METRIC_TABLES` table so `ScenarioTables`, `ensureScenarioTables` (CREATE AS + TTL strip), `truncate` / `drop`, and `assertSourceTablesExist` all cover the per-scenario `eval_<slug>_otel_metrics_*` tables.

- **Seed wiring** (`scenarios/seedScenario.ts`, `cli.ts`): Threaded metric batches through seeding with per-type insert counts surfaced in the `seed` CLI output.

- **Source creation** (`hyperdx/setup.ts`, `hyperdx/config.ts`): Added `buildMetricSourceBody` and now create a `kind:'metric'` Source for every scenario (symmetrical with traces/logs), linking all five `metricTables` + the scenario's `logSourceId`, and persist `metricsSourceId` in the config.

- **Exports & tests** (`index.ts`, `__tests__/metrics.test.ts`, new): Exported the new metric types and added 19 unit tests covering generator determinism/anchoring, defaults, and insert-object shapes (including exp-histogram bucket mapping and table-name derivation).

### Testing

- Unit tests to cover new functionality.
- Existing scenarios run unaffected.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4783
- Related PRs:
