### PR TITLE
feat(app): add Share button with compact shareable links

### DIFF
--- a/.changeset/share-link-button.md
+++ b/.changeset/share-link-button.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/app': minor
+---
+
+feat: Add a Share button that copies a shareable link to the clipboard on
+search, Chart Explorer, dashboards, and the row/session side panels. Links whose
+view state is large (e.g. Chart Explorer) are compressed into a single
+`?share=` token using the browser-native `CompressionStream` (raw DEFLATE +
+base64url) so they are far shorter than the raw query-param URL; small links
+(e.g. a dashboard identified by its path) stay plain so they are never made
+longer. Empty and duplicate query params are dropped from shared links.

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -22,6 +22,7 @@ import {
   MANTINE_FONT_MAP,
 } from '@/config/fonts';
 import { ibmPlexMono, inter, roboto, robotoMono } from '@/fonts';
+import { useExpandShareLink } from '@/hooks/useExpandShareLink';
 import { AppThemeProvider, useAppTheme } from '@/theme/ThemeProvider';
 import { ThemeWrapper } from '@/ThemeWrapper';
 import { NextApiConfigResponseData } from '@/types';
@@ -93,6 +94,9 @@ function AppContent({
   const { userPreferences } = useUserPreferences();
   const resolvedColorScheme = useResolvedColorScheme();
   const { themeName } = useAppTheme();
+
+  // Expand a `?share=` link (if present) into normal query params on any page.
+  useExpandShareLink();
 
   // ClickStack theme always uses Inter font - user preference is ignored
   // HyperDX theme allows user to select font preference

--- a/packages/app/src/DBChartPage.tsx
+++ b/packages/app/src/DBChartPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { parseAsJson, useQueryState } from 'nuqs';
@@ -27,6 +27,7 @@ import api from '@/api';
 import { DEFAULT_CHART_CONFIG } from '@/ChartUtils';
 import EditTimeChartForm from '@/components/DBEditTimeChartForm';
 import { InputControlled } from '@/components/InputControlled';
+import ShareLinkButton from '@/components/ShareLinkButton';
 import { SourceSelectControlled } from '@/components/SourceSelect';
 import { useChartAssistant } from '@/hooks/ai';
 import { withAppNav } from '@/layout';
@@ -34,6 +35,7 @@ import { useSources } from '@/source';
 import { useBrandDisplayName } from '@/theme/ThemeProvider';
 import { parseTimeQuery, useNewTimeQuery } from '@/timeQuery';
 import { useLocalStorage } from '@/utils';
+import { freezeTimeRange } from '@/utils/shareLink';
 
 import OnboardingModal from './components/OnboardingModal';
 
@@ -227,11 +229,22 @@ function DBChartExplorerPage() {
     }),
   );
 
+  // Build the query string for the Share button, freezing the time range to an
+  // absolute window so recipients see the same data. Chart Explorer state is a
+  // large `config` JSON blob, so buildShareUrl compresses it.
+  const getShareSearch = useCallback(
+    () => freezeTimeRange(window.location.search, searchedTimeRange),
+    [searchedTimeRange],
+  );
+
   return (
     <Box data-testid="chart-explorer-page" p="sm">
       <Head>
         <title>Chart Explorer - {brandName}</title>
       </Head>
+      <Group justify="flex-end" mb="sm">
+        <ShareLinkButton getShareSearch={getShareSearch} />
+      </Group>
       <OnboardingModal />
       <AIAssistant
         setConfig={setChartConfig}

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -126,6 +126,7 @@ import { FavoriteButton } from '@/components/FavoriteButton';
 import FullscreenPanelModal from '@/components/FullscreenPanelModal';
 import { PageHeader } from '@/components/PageHeader';
 import { PageLayout } from '@/components/PageLayout';
+import ShareLinkButton from '@/components/ShareLinkButton';
 import { TimePicker } from '@/components/TimePicker';
 import { parseTimeRangeInput } from '@/components/TimePicker/utils';
 import {
@@ -139,6 +140,7 @@ import { useAlertAnnotations } from '@/hooks/useAlertAnnotations';
 import useDashboardContainers, {
   TabDeleteAction,
 } from '@/hooks/useDashboardContainers';
+import { freezeTimeRange } from '@/utils/shareLink';
 import { calculateNextTilePosition, makeId } from '@/utils/tilePositioning';
 
 import ChartContainer, {
@@ -1788,6 +1790,13 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setDisplayedTimeInputValue,
   });
 
+  // Build the query string for the Share button, freezing the time range to an
+  // absolute window so recipients see the same data.
+  const getShareSearch = useCallback(
+    () => freezeTimeRange(window.location.search, searchedTimeRange),
+    [searchedTimeRange],
+  );
+
   const {
     granularityOverride,
     isRefreshEnabled,
@@ -2610,6 +2619,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           </Button>
         </Tags>
       )}
+      <ShareLinkButton getShareSearch={getShareSearch} px="xs" />
       {/* local dashboards cant be "deleted" */}
       <Menu width={250}>
         <Menu.Target>

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -135,6 +135,7 @@ import DBSqlRowTableWithSideBar from './components/DBSqlRowTableWithSidebar';
 import PatternTable from './components/PatternTable';
 import { DBSearchHeatmapChart } from './components/Search/DBSearchHeatmapChart';
 import DirectTraceSidePanel from './components/Search/DirectTraceSidePanel';
+import ShareLinkButton from './components/ShareLinkButton';
 import SourceSchemaPreview, {
   isSourceSchemaPreviewEnabled,
 } from './components/SourceSchemaPreview';
@@ -158,6 +159,7 @@ import {
   parseAsSortingStateString,
   parseAsStringEncoded,
 } from './utils/queryParsers';
+import { freezeTimeRange } from './utils/shareLink';
 import { LOCAL_STORE_CONNECTIONS_KEY } from './connection';
 import { DBSearchPageAlertModal } from './DBSearchPageAlertModal';
 import { EditablePageName } from './EditablePageName';
@@ -1109,6 +1111,13 @@ export function DBSearchPage() {
       setDisplayedTimeInputValue,
       updateInput: !isLive,
     });
+
+  // Build the query string for the Share button, freezing the time range to an
+  // absolute window so recipients see the same data.
+  const getShareSearch = useCallback(
+    () => freezeTimeRange(window.location.search, searchedTimeRange),
+    [searchedTimeRange],
+  );
 
   // Sync url state back with form state
   // (ex. for history navigation)
@@ -2189,6 +2198,7 @@ export function DBSearchPage() {
                 Update
               </Button>
             )}
+            <ShareLinkButton getShareSearch={getShareSearch} />
             {!IS_LOCAL_MODE && (
               <Button
                 data-testid="alerts-button"

--- a/packages/app/src/SessionSidePanel.tsx
+++ b/packages/app/src/SessionSidePanel.tsx
@@ -44,6 +44,7 @@ import {
   copyTextToClipboard,
 } from '@/utils/clipboard';
 import { parseAsJsonEncoded } from '@/utils/queryParsers';
+import { buildShareUrl } from '@/utils/shareLink';
 import { ZIndexContext } from '@/zIndex';
 
 import useSidePanelStack from './hooks/useSidePanelStack';
@@ -147,7 +148,8 @@ export default function SessionSidePanel({
   useHotkeys(['esc'], handleClose, { enabled: !selectedEvent });
 
   const shareSession = useCallback(async () => {
-    const ok = await copyTextToClipboard(window.location.href);
+    const url = await buildShareUrl(window.location.search);
+    const ok = await copyTextToClipboard(url);
     notifications.show(
       ok
         ? { color: 'green', message: 'Copied link to clipboard' }
@@ -245,6 +247,7 @@ export default function SessionSidePanel({
                       leftSection={<IconLink size={14} />}
                       style={{ fontSize: '12px' }}
                       onClick={shareSession}
+                      data-testid="session-share-button"
                     >
                       Share Session
                     </Button>

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -33,7 +33,14 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconCopy, IconKeyboard, IconShare, IconX } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import {
+  IconCheck,
+  IconCopy,
+  IconKeyboard,
+  IconShare,
+  IconX,
+} from '@tabler/icons-react';
 
 import useResizable from '@/hooks/useResizable';
 import { WithClause } from '@/hooks/useRowWhere';
@@ -48,7 +55,12 @@ import TabBar from '@/TabBar';
 import { SearchConfig } from '@/types';
 import { FormatTime } from '@/useFormatTime';
 import { formatDistanceToNowStrictShort } from '@/utils';
+import {
+  CLIPBOARD_ERROR_MESSAGE,
+  copyTextToClipboard,
+} from '@/utils/clipboard';
 import { getHighlightedAttributesFromData } from '@/utils/highlightedAttributes';
+import { buildShareUrl } from '@/utils/shareLink';
 import { useZIndex, ZIndexContext } from '@/zIndex';
 
 import ServiceMapSidePanel from './ServiceMap/ServiceMapSidePanel';
@@ -117,6 +129,19 @@ function SidePanelHeaderActions({
   onToggleFullWidth?: () => void;
 }) {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
+
+  const handleShareCopy = useCallback(async () => {
+    const ok = await copyTextToClipboard(
+      await buildShareUrl(window.location.search),
+    );
+    if (!ok) {
+      notifications.show({ color: 'red', message: CLIPBOARD_ERROR_MESSAGE });
+      return;
+    }
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }, []);
 
   return (
     <>
@@ -138,26 +163,21 @@ function SidePanelHeaderActions({
             <IconKeyboard size={16} />
           </ActionIcon>
         </Tooltip>
-        <CopyButton
-          value={typeof window !== 'undefined' ? window.location.href : ''}
+        <Tooltip
+          label={shareCopied ? 'Copied!' : 'Share link'}
+          position="bottom"
         >
-          {({ copied, copy }) => (
-            <Tooltip
-              label={copied ? 'Copied!' : 'Share link'}
-              position="bottom"
-            >
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={copy}
-                aria-label="Share"
-              >
-                <IconShare size={16} />
-              </ActionIcon>
-            </Tooltip>
-          )}
-        </CopyButton>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="sm"
+            onClick={handleShareCopy}
+            aria-label="Share"
+            data-testid="side-panel-share-button"
+          >
+            {shareCopied ? <IconCheck size={16} /> : <IconShare size={16} />}
+          </ActionIcon>
+        </Tooltip>
         <Tooltip label="Close" position="bottom">
           <ActionIcon
             variant="subtle"

--- a/packages/app/src/components/ShareLinkButton.tsx
+++ b/packages/app/src/components/ShareLinkButton.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react';
+import { Button, ButtonProps, Tooltip } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconCheck, IconLink } from '@tabler/icons-react';
+
+import {
+  CLIPBOARD_ERROR_MESSAGE,
+  copyTextToClipboard,
+} from '@/utils/clipboard';
+import { buildShareUrl } from '@/utils/shareLink';
+
+const COPIED_RESET_MS = 2000;
+
+type ShareLinkButtonProps = {
+  /**
+   * Returns the query string (without a leading '?') to encode into the link.
+   * Lets each page normalize state first (e.g. freeze the time range).
+   */
+  getShareSearch: () => string;
+  label?: string;
+} & ButtonProps;
+
+/**
+ * Copies a compact, self-contained shareable link for the current view to the
+ * clipboard. The link collapses the whole query string into a single
+ * compressed `?share=` token so it is far shorter than the raw URL.
+ */
+export default function ShareLinkButton({
+  getShareSearch,
+  label = 'Share',
+  ...buttonProps
+}: ShareLinkButtonProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const url = await buildShareUrl(getShareSearch());
+    const ok = await copyTextToClipboard(url);
+    if (!ok) {
+      notifications.show({ color: 'red', message: CLIPBOARD_ERROR_MESSAGE });
+      return;
+    }
+    notifications.show({
+      color: 'green',
+      message: 'Copied shareable link to clipboard',
+    });
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), COPIED_RESET_MS);
+  }, [getShareSearch]);
+
+  return (
+    <Tooltip label="Copy a shareable link to this view" position="bottom">
+      <Button
+        data-testid="share-link-button"
+        variant="secondary"
+        size="xs"
+        leftSection={
+          isCopied ? <IconCheck size={14} /> : <IconLink size={14} />
+        }
+        style={{ flexShrink: 0 }}
+        onClick={handleShare}
+        {...buttonProps}
+      >
+        {isCopied ? 'Copied!' : label}
+      </Button>
+    </Tooltip>
+  );
+}

--- a/packages/app/src/hooks/useExpandShareLink.ts
+++ b/packages/app/src/hooks/useExpandShareLink.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
+import { notifications } from '@mantine/notifications';
+
+import { decodeShareToken, SHARE_PARAM } from '@/utils/shareLink';
+
+/**
+ * On page load, expand a `?share=<token>` link back into the full set of query
+ * params it encodes, then replace the URL (shallow) so all existing
+ * `useQueryState` hooks read normal params. This is a no-op when there is no
+ * share token, so it is backward compatible with existing long URLs.
+ *
+ * Reads directly from `window.location.search` (always accurate on the client)
+ * rather than `router.query`, so it doesn't depend on router readiness timing.
+ *
+ * Call this near the top of any page that renders a ShareLinkButton.
+ */
+export function useExpandShareLink(): void {
+  const router = useRouter();
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (handledRef.current) {
+      return;
+    }
+
+    const token = new URLSearchParams(window.location.search).get(SHARE_PARAM);
+    if (!token) {
+      return;
+    }
+    handledRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      const expanded = await decodeShareToken(token);
+      if (cancelled) {
+        return;
+      }
+      if (expanded == null) {
+        notifications.show({
+          color: 'red',
+          message: 'This shared link is invalid or corrupted.',
+        });
+        // Strip the bad token; render from whatever real params remain.
+        router.replace(window.location.pathname, undefined, { shallow: true });
+        return;
+      }
+      router.replace(`${window.location.pathname}?${expanded}`, undefined, {
+        shallow: true,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount: window.location is the source of truth for the token.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/packages/app/src/setupTests.tsx
+++ b/packages/app/src/setupTests.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 /* Polyfills for browser APIs in Node.js test environment */
+import { CompressionStream, DecompressionStream } from 'node:stream/web';
 import { TextDecoder, TextEncoder } from 'util';
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
@@ -9,6 +10,12 @@ import structuredClone from '@ungap/structured-clone';
 import '@testing-library/jest-dom';
 global.TextEncoder = TextEncoder as any;
 global.TextDecoder = TextDecoder as any;
+if (typeof globalThis.CompressionStream === 'undefined') {
+  global.CompressionStream = CompressionStream as any;
+}
+if (typeof globalThis.DecompressionStream === 'undefined') {
+  global.DecompressionStream = DecompressionStream as any;
+}
 
 /* Mocks for mantine */
 class ResizeObserver {

--- a/packages/app/src/utils/__tests__/shareLink.test.ts
+++ b/packages/app/src/utils/__tests__/shareLink.test.ts
@@ -1,0 +1,126 @@
+import {
+  buildShareUrl,
+  decodeShareToken,
+  encodeShareToken,
+  freezeTimeRange,
+  SHARE_PARAM,
+} from '@/utils/shareLink';
+
+describe('shareLink', () => {
+  // Mimic a real nuqs-serialized search URL: repeated keys + double
+  // percent-encoding (parseAsStringEncoded / parseAsJsonEncoded). That double
+  // encoding + JSON redundancy is what makes real links huge, and what
+  // compression crushes.
+  const doubleEncode = (s: string) => encodeURIComponent(encodeURIComponent(s));
+  const FILTERS = JSON.stringify(
+    Array.from({ length: 6 }, (_, i) => ({
+      type: 'sql',
+      condition: `ResourceAttributes['service.name'] = 'checkout-service-${i}'`,
+    })),
+  );
+  const SAMPLE_SEARCH = [
+    'source=6a1e2b5502d0c8cdc7aa88ea',
+    'whereLanguage=lucene',
+    `where=${doubleEncode('ServiceName:"granola-app" SeverityText:"error" Body:"cache-sequence-mismatch"')}`,
+    `filters=${doubleEncode(FILTERS)}`,
+    'from=1784109836561',
+    'to=1784111636565',
+    'isLive=false',
+  ].join('&');
+
+  describe('encode/decode round-trip', () => {
+    it('returns the original query string', async () => {
+      const token = await encodeShareToken(SAMPLE_SEARCH);
+      expect(await decodeShareToken(token)).toBe(SAMPLE_SEARCH);
+    });
+
+    it('produces a URL-safe token (base64url alphabet only)', async () => {
+      const token = await encodeShareToken(SAMPLE_SEARCH);
+      // No '+', '/', '=' or space, so it survives the URL bar untouched.
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe('decodeShareToken', () => {
+    it('returns null for an empty token', async () => {
+      expect(await decodeShareToken('')).toBeNull();
+    });
+
+    it('returns null (never throws) on a malformed token', async () => {
+      await expect(decodeShareToken('#not-a-valid-token#')).resolves.toBeNull();
+      const truncated = (await encodeShareToken('x')).slice(0, 2);
+      await expect(decodeShareToken(truncated)).resolves.toBeNull();
+    });
+  });
+
+  describe('encodeShareToken', () => {
+    it('produces a token shorter than the raw query string', async () => {
+      // The whole point of the feature: a compressed token is meaningfully
+      // shorter than the (double percent-encoded) raw query string.
+      const token = await encodeShareToken(SAMPLE_SEARCH);
+      expect(token.length).toBeLessThan(SAMPLE_SEARCH.length);
+    });
+  });
+
+  describe('buildShareUrl', () => {
+    it('compresses a large query string into a share token that decodes back', async () => {
+      const url = await buildShareUrl(SAMPLE_SEARCH);
+      const parsed = new URL(url);
+      expect(parsed.origin).toBe(window.location.origin);
+      expect(parsed.pathname).toBe(window.location.pathname);
+
+      const token = parsed.searchParams.get(SHARE_PARAM);
+      expect(token).not.toBeNull();
+      expect(await decodeShareToken(token ?? '')).toBe(SAMPLE_SEARCH);
+    });
+
+    it('returns a plain URL (no compression) when the query string is small', async () => {
+      // Path-identified pages (e.g. /dashboards/<id>) have tiny transient
+      // state, so compression would make the link longer — keep it plain.
+      const url = await buildShareUrl(
+        'from=1784109836561&to=1784111636565&isLive=false',
+      );
+      expect(url).not.toContain(`${SHARE_PARAM}=`);
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('from')).toBe('1784109836561');
+      expect(parsed.searchParams.get('isLive')).toBe('false');
+    });
+
+    it('strips a leading "?" so it accepts window.location.search directly', async () => {
+      const url = await buildShareUrl('?from=1&to=2');
+      expect(url).not.toContain('??');
+      expect(new URL(url).searchParams.get('from')).toBe('1');
+    });
+
+    it('drops empty and duplicate params without touching survivors', async () => {
+      const url = await buildShareUrl(
+        'source=abc&where=&select=&filters=%255B%255D&source=xyz&from=1',
+      );
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get('where')).toBeNull();
+      expect(parsed.searchParams.get('select')).toBeNull();
+      expect(parsed.searchParams.get('filters')).toBeNull();
+      // Duplicate key keeps the first occurrence (matches nuqs `.get()`).
+      expect(parsed.searchParams.getAll('source')).toEqual(['abc']);
+      expect(parsed.searchParams.get('from')).toBe('1');
+    });
+  });
+
+  describe('freezeTimeRange', () => {
+    it('pins absolute from/to, drops tq, disables live, and keeps other params', () => {
+      const from = new Date(1784109836561);
+      const to = new Date(1784111636565);
+      const out = freezeTimeRange('tq=Past+1h&source=abc&isLive=true', [
+        from,
+        to,
+      ]);
+      const params = new URLSearchParams(out);
+
+      expect(params.get('tq')).toBeNull();
+      expect(params.get('from')).toBe(String(from.getTime()));
+      expect(params.get('to')).toBe(String(to.getTime()));
+      expect(params.get('isLive')).toBe('false');
+      expect(params.get('source')).toBe('abc');
+    });
+  });
+});

--- a/packages/app/src/utils/shareLink.ts
+++ b/packages/app/src/utils/shareLink.ts
@@ -1,0 +1,201 @@
+/**
+ * Reserved query param that carries a compressed snapshot of a page's view
+ * state. Kept short since it prefixes every shared link.
+ */
+export const SHARE_PARAM = 'share';
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64UrlToBytes(token: string): Uint8Array {
+  const base64 = token.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function readAll(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.length;
+    }
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+async function pipe(
+  input: Uint8Array,
+  stream: CompressionStream | DecompressionStream,
+): Promise<Uint8Array> {
+  // Drive both ends concurrently (no backpressure), and settle BOTH sides even
+  // on error so a failing stream (e.g. a corrupt token) can't leak an unhandled
+  // rejection into a later task.
+  const writer = stream.writable.getWriter();
+  const write = writer.write(input as BufferSource).then(() => writer.close());
+  const read = readAll(stream.readable as ReadableStream<Uint8Array>);
+  const [writeResult, readResult] = await Promise.allSettled([write, read]);
+  if (writeResult.status === 'rejected') {
+    throw writeResult.reason;
+  }
+  if (readResult.status === 'rejected') {
+    throw readResult.reason;
+  }
+  return readResult.value;
+}
+
+/**
+ * Compress a URL query string into a compact, URL-safe token using the native
+ * `CompressionStream` (raw DEFLATE) + base64url. base64url is inherently
+ * URL-safe (no `+`, `/`, `=`), so the token survives the URL bar untouched.
+ *
+ * @param search The query string WITHOUT the leading '?'.
+ */
+export async function encodeShareToken(search: string): Promise<string> {
+  const compressed = await pipe(
+    new TextEncoder().encode(search),
+    new CompressionStream('deflate-raw'),
+  );
+  return bytesToBase64Url(compressed);
+}
+
+/**
+ * Decode a share token back into the original query string. Returns `null` if
+ * the token is empty or cannot be decompressed (never throws, so a malformed
+ * link can't crash the page).
+ */
+export async function decodeShareToken(token: string): Promise<string | null> {
+  if (!token) {
+    return null;
+  }
+  try {
+    const bytes = await pipe(
+      base64UrlToBytes(token),
+      new DecompressionStream('deflate-raw'),
+    );
+    const decoded = new TextDecoder().decode(bytes);
+    return decoded || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drop noise that only inflates a shared link, without touching the encoding of
+ * any surviving pair (byte-safe round-trip):
+ *   - a leading '?' (so callers can pass `window.location.search` directly),
+ *   - the `share` param itself,
+ *   - empty values (`where=`, `select=`, empty `filters=[]`) — these equal the
+ *     page defaults, so their absence restores the same state,
+ *   - duplicate keys (keep the first, matching nuqs' `.get()` semantics).
+ */
+function cleanSearch(search: string): string {
+  const raw = search.replace(/^\?+/, '');
+  if (!raw) {
+    return '';
+  }
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  for (const pair of raw.split('&')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    const key = eq === -1 ? pair : pair.slice(0, eq);
+    const value = eq === -1 ? '' : pair.slice(eq + 1);
+    if (key === SHARE_PARAM || seen.has(key)) continue;
+    if (isEmptyValue(value)) continue;
+    seen.add(key);
+    kept.push(pair); // keep the original pair verbatim
+  }
+  return kept.join('&');
+}
+
+/** True for '', '[]' or '{}' at either encoding depth (single or double). */
+function isEmptyValue(value: string): boolean {
+  let decoded = value;
+  for (let i = 0; i < 2; i++) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded === '' || decoded === '[]' || decoded === '{}';
+}
+
+/**
+ * Build an absolute, shareable URL for the current page, returning the SHORTER
+ * of the plain URL (`origin/path?<search>`) or the compressed URL
+ * (`origin/path?share=<token>`).
+ *
+ * Compression only helps when the query state is large. For pages whose
+ * identity lives in the path (e.g. `/dashboards/<id>`) the transient state is
+ * tiny, so the plain URL wins. `useExpandShareLink` is a no-op on plain URLs,
+ * so either form is safe to open. Falls back to the plain URL if the browser
+ * lacks `CompressionStream` or compression fails.
+ *
+ * @param search The (already URL-encoded) query string to share; a leading '?'
+ *   is tolerated.
+ */
+export async function buildShareUrl(search: string): Promise<string> {
+  const query = cleanSearch(search);
+  const { origin, pathname } = window.location;
+  const base = `${origin}${pathname}`;
+  const plain = query ? `${base}?${query}` : base;
+  if (!query || typeof CompressionStream === 'undefined') {
+    return plain;
+  }
+  try {
+    const compressed = `${base}?${SHARE_PARAM}=${await encodeShareToken(query)}`;
+    return compressed.length < plain.length ? compressed : plain;
+  } catch {
+    return plain;
+  }
+}
+
+/**
+ * Freeze a query string's time range to absolute from/to values so a shared
+ * link shows recipients the same window rather than re-evaluating a relative
+ * range (e.g. "Past 1h") against their own clock. Also disables live tailing.
+ * Mirrors the intent of DBSearchPage's `generateSearchUrl`.
+ *
+ * @param search The query string to normalize, without a leading '?'.
+ * @param timeRange The resolved [from, to] range from `useNewTimeQuery`.
+ */
+export function freezeTimeRange(
+  search: string,
+  timeRange: [Date, Date],
+): string {
+  const params = new URLSearchParams(search);
+  params.delete(SHARE_PARAM);
+  params.delete('tq');
+  params.set('from', String(timeRange[0].getTime()));
+  params.set('to', String(timeRange[1].getTime()));
+  params.set('isLive', 'false');
+  return params.toString();
+}

--- a/packages/app/tests/e2e/components/ShareButtonComponent.ts
+++ b/packages/app/tests/e2e/components/ShareButtonComponent.ts
@@ -1,0 +1,44 @@
+/**
+ * ShareButtonComponent - the "Share" button (data-testid="share-link-button")
+ * rendered on the search page, Chart Explorer and dashboards. Clicking it
+ * copies a shareable link to the clipboard — a compressed `?share=` token when
+ * the view state is large, or a plain URL when it is small.
+ *
+ * Reading the clipboard requires the browser context to have been granted
+ * 'clipboard-read'/'clipboard-write' permissions (see share.spec.ts's
+ * `test.use({ permissions: [...] })`).
+ */
+import { expect, Locator, Page } from '@playwright/test';
+
+export class ShareButtonComponent {
+  readonly page: Page;
+  private readonly button: Locator;
+  private readonly successToast: Locator;
+
+  constructor(page: Page, testId: string = 'share-link-button') {
+    this.page = page;
+    this.button = page.getByTestId(testId);
+    this.successToast = page.getByText('Copied shareable link to clipboard');
+  }
+
+  get shareButton() {
+    return this.button;
+  }
+
+  /**
+   * Click the Share button and wait for the success toast, confirming the copy
+   * completed.
+   */
+  async copyLink() {
+    await this.button.click();
+    await expect(this.successToast).toBeVisible();
+  }
+
+  /**
+   * Click Share and return the URL that was copied to the clipboard.
+   */
+  async copyAndReadLink(): Promise<string> {
+    await this.copyLink();
+    return this.page.evaluate(() => navigator.clipboard.readText());
+  }
+}

--- a/packages/app/tests/e2e/components/SidePanelComponent.ts
+++ b/packages/app/tests/e2e/components/SidePanelComponent.ts
@@ -4,6 +4,8 @@
  */
 import { Locator, Page } from '@playwright/test';
 
+import { readCopiedLink } from '../utils/clipboard';
+
 export class SidePanelComponent {
   readonly page: Page;
   private readonly panelContainer: Locator;
@@ -160,5 +162,19 @@ export class SidePanelComponent {
    */
   get content() {
     return this.panelContainer.getByTestId('side-panel-content');
+  }
+
+  /**
+   * The "Share link" action in the panel header (copies a shareable link).
+   */
+  get shareButton() {
+    return this.page.getByTestId('side-panel-share-button');
+  }
+
+  /**
+   * Click the panel's Share action and return the URL copied to the clipboard.
+   */
+  async shareAndReadLink(): Promise<string> {
+    return readCopiedLink(this.page, () => this.shareButton.click());
   }
 }

--- a/packages/app/tests/e2e/features/share/share.spec.ts
+++ b/packages/app/tests/e2e/features/share/share.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * E2E coverage for the "Share" button that copies a shareable link to the
+ * clipboard on the search page, Chart Explorer, dashboards, and the row/session
+ * side panels.
+ *
+ * Verifies the whole round-trip: click Share -> a URL lands on the clipboard ->
+ * opening it restores the view. Also asserts the two link shapes: large state
+ * (Chart Explorer) is compressed into a `?share=` token that expands on load,
+ * while a path-identified dashboard stays a plain URL.
+ */
+import { ChartExplorerPage } from '../../page-objects/ChartExplorerPage';
+import { DashboardPage } from '../../page-objects/DashboardPage';
+import { SearchPage } from '../../page-objects/SearchPage';
+import { SessionsPage } from '../../page-objects/SessionsPage';
+import { expect, test } from '../../utils/base-test';
+import {
+  DEFAULT_LOGS_SOURCE_NAME,
+  DEFAULT_TRACES_SOURCE_NAME,
+} from '../../utils/constants';
+
+test.describe('Share link', { tag: ['@share', '@full-stack'] }, () => {
+  // Reading the clipboard back requires these context permissions; localhost is
+  // a secure context, so navigator.clipboard works once granted.
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('search: copies a link that restores the selected source and time', async ({
+    page,
+  }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.goto();
+    // Switch to a non-default source so restoring it is unambiguous proof the
+    // link carried the state (not just the page default).
+    await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+    await searchPage.timePicker.selectRelativeTime('Last 1 days');
+    await searchPage.submitEmptySearch();
+
+    const link = await searchPage.share.copyAndReadLink();
+    expect(link).toContain('/search');
+
+    // Open the shared link fresh and confirm the view is restored from the URL.
+    await page.goto(link);
+    await expect(searchPage.currentSource).toHaveValue(
+      DEFAULT_TRACES_SOURCE_NAME,
+      { timeout: 15000 },
+    );
+    // The time range was frozen to an absolute window on share.
+    const reopened = new URL(page.url()).searchParams;
+    expect(reopened.get('from')).toBeTruthy();
+    expect(reopened.get('to')).toBeTruthy();
+
+    // A compressed `?share=` token expands back to normal params after load.
+    if (new URL(link).searchParams.has('share')) {
+      expect(reopened.has('share')).toBe(false);
+    }
+  });
+
+  test('dashboard: copies a plain (uncompressed) link for the dashboard', async ({
+    page,
+  }) => {
+    const dashboardPage = new DashboardPage(page);
+    await dashboardPage.goto();
+    await dashboardPage.createNewDashboard();
+    await dashboardPage.waitForLoaded();
+    const dashboardId = dashboardPage.getCurrentDashboardId();
+
+    await expect(dashboardPage.share.shareButton).toBeVisible();
+    const link = await dashboardPage.share.copyAndReadLink();
+
+    // Dashboard identity lives in the path and its transient state is tiny, so
+    // the link stays plain (compression would only make it longer).
+    expect(link).toContain(`/dashboards/${dashboardId}`);
+    expect(new URL(link).searchParams.has('share')).toBe(false);
+  });
+
+  test('chart explorer: copies a compressed link that restores the chart', async ({
+    page,
+  }) => {
+    const chartPage = new ChartExplorerPage(page);
+    await chartPage.goto();
+    await expect(chartPage.form).toBeVisible();
+    await chartPage.chartEditor.selectSource(DEFAULT_LOGS_SOURCE_NAME);
+    await chartPage.chartEditor.runQuery();
+    await expect(chartPage.getFirstChart()).toBeVisible();
+
+    const link = await chartPage.share.copyAndReadLink();
+    expect(link).toContain('/chart');
+    // The chart config is a large JSON blob, so the link is compressed.
+    expect(new URL(link).searchParams.has('share')).toBe(true);
+
+    // Opening it expands the token back to normal params and re-renders.
+    await page.goto(link);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has('share'))
+      .toBe(false);
+    await expect(chartPage.getFirstChart()).toBeVisible();
+  });
+
+  test('row side panel: shares a link from the row detail drawer', async ({
+    page,
+  }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.goto();
+    // Non-default source, so restoring it proves the panel's Share copied the
+    // full view link (not just the page default).
+    await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+    await searchPage.timePicker.selectRelativeTime('Last 1 days');
+    await searchPage.submitEmptySearch();
+    await expect(searchPage.table.firstRow).toBeVisible();
+
+    // Open the row detail drawer, then share from its header.
+    await searchPage.table.clickFirstRow();
+    await expect(searchPage.sidePanel.tabs).toBeVisible();
+    await expect(searchPage.sidePanel.shareButton).toBeVisible();
+
+    const link = await searchPage.sidePanel.shareAndReadLink();
+    expect(link).toContain('/search');
+
+    await page.goto(link);
+    await expect(searchPage.currentSource).toHaveValue(
+      DEFAULT_TRACES_SOURCE_NAME,
+      { timeout: 15000 },
+    );
+  });
+
+  test('session side panel: shares a link from the session replay drawer', async ({
+    page,
+  }) => {
+    const sessionsPage = new SessionsPage(page);
+    // Priming /search first mirrors the existing sessions specs and ensures the
+    // source fixtures are in place before the sessions list loads.
+    await page.goto('/search');
+    await sessionsPage.goto();
+    await sessionsPage.selectDataSource();
+    await expect(sessionsPage.getFirstSessionCard()).toBeVisible();
+    await sessionsPage.openFirstSession();
+    await expect(sessionsPage.sessionSidePanel).toBeVisible();
+
+    await expect(sessionsPage.shareSessionButton).toBeVisible();
+    const link = await sessionsPage.shareAndReadLink();
+    expect(link).toContain('/sessions');
+  });
+});

--- a/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
+++ b/packages/app/tests/e2e/page-objects/ChartExplorerPage.ts
@@ -5,15 +5,18 @@
 import { Locator, Page } from '@playwright/test';
 
 import { ChartEditorComponent } from '../components/ChartEditorComponent';
+import { ShareButtonComponent } from '../components/ShareButtonComponent';
 
 export class ChartExplorerPage {
   readonly page: Page;
   readonly chartEditor: ChartEditorComponent;
+  readonly share: ShareButtonComponent;
   private readonly chartForm: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.chartEditor = new ChartEditorComponent(page);
+    this.share = new ShareButtonComponent(page);
     this.chartForm = page.locator('[data-testid="chart-explorer-form"]');
   }
 

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -6,6 +6,7 @@ import { DisplayType } from '@hyperdx/common-utils/dist/types';
 import { expect, Locator, Page } from '@playwright/test';
 
 import { ChartEditorComponent } from '../components/ChartEditorComponent';
+import { ShareButtonComponent } from '../components/ShareButtonComponent';
 import { TimePickerComponent } from '../components/TimePickerComponent';
 import { getSqlEditor } from '../utils/locators';
 
@@ -67,6 +68,7 @@ export class DashboardPage {
   readonly page: Page;
   readonly timePicker: TimePickerComponent;
   readonly chartEditor: ChartEditorComponent;
+  readonly share: ShareButtonComponent;
   readonly granularityPicker: Locator;
   readonly searchInput: Locator;
 
@@ -102,6 +104,7 @@ export class DashboardPage {
     this.page = page;
     this.timePicker = new TimePickerComponent(page);
     this.chartEditor = new ChartEditorComponent(page);
+    this.share = new ShareButtonComponent(page);
 
     this.createDashboardButton = page.locator(
       '[data-testid="create-dashboard-button"]',

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -8,6 +8,7 @@ import { FilterComponent } from '../components/FilterComponent';
 import { InfrastructurePanelComponent } from '../components/InfrastructurePanelComponent';
 import { SavedSearchModalComponent } from '../components/SavedSearchModalComponent';
 import { SearchPageAlertModalComponent } from '../components/SearchPageAlertModalComponent';
+import { ShareButtonComponent } from '../components/ShareButtonComponent';
 import { SidePanelComponent } from '../components/SidePanelComponent';
 import { TableComponent } from '../components/TableComponent';
 import { TimePickerComponent } from '../components/TimePickerComponent';
@@ -23,6 +24,7 @@ export class SearchPage {
   readonly sidePanel: SidePanelComponent;
   readonly infrastructure: InfrastructurePanelComponent;
   readonly filters: FilterComponent;
+  readonly share: ShareButtonComponent;
   readonly savedSearchModal: SavedSearchModalComponent;
   readonly savedSearchNameTitle: Locator;
   readonly alertModal: SearchPageAlertModalComponent;
@@ -52,6 +54,7 @@ export class SearchPage {
     this.sidePanel = new SidePanelComponent(page, 'row-side-panel');
     this.infrastructure = new InfrastructurePanelComponent(page);
     this.filters = new FilterComponent(page);
+    this.share = new ShareButtonComponent(page);
     this.savedSearchModal = new SavedSearchModalComponent(page);
     this.alertModal = new SearchPageAlertModalComponent(page);
     this.alertsButtonLocator = page.getByTestId('alerts-button');

--- a/packages/app/tests/e2e/page-objects/SessionsPage.ts
+++ b/packages/app/tests/e2e/page-objects/SessionsPage.ts
@@ -4,6 +4,7 @@
  */
 import { Locator, Page } from '@playwright/test';
 
+import { readCopiedLink } from '../utils/clipboard';
 import { DEFAULT_SESSIONS_SOURCE_NAME } from '../utils/constants';
 
 export class SessionsPage {
@@ -73,6 +74,20 @@ export class SessionsPage {
    */
   get sessionSidePanel() {
     return this.page.getByTestId('session-side-panel');
+  }
+
+  /**
+   * The "Share Session" button in the session replay drawer header.
+   */
+  get shareSessionButton() {
+    return this.page.getByTestId('session-share-button');
+  }
+
+  /**
+   * Click "Share Session" and return the URL copied to the clipboard.
+   */
+  async shareAndReadLink(): Promise<string> {
+    return readCopiedLink(this.page, () => this.shareSessionButton.click());
   }
 
   /**

--- a/packages/app/tests/e2e/utils/clipboard.ts
+++ b/packages/app/tests/e2e/utils/clipboard.ts
@@ -1,0 +1,23 @@
+import { expect, Page } from '@playwright/test';
+
+/**
+ * Clear the clipboard, run `trigger` (which copies), then wait for the
+ * clipboard to be populated and return its contents.
+ *
+ * Use this when the copy action has no reliable visible success signal (e.g.
+ * the row side panel's Share icon just swaps to a check). Requires the context
+ * to have 'clipboard-read'/'clipboard-write' permissions.
+ */
+export async function readCopiedLink(
+  page: Page,
+  trigger: () => Promise<void>,
+): Promise<string> {
+  await page.evaluate(() => navigator.clipboard.writeText(''));
+  await trigger();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()), {
+      timeout: 10_000,
+    })
+    .not.toBe('');
+  return page.evaluate(() => navigator.clipboard.readText());
+}


### PR DESCRIPTION
## Summary

Adds a **Share** button — on search, Chart Explorer, dashboards, and the row/session side panels — that copies a shareable link to the clipboard. HyperDX serializes the entire view state into the URL, which produces very long, double-percent-encoded links; this button collapses large state into a single compressed `?share=` token (using the browser-native `CompressionStream` — raw DEFLATE + base64url, so **no new dependency**), while small path-identified views (e.g. a dashboard) stay a plain URL so links are never made longer. A global hook in `_app` expands `?share=` tokens back into normal query params on load, so every existing `useQueryState` binding works unchanged and old long links keep working. It's covered by unit tests (encode/decode round-trip, URL-safety, compressed-vs-plain selection, empty/duplicate-param cleaning) and five end-to-end Playwright tests spanning all surfaces, plus a changeset.

### Screenshots or video

New "Share" button in the search / Chart Explorer / dashboard toolbars and in the row/session side-panel headers; it copies a link and shows a "Copied shareable link to clipboard" toast. (No before state — new feature. Static screenshots not captured in this run; behavior is exercised by the preview steps below and the E2E suite.)

### How to test on Vercel preview

**Preview routes:** /search, /chart

**Steps:**

1. Open /search and wait for the results table to load.
2. Click the Share button (data-testid="share-link-button").
3. Verify a notification reading "Copied shareable link to clipboard" appears.
4. Open /chart and pick a source in the source picker (data-testid="source-selector").
5. Click the Share button (data-testid="share-link-button").
6. Confirm a "Copied shareable link to clipboard" notification appears.

### References

- Linear Issue:
- Related PRs:
