### PR TITLE
fix: Fix duplicate key error on trace viewer ticks

### DIFF
--- a/.changeset/eighty-planets-mate.md
+++ b/.changeset/eighty-planets-mate.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Fix duplicate key error on trace viewer ticks

--- a/packages/app/src/components/TimelineChart/TimelineMinimap.tsx
+++ b/packages/app/src/components/TimelineChart/TimelineMinimap.tsx
@@ -113,7 +113,7 @@ export const TimelineMinimap = memo(function ({
       const val = i * interval;
       const frac = val / maxVal;
       if (frac > 1) break;
-      result.push({ frac, label: renderMs(val) });
+      result.push({ val, frac, label: renderMs(val) });
     }
     return result;
   }, [maxVal]);
@@ -275,9 +275,9 @@ export const TimelineMinimap = memo(function ({
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
     >
-      {ticks.map(({ frac, label }) => (
+      {ticks.map(({ val, frac, label }) => (
         <div
-          key={label}
+          key={val}
           className={styles.tick}
           style={{ left: `${frac * 100}%`, height: MINIMAP_HEIGHT }}
         >


### PR DESCRIPTION
## Summary

This PR fixes a duplicate key error logged by react for the trace minimap when multiple time ticks rounded to the same label. The key is now the unique `val` instead of the rounded value.

### Screenshots or video

#### Before

Duplicate ticks:

<img width="1333" height="202" alt="Screenshot 2026-07-15 at 1 15 56 PM" src="https://github.com/user-attachments/assets/dd6dbb43-ecf8-43fa-9366-21f52eb95d53" />


Duplicate key errors:

<img width="713" height="470" alt="Screenshot 2026-07-15 at 12 02 03 PM" src="https://github.com/user-attachments/assets/8ce61374-53f8-4292-99cc-33b97e839a62" />

#### After

None of the same warnings

<img width="710" height="188" alt="Screenshot 2026-07-15 at 12 14 51 PM" src="https://github.com/user-attachments/assets/f0dfb93a-e08d-499b-93b7-2a37da0ce667" />


### How to test on local

Lookup trace id: `75f6402fba79e0c0501bd07191530342` and show logs only. The warning won't appear in the preview environment because it's a prod build.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue:
- Related PRs:
