### PR TITLE
fix(hdx-eval): don't reseed log-only/metric-only scenarios every run

### DIFF
--- a/packages/hdx-eval/src/clickhouse/schema.ts
+++ b/packages/hdx-eval/src/clickhouse/schema.ts
@@ -150,24 +150,39 @@ async function removeTtlIfPresent(
 }
 
 /**
- * Return `true` when the scenario's traces table exists and has at least one
- * row. A quick, cheap check to decide whether an auto-seed is needed before
- * a `run`.
+ * Return `true` when ANY of the scenario's primary data tables (traces, logs,
+ * or any metric table) exists and has at least one row. A quick, cheap check
+ * to decide whether an auto-seed is needed before a `run`.
+ *
+ * We check all signal tables (not just traces) because log-only scenarios like
+ * `noisy-signals` and metric-only scenarios legitimately leave the traces table
+ * empty — a traces-only check would report them as unseeded and force a full
+ * (~10 min) reseed on every run.
  */
 export async function scenarioIsSeeded(
   client: ClickHouseClient,
   scenario: string,
 ): Promise<boolean> {
   const tables = scenarioTables(scenario);
-  if (!(await tableExists(client, EVAL_DATABASE, tables.traces))) {
-    return false;
+  const dataTables = [
+    tables.traces,
+    tables.logs,
+    ...METRIC_TABLES.map(({ field }) => tables[field]),
+  ];
+  for (const table of dataTables) {
+    if (!(await tableExists(client, EVAL_DATABASE, table))) {
+      continue;
+    }
+    const rs = await client.query({
+      query: `SELECT 1 FROM ${EVAL_DATABASE}.${table} LIMIT 1`,
+      format: 'JSONEachRow',
+    });
+    const rows = await rs.json<unknown>();
+    if (rows.length > 0) {
+      return true;
+    }
   }
-  const rs = await client.query({
-    query: `SELECT 1 FROM ${EVAL_DATABASE}.${tables.traces} LIMIT 1`,
-    format: 'JSONEachRow',
-  });
-  const rows = await rs.json<unknown>();
-  return rows.length > 0;
+  return false;
 }
 
 export async function truncateScenarioTables(


### PR DESCRIPTION
## What

`scenarioIsSeeded` (the pre-run check that decides whether the eval harness needs to auto-seed ClickHouse) only ever inspected the scenario's **traces** table. Now it checks all of the scenario's primary data tables (traces, logs, and every metric table) and treats the scenario as seeded if any one of them has rows.

## Why

Log-only scenarios (`noisy-signals`) and metric-only scenarios legitimately leave their traces table empty — the generator yields `{ traces: [], logs: [...] }` at every emission site. The old traces-only check therefore always reported them as unseeded:

```
No data found for noisy-signals — auto-seeding...
```

...and forced a full reseed (~10 min for 16M rows) on **every single run**, even though the data was already present. `service-health-check` avoided this only because it happens to emit both logs and traces.

Beyond the wasted time, the false "unseeded" verdict also triggers an in-place reseed of whichever ClickHouse the top-level `clickhouse` config points at, which in a dual-slot A/B setup silently rewrites one slot's data mid-run (harmless only because seeding is deterministic for a fixed seed + anchor, but surprising).

## How

`packages/hdx-eval/src/clickhouse/schema.ts` — `scenarioIsSeeded` now iterates `[traces, logs, ...metricTables]`, skips tables that don't exist, and returns `true` on the first table with ≥1 row (short-circuits, so the common case stays a single cheap query). Falls back to `false` only when every data table is absent or empty.

## Impact

- Log-only and metric-only scenarios (`noisy-signals`, `metric-saturation`) no longer reseed on every run — restores ~10 min/run of lost velocity.
- Trace-bearing scenarios are unaffected (traces is still checked first).
- `--reseed` / `--live` still force a reseed as before.

## Testing

- `tsc --noEmit` clean on `@hyperdx/hdx-eval`.
- eslint / lint-staged / knip pass.
- Verified against live data: `eval_noisy_signals_otel_logs` has 16M rows with an empty traces table — the old check returned unseeded, the new check returns seeded.

`@hyperdx/hdx-eval` is a private (unpublished) internal tooling package, so no changeset is included.
