### PR TITLE
fix(cli): fix esbuild parse error breaking npm publish and add CLI build to CI

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,6 +9,9 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"]
+    },
+    "ci:build": {
+      "dependsOn": ["^ci:build"]
     }
   },
   "tasksRunnerOptions": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "compile:macos": "bun build src/cli.tsx --compile --target=bun-darwin-arm64 --outfile dist/hdx-darwin-arm64",
     "compile:macos-x64": "bun build src/cli.tsx --compile --target=bun-darwin-x64 --outfile dist/hdx-darwin-x64",
     "lint": "npx eslint . --ext .ts,.tsx --max-warnings 9",
+    "ci:build": "tsup",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
     "ci:unit": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --ci --passWithNoTests",
     "dev:unit": "NODE_OPTIONS=--experimental-vm-modules jest --watchAll --runInBand"

--- a/packages/cli/src/termchart/ansi.ts
+++ b/packages/cli/src/termchart/ansi.ts
@@ -36,7 +36,10 @@ export const PLOT_COLORS: Record<string, string> = {
 /** Map ANSI color names to chalk functions for legend / bar text. */
 export function chalkColor(color: SeriesColor): (s: string) => string {
   const fn = (chalk as unknown as Record<string, unknown>)[color];
-  return typeof fn === 'function' ? (fn as (s: string) => string) : s => s;
+  if (typeof fn === 'function') {
+    return fn as (s: string) => string;
+  }
+  return (s: string) => s;
 }
 
 export function truncate(s: string, max: number): string {


### PR DESCRIPTION
## Why

The `@hyperdx/cli` 0.6.0 npm publish failed in the Release workflow ([run 29614060870](https://github.com/hyperdxio/hyperdx/actions/runs/29614060870/job/87995114421)):

```
✘ [ERROR] Expected ":" but found ";"
    src/termchart/ansi.ts:39:74
```

**Root cause:** tsup 8.4.0 pins esbuild 0.25.1, which hits a TS parsing ambiguity on
`cond ? (fn as (s: string) => string) : s => s` — the parenthesized true branch followed by `: s => s` gets speculatively parsed as an arrow function with a return-type annotation, so the conditional never finds its `:`. `tsc` and esbuild ≥0.28 parse it fine, which is why `ci:lint` passed and the break only surfaced at `prepublishOnly` during publish.

**Why CI missed it:** the CLI had no `ci:build` target — `make ci-build` only built `common-utils`, so tsup never ran for the CLI until the release publish step.

## What

- Rewrite `chalkColor` in `packages/cli/src/termchart/ansi.ts` as explicit if/return (verified against esbuild 0.25.1).
- Add `"ci:build": "tsup"` to `packages/cli` and `ci:build` → `^ci:build` target deps in `nx.json` so common-utils builds first (CLI bundles `@hyperdx/common-utils/dist/*`). Since `make ci-build` already runs in the Main workflow's lint/unit jobs and in the Release workflow, the CLI bundle is now built on every PR and before every publish.

## Verification

- `make ci-build` — builds common-utils then CLI, tsup succeeds
- `packages/cli yarn ci:lint` — clean (0 errors)
- Repro confirmed: esbuild 0.25.1 fails on the old code, passes on the new

## Notes

No changeset: 0.6.0 is versioned but unpublished; the Release workflow on main will retry and publish it once this lands.