### PR TITLE
feat(traces): break-word attribute wrapping + layout toggle

### DIFF
--- a/.changeset/trace-ui-wrap-and-layout.md
+++ b/.changeset/trace-ui-wrap-and-layout.md
@@ -1,0 +1,11 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: Improve the trace/span detail UI (HDX-4853)
+
+- Long span attribute values with no break points (e.g. `url.path`) now wrap
+  fully when wrap mode is on instead of being clipped.
+- Add a toggle to move the selected span's detail panel between the right side
+  (default) and the bottom of the waterfall, restoring the older top/bottom
+  layout.

--- a/.changeset/trace-ui-wrap-and-layout.md
+++ b/.changeset/trace-ui-wrap-and-layout.md
@@ -6,6 +6,11 @@ fix: Improve the trace/span detail UI (HDX-4853)
 
 - Long span attribute values with no break points (e.g. `url.path`) now wrap
   fully when wrap mode is on instead of being clipped.
+- Long attribute keys (e.g. `longtask.attribution.entry_type`) now wrap and
+  are capped at half the row width so they can't squeeze the value column to
+  nothing.
 - Add a toggle to move the selected span's detail panel between the right side
   (default) and the bottom of the waterfall, restoring the older top/bottom
   layout.
+- The span detail panel's Overview/Column Values content now aligns flush
+  with the tab bar instead of being inset by extra padding.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+# Fix: waterfall collapses under bottom-layout detail panel (PR #2693 review)
+
+## Context
+
+Greptile review comment [r3628068997](https://github.com/hyperdxio/hyperdx/pull/2693#discussion_r3628068997)
+on `packages/app/src/components/DBTracePanel.tsx:423` (branch `karl/span-sidebar-feedback`):
+
+> When the detail panel is in bottom layout, resizing it large leaves this pane with only
+> `100 - bottomPanelSize` of the column height and `minHeight: 0`. … Once this outer pane
+> becomes shorter than that chrome, the timeline area has no remaining height, so the trace
+> chart is clipped or disappears while the detail pane still keeps its `200px` floor. The
+> split needs to reserve a usable minimum height for the waterfall side too.
+
+Confirmed in code: the waterfall pane (`DBTracePanel.tsx` ~line 421–429) has
+`flex: ${100 - detailPanelSize} 1 0` with `minHeight: 0` / `overflow: hidden`, while the
+detail pane (~line 487–500) gets `minHeight: 200` in bottom layout. The waterfall's fixed
+chrome above the timeline (`DBTraceWaterfallChart.tsx`) is:
+
+- `TimelineMinimap`: 52px (`TICK_HEIGHT 18 + BAR_AREA_HEIGHT 34`) + `mb="md"` ≈ **68px**
+- Controls bar (`Group my="xs"`, 22px buttons) ≈ **42px**
+- (optional) filters form / highlighted-attributes list — variable
+
+So below ~110px the timeline (`flex: 1` wrapper) has zero height and the chart disappears,
+while the divider can still be dragged further because `useResizable`'s clamp is
+window-relative, not container-relative.
+
+## Approach
+
+CSS-only fix, symmetric with the detail pane's existing floor: give the waterfall pane its
+own minimum size when a span is selected. Flexbox won't shrink an item below its
+`min-height`/`min-width`, so the split pins there even if `detailPanelSize` keeps growing —
+exactly the same (already-shipped) behavior as the detail pane's `minWidth: 300` /
+`minHeight: 200` floors. No changes to `useResizable` needed (its window-relative clamp is
+imprecise for this nested container anyway; the CSS floor is the robust guard).
+
+Floor value: **200px** in bottom layout — covers minimap (68) + controls (42) + ~4 timeline
+rows (4 × 22 = 88). Matches the detail pane's 200px floor for symmetry.
+
+Also apply the equivalent guard in side layout (`minWidth: 300`, matching the detail pane's
+`minWidth: 300`), since the same collapse happens horizontally — the review comment says
+"reserve a usable minimum … for the waterfall side too".
+
+## Files to modify
+
+- `packages/app/src/components/DBTracePanel.tsx` — waterfall pane style (~line 421–429), one change:
+
+```tsx
+<div
+  style={{
+    flex: selectedSpan ? `${100 - detailPanelSize} 1 0` : '1 1 100%',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    minWidth: selectedSpan && isSideLayout ? 300 : 0,
+    minHeight: selectedSpan && !isSideLayout ? 200 : 0,
+  }}
+>
+```
+
+(Keep `0` when no span is selected so the pane can still fill/shrink freely in the
+single-pane state.)
+
+## Reuse
+
+- Existing floor pattern: detail pane already uses `minWidth: 300` / `minHeight: 200` in
+  the same file — we mirror it, no new utilities.
+- `useResizable` (`packages/app/src/hooks/useResizable.tsx`) stays untouched.
+
+## Steps
+
+- [ ] Add conditional `minWidth`/`minHeight` floors to the waterfall pane div in
+      `DBTracePanel.tsx` (single style change above).
+- [ ] Extend `packages/app/src/components/__tests__/DBTracePanel.test.tsx` (which already
+      covers the layout toggle): assert the waterfall pane has `min-height: 200px` when a
+      span is selected in bottom layout (and `min-width: 300px` in side layout).
+- [ ] Reply to / resolve the Greptile thread on the PR after pushing.
+
+## Verification
+
+- `yarn workspace @hyperdx/app jest DBTracePanel` — existing + new tests pass.
+- Manual (dev app or Vercel preview, per PR test steps): open a trace, select a span,
+  toggle to bottom layout, drag the divider all the way up → the waterfall keeps ≥200px
+  (minimap + controls + a few rows visible), timeline never disappears. Repeat in side
+  layout dragging the divider fully left → waterfall keeps ≥300px width.

--- a/packages/app/src/components/DBRowDataPanel.tsx
+++ b/packages/app/src/components/DBRowDataPanel.tsx
@@ -288,11 +288,15 @@ export function RowDataPanel({
   source,
   rowId,
   aliasWith,
+  flush = false,
   'data-testid': dataTestId,
 }: {
   source: TSource;
   rowId: string | undefined | null;
   aliasWith?: WithClause[];
+  // When true, drop the horizontal margin so content aligns flush with
+  // surrounding chrome (e.g. the tab bar in the trace span detail panel).
+  flush?: boolean;
   'data-testid'?: string;
 }) {
   const { data } = useRowData({ source, rowId, aliasWith });
@@ -310,7 +314,7 @@ export function RowDataPanel({
 
   return (
     <div className="flex-grow-1 overflow-auto" data-testid={dataTestId}>
-      <Box mx="md" my="sm">
+      <Box mx={flush ? 0 : 'md'} my="sm">
         <DBRowJsonViewer
           data={firstRow}
           jsonColumns={jsonColumns}

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -28,14 +28,19 @@ export function RowOverviewPanel({
   rowId,
   aliasWith,
   hideHeader = false,
+  flush = false,
   'data-testid': dataTestId,
 }: {
   source: TSource;
   rowId: string | undefined | null;
   aliasWith?: WithClause[];
   hideHeader?: boolean;
+  // When true, drop the horizontal padding so content aligns flush with
+  // surrounding chrome (e.g. the tab bar in the trace span detail panel).
+  flush?: boolean;
   'data-testid'?: string;
 }) {
+  const contentPx = flush ? 0 : 'md';
   const { data } = useRowData({ source, rowId, aliasWith });
   const { onPropertyAddClick, generateSearchUrl, onOpenLinkedTrace } =
     useContext(RowSidePanelContext);
@@ -198,7 +203,7 @@ export function RowOverviewPanel({
   return (
     <div className="flex-grow-1 overflow-auto" data-testid={dataTestId}>
       {!hideHeader && (
-        <Box px="sm" pt="md">
+        <Box px={flush ? 0 : 'sm'} pt="md">
           <DBRowSidePanelHeader
             attributes={highlightedAttributeValues}
             mainContent={mainContent}
@@ -230,12 +235,12 @@ export function RowOverviewPanel({
         {isHttpRequest && (
           <Accordion.Item value="network">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 HTTP Request
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box px={contentPx}>
                 <NetworkPropertySubpanel
                   eventAttributes={flattenedEventAttributes}
                 />
@@ -247,12 +252,12 @@ export function RowOverviewPanel({
         {hasException && (
           <Accordion.Item value="exception">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 Exception
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box px={contentPx}>
                 <ExceptionSubpanel
                   exceptionValues={exceptionValues}
                   breadcrumbs={[]}
@@ -265,15 +270,30 @@ export function RowOverviewPanel({
           </Accordion.Item>
         )}
 
+        {hasSpanEvents && (
+          <Accordion.Item value="spanEvents">
+            <Accordion.Control>
+              <Text size="sm" ps={contentPx}>
+                Span Events
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Box px={contentPx}>
+                <SpanEventsSubpanel spanEvents={firstRow?.__hdx_span_events} />
+              </Box>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+
         {Object.keys(topLevelAttributes).length > 0 && (
           <Accordion.Item value="topLevelAttributes">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 Top Level Attributes
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box px={contentPx}>
                 <DBRowJsonViewer
                   data={topLevelAttributes}
                   jsonColumns={jsonColumns}
@@ -287,12 +307,12 @@ export function RowOverviewPanel({
         {Object.keys(filteredEventAttributes).length > 0 && (
           <Accordion.Item value="eventAttributes">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 {source.kind === 'log' ? 'Log' : 'Span'} Attributes
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box px={contentPx}>
                 <DBRowJsonViewer
                   data={filteredEventAttributes}
                   jsonColumns={jsonColumns}
@@ -339,12 +359,12 @@ export function RowOverviewPanel({
         {Object.keys(resourceAttributes).length > 0 && (
           <Accordion.Item value="resourceAttributes">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 Resource Attributes
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Flex wrap="wrap" gap="2px" mx="md" mb="lg">
+              <Flex wrap="wrap" gap="2px" mx={contentPx} mb="lg">
                 {Object.entries(resourceAttributes).map(([key, value]) => (
                   <EventTag
                     {...(onPropertyAddClick

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -1,4 +1,6 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { useAtom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
 import { useQueryState } from 'nuqs';
 import { useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
@@ -20,7 +22,11 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconX } from '@tabler/icons-react';
+import {
+  IconLayoutBottombar,
+  IconLayoutSidebarRight,
+  IconX,
+} from '@tabler/icons-react';
 
 import { DBTraceWaterfallChartContainer } from '@/components/DBTraceWaterfallChart';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
@@ -68,6 +74,15 @@ enum SpanDetailTab {
   Infrastructure = 'infrastructure',
 }
 
+type TraceDetailLayout = 'side' | 'bottom';
+
+const TRACE_DETAIL_LAYOUT_KEY = 'hdx_trace_detail_layout';
+
+const traceDetailLayoutAtom = atomWithStorage<TraceDetailLayout>(
+  TRACE_DETAIL_LAYOUT_KEY,
+  'side',
+);
+
 // Renders the inline detail for the currently-selected span. Mounted only while
 // a span is selected, so it can call useRowData with a real source rather than
 // the parent passing a placeholder when nothing is selected. Owns the active
@@ -77,11 +92,15 @@ function SpanDetailPanel({
   rowId,
   aliasWith,
   onClose,
+  isSideLayout,
+  onToggleLayout,
 }: {
   source: TSource;
   rowId: string;
   aliasWith?: WithClause[];
   onClose: () => void;
+  isSideLayout: boolean;
+  onToggleLayout: () => void;
 }) {
   const [displayedTab, setDisplayedTab] = useState<SpanDetailTab>(
     SpanDetailTab.Overview,
@@ -129,18 +148,46 @@ function SpanDetailPanel({
           activeItem={effectiveTab}
           onClick={(v: any) => setDisplayedTab(v)}
         />
-        <Tooltip label="Close" position="bottom">
-          <ActionIcon
-            variant="subtle"
-            color="gray"
-            size="sm"
-            onClick={onClose}
-            aria-label="Close span details"
-            style={{ position: 'absolute', right: 0, top: 0 }}
+        <Group
+          gap={4}
+          wrap="nowrap"
+          style={{ position: 'absolute', right: 0, top: 0 }}
+        >
+          <Tooltip
+            label={
+              isSideLayout
+                ? 'Show details at the bottom'
+                : 'Show details on the side'
+            }
+            position="bottom"
           >
-            <IconX size={16} />
-          </ActionIcon>
-        </Tooltip>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={onToggleLayout}
+              aria-label="Toggle span detail layout"
+              data-testid="trace-detail-layout-toggle"
+            >
+              {isSideLayout ? (
+                <IconLayoutBottombar size={16} />
+              ) : (
+                <IconLayoutSidebarRight size={16} />
+              )}
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Close" position="bottom">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={onClose}
+              aria-label="Close span details"
+            >
+              <IconX size={16} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
       </div>
       {effectiveTab === SpanDetailTab.Overview && (
         <RowOverviewPanel source={source} rowId={rowId} aliasWith={aliasWith} />
@@ -278,10 +325,16 @@ export default function DBTracePanel({
   const [isSourceSchemaPreviewOpen, setIsSourceSchemaPreviewOpen] =
     useState(false);
 
-  // Parent owns the horizontal split sizing; the waterfall lives on the left
-  // and the selected span's detail renders inline on the right.
+  const [detailLayout, setDetailLayout] = useAtom(traceDetailLayoutAtom);
+  const isSideLayout = detailLayout === 'side';
+
   const { size: rightPanelSize, startResize: startHorizontalResize } =
     useResizable(35, 'right');
+
+  const { size: bottomPanelSize, startResize: startVerticalResize } =
+    useResizable(40, 'top');
+
+  const detailPanelSize = isSideLayout ? rightPanelSize : bottomPanelSize;
 
   const handleCloseSpanDetails = useCallback(() => {
     setEventRowWhere(null);
@@ -346,10 +399,10 @@ export default function DBTracePanel({
           </Flex>
         </Stack>
       )}
-      {/* Inline resizable split view: waterfall (left) + span detail (right) */}
       <div
         style={{
           display: 'flex',
+          flexDirection: isSideLayout ? 'row' : 'column',
           flex: 1,
           minHeight: 0,
           minWidth: 0,
@@ -357,11 +410,12 @@ export default function DBTracePanel({
       >
         <div
           style={{
-            flex: selectedSpan ? `${100 - rightPanelSize} 1 0` : '1 1 100%',
+            flex: selectedSpan ? `${100 - detailPanelSize} 1 0` : '1 1 100%',
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
             minWidth: 0,
+            minHeight: 0,
           }}
         >
           {traceSourceData?.kind === SourceKind.Trace && traceId && (
@@ -404,8 +458,14 @@ export default function DBTracePanel({
 
         {selectedSpan != null && (
           <Box
-            className={resizeStyles.resizeHandleInline}
-            onMouseDown={startHorizontalResize}
+            className={
+              isSideLayout
+                ? resizeStyles.resizeHandleInline
+                : resizeStyles.resizeHandleInlineY
+            }
+            onMouseDown={
+              isSideLayout ? startHorizontalResize : startVerticalResize
+            }
           />
         )}
 
@@ -414,11 +474,19 @@ export default function DBTracePanel({
           selectedSpanSource != null && (
             <div
               style={{
-                flex: `${rightPanelSize} 1 0`,
+                flex: `${detailPanelSize} 1 0`,
                 overflow: 'auto',
-                minWidth: 300,
-                borderLeft: '1px solid var(--color-border)',
-                paddingLeft: 'var(--mantine-spacing-sm)',
+                ...(isSideLayout
+                  ? {
+                      minWidth: 300,
+                      borderLeft: '1px solid var(--color-border)',
+                      paddingLeft: 'var(--mantine-spacing-sm)',
+                    }
+                  : {
+                      minHeight: 200,
+                      borderTop: '1px solid var(--color-border)',
+                      paddingTop: 'var(--mantine-spacing-sm)',
+                    }),
               }}
             >
               <SpanDetailPanel
@@ -426,6 +494,10 @@ export default function DBTracePanel({
                 rowId={selectedSpan.id}
                 aliasWith={selectedSpan.aliasWith}
                 onClose={handleCloseSpanDetails}
+                isSideLayout={isSideLayout}
+                onToggleLayout={() =>
+                  setDetailLayout(isSideLayout ? 'bottom' : 'side')
+                }
               />
             </div>
           )}

--- a/packages/app/src/components/DBTracePanel.tsx
+++ b/packages/app/src/components/DBTracePanel.tsx
@@ -189,11 +189,23 @@ function SpanDetailPanel({
           </Tooltip>
         </Group>
       </div>
+      {/* `flush` drops the panels' inline padding so content aligns with the
+          tab bar; the wrapping container already provides the outer inset. */}
       {effectiveTab === SpanDetailTab.Overview && (
-        <RowOverviewPanel source={source} rowId={rowId} aliasWith={aliasWith} />
+        <RowOverviewPanel
+          source={source}
+          rowId={rowId}
+          aliasWith={aliasWith}
+          flush
+        />
       )}
       {effectiveTab === SpanDetailTab.Parsed && (
-        <RowDataPanel source={source} rowId={rowId} aliasWith={aliasWith} />
+        <RowDataPanel
+          source={source}
+          rowId={rowId}
+          aliasWith={aliasWith}
+          flush
+        />
       )}
       {effectiveTab === SpanDetailTab.Infrastructure && hasK8sContext && (
         <Box style={{ overflowY: 'auto' }}>

--- a/packages/app/src/components/HyperJson.module.scss
+++ b/packages/app/src/components/HyperJson.module.scss
@@ -158,6 +158,11 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+
+  // Cap the key column so long keys (e.g. `longtask.attribution.entry_type`)
+  // can't stretch the row and squeeze the value column to nothing
+  max-width: 50%;
+  min-width: 0;
 }
 
 .key {
@@ -167,6 +172,9 @@
   cursor: pointer;
   display: flex;
   gap: 6px;
+
+  // Wrap unbroken keys (dots don't break) within the keyContainer cap
+  overflow-wrap: anywhere;
 
   // @extend .hoverable;
   // @extend .clickable;

--- a/packages/app/src/components/HyperJson.module.scss
+++ b/packages/app/src/components/HyperJson.module.scss
@@ -183,6 +183,7 @@
   align-items: flex-start;
   gap: 3px;
   max-width: 100%;
+  min-width: 0;
 }
 
 .value {
@@ -199,7 +200,10 @@
 .string {
   color: var(--color-json-string);
   white-space: pre;
-  overflow-wrap: break-word;
+
+  // `anywhere` (vs `break-word`) so when wrapping is enabled long
+  // unbroken tokens like URLs/paths break instead of overflowing
+  overflow-wrap: anywhere;
 
   &::before,
   &::after {

--- a/packages/app/src/components/__tests__/DBTracePanel.test.tsx
+++ b/packages/app/src/components/__tests__/DBTracePanel.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { SourceKind } from '@hyperdx/common-utils/dist/types';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import DBTracePanel from '@/components/DBTracePanel';
 
 let mockSources: Record<string, any> = {};
+// Controls the value returned by the mocked `useQueryState('eventRowWhere')`
+// so tests can render with or without a selected span. Prefixed with `mock` so
+// the hoisted jest.mock factory may reference it.
+let mockEventRowWhere: any = null;
 
 jest.mock('nuqs', () => ({
-  useQueryState: () => [null, jest.fn()],
+  useQueryState: () => [mockEventRowWhere, jest.fn()],
 }));
 
 jest.mock('@/utils/queryParsers', () => ({
@@ -47,7 +51,12 @@ jest.mock('../SourceSelect', () => ({
 // and would otherwise need a QueryClient provider; stub it for this unit test.
 jest.mock('../DBRowDataPanel', () => ({
   useRowData: () => ({ data: undefined }),
+  rowHasK8sContext: () => false,
   RowDataPanel: () => <div>row data panel</div>,
+}));
+
+jest.mock('../DBRowOverviewPanel', () => ({
+  RowOverviewPanel: () => <div>overview panel</div>,
 }));
 
 jest.mock('../DBInfraPanel', () => ({
@@ -64,6 +73,7 @@ jest.mock('../SourceSchemaPreview', () => ({
 
 describe('DBTracePanel', () => {
   beforeEach(() => {
+    mockEventRowWhere = null;
     mockSources = {
       'trace-source': {
         id: 'trace-source',
@@ -123,5 +133,49 @@ describe('DBTracePanel', () => {
 
     // Trace id lives in the side-panel header now, not the trace panel body.
     expect(screen.queryByText(/trace-123/)).not.toBeInTheDocument();
+  });
+
+  it('toggles the span detail layout and persists the choice', () => {
+    localStorage.clear();
+    mockEventRowWhere = {
+      id: 'span-1',
+      type: SourceKind.Trace,
+      aliasWith: [],
+      traceId: 'trace-123',
+    };
+    renderWithMantine(
+      <DBTracePanel
+        traceId="trace-123"
+        parentSourceId="trace-source"
+        childSourceId="log-source"
+        dateRange={[new Date(0), new Date(1000)]}
+        focusDate={new Date(500)}
+      />,
+    );
+
+    const toggle = screen.getByTestId('trace-detail-layout-toggle');
+
+    // Default 'side' layout: the control offers switching to the bottom layout.
+    expect(
+      toggle.querySelector('.tabler-icon-layout-bottombar'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    // Now in 'bottom' layout: the control offers switching back to the side.
+    expect(
+      toggle.querySelector('.tabler-icon-layout-sidebar-right'),
+    ).toBeInTheDocument();
+    expect(
+      JSON.parse(localStorage.getItem('hdx_trace_detail_layout') as string),
+    ).toBe('bottom');
+
+    fireEvent.click(toggle);
+    // Back to 'side'; leave the shared atom at its default for other tests.
+    expect(
+      toggle.querySelector('.tabler-icon-layout-bottombar'),
+    ).toBeInTheDocument();
+    expect(
+      JSON.parse(localStorage.getItem('hdx_trace_detail_layout') as string),
+    ).toBe('side');
   });
 });

--- a/packages/app/src/components/__tests__/HyperJson.test.tsx
+++ b/packages/app/src/components/__tests__/HyperJson.test.tsx
@@ -20,4 +20,19 @@ describe('HyperJson wrap markers', () => {
 
     expect(container.querySelector('.withPreWrap')).not.toBeInTheDocument();
   });
+
+  // Long unbroken keys (dots don't produce break opportunities) rely on the
+  // `.keyContainer` max-width cap + `.key` overflow-wrap so they can't
+  // squeeze the value column to nothing. jsdom doesn't compute layout, so
+  // assert the key renders inside the elements carrying those styles.
+  it('renders long unbroken keys inside the capped key container', () => {
+    const longKey = 'longtask.attribution.entry_type';
+    const { container } = renderWithMantine(
+      <HyperJson data={{ [longKey]: 'task-attribution' }} />,
+    );
+
+    const key = container.querySelector('.keyContainer > .key');
+    expect(key).toBeInTheDocument();
+    expect(key).toHaveTextContent(longKey);
+  });
 });

--- a/packages/app/src/components/__tests__/HyperJson.test.tsx
+++ b/packages/app/src/components/__tests__/HyperJson.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import HyperJson from '@/components/HyperJson';
+
+describe('HyperJson wrap markers', () => {
+  const data = { 'url.path': '/bitdrift.internal_api.unary.example/VeryLong' };
+
+  it('applies withPreWrap when wrap mode is on (whiteSpace="pre-wrap")', () => {
+    const { container } = renderWithMantine(
+      <HyperJson data={data} whiteSpace="pre-wrap" />,
+    );
+
+    expect(container.querySelector('.withPreWrap')).toBeInTheDocument();
+  });
+
+  it('does not apply withPreWrap when wrap mode is off (whiteSpace="pre")', () => {
+    const { container } = renderWithMantine(
+      <HyperJson data={data} whiteSpace="pre" />,
+    );
+
+    expect(container.querySelector('.withPreWrap')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/styles/ResizablePanel.module.scss
+++ b/packages/app/styles/ResizablePanel.module.scss
@@ -42,6 +42,28 @@
   }
 }
 
+.resizeHandleInlineY {
+  position: relative;
+  left: auto;
+  top: auto;
+  bottom: auto;
+  height: 6px;
+  flex-shrink: 0;
+  cursor: row-resize;
+  transition: all 150ms ease;
+  z-index: 10;
+
+  &:hover,
+  &:active {
+    background-color: var(--color-bg-neutral);
+  }
+
+  &:active {
+    background-color: var(--color-bg-neutral);
+    height: 8px;
+  }
+}
+
 .resizeYHandle {
   position: absolute;
   bottom: -3px;


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Addresses user feedback from [#2689](https://github.com/hyperdxio/hyperdx/issues/2689) about the redesigned trace UI.

What changed
- Attribute wrapping: Long span attribute values with no break points (e.g. url.path) now wrap fully when wrap mode is on, instead of being clipped with no way to see the full value.
- Layout toggle: Added a control next to the span detail's close button to move the detail panel between the right side (default) and the bottom of the waterfall. The choice is persisted.

Review follow-ups (from @elizabetdev):
- Key wrapping: Long attribute keys (e.g. `longtask.attribution.entry_type`) now wrap and are capped at half the row width so they can't squeeze the value column down to one character per line.
- Tab alignment: The span detail panel's Overview/Column Values content is now flush with the tab bar (removed the extra inline padding, scoped to the trace detail panel only — the row drawer and inline expanded row are unchanged).

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->


https://github.com/user-attachments/assets/e68bb3b3-56b9-45d7-9ad2-589e9ca3c1f5

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/search`

**Steps:**

1. Run a search over the Demo Traces source and click a result row to open the row side panel, then open the Trace tab.
2. In the trace waterfall, click a span to open the span detail panel on the right.
3. Verify the detail panel content (span header card, "Top Level Attributes" section) is left-aligned with the Overview/Column Values tab bar above it, with no extra horizontal inset.
4. Click the layout toggle (data-testid `trace-detail-layout-toggle`) next to the close button and verify the detail panel moves to the bottom of the waterfall, then toggle it back.
5. In the attributes list, enable wrap mode (the wrap toggle in the attributes toolbar) and find a long unbroken attribute value (e.g. a URL path) — verify it wraps across lines instead of being clipped.
6. Narrow the detail panel by dragging the resize divider and confirm long attribute keys wrap within roughly the left half of the row while values remain readable (not squeezed to one character per line).

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4853
- GitHub Issue: Closes #2689

