### PR TITLE
fix(app): clear VirtualMultiSelect search input on select/add

### DIFF
--- a/.changeset/clear-virtualmultiselect-input.md
+++ b/.changeset/clear-virtualmultiselect-input.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: clear the VirtualMultiSelect search input after selecting a value

--- a/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.tsx
+++ b/packages/app/src/components/VirtualMultiSelect/VirtualMultiSelect.tsx
@@ -66,10 +66,12 @@ export function VirtualMultiSelect({
     },
   });
 
-  const handleSelectValue = (val: string) =>
+  const handleSelectValue = (val: string) => {
     onChange(
       values.includes(val) ? values.filter(v => v !== val) : [...values, val],
     );
+    setSearch('');
+  };
 
   const handleRemoveValue = (val: string) =>
     onChange(values.filter(v => v !== val));


### PR DESCRIPTION
## Why

Previously, when a user typed a search value into the `VirtualMultiSelect` and then added it as a value, the typed text was left behind in the input. This diverges from the behavior of a non-virtualized Mantine `MultiSelect` with search, which clears the input after a value is selected.

This has been requested by at least 3 independent users.

### Before

https://github.com/user-attachments/assets/24f0dba2-63cc-4e12-b164-5a02356f9fa8

### After

https://github.com/user-attachments/assets/faa0b7a0-afa4-496e-81fb-9b9ba7692ba3

## Testing

This can be tested in the preview environment by creating a dashboard filter and searching for + selecting a value.

Closes [HDX-4816](https://linear.app/clickhouse/issue/HDX-4816/clear-out-virtualmultiselect-input-when-clicking-enter-selecting-a)