### PR TITLE
feat(evals): add a metrics A/B harness

### DIFF
--- a/.changeset/perfect-crabs-kneel.md
+++ b/.changeset/perfect-crabs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/hdx-eval": patch
+---
+
+feat(evals): add a metrics A/B harness

--- a/agent_docs/evals.md
+++ b/agent_docs/evals.md
@@ -255,6 +255,22 @@ yarn workspace @hyperdx/hdx-eval dev setup-hyperdx
 yarn workspace @hyperdx/hdx-eval dev run error-root-cause --mcp hyperdx --runs 1 --no-judge
 ```
 
+### Metric support A/B (single slot)
+
+`setup-hyperdx` provisions a metrics-blind `hdx-nometrics` arm alongside the
+regular `hyperdx` entry — same team, same data. The harness routes the arm
+through a per-run scoping proxy that hides metric sources from
+`clickstack_list_sources`, rejects tool calls naming a metric `sourceId`, and
+pins `clickstack_sql` to a Connection backed by a restricted ClickHouse user
+that cannot `SELECT` any metric table (closes the raw-SQL loophole); the metric
+tools are also denied and the metric hint is dropped from the system prompt. The
+metrics arm is the regular `hyperdx` entry.
+
+```bash
+yarn workspace @hyperdx/hdx-eval dev run metric-saturation \
+  --mcp hdx-nometrics,hyperdx --baseline hdx-nometrics --runs 3
+```
+
 ### Model comparison (same MCP, different models)
 
 Compare how different models perform on the same MCP and data. Useful for

--- a/packages/hdx-eval/README.md
+++ b/packages/hdx-eval/README.md
@@ -111,6 +111,45 @@ yarn workspace @hyperdx/hdx-eval dev run error-root-cause \
   --runs 5
 ```
 
+## Metrics A/B (hyperdx vs hdx-nometrics)
+
+`setup-hyperdx` also provisions a metrics-blind arm for measuring whether metric
+support improves investigation outcomes on a **single** slot. Both arms use the
+same team, account, and data; the `hdx-nometrics` arm is scoped by the harness:
+
+- A **scoping proxy** (`src/harness/scoping.ts`, spawned in-process per run)
+  sits between Claude Code and the MCP. It structurally filters metric-kind
+  sources out of `clickstack_list_sources` responses, rejects any tool call
+  whose `sourceId` references a hidden source, and rewrites every
+  `clickstack_sql` call's `connectionId` to a restricted Connection. Driven by
+  the `scoping` field on the MCP config entry.
+- A restricted ClickHouse user `hdx_eval_nometrics` with a wildcard `SELECT`
+  grant on `default` and `SELECT` explicitly revoked on every
+  `eval_<scenario>_otel_metrics_*` table and the base `otel_metrics_*` tables. A
+  second Connection on the same team stores these credentials — raw SQL from the
+  scoped arm always executes under this user's grants.
+- An `hdx-nometrics` entry in `eval.config.json` with `metricsAvailable: false`
+  (the metric hint is dropped from the system prompt), the metric tools
+  (`clickstack_list_metrics`, `clickstack_describe_metric`) denied, and
+  `enabled: false` so the default `--mcp all` matrix is unchanged — the arm runs
+  only when named explicitly.
+
+Why the proxy rewrites SQL instead of parsing it: `clickstack_sql` runs raw SQL
+with the named Connection's stored ClickHouse credentials and has no table
+restriction, so tool denial alone could not stop the arm from reading the metric
+tables. The proxy never interprets SQL — it only decides _as whom_ SQL runs, and
+the restricted user's grants (the tables also vanish from `SHOW TABLES` for that
+user) remain the enforcement boundary. Metric-typed
+`clickstack_timeseries`/`clickstack_table` params hard-fail server-side for
+non-metric sources, and metric `sourceId`s never reach the agent.
+
+Run the comparison:
+
+```bash
+yarn workspace @hyperdx/hdx-eval dev run metric-saturation \
+  --mcp hdx-nometrics,hyperdx --baseline hdx-nometrics --runs 3
+```
+
 ## MCP Configuration
 
 MCPs are defined in `eval.config.json` under the `mcps` key. Each entry

--- a/packages/hdx-eval/src/__tests__/config.test.ts
+++ b/packages/hdx-eval/src/__tests__/config.test.ts
@@ -97,6 +97,91 @@ describe('readConfig plugin validation', () => {
   });
 });
 
+describe('readConfig mcps.metricsAvailable validation', () => {
+  const tmpRoot = join('/tmp', `hdx-eval-config-metrics-test-${Date.now()}`);
+
+  beforeAll(() => {
+    mkdirSync(tmpRoot, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeTmpConfig(name: string, config: unknown): string {
+    const p = join(tmpRoot, `${name}.json`);
+    writeFileSync(p, JSON.stringify(config, null, 2));
+    return p;
+  }
+
+  it('accepts an MCP with metricsAvailable: false', () => {
+    const p = writeTmpConfig('metrics-false', {
+      mcps: { hyperdx: { ...VALID_MCP, metricsAvailable: false } },
+    });
+    expect(readConfig(p).mcps.hyperdx.metricsAvailable).toBe(false);
+  });
+
+  it('accepts an MCP without metricsAvailable', () => {
+    const p = writeTmpConfig('metrics-absent', { mcps: baseConfig.mcps });
+    expect(readConfig(p).mcps.hyperdx.metricsAvailable).toBeUndefined();
+  });
+
+  it('rejects a non-boolean metricsAvailable', () => {
+    const p = writeTmpConfig('metrics-string', {
+      mcps: { hyperdx: { ...VALID_MCP, metricsAvailable: 'yes' } },
+    });
+    expect(() => readConfig(p)).toThrow(
+      `Eval config 'mcps.hyperdx.metricsAvailable' must be a boolean`,
+    );
+  });
+
+  it('accepts an MCP with a valid scoping policy', () => {
+    const p = writeTmpConfig('scoping-valid', {
+      mcps: {
+        hyperdx: {
+          ...VALID_MCP,
+          scoping: {
+            hideSourceKinds: ['metric'],
+            pinSqlConnectionId: 'abc123',
+          },
+        },
+      },
+    });
+    expect(readConfig(p).mcps.hyperdx.scoping).toEqual({
+      hideSourceKinds: ['metric'],
+      pinSqlConnectionId: 'abc123',
+    });
+  });
+
+  it('rejects scoping with a non-array hideSourceKinds', () => {
+    const p = writeTmpConfig('scoping-bad-kinds', {
+      mcps: {
+        hyperdx: { ...VALID_MCP, scoping: { hideSourceKinds: 'metric' } },
+      },
+    });
+    expect(() => readConfig(p)).toThrow(
+      `Eval config 'mcps.hyperdx.scoping.hideSourceKinds' must be an array of strings`,
+    );
+  });
+
+  it('rejects scoping on a stdio MCP', () => {
+    const p = writeTmpConfig('scoping-stdio', {
+      mcps: {
+        ch: {
+          type: 'stdio',
+          command: 'uv',
+          toolPattern: 'mcp__ch__*',
+          label: 'CH',
+          scoping: { hideSourceKinds: ['metric'] },
+        },
+      },
+    });
+    expect(() => readConfig(p)).toThrow(
+      `Eval config 'mcps.ch.scoping' is only supported for http MCPs`,
+    );
+  });
+});
+
 describe('getPluginDefinition', () => {
   it('returns the definition for a known plugin', () => {
     expect(getPluginDefinition(baseConfig, 'urlplugin')).toEqual({

--- a/packages/hdx-eval/src/__tests__/metric-saturation.test.ts
+++ b/packages/hdx-eval/src/__tests__/metric-saturation.test.ts
@@ -227,4 +227,23 @@ describe('metric-saturation system prompt', () => {
     // Still the default SRE investigation framing.
     expect(prompt).toMatch(/You are an SRE/i);
   });
+
+  it('omits the metric hint when the arm has no metric support', () => {
+    const prompt = buildSystemPrompt(
+      metricSaturationScenario,
+      '2026-05-10T20:00:00.000Z',
+      'baseline',
+      undefined,
+      false,
+    );
+    expect(prompt).not.toMatch(/metric source is available/i);
+    // Traces and logs tables are still listed.
+    expect(prompt).toContain(
+      '- Traces: default.eval_metric_saturation_otel_traces',
+    );
+    expect(prompt).toContain(
+      '- Logs:   default.eval_metric_saturation_otel_logs',
+    );
+    expect(prompt).toMatch(/You are an SRE/i);
+  });
 });

--- a/packages/hdx-eval/src/__tests__/scoping.test.ts
+++ b/packages/hdx-eval/src/__tests__/scoping.test.ts
@@ -1,0 +1,213 @@
+import {
+  decideRequest,
+  extractToolResultText,
+  rewriteListSourcesText,
+  rewriteToolResponsePayload,
+} from '@/harness/scoping';
+import type { McpScoping } from '@/harness/types';
+
+const SCOPING: McpScoping = {
+  hideSourceKinds: ['metric'],
+  pinSqlConnectionId: 'conn-restricted',
+};
+
+const HIDDEN = new Set(['src-metric-1']);
+
+function toolCall(
+  name: string,
+  args: Record<string, unknown>,
+  id: number = 7,
+): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  });
+}
+
+describe('decideRequest', () => {
+  it('forwards non-tool-call traffic untouched', () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    });
+    expect(decideRequest(SCOPING, HIDDEN, body)).toEqual({
+      action: 'forward',
+      body,
+      rewriteListSources: false,
+    });
+  });
+
+  it('forwards non-JSON bodies untouched', () => {
+    expect(decideRequest(SCOPING, HIDDEN, 'not json')).toEqual({
+      action: 'forward',
+      body: 'not json',
+      rewriteListSources: false,
+    });
+  });
+
+  it('rejects tool calls whose sourceId is hidden, mimicking a not-found error', () => {
+    const decision = decideRequest(
+      SCOPING,
+      HIDDEN,
+      toolCall('mcp__hdx-nometrics__clickstack_timeseries', {
+        sourceId: 'src-metric-1',
+      }),
+    );
+    expect(decision.action).toBe('reject');
+    if (decision.action !== 'reject') throw new Error('unreachable');
+    expect(decision.response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 7,
+      result: expect.objectContaining({ isError: true }),
+    });
+    expect(JSON.stringify(decision.response)).toContain(
+      'Source not found: src-metric-1',
+    );
+  });
+
+  it('allows tool calls with visible sourceIds', () => {
+    const body = toolCall('clickstack_table', { sourceId: 'src-trace-1' });
+    expect(decideRequest(SCOPING, HIDDEN, body)).toEqual({
+      action: 'forward',
+      body,
+      rewriteListSources: false,
+    });
+  });
+
+  it('pins clickstack_sql to the configured connectionId', () => {
+    const decision = decideRequest(
+      SCOPING,
+      HIDDEN,
+      toolCall('mcp__hdx-nometrics__clickstack_sql', {
+        connectionId: 'conn-unrestricted',
+        sql: 'SELECT 1',
+      }),
+    );
+    expect(decision.action).toBe('forward');
+    if (decision.action !== 'forward') throw new Error('unreachable');
+    const parsed = JSON.parse(decision.body);
+    expect(parsed.params.arguments.connectionId).toBe('conn-restricted');
+    expect(parsed.params.arguments.sql).toBe('SELECT 1');
+  });
+
+  it('flags list_sources calls for response rewriting', () => {
+    const body = toolCall('mcp__hdx-nometrics__clickstack_list_sources', {});
+    expect(decideRequest(SCOPING, HIDDEN, body)).toEqual({
+      action: 'forward',
+      body,
+      rewriteListSources: true,
+    });
+  });
+});
+
+describe('rewriteListSourcesText', () => {
+  const output = {
+    sources: [
+      { id: 'src-trace-1', kind: 'trace', connectionId: 'conn-unrestricted' },
+      { id: 'src-log-1', kind: 'log', connectionId: 'conn-unrestricted' },
+      { id: 'src-metric-1', kind: 'metric', connectionId: 'conn-unrestricted' },
+    ],
+    connections: [
+      { id: 'conn-unrestricted', name: 'hdx-eval-clickhouse' },
+      { id: 'conn-restricted', name: 'hdx-eval-clickhouse-nometrics' },
+    ],
+    nextStep: 'Call clickstack_describe_source ...',
+  };
+
+  it('drops hidden-kind sources and reports their ids', () => {
+    const { text, hiddenIds } = rewriteListSourcesText(
+      SCOPING,
+      JSON.stringify(output),
+    );
+    const rewritten = JSON.parse(text);
+    expect(rewritten.sources.map((s: { id: string }) => s.id)).toEqual([
+      'src-trace-1',
+      'src-log-1',
+    ]);
+    expect(hiddenIds).toEqual(['src-metric-1']);
+    expect(rewritten.nextStep).toBe(output.nextStep);
+  });
+
+  it('pins connectionIds and reduces connections to the pinned one', () => {
+    const { text } = rewriteListSourcesText(SCOPING, JSON.stringify(output));
+    const rewritten = JSON.parse(text);
+    for (const s of rewritten.sources) {
+      expect(s.connectionId).toBe('conn-restricted');
+    }
+    expect(rewritten.connections).toEqual([
+      { id: 'conn-restricted', name: 'hdx-eval-clickhouse-nometrics' },
+    ]);
+  });
+
+  it('leaves connections untouched when no pin is configured', () => {
+    const { text } = rewriteListSourcesText(
+      { hideSourceKinds: ['metric'] },
+      JSON.stringify(output),
+    );
+    const rewritten = JSON.parse(text);
+    expect(rewritten.connections).toHaveLength(2);
+    expect(rewritten.sources[0].connectionId).toBe('conn-unrestricted');
+  });
+
+  it('passes through non-JSON payloads', () => {
+    expect(rewriteListSourcesText(SCOPING, 'oops')).toEqual({
+      text: 'oops',
+      hiddenIds: [],
+    });
+  });
+});
+
+describe('rewriteToolResponsePayload', () => {
+  const message = {
+    jsonrpc: '2.0',
+    id: 3,
+    result: { content: [{ type: 'text', text: 'ORIGINAL' }] },
+  };
+
+  it('rewrites plain JSON bodies', () => {
+    const rewritten = rewriteToolResponsePayload(
+      JSON.stringify(message),
+      'application/json',
+      () => 'REWRITTEN',
+    );
+    expect(JSON.parse(rewritten).result.content[0].text).toBe('REWRITTEN');
+  });
+
+  it('rewrites data lines in SSE bodies, preserving other lines', () => {
+    const sse = `event: message\ndata: ${JSON.stringify(message)}\n\n`;
+    const rewritten = rewriteToolResponsePayload(
+      sse,
+      'text/event-stream',
+      () => 'REWRITTEN',
+    );
+    expect(rewritten).toContain('event: message');
+    const dataLine = rewritten.split('\n').find(l => l.startsWith('data: '))!;
+    expect(JSON.parse(dataLine.slice(6)).result.content[0].text).toBe(
+      'REWRITTEN',
+    );
+  });
+
+  it('leaves payloads without a tool result untouched', () => {
+    const notify = JSON.stringify({ jsonrpc: '2.0', method: 'ping' });
+    expect(
+      rewriteToolResponsePayload(notify, 'application/json', () => 'X'),
+    ).toBe(notify);
+  });
+});
+
+describe('extractToolResultText', () => {
+  it('extracts from JSON and SSE payloads', () => {
+    const message = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { content: [{ type: 'text', text: 'PAYLOAD' }] },
+    });
+    expect(extractToolResultText(message)).toBe('PAYLOAD');
+    expect(extractToolResultText(`data: ${message}\n\n`)).toBe('PAYLOAD');
+    expect(extractToolResultText('nope')).toBeNull();
+  });
+});

--- a/packages/hdx-eval/src/__tests__/setup.test.ts
+++ b/packages/hdx-eval/src/__tests__/setup.test.ts
@@ -1,0 +1,45 @@
+import { nometricsGrantStatements } from '@/hyperdx/setup';
+import { SCENARIO_NAMES } from '@/scenarios';
+
+describe('nometricsGrantStatements', () => {
+  const statements = nometricsGrantStatements();
+
+  it('emits CREATE USER + wildcard GRANT + one REVOKE per metric table', () => {
+    // 5 base otel_metrics_* tables + 5 eval metric tables per scenario.
+    expect(statements).toHaveLength(2 + 5 + SCENARIO_NAMES.length * 5);
+    expect(statements[0]).toBe(
+      "CREATE USER IF NOT EXISTS hdx_eval_nometrics IDENTIFIED WITH plaintext_password BY 'hdx_eval_nometrics'",
+    );
+    expect(statements[1]).toBe(
+      'GRANT SELECT ON default.* TO hdx_eval_nometrics',
+    );
+    for (const stmt of statements.slice(2)) {
+      expect(stmt).toMatch(
+        /^REVOKE SELECT ON default\.(eval_\w+_)?otel_metrics_\w+ FROM hdx_eval_nometrics$/,
+      );
+    }
+  });
+
+  it('revokes SELECT on every metric-saturation metric table', () => {
+    expect(statements).toContain(
+      'REVOKE SELECT ON default.eval_metric_saturation_otel_metrics_gauge FROM hdx_eval_nometrics',
+    );
+    expect(statements).toContain(
+      'REVOKE SELECT ON default.eval_metric_saturation_otel_metrics_exponential_histogram FROM hdx_eval_nometrics',
+    );
+    expect(statements).toContain(
+      'REVOKE SELECT ON default.otel_metrics_gauge FROM hdx_eval_nometrics',
+    );
+  });
+
+  it('mentions the user in every statement and honors overrides', () => {
+    for (const stmt of statements) {
+      expect(stmt).toContain('hdx_eval_nometrics');
+    }
+    const custom = nometricsGrantStatements('other_user', 'pw');
+    expect(custom[0]).toBe(
+      "CREATE USER IF NOT EXISTS other_user IDENTIFIED WITH plaintext_password BY 'pw'",
+    );
+    expect(custom.every(s => s.includes('other_user'))).toBe(true);
+  });
+});

--- a/packages/hdx-eval/src/cli.ts
+++ b/packages/hdx-eval/src/cli.ts
@@ -354,6 +354,13 @@ program
       } else {
         console.log('  sources:    created', result.created.sources.join(', '));
       }
+      if (result.nometrics.ready) {
+        console.log('  nometrics arm: ready');
+      } else {
+        console.log(
+          '  nometrics arm: SKIPPED — see warning above; re-run setup-hyperdx after fixing',
+        );
+      }
     },
   );
 

--- a/packages/hdx-eval/src/clickhouse/schema.ts
+++ b/packages/hdx-eval/src/clickhouse/schema.ts
@@ -29,6 +29,10 @@ const METRIC_TABLES = [
 
 type MetricTableField = (typeof METRIC_TABLES)[number]['field'];
 
+export const METRIC_SOURCE_TABLES: readonly string[] = METRIC_TABLES.map(
+  t => t.source,
+);
+
 export type ScenarioTables = {
   traces: string;
   logs: string;

--- a/packages/hdx-eval/src/harness/claudeSpawn.ts
+++ b/packages/hdx-eval/src/harness/claudeSpawn.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import type { EvalConfig } from '@/hyperdx/config';
 
 import { allowedToolsPattern, buildMcpConfig } from './mcpConfig';
+import { type ScopingProxyHandle, startScopingProxy } from './scoping';
 import { buildSettings, deniedToolsFor } from './settingsFile';
 import {
   chunkToLines,
@@ -71,7 +72,18 @@ export async function runClaude(opts: SpawnOptions): Promise<SpawnResult> {
   const mcpConfigPath = join(tempdir, 'mcp-config.json');
   const settingsPath = join(tempdir, 'settings.json');
 
-  const mcpDef = opts.mcpDef;
+  // Scoped arms (e.g. hdx-nometrics) talk to the MCP through a local
+  // policy-enforcing proxy — one per run, torn down in the finally below.
+  let proxy: ScopingProxyHandle | undefined;
+  let mcpDef = opts.mcpDef;
+  if (mcpDef.type === 'http' && mcpDef.scoping) {
+    proxy = await startScopingProxy({
+      upstreamUrl: mcpDef.url,
+      headers: mcpDef.headers,
+      scoping: mcpDef.scoping,
+    });
+    mcpDef = { ...mcpDef, url: proxy.url };
+  }
   writeFileSync(
     mcpConfigPath,
     JSON.stringify(buildMcpConfig(mcpDef, opts.mcp), null, 2),
@@ -207,6 +219,7 @@ export async function runClaude(opts: SpawnOptions): Promise<SpawnResult> {
       tempdir,
     };
   } finally {
+    await proxy?.close();
     // Clean up the temp directory to avoid leaking MCP configs with API keys.
     // This runs even if spawn() rejects (e.g. ENOENT when claude is not on PATH).
     try {

--- a/packages/hdx-eval/src/harness/runRun.ts
+++ b/packages/hdx-eval/src/harness/runRun.ts
@@ -58,6 +58,7 @@ export async function runCell(opts: RunCellOptions): Promise<RunRecord> {
     opts.anchorTimeIso,
     promptVariant,
     opts.maxTurns,
+    mcpDef.metricsAvailable !== false,
   );
 
   const result = await runClaude({

--- a/packages/hdx-eval/src/harness/scoping.ts
+++ b/packages/hdx-eval/src/harness/scoping.ts
@@ -1,0 +1,431 @@
+import { createServer, request as httpRequest, type Server } from 'http';
+import { request as httpsRequest } from 'https';
+
+import type { McpScoping } from './types';
+
+// ─── Pure policy core ────────────────────────────────────────────────────────
+// Everything below `startScopingProxy` is side-effect free and unit-tested
+// without a network. The proxy applies a structural policy — it never
+// parses SQL:
+//   1. Sources whose kind is in `hideSourceKinds` are removed from
+//      clickstack_list_sources output, and any tool call whose `sourceId`
+//      references one is rejected with a not-found error (mirroring the
+//      server's own wording so the agent recovers naturally).
+//   2. clickstack_sql's `connectionId` is rewritten to
+//      `pinSqlConnectionId`, so raw SQL always executes under the
+//      restricted ClickHouse user's grants. The database stays the
+//      enforcement boundary; the proxy only decides *as whom* SQL runs.
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: Record<string, unknown>;
+  };
+};
+
+export type RequestDecision =
+  | { action: 'forward'; body: string; rewriteListSources: boolean }
+  | { action: 'reject'; response: Record<string, unknown> };
+
+/**
+ * Decide what to do with an incoming JSON-RPC request body. Non-tool-call
+ * traffic (initialize, tools/list, notifications) is forwarded untouched.
+ */
+export function decideRequest(
+  scoping: McpScoping,
+  hiddenSourceIds: ReadonlySet<string>,
+  rawBody: string,
+): RequestDecision {
+  let parsed: JsonRpcRequest;
+  try {
+    parsed = JSON.parse(rawBody) as JsonRpcRequest;
+  } catch {
+    return { action: 'forward', body: rawBody, rewriteListSources: false };
+  }
+  if (parsed?.method !== 'tools/call' || !parsed.params?.name) {
+    return { action: 'forward', body: rawBody, rewriteListSources: false };
+  }
+
+  const toolName = parsed.params.name;
+  const args = parsed.params.arguments ?? {};
+
+  const sourceId = args.sourceId;
+  if (typeof sourceId === 'string' && hiddenSourceIds.has(sourceId)) {
+    // Mirror the server's own not-found wording so the agent recovers
+    // the same way it would from a genuinely unknown id.
+    return {
+      action: 'reject',
+      response: {
+        jsonrpc: '2.0',
+        id: parsed.id ?? null,
+        result: {
+          content: [
+            {
+              type: 'text',
+              text: `Source not found: ${sourceId}. Call clickstack_list_sources to discover available source IDs.`,
+            },
+          ],
+          isError: true,
+        },
+      },
+    };
+  }
+
+  if (
+    toolName.endsWith('clickstack_sql') &&
+    scoping.pinSqlConnectionId &&
+    args.connectionId !== scoping.pinSqlConnectionId
+  ) {
+    const pinned: JsonRpcRequest = {
+      ...parsed,
+      params: {
+        ...parsed.params,
+        arguments: { ...args, connectionId: scoping.pinSqlConnectionId },
+      },
+    };
+    return {
+      action: 'forward',
+      body: JSON.stringify(pinned),
+      rewriteListSources: false,
+    };
+  }
+
+  return {
+    action: 'forward',
+    body: rawBody,
+    rewriteListSources: toolName.endsWith('clickstack_list_sources'),
+  };
+}
+
+type ListSourcesOutput = {
+  sources?: Array<Record<string, unknown>>;
+  connections?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+};
+
+/**
+ * Rewrite the JSON text payload of a clickstack_list_sources result:
+ * drop hidden-kind sources (returning their ids), pin the remaining
+ * sources' `connectionId`, and reduce the connections list to the pinned
+ * one so the agent's world model is consistent.
+ */
+export function rewriteListSourcesText(
+  scoping: McpScoping,
+  text: string,
+): { text: string; hiddenIds: string[] } {
+  let output: ListSourcesOutput;
+  try {
+    output = JSON.parse(text) as ListSourcesOutput;
+  } catch {
+    return { text, hiddenIds: [] };
+  }
+  if (!Array.isArray(output.sources)) return { text, hiddenIds: [] };
+
+  const hiddenIds: string[] = [];
+  const kept = output.sources.filter(s => {
+    if (
+      typeof s.kind === 'string' &&
+      scoping.hideSourceKinds.includes(s.kind)
+    ) {
+      if (typeof s.id === 'string') hiddenIds.push(s.id);
+      return false;
+    }
+    return true;
+  });
+
+  const pin = scoping.pinSqlConnectionId;
+  const rewritten: ListSourcesOutput = {
+    ...output,
+    sources: pin ? kept.map(s => ({ ...s, connectionId: pin })) : kept,
+  };
+  if (pin && Array.isArray(output.connections)) {
+    rewritten.connections = output.connections.filter(c => c.id === pin);
+  }
+  return { text: JSON.stringify(rewritten, null, 2), hiddenIds };
+}
+
+/**
+ * Apply `rewriteText` to the tool-result text inside a raw MCP HTTP
+ * response payload — either a plain JSON-RPC body or an SSE stream with
+ * `data:` lines. Unrecognized payloads pass through unchanged.
+ */
+export function rewriteToolResponsePayload(
+  payload: string,
+  contentType: string,
+  rewriteText: (text: string) => string,
+): string {
+  const rewriteMessage = (raw: string): string => {
+    try {
+      const msg = JSON.parse(raw) as {
+        result?: { content?: Array<{ type?: string; text?: string }> };
+      };
+      const item = msg?.result?.content?.[0];
+      if (item?.type === 'text' && typeof item.text === 'string') {
+        item.text = rewriteText(item.text);
+        return JSON.stringify(msg);
+      }
+    } catch {
+      // Not JSON — leave untouched.
+    }
+    return raw;
+  };
+
+  if (contentType.includes('text/event-stream')) {
+    return payload
+      .split('\n')
+      .map(line =>
+        line.startsWith('data: ')
+          ? `data: ${rewriteMessage(line.slice(6))}`
+          : line,
+      )
+      .join('\n');
+  }
+  return rewriteMessage(payload);
+}
+
+/** Extract the first tool-result text from a raw MCP HTTP response payload. */
+export function extractToolResultText(payload: string): string | null {
+  const tryParse = (raw: string): string | null => {
+    try {
+      const msg = JSON.parse(raw) as {
+        result?: { content?: Array<{ type?: string; text?: string }> };
+      };
+      const item = msg?.result?.content?.[0];
+      return item?.type === 'text' && typeof item.text === 'string'
+        ? item.text
+        : null;
+    } catch {
+      return null;
+    }
+  };
+  const direct = tryParse(payload);
+  if (direct !== null) return direct;
+  for (const line of payload.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const text = tryParse(line.slice(6));
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+// ─── Proxy server ────────────────────────────────────────────────────────────
+
+export type ScopingProxyHandle = {
+  url: string;
+  close(): Promise<void>;
+};
+
+/** Headers that must not be forwarded verbatim between hops.
+ *  `content-encoding` is response-side: undici's fetch transparently
+ *  decompresses the body, so forwarding the original encoding header with
+ *  a decompressed payload would corrupt the client's view. */
+const HOP_HEADERS = new Set([
+  'host',
+  'connection',
+  'content-length',
+  'content-encoding',
+  'transfer-encoding',
+  'keep-alive',
+]);
+
+async function readBody(req: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * Fetch the upstream source inventory once so hidden-source rejection works
+ * even before the agent's first list_sources call. The HyperDX MCP accepts a
+ * bare stateless tools/call. Throws on failure — running the arm without
+ * the hidden-id set would silently void the isolation guarantee.
+ */
+async function fetchHiddenSourceIds(
+  upstreamUrl: string,
+  headers: Record<string, string>,
+  scoping: McpScoping,
+): Promise<Set<string>> {
+  const res = await fetch(upstreamUrl, {
+    method: 'POST',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    signal: AbortSignal.timeout(15_000),
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'tools/call',
+      params: { name: 'clickstack_list_sources', arguments: {} },
+    }),
+  });
+  const payload = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `scoping proxy: upstream list_sources probe failed (${res.status}): ${payload.slice(0, 200)}`,
+    );
+  }
+  const text = extractToolResultText(payload);
+  if (text === null) {
+    throw new Error(
+      'scoping proxy: could not parse upstream list_sources response',
+    );
+  }
+  return new Set(rewriteListSourcesText(scoping, text).hiddenIds);
+}
+
+/**
+ * Start a local HTTP proxy in front of an MCP server that enforces an
+ * `McpScoping` policy. Returns the proxy URL to hand to Claude Code and a
+ * `close` disposer. One proxy per run — it is stateless apart from the
+ * hidden-source-id set.
+ */
+export async function startScopingProxy(opts: {
+  upstreamUrl: string;
+  headers?: Record<string, string>;
+  scoping: McpScoping;
+}): Promise<ScopingProxyHandle> {
+  const upstreamHeaders = opts.headers ?? {};
+  const hiddenSourceIds = await fetchHiddenSourceIds(
+    opts.upstreamUrl,
+    upstreamHeaders,
+    opts.scoping,
+  );
+
+  const target = new URL(opts.upstreamUrl);
+  const requestUpstream =
+    target.protocol === 'https:' ? httpsRequest : httpRequest;
+
+  const server: Server = createServer(async (req, res) => {
+    let rawBody = '';
+    try {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        rawBody = await readBody(req);
+      }
+    } catch {
+      res.writeHead(400).end();
+      return;
+    }
+
+    let forwardBody = rawBody;
+    let rewriteListSources = false;
+    if (req.method === 'POST' && rawBody) {
+      const decision = decideRequest(opts.scoping, hiddenSourceIds, rawBody);
+      if (decision.action === 'reject') {
+        const body = JSON.stringify(decision.response);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(body);
+        return;
+      }
+      forwardBody = decision.body;
+      rewriteListSources = decision.rewriteListSources;
+    }
+
+    // Forward with the client's headers (minus hop-by-hop), overlaying the
+    // configured upstream headers (Authorization). Node lowercases incoming
+    // header names, so overlay case-insensitively — a duplicate
+    // `authorization`/`Authorization` pair would reach the upstream as a
+    // comma-joined value and fail bearer parsing. `accept-encoding` is
+    // forced to identity so the rewrite path never sees compressed bodies.
+    const headers: Record<string, string | number> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (HOP_HEADERS.has(key.toLowerCase())) continue;
+      if (typeof value === 'string') headers[key] = value;
+    }
+    for (const [key, value] of Object.entries(upstreamHeaders)) {
+      delete headers[key.toLowerCase()];
+      headers[key] = value;
+    }
+    headers['accept-encoding'] = 'identity';
+    if (forwardBody) headers['content-length'] = Buffer.byteLength(forwardBody);
+
+    // Raw node:http instead of fetch: no body timeout (the MCP SSE GET
+    // stream stays open for the whole run — undici's 300s bodyTimeout
+    // would sever it and crash the pipe), and true bidirectional streaming.
+    const upstreamReq = requestUpstream(
+      target,
+      { method: req.method, headers },
+      upstreamRes => {
+        const responseHeaders: Record<string, string> = {};
+        for (const [key, value] of Object.entries(upstreamRes.headers)) {
+          if (HOP_HEADERS.has(key)) continue;
+          if (typeof value === 'string') responseHeaders[key] = value;
+        }
+        const status = upstreamRes.statusCode ?? 502;
+
+        if (rewriteListSources) {
+          const chunks: Buffer[] = [];
+          upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk));
+          upstreamRes.on('end', () => {
+            const rewritten = rewriteToolResponsePayload(
+              Buffer.concat(chunks).toString('utf8'),
+              upstreamRes.headers['content-type'] ?? '',
+              text => {
+                const result = rewriteListSourcesText(opts.scoping, text);
+                // Keep the deny set fresh — sources may be recreated
+                // between proxy start and this call.
+                for (const id of result.hiddenIds) hiddenSourceIds.add(id);
+                return result.text;
+              },
+            );
+            res.writeHead(status, responseHeaders);
+            res.end(rewritten);
+          });
+          upstreamRes.on('error', () => res.destroy());
+          return;
+        }
+
+        res.writeHead(status, responseHeaders);
+        upstreamRes.pipe(res);
+        upstreamRes.on('error', () => res.destroy());
+      },
+    );
+
+    upstreamReq.on('error', e => {
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+      }
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32000,
+            message: `scoping proxy error: ${e instanceof Error ? e.message : e}`,
+          },
+        }),
+      );
+    });
+    // If the client goes away (run teardown, SSE reconnect), release the
+    // upstream connection too.
+    res.on('close', () => upstreamReq.destroy());
+
+    upstreamReq.end(forwardBody || undefined);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('scoping proxy: failed to bind a local port');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>(resolve => {
+        server.close(() => resolve());
+        // Sever any open SSE streams so close() cannot hang.
+        server.closeAllConnections();
+      }),
+  };
+}

