### PR TITLE
ci(test): enforce coverage floors at current levels

### DIFF
--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -25,4 +25,15 @@ module.exports = {
     '^ky$': '<rootDir>/src/__mocks__/ky-universal.ts',
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.tsx'],
+  // Coverage floor pinned just below measured reality so coverage can only
+  // ratchet up. Decay below these numbers fails the build. Raise them
+  // deliberately as coverage improves; never lower them silently.
+  coverageThreshold: {
+    global: {
+      statements: 53,
+      branches: 37,
+      functions: 38,
+      lines: 54,
+    },
+  },
 };

--- a/packages/common-utils/jest.config.js
+++ b/packages/common-utils/jest.config.js
@@ -15,4 +15,15 @@ module.exports = {
   moduleNameMapper: {
     '@/(.*)$': '<rootDir>/$1',
   },
+  // Coverage floor pinned just below measured reality so coverage can only
+  // ratchet up. Decay below these numbers fails the build. Raise them
+  // deliberately as coverage improves; never lower them silently.
+  coverageThreshold: {
+    global: {
+      statements: 86,
+      branches: 78,
+      functions: 85,
+      lines: 86,
+    },
+  },
 };

--- a/packages/hdx-eval/jest.config.js
+++ b/packages/hdx-eval/jest.config.js
@@ -12,4 +12,15 @@ module.exports = {
   moduleNameMapper: {
     '@/(.*)$': '<rootDir>/$1',
   },
+  // Coverage floor pinned just below measured reality so coverage can only
+  // ratchet up. Decay below these numbers fails the build. Raise them
+  // deliberately as coverage improves; never lower them silently.
+  coverageThreshold: {
+    global: {
+      statements: 70,
+      branches: 55,
+      functions: 72,
+      lines: 71,
+    },
+  },
 };

--- a/packages/hdx-eval/package.json
+++ b/packages/hdx-eval/package.json
@@ -36,7 +36,7 @@
     "lint": "npx eslint --quiet . --ext .ts",
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
-    "ci:unit": "jest --ci --forceExit",
+    "ci:unit": "jest --ci --coverage --forceExit",
     "dev:unit": "jest --watch",
     "viewer": "node scripts/viewer/server.js"
   }


### PR DESCRIPTION
Jest already collects coverage but nothing gates on it, so coverage can decay unnoticed. This pins per-package coverage thresholds just below the current measured levels, so the floor can only rise — decay becomes a build failure.

## What changed

- Added `coverageThreshold.global` (statements/branches/functions/lines) to the unit `jest.config.js` of `packages/app`, `packages/common-utils`, and `packages/hdx-eval`, each set to the measured value minus ~1 point.
- `packages/hdx-eval`'s `ci:unit` gained `--coverage` so its threshold is actually collected.

## Key decisions

- Thresholds are pinned ~1 below measured (not at a round number), so the gate passes today and only moves up deliberately.
- `packages/api` is **deferred** — its `ci:unit` doesn't exist until the API unit/integration split (#2653) merges; the API floor is a follow-up once that lands.
- `packages/cli` is skipped (a single test file — a threshold there would be theatre).

## Impact

- A change that drops coverage below the floor fails the unit job.
- Tests/config only — no changeset.
- **Follow-up to track:** there's no `collectCoverageFrom`, so a brand-new *entirely untested* file doesn't lower the global percentage and won't trip the floor. Adding it later would re-baseline all thresholds; worth a tracked issue rather than expanding this PR.

<details>
<summary>Implementation detail</summary>

Verified both directions: `make ci-unit` passes with the floors; temporarily setting `statements: 99` in common-utils fails with a threshold error; reverted.

</details>