### PR TITLE
feat: Show exponential histogram metrics in the metric name drop-down

### DIFF
--- a/.changeset/bright-histograms-toggle.md
+++ b/.changeset/bright-histograms-toggle.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+feat: Show exponential histogram metrics in the metric name drop-down, gated behind `NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS`.

--- a/packages/app/src/components/MetricNameSelect.tsx
+++ b/packages/app/src/components/MetricNameSelect.tsx
@@ -7,6 +7,7 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import { Select } from '@mantine/core';
 
+import { IS_EXPONENTIAL_HISTOGRAMS_ENABLED } from '@/config';
 import { useGetKeyValues } from '@/hooks/useMetadata';
 import { capitalizeFirstLetter } from '@/utils';
 
@@ -60,7 +61,12 @@ function useMetricNames(
   metricSource: TMetricSource,
   dateRange?: DateRange['dateRange'],
 ) {
-  const { gaugeConfig, histogramConfig, sumConfig } = useMemo(() => {
+  const {
+    gaugeConfig,
+    histogramConfig,
+    sumConfig,
+    exponentialHistogramConfig,
+  } = useMemo(() => {
     return {
       gaugeConfig: chartConfigByMetricType({
         dateRange,
@@ -76,6 +82,11 @@ function useMetricNames(
         dateRange,
         metricSource,
         metricType: MetricsDataType.Sum,
+      }),
+      exponentialHistogramConfig: chartConfigByMetricType({
+        dateRange,
+        metricSource,
+        metricType: MetricsDataType.ExponentialHistogram,
       }),
     };
   }, [metricSource, dateRange]);
@@ -98,11 +109,27 @@ function useMetricNames(
     limit: MAX_METRIC_NAME_OPTIONS,
     disableRowLimit: true,
   });
+  const { data: exponentialHistogramMetrics } = useGetKeyValues(
+    {
+      chartConfig: exponentialHistogramConfig,
+      keys: ['MetricName'],
+      limit: MAX_METRIC_NAME_OPTIONS,
+      disableRowLimit: true,
+    },
+    {
+      enabled:
+        IS_EXPONENTIAL_HISTOGRAMS_ENABLED &&
+        !!metricSource.metricTables?.[MetricsDataType.ExponentialHistogram],
+    },
+  );
 
   return {
     gaugeMetrics: gaugeMetrics?.[0].value,
     histogramMetrics: histogramMetrics?.[0].value,
     sumMetrics: sumMetrics?.[0].value,
+    exponentialHistogramMetrics: IS_EXPONENTIAL_HISTOGRAMS_ENABLED
+      ? exponentialHistogramMetrics?.[0].value
+      : undefined,
   };
 }
 
@@ -110,21 +137,26 @@ export function getMetricOptions(
   gaugeMetrics: string[] | undefined,
   histogramMetrics: string[] | undefined,
   sumMetrics: string[] | undefined,
+  exponentialHistogramMetrics: string[] | undefined,
   metricName: string | null | undefined,
   metricType: MetricsDataType,
 ) {
   const metricsFromQuery = [
     ...(gaugeMetrics?.map(metric => ({
-      value: `${metric}${SEPARATOR}gauge`,
+      value: `${metric}${SEPARATOR}${MetricsDataType.Gauge}`,
       label: `${metric} (Gauge)`,
     })) ?? []),
     ...(histogramMetrics?.map(metric => ({
-      value: `${metric}${SEPARATOR}histogram`,
+      value: `${metric}${SEPARATOR}${MetricsDataType.Histogram}`,
       label: `${metric} (Histogram)`,
     })) ?? []),
     ...(sumMetrics?.map(metric => ({
-      value: `${metric}${SEPARATOR}sum`,
+      value: `${metric}${SEPARATOR}${MetricsDataType.Sum}`,
       label: `${metric} (Sum)`,
+    })) ?? []),
+    ...(exponentialHistogramMetrics?.map(metric => ({
+      value: `${metric}${SEPARATOR}${MetricsDataType.ExponentialHistogram}`,
+      label: `${metric} (Exponential Histogram)`,
     })) ?? []),
   ];
   // if saved metric does not exist in the available options, assume it exists
@@ -166,18 +198,30 @@ export function MetricNameSelect({
   onFocus?: () => void;
   'data-testid'?: string;
 }) {
-  const { gaugeMetrics, histogramMetrics, sumMetrics } =
-    useMetricNames(metricSource);
+  const {
+    gaugeMetrics,
+    histogramMetrics,
+    sumMetrics,
+    exponentialHistogramMetrics,
+  } = useMetricNames(metricSource);
 
   const options = useMemo(() => {
     return getMetricOptions(
       gaugeMetrics,
       histogramMetrics,
       sumMetrics,
+      exponentialHistogramMetrics,
       metricName,
       metricType,
     );
-  }, [gaugeMetrics, histogramMetrics, sumMetrics, metricName, metricType]);
+  }, [
+    gaugeMetrics,
+    histogramMetrics,
+    sumMetrics,
+    exponentialHistogramMetrics,
+    metricName,
+    metricType,
+  ]);
 
   const currentValue =
     metricName && metricType ? `${metricName}${SEPARATOR}${metricType}` : null;

--- a/packages/app/src/components/__tests__/MetricNameSelect.test.ts
+++ b/packages/app/src/components/__tests__/MetricNameSelect.test.ts
@@ -11,6 +11,7 @@ describe('getMetricOptions', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         null,
         MetricsDataType.Gauge,
       );
@@ -18,12 +19,20 @@ describe('getMetricOptions', () => {
     });
 
     it('returns empty array when all metric lists are empty', () => {
-      const result = getMetricOptions([], [], [], null, MetricsDataType.Gauge);
+      const result = getMetricOptions(
+        [],
+        [],
+        [],
+        [],
+        null,
+        MetricsDataType.Gauge,
+      );
       expect(result).toEqual([]);
     });
 
     it('adds saved metricName when it is not in empty results', () => {
       const result = getMetricOptions(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -45,6 +54,7 @@ describe('getMetricOptions', () => {
         ['cpu.usage'],
         undefined,
         undefined,
+        undefined,
         null,
         MetricsDataType.Gauge,
       );
@@ -57,6 +67,7 @@ describe('getMetricOptions', () => {
       const result = getMetricOptions(
         undefined,
         ['request.duration'],
+        undefined,
         undefined,
         null,
         MetricsDataType.Histogram,
@@ -74,6 +85,7 @@ describe('getMetricOptions', () => {
         undefined,
         undefined,
         ['bytes.sent'],
+        undefined,
         null,
         MetricsDataType.Sum,
       );
@@ -82,9 +94,27 @@ describe('getMetricOptions', () => {
       ]);
     });
 
+    it('returns a single exponential histogram option', () => {
+      const result = getMetricOptions(
+        undefined,
+        undefined,
+        undefined,
+        ['request.duration'],
+        null,
+        MetricsDataType.ExponentialHistogram,
+      );
+      expect(result).toEqual([
+        {
+          value: `request.duration${SEPARATOR}${MetricsDataType.ExponentialHistogram}`,
+          label: 'request.duration (Exponential Histogram)',
+        },
+      ]);
+    });
+
     it('does not duplicate a saved metricName already present in results', () => {
       const result = getMetricOptions(
         ['cpu.usage'],
+        undefined,
         undefined,
         undefined,
         'cpu.usage',
@@ -102,6 +132,7 @@ describe('getMetricOptions', () => {
         ['cpu.usage'],
         undefined,
         undefined,
+        undefined,
         'missing.metric',
         MetricsDataType.Gauge,
       );
@@ -117,17 +148,22 @@ describe('getMetricOptions', () => {
     const gaugeMetrics = ['cpu.usage', 'mem.usage', 'disk.usage'];
     const histogramMetrics = ['request.duration', 'db.query.duration'];
     const sumMetrics = ['bytes.sent', 'bytes.received', 'requests.total'];
+    const exponentialHistogramMetrics = [
+      'http.request.duration',
+      'rpc.server.duration',
+    ];
 
     it('returns all options for all metric types', () => {
       const result = getMetricOptions(
         gaugeMetrics,
         histogramMetrics,
         sumMetrics,
+        exponentialHistogramMetrics,
         null,
         MetricsDataType.Gauge,
       );
 
-      expect(result).toHaveLength(8);
+      expect(result).toHaveLength(10);
 
       expect(result).toContainEqual({
         value: `cpu.usage${SEPARATOR}gauge`,
@@ -161,6 +197,14 @@ describe('getMetricOptions', () => {
         value: `requests.total${SEPARATOR}sum`,
         label: 'requests.total (Sum)',
       });
+      expect(result).toContainEqual({
+        value: `http.request.duration${SEPARATOR}${MetricsDataType.ExponentialHistogram}`,
+        label: 'http.request.duration (Exponential Histogram)',
+      });
+      expect(result).toContainEqual({
+        value: `rpc.server.duration${SEPARATOR}${MetricsDataType.ExponentialHistogram}`,
+        label: 'rpc.server.duration (Exponential Histogram)',
+      });
     });
 
     it('does not duplicate a saved metricName already present among multiple options', () => {
@@ -168,10 +212,11 @@ describe('getMetricOptions', () => {
         gaugeMetrics,
         histogramMetrics,
         sumMetrics,
+        exponentialHistogramMetrics,
         'mem.usage',
         MetricsDataType.Gauge,
       );
-      expect(result).toHaveLength(8);
+      expect(result).toHaveLength(10);
       const values = result.map(r => r.value);
       expect(
         values.filter(v => v === `mem.usage${SEPARATOR}gauge`),
@@ -183,10 +228,11 @@ describe('getMetricOptions', () => {
         gaugeMetrics,
         histogramMetrics,
         sumMetrics,
+        exponentialHistogramMetrics,
         'absent.metric',
         MetricsDataType.Histogram,
       );
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(11);
       expect(result).toContainEqual({
         value: `absent.metric${SEPARATOR}histogram`,
         label: 'absent.metric (Histogram)',

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -66,3 +66,5 @@ export const IS_METRICS_ENABLED = true;
 export const IS_MTVIEWS_ENABLED = false;
 export const IS_SESSIONS_ENABLED = true;
 export const IS_PROMQL_ENABLED = env('NEXT_PUBLIC_ENABLE_PROMQL') === 'true';
+export const IS_EXPONENTIAL_HISTOGRAMS_ENABLED =
+  env('NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS') === 'true';


### PR DESCRIPTION
## Summary

This PR updates the chart editor to include Exponential Histogram metric names in the metric name selector. This behavior is gated behind a new `NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS` environment variable, which is disabled in all environments while support for querying exponential histogram metrics is in progress.

### Screenshots or video

<img width="1177" height="320" alt="Screenshot 2026-07-20 at 3 39 54 PM" src="https://github.com/user-attachments/assets/a0c3bf3b-7acc-46af-8c70-64576c52978f" />

### How to test on Vercel preview

This must be tested locally, so that you can enable the NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS flag. You'll also likely need to insert a metric data point into the `otel_metrics_exponential_histogram` table and ensure your Metrics source has registered that table.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4851
- Related PRs:
