### PR TITLE
feat(mcp): expose table tile alternateRowBackground in dashboard authoring schema

### DIFF
--- a/.changeset/table-tile-alternate-row-mcp.md
+++ b/.changeset/table-tile-alternate-row-mcp.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/api": patch
+---
+
+feat(mcp): expose table tile alternate row background in the dashboard authoring tool
+
+The clickstack_save_dashboard MCP tool now accepts alternateRowBackground on builder table tiles, so AI-authored dashboards can turn on zebra striping. Defaults to false.

--- a/packages/api/src/mcp/__tests__/dashboards/saveDashboard.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/saveDashboard.int.test.ts
@@ -191,6 +191,7 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
               select: [{ aggFn: 'count' }],
               groupBy: 'SpanName',
               groupByColumnsOnLeft: true,
+              alternateRowBackground: true,
             },
           },
           {
@@ -251,6 +252,7 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
       );
       expect(tableTile).toBeDefined();
       expect(tableTile.config.groupByColumnsOnLeft).toBe(true);
+      expect(tableTile.config.alternateRowBackground).toBe(true);
     });
 
     it('should create a dashboard with a raw SQL tile', async () => {

--- a/packages/api/src/mcp/prompts/dashboards/content.ts
+++ b/packages/api/src/mcp/prompts/dashboards/content.ts
@@ -96,7 +96,7 @@ Apply these before calling clickstack_save_dashboard. Each rule is enforced by t
 
 3. GROUP BY HAS NO ALIAS HOOK. The chart config's groupBy is a single expression string and the renderer uses it verbatim as the column header (tables) and as the raw column name everywhere else (CSV export, tooltips, orderBy references, onClick template references). Grouping a table by SpanAttributes['http.route'] produces a column header that reads literally as arrayElement(SpanAttributes, 'http.route'). When a top-level column carries the same semantic, prefer it: SpanName for operation, ServiceName for service, SeverityText for log severity. When the dimension exists only as a Map attribute and the column header matters, drop to a raw SQL tile (configType: "sql") and write the column with AS alias. Line, stacked_bar, and pie tiles legend by the value not the column name, so the issue is invisible on the chart itself but still bites CSV export and onClick template references.
 
-4. INVENTORY-STYLE TABLES PUT THE GROUP BY ON THE LEFT. Set groupByColumnsOnLeft: true on tables that read like a list of things (one row per service, per endpoint, per tenant).
+4. INVENTORY-STYLE TABLES PUT THE GROUP BY ON THE LEFT. Set groupByColumnsOnLeft: true on tables that read like a list of things (one row per service, per endpoint, per tenant). For wide tables that are hard to scan, set alternateRowBackground: true to zebra-stripe the rows (default false).
 
 5. RED COLUMNS FOR SERVICE / ENDPOINT TABLES. Request rate (count), Error rate (count with where: "StatusCode:STATUS_CODE_ERROR"), Duration (quantile P95 on the Duration column). Three columns, all aliased.
 

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -587,6 +587,13 @@ const mcpTableTileSchema = mcpTileLayoutSchema.extend({
         'Render Group By columns on the left side of the table, before the series columns. ' +
           'Default false (Group By columns on the right).',
       ),
+    alternateRowBackground: z
+      .boolean()
+      .optional()
+      .describe(
+        'Zebra-stripe the table by tinting alternating rows, which aids scanning on wide tables. ' +
+          'Default false.',
+      ),
     numberFormat: mcpNumberFormatSchema
       .optional()
       .describe(tileLevelNumberFormatDescription),


### PR DESCRIPTION
## Summary

Stacked on #2698 (external Dashboards API); merge that first. Adds `alternateRowBackground` to the MCP `clickstack_save_dashboard` builder table tile schema and a short prompt guidance line, so AI-authored dashboards can turn on zebra striping. The MCP save path validates and converts through the external dashboard schema, so the field only persists once #2698 lands.

- `schemas.ts`: adds the optional boolean to `mcpTableTileSchema.config`, next to `groupByColumnsOnLeft`.
- `content.ts`: one guidance sentence appended to the existing inventory-style-tables rule.
- Handler round-trip test: the multi-tile create test now sends and asserts `alternateRowBackground: true` on the returned builder table tile.

## Open question for review: expose it on the raw SQL MCP tile schema too?

I kept this to the builder table tile (`mcpTableTileSchema`) for now. Worth a second opinion though: `alternateRowBackground` lives on the shared chart-settings schema, so #2698 exposes it on both the builder and raw SQL external table configs, and the app (from #2519) applies striping to raw SQL table tiles as well.

`mcpSqlTileSchema` already carries `numberFormat`, `color`, and `onClick`, so adding `alternateRowBackground` there would mirror `onClick` exactly (a table-only field on the shared SQL schema, carried table-guarded through the external round-trip). The counterargument is keeping the MCP SQL tile schema lean. I'm happy to add it here if you want full parity across the MCP surface; left it out to keep the tool schema tight. Your call.

## Test plan

- `mcp/__tests__/dashboards/saveDashboard.int.test.ts`: 59/59 pass; the multi-tile create round-trip asserts `alternateRowBackground: true` survives on the returned builder table tile.
- `tsc --noEmit` and eslint clean.

Incremental scope vs the base branch is 2 files / 9 production lines (Tier 2).
