### PR TITLE
feat(app): clarify selected source in source picker

### DIFF
--- a/.changeset/source-select-selected-indicator.md
+++ b/.changeset/source-select-selected-indicator.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+feat(app): make the selected source clearer in the source picker. The dropdown now marks the current source with a trailing check and a persistent highlight background, adds a small gap between options for readability, and documents the component in Storybook. Introduces a reusable `--color-bg-option-active` theme token (HyperDX + ClickStack, light + dark) for highlighting hovered/selected rows in floating surfaces.

--- a/packages/app/src/components/SourceSelect.stories.tsx
+++ b/packages/app/src/components/SourceSelect.stories.tsx
@@ -1,0 +1,161 @@
+import { http, HttpResponse } from 'msw';
+import { useForm } from 'react-hook-form';
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import { Box } from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { SourceSelectControlled } from './SourceSelect';
+
+const mockSources = [
+  {
+    id: 'source-logs',
+    name: 'OpenAPI LB Logs New',
+    kind: SourceKind.Log,
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_logs' },
+    timestampValueExpression: 'Timestamp',
+  },
+  {
+    id: 'source-console-logs',
+    name: 'Console API LB Logs New',
+    kind: SourceKind.Log,
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'console_logs' },
+    timestampValueExpression: 'Timestamp',
+  },
+  {
+    id: 'source-traces',
+    name: 'Data Plane Traces',
+    kind: SourceKind.Trace,
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_traces' },
+    timestampValueExpression: 'Timestamp',
+  },
+  {
+    id: 'source-sessions',
+    name: 'Sessions',
+    kind: SourceKind.Session,
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'hyperdx_sessions' },
+    timestampValueExpression: 'Timestamp',
+  },
+  {
+    id: 'source-metrics',
+    name: 'System Metrics',
+    kind: SourceKind.Metric,
+    connection: 'conn-1',
+    from: { databaseName: 'default', tableName: 'otel_metrics' },
+    timestampValueExpression: 'TimeUnix',
+  },
+];
+
+const sourcesHandler = http.get('*/api/sources', () =>
+  HttpResponse.json(mockSources),
+);
+
+/**
+ * `SourceSelectControlled` is the data-source picker used across the search,
+ * chart, and dashboard surfaces. It is a `react-hook-form`-controlled Mantine
+ * `Select` that lists the team's sources (optionally grouped by section), shows
+ * the selected source's signal-kind icon on the left, and can render an
+ * adjacent kebab menu for source-management actions.
+ *
+ * The dropdown marks the currently selected source with a trailing check so it
+ * is easy to tell which source is active while scanning the list.
+ */
+const meta: Meta<typeof SourceSelectControlled> = {
+  title: 'Components/SourceSelect',
+  component: SourceSelectControlled,
+  parameters: {
+    layout: 'padded',
+    msw: { handlers: { sources: sourcesHandler } },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+      description: 'Mantine input size',
+    },
+  },
+};
+
+export default meta;
+
+type StoryArgs = {
+  size?: string;
+  defaultSourceId?: string;
+  withMenu?: boolean;
+  allowedSourceKinds?: SourceKind[];
+};
+
+const SourceSelectWrapper = ({
+  size,
+  defaultSourceId = 'source-logs',
+  withMenu,
+  allowedSourceKinds,
+}: StoryArgs) => {
+  const { control } = useForm<{ source: string }>({
+    defaultValues: { source: defaultSourceId },
+  });
+
+  return (
+    <Box style={{ maxWidth: 420 }}>
+      <SourceSelectControlled
+        control={control}
+        name="source"
+        size={size}
+        allowedSourceKinds={allowedSourceKinds}
+        onSchemaPreview={withMenu ? () => {} : undefined}
+        onEdit={withMenu ? () => {} : undefined}
+        onManageSources={withMenu ? () => {} : undefined}
+        onCreate={withMenu ? () => {} : undefined}
+      />
+    </Box>
+  );
+};
+
+type Story = StoryObj<typeof SourceSelectWrapper>;
+
+/**
+ * A source is pre-selected. Open the dropdown to see the active source marked
+ * with a check, alongside each source's signal-kind icon.
+ */
+export const Default: Story = {
+  render: args => <SourceSelectWrapper {...args} />,
+  args: {
+    size: 'sm',
+    defaultSourceId: 'source-logs',
+  },
+};
+
+/** With the adjacent source-management kebab menu (view schema, edit, etc.). */
+export const WithManagementMenu: Story = {
+  name: 'With Management Menu',
+  render: args => <SourceSelectWrapper {...args} />,
+  args: {
+    size: 'sm',
+    defaultSourceId: 'source-traces',
+    withMenu: true,
+  },
+};
+
+/** No source selected yet — shows the generic placeholder icon and text. */
+export const NoSelection: Story = {
+  name: 'No Selection (Placeholder)',
+  render: args => <SourceSelectWrapper {...args} />,
+  args: {
+    size: 'sm',
+    defaultSourceId: '',
+  },
+};
+
+/** Restricted to a single signal kind via `allowedSourceKinds`. */
+export const LogsOnly: Story = {
+  name: 'Logs Only',
+  render: args => <SourceSelectWrapper {...args} />,
+  args: {
+    size: 'sm',
+    defaultSourceId: 'source-logs',
+    allowedSourceKinds: [SourceKind.Log],
+  },
+};

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import {
+  IconCheck,
   IconCode,
   IconDotsVertical,
   IconPencil,
@@ -189,14 +190,19 @@ function SourceSelectControlledComponent({
 
   const sourceKindMap = useSourceKindMap(data);
 
+  // Mantine passes `checked` to renderOption for the currently selected
+  // option; render a trailing check so the active source is obvious in the
+  // dropdown (the closed input only shows the kind icon + label).
   const renderOption = useCallback(
-    ({ option }: { option: ComboboxItem }) => {
+    ({ option, checked }: { option: ComboboxItem; checked?: boolean }) => {
       const icon = SOURCE_KIND_ICONS[sourceKindMap.get(option.value) ?? ''];
-      if (!icon) return option.label;
       return (
-        <Group gap="xs" wrap="nowrap">
+        <Group gap="xs" wrap="nowrap" w="100%">
           {icon}
-          {option.label}
+          <span style={{ flex: 1 }}>{option.label}</span>
+          {checked && (
+            <IconCheck size={14} color="var(--color-text-brand)" stroke={2.5} />
+          )}
         </Group>
       );
     },
@@ -234,6 +240,7 @@ function SourceSelectControlledComponent({
           input: styles.sourceSelectInput,
           groupLabel: styles.groupLabel,
           dropdown: styles.sourceSelectDropdown,
+          option: styles.sourceSelectOption,
         }}
         renderOption={renderOption}
         filter={sourceSelectFilter}

--- a/packages/app/src/theme/themes/clickstack/_tokens.scss
+++ b/packages/app/src/theme/themes/clickstack/_tokens.scss
@@ -126,6 +126,11 @@
   --color-bg-header: var(--click-global-color-background-default);
   --color-bg-hover: var(--palette-neutral-725);
   --color-bg-active: var(--palette-neutral-800);
+
+  /* Highlight background for an interactive row inside a floating surface
+     (Select/Combobox options, Menu items, popover/dropdown lists) when it is
+     hovered or is the currently-selected entry. */
+  --color-bg-option-active: var(--palette-neutral-712);
   --color-bg-field: var(--click-field-color-background-default);
   --color-bg-field-highlighted: var(--palette-neutral-650);
   --color-bg-field-addon: var(--palette-neutral-712);
@@ -328,6 +333,11 @@
   --color-bg-modal: var(--click-global-color-background-default);
   --color-bg-hover: #e9ecef;
   --color-bg-active: #dee2e6;
+
+  /* Highlight background for an interactive row inside a floating surface
+     (Select/Combobox options, Menu items, popover/dropdown lists) when it is
+     hovered or is the currently-selected entry. */
+  --color-bg-option-active: var(--click-global-color-background-muted);
   --color-bg-field: var(--click-field-color-background-default);
   --color-bg-field-highlighted: var(--click-global-color-background-default);
   --color-bg-field-addon: var(--click-global-color-background-default);

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -41,6 +41,11 @@
   --color-bg-header: var(--mantine-color-dark-9);
   --color-bg-hover: var(--mantine-color-dark-6);
   --color-bg-active: var(--mantine-color-dark-5);
+
+  /* Highlight background for an interactive row inside a floating surface
+     (Select/Combobox options, Menu items, popover/dropdown lists) when it is
+     hovered or is the currently-selected entry. */
+  --color-bg-option-active: var(--mantine-color-dark-5);
   --color-bg-field: var(--mantine-color-dark-7);
   --color-bg-field-highlighted: var(--mantine-color-dark-6);
   --color-bg-field-addon: var(--mantine-color-dark-6);
@@ -149,6 +154,11 @@
   --color-bg-modal: var(--mantine-color-white);
   --color-bg-hover: var(--mantine-color-gray-1);
   --color-bg-active: var(--mantine-color-gray-4);
+
+  /* Highlight background for an interactive row inside a floating surface
+     (Select/Combobox options, Menu items, popover/dropdown lists) when it is
+     hovered or is the currently-selected entry. */
+  --color-bg-option-active: var(--color-bg-sidenav-link-active);
   --color-bg-field: #f9f9fc;
   --color-bg-field-highlighted: var(--mantine-color-white);
   --color-bg-field-addon: var(--mantine-color-white);

--- a/packages/app/styles/SourceSelectControlled.module.scss
+++ b/packages/app/styles/SourceSelectControlled.module.scss
@@ -35,7 +35,6 @@
 .sourceSelectGroup {
   display: inline-flex;
   align-items: stretch;
-  gap: 0;
 
   &[data-with-menu] {
     /* Square only the right edge of the input. */
@@ -88,6 +87,29 @@
  */
 .sourceMenuButton {
   flex-shrink: 0;
+}
+
+/* Option hover + selection backgrounds, both driven by the shared
+ * `--color-bg-option-active` floating-surface token. Mantine's Select marks the
+ * chosen option with `data-checked` (the keyboard-highlighted row uses
+ * `data-combobox-active` instead), so we target that for selection; hover reuses
+ * the same token. The class + attribute selectors out-specify Mantine's own
+ * zero-specificity `:where(...)` rules without `!important`. Selection also
+ * carries a trailing check rendered in `renderOption`.
+ */
+.sourceSelectOption {
+  /* Small breathing room between options so the rows (and their hover/selected
+     backgrounds) read as distinct pills rather than one continuous list. */
+  margin-block: 2px;
+
+  &:hover,
+  &[data-checked] {
+    background-color: var(--color-bg-option-active);
+  }
+
+  &[data-checked] {
+    color: inherit;
+  }
 }
 
 /* Grouped dropdown decoupled from the compact picker (comboboxProps


### PR DESCRIPTION
## Summary

The source picker (`SourceSelect`) made it hard to tell which source was currently selected — the open dropdown gave no visual indication of the active source. This makes the current selection obvious and documents the component.

- **Selected indicator**: the dropdown now marks the current source with a trailing check (mirroring the existing `SourceMultiSelect` pattern) plus a persistent highlight background. Root cause was the custom `renderOption` dropping Mantine's default selected treatment; the highlight targets `data-checked` (single `Select` never sets `data-combobox-selected`).
- **Readability**: a small vertical gap between options so rows read as distinct pills.
- **Theme token**: introduces a reusable `--color-bg-option-active` token (HyperDX + ClickStack, light + dark) for highlighting hovered/selected rows in floating surfaces (Select/Combobox options, Menu items, popover lists), instead of hardcoding a color.
- **Storybook**: new `SourceSelect.stories.tsx` documenting the component (default/pre-selected, management menu, no selection, logs-only), with MSW-mocked sources.

<img width="399" height="198" alt="Screenshot 2026-07-15 at 18 12 46" src="https://github.com/user-attachments/assets/c679b724-ce74-44f4-9536-e1b8856a9806" />


## Test plan

- [ ] Open the source picker on the search page — the selected source shows a check + highlight, and options have breathing room between them.
- [ ] Verify in both light and dark mode, and in both HyperDX and ClickStack themes.
- [ ] Run Storybook (`cd packages/app && yarn storybook`) → Components/SourceSelect renders all stories.

Made with [Cursor](https://cursor.com)