### PR TITLE
feat(dashboards): add background area sparklines to Browser RUM number tiles

### DIFF
--- a/.changeset/browser-rum-number-tile-sparklines.md
+++ b/.changeset/browser-rum-number-tile-sparklines.md
@@ -1,0 +1,10 @@
+---
+'@hyperdx/app': patch
+---
+
+feat(dashboards): add background area sparklines to the Browser RUM dashboard
+number tiles. Each of the ten single-value tiles (LCP / INP / CLS p75, Median
+and p90 Page Load, Page Views, Active Sessions, Sessions w/ Errors, JS Errors,
+AJAX Errors) now renders a faint trend line behind its value so the metric's
+movement over the selected range is visible at a glance. Implemented entirely
+via the existing number-tile `backgroundChart` field — no renderer changes.

--- a/packages/app/src/dashboardTemplates/browser-rum.json
+++ b/packages/app/src/dashboardTemplates/browser-rum.json
@@ -151,7 +151,8 @@
             "color": "chart-error",
             "label": "Poor"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -201,7 +202,8 @@
             "color": "chart-error",
             "label": "Poor"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -251,7 +253,8 @@
             "color": "chart-error",
             "label": "Poor"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -297,7 +300,8 @@
             "color": "chart-error",
             "label": "Poor (> 4 s)"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -343,7 +347,8 @@
             "color": "chart-error",
             "label": "Poor (> 6 s)"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -496,7 +501,8 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -526,7 +532,8 @@
           "output": "number",
           "mantissa": 0,
           "thousandSeparated": true
-        }
+        },
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -788,7 +795,8 @@
             "color": "chart-warning",
             "label": "Errors present"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -827,7 +835,8 @@
             "color": "chart-warning",
             "label": "Errors present"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {
@@ -866,7 +875,8 @@
             "color": "chart-warning",
             "label": "Errors present"
           }
-        ]
+        ],
+        "backgroundChart": { "type": "area" }
       }
     },
     {


### PR DESCRIPTION
## Summary

The Browser RUM preset dashboard's ten single-value "number" tiles (Core Web Vitals, page-load percentiles, traffic counts, error counts) showed only a static number with no sense of how the metric was trending. This PR enables the existing number-tile `backgroundChart` field on each of those tiles so they render a faint blue **area** sparkline of the value's trend over the selected range — directly behind the number, matching the concept mock. It's a **data-only** change to `browser-rum.json`: the schema (`backgroundChart`), the renderer (`NumberTileBackgroundChart` → `Sparkline`), and the editor control already ship, so no application code changed. The existing `colorRules` still color the number itself by threshold; the sparkline is a separate blue trend layer underneath.

### Screenshots or video

UI change is the sparkline layer behind each RUM number tile (see the linked concept mock). Best viewed on the Vercel preview via the steps below — the sparkline renders once the tile's query returns ≥2 time buckets.

<img width="2765" height="887" alt="image" src="https://github.com/user-attachments/assets/0e3eecd8-fbe2-4772-b874-96a9c86eac00" />

### How to test on Vercel preview

**Preview routes:** /dashboards/import?template=browser-rum

**Steps:**

1. Open `/dashboards/import?template=browser-rum` to preview the Browser RUM template import.
2. Confirm the dashboard preview renders its number tiles, including "LCP p75 (ms)", "Page Views", and "JS Errors".
3. Verify each number tile shows its value on top and, where the query returns data over the range, a faint blue area sparkline behind it (tiles with no matching RUM data simply show the number, which is expected).

### References

- Linear Issue:
- Related PRs: #2671 (Browser RUM web-vitals color coding — same template)
