### PR TITLE
feat(mcp): add client identity to tool spans

### DIFF
--- a/.changeset/mcp-client-span-attributes.md
+++ b/.changeset/mcp-client-span-attributes.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+Add MCP client name and version attributes to tool-invocation spans.

--- a/packages/api/src/mcp/__tests__/mcpClient.test.ts
+++ b/packages/api/src/mcp/__tests__/mcpClient.test.ts
@@ -1,0 +1,38 @@
+import { userAgentClientInfo } from '@/mcp/utils/mcpClient';
+
+describe('userAgentClientInfo', () => {
+  it.each([
+    ['Cursor/1.5.0 (darwin)', { name: 'cursor', version: '1.5.0' }],
+    ['opencode/1.18.0', { name: 'opencode', version: '1.18.0' }],
+    ['claude-code/2.1.185 (cli)', { name: 'claude-code', version: '2.1.185' }],
+    ['node', { name: 'node', version: undefined }],
+    ['Some Client 2.0', { name: 'some', version: undefined }],
+    [
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0',
+      { name: 'mozilla', version: '5.0' },
+    ],
+  ])('extracts client identity from %p', (raw, expected) => {
+    expect(userAgentClientInfo(raw)).toEqual(expected);
+  });
+
+  it('returns an empty identity for a missing header', () => {
+    expect(userAgentClientInfo(undefined)).toEqual({});
+  });
+
+  it('returns an empty identity for a blank/whitespace header', () => {
+    expect(userAgentClientInfo('   ')).toEqual({});
+  });
+
+  it('returns an empty identity when the product name is missing', () => {
+    expect(userAgentClientInfo('/1.0')).toEqual({});
+  });
+
+  it('caps name and version at 32 characters', () => {
+    const clientInfo = userAgentClientInfo(
+      `${'a'.repeat(50)}/${'1'.repeat(50)}`,
+    );
+
+    expect(clientInfo.name).toHaveLength(32);
+    expect(clientInfo.version).toHaveLength(32);
+  });
+});

--- a/packages/api/src/mcp/__tests__/tracing.test.ts
+++ b/packages/api/src/mcp/__tests__/tracing.test.ts
@@ -72,11 +72,23 @@ jest.mock('@/utils/logger', () => ({
   },
 }));
 
+import type { McpContext } from '@/mcp/tools/types';
 import { mcpServerError, mcpUserError } from '@/mcp/utils/errors';
+import type { McpClientInfo } from '@/mcp/utils/mcpClient';
 import { withToolTracing } from '@/mcp/utils/tracing';
 
+// Build a context whose mcpClient resolves to the given identity. The actual
+// clientInfo/User-Agent resolution logic is covered in mcpClient.test.ts.
+function ctx(clientInfo: McpClientInfo = {}): McpContext {
+  return {
+    teamId: 'team-123',
+    userId: 'user-456',
+    mcpClient: clientInfo,
+  };
+}
+
 describe('withToolTracing', () => {
-  const context = { teamId: 'team-123', userId: 'user-456' };
+  const context = ctx();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -115,6 +127,88 @@ describe('withToolTracing', () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       'mcp.user.id',
       'user-456',
+    );
+  });
+
+  it('should set client name and version attributes when resolved', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+
+    const traced = withToolTracing(
+      'my_tool',
+      ctx({ name: 'cursor', version: '1.2.3' }),
+      handler,
+    );
+    await traced({});
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'mcp.client.name',
+      'cursor',
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'mcp.client.version',
+      '1.2.3',
+    );
+  });
+
+  it('should set only the client name when version is unresolved', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+
+    const traced = withToolTracing(
+      'my_tool',
+      ctx({ name: 'opencode' }),
+      handler,
+    );
+    await traced({});
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'mcp.client.name',
+      'opencode',
+    );
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'mcp.client.version',
+      expect.anything(),
+    );
+  });
+
+  it('should not set client attributes when identity is unresolved', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+
+    const traced = withToolTracing('my_tool', ctx({}), handler);
+    await traced({});
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'mcp.client.name',
+      expect.anything(),
+    );
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'mcp.client.version',
+      expect.anything(),
+    );
+  });
+
+  it('should tolerate a context without an mcpClient', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+
+    const contextNoClient = { teamId: 'team-123', userId: 'user-456' };
+
+    const traced = withToolTracing('my_tool', contextNoClient, handler);
+    await traced({});
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      'mcp.tool.name',
+      'my_tool',
+    );
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      'mcp.client.name',
+      expect.anything(),
     );
   });
 

--- a/packages/api/src/mcp/app.ts
+++ b/packages/api/src/mcp/app.ts
@@ -8,6 +8,7 @@ import rateLimiter, { rateLimiterKeyGenerator } from '@/utils/rateLimiter';
 
 import { createServer } from './mcpServer';
 import { McpContext } from './tools/types';
+import { userAgentClientInfo } from './utils/mcpClient';
 
 const app = createMcpExpressApp();
 
@@ -42,6 +43,7 @@ app.all('/', mcpRateLimiter, validateUserAccessKey, async (req, res) => {
   const context: McpContext = {
     teamId: teamId.toString(),
     userId,
+    mcpClient: userAgentClientInfo(req.get('User-Agent')),
   };
 
   setTraceAttributes({

--- a/packages/api/src/mcp/tools/types.ts
+++ b/packages/api/src/mcp/tools/types.ts
@@ -2,9 +2,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { AnyZodObject } from 'zod';
 
+import type { McpClientInfo } from '@/mcp/utils/mcpClient';
+
 export type McpContext = {
   teamId: string;
   userId: string;
+  /**
+   * Identity of the calling MCP client application, parsed from User-Agent.
+   */
+  mcpClient?: McpClientInfo;
 };
 
 /**

--- a/packages/api/src/mcp/utils/mcpClient.ts
+++ b/packages/api/src/mcp/utils/mcpClient.ts
@@ -1,0 +1,26 @@
+/** MCP client information, e.g. name "cursor", version "1.2.3". */
+export type McpClientInfo = {
+  name?: string;
+  version?: string;
+};
+
+/** Parse the first User-Agent product into bounded client identity fields. */
+export function userAgentClientInfo(rawUserAgent?: string): McpClientInfo {
+  const product = rawUserAgent?.trim().split(/\s+/, 1)[0];
+  if (!product) {
+    return {};
+  }
+
+  const separator = product.indexOf('/');
+  const rawName = separator === -1 ? product : product.slice(0, separator);
+  if (!rawName) {
+    return {};
+  }
+
+  const rawVersion =
+    separator === -1 ? undefined : product.slice(separator + 1);
+  return {
+    name: rawName.slice(0, 32).toLowerCase(),
+    version: rawVersion ? rawVersion.slice(0, 32) : undefined,
+  };
+}

--- a/packages/api/src/mcp/utils/tracing.ts
+++ b/packages/api/src/mcp/utils/tracing.ts
@@ -27,7 +27,7 @@ const toolErrorCounter = getCounter('hyperdx.mcp.tool.errors', {
  *
  * The returned function signature is a strict subset of the SDK's
  * `ToolCallback`: it accepts `(args, _extra?)` and returns
- * `Promise<CallToolResult>`.  The extra parameter is accepted but unused.
+ * `Promise<CallToolResult>`. The extra parameter is accepted but unused.
  */
 export function withToolTracing<TArgs>(
   toolName: string,
@@ -35,10 +35,14 @@ export function withToolTracing<TArgs>(
   handler: (args: TArgs) => Promise<ToolResult>,
 ): (args: TArgs, _extra?: unknown) => Promise<CallToolResult> {
   return async (args: TArgs) => {
+    const { name: clientName, version: clientVersion } =
+      context.mcpClient ?? {};
     const logContext = {
       tool: toolName,
       teamId: context.teamId,
       userId: context.userId,
+      mcpClientName: clientName,
+      mcpClientVersion: clientVersion,
     };
 
     return withSpan(
@@ -48,6 +52,12 @@ export function withToolTracing<TArgs>(
         span.setAttribute('mcp.tool.name', toolName);
         span.setAttribute('mcp.team.id', context.teamId);
         span.setAttribute('mcp.user.id', context.userId);
+        if (clientName) {
+          span.setAttribute('mcp.client.name', clientName);
+        }
+        if (clientVersion) {
+          span.setAttribute('mcp.client.version', clientVersion);
+        }
 
         logger.info(logContext, `MCP tool invoked: ${toolName}`);
 


### PR DESCRIPTION
## Summary

MCP tool spans now identify the calling client application and version, making MCP traffic segmentable by clients such as Claude Code, OpenCode, and Cursor. Because the HTTP endpoint is stateless, identity is derived from a bounded first-product token in each request's User-Agent rather than relying on initialization state. Missing or malformed headers safely omit the attributes, and client values remain telemetry-only.

<img width="386" height="71" alt="Screenshot 2026-07-21 at 12 28 59 PM" src="https://github.com/user-attachments/assets/36769f6f-b809-4c53-a591-d54e1917b1dc" />
<img width="396" height="65" alt="Screenshot 2026-07-21 at 12 28 41 PM" src="https://github.com/user-attachments/assets/4282605e-5b2d-469e-bd4f-068ffee1c807" />


## Test Plan

- `yarn ci:unit src/mcp`
- `yarn tsc --noEmit`
- Live MCP calls verified `mcp.client.name=opencode` and `mcp.client.version=1.18.0` on `mcp.tool.*` spans
