### PR TITLE
feat: Implement quantile+sum for exponential histogram metrics

### DIFF
--- a/.changeset/fuzzy-counts-flow.md
+++ b/.changeset/fuzzy-counts-flow.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+feat: Support count aggregations over exponential histogram metrics

--- a/.changeset/olive-mugs-try.md
+++ b/.changeset/olive-mugs-try.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/api": patch
+---
+
+feat: Implement quantile for exponential histogram metrics

--- a/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
+++ b/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
@@ -1575,6 +1575,12 @@ describe('renderChartConfig', () => {
   });
 
   describe('Query Metrics - Exponential Histogram', () => {
+    type CountResult = {
+      __hdx_time_bucket: string;
+      Value: string;
+      group?: string[];
+    };
+
     type QuantileResult = {
       __hdx_time_bucket: string;
       Value: number;
@@ -1591,6 +1597,65 @@ describe('renderChartConfig', () => {
       (!('group' in result) ||
         (Array.isArray(result.group) &&
           result.group.every(value => typeof value === 'string')));
+
+    const isCountResult = (result: unknown): result is CountResult =>
+      typeof result === 'object' &&
+      result !== null &&
+      '__hdx_time_bucket' in result &&
+      typeof result.__hdx_time_bucket === 'string' &&
+      'Value' in result &&
+      typeof result.Value === 'string' &&
+      (!('group' in result) ||
+        (Array.isArray(result.group) &&
+          result.group.every(value => typeof value === 'string')));
+
+    const queryCount = async (
+      metricName: string,
+      {
+        dateRange = [new Date(now), nowPlus('3m')],
+        granularity = '1 minute',
+        groupBy,
+      }: {
+        dateRange?: [Date, Date];
+        granularity?: '1 minute' | '2 minute' | null;
+        groupBy?: string;
+      } = {},
+    ) => {
+      const query = await renderChartConfig(
+        {
+          select: [
+            {
+              aggFn: 'count',
+              metricName,
+              metricType: MetricsDataType.ExponentialHistogram,
+              valueExpression: 'Value',
+            },
+          ],
+          from: metricSource.from,
+          where: '',
+          metricTables: TEST_METRIC_TABLES,
+          dateRange,
+          groupBy,
+          granularity: granularity ?? undefined,
+          timestampValueExpression: metricSource.timestampValueExpression,
+          connection: connection.id,
+        },
+        metadata,
+        querySettings,
+      );
+
+      const results = await queryData(query);
+      if (!results.every(isCountResult)) {
+        throw new Error('unexpected exponential histogram count query result');
+      }
+      return results.sort(
+        (left, right) =>
+          left.__hdx_time_bucket.localeCompare(right.__hdx_time_bucket) ||
+          JSON.stringify(left.group ?? []).localeCompare(
+            JSON.stringify(right.group ?? []),
+          ),
+      );
+    };
 
     const queryQuantile = async (
       level: number,
@@ -1662,6 +1727,266 @@ describe('renderChartConfig', () => {
           },
         ],
       });
+
+    it('counts delta-temporality observations directly', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.delta',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([-4, 0, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.delta')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '3',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '2',
+        },
+      ]);
+    });
+
+    it('subtracts cumulative counts using a warm-up point outside the requested range', async () => {
+      const startTime = nowPlus('-2m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.cumulative.warmup',
+        points: [
+          {
+            TimeUnix: nowPlus('-1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4, 8]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4, 8, 16, 32]),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.cumulative.warmup')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '1',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '2',
+        },
+      ]);
+    });
+
+    it('does not attribute a predecessor-less cumulative count to its first visible bucket', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.cumulative.missing.predecessor',
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('-10m'),
+            ...bucketExponentialHistogramObservations([2, 4, 8]),
+          },
+        ],
+      });
+
+      expect(
+        await queryCount('test.count.cumulative.missing.predecessor'),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '0',
+        },
+      ]);
+    });
+
+    it('suppresses an unknown-start reset and uses it as the next baseline', async () => {
+      const resetTime = nowPlus('1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.cumulative.unknown.reset',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+          {
+            TimeUnix: resetTime,
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([-4, 0, 2]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([-4, -2, 0, 2, 4]),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.cumulative.unknown.reset')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(resetTime),
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('2m')),
+          Value: '2',
+        },
+      ]);
+    });
+
+    it('uses the current count after a known cumulative reset', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.cumulative.known.reset',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([2, 4, 8]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('30s'),
+            ...bucketExponentialHistogramObservations([-4, 0]),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.cumulative.known.reset')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '2',
+        },
+      ]);
+    });
+
+    it('uses the current count after a decrease-inferred cumulative reset', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.cumulative.decrease',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4, 8]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([16]),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.cumulative.decrease')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '1',
+        },
+      ]);
+    });
+
+    it('keeps count continuity across scale and bucket-layout changes', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.count.scale.change',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([-16, 0, 2, 4], -1),
+          },
+        ],
+      });
+
+      expect(await queryCount('test.count.scale.change')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: '3',
+        },
+      ]);
+    });
+
+    it('sums series by the requested group and time bucket', async () => {
+      await Promise.all([
+        seedGroupedCumulativeSeries({
+          attributes: { host: 'host-a', service: 'api' },
+          metricName: 'test.count.grouped',
+          observations: [2, 4],
+        }),
+        seedGroupedCumulativeSeries({
+          attributes: { host: 'host-a', service: 'worker' },
+          metricName: 'test.count.grouped',
+          observations: [8],
+        }),
+        seedGroupedCumulativeSeries({
+          attributes: { host: 'host-b', service: 'api' },
+          metricName: 'test.count.grouped',
+          observations: [16, 32, 64],
+        }),
+      ]);
+
+      expect(
+        await queryCount('test.count.grouped', {
+          groupBy: `Attributes['host']`,
+        }),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          group: ['host-a'],
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          group: ['host-b'],
+          Value: '0',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          group: ['host-a'],
+          Value: '3',
+        },
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          group: ['host-b'],
+          Value: '3',
+        },
+      ]);
+    });
 
     it('calculates a quantile for a single series', async () => {
       await seedExponentialHistogramMetric({

--- a/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
+++ b/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
@@ -14,6 +14,7 @@ import ms from 'ms';
 import * as config from '@/config';
 import { createTeam } from '@/controllers/team';
 import {
+  bucketExponentialHistogramObservations,
   bulkInsertLogs,
   bulkInsertMetricsGauge,
   bulkInsertMetricsHistogram,
@@ -23,6 +24,7 @@ import {
   DEFAULT_METRICS_TABLE,
   executeSqlCommand,
   getServer,
+  seedExponentialHistogramMetric,
 } from '@/fixtures';
 import Connection from '@/models/connection';
 import { Source } from '@/models/source';
@@ -50,6 +52,8 @@ describe('renderChartConfig', () => {
   let clickhouseClient: ClickhouseClient;
 
   const nowPlus = time_val => new Date(now + ms(time_val));
+  const toClickHouseISOString = (date: Date) =>
+    date.toISOString().replace('.000Z', 'Z');
 
   const queryData = async (chsql: ChSql) => {
     try {
@@ -1567,6 +1571,1817 @@ describe('renderChartConfig', () => {
       );
       const res = await queryData(query);
       expect(res).toMatchSnapshot();
+    });
+  });
+
+  describe('Query Metrics - Exponential Histogram', () => {
+    type QuantileResult = {
+      __hdx_time_bucket: string;
+      Value: number;
+      group?: string[];
+    };
+
+    const isQuantileResult = (result: unknown): result is QuantileResult =>
+      typeof result === 'object' &&
+      result !== null &&
+      '__hdx_time_bucket' in result &&
+      typeof result.__hdx_time_bucket === 'string' &&
+      'Value' in result &&
+      typeof result.Value === 'number' &&
+      (!('group' in result) ||
+        (Array.isArray(result.group) &&
+          result.group.every(value => typeof value === 'string')));
+
+    const queryQuantile = async (
+      level: number,
+      metricName: string,
+      {
+        dateRange = [new Date(now), nowPlus('2m')],
+        granularity = '1 minute',
+        groupBy,
+        where = '',
+      }: {
+        dateRange?: [Date, Date];
+        granularity?: '1 minute' | null;
+        groupBy?: string;
+        where?: string;
+      } = {},
+    ) => {
+      const query = await renderChartConfig(
+        {
+          select: [
+            {
+              aggFn: 'quantile',
+              level,
+              metricName,
+              metricType: MetricsDataType.ExponentialHistogram,
+              valueExpression: 'Value',
+            },
+          ],
+          from: metricSource.from,
+          where,
+          metricTables: TEST_METRIC_TABLES,
+          dateRange,
+          groupBy,
+          granularity: granularity ?? undefined,
+          timestampValueExpression: metricSource.timestampValueExpression,
+          connection: connection.id,
+        },
+        metadata,
+        querySettings,
+      );
+
+      const results = await queryData(query);
+      if (!results.every(isQuantileResult)) {
+        throw new Error('unexpected exponential histogram query result');
+      }
+      return results;
+    };
+
+    const seedGroupedCumulativeSeries = async ({
+      attributes,
+      metricName,
+      observations,
+    }: {
+      attributes: Record<string, string>;
+      metricName: string;
+      observations: number[];
+    }) =>
+      seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: attributes,
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: attributes,
+            ...bucketExponentialHistogramObservations(observations),
+          },
+        ],
+      });
+
+    it('calculates a quantile for a single series', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.request.duration',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      expect(await queryQuantile(0.5, 'test.request.duration')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: 2,
+        },
+      ]);
+    });
+
+    it('returns no rows when no data points match the query', async () => {
+      expect(await queryQuantile(0.5, 'test.metric.never.seeded')).toEqual([]);
+    });
+
+    it('uses logarithmic interpolation within a positive exponential bucket', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.positive.interpolation',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.positive.interpolation');
+
+      // At scale 0, both observations occupy (2, 4]. Halfway through an
+      // exponential bucket is its geometric midpoint: 2 * sqrt(2), not 3.
+      expect(result.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('1m')),
+      );
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('orders negative buckets before zero and interpolates them toward zero', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.interpolation',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-4, -4, 0, 2]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.25, 'test.negative.interpolation');
+
+      // The first two observations are in [-4, -2). Rank 1 is halfway through
+      // that bucket, whose logarithmic midpoint is -2 * sqrt(2).
+      expect(result.Value).toBeCloseTo(-Math.sqrt(8));
+    });
+
+    it('orders multiple populated negative buckets from the largest magnitude toward zero', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.multiple.bucket.order',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-8, -8, -4, -2]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.375,
+        'test.negative.multiple.bucket.order',
+      );
+
+      // Negative buckets are traversed as [-8, -4), [-4, -2), [-2, -1).
+      // Rank 1.5 is 75% of the way through the first two-count bucket, so
+      // logarithmic interpolation toward zero gives -2^2.25.
+      expect(result.Value).toBeCloseTo(-(2 ** 2.25));
+    });
+
+    it('returns zero when the requested rank falls in the zero bucket', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.zero.bucket',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-2, 0, 0, 4]),
+          },
+        ],
+      });
+
+      // One negative observation precedes two zero observations, so rank 2
+      // falls in the zero bucket and the median is exactly zero.
+      expect(await queryQuantile(0.5, 'test.zero.bucket')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: 0,
+        },
+      ]);
+    });
+
+    it('returns a negative bucket upper boundary when the rank ends at the zero bucket border', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.zero.border',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-4, -4, 0, 0]),
+          },
+        ],
+      });
+
+      // Rank 2 ends exactly at the top of negative bucket [-4, -2), just
+      // before the zero bucket begins. The sign-flip boundary must resolve to
+      // the bucket's upper boundary -2, not to zero.
+      expect(await queryQuantile(0.5, 'test.negative.zero.border')).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: -2,
+        },
+      ]);
+    });
+
+    it('returns the outer bucket boundaries for quantile levels zero and one', async () => {
+      const metricName = 'test.quantile.endpoints';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-8, -4, 2, 4]),
+          },
+        ],
+      });
+
+      // Level zero starts at the lower numeric boundary of the first negative
+      // bucket. Level one ends at the upper boundary of the last positive one.
+      expect((await queryQuantile(0, metricName))[0]?.Value).toBe(-8);
+      expect((await queryQuantile(1, metricName))[0]?.Value).toBe(4);
+    });
+
+    it('returns single-sided outer boundaries for quantile levels zero and one', async () => {
+      const negativeOnly = 'test.quantile.endpoints.negative.only';
+      const positiveOnly = 'test.quantile.endpoints.positive.only';
+      await seedExponentialHistogramMetric({
+        metricName: negativeOnly,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([-4, -2]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: positiveOnly,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      // With only negative buckets, level one must end at the upper (least
+      // negative) boundary of [-2, -1) and stay negative. With only positive
+      // buckets, level zero starts at the lower boundary of (1, 2].
+      expect((await queryQuantile(1, negativeOnly))[0]?.Value).toBe(-1);
+      expect((await queryQuantile(0, positiveOnly))[0]?.Value).toBe(1);
+    });
+
+    it('returns zero for quantile levels zero and one when only the zero bucket is populated', async () => {
+      const metricName = 'test.quantile.endpoints.zero.only';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([0, 0]),
+          },
+        ],
+      });
+
+      // With empty negative and positive bucket arrays, both endpoint levels
+      // resolve within the zero bucket, which represents exactly zero.
+      expect((await queryQuantile(0, metricName))[0]?.Value).toBe(0);
+      expect((await queryQuantile(1, metricName))[0]?.Value).toBe(0);
+    });
+
+    it('subtracts cumulative bucket counts instead of quantiling lifetime counts', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.delta',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.cumulative.delta');
+
+      // Only the two newly recorded 4s belong to the second interval. Including
+      // the lifetime 2s would place the median at 2 instead of 2 * sqrt(2).
+      expect(result.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('1m')),
+      );
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('uses a cumulative warm-up point outside the requested range as the subtraction baseline', async () => {
+      const startTime = nowPlus('-2m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.warmup',
+        points: [
+          {
+            TimeUnix: nowPlus('-1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.cumulative.warmup');
+
+      // The -1m point is fetched only to establish the baseline. It must not be
+      // returned, and the first visible bucket contains only the two new 4s.
+      expect(result.__hdx_time_bucket).toBe(
+        toClickHouseISOString(new Date(now)),
+      );
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('emits no value for a predecessor-less cumulative point whose start predates the requested range', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.missing.predecessor',
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('-10m'),
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+        ],
+      });
+
+      // With no predecessor, the portion of the lifetime counts belonging to
+      // this interval is unknowable. Returning no quantile avoids a false spike.
+      expect(
+        await queryQuantile(0.5, 'test.cumulative.missing.predecessor'),
+      ).toEqual([]);
+    });
+
+    it('emits no value for a predecessor-less cumulative point whose start falls inside the requested range', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.midrange.start',
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('30s'),
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+        ],
+      });
+
+      // Even though this new series' entire lifetime lies inside the requested
+      // range, a predecessor-less cumulative point is suppressed rather than
+      // attributed to the chart bucket it first appears in.
+      expect(
+        await queryQuantile(0.5, 'test.cumulative.midrange.start'),
+      ).toEqual([]);
+    });
+
+    it('emits no value when the cumulative baseline precedes the one-interval warm-up window', async () => {
+      const startTime = nowPlus('-3m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.stale.baseline',
+        points: [
+          {
+            TimeUnix: nowPlus('-2m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+        ],
+      });
+
+      // The warm-up fetch reaches back exactly one granularity interval, so a
+      // baseline two minutes before the range is never read. The in-range
+      // point is then predecessor-less and contributes nothing.
+      expect(
+        await queryQuantile(0.5, 'test.cumulative.stale.baseline'),
+      ).toEqual([]);
+    });
+
+    it('treats an unknown-start reset point as zero contribution and uses it as the next baseline', async () => {
+      const originalStartTime = nowPlus('-1m');
+      const resetTime = nowPlus('1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.unknown.reset',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: originalStartTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: resetTime,
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([2, 4, 4]),
+          },
+        ],
+      });
+
+      // StartTimeUnix == TimeUnix marks an unknown-start reset and contributes
+      // nothing at 1m. The 2m point subtracts that marker, leaving only one 2.
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.unknown.reset',
+      );
+      expect(result.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('2m')),
+      );
+      expect(result.Value).toBeCloseTo(Math.sqrt(2));
+    });
+
+    it('handles an unknown-start cumulative reset spanning negative, zero, and positive buckets', async () => {
+      const resetTime = nowPlus('1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.unknown.reset.all.buckets',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: resetTime,
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([-4, 0, 2]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: resetTime,
+            ...bucketExponentialHistogramObservations([-4, -2, 0, 2]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.unknown.reset.all.buckets',
+      );
+
+      // The reset marker's negative, zero, and positive counts contribute
+      // nothing. The next point subtracts all three sides of that baseline,
+      // leaving only the newly recorded -2 in negative bucket [-2, -1).
+      expect(result.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('2m')),
+      );
+      expect(result.Value).toBeCloseTo(-Math.sqrt(2));
+    });
+
+    it('uses all current counts after a known cumulative reset', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.known.reset',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('30s'),
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.cumulative.known.reset');
+
+      // The changed start time is earlier than the point time, so this is a
+      // known reset with an implicit zero baseline. Both new-sequence 4s count.
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('uses the complete negative, zero, and positive distribution after a known cumulative reset', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.known.reset.all.buckets',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([-4, -4, 0, 0, 2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('30s'),
+            ...bucketExponentialHistogramObservations([-2, 0, 4]),
+          },
+        ],
+      });
+
+      // The changed start time begins a true reset sequence, so none of the old
+      // negative, zero, or positive counts are subtracted. In the new three-count
+      // distribution, rank 1.5 falls in the zero bucket.
+      expect(
+        await queryQuantile(0.5, 'test.cumulative.known.reset.all.buckets'),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: 0,
+        },
+      ]);
+    });
+
+    it('detects a cumulative reset from a decreased zero count with an unchanged start time', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.zero.decrease',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, 0, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, 2, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.zero.decrease',
+      );
+
+      // ZeroCount falls from two to one while every existing positive bucket
+      // is nondecreasing. The decrease alone identifies a reset, so the entire
+      // current [0, 2, 4] distribution is used and p50 is sqrt(2).
+      expect(result.Value).toBeCloseTo(Math.sqrt(2));
+    });
+
+    it('detects a cumulative reset from a decreased positive bucket with an unchanged start time', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.positive.decrease',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, 2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, 2, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.positive.decrease',
+      );
+
+      // The count in positive bucket (1, 2] falls from two to one while the
+      // zero count is unchanged. Treating the point as a new sequence yields
+      // the current [0, 2, 4] distribution and p50 = sqrt(2).
+      expect(result.Value).toBeCloseTo(Math.sqrt(2));
+    });
+
+    it('detects a cumulative reset from a decreased negative bucket with an unchanged start time', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.negative.decrease',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, -2, -2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([0, -2, -4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.negative.decrease',
+      );
+
+      // The [-2, -1) bucket falls from two to one while ZeroCount is stable.
+      // The current [-4, -2, 0] distribution is therefore used directly;
+      // rank 1.5 lies halfway through [-2, -1), giving -sqrt(2).
+      expect(result.Value).toBeCloseTo(-Math.sqrt(2));
+    });
+
+    it('detects a cumulative reset when a previous bucket disappears outside the current range', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.disappearing.bucket',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.disappearing.bucket',
+      );
+
+      // PositiveOffset moves from bucket index 0 to 1. Looking up the missing
+      // old bucket as zero detects its decrease and treats both current 4s as
+      // the new sequence, whose p50 is the bucket midpoint sqrt(8).
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('detects a cumulative reset when the current range shrinks below a previous upper bucket', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.shrinking.range',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 8]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.shrinking.range',
+      );
+
+      // The current array covers only bucket index 0, while the previous
+      // point held a positive count in bucket index 2 above that range. The
+      // vanished count is a decrease, so both current 2s form a new sequence
+      // whose p50 is the bucket midpoint sqrt(2).
+      expect(result.Value).toBeCloseTo(Math.sqrt(2));
+    });
+
+    it('detects a cumulative reset when the current negative range shrinks below a previous upper bucket', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.cumulative.reset.shrinking.negative.range',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([-2, -8]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([-2, -2]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.cumulative.reset.shrinking.negative.range',
+      );
+
+      // Mirror of the positive shrinking-range case: the previous -8 count
+      // sits above the current negative bucket range, so its disappearance
+      // marks a reset and both current -2s count, giving p50 -sqrt(2).
+      expect(result.Value).toBeCloseTo(-Math.sqrt(2));
+    });
+
+    it('uses delta-temporality bucket counts directly without subtracting the previous point', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.delta.temporality',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      const results = await queryQuantile(0.5, 'test.delta.temporality');
+
+      // The second point is already an interval distribution. Its median rank
+      // ends at the top of the (1, 2] bucket, so the result is exactly 2. If it
+      // were treated as cumulative, only the newly appearing 4 bucket remains.
+      expect(results).toHaveLength(2);
+      const firstInterval = results.find(
+        result =>
+          result.__hdx_time_bucket === toClickHouseISOString(new Date(now)),
+      );
+      const secondInterval = results.find(
+        result =>
+          result.__hdx_time_bucket === toClickHouseISOString(nowPlus('1m')),
+      );
+      expect(firstInterval?.Value).toBeCloseTo(Math.sqrt(2));
+      expect(secondInterval?.Value).toBe(2);
+    });
+
+    it('ignores unspecified-temporality exponential histograms', async () => {
+      const metricName = 'test.unspecified.temporality';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 0,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      expect(await queryQuantile(0.5, metricName)).toEqual([]);
+    });
+
+    it('sums multiple cumulative interval deltas from one series within a single chart bucket', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.multiple.points.same.chart.bucket',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('20s'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2]),
+          },
+          {
+            TimeUnix: nowPlus('40s'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      // The two sub-minute increases are [2] and [4]. They must be summed into
+      // one minute bucket before selecting a quantile; [2, 4] has p50 = 2.
+      expect(
+        await queryQuantile(0.5, 'test.multiple.points.same.chart.bucket'),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: 2,
+        },
+      ]);
+    });
+
+    it('sums multiple delta points from one series within a single chart bucket', async () => {
+      const metricName = 'test.multiple.delta.points.same.chart.bucket';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('20s'),
+            ...bucketExponentialHistogramObservations([2]),
+          },
+          {
+            TimeUnix: nowPlus('40s'),
+            ...bucketExponentialHistogramObservations([4]),
+          },
+        ],
+      });
+
+      // Both delta points fall inside the first minute bucket, so their
+      // interval counts sum to [2, 4], whose median rank reaches the upper
+      // boundary of the (1, 2] bucket.
+      expect(await queryQuantile(0.5, metricName)).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(new Date(now)),
+          Value: 2,
+        },
+      ]);
+    });
+
+    it('combines cumulative and delta temporality series within the same output group', async () => {
+      const metricName = 'test.mixed.temporality.group';
+      const groupAttributes = { route: '/mixed' };
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ResourceAttributes: { producer: 'cumulative' },
+            Attributes: { ...groupAttributes, instance: 'cumulative-a' },
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('-1m'),
+            ResourceAttributes: { producer: 'cumulative' },
+            Attributes: { ...groupAttributes, instance: 'cumulative-a' },
+            ...bucketExponentialHistogramObservations([2]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ResourceAttributes: { producer: 'delta' },
+            Attributes: { ...groupAttributes, instance: 'delta-a' },
+            ...bucketExponentialHistogramObservations([4]),
+          },
+        ],
+      });
+
+      // The cumulative series contributes its [2] increase and the delta series
+      // contributes [4] directly. After spatial aggregation, rank 1 reaches the
+      // upper boundary of the first positive bucket, producing p50 = 2.
+      expect(
+        await queryQuantile(0.5, metricName, {
+          groupBy: "Attributes['route']",
+        }),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          group: ['/mixed'],
+          Value: 2,
+        },
+      ]);
+    });
+
+    it('combines mixed temporalities and mixed scales within the same output group', async () => {
+      const metricName = 'test.mixed.temporality.and.scale.group';
+      const groupAttributes = { route: '/mixed-scale-temporality' };
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            Attributes: { ...groupAttributes, instance: 'cumulative-fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('-1m'),
+            Attributes: { ...groupAttributes, instance: 'cumulative-fine' },
+            ...bucketExponentialHistogramObservations([2], 1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { ...groupAttributes, instance: 'delta-coarse' },
+            ...bucketExponentialHistogramObservations([16], -1),
+          },
+        ],
+      });
+
+      // The cumulative scale-1 observation downscales into scale -1 bucket 0;
+      // the delta observation is already in bucket 1. Their combined p50 ends
+      // at bucket 0's upper boundary, which is 4.
+      expect(
+        await queryQuantile(0.5, metricName, {
+          groupBy: "Attributes['route']",
+        }),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          group: ['/mixed-scale-temporality'],
+          Value: 4,
+        },
+      ]);
+    });
+
+    it('normalizes different scales across independent series before combining their buckets', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.scale.across.series',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([4], -1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: 'test.scale.across.series',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([4], 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.scale.across.series');
+
+      // Both observations normalize into scale -1 bucket 0, whose bounds are
+      // (1, 4]. Their median is the bucket's geometric midpoint, 2.
+      expect(result.Value).toBeCloseTo(2);
+    });
+
+    it('normalizes an unaligned multi-bucket range across multiple coarser bucket boundaries', async () => {
+      const metricName = 'test.scale.unaligned.multi.bucket.range';
+      const fineObservations = [
+        { index: 1, count: 1 },
+        { index: 2, count: 2 },
+        { index: 3, count: 3 },
+        { index: 4, count: 4 },
+        { index: 5, count: 5 },
+        { index: 6, count: 6 },
+        { index: 7, count: 7 },
+        { index: 8, count: 8 },
+        { index: 9, count: 9 },
+      ].flatMap(({ index, count }) =>
+        Array.from({ length: count }, () => 2 ** ((index + 0.5) / 2)),
+      );
+
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations(fineObservations, 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName);
+
+      // Scale 1 indexes 1..9 have counts 1..9. Normalizing to scale -1 uses
+      // a divisor of 4, and the unaligned offset 1 produces coarse counts
+      // [1+2+3, 4+5+6+7, 8+9] = [6, 22, 17]. Rank 22.5 is therefore 75%
+      // through coarse bucket index 1, whose bounds are (4, 16]. Log-linear
+      // interpolation gives 4 * 4^0.75 = sqrt(128).
+      expect(result.Value).toBeCloseTo(Math.sqrt(128));
+    });
+
+    it('normalizes an unaligned negative multi-bucket range across multiple coarser bucket boundaries', async () => {
+      const metricName = 'test.scale.unaligned.negative.multi.bucket.range';
+      const fineObservations = [
+        { index: 1, count: 1 },
+        { index: 2, count: 2 },
+        { index: 3, count: 3 },
+        { index: 4, count: 4 },
+        { index: 5, count: 5 },
+        { index: 6, count: 6 },
+        { index: 7, count: 7 },
+        { index: 8, count: 8 },
+        { index: 9, count: 9 },
+      ].flatMap(({ index, count }) =>
+        Array.from({ length: count }, () => -(2 ** ((index + 0.5) / 2))),
+      );
+
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations(fineObservations, 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName);
+
+      // Magnitude indexes 1..9 normalize to counts [6, 22, 17] at scale -1.
+      // Negative ordering reverses those to [17, 22, 6]. Rank 22.5 is 25%
+      // through magnitude bucket index 1, interpolating from -16 toward -4
+      // to produce -sqrt(128).
+      expect(result.Value).toBeCloseTo(-Math.sqrt(128));
+    });
+
+    it('preserves internal empty buckets while normalizing a sparse fine-scale range', async () => {
+      const metricName = 'test.scale.sparse.internal.empty.buckets';
+      const fineObservations = [1, 9].map(index => 2 ** ((index + 0.5) / 2));
+
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations(fineObservations, 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.75, metricName);
+
+      // Fine indexes 1 and 9 create a dense source array with seven internal
+      // zeroes. At scale -1 they become coarse counts [1, 0, 1]. Rank 1.5
+      // skips the empty middle bucket and lands halfway through (16, 64].
+      expect(result.Value).toBeCloseTo(32);
+    });
+
+    it('normalizes a scale change within one cumulative series before calculating its delta', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.scale.within.series',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4], 0),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.scale.within.series');
+
+      // After the scale-1 baseline is downscaled to scale 0, its 2 is removed
+      // from the cumulative point and only the newly recorded 4 remains.
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('normalizes mixed scales and an in-series scale change before aggregating a group', async () => {
+      const metricName = 'test.mixed.scale.group';
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            Attributes: { route: '/mixed-scale', instance: 'changing' },
+            ...bucketExponentialHistogramObservations([2], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            Attributes: { route: '/mixed-scale', instance: 'changing' },
+            ...bucketExponentialHistogramObservations([2, 4], 0),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/mixed-scale', instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/mixed-scale', instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([4], -1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName, {
+        groupBy: "Attributes['route']",
+      });
+
+      // The changing series first normalizes its scale-1 baseline and scale-0
+      // cumulative point to scale -1, leaving one new 4. The coarse series adds
+      // another 4. Both land in scale -1 bucket (1, 4], whose midpoint is 2.
+      expect(result).toMatchObject({
+        __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+        group: ['/mixed-scale'],
+      });
+      expect(result.Value).toBeCloseTo(2);
+    });
+
+    it('floors negative bucket indexes when normalizing to a coarser scale', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.bucket.index',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], 0),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([0.5], 0),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.bucket.index',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([0.5], 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.negative.bucket.index');
+
+      // Fine-scale index -3 must floor to coarse-scale index -2, not truncate
+      // to -1. Scale-0 bucket -2 is (0.25, 0.5], with midpoint sqrt(0.125).
+      expect(result.Value).toBeCloseTo(Math.sqrt(0.125));
+    });
+
+    it('floors negative bucket indexes for negative observations when normalizing to a coarser scale', async () => {
+      const metricName = 'test.negative.side.bucket.index';
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], 0),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([-0.5], 0),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([-0.5], 1),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName);
+
+      // The negative buckets downscale separately from the positive ones, so
+      // fine-scale magnitude index -3 must also floor to coarse index -2.
+      // Scale-0 negative bucket -2 spans [-0.5, -0.25), with logarithmic
+      // midpoint -sqrt(0.125).
+      expect(result.Value).toBeCloseTo(-Math.sqrt(0.125));
+    });
+
+    it('interpolates at the finest valid scale without downscaling', async () => {
+      const scale = 20;
+      await seedExponentialHistogramMetric({
+        metricName: 'test.scale.maximum.fine.interpolation',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2, 2], scale),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.scale.maximum.fine.interpolation',
+      );
+
+      // At scale 20, value 2 occupies index 2^20 - 1. Its midpoint is only
+      // half a scale-20 logarithmic step below 2.
+      const expected = 2 ** (1 - 0.5 / 2 ** scale);
+      expect(result.Value).toBeCloseTo(expected);
+    });
+
+    it('normalizes across the full valid scale range without overflowing the divisor', async () => {
+      const metricName = 'test.scale.full.range.normalization';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'coarse' },
+            ...bucketExponentialHistogramObservations([], -10),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { instance: 'fine' },
+            ...bucketExponentialHistogramObservations([2, 2], 20),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName);
+
+      // The scale difference is 30, so the divisor is 2^30. Fine index
+      // 2^20 - 1 maps to scale -10 bucket 0, whose logarithmic midpoint is
+      // 2^512. Compare relatively because the expected value is enormous.
+      expect(result.Value / 2 ** 512).toBeCloseTo(1);
+    });
+
+    it('handles a cumulative bucket offset expanding toward smaller values', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.offset.expansion',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([4]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, 'test.offset.expansion');
+
+      // Adding 2 expands PositiveOffset from 1 to 0. Absolute bucket indexes
+      // align the old 4 correctly, leaving the new 2 as the only delta count.
+      expect(result.Value).toBeCloseTo(Math.sqrt(2));
+    });
+
+    it('handles a cumulative negative-bucket offset expanding toward smaller magnitudes', async () => {
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName: 'test.negative.offset.expansion',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([-4]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ...bucketExponentialHistogramObservations([-2, -4]),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.negative.offset.expansion',
+      );
+
+      // Adding -2 expands NegativeOffset from magnitude index 1 to 0. The old
+      // -4 count remains aligned by absolute index, leaving -2 as the delta.
+      expect(result.Value).toBeCloseTo(-Math.sqrt(2));
+    });
+
+    it('normalizes a scale change before using all counts from a known reset', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.scale.change.with.known.reset',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([2, 2], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('30s'),
+            ...bucketExponentialHistogramObservations([4, 4], 0),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(
+        0.5,
+        'test.scale.change.with.known.reset',
+      );
+
+      // Both points normalize to scale 0 before reset detection. The changed
+      // start time then selects the complete current [4, 4] distribution.
+      expect(result.Value).toBeCloseTo(Math.sqrt(8));
+    });
+
+    it('ignores other metrics, filtered attribute series, and points outside the requested range', async () => {
+      await seedExponentialHistogramMetric({
+        metricName: 'test.isolated.metric',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([2, 4]),
+          },
+          {
+            TimeUnix: nowPlus('3m'),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([2, 4, 1024, 1024]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: 'test.isolated.metric',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/noise' },
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/noise' },
+            ...bucketExponentialHistogramObservations([1024, 1024]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: 'test.unrelated.metric',
+        points: [
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([2048, 2048]),
+          },
+        ],
+      });
+
+      // Only /target's in-range [2, 4] distribution is selected. The 3m point
+      // may be read by the forward warm-up interval but must be filtered from
+      // the final chart, while the other route and metric must not contribute.
+      expect(
+        await queryQuantile(0.5, 'test.isolated.metric', {
+          where: "Attributes['route'] = '/target'",
+        }),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: 2,
+        },
+      ]);
+    });
+
+    it('excludes lower-scale filtered series and unrelated metrics before choosing the normalized scale', async () => {
+      const metricName = 'test.filtered.scale.isolation';
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([2, 2], 1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/noise' },
+            ...bucketExponentialHistogramObservations([2 ** 512], -10),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName: 'test.filtered.scale.unrelated.metric',
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/target' },
+            ...bucketExponentialHistogramObservations([2 ** 512], -10),
+          },
+        ],
+      });
+
+      const [result] = await queryQuantile(0.5, metricName, {
+        where: "Attributes['route'] = '/target'",
+      });
+
+      // Filtering leaves only the scale-1 target before min(Scale) is taken.
+      // Its two 2s remain in scale-1 bucket (sqrt(2), 2], with midpoint 2^0.75.
+      expect(result.Value).toBeCloseTo(2 ** 0.75);
+    });
+
+    it('calculates quantiles without time bucketing when granularity is omitted', async () => {
+      const metricName = 'test.no.granularity';
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+        ],
+      });
+
+      expect(
+        await queryQuantile(0.5, metricName, { granularity: null }),
+      ).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          Value: Math.sqrt(8),
+        },
+      ]);
+    });
+
+    it('returns an exponential-histogram quantile under a custom value alias', async () => {
+      const metricName = 'test.custom.quantile.alias';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+        ],
+      });
+
+      const query = await renderChartConfig(
+        {
+          select: [
+            {
+              aggFn: 'quantile',
+              alias: 'P50',
+              level: 0.5,
+              metricName,
+              metricType: MetricsDataType.ExponentialHistogram,
+              valueExpression: 'Value',
+            },
+          ],
+          from: metricSource.from,
+          where: '',
+          metricTables: TEST_METRIC_TABLES,
+          dateRange: [new Date(now), nowPlus('2m')],
+          granularity: '1 minute',
+          timestampValueExpression: metricSource.timestampValueExpression,
+          connection: connection.id,
+        },
+        metadata,
+        querySettings,
+      );
+
+      expect(await queryData(query)).toEqual([
+        {
+          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+          P50: Math.sqrt(8),
+        },
+      ]);
+    });
+
+    it('uses one normalized scale across output groups while calculating each group independently', async () => {
+      const metricName = 'test.scale.across.output.groups';
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/fine' },
+            ...bucketExponentialHistogramObservations([], 1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/fine' },
+            ...bucketExponentialHistogramObservations([2, 2], 1),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/coarse' },
+            ...bucketExponentialHistogramObservations([], -1),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/coarse' },
+            ...bucketExponentialHistogramObservations([16, 16], -1),
+          },
+        ],
+      });
+
+      const results = await queryQuantile(0.5, metricName, {
+        groupBy: "Attributes['route']",
+      });
+      const fine = results.find(result => _.isEqual(result.group, ['/fine']));
+      const coarse = results.find(result =>
+        _.isEqual(result.group, ['/coarse']),
+      );
+
+      // The global minimum scale is -1. The fine group's 2s therefore land in
+      // (1, 4] and produce midpoint 2, while the coarse group's 16s remain in
+      // (4, 16] and produce midpoint 8. Counts never cross group boundaries.
+      expect(results).toHaveLength(2);
+      expect(fine?.Value).toBeCloseTo(2);
+      expect(coarse?.Value).toBeCloseTo(8);
+    });
+
+    it('calculates each single-attribute group quantile across multiple series in that group', async () => {
+      const metricName = 'test.groupby.route';
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/checkout', instance: 'checkout-a' },
+        observations: [2],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/checkout', instance: 'checkout-b' },
+        observations: [4],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/search', instance: 'search-a' },
+        observations: [4, 4],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/search', instance: 'search-b' },
+        observations: [4, 4],
+      });
+
+      const results = await queryQuantile(0.5, metricName, {
+        groupBy: "Attributes['route']",
+      });
+      const checkout = results.find(result =>
+        _.isEqual(result.group, ['/checkout']),
+      );
+      const search = results.find(result =>
+        _.isEqual(result.group, ['/search']),
+      );
+
+      expect(results).toHaveLength(2);
+      // /checkout combines one 2 and one 4 from distinct instances. Rank 1
+      // reaches the upper boundary of the first bucket, so its p50 is 2.
+      expect(checkout).toEqual({
+        __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+        group: ['/checkout'],
+        Value: 2,
+      });
+      // /search combines four 4s across its two instances. Rank 2 is halfway
+      // through scale-0 bucket (2, 4], producing its geometric midpoint.
+      expect(search?.Value).toBeCloseTo(Math.sqrt(8));
+      expect(search?.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('1m')),
+      );
+    });
+
+    it('keeps cumulative predecessor chains separate for groups outside metric attributes', async () => {
+      const metricName = 'test.groupby.service-name';
+      const startTime = nowPlus('-1m');
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: startTime,
+            ServiceName: 'service-a',
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: startTime,
+            ServiceName: 'service-a',
+            ...bucketExponentialHistogramObservations([2]),
+          },
+          {
+            TimeUnix: nowPlus('20s'),
+            StartTimeUnix: startTime,
+            ServiceName: 'service-b',
+            ...bucketExponentialHistogramObservations([]),
+          },
+          {
+            TimeUnix: nowPlus('80s'),
+            StartTimeUnix: startTime,
+            ServiceName: 'service-b',
+            ...bucketExponentialHistogramObservations([2]),
+          },
+        ],
+      });
+
+      const results = await queryQuantile(0.5, metricName, {
+        groupBy: 'ServiceName',
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          {
+            __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+            group: ['service-a'],
+            Value: Math.sqrt(2),
+          },
+          {
+            __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+            group: ['service-b'],
+            Value: Math.sqrt(2),
+          },
+        ]),
+      );
+    });
+
+    it('calculates each composite group quantile across multiple series in that group', async () => {
+      const metricName = 'test.groupby.route.method';
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/orders', method: 'GET', instance: 'get-a' },
+        observations: [0],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/orders', method: 'GET', instance: 'get-b' },
+        observations: [0, 2, 2],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/orders', method: 'POST', instance: 'post-a' },
+        observations: [-4, -4],
+      });
+      await seedGroupedCumulativeSeries({
+        metricName,
+        attributes: { route: '/orders', method: 'POST', instance: 'post-b' },
+        observations: [-4, -4],
+      });
+
+      const results = await queryQuantile(0.5, metricName, {
+        groupBy: "Attributes['route'], Attributes['method']",
+      });
+      const get = results.find(result =>
+        _.isEqual(result.group, ['/orders', 'GET']),
+      );
+      const post = results.find(result =>
+        _.isEqual(result.group, ['/orders', 'POST']),
+      );
+
+      expect(results).toHaveLength(2);
+      // GET combines two zero counts and two positive counts across its two
+      // instances. Rank 2 lands at the end of the zero bucket, so p50 is zero.
+      expect(get).toEqual({
+        __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+        group: ['/orders', 'GET'],
+        Value: 0,
+      });
+      // POST combines four -4 observations across two instances. Halfway
+      // through negative bucket [-4, -2) is the logarithmic value -sqrt(8).
+      expect(post?.Value).toBeCloseTo(-Math.sqrt(8));
+      expect(post?.__hdx_time_bucket).toBe(
+        toClickHouseISOString(nowPlus('1m')),
+      );
     });
   });
 

--- a/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
+++ b/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
@@ -3494,6 +3494,76 @@ describe('renderChartConfig', () => {
       expect(res).toMatchSnapshot();
     });
 
+    it('should merge exponential histogram buckets across metricNameSql aliases after calculating per-name deltas', async () => {
+      const attributes = { service: 'shared-service' };
+      await Promise.all([
+        seedExponentialHistogramMetric({
+          metricName: 'container.cpu.utilization',
+          points: [
+            {
+              TimeUnix: new Date(now),
+              Attributes: attributes,
+              ...bucketExponentialHistogramObservations([]),
+            },
+            {
+              TimeUnix: nowPlus('1m'),
+              Attributes: attributes,
+              ...bucketExponentialHistogramObservations([2, 2, 2, 8]),
+            },
+          ],
+        }),
+        seedExponentialHistogramMetric({
+          metricName: 'container.cpu.usage',
+          points: [
+            {
+              TimeUnix: nowPlus('10s'),
+              Attributes: attributes,
+              ...bucketExponentialHistogramObservations([]),
+            },
+            {
+              TimeUnix: nowPlus('70s'),
+              Attributes: attributes,
+              ...bucketExponentialHistogramObservations([
+                2, 2, 2, 2, 2, 2, 2, 8, 8, 8,
+              ]),
+            },
+          ],
+        }),
+      ]);
+
+      const query = await renderChartConfig(
+        {
+          select: [
+            {
+              aggFn: 'quantile',
+              level: 0.75,
+              metricName: 'container.cpu.utilization',
+              metricNameSql:
+                "MetricName IN ('container.cpu.utilization', 'container.cpu.usage')",
+              metricType: MetricsDataType.ExponentialHistogram,
+              valueExpression: 'Value',
+            },
+          ],
+          from: metricSource.from,
+          where: '',
+          metricTables: TEST_METRIC_TABLES,
+          dateRange: [new Date(now), nowPlus('2m')],
+          granularity: '1 minute',
+          timestampValueExpression: metricSource.timestampValueExpression,
+          connection: connection.id,
+        },
+        metadata,
+        querySettings,
+      );
+
+      const res = await queryData(query);
+      expect(res).toHaveLength(1);
+      expect(res[0]).toEqual({
+        __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
+        Value: expect.closeTo(2 ** (17 / 8)),
+      });
+    });
+
     it('should handle metrics without metricNameSql (backward compatibility)', async () => {
       // Test querying the old metric name directly without migration SQL
       const query = await renderChartConfig(

--- a/packages/api/src/fixtures.ts
+++ b/packages/api/src/fixtures.ts
@@ -402,6 +402,119 @@ export const bulkInsertMetricsHistogram = async (
   );
 };
 
+type ExponentialHistogramMetricPoint = {
+  TimeUnix: Date;
+  ServiceName?: string;
+  Scale?: number;
+  Count?: number;
+  Sum?: number;
+  ZeroCount?: number;
+  PositiveOffset?: number;
+  PositiveBucketCounts?: number[];
+  NegativeOffset?: number;
+  NegativeBucketCounts?: number[];
+  StartTimeUnix?: Date;
+  ResourceAttributes?: Record<string, string>;
+  ScopeAttributes?: Record<string, string>;
+  Attributes?: Record<string, string>;
+};
+
+type DenseExponentialHistogramBuckets = {
+  offset: number;
+  counts: number[];
+};
+
+const toDenseExponentialHistogramBuckets = (
+  buckets: Map<number, number>,
+): DenseExponentialHistogramBuckets => {
+  if (buckets.size === 0) {
+    return { offset: 0, counts: [] };
+  }
+
+  const indexes = [...buckets.keys()];
+  const offset = Math.min(...indexes);
+  const counts = Array(Math.max(...indexes) - offset + 1).fill(0);
+  for (const [index, count] of buckets) {
+    counts[index - offset] = count;
+  }
+  return { offset, counts };
+};
+
+export const bucketExponentialHistogramObservations = (
+  observations: number[],
+  scale = 0,
+) => {
+  if (!Number.isInteger(scale)) {
+    throw new Error('exponential histogram scale must be an integer');
+  }
+
+  const positiveBuckets = new Map<number, number>();
+  const negativeBuckets = new Map<number, number>();
+  let zeroCount = 0;
+
+  for (const observation of observations) {
+    if (!Number.isFinite(observation)) {
+      throw new Error('exponential histogram observations must be finite');
+    }
+    if (observation === 0) {
+      zeroCount += 1;
+      continue;
+    }
+
+    const buckets = observation > 0 ? positiveBuckets : negativeBuckets;
+    const index = Math.ceil(Math.log2(Math.abs(observation)) * 2 ** scale) - 1;
+    buckets.set(index, (buckets.get(index) ?? 0) + 1);
+  }
+
+  const positive = toDenseExponentialHistogramBuckets(positiveBuckets);
+  const negative = toDenseExponentialHistogramBuckets(negativeBuckets);
+  return {
+    Scale: scale,
+    Count: observations.length,
+    Sum: observations.reduce((sum, observation) => sum + observation, 0),
+    ZeroCount: zeroCount,
+    PositiveOffset: positive.offset,
+    PositiveBucketCounts: positive.counts,
+    NegativeOffset: negative.offset,
+    NegativeBucketCounts: negative.counts,
+  };
+};
+
+export const seedExponentialHistogramMetric = async ({
+  metricName,
+  points,
+  aggregationTemporality = 2,
+}: {
+  metricName: string;
+  points: ExponentialHistogramMetricPoint[];
+  aggregationTemporality?: number;
+}) => {
+  if (!config.IS_CI) {
+    throw new Error('ONLY execute this in CI env 😈 !!!');
+  }
+
+  const startTimeUnix = points[0]?.StartTimeUnix ?? points[0]?.TimeUnix;
+  await bulkInsertData(
+    `${DEFAULT_DATABASE}.${DEFAULT_METRICS_TABLE.EXPONENTIAL_HISTOGRAM}`,
+    points.map(point => ({
+      MetricName: metricName,
+      ServiceName: 'test-service',
+      ResourceAttributes: {},
+      ScopeAttributes: {},
+      Attributes: {},
+      StartTimeUnix: startTimeUnix,
+      AggregationTemporality: aggregationTemporality,
+      Scale: 0,
+      ZeroCount: 0,
+      PositiveOffset: 0,
+      PositiveBucketCounts: [],
+      NegativeOffset: 0,
+      NegativeBucketCounts: [],
+      ...point,
+    })),
+  );
+};
+
 enum MetricsDataType {
   Gauge = 'Gauge',
   Histogram = 'Histogram',

--- a/packages/common-utils/src/core/histogram.ts
+++ b/packages/common-utils/src/core/histogram.ts
@@ -1,6 +1,8 @@
 import { ChSql, chSql } from '@/clickhouse';
 import { BuilderChartConfig } from '@/types';
 
+import { FIXED_TIME_BUCKET_EXPR_ALIAS } from './renderChartConfig';
+
 type WithClauses = BuilderChartConfig['with'];
 type TemplatedInput = ChSql | string;
 
@@ -193,5 +195,355 @@ const translateHistogramQuantile = ({
           FROM points
           WHERE length(point) > 1 AND total > 0
           `,
+  },
+];
+
+// Assumption: `from` filters for a single MetricName.
+export const translateExponentialHistogram = ({
+  select,
+  ...rest
+}: {
+  select: Exclude<BuilderChartConfig['select'], string>[number];
+  timeBucketSelect: TemplatedInput;
+  groupBy?: TemplatedInput;
+  from: TemplatedInput;
+  where: TemplatedInput;
+  valueAlias: TemplatedInput;
+}) => {
+  if (select.aggFn === 'quantile') {
+    if (!('level' in select) || select.level === null)
+      throw new Error('quantile must have a level');
+    return translateExponentialHistogramQuantile({
+      ...rest,
+      level: select.level,
+    });
+  }
+  throw new Error(`${select.aggFn} is not supported for histograms currently`);
+};
+
+const translateExponentialHistogramQuantile = ({
+  timeBucketSelect,
+  groupBy,
+  from,
+  where,
+  valueAlias,
+  level,
+}: {
+  timeBucketSelect: TemplatedInput;
+  groupBy?: TemplatedInput;
+  from: TemplatedInput;
+  where: TemplatedInput;
+  valueAlias: TemplatedInput;
+  level: number;
+}): WithClauses => [
+  // Filter for the relevant source data
+  {
+    name: 'filtered_series',
+    sql: chSql`
+      SELECT
+        TimeUnix,
+        StartTimeUnix,
+        AggregationTemporality,
+        Scale,
+        ${ATTR_HASH_EXPR} AS attr_hash,
+        ${groupBy ? chSql`[${groupBy}] as group,` : ''}
+        ZeroCount,
+        PositiveOffset,
+        PositiveBucketCounts,
+        NegativeOffset,
+        NegativeBucketCounts
+      FROM ${from}
+      WHERE ${where}
+    `,
+  },
+  // Series with non-matching Scales must be normalized to the minimum scale (largest bucket width)
+  // so that they can be aggregated together. Consecutive buckets are summed when reducing scale.
+  // Buckets are combined by summing their counts. Series already at the normalized scale pass through.
+  {
+    name: 'series_with_normalized_scale',
+    sql: chSql`
+      SELECT
+        TimeUnix,
+        StartTimeUnix,
+        AggregationTemporality,
+        normalized_scale AS Scale,
+        attr_hash,
+        ${groupBy ? 'group,' : ''}
+        ZeroCount,
+        
+        assumeNotNull((SELECT min(Scale) FROM filtered_series)) AS normalized_scale,
+        series.Scale - normalized_scale AS scale_shift,
+        bitShiftLeft(toInt64(1), scale_shift) AS scale_divisor, ${'' /* 2^scale_shift */}
+
+        ${'' /* Indexes at the normalized scale are floor(index / scale_divisor); right shift floor-divides by 2^scale_shift. */}
+        series.PositiveOffset + length(series.PositiveBucketCounts) - 1 AS positive_last_index,
+        bitShiftRight(series.PositiveOffset, scale_shift) AS normalized_positive_offset,
+        normalized_negative_offset AS NegativeOffset,
+
+        series.NegativeOffset + length(series.NegativeBucketCounts) - 1 AS negative_last_index,
+        bitShiftRight(series.NegativeOffset, scale_shift) AS normalized_negative_offset,
+        normalized_positive_offset AS PositiveOffset,
+
+        ${'' /* Downscale buckets by splitting at normalized-bucket boundaries (absolute index divisible by scale_divisor) and summing each group */}
+        if(
+          scale_shift = 0,
+          series.PositiveBucketCounts,
+          arrayMap(
+            bucket_group -> arraySum(bucket_group),
+            arraySplit(
+              (count, index) -> positiveModulo(index, scale_divisor) = 0,
+              series.PositiveBucketCounts,
+              range(series.PositiveOffset, positive_last_index + 1)
+            )
+          )
+        ) AS PositiveBucketCounts,
+
+        if(
+          scale_shift = 0,
+          series.NegativeBucketCounts,
+          arrayMap(
+            bucket_group -> arraySum(bucket_group),
+            arraySplit(
+              (count, index) -> positiveModulo(index, scale_divisor) = 0,
+              series.NegativeBucketCounts,
+              range(series.NegativeOffset, negative_last_index + 1)
+            )
+          )
+        ) AS NegativeBucketCounts
+      FROM filtered_series AS series
+    `,
+  },
+  // Normalize cumulative count series to deltas, and pass through
+  // delta-temporality series unchanged. UNION the normalized points.
+  {
+    name: 'normalized_deltas',
+    sql: chSql`
+      SELECT
+        TimeUnix,
+        Scale,
+        ${groupBy ? 'group,' : ''}
+
+        ${'' /* Points with no usable predecessor or (StartTimeUnix = TimeUnix) contribute no delta */}
+        is_first_series_point OR StartTimeUnix = TimeUnix AS use_zero_counts,
+
+        ${'' /* Changed StartTimeUnix or decreased counts are resets, so the current counts = delta. */}
+        NOT use_zero_counts
+          AND (
+            StartTimeUnix != previous_start_time
+            OR current_zero_count < previous_zero_count
+            OR positive_counts_decreased
+            OR negative_counts_decreased
+          ) AS use_current_counts,
+
+        ${'' /** Subtract previous counts from current counts to find the delta values */}
+        multiIf(
+          use_zero_counts, 0,
+          use_current_counts, current_zero_count,
+          current_zero_count - previous_zero_count
+        ) AS ZeroCount,
+        if(
+          use_zero_counts,
+          emptyArrayInt64(),
+          range(
+            PositiveOffset,
+            PositiveOffset + length(current_positive_bucket_counts)
+          )
+        ) AS positive_bucket_indexes,
+        multiIf(
+          use_zero_counts,
+          emptyArrayInt64(),
+          use_current_counts,
+          current_positive_bucket_counts,
+          positive_deltas
+        ) AS positive_bucket_counts,
+        if(
+          use_zero_counts,
+          emptyArrayInt64(),
+          range(
+            NegativeOffset,
+            NegativeOffset + length(current_negative_bucket_counts)
+          )
+        ) AS negative_bucket_indexes,
+        multiIf(
+          use_zero_counts,
+          emptyArrayInt64(),
+          use_current_counts,
+          current_negative_bucket_counts,
+          negative_deltas
+        ) AS negative_bucket_counts
+      FROM (
+        SELECT
+          TimeUnix,
+          StartTimeUnix,
+          Scale,
+          attr_hash,
+          ${groupBy ? 'group,' : ''}
+          PositiveOffset,
+          NegativeOffset,
+
+          ${'' /** Cast to Int64 so every multiIf/if branch over these columns in normalized_deltas shares one type; mixing Array(UInt64) with the Int64 delta arrays would otherwise produce a Variant type that breaks sumMap. */}
+          toInt64(series.ZeroCount) AS current_zero_count,
+          series.PositiveBucketCounts::Array(Int64) AS current_positive_bucket_counts,
+          series.NegativeBucketCounts::Array(Int64) AS current_negative_bucket_counts,
+
+          count() OVER prev_row = 0 AS is_first_series_point,
+          toInt64(any(series.ZeroCount) OVER prev_row) AS previous_zero_count,
+          any(series.StartTimeUnix) OVER prev_row AS previous_start_time,
+          any(series.PositiveOffset) OVER prev_row AS previous_positive_offset,
+          any(series.NegativeOffset) OVER prev_row AS previous_negative_offset,
+          (any(series.PositiveBucketCounts) OVER prev_row)::Array(Int64)
+            AS previous_positive_bucket_counts,
+          (any(series.NegativeBucketCounts) OVER prev_row)::Array(Int64)
+            AS previous_negative_bucket_counts,
+
+          ${'' /** Shift the previous counts to align with the current array's index window (defined by current Offsets) */}
+          arrayResize(
+            arrayConcat(
+              arrayWithConstant(greatest(0, previous_positive_offset - series.PositiveOffset), 0),
+              arraySlice(
+                previous_positive_bucket_counts,
+                1 + greatest(0, series.PositiveOffset - previous_positive_offset)
+              )
+            ),
+            length(current_positive_bucket_counts)
+          ) AS aligned_previous_positive_counts,
+          arrayResize(
+            arrayConcat(
+              arrayWithConstant(greatest(0, previous_negative_offset - series.NegativeOffset), 0),
+              arraySlice(
+                previous_negative_bucket_counts,
+                1 + greatest(0, series.NegativeOffset - previous_negative_offset)
+              )
+            ),
+            length(current_negative_bucket_counts)
+          ) AS aligned_previous_negative_counts,
+          
+          ${'' /** Element-wise deltas between current and previous bucket counts */}
+          current_positive_bucket_counts - aligned_previous_positive_counts
+            AS positive_deltas,
+          current_negative_bucket_counts - aligned_previous_negative_counts
+            AS negative_deltas,
+
+          ${'' /* A bucket count decreased iff a current count decreased, or a positive previous count was dropped during alignment. */}
+          arrayMin(positive_deltas) < 0
+            OR arraySum(previous_positive_bucket_counts) > arraySum(aligned_previous_positive_counts)
+            AS positive_counts_decreased,
+          arrayMin(negative_deltas) < 0
+            OR arraySum(previous_negative_bucket_counts) > arraySum(aligned_previous_negative_counts)
+            AS negative_counts_decreased
+        FROM (
+          SELECT *
+          FROM series_with_normalized_scale
+          WHERE AggregationTemporality = 2
+          ${'' /** Keep the input ordering aligned with the prev_row window sort/partition keys. */}
+          ORDER BY ${groupBy ? 'group, ' : ''}attr_hash, TimeUnix
+        ) AS series
+        WINDOW prev_row AS (
+          PARTITION BY ${groupBy ? 'group, ' : ''}attr_hash
+          ORDER BY TimeUnix
+          ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
+        )
+      )
+
+      UNION ALL
+
+      ${'' /** Delta-temporality branch: interval counts pass through directly. */}
+      SELECT
+        TimeUnix,
+        Scale,
+        ${groupBy ? 'group,' : ''}
+        toUInt8(0) AS use_zero_counts,
+        toUInt8(1) AS use_current_counts,
+        toInt64(ZeroCount) AS ZeroCount,
+        range(
+          PositiveOffset,
+          PositiveOffset + length(PositiveBucketCounts)
+        ) AS positive_bucket_indexes,
+        PositiveBucketCounts::Array(Int64) AS positive_bucket_counts,
+        range(
+          NegativeOffset,
+          NegativeOffset + length(NegativeBucketCounts)
+        ) AS negative_bucket_indexes,
+        NegativeBucketCounts::Array(Int64) AS negative_bucket_counts
+      FROM series_with_normalized_scale
+      WHERE AggregationTemporality = 1
+    `,
+  },
+  // Sum bucket deltas across series for each (time bucket, group) tuple.
+  {
+    name: 'summed_buckets',
+    sql: chSql`
+      SELECT
+        ${timeBucketSelect},
+        ${groupBy ? 'group,' : ''}
+        any(Scale) AS Scale,
+        sum(ZeroCount) AS ZeroCount,
+        sumMap(positive_bucket_indexes, positive_bucket_counts) AS positive_buckets,
+        sumMap(negative_bucket_indexes, negative_bucket_counts) AS negative_buckets
+      FROM normalized_deltas
+      GROUP BY ${FIXED_TIME_BUCKET_EXPR_ALIAS}${groupBy ? ', group' : ''}
+    `,
+  },
+  // Select the bucket containing the requested quantile rank.
+  {
+    name: 'selected_quantile_buckets',
+    sql: chSql`
+      SELECT
+        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
+        ${groupBy ? 'group,' : ''}
+        Scale,
+
+        ${'' /* Negative, zero, and positive buckets arranged in ascending value order. */}
+        length(negative_buckets.1) AS negative_bucket_count,
+        arrayConcat(
+          arrayReverse(negative_buckets.1),
+          [0],
+          positive_buckets.1
+        ) AS bucket_indexes,
+        arrayConcat(
+          arrayReverse(negative_buckets.2),
+          [ZeroCount],
+          positive_buckets.2
+        ) AS bucket_counts,
+        
+        ${'' /* Requested rank and cumulative count at every ordered bucket; the last cumulative count is the total. */}
+        arrayCumSum(bucket_counts) AS cumulative_counts,
+        cumulative_counts[-1] AS total,
+        ${{ Float64: level }} * total AS rank,
+
+        ${'' /* First non-empty bucket containing the requested rank. */}
+        arrayFirstIndex(
+          (cumulative_count, bucket_count) -> bucket_count > 0 AND cumulative_count >= rank,
+          cumulative_counts,
+          bucket_counts
+        ) AS selected_bucket_position,
+        
+        ${'' /* The first negative_bucket_count positions hold negative buckets and the next position holds the zero bucket, so the selected side is the sign of the position relative to the zero bucket's position. */}
+        sign(selected_bucket_position - negative_bucket_count - 1) AS selected_bucket_side,
+        bucket_indexes[selected_bucket_position] AS selected_bucket_index,
+
+        ${'' /* An out-of-range array subscript returns 0, so the first position needs no special case. */}
+        (rank - cumulative_counts[selected_bucket_position - 1])
+          / bucket_counts[selected_bucket_position] AS fraction_within_bucket
+      FROM summed_buckets
+      WHERE total > 0 AND selected_bucket_position > 0
+    `,
+  },
+  // Interpolate (log-linear) the quantile within the selected bucket
+  {
+    name: 'metrics',
+    sql: chSql`
+      SELECT
+        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
+        ${groupBy ? 'group,' : ''}
+        multiIf(
+          selected_bucket_side < 0,
+          -exp2((selected_bucket_index + 1 - fraction_within_bucket) * exp2(-Scale)),
+          selected_bucket_side > 0,
+          exp2((selected_bucket_index + fraction_within_bucket) * exp2(-Scale)),
+          0 ${'' /* ZeroThreshold is not stored, so the zero bucket represents exactly zero. */}
+        ) AS "${valueAlias}"
+      FROM selected_quantile_buckets
+    `,
   },
 ];

--- a/packages/common-utils/src/core/histogram.ts
+++ b/packages/common-utils/src/core/histogram.ts
@@ -198,7 +198,6 @@ const translateHistogramQuantile = ({
   },
 ];
 
-// Assumption: `from` filters for a single MetricName.
 export const translateExponentialHistogram = ({
   select,
   ...rest
@@ -241,6 +240,7 @@ const translateExponentialHistogramQuantile = ({
     name: 'filtered_series',
     sql: chSql`
       SELECT
+        MetricName,
         TimeUnix,
         StartTimeUnix,
         AggregationTemporality,
@@ -263,6 +263,7 @@ const translateExponentialHistogramQuantile = ({
     name: 'series_with_normalized_scale',
     sql: chSql`
       SELECT
+        MetricName,
         TimeUnix,
         StartTimeUnix,
         AggregationTemporality,
@@ -319,6 +320,7 @@ const translateExponentialHistogramQuantile = ({
     name: 'normalized_deltas',
     sql: chSql`
       SELECT
+        MetricName,
         TimeUnix,
         Scale,
         ${groupBy ? 'group,' : ''}
@@ -373,6 +375,7 @@ const translateExponentialHistogramQuantile = ({
         ) AS negative_bucket_counts
       FROM (
         SELECT
+          MetricName,
           TimeUnix,
           StartTimeUnix,
           Scale,
@@ -436,10 +439,10 @@ const translateExponentialHistogramQuantile = ({
           FROM series_with_normalized_scale
           WHERE AggregationTemporality = 2
           ${'' /** Keep the input ordering aligned with the prev_row window sort/partition keys. */}
-          ORDER BY ${groupBy ? 'group, ' : ''}attr_hash, TimeUnix
+          ORDER BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash, TimeUnix
         ) AS series
         WINDOW prev_row AS (
-          PARTITION BY ${groupBy ? 'group, ' : ''}attr_hash
+          PARTITION BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash
           ORDER BY TimeUnix
           ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
         )
@@ -449,6 +452,7 @@ const translateExponentialHistogramQuantile = ({
 
       ${'' /** Delta-temporality branch: interval counts pass through directly. */}
       SELECT
+        MetricName,
         TimeUnix,
         Scale,
         ${groupBy ? 'group,' : ''}

--- a/packages/common-utils/src/core/histogram.ts
+++ b/packages/common-utils/src/core/histogram.ts
@@ -5,6 +5,13 @@ import { FIXED_TIME_BUCKET_EXPR_ALIAS } from './renderChartConfig';
 
 type WithClauses = BuilderChartConfig['with'];
 type TemplatedInput = ChSql | string;
+type HistogramCountInput = {
+  timeBucketSelect: TemplatedInput;
+  groupBy?: TemplatedInput;
+  from: TemplatedInput;
+  where: TemplatedInput;
+  valueAlias: TemplatedInput;
+};
 
 // SQL expression for hashing metric attributes into a per-series key.
 // Variadic cityHash64 over the three attribute scopes — works for both
@@ -45,13 +52,7 @@ const translateHistogramCount = ({
   from,
   where,
   valueAlias,
-}: {
-  timeBucketSelect: TemplatedInput;
-  groupBy?: TemplatedInput;
-  from: TemplatedInput;
-  where: TemplatedInput;
-  valueAlias: TemplatedInput;
-}): WithClauses => [
+}: HistogramCountInput): WithClauses => [
   {
     name: 'source',
     sql: chSql`
@@ -217,8 +218,67 @@ export const translateExponentialHistogram = ({
       level: select.level,
     });
   }
-  throw new Error(`${select.aggFn} is not supported for histograms currently`);
+  if (select.aggFn === 'count') {
+    return translateExponentialHistogramCount(rest);
+  }
+  throw new Error(
+    `${select.aggFn} is not currently supported for exponential histogram metrics`,
+  );
 };
+
+const translateExponentialHistogramCount = ({
+  timeBucketSelect,
+  groupBy,
+  from,
+  where,
+  valueAlias,
+}: HistogramCountInput): WithClauses => [
+  {
+    name: 'source',
+    sql: chSql`
+      SELECT
+        MetricName,
+        TimeUnix,
+        StartTimeUnix,
+        AggregationTemporality,
+        ${timeBucketSelect},
+        ${groupBy ? chSql`[${groupBy}] AS group,` : ''}
+        ${ATTR_HASH_EXPR} AS attr_hash,
+        toInt64(Count) AS current_count,
+        count() OVER prev_row = 0 AS is_first_series_point,
+        toInt64(any(Count) OVER prev_row) AS previous_count,
+        any(StartTimeUnix) OVER prev_row AS previous_start_time,
+        CASE
+          WHEN AggregationTemporality = 1 THEN current_count
+          WHEN AggregationTemporality = 2 THEN
+            multiIf(
+              is_first_series_point OR StartTimeUnix = TimeUnix, 0,
+              StartTimeUnix != previous_start_time OR current_count < previous_count, current_count,
+              current_count - previous_count
+            )
+          ELSE 0
+        END AS delta
+      FROM ${from}
+      WHERE ${where}
+      WINDOW prev_row AS (
+        PARTITION BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash, AggregationTemporality
+        ORDER BY TimeUnix
+        ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
+      )
+    `,
+  },
+  {
+    name: 'metrics',
+    sql: chSql`
+      SELECT
+        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
+        ${groupBy ? 'group,' : ''}
+        sum(delta) AS "${valueAlias}"
+      FROM source
+      GROUP BY ${FIXED_TIME_BUCKET_EXPR_ALIAS}${groupBy ? ', group' : ''}
+    `,
+  },
+];
 
 const translateExponentialHistogramQuantile = ({
   timeBucketSelect,
@@ -473,7 +533,8 @@ const translateExponentialHistogramQuantile = ({
       WHERE AggregationTemporality = 1
     `,
   },
-  // Sum bucket deltas across series for each (time bucket, group) tuple.
+  // Sum bucket deltas across series and metric-name aliases for each
+  // (time bucket, group) tuple.
   {
     name: 'summed_buckets',
     sql: chSql`

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -3,7 +3,10 @@ import * as SQLParser from 'node-sql-parser';
 import SqlString from 'sqlstring';
 
 import { ChSql, chSql, concatChSql, wrapChSqlIfNotEmpty } from '@/clickhouse';
-import { translateHistogram } from '@/core/histogram';
+import {
+  translateExponentialHistogram,
+  translateHistogram,
+} from '@/core/histogram';
 import { Metadata } from '@/core/metadata';
 import {
   convertDateRangeToGranularityString,
@@ -48,7 +51,6 @@ import {
   SearchCondition,
   SearchConditionLanguage,
   SelectList,
-  SelectSQLStatement,
   SortSpecificationList,
   SqlAstFilter,
   SQLInterval,
@@ -75,14 +77,6 @@ type ColumnRef = SQLParser.ColumnRef & {
     index: { type: string; value: string };
   }[];
 };
-
-function determineTableName(select: SelectSQLStatement): string {
-  if ('metricTables' in select.from) {
-    return select.from.tableName;
-  }
-
-  return '';
-}
 
 const DEFAULT_METRIC_TABLE_TIME_COLUMN = 'TimeUnix';
 export const FIXED_TIME_BUCKET_EXPR_ALIAS = '__hdx_time_bucket';
@@ -338,7 +332,7 @@ const fastifySQL = ({
     traverse(ast.where);
 
     return parser.sqlify(ast);
-  } catch (e) {
+  } catch {
     return rawSQL;
   }
 };
@@ -1653,7 +1647,7 @@ async function translateMetricChartConfig(
   }
 
   // assumes all the selects are from a single metric type, for now
-  const { select, from, filters, where, ...restChartConfig } = chartConfig;
+  const { select, from, filters, ...restChartConfig } = chartConfig;
   if (!select || !Array.isArray(select)) {
     throw new Error('multi select or string select on metrics not supported');
   }
@@ -1666,6 +1660,17 @@ async function translateMetricChartConfig(
       `aggFn 'increase' is only supported for Sum (counter) metrics (got metricType=${metricType})`,
     );
   }
+
+  const isExponentialHistogram =
+    metricType === MetricsDataType.ExponentialHistogram &&
+    metricName &&
+    MetricsDataType.ExponentialHistogram in metricTables &&
+    metricTables[MetricsDataType.ExponentialHistogram];
+  const isHistogram =
+    metricType === MetricsDataType.Histogram &&
+    metricName &&
+    MetricsDataType.Histogram in metricTables &&
+    metricTables[MetricsDataType.Histogram];
 
   // AttributesHash is computed inline with a variadic cityHash64 call
   // (HDX-4466). This works for both Map(LowCardinality(String), String) and
@@ -2021,12 +2026,7 @@ async function translateMetricChartConfig(
         : restChartConfig.whereLanguage,
       timestampValueExpression: `\`${timeBucketCol}\``,
     };
-  } else if (
-    metricType === MetricsDataType.Histogram &&
-    metricName &&
-    MetricsDataType.Histogram in metricTables &&
-    metricTables[MetricsDataType.Histogram]
-  ) {
+  } else if (isHistogram || isExponentialHistogram) {
     const { alias } = _select;
     // Use the alias from the select, defaulting to 'Value' for backwards compatibility
     const valueAlias = alias || 'Value';
@@ -2039,7 +2039,8 @@ async function translateMetricChartConfig(
       ...chartConfig,
       from: {
         ...from,
-        tableName: metricTables[MetricsDataType.Histogram],
+        // eslint-disable-next-line security/detect-object-injection
+        tableName: metricTables[metricType],
       },
       filters: [
         ...(filters ?? []),
@@ -2075,25 +2076,30 @@ async function translateMetricChartConfig(
       );
     }
 
+    const translationInput = {
+      select: _select,
+      timeBucketSelect: timeBucketSelect.sql
+        ? chSql`${timeBucketSelect}`
+        : 'TimeUnix AS `__hdx_time_bucket`',
+      groupBy,
+      from: renderFrom({
+        from: {
+          ...from,
+          // eslint-disable-next-line security/detect-object-injection
+          tableName: metricTables[metricType],
+        },
+        isRenderingRawSqlTemplate: chartConfig.isRenderingRawSqlTemplate,
+        metricType,
+      }),
+      where,
+      valueAlias,
+    };
+
     return {
       ...restChartConfig,
-      with: translateHistogram({
-        select: _select,
-        timeBucketSelect: timeBucketSelect.sql
-          ? chSql`${timeBucketSelect}`
-          : 'TimeUnix AS `__hdx_time_bucket`',
-        groupBy,
-        from: renderFrom({
-          from: {
-            ...from,
-            tableName: metricTables[MetricsDataType.Histogram],
-          },
-          isRenderingRawSqlTemplate: chartConfig.isRenderingRawSqlTemplate,
-          metricType: MetricsDataType.Histogram,
-        }),
-        where,
-        valueAlias,
-      }),
+      with: isExponentialHistogram
+        ? translateExponentialHistogram(translationInput)
+        : translateHistogram(translationInput),
       select: `\`__hdx_time_bucket\`${groupBy ? ', group' : ''}, "${valueAlias}"`,
       from: {
         databaseName: '',


### PR DESCRIPTION
## Summary

This PR implements quantile and sum aggregations over OTEL Exponential Histogram metrics in the query builder.

max/min/sum aggregations are not supported, consistent with the histogram metrics implementation, because max/min/sum are optional in the OTEL Histogram data model. Similarly avg is not supported because it would rely on the unsupported sum aggregation.

**Known limitation:** Only timeseries display type is correct, inline with the existing histogram metric type. HDX-4858 will address this limitation.

### Exponential Histogram Data Model

See the OTEL Docs: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram

Important notes:

1. Scale can differ between and within series. To correctly aggregate counts, the smallest scale must be used, and metrics with larger scales must be converted to the smaller series (courser buckets).
2. Offsets can (and often do) differ between data points in the same series, so calculating deltas from cumulative counts requires first aligning bucket indexes between the current and previous data point.

### Query details

The quantile query is horrifying! It is broken into a few CTEs:

1. `filtered_series` - first step, apply filters so that later stages are only working with the relevant data
2. `series_with_normalized_scale` - Convert all data points to the minimum Scale value, so that they can be aggregated later. Finer-grained buckets are combined to reduce Scale. Offsets are accounted for so that the buckets being combined are aligned correctly.
3. `normalized_deltas` - This is a passthrough for metrics with delta temporality. For cumulative temporality, this converts cumulative counts in each data point to deltas, by comparing counts in each data point to the counts from the previous data point in the same series, via a window function. This is the most expensive part of the process, for cumulative metrics.
4. `summed_buckets` - Sum bucket counts across timeseries by time bucket + custom group by
5. `selected_quantile_buckets` - for each time bucket + custom group by, find the histogram bucket containing the requested quantile level. This requires combining negative, zero, and positive counts, in bucket order, then converting each bucket to a cumulative sum (sum of its own counts and counts in all lesser buckets).
6. `metrics` - Within the bucket, estimate the quantile value by interpolating between the bucket's upper and lower bounds. Use log-linear interpolation to match Prometheus behavior.

### Screenshots or video

<img width="2498" height="478" alt="Screenshot 2026-07-21 at 11 49 08 AM" src="https://github.com/user-attachments/assets/ca9bffc2-6579-4892-bc4c-9696dc60aa4f" />
<img width="2070" height="1093" alt="Screenshot 2026-07-21 at 11 49 32 AM" src="https://github.com/user-attachments/assets/f617b740-9a16-4398-ba46-b0d4515a549e" />
<img width="2493" height="429" alt="Screenshot 2026-07-22 at 7 55 57 AM" src="https://github.com/user-attachments/assets/bfbb1a3d-102c-44cf-9d92-36cab0f10f2c" />


### How to test locally

This can be tested locally by

1. Setting `NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS=true` in .env.local
2. Inserting some Exponential Histogram data into ClickHouse (and adding otel_metrics_exponential_histogram to your Metrics source configuration)
3. Building charts showing timeseries quantiles over the metric

Comparing the data to identical metrics sent to prometheus + grafana is a good sanity check, and agents can set this up relatively well.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4829
- Related PRs:
