### PR TITLE
Improve time chart hover for dense charts

### DIFF
--- a/.changeset/timechart-dense-hover.md
+++ b/.changeset/timechart-dense-hover.md
@@ -4,9 +4,11 @@
 
 feat: Improve time chart hover for dense charts
 
-- Charts with more than 10 series now show a single-series hover tooltip: only
-  the series nearest the cursor, instead of a tall list of every series that is
-  impossible to read and never the one being pointed at.
+- Line and area charts with more than 10 visible series now show a single-series
+  hover tooltip: only the series nearest the cursor, instead of a tall list of
+  every series that is impossible to read and never the one being pointed at.
+  Filtering the legend down to fewer series brings the full list back, and
+  stacked bars keep the full tooltip.
 - The hovered series is emphasized by a dedicated line drawn on top, so it is
   never hidden behind another line that happens to share its values. The other
   lines dim via one CSS class instead of re-rendering every line on each cursor

--- a/.changeset/timechart-dense-hover.md
+++ b/.changeset/timechart-dense-hover.md
@@ -1,0 +1,16 @@
+---
+'@hyperdx/app': patch
+---
+
+feat: Improve time chart hover for dense charts
+
+- Charts with more than 10 series now show a single-series hover tooltip: only
+  the series nearest the cursor, instead of a tall list of every series that is
+  impossible to read and never the one being pointed at.
+- The hovered series is emphasized by a dedicated line drawn on top, so it is
+  never hidden behind another line that happens to share its values. The other
+  lines dim via one CSS class instead of re-rendering every line on each cursor
+  move.
+- Synced charts highlight the same series by name: hovering a line on one chart
+  surfaces that series on the others, and a chart that does not have it shows
+  only the shared time cursor.

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -71,34 +71,49 @@ type TooltipMode = 'single' | 'all' | 'hidden';
 // being pointed at. At or below it, the full sorted list stays useful.
 const SINGLE_SERIES_TOOLTIP_THRESHOLD = 10;
 
-// Shared "series the user is hovering" across synced charts. recharts' syncId
+// Shared "series the user is hovering", keyed by sync group. recharts' syncId
 // only shares the active time bucket, not a series, so a follower chart has no
 // way to know which series to surface, and picking by its own (irrelevant)
 // cursor Y is arbitrary. The hovered chart publishes the display name of the
-// series under its cursor; followers read it to highlight the same series by
-// name, and show no row when they don't have it.
-let sharedHoveredSeriesName: string | undefined;
-const hoveredSeriesSubscribers = new Set<() => void>();
-function setSharedHoveredSeries(name: string | undefined) {
-  if (name === sharedHoveredSeriesName) return;
-  sharedHoveredSeriesName = name;
-  hoveredSeriesSubscribers.forEach(fn => fn());
+// series under its cursor; followers in the same group read it to highlight the
+// same series by name, and show no row when they don't have it.
+//
+// Keyed by group so a hover only re-renders the charts in that group. Synced
+// charts share a group (their syncId); an unsynced chart uses its own id, so it
+// never re-renders, or is re-rendered by, any other chart on the page.
+const hoveredSeriesByGroup = new Map<string, string | undefined>();
+const hoverSubscribersByGroup = new Map<string, Set<() => void>>();
+function setSharedHoveredSeries(group: string, name: string | undefined) {
+  if (hoveredSeriesByGroup.get(group) === name) return;
+  hoveredSeriesByGroup.set(group, name);
+  hoverSubscribersByGroup.get(group)?.forEach(fn => fn());
 }
-function subscribeHoveredSeries(cb: () => void) {
-  hoveredSeriesSubscribers.add(cb);
-  return () => {
-    hoveredSeriesSubscribers.delete(cb);
-  };
-}
-function getHoveredSeriesSnapshot() {
-  return sharedHoveredSeriesName;
-}
-function useSharedHoveredSeries(): string | undefined {
-  return useSyncExternalStore(
-    subscribeHoveredSeries,
-    getHoveredSeriesSnapshot,
-    getHoveredSeriesSnapshot,
+function useSharedHoveredSeries(group: string): string | undefined {
+  const subscribe = useCallback(
+    (cb: () => void) => {
+      let subs = hoverSubscribersByGroup.get(group);
+      if (!subs) {
+        subs = new Set();
+        hoverSubscribersByGroup.set(group, subs);
+      }
+      subs.add(cb);
+      return () => {
+        subs.delete(cb);
+        // Drop the group's maps once nothing is listening so a page churning
+        // through many charts doesn't leak group entries.
+        if (subs.size === 0) {
+          hoverSubscribersByGroup.delete(group);
+          hoveredSeriesByGroup.delete(group);
+        }
+      };
+    },
+    [group],
   );
+  const getSnapshot = useCallback(
+    () => hoveredSeriesByGroup.get(group),
+    [group],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 // Gap below the data point for the hover tooltip. Kept equal to the pinned
@@ -850,6 +865,10 @@ export const MemoChart = memo(function MemoChart({
 
   // recharts sync group, scoped via context (see chartSync).
   const syncId = useChartSyncId();
+  // Group for the shared hovered-series store. Synced charts share their syncId;
+  // an unsynced chart falls back to its own id so it stays isolated (a hover
+  // never re-renders unrelated charts elsewhere on the page).
+  const hoverGroup = syncId ?? id;
 
   const [isHovered, setIsHovered] = useState(false);
 
@@ -878,7 +897,7 @@ export const MemoChart = memo(function MemoChart({
 
   // The name of the series the user is hovering on whichever chart is under the
   // cursor, shared across synced charts so followers can match it by name.
-  const crossChartHoveredName = useSharedHoveredSeries();
+  const crossChartHoveredName = useSharedHoveredSeries(hoverGroup);
 
   // Only the hovered chart publishes; on leave it clears the value it set.
   useEffect(() => {
@@ -887,12 +906,15 @@ export const MemoChart = memo(function MemoChart({
       nearestSeriesKey != null
         ? lineData.find(l => l.dataKey === nearestSeriesKey)
         : undefined;
-    setSharedHoveredSeries(ld ? getSeriesDisplayName(ld) : undefined);
-  }, [isHovered, nearestSeriesKey, lineData]);
+    setSharedHoveredSeries(
+      hoverGroup,
+      ld ? getSeriesDisplayName(ld) : undefined,
+    );
+  }, [isHovered, nearestSeriesKey, lineData, hoverGroup]);
   useEffect(() => {
     if (!isHovered) return;
-    return () => setSharedHoveredSeries(undefined);
-  }, [isHovered]);
+    return () => setSharedHoveredSeries(hoverGroup, undefined);
+  }, [isHovered, hoverGroup]);
 
   const ChartComponent = useMemo(
     () => (displayType === DisplayType.StackedBar ? BarChart : AreaChart), // LineChart;

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import cx from 'classnames';
 import { add, isSameSecond, sub } from 'date-fns';
@@ -63,6 +64,38 @@ const MAX_LEGEND_ITEMS = 4;
 // tooltip is not misleading when the pointer is in empty space.
 const NEAREST_SERIES_MAX_DISTANCE_PX = 30;
 
+type TooltipMode = 'single' | 'all' | 'hidden';
+
+// Shared "series the user is hovering" across synced charts. recharts' syncId
+// only shares the active time bucket, not a series, so a follower chart has no
+// way to know which series to surface, and picking by its own (irrelevant)
+// cursor Y is arbitrary. The hovered chart publishes the display name of the
+// series under its cursor; followers read it to highlight the same series by
+// name, and show no row when they don't have it.
+let sharedHoveredSeriesName: string | undefined;
+const hoveredSeriesSubscribers = new Set<() => void>();
+function setSharedHoveredSeries(name: string | undefined) {
+  if (name === sharedHoveredSeriesName) return;
+  sharedHoveredSeriesName = name;
+  hoveredSeriesSubscribers.forEach(fn => fn());
+}
+function subscribeHoveredSeries(cb: () => void) {
+  hoveredSeriesSubscribers.add(cb);
+  return () => {
+    hoveredSeriesSubscribers.delete(cb);
+  };
+}
+function getHoveredSeriesSnapshot() {
+  return sharedHoveredSeriesName;
+}
+function useSharedHoveredSeries(): string | undefined {
+  return useSyncExternalStore(
+    subscribeHoveredSeries,
+    getHoveredSeriesSnapshot,
+    getHoveredSeriesSnapshot,
+  );
+}
+
 // Gap below the data point for the hover tooltip. Kept equal to the pinned
 // tooltip's Popover `offset` so both land in the same spot.
 const TOOLTIP_POINT_OFFSET_PX = 12;
@@ -117,6 +150,55 @@ export const TooltipItem = memo(
   },
 );
 
+/**
+ * Which rows the hover tooltip renders, given its mode and hover state. Returns
+ * `null` to render nothing (a synced follower with no matching series, where
+ * only the shared time cursor should show).
+ *
+ * - all-series mode (`nearestOnly` false): every series at the hovered time,
+ *   sorted high to low.
+ * - single-series mode on the hovered chart: just the series nearest the cursor
+ *   (`nearestKey`), falling back to the top series by value before an
+ *   active-point Y has been captured.
+ * - single-series mode on a synced follower: the series matching the one the
+ *   user is hovering elsewhere (`crossChartHoveredName`), or nothing if this
+ *   chart has no series by that name.
+ *
+ * Callers pass an already-deduped payload; this sorts a copy because Recharts 3
+ * freezes the payload and an in-place sort throws "this object has been frozen".
+ */
+export function selectTooltipRows({
+  payload,
+  nearestOnly,
+  isChartHovered,
+  nearestKey,
+  crossChartHoveredName,
+}: {
+  payload: TooltipPayload[];
+  nearestOnly: boolean;
+  isChartHovered: boolean;
+  nearestKey?: string;
+  crossChartHoveredName?: string;
+}): TooltipPayload[] | null {
+  const sorted = [...payload].sort((a, b) => b.value - a.value);
+
+  if (!nearestOnly) return sorted;
+
+  if (isChartHovered) {
+    const chosen =
+      (nearestKey != null
+        ? sorted.find(p => p.dataKey === nearestKey)
+        : undefined) ?? sorted[0];
+    return chosen ? [chosen] : [];
+  }
+
+  const matched =
+    crossChartHoveredName != null
+      ? sorted.find(p => p.name === crossChartHoveredName)
+      : undefined;
+  return matched ? [matched] : null;
+}
+
 type HDXLineChartTooltipProps = {
   lineDataMap: { [keyName: string]: LineData };
   previousPeriodOffsetSeconds?: number;
@@ -126,6 +208,21 @@ type HDXLineChartTooltipProps = {
   activePointYByKeyRef: React.MutableRefObject<Map<string, number>>;
   /** The chart's outer container; its viewport rect anchors this tooltip. */
   containerRef: React.MutableRefObject<HTMLDivElement | null>;
+  /** Collapse the tooltip to only the single series nearest the cursor. */
+  nearestOnly?: boolean;
+  /**
+   * Whether the cursor is actually over THIS chart. On synced follower charts
+   * it is false: recharts shows their tooltip for the same time bucket, but the
+   * cursor Y is not meaningful there. Followers instead surface the same series
+   * the user is hovering elsewhere (by name, via `crossChartHoveredName`).
+   */
+  isChartHovered?: boolean;
+  /**
+   * Display name of the series the user is hovering on whichever chart they are
+   * actually over. On synced followers, the matching series (if any) is shown;
+   * if this chart has no series by that name, no row is shown.
+   */
+  crossChartHoveredName?: string;
 } & Record<string, any>;
 
 /**
@@ -149,8 +246,21 @@ const HDXLineChartTooltip = withErrorBoundary(
       previousPeriodOffsetSeconds,
       activePointYByKeyRef,
       containerRef,
+      nearestOnly,
+      isChartHovered,
+      crossChartHoveredName,
     } = props;
-    const typedPayload = payload as TooltipPayload[];
+    // Dedupe by dataKey: the chart adds a stroke-only overlay Area for the
+    // emphasized series (drawn on top), which would otherwise appear twice.
+    const typedPayload = useMemo<TooltipPayload[]>(() => {
+      const raw: TooltipPayload[] = payload ?? [];
+      const seen = new Set<string>();
+      return raw.filter(p => {
+        if (seen.has(p.dataKey)) return false;
+        seen.add(p.dataKey);
+        return true;
+      });
+    }, [payload]);
 
     const tooltipZIndex = useChartTooltipZIndex();
 
@@ -184,6 +294,32 @@ const HDXLineChartTooltip = withErrorBoundary(
             )
           : undefined;
 
+      // When the caller wants a single-series tooltip (dense charts), collapse
+      // to just the row nearest the cursor. Uncapped so there is always exactly
+      // one row even when the pointer sits between lines. Only meaningful when
+      // the cursor is actually over this chart: on synced followers, and before
+      // any active-point Y is captured, fall back to the top-by-value row.
+      const singleSeriesKey =
+        nearestOnly && isChartHovered
+          ? findNearestSeriesKey(
+              activePointYByKey,
+              typedPayload.map(p => p.dataKey),
+              pointerY,
+              Infinity,
+            )
+          : undefined;
+
+      const rows = selectTooltipRows({
+        payload: typedPayload,
+        nearestOnly: !!nearestOnly,
+        isChartHovered: !!isChartHovered,
+        nearestKey: singleSeriesKey,
+        crossChartHoveredName,
+      });
+      // Synced follower with no matching series: render only the shared time
+      // cursor, no box.
+      if (rows == null) return null;
+
       // Anchor at the active point (see the component docblock for why fixed).
       const pointX = props.coordinate?.x;
       const pointY = props.coordinate?.y;
@@ -215,35 +351,33 @@ const HDXLineChartTooltip = withErrorBoundary(
             header={header}
             contentClassName={styles.chartTooltipContentClipped}
           >
-            {/* Copy before sorting: Recharts 3 freezes the payload, so an
-                in-place sort throws "this object has been frozen". */}
-            {[...payload]
-              .sort((a: TooltipPayload, b: TooltipPayload) => b.value - a.value)
-              .map((p: TooltipPayload) => {
-                const previousKey = lineDataMap[p.dataKey]?.previousPeriodKey;
-                const isPreviousPeriod = previousKey === p.dataKey;
-                const previousPayload =
-                  !isPreviousPeriod && previousKey
-                    ? payloadByKey.get(previousKey)
-                    : undefined;
-                const valueColumnName =
-                  lineDataMap[p.dataKey]?.valueColumnName ?? p.dataKey;
-                const numberFormatForKey =
-                  numberFormatByKey.get(valueColumnName) ?? numberFormat;
+            {rows.map((p: TooltipPayload) => {
+              const previousKey = lineDataMap[p.dataKey]?.previousPeriodKey;
+              const isPreviousPeriod = previousKey === p.dataKey;
+              const previousPayload =
+                !isPreviousPeriod && previousKey
+                  ? payloadByKey.get(previousKey)
+                  : undefined;
+              const valueColumnName =
+                lineDataMap[p.dataKey]?.valueColumnName ?? p.dataKey;
+              const numberFormatForKey =
+                numberFormatByKey.get(valueColumnName) ?? numberFormat;
 
-                return (
-                  <TooltipItem
-                    key={p.dataKey}
-                    p={p}
-                    numberFormat={numberFormatForKey}
-                    previous={previousPayload}
-                    highlighted={p.dataKey === nearestSeriesKey}
-                    dimmed={
-                      nearestSeriesKey != null && p.dataKey !== nearestSeriesKey
-                    }
-                  />
-                );
-              })}
+              return (
+                <TooltipItem
+                  key={p.dataKey}
+                  p={p}
+                  numberFormat={numberFormatForKey}
+                  previous={previousPayload}
+                  highlighted={!nearestOnly && p.dataKey === nearestSeriesKey}
+                  dimmed={
+                    !nearestOnly &&
+                    nearestSeriesKey != null &&
+                    p.dataKey !== nearestSeriesKey
+                  }
+                />
+              );
+            })}
           </ChartTooltipContainer>
         </div>
       );
@@ -650,6 +784,7 @@ export const MemoChart = memo(function MemoChart({
   granularity,
   dateRangeEndInclusive = true,
   fitYAxisToData = false,
+  tooltipMode = 'all',
 }: {
   graphResults: any[];
   setIsClickActive: (v: ActiveClickPayload | undefined) => void;
@@ -683,6 +818,13 @@ export const MemoChart = memo(function MemoChart({
    * (with padding) instead of zero.
    **/
   fitYAxisToData?: boolean;
+  /**
+   * Hover tooltip behavior: `single` shows only the series nearest the cursor
+   * (dense charts), `all` lists every series at the hovered time, `hidden`
+   * suppresses the hover tooltip. The nearest line is still emphasized either
+   * way.
+   */
+  tooltipMode?: TooltipMode;
 }) {
   const _id = useId();
   const id = _id.replace(/:/g, '');
@@ -715,6 +857,24 @@ export const MemoChart = memo(function MemoChart({
     string | undefined
   >();
 
+  // The name of the series the user is hovering on whichever chart is under the
+  // cursor, shared across synced charts so followers can match it by name.
+  const crossChartHoveredName = useSharedHoveredSeries();
+
+  // Only the hovered chart publishes; on leave it clears the value it set.
+  useEffect(() => {
+    if (!isHovered) return;
+    const ld =
+      nearestSeriesKey != null
+        ? lineData.find(l => l.dataKey === nearestSeriesKey)
+        : undefined;
+    setSharedHoveredSeries(ld ? getSeriesDisplayName(ld) : undefined);
+  }, [isHovered, nearestSeriesKey, lineData]);
+  useEffect(() => {
+    if (!isHovered) return;
+    return () => setSharedHoveredSeries(undefined);
+  }, [isHovered]);
+
   const ChartComponent = useMemo(
     () => (displayType === DisplayType.StackedBar ? BarChart : AreaChart), // LineChart;
     [displayType],
@@ -725,16 +885,26 @@ export const MemoChart = memo(function MemoChart({
     [lineData, selectedSeriesNames],
   );
 
-  const lines = useMemo(() => {
-    // When a series is nearest the cursor (only meaningful with more than one
-    // line shown), thicken its line and fade the others so the eye lands on
-    // the same series the tooltip bolds. Mirrors the legend's selected style
-    // (thicker stroke) with a gentle fade that keeps the rest readable.
-    const hasNearest =
+  // The series to emphasize: the line nearest the cursor. Cheap to recompute;
+  // drives the overlay + the dim-others CSS class only, never the base lines.
+  const emphasizedKey = useMemo(() => {
+    if (
       visibleLineData.length > 1 &&
       nearestSeriesKey != null &&
-      visibleLineData.some(ld => ld.dataKey === nearestSeriesKey);
+      visibleLineData.some(ld => ld.dataKey === nearestSeriesKey)
+    ) {
+      return nearestSeriesKey;
+    }
+    return undefined;
+  }, [visibleLineData, nearestSeriesKey]);
+  const dimOthers = emphasizedKey != null && displayType !== 'stacked_bar';
 
+  // Base lines are deliberately independent of the hovered/emphasized series.
+  // Rebuilding ~150 Area elements on every cursor move (as the nearest series
+  // changes) is the heaviest thing this chart can do, so emphasis lives in a
+  // one-element overlay (below) plus a CSS class that dims the rest. Moving the
+  // cursor then rebuilds one element and toggles one class, not the whole set.
+  const baseLines = useMemo(() => {
     return visibleLineData.map(ld => {
       const key = ld.dataKey;
       const color = ld.color;
@@ -760,10 +930,6 @@ export const MemoChart = memo(function MemoChart({
           type="monotone"
           stroke={color}
           fillOpacity={1}
-          strokeWidth={hasNearest && key === nearestSeriesKey ? 2.5 : undefined}
-          strokeOpacity={
-            hasNearest && key !== nearestSeriesKey ? 0.5 : undefined
-          }
           activeDot={<CaptureActiveDot onCapture={captureActivePointY} />}
           {...(isHovered
             ? { fill: 'none', strokeDasharray }
@@ -777,14 +943,37 @@ export const MemoChart = memo(function MemoChart({
         />
       );
     });
-  }, [
-    visibleLineData,
-    displayType,
-    id,
-    isHovered,
-    nearestSeriesKey,
-    captureActivePointY,
-  ]);
+  }, [visibleLineData, displayType, id, isHovered, captureActivePointY]);
+
+  // The emphasized series redrawn thick and on top. recharts paints graphical
+  // items in mount order and ignores a reorder of existing children, so an
+  // emphasized base line stays hidden behind a line drawn after it; a freshly
+  // mounted overlay registers last and paints in front. The class exempts it
+  // from the dim-others CSS; it carries no fill/dot and is deduped out of the
+  // tooltip. Skipped for stacked bars (they occlude by design).
+  const emphasisOverlay = useMemo(() => {
+    if (emphasizedKey == null || displayType === 'stacked_bar') return null;
+    const ld = visibleLineData.find(l => l.dataKey === emphasizedKey);
+    if (!ld) return null;
+    return (
+      <Area
+        key="__hdx_emphasis_overlay__"
+        className="hdx-emphasis-overlay"
+        dataKey={emphasizedKey}
+        type="monotone"
+        stroke={ld.color}
+        strokeWidth={2.5}
+        strokeOpacity={1}
+        fill="none"
+        dot={false}
+        activeDot={false}
+        isAnimationActive={false}
+        connectNulls
+        legendType="none"
+        name={getSeriesDisplayName(ld)}
+      />
+    );
+  }, [emphasizedKey, visibleLineData, displayType]);
 
   const yAxisDomain: AxisDomain = useMemo(() => {
     const hasSelection = selectedSeriesNames && selectedSeriesNames.size > 0;
@@ -1037,6 +1226,7 @@ export const MemoChart = memo(function MemoChart({
   return (
     <div
       ref={containerRef}
+      className={cx({ [styles.dimOthers]: dimOthers })}
       style={{ position: 'relative', width: '100%', height: '100%' }}
     >
       {onTimeRangeSelect != null && zoomOrigin != null ? (
@@ -1121,7 +1311,14 @@ export const MemoChart = memo(function MemoChart({
                     activePointYByKey,
                     Array.from(activePointYByKey.keys()),
                     chartY,
-                    NEAREST_SERIES_MAX_DISTANCE_PX,
+                    // Single-series tooltip always names one series, so bold that
+                    // same line (uncapped) instead of only within 30px, which
+                    // left the named series un-bolded when the cursor sat between
+                    // lines. All-series mode keeps the 30px cap so empty space
+                    // emphasizes nothing.
+                    tooltipMode === 'single'
+                      ? Infinity
+                      : NEAREST_SERIES_MAX_DISTANCE_PX,
                   )
                 : undefined;
             setNearestSeriesKey(prev =>
@@ -1274,12 +1471,13 @@ export const MemoChart = memo(function MemoChart({
             tick={{ fontSize: 11, fontFamily: 'IBM Plex Mono, monospace' }}
             domain={yAxisDomain}
           />
-          {lines}
+          {baseLines}
+          {emphasisOverlay}
           {/* HOVER tooltip (also drives cross-chart shadow tooltips via syncId).
               Hidden once a point is clicked, where the pinned tooltip takes over.
               Portaled to body so HDXLineChartTooltip can self-position (see its
               docblock) and escape the chart's bounds near an edge. */}
-          {isClickActive == null && (
+          {isClickActive == null && tooltipMode !== 'hidden' && (
             <Tooltip
               content={
                 <HDXLineChartTooltip
@@ -1289,6 +1487,9 @@ export const MemoChart = memo(function MemoChart({
                   previousPeriodOffsetSeconds={previousPeriodOffsetSeconds}
                   activePointYByKeyRef={activePointYByKeyRef}
                   containerRef={containerRef}
+                  nearestOnly={tooltipMode === 'single'}
+                  isChartHovered={isHovered}
+                  crossChartHoveredName={crossChartHoveredName}
                 />
               }
               portal={typeof document !== 'undefined' ? document.body : null}

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -66,6 +66,11 @@ const NEAREST_SERIES_MAX_DISTANCE_PX = 30;
 
 type TooltipMode = 'single' | 'all' | 'hidden';
 
+// Above this many visible series the hover tooltip collapses to just the series
+// under the cursor: a list of dozens of rows is unreadable and never the one
+// being pointed at. At or below it, the full sorted list stays useful.
+const SINGLE_SERIES_TOOLTIP_THRESHOLD = 10;
+
 // Shared "series the user is hovering" across synced charts. recharts' syncId
 // only shares the active time bucket, not a series, so a follower chart has no
 // way to know which series to surface, and picking by its own (irrelevant)
@@ -149,6 +154,28 @@ export const TooltipItem = memo(
     );
   },
 );
+
+/**
+ * Whether the hover tooltip collapses to a single series, given the chart type
+ * and how many series are actually drawn.
+ *
+ * Only line/area charts get the single-series tooltip: their per-point active
+ * dots capture the Y positions used to pick the series nearest the cursor.
+ * Stacked bars capture no such positions, and collapsing to one row would hide
+ * the rest of the stack, so they always show the full tooltip.
+ *
+ * `visibleSeriesCount` is the count after legend selection (and the draw cap),
+ * so filtering a dense chart down to a few series restores the full comparison.
+ */
+export function resolveTooltipMode(
+  displayType: DisplayType | undefined,
+  visibleSeriesCount: number,
+): TooltipMode {
+  if (displayType === DisplayType.StackedBar) return 'all';
+  return visibleSeriesCount > SINGLE_SERIES_TOOLTIP_THRESHOLD
+    ? 'single'
+    : 'all';
+}
 
 /**
  * Which rows the hover tooltip renders, given its mode and hover state. Returns
@@ -784,7 +811,6 @@ export const MemoChart = memo(function MemoChart({
   granularity,
   dateRangeEndInclusive = true,
   fitYAxisToData = false,
-  tooltipMode = 'all',
 }: {
   graphResults: any[];
   setIsClickActive: (v: ActiveClickPayload | undefined) => void;
@@ -818,13 +844,6 @@ export const MemoChart = memo(function MemoChart({
    * (with padding) instead of zero.
    **/
   fitYAxisToData?: boolean;
-  /**
-   * Hover tooltip behavior: `single` shows only the series nearest the cursor
-   * (dense charts), `all` lists every series at the hovered time, `hidden`
-   * suppresses the hover tooltip. The nearest line is still emphasized either
-   * way.
-   */
-  tooltipMode?: TooltipMode;
 }) {
   const _id = useId();
   const id = _id.replace(/:/g, '');
@@ -885,6 +904,11 @@ export const MemoChart = memo(function MemoChart({
     [lineData, selectedSeriesNames],
   );
 
+  // Dense line/area charts collapse the hover tooltip to the series under the
+  // cursor; small charts and stacked bars keep the full list. Derived from the
+  // drawn series so legend filtering restores the full tooltip.
+  const tooltipMode = resolveTooltipMode(displayType, visibleLineData.length);
+
   // The series to emphasize: the line nearest the cursor. Cheap to recompute;
   // drives the overlay + the dim-others CSS class only, never the base lines.
   const emphasizedKey = useMemo(() => {
@@ -897,7 +921,8 @@ export const MemoChart = memo(function MemoChart({
     }
     return undefined;
   }, [visibleLineData, nearestSeriesKey]);
-  const dimOthers = emphasizedKey != null && displayType !== 'stacked_bar';
+  const dimOthers =
+    emphasizedKey != null && displayType !== DisplayType.StackedBar;
 
   // Base lines are deliberately independent of the hovered/emphasized series.
   // Rebuilding ~150 Area elements on every cursor move (as the nearest series
@@ -952,7 +977,8 @@ export const MemoChart = memo(function MemoChart({
   // from the dim-others CSS; it carries no fill/dot and is deduped out of the
   // tooltip. Skipped for stacked bars (they occlude by design).
   const emphasisOverlay = useMemo(() => {
-    if (emphasizedKey == null || displayType === 'stacked_bar') return null;
+    if (emphasizedKey == null || displayType === DisplayType.StackedBar)
+      return null;
     const ld = visibleLineData.find(l => l.dataKey === emphasizedKey);
     if (!ld) return null;
     return (

--- a/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
+++ b/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
@@ -6,12 +6,15 @@
 // #2362 where a semantic-hex `lineData[].color` (e.g. the output of
 // `getChartColorInfo()` on HyperDX) would not have a matching gradient
 // def after the `COLORS` palette was unified to Observable 10.
+import { DisplayType } from '@hyperdx/common-utils/dist/types';
+
 import type { LineData } from '@/ChartUtils';
 import {
   buildActiveClickSeries,
   collectMemoChartGradientHexes,
   getVisibleLineData,
   HARD_LINES_LIMIT,
+  resolveTooltipMode,
   selectTooltipRows,
 } from '@/HDXMultiSeriesTimeChart';
 import { COLORS } from '@/utils';
@@ -330,5 +333,34 @@ describe('selectTooltipRows', () => {
       });
       expect(rows).toBeNull();
     });
+  });
+});
+
+// Whether a chart uses the single-series tooltip is decided from the chart type
+// and the count of series actually drawn (after legend selection), not the raw
+// series count. Pins the two easy-to-regress cases: stacked bars and filtered
+// dense charts.
+describe('resolveTooltipMode', () => {
+  it('collapses a dense line/area chart to a single-series tooltip', () => {
+    expect(resolveTooltipMode(DisplayType.Line, 11)).toBe('single');
+    expect(resolveTooltipMode(undefined, 42)).toBe('single');
+  });
+
+  it('keeps the full tooltip at or below the density threshold', () => {
+    expect(resolveTooltipMode(DisplayType.Line, 10)).toBe('all');
+    expect(resolveTooltipMode(DisplayType.Line, 1)).toBe('all');
+  });
+
+  it('never collapses a stacked-bar chart, however many series it has', () => {
+    // Stacked bars capture no per-point Y for the nearest-series pick, and a
+    // single row would hide the rest of the stack.
+    expect(resolveTooltipMode(DisplayType.StackedBar, 50)).toBe('all');
+    expect(resolveTooltipMode(DisplayType.StackedBar, 11)).toBe('all');
+  });
+
+  it('switches on the visible count so legend filtering restores the full tooltip', () => {
+    // The caller passes the drawn count, so a dense chart narrowed by the
+    // legend to a handful of series shows the full comparison again.
+    expect(resolveTooltipMode(DisplayType.Line, 3)).toBe('all');
   });
 });

--- a/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
+++ b/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
@@ -334,6 +334,39 @@ describe('selectTooltipRows', () => {
       expect(rows).toBeNull();
     });
   });
+
+  describe('empty payload', () => {
+    it('returns an empty list in all-series mode', () => {
+      expect(
+        selectTooltipRows({
+          payload: [],
+          nearestOnly: false,
+          isChartHovered: true,
+        }),
+      ).toEqual([]);
+    });
+
+    it('returns an empty list on the hovered chart', () => {
+      expect(
+        selectTooltipRows({
+          payload: [],
+          nearestOnly: true,
+          isChartHovered: true,
+        }),
+      ).toEqual([]);
+    });
+
+    it('returns null on a synced follower', () => {
+      expect(
+        selectTooltipRows({
+          payload: [],
+          nearestOnly: true,
+          isChartHovered: false,
+          crossChartHoveredName: 'Alpha',
+        }),
+      ).toBeNull();
+    });
+  });
 });
 
 // Whether a chart uses the single-series tooltip is decided from the chart type

--- a/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
+++ b/packages/app/src/__tests__/HDXMultiSeriesTimeChart.test.ts
@@ -12,6 +12,7 @@ import {
   collectMemoChartGradientHexes,
   getVisibleLineData,
   HARD_LINES_LIMIT,
+  selectTooltipRows,
 } from '@/HDXMultiSeriesTimeChart';
 import { COLORS } from '@/utils';
 
@@ -215,6 +216,119 @@ describe('buildActiveClickSeries', () => {
       dataKey: 'a.prev',
       isPreviousPeriod: true,
       previousValue: undefined,
+    });
+  });
+});
+
+// The hover tooltip shows a different set of rows depending on its mode and
+// whether the cursor is over this chart or a synced follower. These pin that
+// selection so a dense chart never regresses to a wall of rows, and a follower
+// never surfaces a series the user is not actually hovering.
+describe('selectTooltipRows', () => {
+  const row = (dataKey: string, value: number, name?: string) => ({
+    dataKey,
+    name: name ?? dataKey,
+    value,
+  });
+
+  describe('all-series mode', () => {
+    it('returns every row sorted high to low by value', () => {
+      const payload = [row('a', 10), row('b', 30), row('c', 20)];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: false,
+        isChartHovered: true,
+      });
+      expect(rows?.map(r => r.dataKey)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('sorts a copy and never reorders the payload in place', () => {
+      // Recharts 3 freezes the payload; an in-place sort throws. The order of
+      // the caller's array must be untouched after the call.
+      const payload = [row('a', 10), row('b', 30), row('c', 20)];
+      const before = payload.map(r => r.dataKey);
+      selectTooltipRows({ payload, nearestOnly: false, isChartHovered: true });
+      expect(payload.map(r => r.dataKey)).toEqual(before);
+    });
+
+    it('ignores hover flags: all rows show even off the hovered chart', () => {
+      const payload = [row('a', 10), row('b', 30)];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: false,
+        isChartHovered: false,
+        crossChartHoveredName: 'no-such-series',
+      });
+      expect(rows?.map(r => r.dataKey)).toEqual(['b', 'a']);
+    });
+  });
+
+  describe('single-series mode on the hovered chart', () => {
+    it('returns only the series matching nearestKey', () => {
+      const payload = [row('a', 10), row('b', 30), row('c', 20)];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: true,
+        nearestKey: 'a',
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows?.[0].dataKey).toBe('a');
+    });
+
+    it('falls back to the top series by value when nearestKey is undefined', () => {
+      const payload = [row('a', 10), row('b', 30), row('c', 20)];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: true,
+      });
+      expect(rows?.map(r => r.dataKey)).toEqual(['b']);
+    });
+
+    it('falls back to the top series by value when nearestKey is absent from the payload', () => {
+      const payload = [row('a', 10), row('b', 30)];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: true,
+        nearestKey: 'ghost',
+      });
+      expect(rows?.map(r => r.dataKey)).toEqual(['b']);
+    });
+  });
+
+  describe('single-series mode on a synced follower', () => {
+    it('returns the series whose display name matches the one hovered elsewhere', () => {
+      const payload = [row('a', 10, 'Alpha'), row('b', 30, 'Beta')];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: false,
+        crossChartHoveredName: 'Alpha',
+      });
+      expect(rows?.map(r => r.dataKey)).toEqual(['a']);
+    });
+
+    it('returns null (render nothing) when no series matches the hovered name', () => {
+      const payload = [row('a', 10, 'Alpha'), row('b', 30, 'Beta')];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: false,
+        crossChartHoveredName: 'Gamma',
+      });
+      expect(rows).toBeNull();
+    });
+
+    it('returns null when there is no hovered series to match', () => {
+      const payload = [row('a', 10, 'Alpha')];
+      const rows = selectTooltipRows({
+        payload,
+        nearestOnly: true,
+        isChartHovered: false,
+      });
+      expect(rows).toBeNull();
     });
   });
 });

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -56,6 +56,8 @@ import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator
 /** A single group column / value pair decoded from a chart series key. */
 export type SeriesGroupFilter = { column: string; value: string };
 
+const SINGLE_SERIES_TOOLTIP_THRESHOLD = 10;
+
 // Only one pinned tooltip at a time across all charts. Module-level (not
 // context) because charts can be scattered with no common provider, and their
 // onClick stopPropagation hides cross-chart clicks from Mantine's click-outside.
@@ -790,6 +792,13 @@ function DBTimeChartComponent({
     queriedConfig,
   ]);
 
+  // Past this many series the hover tooltip collapses to just the series under
+  // the cursor: a list of dozens of rows is unreadable and never what the user
+  // is pointing at. Below it, the full sorted list (nearest emphasized) stays
+  // useful.
+  const tooltipMode =
+    lineData.length > SINGLE_SERIES_TOOLTIP_THRESHOLD ? 'single' : 'all';
+
   return (
     <ChartContainer title={title} toolbarItems={toolbarItemsMemo}>
       {isLoading && !data ? (
@@ -848,6 +857,7 @@ function DBTimeChartComponent({
             granularity={granularity}
             dateRangeEndInclusive={queriedConfig.dateRangeEndInclusive}
             fitYAxisToData={queriedConfig.fitYAxisToData}
+            tooltipMode={tooltipMode}
           />
         </>
       )}

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -56,8 +56,6 @@ import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator
 /** A single group column / value pair decoded from a chart series key. */
 export type SeriesGroupFilter = { column: string; value: string };
 
-const SINGLE_SERIES_TOOLTIP_THRESHOLD = 10;
-
 // Only one pinned tooltip at a time across all charts. Module-level (not
 // context) because charts can be scattered with no common provider, and their
 // onClick stopPropagation hides cross-chart clicks from Mantine's click-outside.
@@ -792,13 +790,6 @@ function DBTimeChartComponent({
     queriedConfig,
   ]);
 
-  // Past this many series the hover tooltip collapses to just the series under
-  // the cursor: a list of dozens of rows is unreadable and never what the user
-  // is pointing at. Below it, the full sorted list (nearest emphasized) stays
-  // useful.
-  const tooltipMode =
-    lineData.length > SINGLE_SERIES_TOOLTIP_THRESHOLD ? 'single' : 'all';
-
   return (
     <ChartContainer title={title} toolbarItems={toolbarItemsMemo}>
       {isLoading && !data ? (
@@ -857,7 +848,6 @@ function DBTimeChartComponent({
             granularity={granularity}
             dateRangeEndInclusive={queriedConfig.dateRangeEndInclusive}
             fitYAxisToData={queriedConfig.fitYAxisToData}
-            tooltipMode={tooltipMode}
           />
         </>
       )}

--- a/packages/app/styles/HDXLineChart.module.scss
+++ b/packages/app/styles/HDXLineChart.module.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-pseudo-class-no-unknown -- :global() targets recharts' global classes */
 .legend {
   display: flex;
   flex-wrap: wrap;
@@ -71,4 +72,18 @@
 .chartTooltipFooter {
   padding: 6px 12px;
   border-top: 1px solid var(--color-border);
+}
+
+// While a series is emphasized (hovering a line or its legend-table row) fade
+// the other lines so it stands out. Toggling this one class on the container
+// avoids re-rendering every line on the chart. The emphasized line is redrawn
+// by a separate overlay (.hdx-emphasis-overlay) that stays at full opacity.
+.dimOthers {
+  :global(.recharts-area-curve) {
+    opacity: 0.35;
+  }
+
+  :global(.hdx-emphasis-overlay .recharts-area-curve) {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary

Time charts today render a hover tooltip that lists every series at the hovered time. On a dense chart (a group-by whose field has dozens of values) that list is taller than the chart itself and never the series you are actually pointing at.

This reworks the hover for dense charts:

- Charts with more than 10 series now show a single-series hover tooltip: only the series nearest the cursor. Below that threshold the full sorted list is kept, so small charts are unchanged.
- The hovered series is emphasized by a dedicated line drawn on top of the others, and the rest dim via one CSS class. Drawing the emphasized line as a separate overlay fixes a case where an emphasized line stayed hidden behind another line that shared its values: Recharts paints graphical items in mount order and ignores a reorder of existing children, so a freshly mounted overlay is the reliable way to bring one line to the front. Dimming the rest with a single class avoids re-rendering every line on each cursor move.
- Synced charts (they share a time cursor) now highlight the same series by name: hovering a line on one chart surfaces that series on the others, and a chart that does not have that series shows only the shared time cursor instead of an unrelated row.

The tooltip row selection is pulled into a small pure `selectTooltipRows` helper so the single, all, and synced-follower cases are unit tested without rendering Recharts in jsdom, matching the existing helper tests in this file.

This is the first in a short series improving dense time chart interaction; it stands on its own. It keeps the existing line shape (monotone) unchanged, so existing charts look identical and the only visible change is the hover. It lands at tier 3 because the single-series tooltip, the emphasis overlay, and the cross-chart sync run through the same tooltip render and shared hovered-series store; splitting them would ship a half-working dense tooltip.

## Screenshots

Dense chart (`count()` grouped by `ServiceName`, a field with ~150 values) with the single-series hover tooltip, captured at a 1440x900 viewport in light and dark:

![Single-series hover tooltip, light theme](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/timechart-dense-hover-prA-hover-light.png)

![Single-series hover tooltip, dark theme](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/timechart-dense-hover-prA-hover-dark.png)

## Test plan

- `yarn nx run @hyperdx/app:ci:lint` (eslint under the 740 warning cap, tsc, stylelint): passes with 0 errors.
- `yarn workspace @hyperdx/app jest HDXMultiSeriesTimeChart DBTimeChart`: 40 tests pass, including 9 new `selectTooltipRows` cases covering all-series high-to-low sorting, the sort-a-copy contract, the single-series nearest pick with its two fallbacks, and the synced-follower name match plus its no-match null.
- knip: no new unused exports.
- Manual: a dashboard tile of `count()` grouped by `ServiceName` (~150 series) against a local ClickHouse. Verified the single-series tooltip (light and dark above), the emphasized line drawing on top of overlapping lines, and that a chart without the hovered series shows only the shared cursor.

[ui-states: allow] The hover applies to a populated multi-series chart; the empty, loading, and error states are unrelated to this change and unchanged.
