### PR TITLE
feat(evals): add metrics-saturation scenario

### DIFF
--- a/.changeset/hungry-readers-reflect.md
+++ b/.changeset/hungry-readers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/hdx-eval": patch
+---
+
+feat(evals): add metrics-saturation scenario

--- a/packages/hdx-eval/README.md
+++ b/packages/hdx-eval/README.md
@@ -261,6 +261,7 @@ mirrors HyperDX's `otel_traces` / `otel_logs` exactly.
 |---|---|---|
 | `error-root-cause` | "Checkout requests are failing..." | `payment-service` DB timeout cascading into `checkout-api` 5xx. 6M+ spans, 12M logs, 5 distractors. |
 | `latency-spike` | "p99 latency on api-server has jumped..." | `/api/orders/search` p99 spike for enterprise tenants. 12M+ spans, 5 regions, 5 distractors. |
+| `metric-saturation` | "recommendation-service is intermittently slow / 503s..." | JVM heap leak → GC-pause tail → latency shift → pod-restart cadence. Root cause is **metrics-only** (traces/logs show just mild latency + generic 503s). Exercises all five metric types (gauge/sum/histogram/exp-histogram/summary). Distractors: coincidental deploy, flat CPU, stable neighbor Summary. |
 | `noisy-signals` | "We want to cut log ingest cost..." | ~16M logs across composite cells. Each noisy cell has a load-bearing pattern mixed in. |
 | `segmented-regression` | "API error rate has gone up..." | Enterprise x cache-miss errors at ~12%. Single-axis aggregates dilute the signal. |
 | `service-health-check` | "Generate a service health report..." | Peace-time report — no incident, but 4 novel signals to call out. |

--- a/packages/hdx-eval/src/__tests__/metric-saturation.test.ts
+++ b/packages/hdx-eval/src/__tests__/metric-saturation.test.ts
@@ -1,0 +1,230 @@
+import { buildSystemPrompt } from '@/harness/systemPrompt';
+import { mulberry32 } from '@/rng/seeded';
+import { metricSaturationScenario } from '@/scenarios/metric-saturation/generate';
+import { collectScenario } from '@/scenarios/types';
+
+const NOW_MS = Date.parse('2026-05-10T20:00:00.000Z');
+// 2% volume keeps the test cheap (~5K traces) while preserving every planted
+// metric signal — metrics are fixed-volume and never scaled.
+const TEST_VOLUME_FACTOR = 0.02;
+
+const WINDOW_MS = 2 * 60 * 60 * 1000;
+const LEAK_START_MS = NOW_MS - 90 * 60 * 1000;
+const DEPLOY_MS = NOW_MS - 40 * 60 * 1000;
+const WINDOW_START_MS = NOW_MS - WINDOW_MS;
+
+function run(seed: number, factor = TEST_VOLUME_FACTOR) {
+  return collectScenario(
+    metricSaturationScenario.generate({
+      rng: mulberry32(seed),
+      nowMs: NOW_MS,
+      volumeFactor: factor,
+    }),
+  );
+}
+
+describe('metric-saturation scenario', () => {
+  const result = run(42);
+  const m = result.metrics!;
+
+  it('emits all five OTel metric types', () => {
+    expect(m).toBeDefined();
+    expect(m.gauge!.length).toBeGreaterThan(0);
+    expect(m.sum!.length).toBeGreaterThan(0);
+    expect(m.histogram!.length).toBeGreaterThan(0);
+    expect(m.exponentialHistogram!.length).toBeGreaterThan(0);
+    expect(m.summary!.length).toBeGreaterThan(0);
+  });
+
+  it('is deterministic for a fixed seed (traces + metrics)', () => {
+    const b = run(42);
+    expect(b.traces.length).toBe(result.traces.length);
+    expect(b.logs.length).toBe(result.logs.length);
+    expect(b.traces[10]?.spanId).toBe(result.traces[10]?.spanId);
+    expect(JSON.stringify(b.metrics)).toBe(JSON.stringify(m));
+  });
+
+  it('anchors every metric point at or before now, within the window', () => {
+    const all = [
+      ...m.gauge!,
+      ...m.sum!,
+      ...m.histogram!,
+      ...m.exponentialHistogram!,
+      ...m.summary!,
+    ];
+    for (const pt of all) {
+      expect(pt.timeUnixMs).toBeLessThanOrEqual(NOW_MS);
+      expect(pt.timeUnixMs).toBeGreaterThanOrEqual(WINDOW_START_MS);
+    }
+  });
+
+  describe('gauge — heap leak sawtooth (load-bearing)', () => {
+    const heap = m
+      .gauge!.filter(g => g.metricName === 'process.runtime.jvm.memory.used')
+      .map(g => ({ t: g.timeUnixMs, mb: g.value / 1024 / 1024 }));
+
+    it('is flat at baseline before the leak starts', () => {
+      const preLeak = heap.filter(p => p.t < LEAK_START_MS - 60_000);
+      expect(preLeak.length).toBeGreaterThan(0);
+      const maxPre = Math.max(...preLeak.map(p => p.mb));
+      expect(maxPre).toBeLessThan(850); // baseline ~600 + young-gen jitter
+    });
+
+    it('climbs toward the limit then resets (sawtooth) during the leak', () => {
+      const inLeak = heap.filter(p => p.t >= LEAK_START_MS);
+      const maxIn = Math.max(...inLeak.map(p => p.mb));
+      const minIn = Math.min(...inLeak.map(p => p.mb));
+      expect(maxIn).toBeGreaterThan(1800); // approaches the ~1950MB limit
+      expect(minIn).toBeLessThan(900); // drops back to baseline after restart
+    });
+  });
+
+  it('gauge — CPU utilization stays flat and healthy (rules out CPU)', () => {
+    const cpu = m.gauge!.filter(g => g.metricName === 'system.cpu.utilization');
+    expect(cpu.length).toBeGreaterThan(0);
+    for (const c of cpu) {
+      expect(c.value).toBeGreaterThanOrEqual(0.3);
+      expect(c.value).toBeLessThanOrEqual(0.45);
+    }
+  });
+
+  describe('sum — cumulative restart + GC counters (need a rate)', () => {
+    it('k8s.pod.restarts is monotonic and shows a restart storm', () => {
+      const restarts = m.sum!.filter(s => s.metricName === 'k8s.pod.restarts');
+      for (let i = 1; i < restarts.length; i++) {
+        expect(restarts[i].value).toBeGreaterThanOrEqual(restarts[i - 1].value);
+      }
+      expect(restarts[0].value).toBe(0);
+      expect(restarts[restarts.length - 1].value).toBeGreaterThanOrEqual(3);
+    });
+
+    it('Old-Gen GC collections accelerate once the leak is underway', () => {
+      const oldGc = m
+        .sum!.filter(
+          s =>
+            s.metricName === 'jvm.gc.collections' &&
+            s.attributes?.['gc.name'] === 'G1 Old Generation',
+        )
+        .sort((a, b) => a.timeUnixMs - b.timeUnixMs);
+      const rateOver = (from: number, to: number): number => {
+        const pts = oldGc.filter(
+          p => p.timeUnixMs >= from && p.timeUnixMs < to,
+        );
+        if (pts.length < 2) return 0;
+        return pts[pts.length - 1].value - pts[0].value;
+      };
+      const preRate = rateOver(WINDOW_START_MS, LEAK_START_MS);
+      const leakRate = rateOver(LEAK_START_MS, NOW_MS);
+      expect(leakRate).toBeGreaterThan(preRate * 2);
+    });
+  });
+
+  it('histogram — request-duration mass shifts into the slow buckets in-window', () => {
+    const hist = m
+      .histogram!.filter(h => h.metricName === 'http.server.request.duration')
+      .sort((a, b) => a.timeUnixMs - b.timeUnixMs);
+    // Buckets 7+ correspond to > 500ms (bounds index 6 == 500).
+    const slowFrac = (h: (typeof hist)[number]): number =>
+      h.bucketCounts.slice(7).reduce((a, b) => a + b, 0) / h.count;
+    const early = hist.filter(h => h.timeUnixMs < LEAK_START_MS - 60_000);
+    const late = hist.filter(h => h.timeUnixMs >= NOW_MS - 20 * 60 * 1000);
+    const earlyAvg = early.reduce((a, h) => a + slowFrac(h), 0) / early.length;
+    const lateAvg = late.reduce((a, h) => a + slowFrac(h), 0) / late.length;
+    expect(lateAvg).toBeGreaterThan(earlyAvg * 3);
+  });
+
+  it('exponential histogram — GC-pause distribution develops a heavy tail', () => {
+    const exp = m
+      .exponentialHistogram!.filter(e => e.metricName === 'jvm.gc.pause')
+      .sort((a, b) => a.timeUnixMs - b.timeUnixMs);
+    const early = exp.filter(e => e.timeUnixMs < LEAK_START_MS - 60_000);
+    const late = exp.filter(e => e.timeUnixMs >= NOW_MS - 20 * 60 * 1000);
+    const maxEarly = Math.max(...early.map(e => e.max ?? 0));
+    const maxLate = Math.max(...late.map(e => e.max ?? 0));
+    expect(maxEarly).toBeLessThan(100); // only small young-gen pauses pre-leak
+    expect(maxLate).toBeGreaterThan(400); // full-GC pauses in the tail
+  });
+
+  it('summary — neighbor db.client latency is a stable, unrelated decoy', () => {
+    const sm = m.summary!.filter(
+      s => s.metricName === 'db.client.operation.duration',
+    );
+    expect(sm.length).toBeGreaterThan(0);
+    // It lives on a DIFFERENT service than the incident.
+    for (const s of sm) expect(s.serviceName).toBe('inventory-service');
+    // p99 is flat across the whole window (not correlated with the incident).
+    const p99 = sm.map(s => s.quantiles[2].value);
+    expect(Math.max(...p99) - Math.min(...p99)).toBeLessThan(20);
+  });
+
+  describe('load-bearing property — root cause is NOT in traces/logs', () => {
+    it('no trace span carries memory/GC/heap attributes or messages', () => {
+      const causeRe =
+        /leak|out of memory|oomkill|heap|garbage|gc\.pause|jvm\./i;
+      for (const t of result.traces) {
+        expect(causeRe.test(JSON.stringify(t.spanAttributes))).toBe(false);
+        expect(causeRe.test(t.statusMessage)).toBe(false);
+      }
+    });
+
+    it('no log body reveals the leak/OOM diagnosis', () => {
+      const diagnosticRe = /\bleak\b|out of memory|oomkilled|outofmemoryerror/i;
+      for (const l of result.logs) {
+        expect(diagnosticRe.test(l.body)).toBe(false);
+      }
+    });
+
+    it('trace latency is only mildly elevated (no obvious signal)', () => {
+      const inWindow = result.traces.filter(
+        t => t.timestampMs >= LEAK_START_MS,
+      );
+      const slow = inWindow.filter(t => t.durationNs / 1e6 > 500);
+      const errors = inWindow.filter(t => t.statusCode === 'STATUS_CODE_ERROR');
+      expect(slow.length / inWindow.length).toBeLessThan(0.15);
+      expect(errors.length / inWindow.length).toBeLessThan(0.01);
+    });
+  });
+
+  describe('distractors', () => {
+    it('plants a coincidental deploy that POSTDATES the leak', () => {
+      const deployLog = result.logs.find(l =>
+        /rolled out: version 1\.43\.0 -> 1\.43\.1/.test(l.body),
+      );
+      expect(deployLog).toBeDefined();
+      expect(deployLog!.timestampMs).toBe(DEPLOY_MS);
+      // The leak was already well underway before the deploy: heap climbing
+      // above baseline before DEPLOY_MS proves the deploy isn't the cause.
+      const heapBeforeDeploy = m
+        .gauge!.filter(
+          g =>
+            g.metricName === 'process.runtime.jvm.memory.used' &&
+            g.timeUnixMs >= LEAK_START_MS &&
+            g.timeUnixMs < DEPLOY_MS,
+        )
+        .map(g => g.value / 1024 / 1024);
+      expect(Math.max(...heapBeforeDeploy)).toBeGreaterThan(1000);
+    });
+
+    it('emits ambiguous restart-adjacent log lines (symptom, not cause)', () => {
+      const restartLines = result.logs.filter(l =>
+        /liveness probe failed|received sigterm|readiness probe failed|container recommendation-service restarted/i.test(
+          l.body,
+        ),
+      );
+      expect(restartLines.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('metric-saturation system prompt', () => {
+  it('tells the agent a metric source is available', () => {
+    const prompt = buildSystemPrompt(
+      metricSaturationScenario,
+      '2026-05-10T20:00:00.000Z',
+    );
+    expect(prompt).toMatch(/metric source is available/i);
+    expect(prompt).toMatch(/exponential histogram/i);
+    // Still the default SRE investigation framing.
+    expect(prompt).toMatch(/You are an SRE/i);
+  });
+});

--- a/packages/hdx-eval/src/__tests__/metrics.test.ts
+++ b/packages/hdx-eval/src/__tests__/metrics.test.ts
@@ -2,6 +2,7 @@ import { __metricMappers } from '@/clickhouse/insert';
 import { scenarioTables } from '@/clickhouse/schema';
 import {
   bucketize,
+  expBucketize,
   makeExponentialHistogram,
   makeGauge,
   makeHistogram,
@@ -162,6 +163,66 @@ describe('bucketize', () => {
     expect(sum).toBe(0);
     expect(min).toBe(0);
     expect(max).toBe(0);
+  });
+});
+
+describe('expBucketize', () => {
+  it('maps positive samples into base-2 buckets at scale 0', () => {
+    // scale 0 → base 2, bucket i covers (2^i, 2^(i+1)].
+    // 1→idx -1, 2→idx 0, 3→idx 1, 4→idx 1, 5→idx 2.
+    const r = expBucketize([1, 2, 3, 4, 5], 0);
+    expect(r.scale).toBe(0);
+    expect(r.positiveOffset).toBe(-1);
+    expect(r.positiveBucketCounts).toEqual([1, 1, 2, 1]);
+    expect(r.zeroCount).toBe(0);
+    expect(r.count).toBe(5);
+    expect(r.sum).toBe(15);
+    expect(r.min).toBe(1);
+    expect(r.max).toBe(5);
+  });
+
+  it('routes zero/non-positive samples to zeroCount, not positive buckets', () => {
+    const r = expBucketize([0, 0, 2, 4], 0);
+    expect(r.zeroCount).toBe(2);
+    expect(r.count).toBe(4);
+    // Only 2 (idx 0) and 4 (idx 1) land in positive buckets.
+    expect(r.positiveOffset).toBe(0);
+    expect(r.positiveBucketCounts).toEqual([1, 1]);
+    expect(r.min).toBe(0);
+    expect(r.max).toBe(4);
+  });
+
+  it('feeds straight into makeExponentialHistogram', () => {
+    const e = makeExponentialHistogram({
+      timeUnixMs: NOW_MS,
+      serviceName: 'recommendation-service',
+      metricName: 'jvm.gc.pause',
+      ...expBucketize([12, 15, 800, 1900], 2),
+      aggregationTemporality: 1,
+    });
+    expect(e.count).toBe(4);
+    expect(e.scale).toBe(2);
+    expect(e.aggregationTemporality).toBe(1);
+    // A heavy tail: max bucket index is well above the min (12ms) index.
+    expect(e.positiveBucketCounts.length).toBeGreaterThan(1);
+    expect(e.max).toBe(1900);
+  });
+
+  it('returns zeroed stats for an empty sample set', () => {
+    const r = expBucketize([], 3);
+    expect(r.positiveBucketCounts).toEqual([]);
+    expect(r.positiveOffset).toBe(0);
+    expect(r.zeroCount).toBe(0);
+    expect(r.count).toBe(0);
+    expect(r.sum).toBe(0);
+    expect(r.min).toBe(0);
+    expect(r.max).toBe(0);
+  });
+
+  it('is a pure function of its inputs', () => {
+    const a = expBucketize([5, 50, 500, 5000], 2);
+    const b = expBucketize([5, 50, 500, 5000], 2);
+    expect(a).toEqual(b);
   });
 });
 

--- a/packages/hdx-eval/src/cli.ts
+++ b/packages/hdx-eval/src/cli.ts
@@ -134,6 +134,11 @@ function defaultApiUrl(): string {
 const DEFAULT_EVAL_EMAIL = 'eval@local.test';
 const DEFAULT_EVAL_PASSWORD = 'EvalPass123!#';
 
+// Global fallback turn budget when neither --max-turns nor a per-scenario
+// `maxTurns` override is set. Kept low so exploratory over-querying is
+// penalized; scenarios that need more headroom set `maxTurns` on themselves.
+const DEFAULT_MAX_TURNS = 15;
+
 const program = new Command();
 
 program
@@ -381,10 +386,13 @@ program
       'models are given, every (mcp, model) pair is compared in reports.',
     'claude-opus-4-6',
   )
-  // Lower than the previous 25 — tightens the budget so sloppy agents that
-  // make 20+ exploratory calls can't paper over correctness with volume.
-  // Override with --max-turns if a specific scenario needs more.
-  .option('--max-turns <n>', 'Max tool-use turns', '15')
+  // No commander default: an omitted flag stays `undefined` so we can tell
+  // "user explicitly passed a value" apart from "not passed" and apply the
+  // precedence CLI > scenario.maxTurns > DEFAULT_MAX_TURNS.
+  .option(
+    '--max-turns <n>',
+    `Max tool-use turns. Overrides the per-scenario budget (fallback: ${DEFAULT_MAX_TURNS})`,
+  )
   .option('--seed <n>', 'PRNG seed for re-seeding', '42')
   .option(
     '--timeout <ms>',
@@ -452,7 +460,7 @@ program
         baseline?: string;
         runs: string;
         model: string;
-        maxTurns: string;
+        maxTurns?: string;
         seed: string;
         timeout: string;
         reseed?: true;
@@ -523,7 +531,11 @@ program
         cmdOpts.promptVariant,
       );
       const runs = Number(cmdOpts.runs);
-      const maxTurns = Number(cmdOpts.maxTurns);
+      // Precedence: explicit --max-turns > scenario.maxTurns > DEFAULT_MAX_TURNS.
+      const maxTurns =
+        cmdOpts.maxTurns !== undefined
+          ? Number(cmdOpts.maxTurns)
+          : (scenario.maxTurns ?? DEFAULT_MAX_TURNS);
       const timeoutMs = Number(cmdOpts.timeout);
       const seedNum = Number(cmdOpts.seed);
       const concurrency = Number(cmdOpts.concurrency);

--- a/packages/hdx-eval/src/generators/metrics.ts
+++ b/packages/hdx-eval/src/generators/metrics.ts
@@ -1,5 +1,3 @@
-import type { SeededRng } from '@/rng/seeded';
-
 import type {
   AggregationTemporality,
   ExponentialHistogramMetricRow,
@@ -236,6 +234,81 @@ export function bucketize(
   }
   return {
     bucketCounts,
+    count: samples.length,
+    sum,
+    min: samples.length ? min : 0,
+    max: samples.length ? max : 0,
+  };
+}
+
+/**
+ * Bucketize raw samples into an OTel *exponential* histogram at a fixed
+ * `scale`. Returns the fields consumed by `makeExponentialHistogram`
+ * (`scale`, `zeroCount`, `positiveOffset`, `positiveBucketCounts`, `count`,
+ * `sum`, `min`, `max`), so a caller can spread the result straight into it.
+ *
+ * Bucket mapping follows the OTel spec: base = 2^(2^-scale), and a positive
+ * value `v` maps to index `ceil(log_base(v)) - 1`, so bucket `i` covers the
+ * half-open range `(base^i, base^(i+1)]`. `positiveBucketCounts[j]` holds the
+ * count for index `positiveOffset + j`. Zero-valued samples go to
+ * `zeroCount`; only non-negative samples are expected (GC pause / latency),
+ * so negative buckets are left to the `makeExponentialHistogram` default.
+ * Deterministic — a pure function of its inputs.
+ */
+export function expBucketize(
+  samples: readonly number[],
+  scale: number,
+): {
+  scale: number;
+  zeroCount: number;
+  positiveOffset: number;
+  positiveBucketCounts: number[];
+  count: number;
+  sum: number;
+  min: number;
+  max: number;
+} {
+  const scaleFactor = Math.pow(2, scale) / Math.LN2;
+  const indexOf = (v: number): number =>
+    Math.ceil(Math.log(v) * scaleFactor) - 1;
+
+  let sum = 0;
+  let zeroCount = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let minIdx = Number.POSITIVE_INFINITY;
+  let maxIdx = Number.NEGATIVE_INFINITY;
+  const counts = new Map<number, number>();
+
+  for (const s of samples) {
+    sum += s;
+    if (s < min) min = s;
+    if (s > max) max = s;
+    if (s <= 0) {
+      zeroCount++;
+      continue;
+    }
+    const idx = indexOf(s);
+    counts.set(idx, (counts.get(idx) ?? 0) + 1);
+    if (idx < minIdx) minIdx = idx;
+    if (idx > maxIdx) maxIdx = idx;
+  }
+
+  let positiveOffset = 0;
+  let positiveBucketCounts: number[] = [];
+  if (counts.size > 0) {
+    positiveOffset = minIdx;
+    positiveBucketCounts = new Array<number>(maxIdx - minIdx + 1).fill(0);
+    for (const [idx, c] of counts) {
+      positiveBucketCounts[idx - minIdx] = c;
+    }
+  }
+
+  return {
+    scale,
+    zeroCount,
+    positiveOffset,
+    positiveBucketCounts,
     count: samples.length,
     sum,
     min: samples.length ? min : 0,

--- a/packages/hdx-eval/src/harness/systemPrompt.ts
+++ b/packages/hdx-eval/src/harness/systemPrompt.ts
@@ -61,13 +61,22 @@ export function buildSystemPrompt(
   );
 }
 
-function buildInvestigationSystemPrompt(
+export function buildInvestigationSystemPrompt(
   scenarioName: string,
   anchorTimeIso?: string,
   variant: PromptVariant = 'baseline',
   maxTurns?: number,
+  opts?: {
+    /**
+     * Extra note injected into the data-source list. Scenarios that
+     * seed additional signals (e.g. metrics) use this to tell the agent
+     * those sources exist.
+     */
+    signalsNote?: string;
+  },
 ): string {
   const { traces, logs } = scenarioTables(scenarioName);
+  const signalsNote = opts?.signalsNote ?? '';
   const sharedSchema = '';
   //   `These follow the standard OpenTelemetry ClickHouse schema:
   // - traces have Timestamp DateTime64(9), TraceId, SpanId, ParentSpanId,
@@ -141,6 +150,7 @@ observability data. The OpenTelemetry data lives in ClickHouse:
 
 - Traces: default.${traces}
 - Logs:   default.${logs}
+${signalsNote}
 ${anchorBlock}
 ${sharedSchema}
 

--- a/packages/hdx-eval/src/scenarios/index.ts
+++ b/packages/hdx-eval/src/scenarios/index.ts
@@ -1,6 +1,7 @@
 import { dashboardBuildScenario } from './dashboard-build/generate';
 import { errorRootCauseScenario } from './error-root-cause/generate';
 import { latencySpikeScenario } from './latency-spike/generate';
+import { metricSaturationScenario } from './metric-saturation/generate';
 import { noisySignalsScenario } from './noisy-signals/generate';
 import { segmentedRegressionScenario } from './segmented-regression/generate';
 import { serviceHealthCheckScenario } from './service-health-check/generate';
@@ -10,6 +11,7 @@ export const SCENARIOS: Record<string, Scenario> = {
   [dashboardBuildScenario.name]: dashboardBuildScenario,
   [errorRootCauseScenario.name]: errorRootCauseScenario,
   [latencySpikeScenario.name]: latencySpikeScenario,
+  [metricSaturationScenario.name]: metricSaturationScenario,
   [noisySignalsScenario.name]: noisySignalsScenario,
   [segmentedRegressionScenario.name]: segmentedRegressionScenario,
   [serviceHealthCheckScenario.name]: serviceHealthCheckScenario,

--- a/packages/hdx-eval/src/scenarios/metric-saturation/generate.ts
+++ b/packages/hdx-eval/src/scenarios/metric-saturation/generate.ts
@@ -1,0 +1,575 @@
+/**
+ * metric-saturation scenario.
+ *
+ * Story: recommendation-service (an allocation-heavy JVM ML scorer) has a slow
+ * heap memory leak — an unbounded candidate/embedding cache. Over ~90 minutes
+ * the G1 Old Gen heap climbs toward the ~2GB limit; full-GC pause time grows a
+ * heavy tail that stalls request handling, and the pod OOM-restarts on a
+ * cadence (heap drops back to baseline, then climbs again). Requests mostly
+ * still succeed (degraded fallback ranking), with only mildly elevated latency
+ * and occasional 503s at restart.
+ *
+ * The leak -> GC-pause -> latency -> restart chain lives ONLY in metrics:
+ *   - Gauge  process.runtime.jvm.memory.used : sawtooth heap (the leak).
+ *   - Gauge  system.cpu.utilization          : flat/healthy (rules out CPU).
+ *   - Sum    k8s.pod.restarts                 : cumulative; rate = restart storm.
+ *   - Sum    jvm.gc.collections               : cumulative; Old-Gen accelerates.
+ *   - Histogram            http.server.request.duration : latency shifts up.
+ *   - ExponentialHistogram jvm.gc.pause                 : heavy tail (mechanism).
+ *   - Summary db.client.operation.duration (inventory-service) : stable decoy.
+ *
+ * Histograms use DELTA temporality (each scrape point = that window's
+ * distribution) so the in-window shift is directly readable.
+ *
+ * Distractors: a coincidental 1.43.1 deploy ~40 min ago (the leak predates it),
+ * flat CPU, and a stable neighbor Summary that cannot be re-aggregated into the
+ * incident window.
+ *
+ * What a successful agent does:
+ *   1. Notices trace latency is only mildly elevated and 503s are generic —
+ *      the cause is not in traces/logs.
+ *   2. Pulls the memory gauge and sees the climbing sawtooth on
+ *      recommendation-service.
+ *   3. Correlates it with the GC-pause exponential-histogram tail and the
+ *      latency-histogram shift.
+ *   4. Reads the cumulative restart/GC counters as a rate to confirm the
+ *      restart cadence.
+ *   5. Rules out the deploy (leak predates it), CPU (flat), and the neighbor
+ *      db.client Summary (stable, unrelated, non-re-aggregatable).
+ */
+import { makeLog } from '@/generators/logs';
+import {
+  bucketize,
+  expBucketize,
+  makeExponentialHistogram,
+  makeGauge,
+  makeHistogram,
+  makeSum,
+  makeSummary,
+} from '@/generators/metrics';
+import {
+  buildResourcePool,
+  envoyAccessLog,
+  normalizeSeverityText,
+  pickResource,
+  serviceOpsDebugLog,
+  spreadTimestamp,
+  upstreamHealthProbeLog,
+} from '@/generators/templates';
+import { makeSpan, msToNs, newSpanId, newTraceId } from '@/generators/traces';
+import type {
+  ExponentialHistogramMetricRow,
+  GaugeMetricRow,
+  HistogramMetricRow,
+  LogRow,
+  SummaryMetricRow,
+  SumMetricRow,
+  TraceRow,
+} from '@/generators/types';
+import { buildInvestigationSystemPrompt } from '@/harness/systemPrompt';
+import type {
+  GenerateContext,
+  MetricBatch,
+  Scenario,
+  ScenarioBatch,
+} from '@/scenarios/types';
+
+import groundTruth from './ground-truth.json';
+
+// ─── Services ───────────────────────────────────────────────────────────────
+
+const SUBJECT_SERVICE = 'recommendation-service';
+const NEIGHBOR_SERVICE = 'inventory-service';
+const PROXY_SERVICE = 'frontend-proxy';
+
+// ─── Time model ───────────────────────────────────────────────────────────
+// 2-hour window, metrics scraped every 120s (a lightweight cadence — one point
+// per series every other minute keeps the scenario solvable in fewer queries).
+// The leak begins 90 min before `now`; a fill cycle (baseline -> limit) takes
+// ~22 min, giving ~4 restart sawtooth cycles across the incident. A single pod
+// carries the leak/restart story (no per-pod fan-out for the agent to chase).
+// Deploy distractor lands 40 min ago — AFTER the leak already started, so it
+// provably isn't the cause.
+
+const HISTORY_WINDOW_MS = 2 * 60 * 60 * 1000;
+const SCRAPE_INTERVAL_MS = 120 * 1000;
+const LEAK_DURATION_MS = 90 * 60 * 1000;
+const FILL_CYCLE_MS = 22 * 60 * 1000;
+const DEPLOY_AGO_MS = 40 * 60 * 1000;
+const POD_STAGGER_MS = 7 * 60 * 1000;
+
+const POD_COUNT = 1;
+
+// Heap (MB).
+const HEAP_BASE_MB = 600;
+const HEAP_LIMIT_MB = 1950;
+
+// GC collection rates (per minute, cumulative counters).
+const YOUNG_GC_PER_MIN = 8;
+const OLD_GC_PER_MIN_BASE = 0.2;
+const OLD_GC_PER_MIN_LEAK = 3.0;
+
+// Latency histogram explicit bounds (milliseconds).
+const LATENCY_BOUNDS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000];
+const LATENCY_SAMPLES_PER_SCRAPE = 200;
+
+// GC-pause exponential-histogram scale (base = 2^(2^-scale)).
+const GC_PAUSE_EXP_SCALE = 2;
+
+// ─── Trace/log floor volumes ────────────────────────────────────────────────
+// Kept deliberately modest: the load-bearing signal is metrics-only, so the
+// trace/log floor exists just to make traces/logs look "mostly normal". A
+// smaller, less varied floor keeps the agent from spelunking log noise instead
+// of reading the metrics.
+
+const TOTAL_RECO_TRACES = 250_000;
+const TOTAL_LOGS = 500_000;
+
+const RECO_MODELS = ['als_v3', 'content_v2', 'hybrid_v1'] as const;
+
+// Log template mix for the noise floor (weights are relative). Intentionally
+// lean — ops chatter plus proxy access/probe lines. No heartbeat memory-as-log
+// decoy: the memory signal lives in the gauge metric, not a log field.
+const LOG_MIX = [
+  { value: 'reco_ops', weight: 60 },
+  { value: 'envoy', weight: 25 },
+  { value: 'health_probe', weight: 15 },
+] as const;
+
+type Rng = GenerateContext['rng'];
+
+// ─── Heap / pressure model ──────────────────────────────────────────────────
+
+/** Per-pod leak-phase origin (staggered so pods don't restart in lockstep). */
+function podLeakStartMs(nowMs: number, pod: number): number {
+  return nowMs - LEAK_DURATION_MS + pod * POD_STAGGER_MS;
+}
+
+/** Heap used (MB) for a pod at time `t`, plus its cumulative restart count. */
+function heapState(
+  nowMs: number,
+  pod: number,
+  t: number,
+  jitterMb: number,
+): { usedMb: number; restarts: number } {
+  const leakStart = podLeakStartMs(nowMs, pod);
+  if (t < leakStart) {
+    // Healthy: stable baseline with a small young-gen oscillation.
+    return { usedMb: HEAP_BASE_MB + jitterMb, restarts: 0 };
+  }
+  const elapsed = t - leakStart;
+  const cyclePos = elapsed % FILL_CYCLE_MS;
+  const frac = cyclePos / FILL_CYCLE_MS;
+  const usedMb =
+    HEAP_BASE_MB + frac * (HEAP_LIMIT_MB - HEAP_BASE_MB) + jitterMb;
+  const restarts = Math.floor(elapsed / FILL_CYCLE_MS);
+  return { usedMb, restarts };
+}
+
+/** Max heap fullness across pods at `t`, clamped to [0,1]. Pre-leak ≈ 0. */
+function heapPressure(nowMs: number, t: number): number {
+  let maxUsed = HEAP_BASE_MB;
+  for (let pod = 0; pod < POD_COUNT; pod++) {
+    const { usedMb } = heapState(nowMs, pod, t, 0);
+    if (usedMb > maxUsed) maxUsed = usedMb;
+  }
+  const p = (maxUsed - HEAP_BASE_MB) / (HEAP_LIMIT_MB - HEAP_BASE_MB);
+  return Math.max(0, Math.min(1, p));
+}
+
+// ─── Metric generation ──────────────────────────────────────────────────────
+
+function generateMetrics(rng: Rng, nowMs: number): MetricBatch {
+  const windowStart = nowMs - HISTORY_WINDOW_MS;
+  const scrapeCount = Math.floor(HISTORY_WINDOW_MS / SCRAPE_INTERVAL_MS);
+
+  const gauge: GaugeMetricRow[] = [];
+  const sum: SumMetricRow[] = [];
+  const histogram: HistogramMetricRow[] = [];
+  const exponentialHistogram: ExponentialHistogramMetricRow[] = [];
+  const summary: SummaryMetricRow[] = [];
+
+  // Cumulative counters (never reset within the window — aggregated view).
+  let cumRestarts = 0;
+  const prevRestartByPod = new Array<number>(POD_COUNT).fill(0);
+  let cumYoungGc = 0;
+  let cumOldGc = 0;
+
+  const resource = (pod: number): Record<string, string> => ({
+    'service.name': SUBJECT_SERVICE,
+    'service.namespace': 'production',
+    'k8s.namespace.name': 'production',
+    'k8s.pod.name': `${SUBJECT_SERVICE}-pod-${pod}`,
+    'k8s.deployment.name': SUBJECT_SERVICE,
+  });
+
+  for (let i = 0; i < scrapeCount; i++) {
+    const t = windowStart + i * SCRAPE_INTERVAL_MS;
+    const pressure = heapPressure(nowMs, t);
+
+    // ── Gauge: per-pod heap + service-level CPU ──────────────────────────
+    for (let pod = 0; pod < POD_COUNT; pod++) {
+      const jitter = rng.range(0, 120); // young-gen oscillation
+      const { usedMb, restarts } = heapState(nowMs, pod, t, jitter);
+      gauge.push(
+        makeGauge({
+          timeUnixMs: t,
+          serviceName: SUBJECT_SERVICE,
+          metricName: 'process.runtime.jvm.memory.used',
+          metricUnit: 'By',
+          metricDescription: 'JVM heap memory used',
+          value: Math.round(usedMb * 1024 * 1024),
+          resourceAttributes: resource(pod),
+          attributes: {
+            'jvm.memory.type': 'heap',
+            'jvm.memory.pool.name': 'G1 Old Gen',
+          },
+        }),
+      );
+      // Count new restarts since the previous scrape for this pod.
+      if (restarts > prevRestartByPod[pod]) {
+        cumRestarts += restarts - prevRestartByPod[pod];
+        prevRestartByPod[pod] = restarts;
+      }
+    }
+
+    // Flat, healthy CPU — the "not CPU" distractor.
+    gauge.push(
+      makeGauge({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'system.cpu.utilization',
+        metricUnit: '1',
+        metricDescription: 'CPU utilization (0-1)',
+        value: Number(rng.range(0.3, 0.42).toFixed(3)),
+        resourceAttributes: resource(0),
+        attributes: { state: 'used' },
+      }),
+    );
+
+    // ── Sum: cumulative restart + GC-collection counters ─────────────────
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'k8s.pod.restarts',
+        metricDescription: 'Cumulative pod restarts',
+        value: cumRestarts,
+        resourceAttributes: resource(0),
+      }),
+    );
+
+    const minutes = SCRAPE_INTERVAL_MS / 60_000;
+    cumYoungGc += YOUNG_GC_PER_MIN * minutes;
+    cumOldGc +=
+      (OLD_GC_PER_MIN_BASE +
+        (OLD_GC_PER_MIN_LEAK - OLD_GC_PER_MIN_BASE) * pressure) *
+      minutes;
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'jvm.gc.collections',
+        metricDescription: 'Cumulative GC collections',
+        value: Math.round(cumYoungGc),
+        resourceAttributes: resource(0),
+        attributes: { 'gc.name': 'G1 Young Generation' },
+      }),
+    );
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'jvm.gc.collections',
+        metricDescription: 'Cumulative GC collections',
+        value: Math.round(cumOldGc),
+        resourceAttributes: resource(0),
+        attributes: { 'gc.name': 'G1 Old Generation' },
+      }),
+    );
+
+    // ── Histogram: request-duration distribution (delta temporality) ─────
+    const latencySamples: number[] = [];
+    const pSlow = 0.01 + 0.12 * pressure;
+    for (let s = 0; s < LATENCY_SAMPLES_PER_SCRAPE; s++) {
+      latencySamples.push(
+        rng.next() < pSlow ? rng.range(500, 3000) : rng.range(8, 120),
+      );
+    }
+    histogram.push(
+      makeHistogram({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'http.server.request.duration',
+        metricUnit: 'ms',
+        metricDescription: 'HTTP server request duration',
+        aggregationTemporality: 1,
+        ...bucketize(latencySamples, LATENCY_BOUNDS_MS),
+        explicitBounds: [...LATENCY_BOUNDS_MS],
+        resourceAttributes: resource(0),
+        attributes: { 'http.route': '/score' },
+      }),
+    );
+
+    // ── Exponential histogram: GC pause durations (delta temporality) ────
+    const pauseSamples: number[] = [];
+    const youngPauses = rng.intRange(6, 12);
+    for (let g = 0; g < youngPauses; g++) pauseSamples.push(rng.range(4, 25));
+    const fullPauses = Math.round(pressure * rng.range(2, 5));
+    for (let g = 0; g < fullPauses; g++)
+      pauseSamples.push(rng.range(400, 2200));
+    exponentialHistogram.push(
+      makeExponentialHistogram({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'jvm.gc.pause',
+        metricUnit: 'ms',
+        metricDescription: 'GC pause duration',
+        aggregationTemporality: 1,
+        ...expBucketize(pauseSamples, GC_PAUSE_EXP_SCALE),
+        resourceAttributes: resource(0),
+        attributes: {},
+      }),
+    );
+
+    // ── Summary: neighbor db.client latency (stable decoy) ───────────────
+    const p50 = rng.range(7, 9);
+    const p95 = rng.range(38, 44);
+    const p99 = rng.range(85, 95);
+    const sCount = rng.intRange(400, 600);
+    summary.push(
+      makeSummary({
+        timeUnixMs: t,
+        serviceName: NEIGHBOR_SERVICE,
+        metricName: 'db.client.operation.duration',
+        metricUnit: 'ms',
+        metricDescription: 'DB client operation duration',
+        count: sCount,
+        sum: Math.round(sCount * p50 * 1.4),
+        quantiles: [
+          { quantile: 0.5, value: Number(p50.toFixed(2)) },
+          { quantile: 0.95, value: Number(p95.toFixed(2)) },
+          { quantile: 0.99, value: Number(p99.toFixed(2)) },
+        ],
+        resourceAttributes: {
+          'service.name': NEIGHBOR_SERVICE,
+          'k8s.namespace.name': 'production',
+        },
+        attributes: { 'db.system': 'postgresql' },
+      }),
+    );
+  }
+
+  return { gauge, sum, histogram, exponentialHistogram, summary };
+}
+
+// ─── Trace/log floor ────────────────────────────────────────────────────────
+
+/** Ambiguous restart-adjacent log lines (hint at restarts, not the cause). */
+const RESTART_LOG_LINES = [
+  'Liveness probe failed: HTTP probe failed with statuscode: 503',
+  'Received SIGTERM, shutting down gracefully',
+  'readiness probe failed: context deadline exceeded',
+  'Container recommendation-service restarted',
+] as const;
+
+function versionAtTime(nowMs: number, t: number): string {
+  return t >= nowMs - DEPLOY_AGO_MS ? '1.43.1' : '1.43.0';
+}
+
+export const metricSaturationScenario: Scenario = {
+  name: 'metric-saturation',
+  maxTurns: 25,
+  agentPrompt: groundTruth.agentPrompt,
+  description:
+    'recommendation-service JVM heap leak: memory gauge sawtooth -> GC-pause (exp-histogram) tail -> latency-histogram shift -> pod-restart (cumulative sum) cadence. Root cause is metrics-only; traces/logs show just mild latency + generic 503s. Exercises all five metric types (gauge/sum/histogram/exp-histogram/summary). Distractors: coincidental deploy, flat CPU, stable neighbor Summary.',
+  buildSystemPrompt: ctx =>
+    buildInvestigationSystemPrompt(
+      'metric-saturation',
+      ctx.anchorTimeIso,
+      ctx.variant,
+      ctx.maxTurns,
+      {
+        signalsNote:
+          '- Metrics: a HyperDX metric source is available (gauge, sum, ' +
+          'histogram, exponential histogram, and summary). Use the metric ' +
+          'tools to explore it alongside traces and logs.',
+      },
+    ),
+  *generate(ctx): Iterable<ScenarioBatch> {
+    const { rng, nowMs } = ctx;
+    const factor = ctx.volumeFactor ?? 1;
+    const batchSize = ctx.batchSize ?? 10_000;
+    const windowStart = nowMs - HISTORY_WINDOW_MS;
+
+    // Metrics first (fixed volume — the planted signal never scales).
+    const metrics = generateMetrics(rng, nowMs);
+    yield { traces: [], logs: [], metrics };
+
+    const resourcePool = buildResourcePool({
+      rng,
+      services: [SUBJECT_SERVICE, NEIGHBOR_SERVICE, PROXY_SERVICE],
+      instancesPerService: 12,
+    });
+
+    // ── Traces: recommendation.score server spans ────────────────────────
+    const totalTraces = Math.max(50, Math.round(TOTAL_RECO_TRACES * factor));
+    const traces: TraceRow[] = [];
+    for (let i = 0; i < totalTraces; i++) {
+      const t = spreadTimestamp(i, totalTraces, windowStart, HISTORY_WINDOW_MS);
+      const pressure = heapPressure(nowMs, t);
+      const pSlow = 0.01 + 0.12 * pressure;
+      const p503 = 0.004 * pressure; // rare, only under pressure
+      const roll = rng.next();
+      const isError = roll < p503;
+      const isSlow = !isError && rng.next() < pSlow;
+      const durationMs = isError
+        ? rng.range(9000, 10000)
+        : isSlow
+          ? rng.range(500, 3000)
+          : rng.range(8, 120);
+
+      const traceId = newTraceId(rng);
+      const spanId = newSpanId(rng);
+      const base = pickResource(rng, resourcePool, SUBJECT_SERVICE);
+      const resourceAttributes = {
+        ...base,
+        'service.version': versionAtTime(nowMs, t),
+      };
+      traces.push(
+        makeSpan({
+          rng,
+          timestampMs: t,
+          traceId,
+          spanId,
+          spanName: 'recommendation.score',
+          spanKind: 'SPAN_KIND_SERVER',
+          serviceName: SUBJECT_SERVICE,
+          durationNs: msToNs(durationMs),
+          statusCode: isError ? 'STATUS_CODE_ERROR' : 'STATUS_CODE_OK',
+          statusMessage: isError ? 'context deadline exceeded' : '',
+          resourceAttributes,
+          spanAttributes: {
+            'reco.model': rng.pick(RECO_MODELS),
+            'reco.candidates': String(rng.intRange(10, 500)),
+            'reco.returned': String(rng.intRange(5, 25)),
+            'http.route': '/score',
+            'http.request.method': 'POST',
+            'http.response.status_code': isError ? '503' : '200',
+          },
+        }),
+      );
+      if (traces.length >= batchSize) {
+        yield { traces: traces.splice(0, traces.length), logs: [] };
+      }
+    }
+    if (traces.length)
+      yield { traces: traces.splice(0, traces.length), logs: [] };
+
+    // ── Logs: ops chatter + proxy access/probe + restart hints ──────────
+    const totalLogs = Math.max(50, Math.round(TOTAL_LOGS * factor));
+    const logs: LogRow[] = [];
+    for (let i = 0; i < totalLogs; i++) {
+      const t = spreadTimestamp(
+        i,
+        totalLogs,
+        windowStart,
+        HISTORY_WINDOW_MS,
+        60_000,
+      );
+      const kind = rng.weightedPick(LOG_MIX);
+      let service = SUBJECT_SERVICE;
+      let body: string;
+      let attrs: Record<string, string>;
+      let sevText: string;
+
+      if (kind === 'reco_ops') {
+        const tmpl = serviceOpsDebugLog({
+          rng,
+          nowMs: t,
+          serviceName: SUBJECT_SERVICE,
+        });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = tmpl.level;
+      } else if (kind === 'envoy') {
+        service = PROXY_SERVICE;
+        const tmpl = envoyAccessLog({ rng, nowMs: t });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = 'info';
+      } else {
+        service = PROXY_SERVICE;
+        const tmpl = upstreamHealthProbeLog({ rng, nowMs: t });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = 'info';
+      }
+
+      logs.push(
+        makeLog({
+          timestampMs: t,
+          serviceName: service,
+          severityText: normalizeSeverityText(sevText),
+          body,
+          resourceAttributes: pickResource(rng, resourcePool, service),
+          logAttributes: { ...attrs, _severity_raw: sevText },
+        }),
+      );
+      if (logs.length >= batchSize) {
+        yield { traces: [], logs: logs.splice(0, logs.length) };
+      }
+    }
+
+    // ── Restart-adjacent hint logs (one per restart event, ambiguous) ────
+    for (let pod = 0; pod < POD_COUNT; pod++) {
+      const leakStart = podLeakStartMs(nowMs, pod);
+      for (
+        let restartMs = leakStart + FILL_CYCLE_MS;
+        restartMs <= nowMs;
+        restartMs += FILL_CYCLE_MS
+      ) {
+        for (const line of RESTART_LOG_LINES) {
+          logs.push(
+            makeLog({
+              timestampMs: restartMs + rng.intRange(0, 2000),
+              serviceName: SUBJECT_SERVICE,
+              severityText: 'WARN',
+              body: line,
+              resourceAttributes: {
+                'service.name': SUBJECT_SERVICE,
+                'k8s.pod.name': `${SUBJECT_SERVICE}-pod-${pod}`,
+              },
+              logAttributes: {
+                'event.name': 'pod.lifecycle',
+                'k8s.pod.name': `${SUBJECT_SERVICE}-pod-${pod}`,
+              },
+            }),
+          );
+        }
+      }
+    }
+
+    // ── Coincidental deploy log (the "blame the deploy" distractor) ──────
+    logs.push(
+      makeLog({
+        timestampMs: nowMs - DEPLOY_AGO_MS,
+        serviceName: SUBJECT_SERVICE,
+        severityText: 'INFO',
+        body: 'Deployment recommendation-service rolled out: version 1.43.0 -> 1.43.1',
+        resourceAttributes: {
+          'service.name': SUBJECT_SERVICE,
+          'service.version': '1.43.1',
+          'k8s.deployment.name': SUBJECT_SERVICE,
+        },
+        logAttributes: {
+          'event.name': 'deployment.rollout',
+          'service.version': '1.43.1',
+        },
+      }),
+    );
+
+    if (logs.length) yield { traces: [], logs };
+  },
+  groundTruth,
+};

--- a/packages/hdx-eval/src/scenarios/metric-saturation/ground-truth.json
+++ b/packages/hdx-eval/src/scenarios/metric-saturation/ground-truth.json
@@ -1,0 +1,116 @@
+{
+  "scenario": "metric-saturation",
+  "agentPrompt": "recommendation-service has been intermittently slow and has thrown occasional 503s over the last couple of hours, but request logs and traces look mostly normal. Figure out the root cause and explain the mechanism.",
+  "expected": {
+    "affectedService": "recommendation-service",
+    "rootCause": "A slow JVM heap memory leak (an unbounded candidate/embedding cache) on recommendation-service. The G1 Old Gen heap climbs steadily until it approaches the ~2GB limit; full-GC pause time develops a heavy tail that stalls request handling, and the pod OOM-restarts on a cadence (~every 20-25 min). After each restart heap drops back to baseline and the cycle repeats.",
+    "mechanismChain": [
+      "process.runtime.jvm.memory.used (gauge) shows a sawtooth: heap climbs from ~600MB toward the ~1950MB limit, then resets on restart. Pre-incident it was flat.",
+      "jvm.gc.pause (exponential histogram) develops a heavy tail (full GCs of 400-2200ms) as the heap fills — the mechanism linking memory pressure to latency. Pre-incident pauses were tight and small (young-gen, ~5-25ms).",
+      "http.server.request.duration (histogram) mass shifts from the low buckets into the 500-5000ms buckets during the incident window.",
+      "k8s.pod.restarts (cumulative sum) steps up repeatedly; its rate/delta reveals a restart storm. jvm.gc.collections{G1 Old Gen} accelerates over the same window."
+    ],
+    "loadBearingSignal": "metrics",
+    "whyTracesLogsInsufficient": "Traces show only mildly elevated latency and a few generic 503s ('context deadline exceeded'); they carry no memory/GC/heap attributes. Logs carry only ambiguous restart lines (liveness probe failed, SIGTERM) with no usable memory signal. The climbing-heap / GC-pause-tail / restart-cadence chain is only reconstructable from metrics.",
+    "metricTypesUsed": {
+      "gauge": "process.runtime.jvm.memory.used (leak, load-bearing); system.cpu.utilization (flat, rules out CPU)",
+      "sum": "k8s.pod.restarts + jvm.gc.collections (cumulative; need a rate/delta)",
+      "histogram": "http.server.request.duration (latency shift, delta temporality)",
+      "exponentialHistogram": "jvm.gc.pause (heavy tail, delta temporality)",
+      "summary": "db.client.operation.duration on inventory-service (stable distractor)"
+    }
+  },
+  "distractors": [
+    {
+      "kind": "neighbor db.client latency summary",
+      "service": "inventory-service",
+      "metric": "db.client.operation.duration (summary)",
+      "whyNotRootCause": "A Summary metric with stable precomputed quantiles (p50/p95/p99) on a DIFFERENT service. It looks like 'a database is a bit slow', but the quantiles are flat across the whole window and uncorrelated with the recommendation-service incident. Crucially, a Summary cannot be re-aggregated or re-bucketed — you cannot zoom into the incident window to recompute it — so it is not diagnostic here. Blaming the database is a calibration failure."
+    },
+    {
+      "kind": "coincidental deploy",
+      "service": "recommendation-service",
+      "versionFrom": "1.43.0",
+      "versionTo": "1.43.1",
+      "minutesAgo": 40,
+      "whyNotRootCause": "recommendation-service rolled out a new version ~40 min ago. Tempting to blame the deploy, but the heap was already climbing ~90 min ago — well before the rollout — and the leak/restart cadence continues unchanged across the version boundary. The deploy did not start or stop the leak."
+    },
+    {
+      "kind": "flat CPU",
+      "metric": "system.cpu.utilization (gauge)",
+      "approxValue": 0.35,
+      "whyNotRootCause": "CPU utilization stays flat and healthy (~35%) throughout. The saturation is memory/GC, not CPU — ruling out CPU exhaustion is part of the diagnosis."
+    },
+    {
+      "kind": "generic 503s in traces",
+      "whyNotRootCause": "The occasional 503s ('context deadline exceeded') are a symptom of GC stalls at restart, not an independent cause. Stopping at 'the service returns 503s' without the memory/GC mechanism is an incomplete answer."
+    }
+  ],
+  "rubric": {
+    "programmatic": [
+      ["names_affected_service", 1, "recommendation-service"],
+      [
+        "names_memory_leak",
+        3,
+        "(memory|heap)[^.\\n]{0,40}?(leak|growth|climb|saturat|exhaust|pressure)|leak[^.\\n]{0,20}?(memory|heap)|old gen"
+      ],
+      [
+        "names_gc_mechanism",
+        2,
+        "(gc|garbage[ -]?collect)[^.\\n]{0,40}?paus|full[ -]?gc|gc[ -]?pause|stop[- ]the[- ]world"
+      ],
+      [
+        "names_restart_cadence",
+        2,
+        "(restart|oom|out of memory|oomkill|crashloop|recycl)"
+      ],
+      [
+        "cites_metric_evidence",
+        2,
+        "(gauge|histogram|metric|jvm[\\s._]|process[\\s._]runtime|memory[\\s._]used|pod[\\s._]restarts?|gc[\\s._]?pause|gc[\\s._]?collection|\\bheap\\b|old[\\s._-]?gen|\\bg1\\b|garbage[\\s-]?collect|restart\\s+(counter|cadence|storm|loop))"
+      ],
+      [
+        "false_blame_cpu",
+        2,
+        "(root cause|caused by|due to|because of|the (issue|problem|cause) is)[^.\\n]{0,60}?\\bcpu",
+        true
+      ],
+      [
+        "false_blame_deploy",
+        2,
+        "(root cause|caused by|due to|because of|the (issue|problem|cause) is)[^.\\n]{0,60}?(deploy|rollout|release|version|1\\.43\\.1)",
+        true
+      ],
+      [
+        "false_blame_database",
+        2,
+        "(root cause|caused by|due to|because of|the (issue|problem|cause) is)[^.\\n]{0,60}?(database|db\\b|inventory-service|db\\.client)",
+        true
+      ]
+    ],
+    "judge": {
+      "criteria": [
+        {
+          "id": "correctness",
+          "weight": 3,
+          "description": "Did the answer identify the root cause as a JVM heap memory leak on recommendation-service that drives GC-pause growth and periodic OOM/restarts? The full mechanism (heap climb -> full-GC pause tail -> request latency -> restart cadence) should be present, not just 'the service is slow' or 'it restarts'."
+        },
+        {
+          "id": "metric_grounding",
+          "weight": 3,
+          "description": "Is the conclusion grounded in metric evidence that is NOT recoverable from traces/logs alone? A strong answer references the climbing memory gauge (sawtooth), the GC-pause distribution tail, the latency histogram shift, and/or the cumulative restart counter (as a rate). An answer that only cites trace latency / 503 counts has not used the load-bearing signal."
+        },
+        {
+          "id": "calibration",
+          "weight": 2,
+          "description": "Did the answer rule out the distractors? Specifically: (a) the coincidental 1.43.1 deploy is not the cause because the leak predates it; (b) CPU is flat, so it is not CPU exhaustion; (c) the inventory-service db.client Summary is stable, unrelated, and cannot be re-aggregated into the incident window; (d) the 503s are a symptom, not the cause. Blaming any of these is a calibration failure."
+        },
+        {
+          "id": "conciseness",
+          "weight": 1,
+          "description": "Was the answer concise, well-structured, and free of filler or unnecessary speculation?"
+        }
+      ]
+    }
+  }
+}

--- a/packages/hdx-eval/src/scenarios/types.ts
+++ b/packages/hdx-eval/src/scenarios/types.ts
@@ -95,6 +95,10 @@ export type PostRunInspectionContext = {
 
 export type Scenario = {
   name: string;
+  /** Optional per-scenario override.
+   The CLI --max-turns option still overrides this.
+   */
+  maxTurns?: number;
   agentPrompt: string;
   description: string;
   /**


### PR DESCRIPTION
## Summary

Add `metric-saturation`, `hdx-eval`'s first metrics-only investigation scenario, plus the small framework additions needed to support it. The planted root cause is reconstructable **only from metrics** — traces/logs look "mostly normal" — so it tests whether an MCP can read across all five OTel metric types.

This scenario is an incident where `recommendation-service` (a JVM ML scorer) develops a slow heap leak: the heap climbs toward its ~2GB limit, GC pauses grow a heavy tail, latency degrades, and the pod OOM-restarts on a ~22-minute cadence. It's engineered so the leak → GC → latency → restart chain is reconstructable *only from metrics* — traces and logs are thin and ambiguous (mildly slow spans, generic 503s, vague restart lines, no memory signal), so a traces/logs-only investigator sees *that* something's wrong but not *why*.

It fills a gap in the eval suite: every existing scenario is answerable from traces and logs alone, so nothing tests an MCP's ability to reason across metrics. This is the first scenario that requires cross-type metric reasoning.

**Scenario (`metric-saturation`)**
- Story: `recommendation-service` JVM heap leak → GC-pause heavy tail → request-latency shift → periodic OOM/pod-restart cadence. Traces show only mild latency + generic 503s; logs carry ambiguous restart lines.
- Exercises all five OTel metric types: gauge (heap sawtooth + flat CPU), sum (cumulative restart/GC counters read as a rate), histogram (latency shift, delta temporality), exponential histogram (GC-pause tail), summary (stable neighbor `db.client` decoy).
- Calibration distractors: coincidental 1.43.1 deploy (leak predates it), flat CPU, stable non-re-aggregatable neighbor Summary.
- Deterministic synthetic generation; `ground-truth.json` defines the programmatic rubric (positive + negative false-blame checks) and LLM-judge criteria (correctness, metric grounding, calibration, conciseness).

**Seeding & Evaluation**
- `setup-hyperdx` wires five seeded metric tables into a single HyperDX `kind:'metric'` Source.
- At run time the agent reaches ClickHouse only through the configured MCP; the harness records the full transcript (tool calls + final answer), and the grade step scores the answer against `ground-truth.json`.
- Seeds metrics: 1 pod, 2h window scraped every 120s = 60 points × 8 rows (2 gauge + 3 sum + 1 histogram + 1 exp-histogram + 1 summary) = 480 metric rows across the five `eval_metric_saturation_otel_metrics_{gauge,sum,histogram,exponential_histogram,summary}` tables.
- Metrics seeding is not scaled by `--volume-factor` and there are no rollup MVs for metrics. Traces & logs are seeded at 250k / 500k rows at factor 1, scaled by `--volume-factor` (e.g. ~25k / ~50k at `0.1`).
- **Type → table → what it tests:**
  - **Gauge** — `process.runtime.jvm.memory.used` (G1 Old Gen) sawtooth ~600→1950MB, resets on restart (the leak); `system.cpu.utilization` flat ~0.35 (not-CPU distractor). Read raw `Value` over time.
  - **Sum** — `k8s.pod.restarts` + `jvm.gc.collections` are **cumulative/monotonic**; only a **rate/delta** reveals the restart storm.
  - **Histogram** — `http.server.request.duration`, **DELTA** temporality so each scrape's `BucketCounts` shows the in-window mass shift into 500–5000ms buckets directly.
  - **Exp-histogram** — `jvm.gc.pause`, DELTA, `scale=2` via new `expBucketize`; positive-bucket tail (400–2200ms) grows with pressure — the memory→latency mechanism.
  - **Summary** — `db.client.operation.duration` on inventory-service, flat quantiles; **can't be re-aggregated** into the incident window, so it's the type-quirk decoy.
- Runs with `maxTurns: 25`.

**Framework support**
- `generators/metrics.ts`: add `expBucketize`, a deterministic exponential-histogram bucketizer feeding `makeExponentialHistogram`.
- `harness/systemPrompt.ts`: add an optional `signalsNote` so investigation scenarios can advertise extra signals (the metric source) in the prompt.
- `scenarios/types.ts` + `cli.ts`: add an optional per-scenario `maxTurns`; `--max-turns` resolves as explicit CLI > `scenario.maxTurns` > default (15).
- Register in `scenarios/index.ts`; document in `README.md`.

**Tests**
- `metric-saturation.test.ts`: structural invariants (five types present, heap sawtooth, restart storm, GC-pause tail, latency shift, stable summary, load-bearing "not in traces/logs" property, distractors).
- `metrics.test.ts`: `expBucketize` unit coverage.

## Eval results
Both arms solve it — HyperDX **96%**, ClickHouse (raw SQL) **91%** combined — confirming the leak → GC → latency → restart chain is reconstructable from metrics either way.

| Metric | HyperDX | ClickHouse (raw SQL) |
|---|---|---|
| Combined score | 96% | 91% |
| Programmatic score | 96% | 100% |
| Judge mean (weighted) | 96% | 97% |
| Tool calls (mean) | 19.3 | 24.3 |
| Tool-error penalty | 0pp | 7pp |
| Duration (mean) | 198s | 197s |
| Completion rate | 3/3 final_answer | 3/3 final_answer |

| Judge criterion | HyperDX | ClickHouse |
|---|---|---|
| correctness | 5.0/5 | 5.0/5 |
| metric_grounding | 5.0/5 | 5.0/5 |
| calibration | 4.3/5 | 4.7/5 |
| conciseness | 4.3/5 | 4.3/5 |

HyperDX's +5pp edge is efficiency, not correctness: fewer tool calls (19.3 vs 24.3) and zero tool errors, while raw SQL over the metric tables needed more calls and took a ~7pp tool-error penalty despite marginally higher underlying programmatic/judge scores. The one HyperDX wrinkle is `cites_metric_evidence` (67% vs 100%) — its answers sometimes state the conclusion without explicitly naming the metric series, a prompt/tool-output nuance rather than a reasoning gap.


### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4784
- Related PRs:
