### PR TITLE
fix: Correctly aggregate non-timeseries histogram charts

### DIFF
--- a/.changeset/tidy-histogram-chart-aggregation.md
+++ b/.changeset/tidy-histogram-chart-aggregation.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+fix: Aggregate histogram metrics across selected range for non-timeseries charts

--- a/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
+++ b/packages/api/src/clickhouse/__tests__/renderChartConfig.int.test.ts
@@ -5,6 +5,7 @@ import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import { getMetadata } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
 import {
+  DisplayType,
   MetricsDataType,
   QuerySettings,
 } from '@hyperdx/common-utils/dist/types';
@@ -68,6 +69,22 @@ describe('renderChartConfig', () => {
       console.error('[ClickhouseClient] Error:', err);
       throw err;
     }
+  };
+
+  const expectNonTimeseriesResults = (
+    results: unknown[],
+    expected: object[],
+  ) => {
+    expect(results).toHaveLength(expected.length);
+    expect(results).toEqual(expect.arrayContaining(expected));
+    expect(
+      results.every(
+        result =>
+          typeof result === 'object' &&
+          result !== null &&
+          !('__hdx_time_bucket' in result),
+      ),
+    ).toBe(true);
   };
 
   beforeAll(async () => {
@@ -968,10 +985,12 @@ describe('renderChartConfig', () => {
       const histPointsA = [
         {
           BucketCounts: [0, 0, 0],
+          Count: 0,
           TimeUnix: new Date(now),
         },
         {
           BucketCounts: [10, 10, 10],
+          Count: 30,
           TimeUnix: new Date(now + ms('1m')),
         },
       ].map(point => ({
@@ -1073,6 +1092,15 @@ describe('renderChartConfig', () => {
         ...point,
       }));
       const histPointsF = [
+        ...['host-a', 'host-b'].flatMap(host =>
+          ['service-1', 'service-2', 'service-3'].map(service => ({
+            TimeUnix: nowPlus('-1m'),
+            ResourceAttributes: { host, service },
+            BucketCounts: [0, 0, 0, 0, 0, 0],
+            Count: 0,
+            Sum: 0,
+          })),
+        ),
         {
           TimeUnix: new Date(now),
           ResourceAttributes: { host: 'host-a', service: 'service-1' },
@@ -1705,17 +1733,284 @@ describe('renderChartConfig', () => {
         );
       });
     });
+
+    const queryNonTimeseriesHistogram = async (
+      metricName: string,
+      select: { aggFn: 'count' } | { aggFn: 'quantile'; level: number },
+    ) => {
+      const query = await renderChartConfig(
+        {
+          displayType: DisplayType.Table,
+          select: [
+            {
+              ...select,
+              metricName,
+              metricType: MetricsDataType.Histogram,
+              valueExpression: 'Value',
+            },
+          ],
+          from: metricSource.from,
+          where: '',
+          metricTables: TEST_METRIC_TABLES,
+          dateRange: [new Date(now), nowPlus('4m')],
+          groupBy: `Attributes['route']`,
+          timestampValueExpression: metricSource.timestampValueExpression,
+          connection: connection.id,
+        },
+        metadata,
+        querySettings,
+      );
+
+      return queryData(query);
+    };
+
+    it('aggregates histogram count and quantile across every timestamp in each non-timeseries group', async () => {
+      const metricName = 'test.non.timeseries.histogram.grouped';
+      await bulkInsertMetricsHistogram([
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/ten' },
+          AggregationTemporality: 1,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [10, 0, 0],
+          Count: 10,
+          TimeUnix: new Date(now),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/ten' },
+          AggregationTemporality: 1,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [0, 10, 0],
+          Count: 10,
+          TimeUnix: nowPlus('1m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/hundred' },
+          AggregationTemporality: 1,
+          ExplicitBounds: [100, 300],
+          BucketCounts: [6, 0, 0],
+          Count: 6,
+          TimeUnix: new Date(now),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/hundred' },
+          AggregationTemporality: 1,
+          ExplicitBounds: [100, 300],
+          BucketCounts: [0, 6, 0],
+          Count: 6,
+          TimeUnix: nowPlus('2m'),
+        },
+      ]);
+
+      // /ten sums 10 + 10 = 20 observations; its standalone p50s are 5 and
+      // 20, while the combined [10, 10, 0] distribution has p50 10.
+      // /hundred sums 6 + 6 = 12; its standalone p50s are 50 and 200, while
+      // the combined [6, 6, 0] distribution has p50 100. The combined
+      // quantiles cannot match if only one timestamp is calculated.
+      expectNonTimeseriesResults(
+        await queryNonTimeseriesHistogram(metricName, { aggFn: 'count' }),
+        [
+          { group: ['/ten'], Value: '20' },
+          { group: ['/hundred'], Value: '12' },
+        ],
+      );
+      expectNonTimeseriesResults(
+        await queryNonTimeseriesHistogram(metricName, {
+          aggFn: 'quantile',
+          level: 0.5,
+        }),
+        [
+          { group: ['/ten'], Value: 10 },
+          { group: ['/hundred'], Value: 100 },
+        ],
+      );
+    });
+
+    it('uses the first visible cumulative histogram point as the baseline', async () => {
+      const metricName = 'test.non.timeseries.histogram.boundaries';
+      await bulkInsertMetricsHistogram([
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          AggregationTemporality: 2,
+          ExplicitBounds: [10],
+          BucketCounts: [2, 0],
+          Count: 2,
+          TimeUnix: nowPlus('-1m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          AggregationTemporality: 2,
+          ExplicitBounds: [10],
+          BucketCounts: [2, 2],
+          Count: 4,
+          TimeUnix: new Date(now),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          AggregationTemporality: 2,
+          ExplicitBounds: [10],
+          BucketCounts: [2, 4],
+          Count: 6,
+          TimeUnix: nowPlus('1m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          AggregationTemporality: 2,
+          ExplicitBounds: [10],
+          BucketCounts: [102, 104],
+          Count: 206,
+          TimeUnix: nowPlus('3m'),
+        },
+      ]);
+
+      const renderQuery = (select: {
+        aggFn: 'count' | 'quantile';
+        level?: number;
+      }) =>
+        renderChartConfig(
+          {
+            displayType: DisplayType.Number,
+            select: [
+              {
+                ...select,
+                metricName,
+                metricType: MetricsDataType.Histogram,
+                valueExpression: 'Value',
+              },
+            ],
+            from: metricSource.from,
+            where: '',
+            metricTables: TEST_METRIC_TABLES,
+            dateRange: [new Date(now), nowPlus('2m')],
+            timestampValueExpression: metricSource.timestampValueExpression,
+            connection: connection.id,
+          },
+          metadata,
+          querySettings,
+        );
+
+      // Only [0m, 2m] is scanned: the 0m cumulative count 4 is the zero-delta
+      // baseline, and the 1m point contributes 6 - 4 = 2. Its bucket delta is
+      // [2, 4] - [2, 2] = [0, 2], whose p50 is the finite lower boundary 10
+      // of the overflow bucket. The -1m and 3m points contribute nothing.
+      expect(await queryData(await renderQuery({ aggFn: 'count' }))).toEqual([
+        { Value: '2' },
+      ]);
+      expect(
+        await queryData(await renderQuery({ aggFn: 'quantile', level: 0.5 })),
+      ).toEqual([{ Value: 10 }]);
+    });
+
+    it('aggregates reset-adjusted histogram count and quantile across each non-timeseries group', async () => {
+      const metricName = 'test.non.timeseries.histogram.reset.grouped';
+      await bulkInsertMetricsHistogram([
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/reset' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [2, 0, 0],
+          Count: 2,
+          TimeUnix: new Date(now),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/reset' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [6, 0, 0],
+          Count: 6,
+          TimeUnix: nowPlus('1m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/reset' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [0, 4, 0],
+          Count: 4,
+          TimeUnix: nowPlus('2m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/normal' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [0, 2, 0],
+          Count: 2,
+          TimeUnix: new Date(now),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/normal' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [4, 2, 0],
+          Count: 6,
+          TimeUnix: nowPlus('1m'),
+        },
+        {
+          MetricName: metricName,
+          ResourceAttributes: {},
+          Attributes: { route: '/normal' },
+          AggregationTemporality: 2,
+          ExplicitBounds: [10, 30],
+          BucketCounts: [4, 6, 0],
+          Count: 10,
+          TimeUnix: nowPlus('3m'),
+        },
+      ]);
+
+      // /reset uses 0 for its first point, [6, 0, 0] - [2, 0, 0] =
+      // [4, 0, 0] for its second, then detects the decrease and uses the
+      // current [0, 4, 0] after reset. /normal produces those same two
+      // interval distributions by subtraction. Both sum to count 8 and
+      // buckets [4, 4, 0], whose p50 is the shared boundary 10.
+      expectNonTimeseriesResults(
+        await queryNonTimeseriesHistogram(metricName, { aggFn: 'count' }),
+        [
+          { group: ['/reset'], Value: '8' },
+          { group: ['/normal'], Value: '8' },
+        ],
+      );
+      expectNonTimeseriesResults(
+        await queryNonTimeseriesHistogram(metricName, {
+          aggFn: 'quantile',
+          level: 0.5,
+        }),
+        [
+          { group: ['/reset'], Value: 10 },
+          { group: ['/normal'], Value: 10 },
+        ],
+      );
+    });
   });
 
   describe('Query Metrics - Exponential Histogram', () => {
     type CountResult = {
-      __hdx_time_bucket: string;
+      __hdx_time_bucket?: string;
       Value: string;
       group?: string[];
     };
 
     type QuantileResult = {
-      __hdx_time_bucket: string;
+      __hdx_time_bucket?: string;
       Value: number;
       group?: string[];
     };
@@ -1723,8 +2018,8 @@ describe('renderChartConfig', () => {
     const isQuantileResult = (result: unknown): result is QuantileResult =>
       typeof result === 'object' &&
       result !== null &&
-      '__hdx_time_bucket' in result &&
-      typeof result.__hdx_time_bucket === 'string' &&
+      (!('__hdx_time_bucket' in result) ||
+        typeof result.__hdx_time_bucket === 'string') &&
       'Value' in result &&
       typeof result.Value === 'number' &&
       (!('group' in result) ||
@@ -1734,8 +2029,8 @@ describe('renderChartConfig', () => {
     const isCountResult = (result: unknown): result is CountResult =>
       typeof result === 'object' &&
       result !== null &&
-      '__hdx_time_bucket' in result &&
-      typeof result.__hdx_time_bucket === 'string' &&
+      (!('__hdx_time_bucket' in result) ||
+        typeof result.__hdx_time_bucket === 'string') &&
       'Value' in result &&
       typeof result.Value === 'string' &&
       (!('group' in result) ||
@@ -1748,14 +2043,19 @@ describe('renderChartConfig', () => {
         dateRange = [new Date(now), nowPlus('3m')],
         granularity = '1 minute',
         groupBy,
+        displayType,
       }: {
         dateRange?: [Date, Date];
         granularity?: '1 minute' | '2 minute' | null;
         groupBy?: string;
+        displayType?: DisplayType;
       } = {},
     ) => {
       const query = await renderChartConfig(
         {
+          displayType:
+            displayType ??
+            (granularity === null ? DisplayType.Number : DisplayType.Line),
           select: [
             {
               aggFn: 'count',
@@ -1783,7 +2083,9 @@ describe('renderChartConfig', () => {
       }
       return results.sort(
         (left, right) =>
-          left.__hdx_time_bucket.localeCompare(right.__hdx_time_bucket) ||
+          (left.__hdx_time_bucket ?? '').localeCompare(
+            right.__hdx_time_bucket ?? '',
+          ) ||
           JSON.stringify(left.group ?? []).localeCompare(
             JSON.stringify(right.group ?? []),
           ),
@@ -1798,15 +2100,20 @@ describe('renderChartConfig', () => {
         granularity = '1 minute',
         groupBy,
         where = '',
+        displayType,
       }: {
         dateRange?: [Date, Date];
         granularity?: '1 minute' | null;
         groupBy?: string;
         where?: string;
+        displayType?: DisplayType;
       } = {},
     ) => {
       const query = await renderChartConfig(
         {
+          displayType:
+            displayType ??
+            (granularity === null ? DisplayType.Number : DisplayType.Line),
           select: [
             {
               aggFn: 'quantile',
@@ -1860,6 +2167,223 @@ describe('renderChartConfig', () => {
           },
         ],
       });
+
+    it('aggregates exponential-histogram count and quantile across every timestamp in each non-timeseries group', async () => {
+      const metricName = 'test.non.timeseries.exponential.histogram.grouped';
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/two' },
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            Attributes: { route: '/two' },
+            ...bucketExponentialHistogramObservations([8, 8]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        aggregationTemporality: 1,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            Attributes: { route: '/four' },
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            Attributes: { route: '/four' },
+            ...bucketExponentialHistogramObservations([16, 16]),
+          },
+        ],
+      });
+
+      // Each group sums two observations at each timestamp, so both counts
+      // are 2 + 2 = 4. The standalone p50s are sqrt(2) and sqrt(32) for
+      // /two, and sqrt(8) and sqrt(128) for /four. Their whole-range p50s
+      // (2 and 4) therefore prove that both timestamps were combined.
+      expectNonTimeseriesResults(
+        await queryCount(metricName, {
+          granularity: null,
+          groupBy: `Attributes['route']`,
+          displayType: DisplayType.Table,
+        }),
+        [
+          { group: ['/two'], Value: '4' },
+          { group: ['/four'], Value: '4' },
+        ],
+      );
+      expectNonTimeseriesResults(
+        await queryQuantile(0.5, metricName, {
+          granularity: null,
+          groupBy: `Attributes['route']`,
+          displayType: DisplayType.Table,
+        }),
+        [
+          { group: ['/two'], Value: 2 },
+          { group: ['/four'], Value: 4 },
+        ],
+      );
+    });
+
+    it('uses the first visible cumulative exponential-histogram point as the baseline', async () => {
+      const metricName = 'test.non.timeseries.exponential.histogram.boundaries';
+      const baseline = Array.from({ length: 10 }, () => 1024);
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: nowPlus('-1m'),
+            ...bucketExponentialHistogramObservations(baseline),
+          },
+          {
+            TimeUnix: new Date(now),
+            ...bucketExponentialHistogramObservations([...baseline, 4]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            ...bucketExponentialHistogramObservations([...baseline, 4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('3m'),
+            ...bucketExponentialHistogramObservations([
+              ...baseline,
+              4,
+              4,
+              ...Array.from({ length: 20 }, () => 2048),
+            ]),
+          },
+        ],
+      });
+
+      // Only [0m, 2m] is scanned. The 0m cumulative count 11 is the
+      // zero-delta baseline; the 1m point contributes 12 - 11 = 1. That one
+      // new observation is 4, whose exponential bucket midpoint is sqrt(8).
+      // The 10-count -1m point and the large 3m point are outside the range.
+      expect(
+        await queryCount(metricName, {
+          dateRange: [new Date(now), nowPlus('2m')],
+          granularity: null,
+        }),
+      ).toEqual([{ Value: '1' }]);
+      expect(
+        await queryQuantile(0.5, metricName, {
+          dateRange: [new Date(now), nowPlus('2m')],
+          granularity: null,
+        }),
+      ).toEqual([{ Value: Math.sqrt(8) }]);
+    });
+
+    it('aggregates every exponential-histogram reset mode across each non-timeseries group', async () => {
+      const metricName = 'test.non.timeseries.exponential.reset.grouped';
+      const originalStartTime = nowPlus('-1m');
+      const unknownResetTime = nowPlus('1m');
+
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/known' },
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/known' },
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: nowPlus('90s'),
+            Attributes: { route: '/known' },
+            ...bucketExponentialHistogramObservations([8, 8]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/decrease' },
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('1m'),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/decrease' },
+            ...bucketExponentialHistogramObservations([2, 2, 4, 4, 8, 8]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/decrease' },
+            ...bucketExponentialHistogramObservations([16, 16]),
+          },
+        ],
+      });
+      await seedExponentialHistogramMetric({
+        metricName,
+        points: [
+          {
+            TimeUnix: new Date(now),
+            StartTimeUnix: originalStartTime,
+            Attributes: { route: '/unknown' },
+            ...bucketExponentialHistogramObservations([2, 2]),
+          },
+          {
+            TimeUnix: unknownResetTime,
+            StartTimeUnix: unknownResetTime,
+            Attributes: { route: '/unknown' },
+            ...bucketExponentialHistogramObservations([4, 4]),
+          },
+          {
+            TimeUnix: nowPlus('2m'),
+            StartTimeUnix: unknownResetTime,
+            Attributes: { route: '/unknown' },
+            ...bucketExponentialHistogramObservations([4, 4, 8, 8]),
+          },
+        ],
+      });
+
+      const queryOptions: {
+        granularity: null;
+        groupBy: string;
+        displayType: DisplayType;
+      } = {
+        granularity: null,
+        groupBy: `Attributes['route']`,
+        displayType: DisplayType.Table,
+      };
+      // /known contributes two 4s before its changed start time makes the two
+      // current 8s a reset delta: count 4, combined p50 4.
+      // /decrease contributes two 8s, then its count decrease makes the two
+      // current 16s a reset delta: count 4, combined p50 8.
+      // /unknown contributes zero at its StartTimeUnix == TimeUnix marker;
+      // the next point subtracts that marker and contributes two 8s:
+      // count 2 and p50 sqrt(32).
+      expectNonTimeseriesResults(await queryCount(metricName, queryOptions), [
+        { group: ['/known'], Value: '4' },
+        { group: ['/decrease'], Value: '4' },
+        { group: ['/unknown'], Value: '2' },
+      ]);
+      expectNonTimeseriesResults(
+        await queryQuantile(0.5, metricName, queryOptions),
+        [
+          { group: ['/known'], Value: 4 },
+          { group: ['/decrease'], Value: 8 },
+          { group: ['/unknown'], Value: Math.sqrt(32) },
+        ],
+      );
+    });
 
     it('counts delta-temporality observations directly', async () => {
       await seedExponentialHistogramMetric({
@@ -3590,7 +4114,6 @@ describe('renderChartConfig', () => {
         await queryQuantile(0.5, metricName, { granularity: null }),
       ).toEqual([
         {
-          __hdx_time_bucket: toClickHouseISOString(nowPlus('1m')),
           Value: Math.sqrt(8),
         },
       ]);

--- a/packages/app/src/components/MetricNameSelect.tsx
+++ b/packages/app/src/components/MetricNameSelect.tsx
@@ -7,7 +7,6 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import { Select } from '@mantine/core';
 
-import { IS_EXPONENTIAL_HISTOGRAMS_ENABLED } from '@/config';
 import { useGetKeyValues } from '@/hooks/useMetadata';
 import { capitalizeFirstLetter } from '@/utils';
 
@@ -118,7 +117,6 @@ function useMetricNames(
     },
     {
       enabled:
-        IS_EXPONENTIAL_HISTOGRAMS_ENABLED &&
         !!metricSource.metricTables?.[MetricsDataType.ExponentialHistogram],
     },
   );
@@ -127,9 +125,7 @@ function useMetricNames(
     gaugeMetrics: gaugeMetrics?.[0].value,
     histogramMetrics: histogramMetrics?.[0].value,
     sumMetrics: sumMetrics?.[0].value,
-    exponentialHistogramMetrics: IS_EXPONENTIAL_HISTOGRAMS_ENABLED
-      ? exponentialHistogramMetrics?.[0].value
-      : undefined,
+    exponentialHistogramMetrics: exponentialHistogramMetrics?.[0].value,
   };
 }
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -66,5 +66,3 @@ export const IS_METRICS_ENABLED = true;
 export const IS_MTVIEWS_ENABLED = false;
 export const IS_SESSIONS_ENABLED = true;
 export const IS_PROMQL_ENABLED = env('NEXT_PUBLIC_ENABLE_PROMQL') === 'true';
-export const IS_EXPONENTIAL_HISTOGRAMS_ENABLED =
-  env('NEXT_PUBLIC_ENABLE_EXPONENTIAL_HISTOGRAMS') === 'true';

--- a/packages/common-utils/src/__tests__/__snapshots__/builderToRawSql.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/builderToRawSql.test.ts.snap
@@ -329,12 +329,16 @@ exports[`renderBuilderConfigAsSqlTemplate metric charts (single-series only) gen
           ExplicitBounds,
           attr_hash,
           any(attr_hash) OVER prev_row AS prev_attr_hash,
+          count() OVER prev_row = 0
+          OR prev_attr_hash != attr_hash AS is_first_series_point,
           any(bounds_hash) OVER prev_row AS prev_bounds_hash,
           any(counts) OVER prev_row AS prev_counts,
           counts,
-          IF(
+          multiIf(
+            AggregationTemporality = 2
+            AND is_first_series_point,
+            arrayWithConstant(length(counts), toInt64(0)),
             AggregationTemporality = 1
-            OR prev_attr_hash != attr_hash
             OR bounds_hash != prev_bounds_hash
             OR arrayExists((x) -> x .2 < x .1, arrayZip(prev_counts, counts)),
             counts,
@@ -374,11 +378,11 @@ exports[`renderBuilderConfigAsSqlTemplate metric charts (single-series only) gen
           )
       )
     GROUP BY
-      \`__hdx_time_bucket\`,
+      __hdx_time_bucket,
       MetricName,
       ExplicitBounds
     ORDER BY
-      \`__hdx_time_bucket\`
+      __hdx_time_bucket
   ),
   points AS (
     SELECT

--- a/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -43,12 +43,17 @@ exports[`renderChartConfig histogram metric queries count should generate a coun
             cityHash64(ExplicitBounds) AS bounds_hash,
             toInt64(Count) AS current_count,
             lagInFrame(toNullable(current_count), 1, NULL) OVER (
-                PARTITION BY group,  attr_hash, bounds_hash, AggregationTemporality
+                PARTITION BY group, attr_hash, bounds_hash, AggregationTemporality
                 ORDER BY TimeUnix
             ) AS prev_count,
             CASE
                 WHEN AggregationTemporality = 1 THEN current_count
-                WHEN AggregationTemporality = 2 THEN greatest(0, current_count - coalesce(prev_count, 0))
+                WHEN AggregationTemporality = 2 AND prev_count IS NOT NULL
+                  THEN if( 
+                    current_count < prev_count,
+                    current_count,
+                    current_count - prev_count
+                  )
                 ELSE 0
             END AS delta
         FROM default.otel_metrics_histogram
@@ -56,10 +61,10 @@ exports[`renderChartConfig histogram metric queries count should generate a coun
     ),metrics AS (
         SELECT
             \`__hdx_time_bucket\`,
-            group,
+group,
             sum(delta) AS "Value"
         FROM source
-        GROUP BY group, \`__hdx_time_bucket\`
+        GROUP BY \`__hdx_time_bucket\`, group
     ) SELECT \`__hdx_time_bucket\`, group, "Value" FROM metrics WHERE (\`__hdx_time_bucket\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket\` <= fromUnixTimestamp64Milli(1765670400000)) LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
 `;
 
@@ -74,12 +79,17 @@ exports[`renderChartConfig histogram metric queries count should generate a coun
             cityHash64(ExplicitBounds) AS bounds_hash,
             toInt64(Count) AS current_count,
             lagInFrame(toNullable(current_count), 1, NULL) OVER (
-                PARTITION BY  attr_hash, bounds_hash, AggregationTemporality
+                PARTITION BY attr_hash, bounds_hash, AggregationTemporality
                 ORDER BY TimeUnix
             ) AS prev_count,
             CASE
                 WHEN AggregationTemporality = 1 THEN current_count
-                WHEN AggregationTemporality = 2 THEN greatest(0, current_count - coalesce(prev_count, 0))
+                WHEN AggregationTemporality = 2 AND prev_count IS NOT NULL
+                  THEN if( 
+                    current_count < prev_count,
+                    current_count,
+                    current_count - prev_count
+                  )
                 ELSE 0
             END AS delta
         FROM default.otel_metrics_histogram
@@ -87,42 +97,45 @@ exports[`renderChartConfig histogram metric queries count should generate a coun
     ),metrics AS (
         SELECT
             \`__hdx_time_bucket\`,
-            
             sum(delta) AS "Value"
         FROM source
         GROUP BY \`__hdx_time_bucket\`
     ) SELECT \`__hdx_time_bucket\`, "Value" FROM metrics WHERE (\`__hdx_time_bucket\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket\` <= fromUnixTimestamp64Milli(1765670400000)) LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
 `;
 
-exports[`renderChartConfig histogram metric queries count should generate a count query without grouping or time bucketing 1`] = `
+exports[`renderChartConfig histogram metric queries count should generate a whole-range count query without a time dimension 1`] = `
 "WITH source AS (
         SELECT
             TimeUnix,
             AggregationTemporality,
-            TimeUnix AS \`__hdx_time_bucket\`,
+            
             
             cityHash64(ScopeAttributes, ResourceAttributes, Attributes) AS attr_hash,
             cityHash64(ExplicitBounds) AS bounds_hash,
             toInt64(Count) AS current_count,
             lagInFrame(toNullable(current_count), 1, NULL) OVER (
-                PARTITION BY  attr_hash, bounds_hash, AggregationTemporality
+                PARTITION BY attr_hash, bounds_hash, AggregationTemporality
                 ORDER BY TimeUnix
             ) AS prev_count,
             CASE
                 WHEN AggregationTemporality = 1 THEN current_count
-                WHEN AggregationTemporality = 2 THEN greatest(0, current_count - coalesce(prev_count, 0))
+                WHEN AggregationTemporality = 2 AND prev_count IS NOT NULL
+                  THEN if( 
+                    current_count < prev_count,
+                    current_count,
+                    current_count - prev_count
+                  )
                 ELSE 0
             END AS delta
         FROM default.otel_metrics_histogram
         WHERE (TimeUnix >= fromUnixTimestamp64Milli(1739318400000) AND TimeUnix <= fromUnixTimestamp64Milli(1765670400000)) AND ((MetricName = 'http.server.duration'))
     ),metrics AS (
         SELECT
-            \`__hdx_time_bucket\`,
             
             sum(delta) AS "Value"
         FROM source
-        GROUP BY \`__hdx_time_bucket\`
-    ) SELECT \`__hdx_time_bucket\`, "Value" FROM metrics WHERE (\`__hdx_time_bucket\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket\` <= fromUnixTimestamp64Milli(1765670400000)) LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
+        
+    ) SELECT "Value" FROM metrics LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
 `;
 
 exports[`renderChartConfig histogram metric queries quantile should generate a query with grouping and time bucketing 1`] = `
@@ -141,15 +154,19 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
                group,
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 
-                      OR prev_attr_hash != attr_hash 
                       OR bounds_hash != prev_bounds_hash 
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -173,21 +190,21 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, group, ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY __hdx_time_bucket, MetricName, group, ExplicitBounds
+          ORDER BY __hdx_time_bucket
           ),points AS (
           SELECT
             \`__hdx_time_bucket\`,
+group,
             MetricName,
-            group,
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
           ),metrics AS (
           SELECT
             \`__hdx_time_bucket\`,
+group,
             MetricName,
-            group,
             point[n].1 AS total,
             0.5 * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
@@ -229,15 +246,19 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
               
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 
-                      OR prev_attr_hash != attr_hash 
                       OR bounds_hash != prev_bounds_hash 
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -261,13 +282,12 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY __hdx_time_bucket, MetricName, ExplicitBounds
+          ORDER BY __hdx_time_bucket
           ),points AS (
           SELECT
             \`__hdx_time_bucket\`,
             MetricName,
-            
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
@@ -275,7 +295,6 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
           SELECT
             \`__hdx_time_bucket\`,
             MetricName,
-            
             point[n].1 AS total,
             0.5 * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
@@ -301,12 +320,12 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
           ) SELECT \`__hdx_time_bucket\`, "Value" FROM metrics WHERE (\`__hdx_time_bucket\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket\` <= fromUnixTimestamp64Milli(1765670400000)) LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
 `;
 
-exports[`renderChartConfig histogram metric queries quantile should generate a query without grouping or time bucketing 1`] = `
+exports[`renderChartConfig histogram metric queries quantile should generate a whole-range query without a time dimension 1`] = `
 "WITH source AS (
           SELECT
             MetricName,
             ExplicitBounds,
-            TimeUnix AS \`__hdx_time_bucket\`,
+            
             
             sumForEach(deltas) as rates
           FROM (
@@ -317,15 +336,19 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
               
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 
-                      OR prev_attr_hash != attr_hash 
                       OR bounds_hash != prev_bounds_hash 
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -349,21 +372,19 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY  MetricName, ExplicitBounds
+          
           ),points AS (
           SELECT
-            \`__hdx_time_bucket\`,
-            MetricName,
             
+            MetricName,
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
           ),metrics AS (
           SELECT
-            \`__hdx_time_bucket\`,
-            MetricName,
             
+            MetricName,
             point[n].1 AS total,
             0.5 * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
@@ -386,7 +407,7 @@ exports[`renderChartConfig histogram metric queries quantile should generate a q
             END AS "Value"
           FROM points
           WHERE length(point) > 1 AND total > 0
-          ) SELECT \`__hdx_time_bucket\`, "Value" FROM metrics WHERE (\`__hdx_time_bucket\` >= fromUnixTimestamp64Milli(1739318400000) AND \`__hdx_time_bucket\` <= fromUnixTimestamp64Milli(1765670400000)) LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
+          ) SELECT "Value" FROM metrics LIMIT 10 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
 `;
 
 exports[`renderChartConfig k8s semantic convention migrations should generate SQL with metricNameSql for container.cpu.utilization histogram metric 1`] = `
@@ -405,15 +426,19 @@ exports[`renderChartConfig k8s semantic convention migrations should generate SQ
               
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 
-                      OR prev_attr_hash != attr_hash 
                       OR bounds_hash != prev_bounds_hash 
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -437,13 +462,12 @@ exports[`renderChartConfig k8s semantic convention migrations should generate SQ
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY __hdx_time_bucket, MetricName, ExplicitBounds
+          ORDER BY __hdx_time_bucket
           ),points AS (
           SELECT
             \`__hdx_time_bucket\`,
             MetricName,
-            
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
@@ -451,7 +475,6 @@ exports[`renderChartConfig k8s semantic convention migrations should generate SQ
           SELECT
             \`__hdx_time_bucket\`,
             MetricName,
-            
             point[n].1 AS total,
             0.95 * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
@@ -493,15 +516,19 @@ exports[`renderChartConfig k8s semantic convention migrations should generate SQ
                group,
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 
-                      OR prev_attr_hash != attr_hash 
                       OR bounds_hash != prev_bounds_hash 
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -525,21 +552,21 @@ exports[`renderChartConfig k8s semantic convention migrations should generate SQ
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, group, ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY __hdx_time_bucket, MetricName, group, ExplicitBounds
+          ORDER BY __hdx_time_bucket
           ),points AS (
           SELECT
             \`__hdx_time_bucket\`,
+group,
             MetricName,
-            group,
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
           ),metrics AS (
           SELECT
             \`__hdx_time_bucket\`,
+group,
             MetricName,
-            group,
             point[n].1 AS total,
             0.99 * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -768,9 +768,9 @@ describe('renderChartConfig', () => {
 
   describe('histogram metric queries', () => {
     describe('quantile', () => {
-      it('should generate a query without grouping or time bucketing', async () => {
+      it('should generate a whole-range query without a time dimension', async () => {
         const config: ChartConfigWithOptDateRange = {
-          displayType: DisplayType.Line,
+          displayType: DisplayType.Number,
           connection: 'test-connection',
           metricTables: {
             gauge: 'otel_metrics_gauge',
@@ -805,6 +805,14 @@ describe('renderChartConfig', () => {
           querySettings,
         );
         const actual = parameterizedQueryToSql(generatedSql);
+        expect(actual).not.toContain('TimeUnix AS `__hdx_time_bucket`');
+        expect(actual).not.toMatch(
+          /SELECT `__hdx_time_bucket`, "Value" FROM metrics/,
+        );
+        expect(actual).toContain(
+          'WHERE (TimeUnix >= fromUnixTimestamp64Milli(1739318400000) AND TimeUnix <= fromUnixTimestamp64Milli(1765670400000))',
+        );
+        expect(actual).not.toContain('toStartOfInterval');
         expect(actual).toMatchSnapshot();
       });
 
@@ -893,9 +901,9 @@ describe('renderChartConfig', () => {
     });
 
     describe('count', () => {
-      it('should generate a count query without grouping or time bucketing', async () => {
+      it('should generate a whole-range count query without a time dimension', async () => {
         const config: ChartConfigWithOptDateRange = {
-          displayType: DisplayType.Line,
+          displayType: DisplayType.Number,
           connection: 'test-connection',
           metricTables: {
             gauge: 'otel_metrics_gauge',
@@ -929,6 +937,14 @@ describe('renderChartConfig', () => {
           querySettings,
         );
         const actual = parameterizedQueryToSql(generatedSql);
+        expect(actual).not.toContain('TimeUnix AS `__hdx_time_bucket`');
+        expect(actual).not.toMatch(
+          /SELECT `__hdx_time_bucket`, "Value" FROM metrics/,
+        );
+        expect(actual).toContain(
+          'WHERE (TimeUnix >= fromUnixTimestamp64Milli(1739318400000) AND TimeUnix <= fromUnixTimestamp64Milli(1765670400000))',
+        );
+        expect(actual).not.toContain('toStartOfInterval');
         expect(actual).toMatchSnapshot();
       });
 

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -21,6 +21,7 @@ import {
 import {
   extractSettingsClauseFromEnd,
   hashCode,
+  isTimeSeriesDisplayType,
   replaceJsonExpressions,
   splitAndTrimWithBracket,
 } from '@/core/utils';
@@ -842,7 +843,7 @@ export abstract class BaseClickhouseClient {
       ),
     );
 
-    const isTimeSeries = config.displayType === 'line';
+    const isTimeSeries = isTimeSeriesDisplayType(config.displayType);
 
     const resultSets = await Promise.all(
       queries.map(async query => {

--- a/packages/common-utils/src/core/histogram.ts
+++ b/packages/common-utils/src/core/histogram.ts
@@ -1,4 +1,4 @@
-import { ChSql, chSql } from '@/clickhouse';
+import { ChSql, chSql, concatChSql } from '@/clickhouse';
 import { BuilderChartConfig } from '@/types';
 
 import { FIXED_TIME_BUCKET_EXPR_ALIAS } from './renderChartConfig';
@@ -6,11 +6,51 @@ import { FIXED_TIME_BUCKET_EXPR_ALIAS } from './renderChartConfig';
 type WithClauses = BuilderChartConfig['with'];
 type TemplatedInput = ChSql | string;
 type HistogramCountInput = {
-  timeBucketSelect: TemplatedInput;
+  timeBucketSelect?: TemplatedInput;
   groupBy?: TemplatedInput;
   from: TemplatedInput;
   where: TemplatedInput;
   valueAlias: TemplatedInput;
+};
+
+export const GROUP_ALIAS = 'group';
+
+const renderTimeBucketProjection = (
+  timeBucketSelect: TemplatedInput | undefined,
+) => (timeBucketSelect ? chSql`${timeBucketSelect},` : chSql``);
+
+const renderChSqlList = (
+  list: (TemplatedInput | undefined)[],
+  separator: string = ', ',
+) =>
+  concatChSql(
+    separator,
+    list.filter(item => item !== undefined).map(item => chSql`${item}`),
+  );
+
+const renderOutputDimensions = ({
+  timeBucketSelect,
+  groupBy,
+}: Pick<HistogramCountInput, 'timeBucketSelect' | 'groupBy'>) => {
+  const rendered = renderChSqlList(
+    [
+      timeBucketSelect ? `\`${FIXED_TIME_BUCKET_EXPR_ALIAS}\`` : undefined,
+      groupBy ? GROUP_ALIAS : undefined,
+    ],
+    ',\n',
+  );
+  return rendered.sql.length > 0 ? chSql`${rendered},` : chSql``;
+};
+
+const renderDimensionGroupBy = ({
+  timeBucketSelect,
+  groupBy,
+}: Pick<HistogramCountInput, 'timeBucketSelect' | 'groupBy'>) => {
+  const rendered = renderChSqlList([
+    timeBucketSelect ? `\`${FIXED_TIME_BUCKET_EXPR_ALIAS}\`` : undefined,
+    groupBy ? GROUP_ALIAS : undefined,
+  ]);
+  return rendered.sql.length > 0 ? chSql`GROUP BY ${rendered}` : chSql``;
 };
 
 // SQL expression for hashing metric attributes into a per-series key.
@@ -26,7 +66,7 @@ export const translateHistogram = ({
   ...rest
 }: {
   select: Exclude<BuilderChartConfig['select'], string>[number];
-  timeBucketSelect: TemplatedInput;
+  timeBucketSelect?: TemplatedInput;
   groupBy?: TemplatedInput;
   from: TemplatedInput;
   where: TemplatedInput;
@@ -59,18 +99,23 @@ const translateHistogramCount = ({
         SELECT
             TimeUnix,
             AggregationTemporality,
-            ${timeBucketSelect},
-            ${groupBy ? chSql`[${groupBy}] AS group,` : ''}
+            ${renderTimeBucketProjection(timeBucketSelect)}
+            ${groupBy ? chSql`[${groupBy}] AS ${GROUP_ALIAS},` : ''}
             ${ATTR_HASH_EXPR} AS attr_hash,
             cityHash64(ExplicitBounds) AS bounds_hash,
             toInt64(Count) AS current_count,
             lagInFrame(toNullable(current_count), 1, NULL) OVER (
-                PARTITION BY ${groupBy ? `group, ` : ''} attr_hash, bounds_hash, AggregationTemporality
+                PARTITION BY ${groupBy ? `${GROUP_ALIAS}, ` : ''}attr_hash, bounds_hash, AggregationTemporality
                 ORDER BY TimeUnix
             ) AS prev_count,
             CASE
                 WHEN AggregationTemporality = 1 THEN current_count
-                WHEN AggregationTemporality = 2 THEN greatest(0, current_count - coalesce(prev_count, 0))
+                WHEN AggregationTemporality = 2 AND prev_count IS NOT NULL
+                  THEN if( ${'' /** When the series resets, take the new current_count as the delta (since it's counting up from 0) */}
+                    current_count < prev_count,
+                    current_count,
+                    current_count - prev_count
+                  )
                 ELSE 0
             END AS delta
         FROM ${from}
@@ -81,11 +126,10 @@ const translateHistogramCount = ({
     name: 'metrics',
     sql: chSql`
         SELECT
-            \`__hdx_time_bucket\`,
-            ${groupBy ? 'group,' : ''}
+            ${renderOutputDimensions({ timeBucketSelect, groupBy })}
             sum(delta) AS "${valueAlias}"
         FROM source
-        GROUP BY ${groupBy ? 'group, ' : ''}\`__hdx_time_bucket\`
+        ${renderDimensionGroupBy({ timeBucketSelect, groupBy })}
     `,
   },
 ];
@@ -98,7 +142,7 @@ const translateHistogramQuantile = ({
   valueAlias,
   level,
 }: {
-  timeBucketSelect: TemplatedInput;
+  timeBucketSelect?: TemplatedInput;
   groupBy?: TemplatedInput;
   from: TemplatedInput;
   where: TemplatedInput;
@@ -111,26 +155,30 @@ const translateHistogramQuantile = ({
           SELECT
             MetricName,
             ExplicitBounds,
-            ${timeBucketSelect},
-            ${groupBy ? 'group,' : ''}
+            ${renderTimeBucketProjection(timeBucketSelect)}
+            ${groupBy ? `${GROUP_ALIAS},` : ''}
             sumForEach(deltas) as rates
           FROM (
             SELECT
               TimeUnix,
               MetricName,
               ExplicitBounds,
-              ${groupBy ? chSql` group,` : ''}
+              ${groupBy ? chSql` ${GROUP_ALIAS},` : ''}
               attr_hash,
               any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
               any(bounds_hash) OVER prev_row AS prev_bounds_hash,
               any(counts) OVER prev_row AS prev_counts,
               counts,
-              IF(
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, ${'' /** The first point in a cumulative/monotonic series contributes 0 delta */}
+                  arrayWithConstant(length(counts), toInt64(0)),
+
                   AggregationTemporality = 1 ${'' /* denotes a metric that is not monotonic e.g. already a delta */}
-                      OR prev_attr_hash != attr_hash ${'' /* the attributes have changed so this is a different metric */}
                       OR bounds_hash != prev_bounds_hash ${'' /* the bucketing has changed so should be treated as different metric */}
                       OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), ${'' /* a data point has gone down, probably a reset event */}
                   counts,
+
                   counts - prev_counts
               ) AS deltas
             FROM (
@@ -140,31 +188,30 @@ const translateHistogramQuantile = ({
                   AggregationTemporality,
                   ExplicitBounds,
                   ResourceAttributes,
-                  Attributes,${groupBy ? chSql`[${groupBy}] as group,` : ''}
+                  Attributes,${groupBy ? chSql`[${groupBy}] as ${GROUP_ALIAS},` : ''}
                   ${ATTR_HASH_EXPR} AS attr_hash,
                   cityHash64(ExplicitBounds) AS bounds_hash,
                   CAST(BucketCounts AS Array(Int64)) counts
               FROM ${from}
               WHERE ${where}
-              ORDER BY ${groupBy ? 'group, ' : ''}attr_hash, TimeUnix ASC
+              ORDER BY ${groupBy ? `${GROUP_ALIAS}, ` : ''}attr_hash, TimeUnix ASC
             )
             WINDOW prev_row AS (
-            ${groupBy ? chSql` PARTITION BY group` : ''}
+            ${groupBy ? chSql` PARTITION BY ${GROUP_ALIAS}` : ''}
               ORDER BY attr_hash, TimeUnix
               ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
             )
           )
-          GROUP BY \`__hdx_time_bucket\`, MetricName, ${groupBy ? 'group, ' : ''}ExplicitBounds
-          ORDER BY \`__hdx_time_bucket\`
+          GROUP BY ${timeBucketSelect ? chSql`${FIXED_TIME_BUCKET_EXPR_ALIAS},` : ''} MetricName, ${groupBy ? `${GROUP_ALIAS}, ` : ''}ExplicitBounds
+          ${timeBucketSelect ? chSql`ORDER BY ${FIXED_TIME_BUCKET_EXPR_ALIAS}` : ''}
           `,
   },
   {
     name: 'points',
     sql: chSql`
           SELECT
-            \`__hdx_time_bucket\`,
+            ${renderOutputDimensions({ timeBucketSelect, groupBy })}
             MetricName,
-            ${groupBy ? 'group,' : ''}
             arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
             length(point) as n
           FROM source
@@ -174,9 +221,8 @@ const translateHistogramQuantile = ({
     name: 'metrics',
     sql: chSql`
           SELECT
-            \`__hdx_time_bucket\`,
+            ${renderOutputDimensions({ timeBucketSelect, groupBy })}
             MetricName,
-            ${groupBy ? 'group,' : ''}
             point[n].1 AS total,
             ${{ Float64: level }} * total AS rank,
             arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
@@ -208,7 +254,7 @@ export const translateExponentialHistogram = ({
   ...rest
 }: {
   select: Exclude<BuilderChartConfig['select'], string>[number];
-  timeBucketSelect: TemplatedInput;
+  timeBucketSelect?: TemplatedInput;
   groupBy?: TemplatedInput;
   from: TemplatedInput;
   where: TemplatedInput;
@@ -245,8 +291,8 @@ const translateExponentialHistogramCount = ({
         TimeUnix,
         StartTimeUnix,
         AggregationTemporality,
-        ${timeBucketSelect},
-        ${groupBy ? chSql`[${groupBy}] AS group,` : ''}
+        ${renderTimeBucketProjection(timeBucketSelect)}
+        ${groupBy ? chSql`[${groupBy}] AS ${GROUP_ALIAS},` : ''}
         ${ATTR_HASH_EXPR} AS attr_hash,
         toInt64(Count) AS current_count,
         count() OVER prev_row = 0 AS is_first_series_point,
@@ -265,7 +311,7 @@ const translateExponentialHistogramCount = ({
       FROM ${from}
       WHERE ${where}
       WINDOW prev_row AS (
-        PARTITION BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash, AggregationTemporality
+        PARTITION BY ${groupBy ? `${GROUP_ALIAS}, ` : ''}MetricName, attr_hash, AggregationTemporality
         ORDER BY TimeUnix
         ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
       )
@@ -275,11 +321,10 @@ const translateExponentialHistogramCount = ({
     name: 'metrics',
     sql: chSql`
       SELECT
-        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
-        ${groupBy ? 'group,' : ''}
+        ${renderOutputDimensions({ timeBucketSelect, groupBy })}
         sum(delta) AS "${valueAlias}"
       FROM source
-      GROUP BY ${FIXED_TIME_BUCKET_EXPR_ALIAS}${groupBy ? ', group' : ''}
+      ${renderDimensionGroupBy({ timeBucketSelect, groupBy })}
     `,
   },
 ];
@@ -292,7 +337,7 @@ const translateExponentialHistogramQuantile = ({
   valueAlias,
   level,
 }: {
-  timeBucketSelect: TemplatedInput;
+  timeBucketSelect?: TemplatedInput;
   groupBy?: TemplatedInput;
   from: TemplatedInput;
   where: TemplatedInput;
@@ -310,7 +355,7 @@ const translateExponentialHistogramQuantile = ({
         AggregationTemporality,
         Scale,
         ${ATTR_HASH_EXPR} AS attr_hash,
-        ${groupBy ? chSql`[${groupBy}] as group,` : ''}
+        ${groupBy ? chSql`[${groupBy}] as ${GROUP_ALIAS},` : ''}
         ZeroCount,
         PositiveOffset,
         PositiveBucketCounts,
@@ -333,7 +378,7 @@ const translateExponentialHistogramQuantile = ({
         AggregationTemporality,
         normalized_scale AS Scale,
         attr_hash,
-        ${groupBy ? 'group,' : ''}
+        ${groupBy ? `${GROUP_ALIAS},` : ''}
         ZeroCount,
         
         assumeNotNull((SELECT min(Scale) FROM filtered_series)) AS normalized_scale,
@@ -387,7 +432,7 @@ const translateExponentialHistogramQuantile = ({
         MetricName,
         TimeUnix,
         Scale,
-        ${groupBy ? 'group,' : ''}
+        ${groupBy ? `${GROUP_ALIAS},` : ''}
 
         ${'' /* Points with no usable predecessor or (StartTimeUnix = TimeUnix) contribute no delta */}
         is_first_series_point OR StartTimeUnix = TimeUnix AS use_zero_counts,
@@ -444,7 +489,7 @@ const translateExponentialHistogramQuantile = ({
           StartTimeUnix,
           Scale,
           attr_hash,
-          ${groupBy ? 'group,' : ''}
+          ${groupBy ? `${GROUP_ALIAS},` : ''}
           PositiveOffset,
           NegativeOffset,
 
@@ -503,10 +548,10 @@ const translateExponentialHistogramQuantile = ({
           FROM series_with_normalized_scale
           WHERE AggregationTemporality = 2
           ${'' /** Keep the input ordering aligned with the prev_row window sort/partition keys. */}
-          ORDER BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash, TimeUnix
+          ORDER BY ${groupBy ? `${GROUP_ALIAS}, ` : ''}MetricName, attr_hash, TimeUnix
         ) AS series
         WINDOW prev_row AS (
-          PARTITION BY ${groupBy ? 'group, ' : ''}MetricName, attr_hash
+          PARTITION BY ${groupBy ? `${GROUP_ALIAS}, ` : ''}MetricName, attr_hash
           ORDER BY TimeUnix
           ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
         )
@@ -519,7 +564,7 @@ const translateExponentialHistogramQuantile = ({
         MetricName,
         TimeUnix,
         Scale,
-        ${groupBy ? 'group,' : ''}
+        ${groupBy ? `${GROUP_ALIAS},` : ''}
         toUInt8(0) AS use_zero_counts,
         toUInt8(1) AS use_current_counts,
         toInt64(ZeroCount) AS ZeroCount,
@@ -543,14 +588,14 @@ const translateExponentialHistogramQuantile = ({
     name: 'summed_buckets',
     sql: chSql`
       SELECT
-        ${timeBucketSelect},
-        ${groupBy ? 'group,' : ''}
+        ${renderTimeBucketProjection(timeBucketSelect)}
+        ${groupBy ? `${GROUP_ALIAS},` : ''}
         any(Scale) AS Scale,
         sum(ZeroCount) AS ZeroCount,
         sumMap(positive_bucket_indexes, positive_bucket_counts) AS positive_buckets,
         sumMap(negative_bucket_indexes, negative_bucket_counts) AS negative_buckets
       FROM normalized_deltas
-      GROUP BY ${FIXED_TIME_BUCKET_EXPR_ALIAS}${groupBy ? ', group' : ''}
+      ${renderDimensionGroupBy({ timeBucketSelect, groupBy })}
     `,
   },
   // Select the bucket containing the requested quantile rank.
@@ -558,8 +603,7 @@ const translateExponentialHistogramQuantile = ({
     name: 'selected_quantile_buckets',
     sql: chSql`
       SELECT
-        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
-        ${groupBy ? 'group,' : ''}
+        ${renderOutputDimensions({ timeBucketSelect, groupBy })}
         Scale,
 
         ${'' /* Negative, zero, and positive buckets arranged in ascending value order. */}
@@ -603,8 +647,7 @@ const translateExponentialHistogramQuantile = ({
     name: 'metrics',
     sql: chSql`
       SELECT
-        ${FIXED_TIME_BUCKET_EXPR_ALIAS},
-        ${groupBy ? 'group,' : ''}
+        ${renderOutputDimensions({ timeBucketSelect, groupBy })}
         multiIf(
           selected_bucket_side < 0,
           -exp2((selected_bucket_index + 1 - fraction_within_bucket) * exp2(-Scale)),

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -4,6 +4,7 @@ import SqlString from 'sqlstring';
 
 import { ChSql, chSql, concatChSql, wrapChSqlIfNotEmpty } from '@/clickhouse';
 import {
+  GROUP_ALIAS,
   translateExponentialHistogram,
   translateHistogram,
 } from '@/core/histogram';
@@ -2034,7 +2035,6 @@ async function translateMetricChartConfig(
     // Render the various clauses from the user input so they can be woven into the CTE queries. The dateRange
     // is manipulated to search forward/back one bucket window to ensure that there is enough data to compute
     // a reasonable value on the ends of the series.
-
     const cteChartConfig = {
       ...chartConfig,
       from: {
@@ -2056,14 +2056,15 @@ async function translateMetricChartConfig(
           : chartConfig.granularity,
     } satisfies BuilderChartConfigWithOptDateRangeEx;
 
-    const timeBucketSelect = isUsingGranularity(cteChartConfig)
+    const hasGranularity = isUsingGranularity(cteChartConfig);
+    const timeBucketSelect = hasGranularity
       ? timeBucketExpr({
           interval: cteChartConfig.granularity,
           timestampValueExpression: cteChartConfig.timestampValueExpression,
           dateRange: cteChartConfig.dateRange,
           isRenderingRawSqlTemplate: chartConfig.isRenderingRawSqlTemplate,
         })
-      : chSql``;
+      : undefined;
     const where = await renderWhere(cteChartConfig, metadata);
 
     // Time bucket grouping is being handled separately, so make sure to ignore the granularity
@@ -2078,9 +2079,7 @@ async function translateMetricChartConfig(
 
     const translationInput = {
       select: _select,
-      timeBucketSelect: timeBucketSelect.sql
-        ? chSql`${timeBucketSelect}`
-        : 'TimeUnix AS `__hdx_time_bucket`',
+      timeBucketSelect,
       groupBy,
       from: renderFrom({
         from: {
@@ -2100,15 +2099,24 @@ async function translateMetricChartConfig(
       with: isExponentialHistogram
         ? translateExponentialHistogram(translationInput)
         : translateHistogram(translationInput),
-      select: `\`__hdx_time_bucket\`${groupBy ? ', group' : ''}, "${valueAlias}"`,
+      select: [
+        ...(hasGranularity ? [`\`${FIXED_TIME_BUCKET_EXPR_ALIAS}\``] : []),
+        ...(groupBy ? [GROUP_ALIAS] : []),
+        `"${valueAlias}"`,
+      ].join(', '),
       from: {
         databaseName: '',
         tableName: 'metrics',
       },
       where: '', // clear up the condition since the where clause is already applied at the upstream CTE
+      // Timeseries queries discard padded buckets here. Non-timeseries queries
+      // scan only the visible range and have no time dimension to filter.
+      dateRange: hasGranularity ? restChartConfig.dateRange : undefined,
       groupBy: undefined,
       granularity: undefined, // time bucketing and granularity is applied at the source CTE
-      timestampValueExpression: '`__hdx_time_bucket`',
+      timestampValueExpression: hasGranularity
+        ? `\`${FIXED_TIME_BUCKET_EXPR_ALIAS}\``
+        : restChartConfig.timestampValueExpression,
       settings: chSql`short_circuit_function_evaluation = 'force_enable'`,
     };
   }


### PR DESCRIPTION
## Summary

This change fixes aggregation of histogram and exponential histogram metrics for display types other than line. It also makes a few correctness improvements.

This PR also removes the feature toggle for exponential histogram support, as this is ready to deploy.

### Non-line Aggregations

1. Previously, stacked_bar was not recognized as a timeseries chart when combining multiple metrics series. Now, stacked_bar is combined by timestamp just like line charts.
2. Previously, charts like Number, Bar, and Pie aggregated by TimeUnix, returning a result for every unique TimeUnix value. Number would display one of them, bar and pie charts would display all of them. Now, display types without `granularity` aggregate over the entire observed time range, and return one result per group.

### Correctness Improvements

1. Previously, for cumulative histogram metrics, the first point in a series was used as the delta value for that timestamp. This generally overcounted results, and didn't match prometheus. Now, the first point represents the baseline and contributes zero delta. Deltas for subsequent points are calculated against that baseline.
2. Previously, in the explicit histogram count and quantile aggregations, the first point after a counter reset contributed 0 delta. This was incorrect because if the counter goes from 100 --> 120 --> 5 --> 20, the (5) sample represents a reset, and should contribute a delta of at least 5, since it is counting up from 0. We now use the first post-reset value as the delta, rather than assume a 0 delta after reset.

## Screenshots or video

Timeseries quantiles and counts continue working for both delta and cumulative temporality. The explicit and exponential histogram quantile values differ due to different interpolation approaches (this is expected). Stacked bar charts now show both series.

<img width="2281" height="955" alt="Screenshot 2026-07-23 at 10 37 14 AM" src="https://github.com/user-attachments/assets/feef95d2-b1bc-41a3-932b-b5a127f59179" />
<img width="2292" height="959" alt="Screenshot 2026-07-23 at 10 38 43 AM" src="https://github.com/user-attachments/assets/efabdd85-a39d-4072-90ba-fee1f10fee2c" />

Bar and Number charts render correctly and aggregate over the entire visible time range

<img width="2285" height="1069" alt="Screenshot 2026-07-23 at 10 58 04 AM" src="https://github.com/user-attachments/assets/18b1080f-4157-4575-898b-daab879beb83" />

Previously, these were not in good shape:

<img width="2300" height="1075" alt="Screenshot 2026-07-23 at 10 59 46 AM" src="https://github.com/user-attachments/assets/2e32316b-238a-4271-941a-5dc76b2ec872" />

## How to test locally

Ask your agent to instrument a service with some histogram data points, then visualize those in dashboard or chart explorer tiles.

## References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4858
- Related PRs:
