### PR TITLE
docs(agent): document semantic Alert/Text/danger variants

### DIFF
--- a/agent_docs/code_style.md
+++ b/agent_docs/code_style.md
@@ -99,6 +99,38 @@ The project uses Mantine UI with **custom variants** defined in `packages/app/sr
 
 This pattern cannot be enforced by ESLint and requires manual code review.
 
+### Semantic component variants (Alert / Text / danger controls)
+
+We ship **themed semantic variants** for `Alert`, `Text`, `Button`, and `ActionIcon` so callouts and status text are token-driven and consistent across the HyperDX and ClickStack brands (and light/dark). **Prefer these over raw Mantine palette colors** (`color="yellow"`, `color="red"`, `c="green"`, etc.).
+
+The variant → token mapping is centralized in `packages/app/src/theme/themes/semanticVariants.ts` (the single source of truth, consumed by both brand themes' `mantineTheme.ts`). See the Storybook stories `Components/Alert` (interactive `Playground`) and `Design Tokens/Semantic Variants` for the full visual matrix.
+
+**`Alert`** — `info` | `success` | `warning` | `danger`. Renders a tinted `-subtle` background with the title, icon, **and body text** in the semantic color token:
+
+```tsx
+// ✅ token-driven, works in both brands + light/dark, meets WCAG AA
+<Alert variant="warning" title="Heads up">This may take a while.</Alert>
+<Alert variant="danger" title="Failed">Could not save the alert.</Alert>
+
+// ❌ hardcoded Mantine palette — not theme-aware, inconsistent contrast
+<Alert color="yellow" title="Heads up">...</Alert>
+<Alert color="red" title="Failed">...</Alert>
+```
+
+**`Text`** — `danger` | `warning` | `success` for inline status/validation text:
+
+```tsx
+<Text variant="danger">Required field</Text>
+<Text variant="success">Connection verified</Text>
+
+// ❌ don't reach for raw palette colors for semantic status text
+<Text c="red.5">Required field</Text>
+```
+
+**`Button` / `ActionIcon` `variant="danger"`** is a **soft** control: a tinted `--color-bg-danger-subtle` background (with hover) and semantic foreground, not a solid red fill. `warning`/`success` are intentionally **not** exposed as control variants — use them on `Text` and `Alert` only.
+
+**Note**: Existing `<Alert color="...">` call sites are untouched; the semantic variants are opt-in. Prefer the variant for any **new** callout, and migrate nearby `color="..."` alerts when you touch them.
+
 ### EmptyState Component (REQUIRED)
 
 **Use `EmptyState` (`@/components/EmptyState`) for all empty/no-data states.** Do not create ad-hoc inline empty states.

--- a/agent_docs/themes.md
+++ b/agent_docs/themes.md
@@ -256,6 +256,55 @@ function TopBar() {
 Both hooks return memoized JSX elements so component identity stays
 stable across renders.
 
+## Semantic component variants (Alert / Text / danger controls)
+
+On top of the raw `--color-*` vars, we expose **semantic component
+variants** so callouts and status text stay token-driven and consistent
+across brands and color modes. Reach for these instead of raw Mantine
+palette props (`color="yellow"`, `color="red"`, `c="green"`, …).
+
+- **`<Alert variant="info|success|warning|danger">`** — tinted `-subtle`
+  background with the title, icon, and **body text** in the semantic
+  color.
+- **`<Text variant="danger|warning|success">`** — semantic inline status
+  text.
+- **`<Button|ActionIcon variant="danger">`** — a *soft* tinted control
+  (`--color-bg-danger-subtle` + hover), not a solid red fill.
+  `warning`/`success` are intentionally not control variants.
+
+The variant → token mapping is centralized in
+**`packages/app/src/theme/themes/semanticVariants.ts`** (single source of
+truth: `SEMANTIC_ALERT_VARS`, `SEMANTIC_TEXT_COLORS`,
+`SEMANTIC_CONTROL_COLORS`), consumed by both brands' `mantineTheme.ts`
+(`Alert.extend`, `Text.extend`, `Button.extend`, `ActionIcon.extend`). It
+references only `--color-*` design tokens — never raw
+`--mantine-color-*`.
+
+### Semantic token families
+
+- **Semantic text**: `--color-text-{danger,warning,success,info}`
+  (+ `--color-text-success-hover`). Used by `Text` and `Alert`
+  foregrounds.
+- **Subtle backgrounds**: `--color-bg-{danger,warning,success,info}-subtle`
+  (+ `-subtle-hover`). Scheme-aware — pale tints in **light** (Mantine
+  `-0`/`-1`), deep tints in **dark** (inlined hex, since the numbered
+  scale's darkest green/yellow shades are mid-tone and can't hit AA).
+  Consumed by `Alert` and the `danger` soft control.
+
+**Accessibility**: every semantic text token clears **WCAG AA (4.5:1)**
+on its `-subtle` tint (including hover) in both schemes. In light mode
+`success`/`warning` text is darkened past the palette with a small
+`color-mix` because `green-9`/`yellow-9`/`orange-9` are mid-tone —
+preserve these `color-mix` adjustments when editing.
+
+**ClickStack `warning` is orange-based**: ClickStack remaps the `yellow`
+palette to its brand gold, so its warning tokens use Mantine `orange`
+(unremapped) for a true orange warning; HyperDX stays yellow-based.
+
+Storybook: `Components/Alert` (interactive `Playground`) and
+`Design Tokens/Semantic Variants` — use the Brand and Theme toolbar
+toggles to review all combinations.
+
 ## Per-brand differences
 
 ### HyperDX (default, green-first)
@@ -359,6 +408,12 @@ A few things that look like bugs but are intentional:
    `theme/semanticColorsGrouped.ts` so the storybook renders it.
 5. Consume it via `var(--color-…)` in your component.
 
+If the token backs a **semantic component variant** (Alert / Text /
+danger control), wire it through `theme/themes/semanticVariants.ts`
+rather than referencing it directly in each brand's `mantineTheme.ts`,
+and verify it in the `Design Tokens/Semantic Variants` story across both
+brands and schemes.
+
 For chart-specific vars (`--color-chart-*`) there are additional steps —
 see `data_viz_colors.md`.
 
@@ -457,7 +512,8 @@ Why each is wrong:
 | ClickStack brand definition                 | `packages/app/src/theme/themes/clickstack/{index.ts,_tokens.scss,mantineTheme.ts,…}` |
 | SSR fallback CSS vars                       | `packages/app/src/theme/themes/_base-tokens.scss`                                  |
 | Semantic var groups (storybook source)      | `packages/app/src/theme/semanticColorsGrouped.ts`                                  |
-| Storybook visual references                 | `packages/app/src/theme/{SemanticColors,ChartColors}.stories.tsx`                  |
+| Semantic component variants (source of truth)| `packages/app/src/theme/themes/semanticVariants.ts`                                |
+| Storybook visual references                 | `packages/app/src/theme/{SemanticColors,SemanticVariants,ChartColors}.stories.tsx` + `packages/app/src/components/Alert.stories.tsx` |
 | Favicon assets                              | `packages/app/public/favicons/{hyperdx,clickstack}/`                               |
 | Provider tests                              | `packages/app/src/theme/__tests__/ThemeProvider.test.tsx`                          |
 | Theme validation tests                      | `packages/app/src/theme/__tests__/index.test.ts`                                   |


### PR DESCRIPTION
## Why

[#2704](https://github.com/hyperdxio/hyperdx/pull/2704) added AA-tuned semantic color tokens and `Alert`/`Text`/`Button`/`ActionIcon` semantic variants, but the agent documentation still steered agents toward raw Mantine palette colors (`color="yellow"`, `color="red"`). This meant AI-generated UI would keep hardcoding non-themed colors instead of using the new token-driven variants.

This PR documents the new variants so agents (and humans) know they exist and prefer them.

## Design skills vs. agent docs

I evaluated whether this warranted a new `.claude/skills/` design skill. It doesn't: skills in this repo are **procedural workflows** (`page-layout`, `refactor-component`, `playwright`), while this is **reference knowledge** about which variants/tokens to use — which already belongs to `themes.md` (semantic tokens) and `code_style.md` (component-variant rules). Adding a skill would fragment the guidance and create a second place to keep in sync.

## What changed

- **`agent_docs/code_style.md`** — new "Semantic component variants (Alert / Text / danger controls)" section: `Alert` (`info`/`success`/`warning`/`danger`), `Text` (`danger`/`warning`/`success`), and the `danger` soft-tint control, each with do/don't examples and pointers to `semanticVariants.ts` + the Storybook stories.
- **`agent_docs/themes.md`** — new "Semantic component variants" section documenting the token families (`--color-text-{danger,warning,success,info}`, `--color-bg-{…}-subtle(-hover)`), the AA / `color-mix` and ClickStack-orange nuances, and `semanticVariants.ts` as the single source of truth; plus a note in "Adding a new semantic CSS variable" and new rows in the file-reference table.

## Notes for reviewers

- Docs-only; no changeset (per `AGENTS.md`, docs changes don't warrant a release).
- Hand-wrapped to match each file's existing line style — `.md` files aren't covered by the repo's lint-staged (only `.mdx`/`.ts`/`.json`/`.yml`), and prettier's `proseWrap: always` would otherwise reflow the whole file.

Made with [Cursor](https://cursor.com)