--- a/packages/hdx-eval/src/harness/systemPrompt.ts
+++ b/packages/hdx-eval/src/harness/systemPrompt.ts
@@ -40,6 +40,7 @@ export function buildSystemPrompt(
   anchorTimeIso?: string,
   variant: PromptVariant = 'baseline',
   maxTurns?: number,
+  metricsAvailable: boolean = true,
 ): string {
   // Scenario-provided custom system prompt — used by dashboard-build, etc.
   if (scenario.buildSystemPrompt) {
@@ -49,6 +50,7 @@ export function buildSystemPrompt(
       anchorTimeIso,
       maxTurns,
       variant,
+      metricsAvailable,
     });
   }
 

--- a/packages/hdx-eval/src/harness/types.ts
+++ b/packages/hdx-eval/src/harness/types.ts
@@ -25,6 +25,20 @@ type StdioMcpTransport = {
 };
 
 /**
+ * Harness-side scoping policy for an HTTP MCP. When set, the harness routes
+ * the MCP through a local proxy (`src/harness/scoping.ts`) that hides the
+ * listed source kinds from `clickstack_list_sources`, rejects tool calls
+ * whose `sourceId` references a hidden source, and pins `clickstack_sql`'s
+ * `connectionId` to the given Connection.
+ */
+export type McpScoping = {
+  /** Source kinds (e.g. 'metric') to hide and reject. */
+  hideSourceKinds: string[];
+  /** Connection ID that clickstack_sql is forced to use. */
+  pinSqlConnectionId?: string;
+};
+
+/**
  * A single MCP definition in the eval config. Fully specifies how to
  * connect to the MCP, which tools it exposes, and how to blind its
  * identity for fair judging.
@@ -41,6 +55,12 @@ export type McpDefinition = (HttpMcpTransport | StdioMcpTransport) & {
   /** Whether this MCP is included when `--mcp all` is used. Default: true.
    *  Explicitly naming a disabled MCP via `--mcp name` still works. */
   enabled?: boolean;
+  /** Whether this MCP arm has metric support (metric Sources + metric
+   *  tools). When false, scenarios omit metric hints from the system
+   *  prompt. Default: true. */
+  metricsAvailable?: boolean;
+  /** Scoping proxy policy — HTTP MCPs only. */
+  scoping?: McpScoping;
 };
 
 /**

--- a/packages/hdx-eval/src/hyperdx/config.ts
+++ b/packages/hdx-eval/src/hyperdx/config.ts
@@ -213,6 +213,41 @@ function validateConfig(raw: unknown, path: string): EvalConfig {
         `Eval config 'mcps.${name}.label' must be a non-empty string`,
       );
     }
+    if (
+      d.metricsAvailable !== undefined &&
+      typeof d.metricsAvailable !== 'boolean'
+    ) {
+      throw new Error(
+        `Eval config 'mcps.${name}.metricsAvailable' must be a boolean`,
+      );
+    }
+    if (d.scoping !== undefined) {
+      const s = d.scoping as Record<string, unknown>;
+      if (!s || typeof s !== 'object') {
+        throw new Error(`Eval config 'mcps.${name}.scoping' must be an object`);
+      }
+      if (
+        !Array.isArray(s.hideSourceKinds) ||
+        s.hideSourceKinds.some(k => typeof k !== 'string')
+      ) {
+        throw new Error(
+          `Eval config 'mcps.${name}.scoping.hideSourceKinds' must be an array of strings`,
+        );
+      }
+      if (
+        s.pinSqlConnectionId !== undefined &&
+        (typeof s.pinSqlConnectionId !== 'string' || !s.pinSqlConnectionId)
+      ) {
+        throw new Error(
+          `Eval config 'mcps.${name}.scoping.pinSqlConnectionId' must be a non-empty string`,
+        );
+      }
+      if (d.type !== 'http') {
+        throw new Error(
+          `Eval config 'mcps.${name}.scoping' is only supported for http MCPs`,
+        );
+      }
+    }
   }
 
   // Validate the optional `plugins` section.

--- a/packages/hdx-eval/src/hyperdx/setup.ts
+++ b/packages/hdx-eval/src/hyperdx/setup.ts
@@ -1,4 +1,5 @@
-import { scenarioTables } from '@/clickhouse/schema';
+import { createEvalClient } from '@/clickhouse/client';
+import { METRIC_SOURCE_TABLES, scenarioTables } from '@/clickhouse/schema';
 import { QUERY_TIMEOUT_SECONDS } from '@/harness/mcpConfig';
 import type { McpDefinition } from '@/harness/types';
 import { SCENARIO_NAMES } from '@/scenarios';
@@ -12,9 +13,50 @@ import {
 } from './config';
 
 const EVAL_CONNECTION_NAME = 'hdx-eval-clickhouse';
+const NOMETRICS_CH_USER = 'hdx_eval_nometrics';
+const NOMETRICS_CH_PASSWORD = 'hdx_eval_nometrics';
+const NOMETRICS_CONNECTION_NAME = 'hdx-eval-clickhouse-nometrics';
 const TRACE_DEFAULT_SELECT =
   'Timestamp, ServiceName, SpanName, Duration, StatusCode';
 const LOG_DEFAULT_SELECT = 'Timestamp, ServiceName, SeverityText, Body';
+
+/**
+ * ClickHouse DDL for the restricted user backing the `hdx-nometrics` arm.
+ *
+ * Denying the metric MCP tools client-side is not enough: `clickstack_sql`
+ * runs raw SQL with the team Connection's stored ClickHouse credentials, so
+ * the no-metrics arm could still read `eval_*_otel_metrics_*` tables. This
+ * user gets a wildcard SELECT grant on `default` with SELECT explicitly
+ * revoked on every metric table — each scenario's `eval_*_otel_metrics_*`
+ * set plus the base `otel_metrics_*` tables (partial revoke). Grants are
+ * name-based, so the statements are idempotent and work before tables exist.
+ */
+export function nometricsGrantStatements(
+  user: string = NOMETRICS_CH_USER,
+  password: string = NOMETRICS_CH_PASSWORD,
+): string[] {
+  const statements = [
+    `CREATE USER IF NOT EXISTS ${user} IDENTIFIED WITH plaintext_password BY '${password}'`,
+    `GRANT SELECT ON default.* TO ${user}`,
+  ];
+  const metricTables = [
+    ...METRIC_SOURCE_TABLES,
+    ...SCENARIO_NAMES.flatMap(name => {
+      const tables = scenarioTables(name);
+      return [
+        tables.metricsGauge,
+        tables.metricsSum,
+        tables.metricsHistogram,
+        tables.metricsExponentialHistogram,
+        tables.metricsSummary,
+      ];
+    }),
+  ];
+  for (const table of metricTables) {
+    statements.push(`REVOKE SELECT ON default.${table} FROM ${user}`);
+  }
+  return statements;
+}
 
 export type SetupOptions = {
   apiUrl: string;
@@ -33,6 +75,8 @@ export type SetupResult = {
   configPath: string;
   config: EvalConfig;
   created: { connection: boolean; sources: string[] };
+  /** Whether the optional `hdx-nometrics` arm was provisioned. */
+  nometrics: { ready: boolean };
 };
 
 export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
@@ -66,75 +110,12 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
     createdConnection = true;
   }
 
-  // 4. Ensure one Trace Source + one Log Source per scenario.
-  let sources = await api.listSources();
-  if (opts.resetSources) {
-    const evalSources = sources.filter(s => s.name.startsWith('eval-'));
-    for (const s of evalSources) {
-      await api.deleteSource(sourceId(s));
-    }
-    sources = await api.listSources();
-  }
-  const sourcesByName = new Map(sources.map(s => [s.name, s]));
-  const created: string[] = [];
-  const scenarioIds: Record<
-    string,
-    { tracesSourceId: string; logsSourceId: string; metricsSourceId: string }
-  > = {};
-
-  for (const name of SCENARIO_NAMES) {
-    const tables = scenarioTables(name);
-    const traceName = `eval-${name}-traces`;
-    const logName = `eval-${name}-logs`;
-    const metricName = `eval-${name}-metrics`;
-
-    let traceSource = sourcesByName.get(traceName);
-    if (!traceSource) {
-      traceSource = await api.createSource(
-        buildTraceSourceBody(traceName, connection._id, tables.traces, {
-          kvRollupTable: tables.tracesKvRollup,
-          keyRollupTable: tables.tracesKeyRollup,
-        }),
-      );
-      created.push(traceName);
-    }
-
-    let logSource = sourcesByName.get(logName);
-    if (!logSource) {
-      logSource = await api.createSource(
-        buildLogSourceBody(logName, connection._id, tables.logs, {
-          kvRollupTable: tables.logsKvRollup,
-          keyRollupTable: tables.logsKeyRollup,
-        }),
-      );
-      created.push(logName);
-    }
-
-    let metricSource = sourcesByName.get(metricName);
-    if (!metricSource) {
-      metricSource = await api.createSource(
-        buildMetricSourceBody(
-          metricName,
-          connection._id,
-          {
-            gauge: tables.metricsGauge,
-            sum: tables.metricsSum,
-            histogram: tables.metricsHistogram,
-            exponentialHistogram: tables.metricsExponentialHistogram,
-            summary: tables.metricsSummary,
-          },
-          sourceId(logSource),
-        ),
-      );
-      created.push(metricName);
-    }
-
-    scenarioIds[name] = {
-      tracesSourceId: sourceId(traceSource),
-      logsSourceId: sourceId(logSource),
-      metricsSourceId: sourceId(metricSource),
-    };
-  }
+  // 4. Ensure one Trace + Log + Metric Source per scenario.
+  const { scenarioIds, created } = await ensureScenarioSources(
+    api,
+    connection._id,
+    { resetSources: opts.resetSources ?? false },
+  );
 
   const mcpUrl = `${opts.apiUrl.replace(/\/$/, '')}/mcp`;
 
@@ -145,21 +126,77 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
     toolPattern: 'mcp__hyperdx__*',
     label: 'HyperDX',
     brandTerms: ['HyperDX', 'hyperdx'],
-    deniedTools: [
-      'mcp__hyperdx__clickstack_delete_dashboard',
-      'mcp__hyperdx__clickstack_get_dashboard',
-      'mcp__hyperdx__clickstack_get_dashboard_tile',
-      'mcp__hyperdx__clickstack_save_dashboard',
-      'mcp__hyperdx__clickstack_patch_dashboard',
-      'mcp__hyperdx__clickstack_search_dashboards',
-      'mcp__hyperdx__clickstack_query_tile',
-      'mcp__hyperdx__clickstack_get_saved_search',
-      'mcp__hyperdx__clickstack_save_saved_search',
-      'mcp__hyperdx__clickstack_get_alert',
-      'mcp__hyperdx__clickstack_get_webhook',
-      'mcp__hyperdx__clickstack_save_alert',
-    ],
+    deniedTools: deniedFor('hyperdx'),
   };
+
+  // 5. Provision the `hdx-nometrics` arm: same team, same MCP, but the
+  // harness routes it through a scoping proxy (`src/harness/scoping.ts`)
+  // that hides metric sources and pins clickstack_sql to a Connection
+  // backed by a restricted ClickHouse user that cannot SELECT the metric
+  // tables (closes the raw-SQL loophole). Best-effort — base setup must
+  // still succeed if this fails.
+  let nometricsReady = false;
+  let nometricsMcp: McpDefinition | undefined;
+  try {
+    // Restricted ClickHouse user. Idempotent DDL; requires access management
+    // on the admin user (the dev ch-server container enables it).
+    const chClient = createEvalClient({
+      url: chHost,
+      username: opts.clickhouse.user,
+      password: opts.clickhouse.password,
+    });
+    try {
+      for (const query of nometricsGrantStatements()) {
+        await chClient.command({ query });
+      }
+    } finally {
+      await chClient.close();
+    }
+
+    // Restricted-user Connection on the same team — the scoping proxy
+    // rewrites every clickstack_sql call to run through it.
+    let restricted = connections.find(
+      c => c.name === NOMETRICS_CONNECTION_NAME,
+    );
+    if (!restricted) {
+      const { id } = await api.createConnection({
+        name: NOMETRICS_CONNECTION_NAME,
+        host: chHost,
+        username: NOMETRICS_CH_USER,
+        password: NOMETRICS_CH_PASSWORD,
+      });
+      restricted = {
+        _id: id,
+        name: NOMETRICS_CONNECTION_NAME,
+        host: chHost,
+        username: NOMETRICS_CH_USER,
+      };
+    }
+
+    nometricsMcp = {
+      type: 'http',
+      url: mcpUrl,
+      headers: { Authorization: `Bearer ${me.accessKey}` },
+      toolPattern: 'mcp__hdx-nometrics__*',
+      label: 'HyperDX (no metrics)',
+      brandTerms: ['HyperDX', 'hyperdx'],
+      deniedTools: deniedFor('hdx-nometrics', METRIC_TOOLS),
+      metricsAvailable: false,
+      enabled: false,
+      scoping: {
+        hideSourceKinds: ['metric'],
+        pinSqlConnectionId: restricted._id,
+      },
+    };
+    nometricsReady = true;
+  } catch (e) {
+    console.warn(
+      `WARN: could not provision the hdx-nometrics arm (${
+        e instanceof Error ? e.message : e
+      }). Ensure the dev ClickHouse container (ch-server) is running, ` +
+        `then re-run setup-hyperdx.`,
+    );
+  }
 
   const clickhouseMcp: McpDefinition = {
     type: 'stdio',
@@ -189,6 +226,7 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
   const config: EvalConfig = {
     mcps: {
       hyperdx: hyperdxMcp,
+      ...(nometricsMcp ? { 'hdx-nometrics': nometricsMcp } : {}),
       clickhouse: clickhouseMcp,
     },
     scenarios: scenarioIds,
@@ -205,7 +243,118 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
     configPath: configPath(),
     config,
     created: { connection: createdConnection, sources: created },
+    nometrics: { ready: nometricsReady },
   };
+}
+
+// MCP tools denied for every HyperDX-flavored arm — dashboard/alert/saved
+// search management is out of scope for investigation evals.
+const BASE_DENIED_TOOLS = [
+  'clickstack_delete_dashboard',
+  'clickstack_get_dashboard',
+  'clickstack_get_dashboard_tile',
+  'clickstack_save_dashboard',
+  'clickstack_patch_dashboard',
+  'clickstack_search_dashboards',
+  'clickstack_query_tile',
+  'clickstack_get_saved_search',
+  'clickstack_save_saved_search',
+  'clickstack_get_alert',
+  'clickstack_get_webhook',
+  'clickstack_save_alert',
+];
+const METRIC_TOOLS = ['clickstack_list_metrics', 'clickstack_describe_metric'];
+
+function deniedFor(key: string, extra: string[] = []): string[] {
+  return [...BASE_DENIED_TOOLS, ...extra].map(t => `mcp__${key}__${t}`);
+}
+
+/**
+ * Ensure the per-scenario Sources exist on the team behind `api`: a Trace,
+ * Log, and Metric Source per scenario. With `resetSources`, deletes all
+ * `eval-*` Sources first.
+ */
+async function ensureScenarioSources(
+  api: HyperdxApiClient,
+  connectionId: string,
+  opts: { resetSources: boolean },
+): Promise<{
+  scenarioIds: Record<
+    string,
+    { tracesSourceId: string; logsSourceId: string; metricsSourceId: string }
+  >;
+  created: string[];
+}> {
+  let sources = await api.listSources();
+  if (opts.resetSources) {
+    const evalSources = sources.filter(s => s.name.startsWith('eval-'));
+    for (const s of evalSources) {
+      await api.deleteSource(sourceId(s));
+    }
+    sources = await api.listSources();
+  }
+  const sourcesByName = new Map(sources.map(s => [s.name, s]));
+  const created: string[] = [];
+  const scenarioIds: Record<
+    string,
+    { tracesSourceId: string; logsSourceId: string; metricsSourceId: string }
+  > = {};
+
+  for (const name of SCENARIO_NAMES) {
+    const tables = scenarioTables(name);
+    const traceName = `eval-${name}-traces`;
+    const logName = `eval-${name}-logs`;
+    const metricName = `eval-${name}-metrics`;
+
+    let traceSource = sourcesByName.get(traceName);
+    if (!traceSource) {
+      traceSource = await api.createSource(
+        buildTraceSourceBody(traceName, connectionId, tables.traces, {
+          kvRollupTable: tables.tracesKvRollup,
+          keyRollupTable: tables.tracesKeyRollup,
+        }),
+      );
+      created.push(traceName);
+    }
+
+    let logSource = sourcesByName.get(logName);
+    if (!logSource) {
+      logSource = await api.createSource(
+        buildLogSourceBody(logName, connectionId, tables.logs, {
+          kvRollupTable: tables.logsKvRollup,
+          keyRollupTable: tables.logsKeyRollup,
+        }),
+      );
+      created.push(logName);
+    }
+
+    let metricSource = sourcesByName.get(metricName);
+    if (!metricSource) {
+      metricSource = await api.createSource(
+        buildMetricSourceBody(
+          metricName,
+          connectionId,
+          {
+            gauge: tables.metricsGauge,
+            sum: tables.metricsSum,
+            histogram: tables.metricsHistogram,
+            exponentialHistogram: tables.metricsExponentialHistogram,
+            summary: tables.metricsSummary,
+          },
+          sourceId(logSource),
+        ),
+      );
+      created.push(metricName);
+    }
+
+    scenarioIds[name] = {
+      tracesSourceId: sourceId(traceSource),
+      logsSourceId: sourceId(logSource),
+      metricsSourceId: sourceId(metricSource),
+    };
+  }
+
+  return { scenarioIds, created };
 }
 
 function sourceId(source: HyperdxSource): string {
@@ -344,16 +493,25 @@ export async function runCheck(
   let mcpReachable = false;
   let chReachable = false;
   if (cfg) {
-    // Check the HyperDX MCP if there's an http-type MCP in the config.
-    const httpMcp = Object.values(cfg.mcps).find(m => m.type === 'http');
-    if (httpMcp && httpMcp.type === 'http') {
-      const accessKey =
-        httpMcp.headers?.Authorization?.replace('Bearer ', '') ?? '';
-      mcpReachable = await apiBearerCheck(httpMcp.url, accessKey);
-      if (!mcpReachable) {
-        errors.push(
-          `HyperDX MCP at ${httpMcp.url} did not respond as expected`,
-        );
+    // Probe every http-type MCP (e.g. both the `hyperdx` and
+    // `hdx-nometrics` arms) so --check validates each access key.
+    const httpMcps = Object.entries(cfg.mcps).filter(
+      (entry): entry is [string, Extract<McpDefinition, { type: 'http' }>] =>
+        entry[1].type === 'http',
+    );
+    mcpReachable = httpMcps.length > 0;
+    for (const [name, def] of httpMcps) {
+      const authHeader = def.headers?.Authorization;
+      if (!authHeader) {
+        mcpReachable = false;
+        errors.push(`mcps.${name}: missing Authorization header`);
+        continue;
+      }
+      const accessKey = authHeader.replace('Bearer ', '');
+      const ok = await apiBearerCheck(def.url, accessKey);
+      if (!ok) {
+        mcpReachable = false;
+        errors.push(`mcps.${name}: MCP unreachable at ${def.url}`);
       }
     }
     if (cfg.clickhouse) {

--- a/packages/hdx-eval/src/scenarios/metric-saturation/generate.ts
+++ b/packages/hdx-eval/src/scenarios/metric-saturation/generate.ts
@@ -389,12 +389,14 @@ export const metricSaturationScenario: Scenario = {
       ctx.anchorTimeIso,
       ctx.variant,
       ctx.maxTurns,
-      {
-        signalsNote:
-          '- Metrics: a HyperDX metric source is available (gauge, sum, ' +
-          'histogram, exponential histogram, and summary). Use the metric ' +
-          'tools to explore it alongside traces and logs.',
-      },
+      ctx.metricsAvailable === false
+        ? undefined
+        : {
+            signalsNote:
+              '- Metrics: a HyperDX metric source is available (gauge, sum, ' +
+              'histogram, exponential histogram, and summary). Use the metric ' +
+              'tools to explore it alongside traces and logs.',
+          },
     ),
   *generate(ctx): Iterable<ScenarioBatch> {
     const { rng, nowMs } = ctx;

--- a/packages/hdx-eval/src/scenarios/types.ts
+++ b/packages/hdx-eval/src/scenarios/types.ts
@@ -62,6 +62,9 @@ export type SystemPromptContext = {
   maxTurns?: number;
   /** Prompt variant — 'hypothesis' enables multi-hypothesis guidance. */
   variant?: PromptVariant;
+  /** False when the selected MCP arm has no metric support (no metric
+   *  Sources / metric tools); scenarios should omit metric hints. */
+  metricsAvailable?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Adds a metrics A/B harness to `packages/hdx-eval` (HDX-4788): a new `hdx-nometrics` MCP arm that runs the same HyperDX MCP with metric support removed, so `dev run <scenario> --mcp hdx-nometrics,hyperdx --baseline hdx-nometrics` measures whether metric support improves investigation outcomes. The metrics arm is the existing `hyperdx` entry — a dedicated `hdx-metrics` clone would be byte-identical apart from the tool-name prefix, so none is added.

The core problem is that denying the metric tools (`clickstack_list_metrics`, `clickstack_describe_metric`) client-side is not enough: `clickstack_sql` executes raw SQL with any team Connection's stored ClickHouse credentials and has no table restriction, and `clickstack_list_sources` exposes the team's metric Sources. Both arms share one team (the OSS API is single-team), so isolation is enforced by the harness:

- **Scoping proxy** (`src/harness/scoping.ts`): an in-process `node:http` proxy started per run for any MCP whose config entry carries a `scoping` policy. It structurally (never by parsing SQL) filters metric-kind sources out of `clickstack_list_sources` responses, rejects any tool call whose `sourceId` references a hidden source (deny set primed from upstream at startup, refreshed on every list_sources pass-through, mimicking the server's own "Source not found" wording), and rewrites every `clickstack_sql` call's `connectionId` to a restricted Connection. Forwarding uses raw `node:http` rather than fetch because undici's default 300s `bodyTimeout` severs the long-lived MCP SSE stream mid-run.
- **Restricted ClickHouse user** (`hdx_eval_nometrics`, created idempotently by `setup-hyperdx`): wildcard `SELECT` on `default` with `SELECT` explicitly revoked on every `eval_<scenario>_otel_metrics_*` table and the base `otel_metrics_*` tables (partial revoke; the tables also vanish from `SHOW TABLES`). A second Connection on the same team stores these credentials, so pinned raw SQL always executes under the database's grants — the proxy only decides *as whom* SQL runs, ClickHouse remains the enforcement boundary.
- **Prompt plumbing**: `metricsAvailable: false` on the MCP definition drops the metric hint from the scenario system prompt (new optional `buildSystemPrompt` parameter threaded through `runCell` → `SystemPromptContext`), so the arm's prompt lists only traces and logs.
- **Setup & checks**: `setup-hyperdx` provisions the CH user, the restricted Connection, and the `hdx-nometrics` config entry (`enabled: false` so the default `--mcp all` matrix is unchanged); provisioning is best-effort with a loud warning on failure. `setup-hyperdx --check` now probes every http MCP entry instead of only the first.

## Eval results

`claude-opus-4-6`, N=3 per arm, baseline `hdx-nometrics`.

| Metric | HyperDX (no metrics) | HyperDX (with metrics) | Δ |
|---|---|---|---|
| Combined score | 17% | 96% | **+78pp** |
| Programmatic score | 44% | 100% | +56pp |
| Judge mean (weighted) | 10% | 93% | +82pp |
| Tool calls (mean) | 31.0 | 26.3 | -4.7 |
| Tool-error penalty | 7pp | 0pp | -7pp |
| Duration (mean) | 301s | 236s | -65s |
| Completion rate | 0/3 final_answer (3/3 timeout) | 3/3 final_answer | — |

| Judge criterion | HyperDX (no metrics) | HyperDX (with metrics) |
|---|---|---|
| correctness | 0.3/5 | 5.0/5 |
| metric_grounding | 0.3/5 | 4.7/5 |
| calibration | 0.3/5 | 4.3/5 |
| conciseness | 2.0/5 | 4.0/5 |

| Programmatic check | HyperDX (no metrics) | HyperDX (with metrics) |
|---|---|---|
| names_affected_service | 33% | 100% |
| names_memory_leak | 0% | 100% |
| names_gc_mechanism | 0% | 100% |
| names_restart_cadence | 33% | 100% |
| cites_metric_evidence | 0% | 100% |
| false_blame_cpu (neg) | 100% | 100% |
| false_blame_deploy (neg) | 100% | 100% |
| false_blame_database (neg) | 100% | 100% |

The no-metrics arm is *blind, not reckless*: it passes all three false-blame negative checks (100% — it never confidently pins the incident on CPU, the coincidental 1.43.1 deploy, or the database) but fails every positive check that requires the metric signal (`names_memory_leak`, `names_gc_mechanism`, `cites_metric_evidence` all 0%). With only thin, ambiguous traces/logs to work from it exhausts the 300s budget on all three runs (0/3 reach a final answer) and lands at judge correctness 0.3/5. Restoring the metric tools flips every positive check to 100%, lifts correctness to 5.0/5, and does it *faster* (236s vs a full 300s timeout) with *fewer* tool calls (26.3 vs 31.0) and zero tool errors — confirming the isolation (scoping proxy + restricted ClickHouse user) removes the metric signal cleanly without otherwise degrading the arm.


### How to test on Vercel preview

N/A — non-UI change (eval harness tooling in `packages/hdx-eval` and docs only).
### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4788
- Related PRs:
