### PR TITLE
ci: enforce immutable installs and scope the docker bake cache

### DIFF
--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: yarn install
+      run: yarn install --immutable
 
     - name: Build dependencies
       shell: bash

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Run Knip
         run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
           cache: 'yarn'
       - name: Install root dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Build dependencies
         run: make ci-build
       - name: Install core libs
@@ -41,7 +41,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
           cache: 'yarn'
       - name: Install root dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Build dependencies
         run: make ci-build
       - name: Run unit tests
@@ -59,13 +59,13 @@ jobs:
           cache-dependency-path: 'yarn.lock'
           cache: 'yarn'
       - name: Install root dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v4
       - name: Spin up docker services
         run: |
           docker buildx create --use --driver=docker-container
-          docker buildx bake -f ./docker-compose.ci.yml --set *.cache-to="type=gha" --set *.cache-from="type=gha" --load
+          docker buildx bake -f ./docker-compose.ci.yml --set *.cache-to="type=gha,mode=max,scope=ci-integration" --set *.cache-from="type=gha,scope=ci-integration" --load
       - name: Build dependencies
         run: make ci-build
       - name: Run integration tests
@@ -264,7 +264,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build App
         run: yarn build:clickhouse


### PR DESCRIPTION
Two CI-time improvements. The headline non-change: I measured caching `node_modules` and it *loses*, so it was deliberately not added — restoring the ~1.8G tree costs ~29.6s (plus a 241M cache download) versus a ~23.2s warm `yarn install`. What did ship is smaller and safe.

## What changed

- `yarn install` → `yarn install --immutable` across the CI install steps (main.yml lint/unit/integration/clickhouse-static-build, knip.yml, and the e2e-setup action). This fails CI on lockfile drift — the same class of bug that would otherwise slip through.
- The integration job's `docker buildx bake` cache goes from an unscoped `type=gha` to `type=gha,mode=max,scope=ci-integration`, so its layers actually persist between runs.

## Key decisions

- **node_modules cache dropped on evidence.** The restore-and-decompress of a 1.8G tree is I/O-bound and slower than yarn's warm-cache linking, so it would make CI slower, not faster. Kept only the existing `setup-node` yarn download cache.
- There is no e2e `bake` step to scope — the e2e stack uses `docker compose pull` of published images.

## Impact

- Marginally faster/more-reliable installs; better docker layer reuse on the integration job.
- `release.yml` and `claude.yml` have their own `yarn install` steps left intentionally out of scope (this PR targets the PR-time CI path).
- CI only — no changeset.
- Built off `main`, so it will conflict in `main.yml` with the lint and integration PRs; on resolution, carry forward `--immutable` and the `mode=max,scope=ci-integration` bake cache.

<details>
<summary>Implementation detail</summary>

`--immutable` is the Yarn 4 flag (repo pins `yarn@4.13.0`). Local dev install paths (`scripts/`, Makefile) are untouched. The single `build:` target in `docker-compose.ci.yml` means the shared `*` bake selector can't cause a scope collision (verified with `buildx bake --print`).

</details>