### PR TITLE
ci(test): run common-utils unit tests in parallel

### DIFF
--- a/packages/common-utils/package.json
+++ b/packages/common-utils/package.json
@@ -46,8 +46,8 @@
     "lint": "npx eslint --quiet . --ext .ts",
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
-    "ci:unit": "jest --runInBand --ci --coverage",
-    "dev:unit": "jest --watchAll --runInBand",
+    "ci:unit": "jest --ci --coverage",
+    "dev:unit": "jest --watchAll",
     "ci:int": "DOTENV_CONFIG_PATH=.env.test jest --config jest.int.config.js --runInBand --ci --coverage",
     "dev:int": "DOTENV_CONFIG_PATH=.env.test jest --config jest.int.config.js --watchAll --runInBand"
   }


### PR DESCRIPTION
`common-utils` was the only package running its unit tests with `--runInBand` (serial); `app` and `api` already run their unit suites in parallel. The flag was slowing the suite down for no benefit — the unit tests are fully mocked and safe to parallelise — so this drops it from `ci:unit` and `dev:unit`.

## Impact

- `yarn ci:unit` in `common-utils` runs on parallel Jest workers. All 1490 tests across 24 suites still pass.
- Warm local runs drop from ~2.5s to ~1.5s (about 40% faster). The gain is larger on CI cold starts where the suites can spread across cores.
- Integration scripts (`ci:int` / `dev:int`) keep `--runInBand` — they share live MongoDB/ClickHouse state and are a separate question.

No changeset — tooling only.