### PR TITLE
[HDX-4831] Add noindex to play-clickstack demo

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,8 @@
       "ignoreDependencies": [
         "eslint-config-next",
         "@chromatic-com/storybook",
-        "@storybook/addon-themes"
+        "@storybook/addon-themes",
+        "react-is"
       ]
     },
     "packages/api": {

--- a/packages/app/next.config.mjs
+++ b/packages/app/next.config.mjs
@@ -86,10 +86,7 @@ const nextConfig = {
             key: 'X-Frame-Options',
             value: 'DENY',
           },
-          // Vercel deployments of this repo only serve the public play demo
-          // (play.hyperdx.io) and previews — never customer installs — so keep
-          // them out of search engine indexes. Self-hosted builds are unaffected.
-          ...(process.env.VERCEL === '1'
+          ...(process.env.NEXT_PUBLIC_NOINDEX === 'true'
             ? [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }]
             : []),
         ],

--- a/packages/app/next.config.mjs
+++ b/packages/app/next.config.mjs
@@ -86,6 +86,12 @@ const nextConfig = {
             key: 'X-Frame-Options',
             value: 'DENY',
           },
+          // Vercel deployments of this repo only serve the public play demo
+          // (play.hyperdx.io) and previews — never customer installs — so keep
+          // them out of search engine indexes. Self-hosted builds are unaffected.
+          ...(process.env.VERCEL === '1'
+            ? [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }]
+            : []),
         ],
       },
     ];

--- a/packages/app/pages/_document.tsx
+++ b/packages/app/pages/_document.tsx
@@ -1,17 +1,12 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
-import { IS_CLICKHOUSE_BUILD } from '@/config';
+import { IS_CLICKHOUSE_BUILD, IS_NOINDEX } from '@/config';
 import { ibmPlexMono, inter, roboto, robotoMono } from '@/fonts';
 import { themes } from '@/theme';
 
 // Applied before React hydrates to prevent a flash of the wrong theme.
 // Reads the runtime value from window.__ENV (set by __ENV.js) and swaps
 // the theme class on <html> so CSS variables are correct on first paint.
-// Vercel deployments of this repo only serve the public play demo
-// (play.hyperdx.io) and previews — never customer installs. Render a robots
-// meta tag there as a fallback for the X-Robots-Tag header in next.config.mjs.
-const IS_VERCEL = process.env.VERCEL === '1';
-
 const validThemes = Object.keys(themes);
 const themeClasses = validThemes.map(t => `theme-${t}`);
 const THEME_INIT_SCRIPT = `
@@ -38,7 +33,7 @@ export default function Document() {
   return (
     <Html lang="en" className={`${fontClasses} theme-hyperdx`}>
       <Head>
-        {IS_VERCEL && <meta name="robots" content="noindex, nofollow" />}
+        {IS_NOINDEX && <meta name="robots" content="noindex, nofollow" />}
         {/* eslint-disable-next-line @next/next/no-sync-scripts */}
         <script src="/__ENV.js" />
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />

--- a/packages/app/pages/_document.tsx
+++ b/packages/app/pages/_document.tsx
@@ -7,6 +7,11 @@ import { themes } from '@/theme';
 // Applied before React hydrates to prevent a flash of the wrong theme.
 // Reads the runtime value from window.__ENV (set by __ENV.js) and swaps
 // the theme class on <html> so CSS variables are correct on first paint.
+// Vercel deployments of this repo only serve the public play demo
+// (play.hyperdx.io) and previews — never customer installs. Render a robots
+// meta tag there as a fallback for the X-Robots-Tag header in next.config.mjs.
+const IS_VERCEL = process.env.VERCEL === '1';
+
 const validThemes = Object.keys(themes);
 const themeClasses = validThemes.map(t => `theme-${t}`);
 const THEME_INIT_SCRIPT = `
@@ -33,6 +38,7 @@ export default function Document() {
   return (
     <Html lang="en" className={`${fontClasses} theme-hyperdx`}>
       <Head>
+        {IS_VERCEL && <meta name="robots" content="noindex, nofollow" />}
         {/* eslint-disable-next-line @next/next/no-sync-scripts */}
         <script src="/__ENV.js" />
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -54,6 +54,7 @@ export const IS_LOCAL_MODE = //true;
   (process.env.NEXT_PUBLIC_IS_LOCAL_MODE ?? 'false') === 'true';
 export const IS_CLICKHOUSE_BUILD =
   process.env.NEXT_PUBLIC_CLICKHOUSE_BUILD === 'true';
+export const IS_NOINDEX = process.env.NEXT_PUBLIC_NOINDEX === 'true';
 
 /** Time captured at module load, use this a stable fallback/default time value instead of Date.now() defined in each React component file */
 // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
## Why

The public play demo (play.hyperdx.io) is served by the Vercel deployment of this repo and currently sends no `X-Robots-Tag` header, no robots meta tag, and has no `robots.txt` — so search engines can crawl and index demo app pages (search results, dashboards), which makes for bad SERP entries that compete with real docs/marketing pages. Vercel only auto-noindexes *preview* deployments; production on a custom domain is fully indexable.

Linear: [HDX-4831](https://linear.app/clickhouse/issue/HDX-4831/add-noindex-to-play-clickstack-demo)

## What

Adds an explicit opt-in flag, `NEXT_PUBLIC_NOINDEX=true`, to be set on the play demo's Vercel project:

- `packages/app/next.config.mjs` — send `X-Robots-Tag: noindex, nofollow` on all routes when the flag is set
- `packages/app/pages/_document.tsx` + `src/config.ts` — render `<meta name="robots" content="noindex, nofollow" />` (via `IS_NOINDEX`, following the `IS_CLICKHOUSE_BUILD` pattern) as a fallback in case a proxy strips the header

Self-hosted and customer installs are unaffected (flag unset by default), so no changeset.

Also fixes a pre-existing pre-commit hook failure: knip flagged `react-is` as unused, but it's intentionally installed to satisfy recharts 3's peer dependency under React 19 (d137eaab4) — added it to `ignoreDependencies` in `knip.json`.

## Deployment

Set `NEXT_PUBLIC_NOINDEX=true` in the play demo's Vercel project env vars before/with merging, then redeploy.

## Testing

- Evaluated `headers()` with and without `NEXT_PUBLIC_NOINDEX=true`: header only present when set
- eslint clean; `npx knip` exits 0

Post-deploy check: `curl -sI https://play.hyperdx.io/search | grep -i x-robots-tag`