### PR TITLE
feat(dashboards): color-code Browser RUM web vitals, page-load & error tiles

### DIFF
--- a/.changeset/browser-rum-web-vitals-colors.md
+++ b/.changeset/browser-rum-web-vitals-colors.md
@@ -7,5 +7,7 @@ The Core Web Vitals tiles (LCP, INP, CLS) now render green / amber / red using
 Google's official good / needs-improvement / poor thresholds, the Median and p90
 Page Load tiles use opinionated latency bands, and the error-count tiles
 (Sessions w/ Errors, JS Errors, AJAX Errors) turn amber when any errors are
-present. Implemented entirely via the existing number-tile `colorRules`
-mechanism — no renderer changes.
+present. A Markdown legend tile at the top of the Performance Overview section
+documents the Core Web Vitals thresholds (with a link to web.dev) so viewers
+understand the standard behind the colors. Implemented entirely via the existing
+number-tile `colorRules` and Markdown-tile mechanisms — no renderer changes.

--- a/.changeset/browser-rum-web-vitals-colors.md
+++ b/.changeset/browser-rum-web-vitals-colors.md
@@ -2,12 +2,15 @@
 '@hyperdx/app': patch
 ---
 
-feat(dashboards): color-code the out-of-the-box Browser RUM dashboard by value.
-The Core Web Vitals tiles (LCP, INP, CLS) now render green / amber / red using
-Google's official good / needs-improvement / poor thresholds, the Median and p90
-Page Load tiles use opinionated latency bands, and the error-count tiles
-(Sessions w/ Errors, JS Errors, AJAX Errors) turn amber when any errors are
-present. A Markdown legend tile at the top of the Performance Overview section
-documents the Core Web Vitals thresholds (with a link to web.dev) so viewers
-understand the standard behind the colors. Implemented entirely via the existing
-number-tile `colorRules` and Markdown-tile mechanisms — no renderer changes.
+feat(dashboards): revamp the out-of-the-box Browser RUM dashboard. Reorganize it
+into four focused sections — Core Web Vitals, Load Time, Traffic & Page Views,
+and Errors — so each metric lives with its peers instead of a single catch-all
+"Performance Overview". Tiles are now color-coded by value: the Core Web Vitals
+tiles (LCP, INP, CLS) render green / amber / red using Google's official good /
+needs-improvement / poor thresholds, the Median and p90 Page Load tiles use
+opinionated latency bands, and the error-count tiles (Sessions w/ Errors, JS
+Errors, AJAX Errors) turn amber when any errors are present. A Markdown legend
+tile in the Core Web Vitals section documents the thresholds (with a link to
+web.dev) so viewers understand the standard behind the colors. Implemented
+entirely via the existing number-tile `colorRules` and Markdown-tile mechanisms
+— no renderer changes.

--- a/.changeset/browser-rum-web-vitals-colors.md
+++ b/.changeset/browser-rum-web-vitals-colors.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/app': patch
+---
+
+feat(dashboards): color-code the out-of-the-box Browser RUM dashboard by value.
+The Core Web Vitals tiles (LCP, INP, CLS) now render green / amber / red using
+Google's official good / needs-improvement / poor thresholds, the Median and p90
+Page Load tiles use opinionated latency bands, and the error-count tiles
+(Sessions w/ Errors, JS Errors, AJAX Errors) turn amber when any errors are
+present. Implemented entirely via the existing number-tile `colorRules`
+mechanism — no renderer changes.

--- a/packages/app/src/dashboardTemplates/browser-rum.json
+++ b/packages/app/src/dashboardTemplates/browser-rum.json
@@ -156,21 +156,21 @@
         "colorRules": [
           {
             "operator": "lte",
-            "value": 2500,
+            "value": 2500000000,
             "color": "chart-success",
-            "label": "Good"
+            "label": "Good (≤ 2.5 s)"
           },
           {
             "operator": "gt",
-            "value": 2500,
+            "value": 2500000000,
             "color": "chart-warning",
-            "label": "Needs improvement"
+            "label": "Needs improvement (2.5–4 s)"
           },
           {
             "operator": "gt",
-            "value": 4000,
+            "value": 4000000000,
             "color": "chart-error",
-            "label": "Poor"
+            "label": "Poor (> 4 s)"
           }
         ]
       }
@@ -202,21 +202,21 @@
         "colorRules": [
           {
             "operator": "lte",
-            "value": 4000,
+            "value": 4000000000,
             "color": "chart-success",
-            "label": "Good"
+            "label": "Good (≤ 4 s)"
           },
           {
             "operator": "gt",
-            "value": 4000,
+            "value": 4000000000,
             "color": "chart-warning",
-            "label": "Needs improvement"
+            "label": "Needs improvement (4–6 s)"
           },
           {
             "operator": "gt",
-            "value": 6000,
+            "value": 6000000000,
             "color": "chart-error",
-            "label": "Poor"
+            "label": "Poor (> 6 s)"
           }
         ]
       }

--- a/packages/app/src/dashboardTemplates/browser-rum.json
+++ b/packages/app/src/dashboardTemplates/browser-rum.json
@@ -83,10 +83,27 @@
   ],
   "tiles": [
     {
-      "id": "rum-006",
+      "id": "rum-legend",
       "containerId": "rum-perf",
       "x": 0,
       "y": 0,
+      "w": 24,
+      "h": 4,
+      "config": {
+        "name": "Core Web Vitals — color legend",
+        "source": "Traces",
+        "displayType": "markdown",
+        "select": [],
+        "where": "",
+        "whereLanguage": "lucene",
+        "markdown": "🟢 **Good**  ·  🟡 **Needs improvement**  ·  🔴 **Poor** — [Core Web Vitals](https://web.dev/articles/vitals) targets, measured at the 75th percentile:\n\n- **LCP** (loading): Good ≤ 2.5 s · Poor > 4 s\n- **INP** (responsiveness): Good ≤ 200 ms · Poor > 500 ms\n- **CLS** (visual stability): Good ≤ 0.1 · Poor > 0.25"
+      }
+    },
+    {
+      "id": "rum-006",
+      "containerId": "rum-perf",
+      "x": 0,
+      "y": 4,
       "w": 6,
       "h": 4,
       "config": {
@@ -116,7 +133,7 @@
       "id": "rum-017",
       "containerId": "rum-perf",
       "x": 6,
-      "y": 0,
+      "y": 4,
       "w": 6,
       "h": 4,
       "config": {
@@ -162,7 +179,7 @@
       "id": "rum-018",
       "containerId": "rum-perf",
       "x": 12,
-      "y": 0,
+      "y": 4,
       "w": 6,
       "h": 4,
       "config": {
@@ -208,7 +225,7 @@
       "id": "rum-001",
       "containerId": "rum-perf",
       "x": 18,
-      "y": 0,
+      "y": 4,
       "w": 6,
       "h": 4,
       "config": {
@@ -258,7 +275,7 @@
       "id": "rum-002",
       "containerId": "rum-perf",
       "x": 0,
-      "y": 4,
+      "y": 8,
       "w": 6,
       "h": 4,
       "config": {
@@ -308,7 +325,7 @@
       "id": "rum-003",
       "containerId": "rum-perf",
       "x": 6,
-      "y": 4,
+      "y": 8,
       "w": 6,
       "h": 4,
       "config": {
@@ -358,7 +375,7 @@
       "id": "rum-005",
       "containerId": "rum-perf",
       "x": 12,
-      "y": 4,
+      "y": 8,
       "w": 6,
       "h": 4,
       "config": {
@@ -388,7 +405,7 @@
       "id": "rum-019",
       "containerId": "rum-perf",
       "x": 18,
-      "y": 4,
+      "y": 8,
       "w": 6,
       "h": 4,
       "config": {
@@ -426,7 +443,7 @@
       "id": "rum-020",
       "containerId": "rum-perf",
       "x": 0,
-      "y": 8,
+      "y": 12,
       "w": 24,
       "h": 7,
       "config": {
@@ -469,7 +486,7 @@
       "id": "rum-021",
       "containerId": "rum-perf",
       "x": 0,
-      "y": 15,
+      "y": 19,
       "w": 12,
       "h": 6,
       "config": {
@@ -500,7 +517,7 @@
       "id": "rum-024",
       "containerId": "rum-perf",
       "x": 12,
-      "y": 15,
+      "y": 19,
       "w": 12,
       "h": 6,
       "config": {

--- a/packages/app/src/dashboardTemplates/browser-rum.json
+++ b/packages/app/src/dashboardTemplates/browser-rum.json
@@ -52,13 +52,18 @@
   ],
   "containers": [
     {
-      "id": "rum-perf",
-      "title": "Performance Overview",
+      "id": "rum-vitals",
+      "title": "Core Web Vitals",
       "collapsed": false
     },
     {
-      "id": "rum-breakdown",
-      "title": "Page Views Breakdown",
+      "id": "rum-loadtime",
+      "title": "Load Time",
+      "collapsed": false
+    },
+    {
+      "id": "rum-traffic",
+      "title": "Traffic & Page Views",
       "collapsed": false
     },
     {
@@ -84,7 +89,7 @@
   "tiles": [
     {
       "id": "rum-legend",
-      "containerId": "rum-perf",
+      "containerId": "rum-vitals",
       "x": 0,
       "y": 0,
       "w": 24,
@@ -100,133 +105,11 @@
       }
     },
     {
-      "id": "rum-006",
-      "containerId": "rum-perf",
+      "id": "rum-001",
+      "containerId": "rum-vitals",
       "x": 0,
       "y": 4,
-      "w": 6,
-      "h": 4,
-      "config": {
-        "name": "Page Views",
-        "source": "Traces",
-        "displayType": "number",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "numberFormat": {
-          "output": "number",
-          "mantissa": 0,
-          "thousandSeparated": true
-        }
-      }
-    },
-    {
-      "id": "rum-017",
-      "containerId": "rum-perf",
-      "x": 6,
-      "y": 4,
-      "w": 6,
-      "h": 4,
-      "config": {
-        "name": "Median Page Load",
-        "source": "Traces",
-        "displayType": "number",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "quantile",
-            "level": 0.5,
-            "valueExpression": "Duration",
-            "aggCondition": "SpanName:\"documentLoad\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "colorRules": [
-          {
-            "operator": "lte",
-            "value": 2500000000,
-            "color": "chart-success",
-            "label": "Good (≤ 2.5 s)"
-          },
-          {
-            "operator": "gt",
-            "value": 2500000000,
-            "color": "chart-warning",
-            "label": "Needs improvement (2.5–4 s)"
-          },
-          {
-            "operator": "gt",
-            "value": 4000000000,
-            "color": "chart-error",
-            "label": "Poor (> 4 s)"
-          }
-        ]
-      }
-    },
-    {
-      "id": "rum-018",
-      "containerId": "rum-perf",
-      "x": 12,
-      "y": 4,
-      "w": 6,
-      "h": 4,
-      "config": {
-        "name": "p90 Page Load",
-        "source": "Traces",
-        "displayType": "number",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "quantile",
-            "level": 0.9,
-            "valueExpression": "Duration",
-            "aggCondition": "SpanName:\"documentLoad\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "colorRules": [
-          {
-            "operator": "lte",
-            "value": 4000000000,
-            "color": "chart-success",
-            "label": "Good (≤ 4 s)"
-          },
-          {
-            "operator": "gt",
-            "value": 4000000000,
-            "color": "chart-warning",
-            "label": "Needs improvement (4–6 s)"
-          },
-          {
-            "operator": "gt",
-            "value": 6000000000,
-            "color": "chart-error",
-            "label": "Poor (> 6 s)"
-          }
-        ]
-      }
-    },
-    {
-      "id": "rum-001",
-      "containerId": "rum-perf",
-      "x": 18,
-      "y": 4,
-      "w": 6,
+      "w": 8,
       "h": 4,
       "config": {
         "name": "LCP p75 (ms)",
@@ -273,10 +156,10 @@
     },
     {
       "id": "rum-002",
-      "containerId": "rum-perf",
-      "x": 0,
-      "y": 8,
-      "w": 6,
+      "containerId": "rum-vitals",
+      "x": 8,
+      "y": 4,
+      "w": 8,
       "h": 4,
       "config": {
         "name": "INP p75 (ms)",
@@ -323,10 +206,10 @@
     },
     {
       "id": "rum-003",
-      "containerId": "rum-perf",
-      "x": 6,
-      "y": 8,
-      "w": 6,
+      "containerId": "rum-vitals",
+      "x": 16,
+      "y": 4,
+      "w": 8,
       "h": 4,
       "config": {
         "name": "CLS p75",
@@ -372,78 +255,102 @@
       }
     },
     {
-      "id": "rum-005",
-      "containerId": "rum-perf",
-      "x": 12,
-      "y": 8,
-      "w": 6,
+      "id": "rum-017",
+      "containerId": "rum-loadtime",
+      "x": 0,
+      "y": 0,
+      "w": 12,
       "h": 4,
       "config": {
-        "name": "Active Sessions",
+        "name": "Median Page Load",
         "source": "Traces",
         "displayType": "number",
         "granularity": "auto",
         "alignDateRangeToGranularity": true,
         "select": [
           {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "aggCondition": "ResourceAttributes.rum.sessionId:*",
+            "aggFn": "quantile",
+            "level": 0.5,
+            "valueExpression": "Duration",
+            "aggCondition": "SpanName:\"documentLoad\"",
             "aggConditionLanguage": "lucene"
           }
         ],
         "where": "",
         "whereLanguage": "lucene",
-        "numberFormat": {
-          "output": "number",
-          "mantissa": 0,
-          "thousandSeparated": true
-        }
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 2500000000,
+            "color": "chart-success",
+            "label": "Good (≤ 2.5 s)"
+          },
+          {
+            "operator": "gt",
+            "value": 2500000000,
+            "color": "chart-warning",
+            "label": "Needs improvement (2.5–4 s)"
+          },
+          {
+            "operator": "gt",
+            "value": 4000000000,
+            "color": "chart-error",
+            "label": "Poor (> 4 s)"
+          }
+        ]
       }
     },
     {
-      "id": "rum-019",
-      "containerId": "rum-perf",
-      "x": 18,
-      "y": 8,
-      "w": 6,
+      "id": "rum-018",
+      "containerId": "rum-loadtime",
+      "x": 12,
+      "y": 0,
+      "w": 12,
       "h": 4,
       "config": {
-        "name": "Sessions w/ Errors",
+        "name": "p90 Page Load",
         "source": "Traces",
         "displayType": "number",
         "granularity": "auto",
         "alignDateRangeToGranularity": true,
         "select": [
           {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "aggCondition": "ResourceAttributes.rum.sessionId:* AND StatusCode:error",
+            "aggFn": "quantile",
+            "level": 0.9,
+            "valueExpression": "Duration",
+            "aggCondition": "SpanName:\"documentLoad\"",
             "aggConditionLanguage": "lucene"
           }
         ],
         "where": "",
         "whereLanguage": "lucene",
-        "numberFormat": {
-          "output": "number",
-          "mantissa": 0,
-          "thousandSeparated": true
-        },
         "colorRules": [
           {
+            "operator": "lte",
+            "value": 4000000000,
+            "color": "chart-success",
+            "label": "Good (≤ 4 s)"
+          },
+          {
             "operator": "gt",
-            "value": 0,
+            "value": 4000000000,
             "color": "chart-warning",
-            "label": "Errors present"
+            "label": "Needs improvement (4–6 s)"
+          },
+          {
+            "operator": "gt",
+            "value": 6000000000,
+            "color": "chart-error",
+            "label": "Poor (> 6 s)"
           }
         ]
       }
     },
     {
       "id": "rum-020",
-      "containerId": "rum-perf",
+      "containerId": "rum-loadtime",
       "x": 0,
-      "y": 12,
+      "y": 4,
       "w": 24,
       "h": 7,
       "config": {
@@ -483,264 +390,10 @@
       }
     },
     {
-      "id": "rum-021",
-      "containerId": "rum-perf",
-      "x": 0,
-      "y": 19,
-      "w": 12,
-      "h": 6,
-      "config": {
-        "name": "Page Views over Time",
-        "source": "Traces",
-        "displayType": "line",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Page Views",
-            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "numberFormat": {
-          "output": "number",
-          "mantissa": 0,
-          "thousandSeparated": true
-        }
-      }
-    },
-    {
-      "id": "rum-024",
-      "containerId": "rum-perf",
-      "x": 12,
-      "y": 19,
-      "w": 12,
-      "h": 6,
-      "config": {
-        "name": "Long Tasks over Time",
-        "source": "Traces",
-        "displayType": "stacked_bar",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Long Tasks",
-            "aggCondition": "SpanName:\"longtask\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "numberFormat": {
-          "output": "number",
-          "mantissa": 0,
-          "thousandSeparated": true
-        }
-      }
-    },
-    {
-      "id": "rum-014",
-      "containerId": "rum-breakdown",
-      "x": 0,
-      "y": 0,
-      "w": 8,
-      "h": 8,
-      "config": {
-        "name": "Top URLs",
-        "source": "Traces",
-        "displayType": "table",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Views",
-            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
-            "aggConditionLanguage": "lucene"
-          },
-          {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "alias": "Sessions",
-            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "groupBy": "coalesce(nullif(SpanAttributes['http.url'], ''), nullif(SpanAttributes['page.url'], ''), nullif(SpanAttributes['location.href'], '')) AS \"URL\"",
-        "orderBy": "Views DESC",
-        "limit": {
-          "limit": 20
-        },
-        "onClick": {
-          "type": "search",
-          "target": {
-            "mode": "id",
-            "id": "Traces"
-          },
-          "whereTemplate": "(SpanAttributes.http.url:\"{{URL}}\" OR SpanAttributes.page.url:\"{{URL}}\" OR SpanAttributes.location.href:\"{{URL}}\")",
-          "whereLanguage": "lucene"
-        },
-        "groupByColumnsOnLeft": true
-      }
-    },
-    {
-      "id": "rum-026",
-      "containerId": "rum-breakdown",
-      "x": 8,
-      "y": 0,
-      "w": 8,
-      "h": 8,
-      "config": {
-        "name": "Top Browsers",
-        "source": "Traces",
-        "displayType": "table",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "alias": "Sessions",
-            "aggCondition": "ResourceAttributes.rum.sessionId:* AND SpanAttributes.http.user_agent:*",
-            "aggConditionLanguage": "lucene"
-          },
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Page Loads",
-            "aggCondition": "ResourceAttributes.rum.sessionId:* AND SpanAttributes.http.user_agent:*",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "groupBy": "multiIf(positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Edg/') > 0, 'Edge', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'OPR/') > 0, 'Opera', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Firefox/') > 0, 'Firefox', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Chrome/') > 0, 'Chrome', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Safari/') > 0, 'Safari', 'Other') AS \"Browser\"",
-        "orderBy": "Sessions DESC",
-        "limit": {
-          "limit": 10
-        },
-        "onClick": {
-          "type": "search",
-          "target": {
-            "mode": "id",
-            "id": "Traces"
-          },
-          "whereTemplate": "positionCaseInsensitive(SpanAttributes['http.user_agent'], '{{Browser}}') > 0",
-          "whereLanguage": "sql"
-        },
-        "groupByColumnsOnLeft": true
-      }
-    },
-    {
-      "id": "rum-027",
-      "containerId": "rum-breakdown",
-      "x": 16,
-      "y": 0,
-      "w": 8,
-      "h": 8,
-      "config": {
-        "name": "Top Countries (requires geoip processor)",
-        "source": "Traces",
-        "displayType": "table",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "alias": "Sessions",
-            "aggCondition": "ResourceAttributes.rum.sessionId:*",
-            "aggConditionLanguage": "lucene"
-          },
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Views",
-            "aggCondition": "ResourceAttributes.rum.sessionId:*",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "groupBy": "coalesce(nullif(ResourceAttributes['geo.country.name'], ''), nullif(SpanAttributes['geo.country.name'], ''), nullif(ResourceAttributes['geo.country.iso_code'], ''), nullif(SpanAttributes['geo.country.iso_code'], '')) AS \"Country\"",
-        "orderBy": "Sessions DESC",
-        "limit": {
-          "limit": 10
-        },
-        "onClick": {
-          "type": "search",
-          "target": {
-            "mode": "id",
-            "id": "Traces"
-          },
-          "whereTemplate": "ResourceAttributes.geo.country.name:\"{{Country}}\"",
-          "whereLanguage": "lucene"
-        },
-        "groupByColumnsOnLeft": true
-      }
-    },
-    {
-      "id": "rum-028",
-      "containerId": "rum-breakdown",
-      "x": 0,
-      "y": 8,
-      "w": 12,
-      "h": 8,
-      "config": {
-        "name": "Top Device Sizes",
-        "source": "Traces",
-        "displayType": "table",
-        "granularity": "auto",
-        "alignDateRangeToGranularity": true,
-        "select": [
-          {
-            "aggFn": "count_distinct",
-            "valueExpression": "ResourceAttributes['rum.sessionId']",
-            "alias": "Sessions",
-            "aggCondition": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:*",
-            "aggConditionLanguage": "lucene"
-          },
-          {
-            "aggFn": "count",
-            "valueExpression": "",
-            "alias": "Views",
-            "aggCondition": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:*",
-            "aggConditionLanguage": "lucene"
-          }
-        ],
-        "where": "",
-        "whereLanguage": "lucene",
-        "groupBy": "SpanAttributes['screen.xy'] AS \"Device\"",
-        "orderBy": "Sessions DESC",
-        "limit": {
-          "limit": 10
-        },
-        "onClick": {
-          "type": "search",
-          "target": {
-            "mode": "id",
-            "id": "Traces"
-          },
-          "whereTemplate": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:\"{{Device}}\"",
-          "whereLanguage": "lucene"
-        },
-        "groupByColumnsOnLeft": true
-      }
-    },
-    {
       "id": "rum-011",
-      "containerId": "rum-breakdown",
-      "x": 12,
-      "y": 8,
+      "containerId": "rum-loadtime",
+      "x": 0,
+      "y": 11,
       "w": 12,
       "h": 8,
       "config": {
@@ -786,14 +439,136 @@
       }
     },
     {
-      "id": "rum-016",
-      "containerId": "rum-breakdown",
-      "x": 0,
-      "y": 16,
-      "w": 24,
+      "id": "rum-024",
+      "containerId": "rum-loadtime",
+      "x": 12,
+      "y": 11,
+      "w": 12,
       "h": 8,
       "config": {
-        "name": "Top Errored Sessions",
+        "name": "Long Tasks over Time",
+        "source": "Traces",
+        "displayType": "stacked_bar",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "alias": "Long Tasks",
+            "aggCondition": "SpanName:\"longtask\"",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0,
+          "thousandSeparated": true
+        }
+      }
+    },
+    {
+      "id": "rum-006",
+      "containerId": "rum-traffic",
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 4,
+      "config": {
+        "name": "Page Views",
+        "source": "Traces",
+        "displayType": "number",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0,
+          "thousandSeparated": true
+        }
+      }
+    },
+    {
+      "id": "rum-005",
+      "containerId": "rum-traffic",
+      "x": 12,
+      "y": 0,
+      "w": 12,
+      "h": 4,
+      "config": {
+        "name": "Active Sessions",
+        "source": "Traces",
+        "displayType": "number",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "aggCondition": "ResourceAttributes.rum.sessionId:*",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0,
+          "thousandSeparated": true
+        }
+      }
+    },
+    {
+      "id": "rum-021",
+      "containerId": "rum-traffic",
+      "x": 0,
+      "y": 4,
+      "w": 24,
+      "h": 6,
+      "config": {
+        "name": "Page Views over Time",
+        "source": "Traces",
+        "displayType": "line",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "alias": "Page Views",
+            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0,
+          "thousandSeparated": true
+        }
+      }
+    },
+    {
+      "id": "rum-014",
+      "containerId": "rum-traffic",
+      "x": 0,
+      "y": 10,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "name": "Top URLs",
         "source": "Traces",
         "displayType": "table",
         "granularity": "auto",
@@ -802,32 +577,22 @@
           {
             "aggFn": "count",
             "valueExpression": "",
-            "aggCondition": "StatusCode:error",
-            "aggConditionLanguage": "lucene",
-            "alias": "Errors"
+            "alias": "Views",
+            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
+            "aggConditionLanguage": "lucene"
           },
           {
             "aggFn": "count_distinct",
-            "valueExpression": "TraceId",
-            "alias": "Traces"
-          },
-          {
-            "aggFn": "any",
-            "valueExpression": "nullif(SpanAttributes['userEmail'], '')",
-            "alias": "User"
-          },
-          {
-            "aggFn": "any",
-            "valueExpression": "ServiceName",
-            "alias": "Service"
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "alias": "Sessions",
+            "aggCondition": "SpanName:\"documentLoad\" OR SpanName:\"routeChange\" OR SpanAttributes.component:\"page-view\" OR SpanAttributes.component:\"navigation\"",
+            "aggConditionLanguage": "lucene"
           }
         ],
-        "where": "ResourceAttributes.rum.sessionId:*",
+        "where": "",
         "whereLanguage": "lucene",
-        "groupBy": "ResourceAttributes['rum.sessionId'] AS \"Session\"",
-        "having": "Errors > 0",
-        "havingLanguage": "sql",
-        "orderBy": "Errors DESC",
+        "groupBy": "coalesce(nullif(SpanAttributes['http.url'], ''), nullif(SpanAttributes['page.url'], ''), nullif(SpanAttributes['location.href'], '')) AS \"URL\"",
+        "orderBy": "Views DESC",
         "limit": {
           "limit": 20
         },
@@ -837,19 +602,202 @@
             "mode": "id",
             "id": "Traces"
           },
-          "whereTemplate": "ResourceAttributes.rum.sessionId:\"{{Session}}\"",
+          "whereTemplate": "(SpanAttributes.http.url:\"{{URL}}\" OR SpanAttributes.page.url:\"{{URL}}\" OR SpanAttributes.location.href:\"{{URL}}\")",
           "whereLanguage": "lucene"
         },
         "groupByColumnsOnLeft": true
       }
     },
     {
-      "id": "rum-007",
+      "id": "rum-026",
+      "containerId": "rum-traffic",
+      "x": 12,
+      "y": 10,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "name": "Top Browsers",
+        "source": "Traces",
+        "displayType": "table",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "alias": "Sessions",
+            "aggCondition": "ResourceAttributes.rum.sessionId:* AND SpanAttributes.http.user_agent:*",
+            "aggConditionLanguage": "lucene"
+          },
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "alias": "Page Loads",
+            "aggCondition": "ResourceAttributes.rum.sessionId:* AND SpanAttributes.http.user_agent:*",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "groupBy": "multiIf(positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Edg/') > 0, 'Edge', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'OPR/') > 0, 'Opera', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Firefox/') > 0, 'Firefox', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Chrome/') > 0, 'Chrome', positionCaseInsensitive(SpanAttributes['http.user_agent'], 'Safari/') > 0, 'Safari', 'Other') AS \"Browser\"",
+        "orderBy": "Sessions DESC",
+        "limit": {
+          "limit": 10
+        },
+        "onClick": {
+          "type": "search",
+          "target": {
+            "mode": "id",
+            "id": "Traces"
+          },
+          "whereTemplate": "positionCaseInsensitive(SpanAttributes['http.user_agent'], '{{Browser}}') > 0",
+          "whereLanguage": "sql"
+        },
+        "groupByColumnsOnLeft": true
+      }
+    },
+    {
+      "id": "rum-027",
+      "containerId": "rum-traffic",
+      "x": 0,
+      "y": 18,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "name": "Top Countries (requires geoip processor)",
+        "source": "Traces",
+        "displayType": "table",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "alias": "Sessions",
+            "aggCondition": "ResourceAttributes.rum.sessionId:*",
+            "aggConditionLanguage": "lucene"
+          },
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "alias": "Views",
+            "aggCondition": "ResourceAttributes.rum.sessionId:*",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "groupBy": "coalesce(nullif(ResourceAttributes['geo.country.name'], ''), nullif(SpanAttributes['geo.country.name'], ''), nullif(ResourceAttributes['geo.country.iso_code'], ''), nullif(SpanAttributes['geo.country.iso_code'], '')) AS \"Country\"",
+        "orderBy": "Sessions DESC",
+        "limit": {
+          "limit": 10
+        },
+        "onClick": {
+          "type": "search",
+          "target": {
+            "mode": "id",
+            "id": "Traces"
+          },
+          "whereTemplate": "ResourceAttributes.geo.country.name:\"{{Country}}\"",
+          "whereLanguage": "lucene"
+        },
+        "groupByColumnsOnLeft": true
+      }
+    },
+    {
+      "id": "rum-028",
+      "containerId": "rum-traffic",
+      "x": 12,
+      "y": 18,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "name": "Top Device Sizes",
+        "source": "Traces",
+        "displayType": "table",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "alias": "Sessions",
+            "aggCondition": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:*",
+            "aggConditionLanguage": "lucene"
+          },
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "alias": "Views",
+            "aggCondition": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:*",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "groupBy": "SpanAttributes['screen.xy'] AS \"Device\"",
+        "orderBy": "Sessions DESC",
+        "limit": {
+          "limit": 10
+        },
+        "onClick": {
+          "type": "search",
+          "target": {
+            "mode": "id",
+            "id": "Traces"
+          },
+          "whereTemplate": "SpanName:\"documentLoad\" AND SpanAttributes.screen.xy:\"{{Device}}\"",
+          "whereLanguage": "lucene"
+        },
+        "groupByColumnsOnLeft": true
+      }
+    },
+    {
+      "id": "rum-019",
       "containerId": "rum-errors",
       "tabId": "rum-errors-overview",
       "x": 0,
       "y": 0,
-      "w": 12,
+      "w": 8,
+      "h": 4,
+      "config": {
+        "name": "Sessions w/ Errors",
+        "source": "Traces",
+        "displayType": "number",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "ResourceAttributes['rum.sessionId']",
+            "aggCondition": "ResourceAttributes.rum.sessionId:* AND StatusCode:error",
+            "aggConditionLanguage": "lucene"
+          }
+        ],
+        "where": "",
+        "whereLanguage": "lucene",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0,
+          "thousandSeparated": true
+        },
+        "colorRules": [
+          {
+            "operator": "gt",
+            "value": 0,
+            "color": "chart-warning",
+            "label": "Errors present"
+          }
+        ]
+      }
+    },
+    {
+      "id": "rum-007",
+      "containerId": "rum-errors",
+      "tabId": "rum-errors-overview",
+      "x": 8,
+      "y": 0,
+      "w": 8,
       "h": 4,
       "config": {
         "name": "JS Errors",
@@ -886,9 +834,9 @@
       "id": "rum-008",
       "containerId": "rum-errors",
       "tabId": "rum-errors-overview",
-      "x": 12,
+      "x": 16,
       "y": 0,
-      "w": 12,
+      "w": 8,
       "h": 4,
       "config": {
         "name": "AJAX Errors",
@@ -958,6 +906,65 @@
           "mantissa": 0,
           "thousandSeparated": true
         }
+      }
+    },
+    {
+      "id": "rum-016",
+      "containerId": "rum-errors",
+      "tabId": "rum-errors-overview",
+      "x": 0,
+      "y": 11,
+      "w": 24,
+      "h": 8,
+      "config": {
+        "name": "Top Errored Sessions",
+        "source": "Traces",
+        "displayType": "table",
+        "granularity": "auto",
+        "alignDateRangeToGranularity": true,
+        "select": [
+          {
+            "aggFn": "count",
+            "valueExpression": "",
+            "aggCondition": "StatusCode:error",
+            "aggConditionLanguage": "lucene",
+            "alias": "Errors"
+          },
+          {
+            "aggFn": "count_distinct",
+            "valueExpression": "TraceId",
+            "alias": "Traces"
+          },
+          {
+            "aggFn": "any",
+            "valueExpression": "nullif(SpanAttributes['userEmail'], '')",
+            "alias": "User"
+          },
+          {
+            "aggFn": "any",
+            "valueExpression": "ServiceName",
+            "alias": "Service"
+          }
+        ],
+        "where": "ResourceAttributes.rum.sessionId:*",
+        "whereLanguage": "lucene",
+        "groupBy": "ResourceAttributes['rum.sessionId'] AS \"Session\"",
+        "having": "Errors > 0",
+        "havingLanguage": "sql",
+        "orderBy": "Errors DESC",
+        "limit": {
+          "limit": 20
+        },
+        "onClick": {
+          "type": "search",
+          "target": {
+            "mode": "id",
+            "id": "Traces"
+          },
+          "whereTemplate": "ResourceAttributes.rum.sessionId:\"{{Session}}\"",
+          "whereLanguage": "lucene"
+        },
+        "groupByColumnsOnLeft": true
       }
     },
     {

--- a/packages/app/src/dashboardTemplates/browser-rum.json
+++ b/packages/app/src/dashboardTemplates/browser-rum.json
@@ -135,7 +135,27 @@
           }
         ],
         "where": "",
-        "whereLanguage": "lucene"
+        "whereLanguage": "lucene",
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 2500,
+            "color": "chart-success",
+            "label": "Good"
+          },
+          {
+            "operator": "gt",
+            "value": 2500,
+            "color": "chart-warning",
+            "label": "Needs improvement"
+          },
+          {
+            "operator": "gt",
+            "value": 4000,
+            "color": "chart-error",
+            "label": "Poor"
+          }
+        ]
       }
     },
     {
@@ -161,7 +181,27 @@
           }
         ],
         "where": "",
-        "whereLanguage": "lucene"
+        "whereLanguage": "lucene",
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 4000,
+            "color": "chart-success",
+            "label": "Good"
+          },
+          {
+            "operator": "gt",
+            "value": 4000,
+            "color": "chart-warning",
+            "label": "Needs improvement"
+          },
+          {
+            "operator": "gt",
+            "value": 6000,
+            "color": "chart-error",
+            "label": "Poor"
+          }
+        ]
       }
     },
     {
@@ -191,7 +231,27 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 2500,
+            "color": "chart-success",
+            "label": "Good"
+          },
+          {
+            "operator": "gt",
+            "value": 2500,
+            "color": "chart-warning",
+            "label": "Needs improvement"
+          },
+          {
+            "operator": "gt",
+            "value": 4000,
+            "color": "chart-error",
+            "label": "Poor"
+          }
+        ]
       }
     },
     {
@@ -221,7 +281,27 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 200,
+            "color": "chart-success",
+            "label": "Good"
+          },
+          {
+            "operator": "gt",
+            "value": 200,
+            "color": "chart-warning",
+            "label": "Needs improvement"
+          },
+          {
+            "operator": "gt",
+            "value": 500,
+            "color": "chart-error",
+            "label": "Poor"
+          }
+        ]
       }
     },
     {
@@ -251,7 +331,27 @@
           "output": "number",
           "mantissa": 3,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "lte",
+            "value": 0.1,
+            "color": "chart-success",
+            "label": "Good"
+          },
+          {
+            "operator": "gt",
+            "value": 0.1,
+            "color": "chart-warning",
+            "label": "Needs improvement"
+          },
+          {
+            "operator": "gt",
+            "value": 0.25,
+            "color": "chart-error",
+            "label": "Poor"
+          }
+        ]
       }
     },
     {
@@ -311,7 +411,15 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "gt",
+            "value": 0,
+            "color": "chart-warning",
+            "label": "Errors present"
+          }
+        ]
       }
     },
     {
@@ -746,7 +854,15 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "gt",
+            "value": 0,
+            "color": "chart-warning",
+            "label": "Errors present"
+          }
+        ]
       }
     },
     {
@@ -777,7 +893,15 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "colorRules": [
+          {
+            "operator": "gt",
+            "value": 0,
+            "color": "chart-warning",
+            "label": "Errors present"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
## Summary

This PR revamps the out-of-the-box **Browser RUM** dashboard template. Previously a single catch-all "Performance Overview" section mixed web vitals, page-load latency, traffic, and session/error counts together, and every KPI tile rendered in the default text color with no signal of health. It now (1) reorganizes the dashboard into four focused sections — **Core Web Vitals**, **Load Time**, **Traffic & Page Views**, and **Errors** — so each metric sits with its peers, and (2) color-codes the number tiles by value (green / amber / red). The Core Web Vitals tiles (LCP, INP, CLS) use Google's official p75 good / needs-improvement / poor thresholds with inclusive-"good" boundaries (matching the `web-vitals` library), the Median and p90 Page Load tiles use opinionated latency bands, and the error-count tiles turn amber when any errors are present. A Markdown legend tile in the Core Web Vitals section documents the thresholds (with a link to web.dev) so viewers understand the standard behind the colors. It is a pure-JSON template change reusing the existing number-tile `colorRules` and Markdown-tile mechanisms — no renderer, schema, or type changes.

New section layout:

- **Core Web Vitals** — legend + LCP / INP / CLS (p75)
- **Load Time** — Median & p90 Page Load, the median/p90/p99 trend, Slowest Pages, Long Tasks
- **Traffic & Page Views** — Page Views, Active Sessions, Page Views over time, Top URLs / Browsers / Countries / Device Sizes
- **Errors** — Overview (Sessions w/ Errors, JS & AJAX errors, Errors over time, Top Errored Sessions), JS Exceptions, API Failures

Color thresholds (semantic tokens `chart-success` / `chart-warning` / `chart-error`; page-load values stored as nanoseconds internally to match the default trace source's `durationPrecision`, shown here in human units):

| Tile | Green (good) | Amber (needs improvement) | Red (poor) |
| :--- | :--- | :--- | :--- |
| LCP p75 | ≤ 2.5 s | 2.5–4 s | > 4 s |
| INP p75 | ≤ 200 ms | 200–500 ms | > 500 ms |
| CLS p75 | ≤ 0.1 | 0.1–0.25 | > 0.25 |
| Median Page Load | ≤ 2.5 s | 2.5–4 s | > 4 s |
| p90 Page Load | ≤ 4 s | 4–6 s | > 6 s |
| Sessions w/ Errors, JS Errors, AJAX Errors | — | > 0 | — |

### Screenshots or video

Color-coding is data-driven and only renders once the tiles have values, so a static screenshot isn't meaningful without RUM data. The visible effect: the dashboard opens as four labeled sections, and the Core Web Vitals / Load Time / Errors KPI tiles show their value in green/amber/red per the thresholds above instead of the default text color.

### How to test on Vercel preview

**Preview routes:** /dashboards/import?template=browser-rum

**Steps:**

1. Open /dashboards/import?template=browser-rum to load the "Browser RUM" template.
2. Proceed through the import (accept the default source mapping) to create the dashboard.
3. Confirm the dashboard renders without errors and shows four sections in order: "Core Web Vitals", "Load Time", "Traffic & Page Views", and "Errors".
4. Confirm the "Core Web Vitals — color legend" Markdown tile renders at the top of the Core Web Vitals section, showing the good/needs-improvement/poor thresholds and a "Core Web Vitals" link, followed by the LCP / INP / CLS tiles.
5. Verify that any number tile with a value is color-coded green/amber/red by threshold. (The demo dataset may not include RUM `webvitals`/`documentLoad` spans; if a tile has no data, confirm it renders in the default color without breaking.)

### References

- Linear Issue: N/A
- Related PRs: N/A
