### PR TITLE
fix: Disable automatic redirects on Webhook requests

### DIFF
--- a/.changeset/disable-webhook-redirects.md
+++ b/.changeset/disable-webhook-redirects.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+fix: Disable redirects when delivering alert webhooks

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3038,95 +3038,128 @@ describe('checkAlerts', () => {
         );
       });
 
-      it('sets state to ALERT and records a WEBHOOK_ERROR when the query succeeds but the generic webhook fails', async () => {
-        global.fetch = jest.fn().mockResolvedValue({
-          ok: false,
+      it.each([
+        {
+          responseDescription: 'an error response',
           status: 500,
-          text: jest.fn().mockResolvedValue('webhook exploded'),
-        }) as any;
+          responseBody: 'webhook exploded',
+          expectedErrorMessage:
+            'Failed to send webhook notification. Check the webhook configuration and destination.',
+        },
+        {
+          responseDescription: 'a redirect response',
+          status: 302,
+          responseBody: 'redirecting',
+          expectedErrorMessage:
+            'Webhook destination responded with a redirect. Redirects are not supported.',
+        },
+      ])(
+        'sets state to ALERT and records a WEBHOOK_ERROR when the generic webhook returns $responseDescription',
+        async ({ status, responseBody, expectedErrorMessage }) => {
+          const redirectTarget = 'http://169.254.169.254/latest/meta-data/';
+          const fetchMock = jest.fn().mockImplementation(async () => {
+            return new Response(responseBody, {
+              status,
+              headers: status === 302 ? { Location: redirectTarget } : {},
+            });
+          });
+          global.fetch = fetchMock as any;
 
-        const {
-          team,
-          webhook,
-          connection,
-          source,
-          teamWebhooksById,
-          clickhouseClient,
-          dashboard,
-        } = await setupTileAlertForErrors({
-          webhookSettings: {
-            service: WebhookService.Generic,
-            url: 'https://webhook.site/fail',
-            name: 'Generic Webhook',
-            description: 'generic webhook',
-            body: JSON.stringify({ text: '{{title}}' }),
-          },
-        });
-
-        const now = new Date('2023-11-16T22:12:00.000Z');
-        const eventMs = now.getTime() - ms('5m');
-        await bulkInsertLogs([
-          {
-            ServiceName: 'api',
-            Timestamp: new Date(eventMs),
-            SeverityText: 'error',
-            Body: 'oh no',
-          },
-          {
-            ServiceName: 'api',
-            Timestamp: new Date(eventMs),
-            SeverityText: 'error',
-            Body: 'oh no',
-          },
-        ]);
-
-        const tile = dashboard.tiles?.find((t: any) => t.id === 'tile-err');
-        const details = await createAlertDetails(
-          team,
-          source,
-          {
-            source: AlertSource.TILE,
-            channel: {
-              type: 'webhook',
-              webhookId: webhook._id.toString(),
-            },
-            interval: '5m',
-            thresholdType: AlertThresholdType.ABOVE,
-            threshold: 1,
-            dashboardId: dashboard.id,
-            tileId: 'tile-err',
-          },
-          {
-            taskType: AlertTaskType.TILE,
-            tile: tile!,
+          const {
+            team,
+            webhook,
+            connection,
+            source,
+            teamWebhooksById,
+            clickhouseClient,
             dashboard,
-          },
-        );
+          } = await setupTileAlertForErrors({
+            webhookSettings: {
+              service: WebhookService.Generic,
+              url: 'https://webhook.site/fail',
+              name: 'Generic Webhook',
+              description: 'generic webhook',
+              body: JSON.stringify({ text: '{{title}}' }),
+            },
+          });
 
-        await processAlertAtTime(
-          now,
-          details,
-          clickhouseClient,
-          connection.id,
-          alertProvider,
-          teamWebhooksById,
-        );
+          const now = new Date('2023-11-16T22:12:00.000Z');
+          const eventMs = now.getTime() - ms('5m');
+          await bulkInsertLogs([
+            {
+              ServiceName: 'api',
+              Timestamp: new Date(eventMs),
+              SeverityText: 'error',
+              Body: 'oh no',
+            },
+            {
+              ServiceName: 'api',
+              Timestamp: new Date(eventMs),
+              SeverityText: 'error',
+              Body: 'oh no',
+            },
+          ]);
 
-        const updated = await Alert.findById(details.alert.id);
-        expect(updated!.state).toBe(AlertState.ALERT);
-        // Query succeeded, so AlertHistory should have been written
-        expect(
-          await AlertHistory.countDocuments({ alert: details.alert.id }),
-        ).toBe(1);
-        expect(updated!.executionErrors).toBeDefined();
-        expect(updated!.executionErrors!.length).toBe(1);
-        expect(updated!.executionErrors![0].type).toBe(
-          AlertErrorType.WEBHOOK_ERROR,
-        );
-        expect(updated!.executionErrors![0].message).toBe(
-          'Failed to send webhook notification. Check the webhook configuration and destination.',
-        );
-      });
+          const tile = dashboard.tiles?.find((t: any) => t.id === 'tile-err');
+          const details = await createAlertDetails(
+            team,
+            source,
+            {
+              source: AlertSource.TILE,
+              channel: {
+                type: 'webhook',
+                webhookId: webhook._id.toString(),
+              },
+              interval: '5m',
+              thresholdType: AlertThresholdType.ABOVE,
+              threshold: 1,
+              dashboardId: dashboard.id,
+              tileId: 'tile-err',
+            },
+            {
+              taskType: AlertTaskType.TILE,
+              tile: tile!,
+              dashboard,
+            },
+          );
+
+          await processAlertAtTime(
+            now,
+            details,
+            clickhouseClient,
+            connection.id,
+            alertProvider,
+            teamWebhooksById,
+          );
+
+          const updated = await Alert.findById(details.alert.id);
+          expect(updated!.state).toBe(AlertState.ALERT);
+          // Query succeeded, so AlertHistory should have been written
+          expect(
+            await AlertHistory.countDocuments({ alert: details.alert.id }),
+          ).toBe(1);
+          expect(updated!.executionErrors).toBeDefined();
+          expect(updated!.executionErrors!.length).toBe(1);
+          expect(updated!.executionErrors![0].type).toBe(
+            AlertErrorType.WEBHOOK_ERROR,
+          );
+          expect(updated!.executionErrors![0].message).toBe(
+            expectedErrorMessage,
+          );
+          expect(fetchMock).toHaveBeenCalledWith(
+            'https://webhook.site/fail',
+            expect.objectContaining({ redirect: 'manual' }),
+          );
+          expect(
+            fetchMock.mock.calls.every(
+              ([requestUrl]) => requestUrl === 'https://webhook.site/fail',
+            ),
+          ).toBe(true);
+          expect(
+            fetchMock.mock.calls.map(([requestUrl]) => requestUrl),
+          ).not.toContain(redirectTarget);
+        },
+      );
 
       it('sets state to OK and records a WEBHOOK_ERROR when a resolving webhook send fails', async () => {
         const fetchMock = jest.fn();
@@ -3746,6 +3779,7 @@ describe('checkAlerts', () => {
       // check if generic webhook was triggered, injected, and parsed, and sent correctly with custom headers
       expect(fetchMock).toHaveBeenCalledWith('https://webhook.site/123', {
         method: 'POST',
+        redirect: 'manual',
         body: JSON.stringify({
           text: `http://app:8080/dashboards/${dashboard.id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "Logs Count" in "My Dashboard" - 3 meets or exceeds 1`,
         }),

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3043,6 +3043,7 @@ describe('checkAlerts', () => {
           responseDescription: 'an error response',
           status: 500,
           responseBody: 'webhook exploded',
+          expectedRequestCount: 3,
           expectedErrorMessage:
             'Failed to send webhook notification. Check the webhook configuration and destination.',
         },
@@ -3050,12 +3051,18 @@ describe('checkAlerts', () => {
           responseDescription: 'a redirect response',
           status: 302,
           responseBody: 'redirecting',
+          expectedRequestCount: 1,
           expectedErrorMessage:
             'Webhook destination responded with a redirect. Redirects are not supported.',
         },
       ])(
         'sets state to ALERT and records a WEBHOOK_ERROR when the generic webhook returns $responseDescription',
-        async ({ status, responseBody, expectedErrorMessage }) => {
+        async ({
+          status,
+          responseBody,
+          expectedRequestCount,
+          expectedErrorMessage,
+        }) => {
           const redirectTarget = 'http://169.254.169.254/latest/meta-data/';
           const fetchMock = jest.fn().mockImplementation(async () => {
             return new Response(responseBody, {
@@ -3150,6 +3157,7 @@ describe('checkAlerts', () => {
             'https://webhook.site/fail',
             expect.objectContaining({ redirect: 'manual' }),
           );
+          expect(fetchMock).toHaveBeenCalledTimes(expectedRequestCount);
           expect(
             fetchMock.mock.calls.every(
               ([requestUrl]) => requestUrl === 'https://webhook.site/fail',

--- a/packages/api/src/tasks/checkAlerts/errors.ts
+++ b/packages/api/src/tasks/checkAlerts/errors.ts
@@ -1,0 +1,12 @@
+export const WEBHOOK_REDIRECT_ERROR_MESSAGE =
+  'Webhook destination responded with a redirect. Redirects are not supported.';
+
+export class WebhookRedirectError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(WEBHOOK_REDIRECT_ERROR_MESSAGE);
+    this.name = 'WebhookRedirectError';
+    this.status = status;
+  }
+}

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -57,6 +57,10 @@ import { ISavedSearch } from '@/models/savedSearch';
 import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
 import {
+  WEBHOOK_REDIRECT_ERROR_MESSAGE,
+  WebhookRedirectError,
+} from '@/tasks/checkAlerts/errors';
+import {
   AlertDetails,
   AlertProvider,
   AlertTask,
@@ -204,6 +208,20 @@ const getErrorMessage = (e: unknown): string => {
     return e.message;
   }
   return String(e);
+};
+
+// Most webhook errors show a hardcoded message to avoid leaking sensitive request details in the UI.
+// Redirect errors are a known class of errors which we want to surface to the user, so it has a specific message.
+const makeWebhookAlertError = (error: unknown): IAlertError => {
+  if (error instanceof WebhookRedirectError) {
+    return {
+      timestamp: new Date(),
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: WEBHOOK_REDIRECT_ERROR_MESSAGE,
+    };
+  }
+
+  return makeAlertError(AlertErrorType.WEBHOOK_ERROR, getErrorMessage(error));
 };
 
 export const doesExceedThreshold = (
@@ -1080,9 +1098,7 @@ export const processAlert = async (
           { alertId: alert.id, group, error: serializeError(e) },
           'Failed to fire channel event',
         );
-        executionErrors.push(
-          makeAlertError(AlertErrorType.WEBHOOK_ERROR, getErrorMessage(e)),
-        );
+        executionErrors.push(makeWebhookAlertError(e));
       }
     };
 

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -36,6 +36,7 @@ import {
   computeAliasWithClauses,
   doesExceedThreshold,
 } from '@/tasks/checkAlerts';
+import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
 import {
   AlertProvider,
   PopulatedAlertChannel,
@@ -394,12 +395,22 @@ const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
   }
 
   try {
-    const response = await withRetry(async () => {
+    await withRetry(async () => {
       const res = await fetch(url, {
         method: 'POST',
+        redirect: 'manual',
         headers: headers as Record<string, string>,
         body,
       });
+
+      // Disallow redirects to avoid redirect-based SSRF.
+      if (res.status >= 300 && res.status < 400) {
+        logger.error(
+          { webhookId: webhook._id.toString(), teamId: webhook.team },
+          'Webhook request was redirected, which is not allowed',
+        );
+        throw new WebhookRedirectError(res.status);
+      }
 
       if (!res.ok) {
         const errorText = await res.text();

--- a/packages/api/src/utils/__tests__/retry.test.ts
+++ b/packages/api/src/utils/__tests__/retry.test.ts
@@ -42,6 +42,18 @@ describe('withRetry', () => {
     expect(fn400).toHaveBeenCalledTimes(1); // aborted early
   });
 
+  it('should not retry on 3xx redirect responses', async () => {
+    const redirectError = new Error('redirect') as any;
+    redirectError.status = 302;
+
+    const fn = jest.fn().mockRejectedValue(redirectError);
+
+    await expect(
+      withRetry(fn, { initialDelayMs: 10, jitter: false }),
+    ).rejects.toThrow('redirect');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it('should retry on 429 Too Many Requests', async () => {
     const error429 = new Error('rate limited') as any;
     error429.status = 429;

--- a/packages/api/src/utils/retry.ts
+++ b/packages/api/src/utils/retry.ts
@@ -13,7 +13,8 @@ interface RetryOptions {
 
 /**
  * Executes a promise-returning function with exponential backoff and retries.
- * Automatically skips retries for 4xx client errors (excluding 429 Too Many Requests).
+ * Automatically skips retries for redirects and 4xx client errors (excluding
+ * 429 Too Many Requests).
  */
 export const withRetry = async <T>(
   fn: () => Promise<T>,
@@ -49,6 +50,12 @@ export const withRetry = async <T>(
         error?.original?.status ??
         error?.code;
       const isStatusNumber = typeof status === 'number';
+
+      // A redirect response is deterministic and retrying would re-send the
+      // request body to the same endpoint without changing the outcome.
+      if (isStatusNumber && status >= 300 && status < 400) {
+        throw error;
+      }
 
       if (options.retryOnlyOnStatus && options.retryOnlyOnStatus.length > 0) {
         // If an explicit whitelist of retryable statuses is provided, ONLY retry those.


### PR DESCRIPTION
## Summary

This PR disables redirects for web requests, preventing redirect-based SSRF.

### Screenshots or video

Webhook requests which are redirected (HTTP 3XX) do not follow the redirect, and instead show a webhook error. This can be diagnosed in the UI:

<img width="1540" height="375" alt="Screenshot 2026-07-17 at 7 26 20 AM" src="https://github.com/user-attachments/assets/38626d0c-ffef-4a37-aa32-17797b407b32" />

### How to test on Vercel preview

This can be tested locally by running the following script as a server that redirects:

<details>
<summary>Redirect Webhook Server</summary>

```js
import http from 'node:http';
import { appendFileSync } from 'node:fs';

const port = Number(process.env.PORT ?? 18080);
const logPath = '/tmp/hyperdx-webhook-redirect-server.log';

const logRequest = ({ body, headers, method, url }) => {
  const message = [
    '',
    '--- Request received ---',
    `${method} ${url}`,
    `Headers: ${JSON.stringify(headers, null, 2)}`,
    `Body: ${body || '<empty>'}`,
  ].join('\n');

  console.log(message);
  appendFileSync(logPath, `${message}\n`);
};

const server = http.createServer((request, response) => {
  const chunks = [];

  request.on('data', chunk => chunks.push(chunk));
  request.on('end', () => {
    const body = Buffer.concat(chunks).toString('utf8');

    logRequest({
      body,
      headers: request.headers,
      method: request.method,
      url: request.url,
    });

    if (request.url === '/redirect') {
      response.writeHead(307, {
        'Content-Type': 'text/plain',
        Location: '/destination',
      });
      response.end('Redirecting to /destination');
      return;
    }

    if (request.url === '/destination') {
      response.writeHead(200, { 'Content-Type': 'application/json' });
      response.end(JSON.stringify({ received: true, body }));
      return;
    }

    response.writeHead(200, { 'Content-Type': 'text/plain' });
    response.end('POST a webhook to /redirect');
  });
});

server.listen(port, '0.0.0.0', () => {
  console.log(`Webhook redirect test server listening on http://localhost:${port}`);
  console.log(`Redirect endpoint: http://localhost:${port}/redirect`);
  console.log(`Redirect target:   http://localhost:${port}/destination`);
  console.log(`Request log:       ${logPath}`);
});
```
</details>

Then register a webhook pointing to `http://localhost:18080/redirect`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Contributes to HDX-4174
- Related PRs:
