### PR TITLE
feat(evals): add deploy-regression scenario (measure organic metric tool adoption)

### DIFF
--- a/.changeset/eval-deploy-regression-scenario.md
+++ b/.changeset/eval-deploy-regression-scenario.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/hdx-eval": patch
+---
+
+feat(evals): add deploy-regression scenario (metrics-neutral) — a checkout-api staged-rollout defect fully solvable from traces/logs, with corroborating-only metrics to measure organic metric-tool adoption

--- a/packages/hdx-eval/README.md
+++ b/packages/hdx-eval/README.md
@@ -260,6 +260,7 @@ mirrors HyperDX's `otel_traces` / `otel_logs` exactly.
 | Scenario | Agent Prompt | What's Planted |
 |---|---|---|
 | `error-root-cause` | "Checkout requests are failing..." | `payment-service` DB timeout cascading into `checkout-api` 5xx. 6M+ spans, 12M logs, 5 distractors. |
+| `deploy-regression` | "Support has been fielding a growing trickle of 'something went wrong at checkout' reports..." | `checkout-api` staged rollout on 3/6 pods → ~7% checkout 500s. Root cause is in **traces/logs** via `k8s.pod.name` cross-tab; metrics only corroborate. 6 distractors. |
 | `latency-spike` | "p99 latency on api-server has jumped..." | `/api/orders/search` p99 spike for enterprise tenants. 12M+ spans, 5 regions, 5 distractors. |
 | `metric-saturation` | "Shoppers are seeing slow/missing recommendations; frontend-proxy logs upstream 503s..." (blinded — culprit service not named) | `recommendation-service` JVM heap leak → GC-pause tail → latency shift → pod-restart cadence. Root cause is **metrics-only** (per-pod × per-pool heap gauges, all five metric types), with 5 distractors incl. a healthy JVM twin. |
 | `noisy-signals` | "We want to cut log ingest cost..." | ~16M logs across composite cells. Each noisy cell has a load-bearing pattern mixed in. |
@@ -407,6 +408,15 @@ Combined score = `0.4 * programmatic + 0.6 * judge - toolErrorPenalty`
   > reduce but don't erase per-model scale differences). Hold the judge constant
   > across runs you compare directly.
 - **Tool error penalty** — up to 20% deducted for high tool-call error rates.
+
+**Adoption (tool use)** is reported alongside the outcome score for scenarios
+with a `transcript` rubric block — regex checks over the serialized tool-call
+transcript (tool names + args). It is intentionally **excluded** from the
+combined score: measuring tool usage must not inflate outcome quality.
+`metric-saturation` (metrics load-bearing) should show ≈100% adoption; the
+interesting readout is `deploy-regression` (metrics merely corroborating),
+where adoption measures whether the agent reaches for metric tools it
+doesn't strictly need.
 
 ### Baseline + Challengers
 

--- a/packages/hdx-eval/README.md
+++ b/packages/hdx-eval/README.md
@@ -410,13 +410,17 @@ Combined score = `0.4 * programmatic + 0.6 * judge - toolErrorPenalty`
 - **Tool error penalty** — up to 20% deducted for high tool-call error rates.
 
 **Adoption (tool use)** is reported alongside the outcome score for scenarios
-with a `transcript` rubric block — regex checks over the serialized tool-call
-transcript (tool names + args). It is intentionally **excluded** from the
-combined score: measuring tool usage must not inflate outcome quality.
-`metric-saturation` (metrics load-bearing) should show ≈100% adoption; the
-interesting readout is `deploy-regression` (metrics merely corroborating),
-where adoption measures whether the agent reaches for metric tools it
-doesn't strictly need.
+with an `adoption` rubric block. Each check declares the scenario's target
+metric names/keys; a tool call counts when its **input args** name one of them
+(separator-tolerant: `jvm.gc.pause` ≡ `jvm_gc_pause`), regardless of which
+tool was called — a dedicated metric tool and raw SQL against the metrics
+tables score identically, so both arms are graded by the same rule. Tool
+names, tool outputs, and the prompt never count. Adoption is intentionally
+**excluded** from the combined score: measuring tool usage must not inflate
+outcome quality. `metric-saturation` (metrics load-bearing) should show
+≈100% adoption; the interesting readout is `deploy-regression` (metrics
+merely corroborating), where adoption measures whether the agent reaches for
+metrics it doesn't strictly need.
 
 ### Baseline + Challengers
 

--- a/packages/hdx-eval/scripts/viewer/public/app.js
+++ b/packages/hdx-eval/scripts/viewer/public/app.js
@@ -200,6 +200,23 @@
     sel.onchange = () => loadBatch(sel.value);
   }
 
+  let batchCopyResetTimer = null;
+  $('#batch-copy').onclick = async () => {
+    const name = $('#batch-select').value || state.batch;
+    if (!name) return;
+    const btn = $('#batch-copy');
+    try {
+      await navigator.clipboard.writeText(name);
+      btn.textContent = 'copied';
+    } catch {
+      btn.textContent = 'failed';
+    }
+    clearTimeout(batchCopyResetTimer);
+    batchCopyResetTimer = setTimeout(() => {
+      btn.textContent = 'copy';
+    }, 1200);
+  };
+
   function renderBatchMeta() {
     const sc = state.summary?.scenarios?.length ?? state.cells.length;
     const cells = state.cells.length;

--- a/packages/hdx-eval/scripts/viewer/public/app.js
+++ b/packages/hdx-eval/scripts/viewer/public/app.js
@@ -316,7 +316,7 @@
                   'span',
                   {
                     class: 'tag adopt',
-                    title: 'metric-tool adoption (not part of combined score)',
+                    title: 'metric adoption (not part of combined score)',
                   },
                   `adopt ${pct(r.adoptionScore)}`,
                 )
@@ -378,7 +378,7 @@
         'combined',
         grade?.combinedScore != null ? grade.combinedScore.toFixed(3) : '—',
       ],
-      // Adoption is only present when the scenario rubric defines transcript
+      // Adoption is only present when the scenario rubric defines adoption
       // checks; omit the field entirely otherwise to avoid a dangling '—'.
       ...(grade?.adoption
         ? [['adoption', pct(grade.adoption.score)]]
@@ -671,8 +671,9 @@
       pane.appendChild(checks);
     }
 
-    // Adoption checks (transcript-aware tool usage). Reported alongside the
-    // outcome score but intentionally excluded from the combined score.
+    // Adoption checks (metric keys matched against tool-call args). Reported
+    // alongside the outcome score but intentionally excluded from the
+    // combined score.
     if (g.adoption?.hits) {
       const checks = el('div', { class: 'grade-section' });
       checks.appendChild(
@@ -707,7 +708,7 @@
         el(
           'div',
           { class: 'muted small', style: 'margin-top:0.6rem; font-size:11px' },
-          'Regexes run against the serialized tool-call transcript (tool names + args). Adoption is reported but NOT part of the combined score.',
+          'Scenario-declared metric keys matched against tool-call input args (any tool; names/outputs never count). Adoption is reported but NOT part of the combined score.',
         ),
       );
       pane.appendChild(checks);

--- a/packages/hdx-eval/scripts/viewer/public/index.html
+++ b/packages/hdx-eval/scripts/viewer/public/index.html
@@ -12,6 +12,7 @@
       <div class="batch-picker">
         <label>batch</label>
         <select id="batch-select"></select>
+        <button id="batch-copy" class="copy-btn" title="Copy batch name" aria-label="Copy batch name">copy</button>
         <span id="batch-meta" class="muted"></span>
       </div>
     </header>

--- a/packages/hdx-eval/scripts/viewer/public/style.css
+++ b/packages/hdx-eval/scripts/viewer/public/style.css
@@ -76,6 +76,20 @@ select {
   min-width: 280px;
 }
 
+.copy-btn {
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  color: var(--text);
+}
+
 main {
   display: flex;
   flex: 1;

--- a/packages/hdx-eval/scripts/viewer/server.js
+++ b/packages/hdx-eval/scripts/viewer/server.js
@@ -83,8 +83,8 @@ function collectRuns(cellDir) {
       idx: i,
       combinedScore: grade?.combinedScore ?? null,
       programmaticScore: grade?.programmatic?.score ?? null,
-      // Transcript-aware tool-adoption score (null when the scenario rubric
-      // has no `transcript` block, so the grade has no `adoption`).
+      // Metric-adoption score (null when the scenario rubric has no
+      // `adoption` block, so the grade has no `adoption`).
       adoptionScore: grade?.adoption?.score ?? null,
       judgeScore: grade?.judge?.weightedScore ?? null,
       termination: traj?.termination ?? null,

--- a/packages/hdx-eval/src/__tests__/deploy-regression.test.ts
+++ b/packages/hdx-eval/src/__tests__/deploy-regression.test.ts
@@ -1,0 +1,758 @@
+import { loadScenarioRubric } from '@/grading/rubric';
+import { buildSystemPrompt } from '@/harness/systemPrompt';
+import { mulberry32 } from '@/rng/seeded';
+import { deployRegressionScenario } from '@/scenarios/deploy-regression/generate';
+import { metricSaturationScenario } from '@/scenarios/metric-saturation/generate';
+import { collectScenario } from '@/scenarios/types';
+
+const NOW_MS = Date.parse('2026-05-10T20:00:00.000Z');
+// 2% volume keeps the test cheap (~8K spans) while preserving every planted
+// signal — metrics and rollout/burst events are fixed-volume, and the defect
+// errors scale with the trace floor (still ~80 at this factor).
+const TEST_VOLUME_FACTOR = 0.02;
+
+const WINDOW_MS = 2 * 60 * 60 * 1000;
+const WINDOW_START_MS = NOW_MS - WINDOW_MS;
+const DEPLOY_MS = NOW_MS - 45 * 60 * 1000;
+// Canary pods flip at deploy + pod * 2min (pods 0..2).
+const LAST_FLIP_MS = DEPLOY_MS + 2 * 2 * 60 * 1000;
+// Innocent payment-service rollout: starts 58 min ago, completes 52 min ago.
+const PAYMENT_DEPLOY_MS = NOW_MS - 58 * 60 * 1000;
+const PAYMENT_COMPLETE_MS = NOW_MS - 52 * 60 * 1000;
+const BURST_START_MS = NOW_MS - 70 * 60 * 1000;
+const BURST_END_MS = BURST_START_MS + 5 * 60 * 1000;
+
+const NEW_VERSION = '2.0.0-rc1';
+const OLD_VERSION = '1.43.1';
+const PAYMENT_NEW_VERSION = '3.7.0';
+const PAYMENT_OLD_VERSION = '3.6.2';
+const FIXED_CODES = new Set(['FREESHIP', 'FLAT5', 'GIFT10']);
+// Defect requests fail fast (TypeError before any I/O); baseline errors are
+// slow (200-1500ms). 50ms cleanly separates them — there is no label to
+// filter by (that's the hardening).
+const FAIL_FAST_NS = 50 * 1e6;
+const STACK_SAMPLE_EVERY = 7;
+
+function run(seed: number, factor = TEST_VOLUME_FACTOR) {
+  return collectScenario(
+    deployRegressionScenario.generate({
+      rng: mulberry32(seed),
+      nowMs: NOW_MS,
+      volumeFactor: factor,
+    }),
+  );
+}
+
+describe('deploy-regression scenario', () => {
+  const result = run(42);
+  const m = result.metrics!;
+
+  const checkoutPosts = result.traces.filter(
+    t =>
+      t.serviceName === 'checkout-api' && t.spanName === 'POST /api/checkout',
+  );
+  // No statusMessage / promo-type / version label identifies defect spans
+  // anymore — reconstruct them the way the scenario defines them: failed
+  // checkouts carrying a fixed-amount promo code that failed fast.
+  const defectSpans = checkoutPosts.filter(
+    t =>
+      t.statusCode === 'STATUS_CODE_ERROR' &&
+      FIXED_CODES.has(t.spanAttributes['checkout.promo_code'] ?? '') &&
+      t.durationNs < FAIL_FAST_NS,
+  );
+  const stackLogs = result.logs.filter(
+    l => l.logAttributes['event.name'] === 'checkout.unhandled_exception',
+  );
+  const genericFailLogs = result.logs.filter(
+    l => l.logAttributes['event.name'] === 'checkout.request_failed',
+  );
+  const floodLogs = result.logs.filter(
+    l => l.logAttributes['event.name'] === 'runtime.deprecation',
+  );
+  const rolloutLogs = result.logs.filter(
+    l => l.logAttributes['event.name'] === 'deployment.rollout',
+  );
+  const checkoutRollout = rolloutLogs.filter(
+    l => l.serviceName === 'checkout-api',
+  );
+  const paymentRollout = rolloutLogs.filter(
+    l => l.serviceName === 'payment-service',
+  );
+  // The intended join: rollout flip events name the pods that updated.
+  const canaryPodNames = new Set(
+    checkoutRollout
+      .map(l => l.logAttributes['k8s.pod.name'])
+      .filter((p): p is string => Boolean(p)),
+  );
+  const canaryFlipMsByPod = new Map(
+    checkoutRollout
+      .filter(l => l.logAttributes['k8s.pod.name'])
+      .map(l => [l.logAttributes['k8s.pod.name'], l.timestampMs] as const),
+  );
+
+  it('is deterministic for a fixed seed (traces + logs + metrics)', () => {
+    const b = run(42);
+    expect(b.traces.length).toBe(result.traces.length);
+    expect(b.logs.length).toBe(result.logs.length);
+    expect(b.traces[10]?.spanId).toBe(result.traces[10]?.spanId);
+    expect(JSON.stringify(b.metrics)).toBe(JSON.stringify(m));
+  });
+
+  it('anchors every row at or before now, within the window', () => {
+    for (const t of result.traces) {
+      expect(t.timestampMs).toBeLessThanOrEqual(NOW_MS);
+      expect(t.timestampMs).toBeGreaterThanOrEqual(WINDOW_START_MS);
+    }
+    for (const l of result.logs) {
+      expect(l.timestampMs).toBeLessThanOrEqual(NOW_MS);
+      expect(l.timestampMs).toBeGreaterThanOrEqual(WINDOW_START_MS);
+    }
+    const allMetrics = [...m.gauge!, ...m.sum!, ...m.histogram!];
+    for (const pt of allMetrics) {
+      expect(pt.timeUnixMs).toBeLessThanOrEqual(NOW_MS);
+      expect(pt.timeUnixMs).toBeGreaterThanOrEqual(WINDOW_START_MS);
+    }
+  });
+
+  it('emits gauge/sum/histogram metrics and nothing else', () => {
+    expect(m.gauge!.length).toBeGreaterThan(0);
+    expect(m.sum!.length).toBeGreaterThan(0);
+    expect(m.histogram!.length).toBeGreaterThan(0);
+    expect(m.exponentialHistogram!.length).toBe(0);
+    expect(m.summary!.length).toBe(0);
+  });
+
+  describe('hardening — no pre-labeled answers', () => {
+    it('checkout-api telemetry carries NO service.version resource attribute', () => {
+      const checkoutTraces = result.traces.filter(
+        t => t.serviceName === 'checkout-api',
+      );
+      expect(checkoutTraces.length).toBeGreaterThan(1000);
+      for (const t of checkoutTraces) {
+        expect(t.resourceAttributes['service.version']).toBeUndefined();
+      }
+      for (const l of result.logs) {
+        if (l.serviceName !== 'checkout-api') continue;
+        expect(l.resourceAttributes['service.version']).toBeUndefined();
+      }
+    });
+
+    it('pods are pinned to one namespace/region — no coarse proxy for the pod split', () => {
+      const pods = [
+        ...result.traces
+          .filter(
+            t =>
+              t.serviceName === 'checkout-api' ||
+              t.serviceName === 'payment-service',
+          )
+          .map(t => t.resourceAttributes),
+      ];
+      for (const r of pods) {
+        expect(r['k8s.namespace.name']).toBe('production');
+        expect(r['service.namespace']).toBe('production');
+        expect(r['cloud.region']).toBe('us-east-1');
+      }
+    });
+
+    it('checkout and payment run on dedicated, DISJOINT node pools (one pod per node)', () => {
+      // The generic resource pool assigns nodes from a shared 4-name list,
+      // which used to make payment's rollout look like it landed "on the
+      // same hosts" as the checkout errors — an accidental cross-service
+      // confounder. Controlled pools now pin one service-prefixed node per
+      // pod, so a node group-by mirrors the pod split instead of inventing
+      // a noisy-neighbor story.
+      const podToNode = (svc: string) => {
+        const map = new Map<string, string>();
+        for (const t of result.traces) {
+          if (t.serviceName !== svc) continue;
+          const r = t.resourceAttributes;
+          expect(r['host.name']).toBe(r['k8s.node.name']);
+          map.set(r['k8s.pod.name'], r['k8s.node.name']);
+        }
+        return map;
+      };
+      const checkout = podToNode('checkout-api');
+      const payment = podToNode('payment-service');
+      // One pod per node: 6 pods ↔ 6 distinct nodes for each service.
+      expect(checkout.size).toBe(6);
+      expect(new Set(checkout.values()).size).toBe(6);
+      expect(payment.size).toBe(6);
+      expect(new Set(payment.values()).size).toBe(6);
+      // Disjoint from each other AND from every other service's nodes.
+      const otherNodes = new Set(
+        result.traces
+          .filter(
+            t =>
+              t.serviceName !== 'checkout-api' &&
+              t.serviceName !== 'payment-service',
+          )
+          .map(t => t.resourceAttributes['k8s.node.name']),
+      );
+      const checkoutNodes = new Set(checkout.values());
+      const paymentNodes = new Set(payment.values());
+      for (const n of checkoutNodes) {
+        expect(paymentNodes.has(n)).toBe(false);
+        expect(otherNodes.has(n)).toBe(false);
+      }
+      for (const n of paymentNodes) expect(otherNodes.has(n)).toBe(false);
+      // Log rows for these services stay inside the same node pools
+      // (deployment-level rollout events carry no node — skip those).
+      for (const l of result.logs) {
+        if (
+          l.serviceName !== 'checkout-api' &&
+          l.serviceName !== 'payment-service'
+        )
+          continue;
+        const node = l.resourceAttributes['k8s.node.name'];
+        if (!node) continue;
+        const pool =
+          l.serviceName === 'checkout-api' ? checkoutNodes : paymentNodes;
+        expect(pool.has(node)).toBe(true);
+      }
+    });
+
+    it('spans carry no promo-type label and no incriminating status message', () => {
+      for (const t of checkoutPosts) {
+        expect(t.spanAttributes['checkout.promo_type']).toBeUndefined();
+        expect(t.statusMessage).not.toMatch(/promo/i);
+      }
+      // Defect and baseline errors share the same generic status message.
+      for (const s of defectSpans) {
+        expect(s.statusMessage).toBe('internal error');
+      }
+    });
+  });
+
+  describe('load-bearing property — root cause IS in traces/logs', () => {
+    it('defect spans exist, confined to rollout-event pods and fixed-amount codes', () => {
+      expect(defectSpans.length).toBeGreaterThan(20);
+      expect(canaryPodNames.size).toBe(3);
+      for (const s of defectSpans) {
+        expect(s.spanAttributes['http.response.status_code']).toBe('500');
+        expect(s.timestampMs).toBeGreaterThanOrEqual(DEPLOY_MS);
+        // The join: every failing pod is one the rollout events flipped,
+        // and the span postdates that pod's flip.
+        const pod = s.resourceAttributes['k8s.pod.name'];
+        expect(canaryPodNames.has(pod)).toBe(true);
+        expect(s.timestampMs).toBeGreaterThanOrEqual(
+          canaryFlipMsByPod.get(pod)!,
+        );
+      }
+      // All three canary pods actually fail (not just one).
+      const failingPods = new Set(
+        defectSpans.map(s => s.resourceAttributes['k8s.pod.name']),
+      );
+      expect(failingPods).toEqual(canaryPodNames);
+    });
+
+    it('percent promo codes never hit the defect, on any pod', () => {
+      const percentErrors = checkoutPosts.filter(
+        t =>
+          t.statusCode === 'STATUS_CODE_ERROR' &&
+          t.spanAttributes['checkout.promo_code'] !== undefined &&
+          !FIXED_CODES.has(t.spanAttributes['checkout.promo_code']) &&
+          t.durationNs < FAIL_FAST_NS,
+      );
+      expect(percentErrors.length).toBe(0);
+    });
+
+    it('stack-trace logs are error-sampled (exact 1-in-7) and trace-correlated', () => {
+      // Deterministic modulo sampling: hits 1, 8, 15, ... log the stack.
+      expect(stackLogs.length).toBe(
+        Math.ceil(defectSpans.length / STACK_SAMPLE_EVERY),
+      );
+      expect(stackLogs.length).toBeGreaterThan(5);
+      const defectTraceIds = new Set(defectSpans.map(s => s.traceId));
+      for (const l of stackLogs) {
+        expect(l.body).toContain("reading 'percentOff'");
+        expect(l.body).toContain('applyPromotion');
+        expect(l.timestampMs).toBeGreaterThanOrEqual(DEPLOY_MS);
+        expect(defectTraceIds.has(l.traceId!)).toBe(true);
+      }
+      // The unsampled majority log a generic line that names neither the
+      // TypeError nor promotions — the confession is buried, not gone.
+      expect(genericFailLogs.length).toBe(
+        defectSpans.length - stackLogs.length,
+      );
+      for (const l of genericFailLogs) {
+        expect(l.body).not.toMatch(
+          /TypeError|percentOff|applyPromotion|promo/i,
+        );
+        expect(defectTraceIds.has(l.traceId!)).toBe(true);
+      }
+    });
+
+    it('the pod cross-tab is the smoking gun: rollout pods fail, the rest stay at baseline', () => {
+      const post = checkoutPosts.filter(t => t.timestampMs >= LAST_FLIP_MS);
+      const canary = post.filter(t =>
+        canaryPodNames.has(t.resourceAttributes['k8s.pod.name']),
+      );
+      const others = post.filter(
+        t => !canaryPodNames.has(t.resourceAttributes['k8s.pod.name']),
+      );
+      const errRate = (spans: typeof post) =>
+        spans.filter(t => t.statusCode === 'STATUS_CODE_ERROR').length /
+        spans.length;
+      expect(canary.length).toBeGreaterThan(100);
+      expect(others.length).toBeGreaterThan(100);
+      expect(errRate(canary)).toBeGreaterThan(0.08);
+      expect(errRate(others)).toBeLessThan(0.02);
+    });
+
+    it('checkout error rate steps up at the deploy', () => {
+      const pre = checkoutPosts.filter(t => t.timestampMs < DEPLOY_MS);
+      const post = checkoutPosts.filter(t => t.timestampMs >= LAST_FLIP_MS);
+      const errRate = (spans: typeof pre) =>
+        spans.filter(t => t.statusCode === 'STATUS_CODE_ERROR').length /
+        spans.length;
+      expect(errRate(pre)).toBeLessThan(0.01);
+      expect(errRate(post)).toBeGreaterThan(0.04);
+    });
+
+    it('plants the checkout rollout events at the deploy boundary', () => {
+      // start event + one per canary pod + pause event.
+      expect(checkoutRollout.length).toBe(5);
+      const start = checkoutRollout.find(l =>
+        /rolling update started: version 1\.43\.1 -> 2\.0\.0-rc1/.test(l.body),
+      );
+      expect(start).toBeDefined();
+      expect(start!.timestampMs).toBe(DEPLOY_MS);
+      expect(
+        checkoutRollout.some(l => /paused at 3\/6 pods/.test(l.body)),
+      ).toBe(true);
+      // Versions live in the event payload (the join key), not in the
+      // resource attributes (which the fleet doesn't stamp).
+      for (const l of checkoutRollout) {
+        expect(l.logAttributes['service.version']).toBe(NEW_VERSION);
+        expect(l.resourceAttributes['service.version']).toBeUndefined();
+      }
+      expect(OLD_VERSION).toBe('1.43.1');
+    });
+  });
+
+  describe('distractors', () => {
+    it('payment-service ran an INNOCENT completed rollout just before the incident', () => {
+      // start event + one per pod (6) + completion event.
+      expect(paymentRollout.length).toBe(8);
+      const start = paymentRollout.find(l =>
+        /rolling update started: version 3\.6\.2 -> 3\.7\.0/.test(l.body),
+      );
+      expect(start).toBeDefined();
+      expect(start!.timestampMs).toBe(PAYMENT_DEPLOY_MS);
+      const complete = paymentRollout.find(l =>
+        /completed: 6\/6 pods updated to version 3\.7\.0/.test(l.body),
+      );
+      expect(complete).toBeDefined();
+      expect(complete!.timestampMs).toBe(PAYMENT_COMPLETE_MS);
+      // The trap geometry: payment's rollout completes BEFORE the checkout
+      // errors begin — closest deploy to the onset, yet innocent.
+      expect(PAYMENT_COMPLETE_MS).toBeLessThan(DEPLOY_MS);
+    });
+
+    it('payment-service is provably healthy on BOTH sides of its rollout', () => {
+      const payment = result.traces.filter(
+        t => t.serviceName === 'payment-service',
+      );
+      expect(payment.length).toBeGreaterThan(100);
+      const byVersion = (v: string) =>
+        payment.filter(t => t.resourceAttributes['service.version'] === v);
+      expect(byVersion(PAYMENT_OLD_VERSION).length).toBeGreaterThan(20);
+      expect(byVersion(PAYMENT_NEW_VERSION).length).toBeGreaterThan(20);
+      for (const p of payment) {
+        expect(p.statusCode).toBe('STATUS_CODE_OK');
+        expect(p.durationNs / 1e6).toBeLessThan(300);
+      }
+    });
+
+    it('deprecation WARN flood steps at the pod flips but is benign', () => {
+      // Scales with volumeFactor: 6000 * 0.02 = 120 at the test factor.
+      expect(floodLogs.length).toBe(120);
+      // Outranks the sampled stack traces in any volume-ranked pattern list.
+      expect(floodLogs.length).toBeGreaterThan(stackLogs.length * 5);
+      for (const l of floodLogs) {
+        expect(l.serviceName).toBe('checkout-api');
+        expect(l.severityText).toBe('WARN');
+        expect(l.body).toContain('DeprecationWarning');
+        expect(l.body).toContain('session');
+        expect(l.body).not.toMatch(/promo/i);
+        // No trace correlation — it never touches a failed request.
+        expect(l.traceId).toBeUndefined();
+        // Emitted only by updated pods, only after their own flip: the
+        // total rate steps up at the exact incident boundaries.
+        const pod = l.resourceAttributes['k8s.pod.name'];
+        expect(canaryPodNames.has(pod)).toBe(true);
+        expect(l.timestampMs).toBeGreaterThanOrEqual(
+          canaryFlipMsByPod.get(pod)!,
+        );
+      }
+    });
+
+    it('recommendation-service 502 burst PREDATES both deploys and self-resolves', () => {
+      const burst = result.traces.filter(
+        t =>
+          t.serviceName === 'recommendation-service' &&
+          t.statusCode === 'STATUS_CODE_ERROR',
+      );
+      expect(burst.length).toBe(150); // fixed planted volume
+      for (const b of burst) {
+        expect(b.timestampMs).toBeGreaterThanOrEqual(BURST_START_MS);
+        expect(b.timestampMs).toBeLessThanOrEqual(BURST_END_MS);
+        expect(b.spanAttributes['http.response.status_code']).toBe('502');
+      }
+      expect(BURST_END_MS).toBeLessThan(PAYMENT_DEPLOY_MS);
+      expect(BURST_END_MS).toBeLessThan(DEPLOY_MS);
+    });
+
+    it('caught-exception noise runs at a constant rate across the deploy', () => {
+      const decoy = result.logs.filter(
+        l => l.logAttributes['error.kind'] === 'NonFatalRetryableError',
+      );
+      expect(decoy.length).toBeGreaterThan(50);
+      const preMs = DEPLOY_MS - WINDOW_START_MS;
+      const postMs = NOW_MS - DEPLOY_MS;
+      const preRate =
+        decoy.filter(l => l.timestampMs < DEPLOY_MS).length / preMs;
+      const postRate =
+        decoy.filter(l => l.timestampMs >= DEPLOY_MS).length / postMs;
+      expect(postRate).toBeGreaterThan(preRate * 0.6);
+      expect(postRate).toBeLessThan(preRate * 1.6);
+    });
+  });
+
+  describe('metrics — corroborating only (the metrics-neutral property)', () => {
+    it('metrics cannot reveal the pod split or the defect', () => {
+      const serialized = JSON.stringify(m);
+      expect(serialized).not.toContain(NEW_VERSION);
+      expect(serialized).not.toMatch(/promo|percentOff|applyPromotion/i);
+      expect(serialized).not.toContain('service.version');
+      expect(serialized).not.toContain('k8s.pod.name');
+    });
+
+    it('5xx request counter (cumulative sum) slope changes at the deploy', () => {
+      const fiveXx = m
+        .sum!.filter(
+          s =>
+            s.metricName === 'http.server.request.count' &&
+            s.attributes?.status_class === '5xx',
+        )
+        .sort((a, b) => a.timeUnixMs - b.timeUnixMs);
+      for (let i = 1; i < fiveXx.length; i++) {
+        expect(fiveXx[i].value).toBeGreaterThanOrEqual(fiveXx[i - 1].value);
+      }
+      const at = (ms: number) =>
+        fiveXx.filter(p => p.timeUnixMs <= ms).pop()?.value ?? 0;
+      const preDelta = at(DEPLOY_MS) - at(WINDOW_START_MS);
+      const postDelta = at(NOW_MS) - at(LAST_FLIP_MS);
+      const preScrapes = (DEPLOY_MS - WINDOW_START_MS) / 120_000;
+      const postScrapes = (NOW_MS - LAST_FLIP_MS) / 120_000;
+      expect(preDelta / preScrapes).toBeLessThan(2);
+      expect(postDelta / postScrapes).toBeGreaterThan(10);
+    });
+
+    it('500-status latency histogram count steps up at the deploy', () => {
+      const errHist = m.histogram!.filter(
+        h =>
+          h.metricName === 'http.server.request.duration' &&
+          h.attributes?.['http.response.status_code'] === '500',
+      );
+      const preAvg =
+        errHist
+          .filter(h => h.timeUnixMs < DEPLOY_MS)
+          .reduce((a, h) => a + h.count, 0) /
+        ((DEPLOY_MS - WINDOW_START_MS) / 120_000);
+      const postAvg =
+        errHist
+          .filter(h => h.timeUnixMs >= LAST_FLIP_MS)
+          .reduce((a, h) => a + h.count, 0) /
+        ((NOW_MS - LAST_FLIP_MS) / 120_000);
+      expect(preAvg).toBeLessThan(2);
+      expect(postAvg).toBeGreaterThan(10);
+    });
+
+    it('CPU and memory gauges stay flat and healthy (rules out infra)', () => {
+      const cpu = m.gauge!.filter(
+        g => g.metricName === 'system.cpu.utilization',
+      );
+      expect(cpu.length).toBeGreaterThan(0);
+      for (const c of cpu) {
+        expect(c.value).toBeGreaterThanOrEqual(0.2);
+        expect(c.value).toBeLessThanOrEqual(0.35);
+      }
+      const mem = m.gauge!.filter(g => g.metricName === 'process.memory.usage');
+      expect(mem.length).toBeGreaterThan(0);
+      for (const g of mem) {
+        const mb = g.value / 1024 / 1024;
+        expect(mb).toBeGreaterThanOrEqual(460);
+        expect(mb).toBeLessThanOrEqual(550);
+      }
+    });
+
+    it('queue-depth red herring is noisy across the WHOLE window on a neighbor', () => {
+      const q = m
+        .gauge!.filter(g => g.metricName === 'inventory.sync.queue.depth')
+        .sort((a, b) => a.timeUnixMs - b.timeUnixMs);
+      expect(q.length).toBeGreaterThan(0);
+      for (const g of q) expect(g.serviceName).toBe('inventory-service');
+      // Present before the burst and after the deploy — uncorrelated with both.
+      expect(q[0].timeUnixMs).toBeLessThan(BURST_START_MS);
+      expect(q[q.length - 1].timeUnixMs).toBeGreaterThan(DEPLOY_MS);
+    });
+  });
+
+  describe('rubric', () => {
+    // An answer that engages every designed observation: the pod split,
+    // the rollout-event join, the staggered onset, the promo cross-tab,
+    // the sampled stack, quantified rates, and both co-timed traps.
+    // One claim per line, bullet style — the answer shape agents actually
+    // produce (the gap regexes are line-bounded, matching the negative-
+    // check convention).
+    const EXCELLENT_ANSWER = [
+      'Root cause: the checkout-api 2.0.0-rc1 canary rollout.',
+      '- The rolling update started at 12:54 and was paused at 3/6 pods for canary observation.',
+      '- Errors ramp in three ~2-minute increments — a staggered onset, one step as each pod flips.',
+      '- Grouping failed POST /api/checkout spans by k8s.pod.name shows the failures confined to 3 of 6 pods (~15% error rate each vs ~0.3% baseline on the rest).',
+      '- Those are exactly the pods named in the deployment.rollout events ("updated to version 2.0.0-rc1").',
+      '- Every failing request carries a fixed-amount promo code (FREESHIP, FLAT5, or GIFT10); percent codes succeed on every pod.',
+      "- The stack trace — TypeError: Cannot read properties of undefined (reading 'percentOff') at applyPromotion — appears on only ~1-in-7 failures; most of the failures log only a generic checkout.request_failed line.",
+      "What's not the cause:",
+      '- The payment-service 3.7.0 rollout is innocent — it completed before the errors began, and payment.authorize is healthy on both versions. Failed checkouts never even reach payment-service.',
+      '- The DeprecationWarning session-cookie flood from the new build is benign WARN noise with no trace correlation to the 500s.',
+      '- The recommendation-service 502 burst predates both deploys and self-resolved. CPU and memory are flat.',
+    ].join('\n');
+
+    // A correct-but-shallow answer: right deploy, right service, but no
+    // mechanism, no join, no quantification, no trap engagement. This is
+    // the answer quality that used to score ~0.95 — it must now leave the
+    // excellence-tier checks on the table.
+    const GENERIC_GOOD_ANSWER = [
+      'checkout-api is failing because of the 2.0.0-rc1 deploy — the new',
+      'version introduced a bug in the promotion handling code. The rollout',
+      'appears paused, and some checkouts on the new build return 500s.',
+      'Rolling back checkout-api should fix it.',
+      'The payment gateway looked fine.',
+    ].join('\n');
+
+    const EXCELLENCE_TIER = [
+      'names_defect_mechanism',
+      'names_fixed_amount_trigger',
+      'cites_rollout_event_join',
+      'names_staggered_onset',
+      'notes_error_sampling',
+      'quantifies_impact',
+      'rules_out_payment_deploy',
+      'rules_out_deprecation_flood',
+    ];
+
+    it('loads and includes transcript (adoption) checks', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      expect(rubric.programmatic.length).toBeGreaterThan(0);
+      expect(rubric.transcript?.length).toBe(2);
+      expect(rubric.transcript![0].id).toBe('used_metric_tool');
+    });
+
+    it('negative checks do not fire on rule-out phrasing', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      const ruleOut = [
+        'The payment-service deploy is not the cause — payment.authorize is healthy on both versions.',
+        'These failures are not caused by the payment-service rollout.',
+        'The deprecation warnings are benign and not the root cause.',
+        'The problem is not the session-cookie deprecation flood.',
+        // Real rule-out phrasings that once tripped the tempered guards
+        // (batch 2026-07-24T08-41-58: "no evidence" was not in the guard
+        // list, so a correct dismissal was scored as false blame).
+        'Deprecation warning ("legacy session-cookie format"): 6,000 WARN-level logs but no evidence these cause failures. Noise, not signal.',
+        'payment-service v3.7.0 rollout: no evidence the deploy caused any checkout failures.',
+        // Hypothesis-then-dismissal phrasings:
+        // rule-out verbs before the subject, hedged causal verbs, interrogatives,
+        // conditionals, and "because" (which contains "caus") must not be
+        // scored as false blame.
+        'I ruled out the payment-service deploy because payment spans were error-free.',
+        'I ruled out the payment-service deploy as the cause of the checkout failures.',
+        'At first glance the payment-service deploy looked like it caused the incident, but payment spans were error-free on both versions.',
+        'Could the root cause be the payment-service deploy? No — payment-service showed zero errors on both versions.',
+        'I checked whether the payment-service deploy caused the errors — it did not.',
+        "It is not the payment-service deploy's fault; failed checkouts never reach payment-service.",
+        'The session-cookie deprecation flood is noise because it never correlates with checkout errors.',
+      ].join('\n');
+      for (const check of rubric.programmatic) {
+        if (!check.negative) continue;
+        const re = new RegExp(check.pattern, check.flags ?? 'i');
+        expect(`${check.id}:${re.test(ruleOut)}`).toBe(`${check.id}:false`);
+      }
+    });
+
+    it('negative checks DO fire on blame phrasing', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      const blame = new Map([
+        [
+          'false_blame_payment_deploy',
+          [
+            'The root cause is the payment-service rollout to 3.7.0.',
+            'The payment-service deploy of 3.7.0 caused the checkout failures.',
+            // Assertive hedges are still blame — only hypothesis framing
+            // ("might", "could", "suspect") is protected.
+            'The most likely root cause is the payment-service deploy.',
+          ],
+        ],
+        [
+          'false_blame_payment',
+          ['Checkout failures are due to a payment-gateway outage.'],
+        ],
+        [
+          'false_blame_deprecation',
+          [
+            'The failures are caused by the session-cookie deprecation in the new build.',
+            'The session-cookie deprecation broke checkout session handling.',
+          ],
+        ],
+      ]);
+      for (const [id, texts] of blame) {
+        const check = rubric.programmatic.find(c => c.id === id);
+        expect(check).toBeDefined();
+        const re = new RegExp(check!.pattern, check!.flags ?? 'i');
+        for (const text of texts) {
+          expect(`${id}:${re.test(text)}`).toBe(`${id}:true`);
+        }
+      }
+    });
+
+    it('every positive check passes on an excellent answer', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      for (const check of rubric.programmatic) {
+        if (check.negative) continue;
+        const re = new RegExp(check.pattern, check.flags ?? 'i');
+        expect(`${check.id}:${re.test(EXCELLENT_ANSWER)}`).toBe(
+          `${check.id}:true`,
+        );
+      }
+    });
+
+    it('no negative check fires on the excellent answer (rule-outs stay safe)', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      for (const check of rubric.programmatic) {
+        if (!check.negative) continue;
+        const re = new RegExp(check.pattern, check.flags ?? 'i');
+        expect(`${check.id}:${re.test(EXCELLENT_ANSWER)}`).toBe(
+          `${check.id}:false`,
+        );
+      }
+    });
+
+    it('excellence-tier checks FAIL on a good-but-generic answer (the old 0.95 ceiling)', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      for (const id of EXCELLENCE_TIER) {
+        const check = rubric.programmatic.find(c => c.id === id);
+        expect(check).toBeDefined();
+        const re = new RegExp(check!.pattern, check!.flags ?? 'i');
+        expect(`${id}:${re.test(GENERIC_GOOD_ANSWER)}`).toBe(`${id}:false`);
+      }
+    });
+
+    it('phrasing variants of real answers pass the fragile checks (regression)', () => {
+      // Both from batch 2026-07-24T08-41-58: equal-quality answers diverged
+      // on wording luck because the regexes demanded exact adjacency.
+      const rubric = loadScenarioRubric('deploy-regression');
+      const cases = new Map([
+        // hyperdx/2 wrote "3 of 6 `checkout-api` pods" — words between the
+        // count and "pods" must not break the match.
+        [
+          'cites_pod_split',
+          'A deployment rolled out to 3 of 6 checkout-api pods.',
+        ],
+        // "v"-prefixed version spelling.
+        [
+          'cites_rollout_event_join',
+          'The rollout events show those pods updated to v2.0.0-rc1.',
+        ],
+      ]);
+      for (const [id, text] of cases) {
+        const check = rubric.programmatic.find(c => c.id === id);
+        expect(check).toBeDefined();
+        const re = new RegExp(check!.pattern, check!.flags ?? 'i');
+        expect(`${id}:${re.test(text)}`).toBe(`${id}:true`);
+      }
+    });
+
+    it('base checks still pass on the good-but-generic answer', () => {
+      const rubric = loadScenarioRubric('deploy-regression');
+      for (const id of [
+        'names_affected_service',
+        'blames_the_deploy',
+        'names_rollout_pause_or_partial',
+      ]) {
+        const check = rubric.programmatic.find(c => c.id === id);
+        expect(check).toBeDefined();
+        const re = new RegExp(check!.pattern, check!.flags ?? 'i');
+        expect(`${id}:${re.test(GENERIC_GOOD_ANSWER)}`).toBe(`${id}:true`);
+      }
+    });
+  });
+});
+
+describe('deploy-regression system prompt', () => {
+  it('advertises the metric source with the exact metric-saturation note (parity)', () => {
+    const noteRe =
+      /- Metrics: a HyperDX metric source is available[\s\S]*?alongside traces and logs\./;
+    const ours = buildSystemPrompt(
+      deployRegressionScenario,
+      '2026-05-10T20:00:00.000Z',
+    );
+    const theirs = buildSystemPrompt(
+      metricSaturationScenario,
+      '2026-05-10T20:00:00.000Z',
+    );
+    const ourNote = ours.match(noteRe)?.[0];
+    const theirNote = theirs.match(noteRe)?.[0];
+    expect(ourNote).toBeDefined();
+    expect(ourNote).toBe(theirNote);
+    // Still the default SRE investigation framing.
+    expect(ours).toMatch(/You are an SRE/i);
+  });
+
+  it('appends the scenario-local budget-discipline note (and only here)', () => {
+    const ours = buildSystemPrompt(
+      deployRegressionScenario,
+      '2026-05-10T20:00:00.000Z',
+    );
+    const theirs = buildSystemPrompt(
+      metricSaturationScenario,
+      '2026-05-10T20:00:00.000Z',
+    );
+    expect(ours).toContain('HARD BUDGETS');
+    expect(ours).toMatch(/wall-clock limit/);
+    expect(ours).toMatch(/Reserve the final turn/);
+    // Scenario-local: metric-saturation's prompt is untouched.
+    expect(theirs).not.toContain('HARD BUDGETS');
+  });
+
+  it('budgets 26 turns — the observable budget must bind before the 300s wall clock', () => {
+    // Completed runs use 21-24 tool calls at ~9-11s each; 32 turns funded
+    // wandering into the wall-clock cliff (half of batch 2026-07-24T08-41-58
+    // timed out and was graded on interim notes).
+    expect(deployRegressionScenario.maxTurns).toBe(26);
+  });
+
+  it('shows a SOFT answer checkpoint in the TURN BUDGET line, not the hard cap', () => {
+    const ours = buildSystemPrompt(
+      deployRegressionScenario,
+      '2026-05-10T20:00:00.000Z',
+      'baseline',
+      deployRegressionScenario.maxTurns,
+    );
+    // cap (26) - margin (8): telling the agent "after ~26 calls, answer"
+    // while the harness cuts at 26 is an instruction to get truncated.
+    expect(ours).toContain('After ~18 tool calls');
+    expect(ours).not.toContain('After ~26 tool calls');
+  });
+
+  it('overrides the judge preamble to forbid crediting unstated claims', () => {
+    // Truncated interim notes must grade deterministically (~0), not as a
+    // coin flip on how much diagnosis the judge fills in from ground truth.
+    expect(deployRegressionScenario.judgeSystemPreamble).toContain(
+      'SCORE ONLY WHAT IS WRITTEN',
+    );
+    expect(deployRegressionScenario.judgeSystemPreamble).toContain(
+      'Return STRICT JSON',
+    );
+  });
+});

--- a/packages/hdx-eval/src/__tests__/deploy-regression.test.ts
+++ b/packages/hdx-eval/src/__tests__/deploy-regression.test.ts
@@ -543,11 +543,17 @@ describe('deploy-regression scenario', () => {
       'rules_out_deprecation_flood',
     ];
 
-    it('loads and includes transcript (adoption) checks', () => {
+    it('loads and includes metric-adoption checks', () => {
       const rubric = loadScenarioRubric('deploy-regression');
       expect(rubric.programmatic.length).toBeGreaterThan(0);
-      expect(rubric.transcript?.length).toBe(2);
-      expect(rubric.transcript![0].id).toBe('used_metric_tool');
+      expect(rubric.adoption?.length).toBe(2);
+      expect(rubric.adoption!.map(c => c.id)).toEqual([
+        'queried_target_metric',
+        'queried_checkout_http_metrics',
+      ]);
+      expect(rubric.adoption![0].metrics).toContain(
+        'http.server.request.duration',
+      );
     });
 
     it('negative checks do not fire on rule-out phrasing', () => {

--- a/packages/hdx-eval/src/__tests__/grade.test.ts
+++ b/packages/hdx-eval/src/__tests__/grade.test.ts
@@ -22,12 +22,13 @@ function buildRun(args: {
     input?: unknown;
   }>;
   finalAnswer: string;
+  mcp?: string;
 }): RunRecord {
   return {
     schemaVersion: 1,
     runId: `${args.scenario}-test-0`,
     scenario: args.scenario,
-    mcp: 'hyperdx',
+    mcp: args.mcp ?? 'hyperdx',
     model: 'claude-sonnet-4-6',
     plugin: 'none',
     runIndex: 0,
@@ -239,14 +240,14 @@ describe('gradeBatch tool-error penalty', () => {
   });
 });
 
-describe('gradeBatch transcript-aware adoption checks', () => {
+describe('gradeBatch metric-adoption checks', () => {
   const tmpRoot = join('/tmp', `hdx-eval-adoption-test-${Date.now()}`);
 
   afterAll(() => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('populates the adoption block from the tool-call transcript', async () => {
+  it('populates the adoption block from tool-call args', async () => {
     const batchDir = join(tmpRoot, 'adopted');
     writeBatch(
       batchDir,
@@ -285,15 +286,55 @@ describe('gradeBatch transcript-aware adoption checks', () => {
     );
     const result = await gradeBatch(batchDir, { skipJudge: true });
     const grade: GradeRecord = result.graded[0];
-    // All four transcript checks hit (used a metric tool, described the JVM
-    // memory metric, described the GC-pause metric, grouped memory by
-    // pod/pool).
+    // All four adoption checks hit (queried a target metric, the JVM memory
+    // metric, a GC metric, and grouped memory by pod/pool in one call).
     expect(grade.adoption).toBeDefined();
+    expect(grade.adoption!.hits.map(h => h.id).sort()).toEqual([
+      'grouped_memory_by_pod_or_pool',
+      'queried_gc_metric',
+      'queried_jvm_memory_metric',
+      'queried_target_metric',
+    ]);
     expect(grade.adoption!.score).toBeCloseTo(1, 5);
     expect(grade.adoption!.hits.every(h => h.satisfied)).toBe(true);
   });
 
-  it('scores zero adoption when no metric tools were used, without touching combinedScore', async () => {
+  it('grants adoption to a clickhouse-arm run that queries the metrics via SQL', async () => {
+    const batchDir = join(tmpRoot, 'sql-adopted');
+    writeBatch(
+      batchDir,
+      'metric-saturation',
+      'clickhouse',
+      buildRun({
+        scenario: 'metric-saturation',
+        mcp: 'clickhouse',
+        toolCalls: [
+          {
+            name: 'mcp__clickhouse__run_select_query',
+            isError: false,
+            input: {
+              query:
+                "SELECT MetricName, avg(Value) FROM otel_metrics_exponential_histogram WHERE MetricName = 'jvm.gc.pause' GROUP BY MetricName",
+            },
+          },
+        ],
+        finalAnswer: 'JVM heap leak on recommendation-service.',
+      }),
+    );
+    const result = await gradeBatch(batchDir, { skipJudge: true });
+    const grade = result.graded[0];
+    // Args-based detection is arm-agnostic: naming the target metric in raw
+    // SQL counts the same as calling a dedicated metric tool…
+    expect(grade.adoption).toBeDefined();
+    expect(grade.adoption!.score).toBeGreaterThan(0);
+    expect(
+      grade.adoption!.hits.find(h => h.id === 'queried_gc_metric')!.satisfied,
+    ).toBe(true);
+    // …and adoption still never feeds the outcome score.
+    expect(grade.combinedScore).toBeCloseTo(grade.programmatic.score, 5);
+  });
+
+  it('scores zero adoption when no tool call names a target metric, without touching combinedScore', async () => {
     const batchDir = join(tmpRoot, 'not-adopted');
     writeBatch(
       batchDir,
@@ -352,8 +393,8 @@ describe('gradeBatch transcript-aware adoption checks', () => {
     expect(grade.combinedScore).toBeLessThan(grade.adoption!.score);
   });
 
-  it('omits the adoption block for scenarios without a transcript rubric', async () => {
-    const batchDir = join(tmpRoot, 'no-transcript-rubric');
+  it('omits the adoption block for scenarios without an adoption rubric', async () => {
+    const batchDir = join(tmpRoot, 'no-adoption-rubric');
     writeBatch(
       batchDir,
       'error-root-cause',

--- a/packages/hdx-eval/src/__tests__/programmatic.test.ts
+++ b/packages/hdx-eval/src/__tests__/programmatic.test.ts
@@ -1,7 +1,8 @@
 import {
+  metricKeyToRegex,
+  runAdoptionChecks,
   runProgrammaticChecks,
-  runTranscriptChecks,
-  serializeTranscript,
+  serializeToolCallArgs,
 } from '@/grading/programmatic';
 import { loadScenarioRubric } from '@/grading/rubric';
 import type { ToolCallRecord } from '@/harness/types';
@@ -156,156 +157,216 @@ describe('runProgrammaticChecks', () => {
   });
 });
 
-describe('serializeTranscript', () => {
-  it('serializes each call as `<name> <compact-json-args>`, one per line', () => {
-    const s = serializeTranscript([
-      toolCall('clickstack_list_metrics', { sourceId: 's1' }),
+describe('serializeToolCallArgs', () => {
+  it('serializes input args as compact JSON, excluding the tool name', () => {
+    const s = serializeToolCallArgs(
       toolCall('clickstack_describe_metric', {
         name: 'process.runtime.jvm.memory.used',
       }),
-    ]);
-    expect(s).toBe(
-      'clickstack_list_metrics {"sourceId":"s1"}\n' +
-        'clickstack_describe_metric {"name":"process.runtime.jvm.memory.used"}',
     );
+    expect(s).toBe('{"name":"process.runtime.jvm.memory.used"}');
+    expect(s).not.toContain('clickstack_describe_metric');
   });
 
-  it('emits the bare tool name when there are no args', () => {
-    expect(serializeTranscript([toolCall('clickstack_list_sources')])).toBe(
-      'clickstack_list_sources',
-    );
+  it('returns an empty string when there are no args', () => {
+    expect(serializeToolCallArgs(toolCall('clickstack_list_sources'))).toBe('');
   });
 
   it('passes through string input verbatim (no double-encoding)', () => {
-    expect(serializeTranscript([toolCall('raw', 'already a string')])).toBe(
-      'raw already a string',
+    expect(serializeToolCallArgs(toolCall('raw', 'already a string'))).toBe(
+      'already a string',
     );
-  });
-
-  it('returns an empty string for no tool calls', () => {
-    expect(serializeTranscript([])).toBe('');
   });
 
   it('does not throw on circular / unserializable input', () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
-    const s = serializeTranscript([toolCall('weird', circular)]);
-    expect(s).toBe('weird [unserializable]');
+    expect(serializeToolCallArgs(toolCall('weird', circular))).toBe(
+      '[unserializable]',
+    );
   });
 
-  it('truncates oversized args so one huge call cannot bloat the transcript', () => {
-    const big = 'x'.repeat(5000);
-    const s = serializeTranscript([toolCall('huge', { blob: big })]);
-    expect(s.length).toBeLessThan(2100);
+  it('truncates oversized args so one huge call cannot bloat matching', () => {
+    const big = 'x'.repeat(50_000);
+    const s = serializeToolCallArgs(toolCall('huge', { blob: big }));
+    expect(s.length).toBeLessThan(20_100);
     expect(s.endsWith('…')).toBe(true);
   });
 });
 
-describe('runTranscriptChecks', () => {
-  it('matches tool names in the serialized transcript', () => {
-    const result = runTranscriptChecks(
+describe('metricKeyToRegex', () => {
+  it('matches the dotted key and its underscore variant, case-insensitively', () => {
+    const rx = metricKeyToRegex('jvm.gc.pause');
+    expect(rx.test("MetricName = 'jvm.gc.pause'")).toBe(true);
+    expect(rx.test('rate(jvm_gc_pause[5m])')).toBe(true);
+    expect(rx.test('JVM.GC.PAUSE')).toBe(true);
+  });
+
+  it('requires the full key — separator prose does not match', () => {
+    const rx = metricKeyToRegex('jvm.gc.pause');
+    expect(rx.test('the gc pause distribution grew a tail')).toBe(false);
+    expect(rx.test('jvm gc pause')).toBe(false); // spaces are not separators
+    expect(rx.test('jvmXgcXpause')).toBe(false); // dots are not wildcards
+  });
+
+  it('escapes regex metacharacters in the key', () => {
+    const rx = metricKeyToRegex('queue.depth{p99}');
+    expect(rx.test('queue.depth{p99}')).toBe(true);
+    expect(() => rx.test('anything')).not.toThrow();
+  });
+});
+
+describe('runAdoptionChecks', () => {
+  const gcCheck = {
+    id: 'queried_gc_metric',
+    weight: 1,
+    metrics: ['jvm.gc.pause'],
+  };
+
+  it('counts a dedicated metric tool naming the metric in its args', () => {
+    const result = runAdoptionChecks(
       [
-        toolCall('clickstack_list_metrics', { sourceId: 's1' }),
-        toolCall('clickstack_sql', { sql: 'SELECT 1' }),
+        toolCall('mcp__hyperdx__clickstack_timeseries', {
+          metricType: 'histogram',
+          metricName: 'jvm.gc.pause',
+        }),
       ],
-      [
-        {
-          id: 'used_metric_tool',
-          weight: 1,
-          pattern: 'clickstack_list_metrics',
-        },
-      ],
+      [gcCheck],
     );
     expect(result.score).toBeCloseTo(1, 5);
     expect(result.hits[0].satisfied).toBe(true);
   });
 
-  it('matches on tool args, enabling "used the right metric" checks', () => {
-    const checks = [
-      {
-        id: 'named_jvm_memory',
-        weight: 1,
-        pattern: 'process\\.runtime\\.jvm\\.memory',
-      },
-    ];
-    const usedRight = runTranscriptChecks(
+  it('counts raw SQL naming the metric — detection is tool-name-agnostic', () => {
+    const result = runAdoptionChecks(
       [
-        toolCall('clickstack_describe_metric', {
-          name: 'process.runtime.jvm.memory.used',
+        toolCall('mcp__clickhouse__run_query', {
+          query:
+            "SELECT * FROM otel_metrics_exponential_histogram WHERE MetricName = 'jvm.gc.pause'",
         }),
       ],
-      checks,
+      [gcCheck],
     );
-    const usedWrong = runTranscriptChecks(
-      [
-        toolCall('clickstack_describe_metric', {
-          name: 'http.server.duration',
-        }),
-      ],
-      checks,
-    );
-    expect(usedRight.score).toBeCloseTo(1, 5);
-    expect(usedWrong.score).toBe(0);
+    expect(result.score).toBeCloseTo(1, 5);
   });
 
-  it('scores zero when the transcript is empty', () => {
-    const result = runTranscriptChecks(
-      [],
-      [{ id: 'used_metric_tool', weight: 1, pattern: 'clickstack' }],
-    );
+  it('ignores metric names that only appear in tool OUTPUT', () => {
+    const call: ToolCallRecord = {
+      ...toolCall('mcp__hyperdx__clickstack_list_metrics', { sourceId: 's1' }),
+      output: 'jvm.gc.pause\nprocess.runtime.jvm.memory.used',
+    };
+    const result = runAdoptionChecks([call], [gcCheck]);
     expect(result.score).toBe(0);
     expect(result.hits[0].satisfied).toBe(false);
   });
+
+  it('ignores tool NAMES — a metric-ish tool name is not adoption', () => {
+    const result = runAdoptionChecks(
+      [toolCall('query_jvm.gc.pause_tool', { sourceId: 's1' })],
+      [gcCheck],
+    );
+    expect(result.score).toBe(0);
+  });
+
+  it('scores zero when there are no tool calls', () => {
+    const result = runAdoptionChecks([], [gcCheck]);
+    expect(result.score).toBe(0);
+    expect(result.hits[0].satisfied).toBe(false);
+  });
+
+  it('alsoPattern must match the SAME call as the metric key', () => {
+    const grouped = {
+      id: 'grouped_memory_by_pod_or_pool',
+      weight: 1,
+      metrics: ['process.runtime.jvm.memory.used'],
+      alsoPattern: 'pool|pod',
+    };
+    // Metric in one call, "pod" in a different call → NOT satisfied.
+    const split = runAdoptionChecks(
+      [
+        toolCall('a', { metric: 'process.runtime.jvm.memory.used' }),
+        toolCall('b', { groupBy: 'k8s.pod.name' }),
+      ],
+      [grouped],
+    );
+    expect(split.hits[0].satisfied).toBe(false);
+    // Both in the same call (SQL, no dedicated tool) → satisfied.
+    const together = runAdoptionChecks(
+      [
+        toolCall('mcp__clickhouse__run_query', {
+          query:
+            "SELECT avg(Value) FROM otel_metrics_gauge WHERE MetricName = 'process.runtime.jvm.memory.used' GROUP BY Attributes['k8s.pod.name']",
+        }),
+      ],
+      [grouped],
+    );
+    expect(together.hits[0].satisfied).toBe(true);
+  });
+
+  it('throws on an invalid alsoPattern', () => {
+    expect(() =>
+      runAdoptionChecks(
+        [toolCall('a', { metric: 'jvm.gc.pause' })],
+        [{ id: 'bad', weight: 1, metrics: ['jvm.gc.pause'], alsoPattern: '(' }],
+      ),
+    ).toThrow(/alsoPattern/);
+  });
 });
 
-describe('rubric.transcript parsing', () => {
-  it('hydrates the metric-saturation transcript block', () => {
+describe('rubric.adoption parsing', () => {
+  it('hydrates the metric-saturation adoption block', () => {
     const rubric = loadScenarioRubric('metric-saturation');
-    expect(rubric.transcript).toBeDefined();
-    expect(rubric.transcript!.length).toBeGreaterThanOrEqual(1);
-    // Tuples hydrate into full ProgrammaticCheck objects with default flags.
-    const used = rubric.transcript!.find(c => c.id === 'used_metric_tool');
-    expect(used).toMatchObject({ weight: 1, flags: 'i' });
-    expect(typeof used!.pattern).toBe('string');
+    expect(rubric.adoption).toBeDefined();
+    expect(rubric.adoption!.length).toBeGreaterThanOrEqual(1);
+    const umbrella = rubric.adoption!.find(
+      c => c.id === 'queried_target_metric',
+    );
+    expect(umbrella).toMatchObject({ weight: 1 });
+    expect(umbrella!.metrics).toContain('process.runtime.jvm.memory.used');
   });
 
-  it('leaves transcript undefined for scenarios without the block', () => {
+  it('leaves adoption undefined for scenarios without the block', () => {
     const rubric = loadScenarioRubric('error-root-cause');
-    expect(rubric.transcript).toBeUndefined();
+    expect(rubric.adoption).toBeUndefined();
   });
 
-  it('the metric-saturation transcript checks all compile as valid regexes', () => {
-    const rubric = loadScenarioRubric('metric-saturation');
-    for (const c of rubric.transcript!) {
-      expect(() => new RegExp(c.pattern, c.flags ?? 'i')).not.toThrow();
+  it('every declared metric key compiles into a valid regex', () => {
+    for (const scenario of ['metric-saturation', 'deploy-regression']) {
+      const rubric = loadScenarioRubric(scenario);
+      for (const c of rubric.adoption!) {
+        for (const key of c.metrics) {
+          expect(() => metricKeyToRegex(key)).not.toThrow();
+        }
+      }
     }
   });
 });
 
-describe('metric-saturation adoption checks (SQL text must not count)', () => {
-  const rubric = () => loadScenarioRubric('metric-saturation').transcript!;
+describe('metric-saturation adoption checks (args-based, arm-agnostic)', () => {
+  const rubric = () => loadScenarioRubric('metric-saturation').adoption!;
   const satisfiedIds = (calls: ToolCallRecord[]) =>
-    runTranscriptChecks(calls, rubric())
+    runAdoptionChecks(calls, rubric())
       .hits.filter(h => h.satisfied)
       .map(h => h.id)
       .sort();
 
-  it('raw SQL mentioning metric names satisfies no adoption check', () => {
-    // A clickhouse-arm run that only reads metric names via SQL must not get
-    // adoption credit — adoption measures hyperdx MCP metric-tool usage.
+  it('raw SQL naming the target metrics gets adoption credit (clickhouse arm)', () => {
+    // The whole point of args-based detection: a clickhouse-arm run that
+    // investigates the metrics via SQL counts the same as metric-tool usage.
     const ids = satisfiedIds([
       toolCall('mcp__clickhouse__run_query', {
         query:
           "SELECT MetricName, Value FROM otel_metrics_gauge WHERE MetricName IN ('process.runtime.jvm.memory.used', 'jvm.gc.pause')",
       }),
-      toolCall('mcp__hyperdx__clickstack_sql', {
-        sql: "SELECT * FROM otel_metrics_histogram WHERE MetricName = 'jvm.gc.pause'",
-      }),
     ]);
-    expect(ids).toEqual([]);
+    expect(ids).toEqual([
+      'queried_gc_metric',
+      'queried_jvm_memory_metric',
+      'queried_target_metric',
+    ]);
   });
 
-  it('metric-tool calls naming the metrics satisfy all adoption checks', () => {
+  it('metric-tool calls naming the metrics satisfy the same checks (hyperdx arm)', () => {
     const ids = satisfiedIds([
       toolCall('mcp__hyperdx__clickstack_describe_metric', {
         sourceId: 's1',
@@ -319,17 +380,35 @@ describe('metric-saturation adoption checks (SQL text must not count)', () => {
       }),
     ]);
     expect(ids).toEqual([
-      'described_gc_pause_metric',
-      'described_jvm_memory_metric',
-      'used_metric_tool',
+      'queried_gc_metric',
+      'queried_jvm_memory_metric',
+      'queried_target_metric',
     ]);
   });
 
-  it('a log/trace timeseries mentioning gc pause in a filter does not count', () => {
-    // clickstack_timeseries only counts as a metric read when the call
-    // carries metricType — charting logs that mention "gc pause" must not.
+  it('grouping the memory metric by pod/pool in the same call satisfies the grouped check', () => {
     const ids = satisfiedIds([
       toolCall('mcp__hyperdx__clickstack_timeseries', {
+        metricType: 'gauge',
+        metric: 'process.runtime.jvm.memory.used',
+        groupBy: ['k8s.pod.name', 'jvm.memory.pool.name'],
+      }),
+    ]);
+    expect(ids).toContain('grouped_memory_by_pod_or_pool');
+  });
+
+  it('a bare list_metrics call (no metric named in args) does not count', () => {
+    const ids = satisfiedIds([
+      toolCall('mcp__hyperdx__clickstack_list_metrics', { sourceId: 's1' }),
+    ]);
+    expect(ids).toEqual([]);
+  });
+
+  it('a log search mentioning "gc pause" prose does not count', () => {
+    // Full metric keys are required — casual prose in a log-body filter must
+    // not earn metric-adoption credit.
+    const ids = satisfiedIds([
+      toolCall('mcp__hyperdx__clickstack_search', {
         sourceId: 'logs-source',
         where: "Body LIKE '%gc pause%'",
       }),

--- a/packages/hdx-eval/src/grading/grade.ts
+++ b/packages/hdx-eval/src/grading/grade.ts
@@ -15,7 +15,7 @@ import {
   judgeCredentialsAvailable,
   parseJudgeSpec,
 } from './judgeModel';
-import { runProgrammaticChecks, runTranscriptChecks } from './programmatic';
+import { runAdoptionChecks, runProgrammaticChecks } from './programmatic';
 import { loadScenarioRubric } from './rubric';
 import {
   COMBINED_SCORE_JUDGE_WEIGHT,
@@ -258,11 +258,13 @@ async function gradeOne(args: {
     rubric.programmatic,
   );
 
-  // Transcript-aware (adoption) checks. Reported alongside the outcome score
-  // but intentionally EXCLUDED from combinedScore below — measuring tool
-  // usage must not inflate outcome quality.
-  const adoption = rubric.transcript
-    ? runTranscriptChecks(record.toolCalls, rubric.transcript)
+  // Metric-adoption checks: did any tool call's input args name the
+  // scenario's target metrics? Args-only and tool-name-agnostic, so both
+  // arms are graded identically. Reported alongside the outcome score but
+  // intentionally EXCLUDED from combinedScore below — measuring tool usage
+  // must not inflate outcome quality.
+  const adoption = rubric.adoption
+    ? runAdoptionChecks(record.toolCalls, rubric.adoption)
     : undefined;
 
   const toolErrors = computeToolErrorStats(record);

--- a/packages/hdx-eval/src/grading/programmatic.ts
+++ b/packages/hdx-eval/src/grading/programmatic.ts
@@ -1,59 +1,107 @@
 import type { ToolCallRecord } from '@/harness/types';
 
 import type {
+  AdoptionCheck,
   ProgrammaticCheck,
   ProgrammaticHit,
   ProgrammaticResult,
 } from './types';
 
-/** Cap per-line length so a single huge tool arg can't bloat the transcript. */
-const MAX_ARGS_CHARS = 2000;
+/**
+ * Cap per-call args length so one enormous payload can't bloat matching.
+ * Generous (20k) because adoption checks must still find a metric name deep
+ * inside a long multi-CTE SQL query.
+ */
+const MAX_ARGS_CHARS = 20_000;
 
 /**
- * Serialize a run's tool-call transcript into a stable, regex-friendly
- * string for transcript-aware programmatic checks. One call per line, in the
- * order they were made, formatted as `<toolName> <compact-JSON-args>`.
- *
- * Only tool **names + input args** are included — outputs are intentionally
- * omitted (large, noisy, and nondeterministic). Args are compact JSON so a
- * rubric can assert on both the tool used (name) and how it was used (args),
- * e.g. "used a metric tool" or "described the JVM memory metric".
+ * Serialize a single tool call's **input args** into a stable, regex-friendly
+ * string. Compact JSON (or the raw string for string inputs). Tool names and
+ * outputs are intentionally excluded — adoption checks must only see how the
+ * agent *asked*, never what the tools returned or what the tool was called.
  */
-export function serializeTranscript(toolCalls: ToolCallRecord[]): string {
-  return toolCalls
-    .map(call => {
-      let args = '';
-      if (call.input !== undefined && call.input !== null) {
-        try {
-          args =
-            typeof call.input === 'string'
-              ? call.input
-              : JSON.stringify(call.input);
-        } catch {
-          // Circular / non-serializable input — fall back to a marker so the
-          // tool name is still gradeable.
-          args = '[unserializable]';
-        }
-      }
-      if (args.length > MAX_ARGS_CHARS) {
-        args = args.slice(0, MAX_ARGS_CHARS) + '…';
-      }
-      return args ? `${call.name} ${args}` : call.name;
-    })
-    .join('\n');
+export function serializeToolCallArgs(call: ToolCallRecord): string {
+  let args = '';
+  if (call.input !== undefined && call.input !== null) {
+    try {
+      args =
+        typeof call.input === 'string'
+          ? call.input
+          : JSON.stringify(call.input);
+    } catch {
+      // Circular / non-serializable input — nothing gradeable.
+      args = '[unserializable]';
+    }
+  }
+  if (args.length > MAX_ARGS_CHARS) {
+    args = args.slice(0, MAX_ARGS_CHARS) + '…';
+  }
+  return args;
 }
 
 /**
- * Run transcript-aware checks against a run's tool-call transcript. Thin
- * wrapper over {@link runProgrammaticChecks} that serializes the transcript
- * first. Result shape is identical to answer checks so reports can treat both
+ * Compile a metric name/key into a separator-tolerant, case-insensitive
+ * regex: every regex metachar is escaped, then each `.` boundary accepts
+ * either `.` or `_` (so `jvm.gc.pause` also matches `jvm_gc_pause`). Full
+ * keys are required — prose like "gc pause" in a log-search filter does not
+ * match.
+ */
+export function metricKeyToRegex(key: string): RegExp {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(escaped.replace(/\\\./g, '[._]'), 'i');
+}
+
+/**
+ * Run metric-adoption checks against a run's tool calls. A check is
+ * satisfied when some **single** tool call's input args contain any of the
+ * check's metric keys (and match `alsoPattern`, when present). Detection is
+ * args-only and tool-name-agnostic, so a raw SQL query naming the metric
+ * counts the same as a dedicated metric tool — the grader never branches on
+ * which MCP/arm produced the call.
+ *
+ * Result shape is identical to answer checks so reports can treat both
  * uniformly.
  */
-export function runTranscriptChecks(
+export function runAdoptionChecks(
   toolCalls: ToolCallRecord[],
-  checks: ProgrammaticCheck[],
+  checks: AdoptionCheck[],
 ): ProgrammaticResult {
-  return runProgrammaticChecks(serializeTranscript(toolCalls), checks);
+  const argsTexts = toolCalls.map(serializeToolCallArgs);
+
+  const hits: ProgrammaticHit[] = [];
+  let totalWeight = 0;
+  let hitWeight = 0;
+
+  for (const check of checks) {
+    totalWeight += check.weight;
+    const metricRegexes = check.metrics.map(metricKeyToRegex);
+    let also: RegExp | null = null;
+    if (check.alsoPattern !== undefined) {
+      try {
+        also = new RegExp(check.alsoPattern, 'i');
+      } catch (err) {
+        throw new Error(
+          `Invalid alsoPattern in adoption check '${check.id}': ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    const matched = argsTexts.some(
+      args =>
+        metricRegexes.some(rx => rx.test(args)) && (!also || also.test(args)),
+    );
+    if (matched) hitWeight += check.weight;
+    hits.push({
+      id: check.id,
+      weight: check.weight,
+      matched,
+      satisfied: matched,
+    });
+  }
+
+  const score = totalWeight === 0 ? 0 : hitWeight / totalWeight;
+  return { hits, score };
 }
 
 export function runProgrammaticChecks(

--- a/packages/hdx-eval/src/grading/rubric.ts
+++ b/packages/hdx-eval/src/grading/rubric.ts
@@ -1,6 +1,6 @@
 import { getScenario } from '@/scenarios';
 
-import type { ProgrammaticCheck, Rubric } from './types';
+import type { AdoptionCheck, ProgrammaticCheck, Rubric } from './types';
 
 export function loadScenarioRubric(scenarioName: string): Rubric {
   const scenario = getScenario(scenarioName);
@@ -17,11 +17,7 @@ export function loadScenarioRubric(scenarioName: string): Rubric {
  * Hydrate a compact tuple `[id, weight, pattern, negative?]` into a
  * ProgrammaticCheck object. The `flags` field always defaults to `"i"`.
  */
-function hydrateCheck(
-  entry: unknown,
-  scenarioName: string,
-  field: 'programmatic' | 'transcript' = 'programmatic',
-): ProgrammaticCheck {
+function hydrateCheck(entry: unknown, scenarioName: string): ProgrammaticCheck {
   if (Array.isArray(entry)) {
     const [id, weight, pattern, negative] = entry;
     if (
@@ -30,7 +26,7 @@ function hydrateCheck(
       typeof pattern !== 'string'
     ) {
       throw new Error(
-        `rubric.${field} for '${scenarioName}': tuple must be [string, number, string, boolean?]`,
+        `rubric.programmatic for '${scenarioName}': tuple must be [string, number, string, boolean?]`,
       );
     }
     return {
@@ -43,21 +39,77 @@ function hydrateCheck(
   }
   if (!entry || typeof entry !== 'object') {
     throw new Error(
-      `rubric.${field} for '${scenarioName}' has a non-object/non-array entry`,
+      `rubric.programmatic for '${scenarioName}' has a non-object/non-array entry`,
     );
   }
   const check = entry as Record<string, unknown>;
   if (typeof check.id !== 'string' || typeof check.pattern !== 'string') {
     throw new Error(
-      `rubric.${field} for '${scenarioName}': each check needs string 'id' and 'pattern'`,
+      `rubric.programmatic for '${scenarioName}': each check needs string 'id' and 'pattern'`,
     );
   }
   if (typeof check.weight !== 'number' || check.weight <= 0) {
     throw new Error(
-      `rubric.${field} for '${scenarioName}': check '${check.id}' weight must be a positive number`,
+      `rubric.programmatic for '${scenarioName}': check '${check.id}' weight must be a positive number`,
     );
   }
   return entry as ProgrammaticCheck;
+}
+
+/**
+ * Validate an `adoption` check entry. Unlike programmatic checks these are
+ * NOT regex tuples: each entry is an object declaring the target metric
+ * names/keys the tool-call args must contain (see {@link AdoptionCheck}).
+ * `alsoPattern` is compiled eagerly so a bad regex fails at rubric load, not
+ * mid-grade.
+ */
+function validateAdoptionCheck(
+  entry: unknown,
+  scenarioName: string,
+): AdoptionCheck {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(
+      `rubric.adoption for '${scenarioName}': each check must be an object ` +
+        `{ id, weight, metrics[], alsoPattern? } — tuples/patterns are not supported`,
+    );
+  }
+  const check = entry as Record<string, unknown>;
+  if (typeof check.id !== 'string') {
+    throw new Error(
+      `rubric.adoption for '${scenarioName}': each check needs a string 'id'`,
+    );
+  }
+  if (typeof check.weight !== 'number' || check.weight <= 0) {
+    throw new Error(
+      `rubric.adoption for '${scenarioName}': check '${check.id}' weight must be a positive number`,
+    );
+  }
+  if (
+    !Array.isArray(check.metrics) ||
+    check.metrics.length === 0 ||
+    check.metrics.some(m => typeof m !== 'string' || m.length === 0)
+  ) {
+    throw new Error(
+      `rubric.adoption for '${scenarioName}': check '${check.id}' needs a non-empty 'metrics' string array`,
+    );
+  }
+  if (check.alsoPattern !== undefined) {
+    if (typeof check.alsoPattern !== 'string') {
+      throw new Error(
+        `rubric.adoption for '${scenarioName}': check '${check.id}' alsoPattern must be a string`,
+      );
+    }
+    try {
+      new RegExp(check.alsoPattern, 'i');
+    } catch (err) {
+      throw new Error(
+        `rubric.adoption for '${scenarioName}': check '${check.id}' alsoPattern is not a valid regex: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return entry as AdoptionCheck;
 }
 
 function validateRubric(raw: unknown, scenarioName: string): Rubric {
@@ -74,18 +126,16 @@ function validateRubric(raw: unknown, scenarioName: string): Rubric {
     hydrateCheck(c, scenarioName),
   );
 
-  // Optional transcript-aware (adoption) checks. Same shape as programmatic
-  // checks but run against the serialized tool-call transcript. Absent ⇒
-  // scenario has no adoption grading.
-  let transcript: ProgrammaticCheck[] | undefined;
-  if (obj.transcript !== undefined) {
-    if (!Array.isArray(obj.transcript)) {
-      throw new Error(
-        `rubric.transcript for '${scenarioName}' must be an array`,
-      );
+  // Optional metric-adoption checks: declared target metric keys matched
+  // against tool-call args (never tool names/outputs). Absent ⇒ scenario has
+  // no adoption grading.
+  let adoption: AdoptionCheck[] | undefined;
+  if (obj.adoption !== undefined) {
+    if (!Array.isArray(obj.adoption)) {
+      throw new Error(`rubric.adoption for '${scenarioName}' must be an array`);
     }
-    transcript = (obj.transcript as unknown[]).map(c =>
-      hydrateCheck(c, scenarioName, 'transcript'),
+    adoption = (obj.adoption as unknown[]).map(c =>
+      validateAdoptionCheck(c, scenarioName),
     );
   }
 
@@ -116,6 +166,6 @@ function validateRubric(raw: unknown, scenarioName: string): Rubric {
   return {
     programmatic,
     judge: judge as Rubric['judge'],
-    ...(transcript ? { transcript } : {}),
+    ...(adoption ? { adoption } : {}),
   };
 }

--- a/packages/hdx-eval/src/grading/types.ts
+++ b/packages/hdx-eval/src/grading/types.ts
@@ -10,6 +10,30 @@ export type ProgrammaticCheck = {
   negative?: boolean;
 };
 
+/**
+ * An adoption check detects metric engagement from tool-call **arguments**
+ * alone: it is satisfied when some single tool call's input args name one of
+ * the scenario's target metrics, regardless of which tool was called. This
+ * keeps the grader arm-agnostic — a ClickStack metric tool naming
+ * `jvm.gc.pause` and a raw SQL query filtering `MetricName = 'jvm.gc.pause'`
+ * both count. Tool names and tool outputs are never matched.
+ */
+export type AdoptionCheck = {
+  id: string;
+  weight: number;
+  /**
+   * Any-of list of full metric names/keys (e.g.
+   * `process.runtime.jvm.memory.used`). Matched case-insensitively with
+   * `.`/`_`-tolerant separators, so `jvm_gc_pause` also counts.
+   */
+  metrics: string[];
+  /**
+   * Optional extra regex that must ALSO match the same call's args (e.g.
+   * `pool|pod` for "grouped the memory metric by pod/pool").
+   */
+  alsoPattern?: string;
+};
+
 type JudgeCriterion = {
   id: string;
   weight: number;
@@ -19,12 +43,11 @@ type JudgeCriterion = {
 export type Rubric = {
   programmatic: ProgrammaticCheck[];
   /**
-   * Optional transcript-aware checks. Same regex-check shape as
-   * `programmatic`, but run against the serialized tool-call transcript
-   * (tool names + args) instead of the final answer. Used to grade
-   * tool-adoption signals (e.g. "used a metric tool").
+   * Optional metric-adoption checks, run against the input args of each
+   * tool call (never tool names, outputs, or the prompt). Absent ⇒ the
+   * scenario has no adoption grading.
    */
-  transcript?: ProgrammaticCheck[];
+  adoption?: AdoptionCheck[];
   judge: { criteria: JudgeCriterion[] };
 };
 
@@ -86,8 +109,8 @@ export type GradeRecord = {
   mcp: McpKind;
   programmatic: ProgrammaticResult;
   /**
-   * Transcript-aware (tool-adoption) check results, when the scenario rubric
-   * defines a `transcript` block. Absent when the rubric has no `transcript` block.
+   * Metric-adoption check results, when the scenario rubric defines an
+   * `adoption` block. Absent when the rubric has no `adoption` block.
    */
   adoption?: ProgrammaticResult;
   judge: JudgeResult | null;

--- a/packages/hdx-eval/src/reports/aggregate.ts
+++ b/packages/hdx-eval/src/reports/aggregate.ts
@@ -253,9 +253,9 @@ function buildCellSummary(
     }
   }
 
-  // Adoption (transcript-aware tool usage). Only pairs whose grade carries an
+  // Adoption (metric keys in tool-call args). Only pairs whose grade carries an
   // `adoption` block contribute; the cell omits `adoption` entirely when the
-  // scenario has no transcript rubric.
+  // scenario has no adoption rubric.
   const adopted = pairs.filter(p => p.grade.adoption);
   let adoption: CellSummary['adoption'];
   if (adopted.length > 0) {

--- a/packages/hdx-eval/src/reports/markdown.ts
+++ b/packages/hdx-eval/src/reports/markdown.ts
@@ -130,7 +130,7 @@ function renderScenarioTable(
     c => val(c?.programmatic.mean, pct),
     d => signedPct(d?.programmaticScore),
   );
-  // Adoption is only graded for scenarios with a transcript rubric; omit the
+  // Adoption is only graded for scenarios with an adoption rubric; omit the
   // row entirely when no cell has adoption data.
   const hasAdoption = columns.some(m => scenario.cells[m]?.adoption);
   if (hasAdoption) {
@@ -249,7 +249,7 @@ function renderAdoptionBreakdown(
   const rows = [
     '#### Adoption per-check (usage rate)',
     '',
-    'Usage rate = share of runs whose tool-call transcript matched the check.',
+    'Usage rate = share of runs whose tool-call args matched the check.',
     '',
     `| Adoption check | ${colHeaders} |`,
     '|---' + '|---'.repeat(columns.length) + '|',

--- a/packages/hdx-eval/src/scenarios/deploy-regression/generate.ts
+++ b/packages/hdx-eval/src/scenarios/deploy-regression/generate.ts
@@ -1,0 +1,1053 @@
+/**
+ * deploy-regression scenario
+ *
+ * Story: checkout-api starts a rolling deploy of 2.0.0-rc1 ~45 min before
+ * `now`. Three of six pods update (one every ~2 min), then the rollout is
+ * paused for canary observation. The new build has a code defect: the
+ * rewritten promotion handler assumes every promo code has a `percentOff`
+ * field, so fixed-amount codes (FREESHIP, FLAT5, GIFT10) throw
+ * `TypeError: Cannot read properties of undefined (reading 'percentOff')`
+ * and the request 500s. Result: ~7-8% of checkouts fail, but ONLY on pods
+ * running 2.0.0-rc1 and ONLY for fixed-amount promo codes.
+ *
+ * Unlike metric-saturation, the full causal chain lives in TRACES + LOGS —
+ * but none of it is pre-labeled:
+ *   - checkout-api telemetry carries NO `service.version` resource
+ *     attribute (realistic: the fleet doesn't stamp build versions into
+ *     OTel resources). The smoking-gun cross-tab is a two-step join:
+ *     group POST /api/checkout errors by `k8s.pod.name` → exactly 3 of 6
+ *     pods are bad → the deployment.rollout event logs name exactly those
+ *     pods flipping to 2.0.0-rc1.
+ *   - Defect spans carry `checkout.promo_code` but no promo-type label,
+ *     and their statusMessage is a generic 'internal error' (same as
+ *     baseline noise). The failure is separable only via the pod × promo
+ *     cross-tab and the fail-fast duration.
+ *   - Only ~1-in-7 defect hits log the full TypeError stack trace
+ *     (error-sampling); the rest emit a generic trace-correlated
+ *     'checkout.request_failed' ERROR that names neither TypeError nor
+ *     promotions.
+ *
+ * Metrics exist but are CORROBORATING ONLY. They are keyed by service, not
+ * version or pod, so they cannot reveal the pod split or the defect:
+ *   - Histogram http.server.request.duration{200|500} : 500-count steps up.
+ *   - Sum       http.server.request.count{2xx|5xx}    : 5xx slope changes.
+ *   - Gauge     system.cpu.utilization / process.memory.usage : flat,
+ *     healthy — rules out infra saturation.
+ *   - Gauge     inventory.sync.queue.depth (inventory-service) : noisy but
+ *     benign across the whole window — a metric red herring.
+ *
+ * The scenario measures ORGANIC metric-tool adoption via the transcript
+ * rubric: the agent doesn't need the metric tools, so reaching for them is
+ * the adoption signal (contrast with metric-saturation, where it's forced).
+ *
+ * Distractors: an INNOCENT completed payment-service rollout minutes before
+ * checkout's (the "blame the other deploy" trap), a deploy-introduced
+ * benign DeprecationWarning flood from the new-build pods that steps at the
+ * SAME boundary as the errors (the "new pattern at the boundary = cause"
+ * trap), healthy payment-service child spans, constant-rate
+ * NonFatalRetryableError caught-exception noise on checkout-api, a brief
+ * self-resolving recommendation-service 502 burst that PREDATES the deploy,
+ * and the noisy queue-depth gauge.
+ *
+ * CONSISTENCY (second hardening round): difficulty lives in the ANSWER
+ * rubric, not in budget cliffs or accidental confounders —
+ *   - checkout-api and payment-service each run on a dedicated, disjoint
+ *     node pool (one pod per node). The old shared 4-node pool made
+ *     payment's rollout look like it landed "on the same hosts" as the
+ *     checkout errors — an undesigned noisy-neighbor rabbit hole that
+ *     burned wall clock without discriminating anything.
+ *   - maxTurns 32 (the raw-SQL arm burns one turn per query and used to
+ *     hit 25 turns with half its wall clock unused).
+ *   - The system prompt appends a scenario-local budget-discipline note
+ *     (hard wall-clock limit exists; reserve the final turn for the
+ *     answer) so runs stop dying mid-hypothesis with nothing written.
+ *
+ * CONSISTENCY (third round): the 300s wall clock, not the turn budget,
+ * turned out to be the binding constraint — half the runs in batch
+ * 2026-07-24T08-41-58 timed out mid-investigation (completed runs needed
+ * 185-273s) and were graded on interim notes, which the judge scored
+ * anywhere from 0.02 to 0.98 depending on how much diagnosis it
+ * hallucinated from the ground-truth facts. Three changes:
+ *   - maxTurns 32 -> 26 so the budget the agent CAN observe (its own
+ *     tool-call count) binds before the wall clock it cannot.
+ *   - The prompt's TURN BUDGET line shows a SOFT answer checkpoint
+ *     (cap - 8) instead of the hard cap (which read as "exhaust the
+ *     whole budget, then answer"), and BUDGET_NOTE is phrased in
+ *     countable tool calls, not unobservable minutes.
+ *   - A scenario-local judge preamble forbids crediting claims the
+ *     answer does not state — truncated interim notes score 0 instead
+ *     of a coin flip.
+ */
+import { makeLog } from '@/generators/logs';
+import {
+  bucketize,
+  makeGauge,
+  makeHistogram,
+  makeSum,
+} from '@/generators/metrics';
+import {
+  buildResourcePool,
+  cacheHitLog,
+  caughtExceptionLog,
+  envoyAccessLog,
+  normalizeSeverityText,
+  pickResource,
+  serviceOpsDebugLog,
+  spreadTimestamp,
+  upstreamHealthProbeLog,
+} from '@/generators/templates';
+import { makeSpan, msToNs, newSpanId, newTraceId } from '@/generators/traces';
+import type {
+  GaugeMetricRow,
+  HistogramMetricRow,
+  LogRow,
+  SumMetricRow,
+  TraceRow,
+} from '@/generators/types';
+import { buildInvestigationSystemPrompt } from '@/harness/systemPrompt';
+import type {
+  GenerateContext,
+  MetricBatch,
+  Scenario,
+  ScenarioBatch,
+} from '@/scenarios/types';
+
+import groundTruth from './ground-truth.json';
+
+// ─── Services ───────────────────────────────────────────────────────────────
+
+const SUBJECT_SERVICE = 'checkout-api';
+const PAYMENT_SERVICE = 'payment-service';
+const NEIGHBOR_SERVICE = 'inventory-service';
+const RECO_SERVICE = 'recommendation-service';
+const PROXY_SERVICE = 'frontend-proxy';
+
+// ─── Time model ─────────────────────────────────────────────────────────────
+// 2-hour window. The rolling deploy starts 45 min before `now`; canary pods
+// flip one at a time every 2 min (pods 0..2), then the rollout pauses at 3/6
+// for canary observation. An INNOCENT payment-service rollout completes
+// shortly before (starts 58 min ago, 6/6 pods by 52 min ago) — close enough
+// to the onset that "a deploy happened around then" cannot attribute blame.
+// The recommendation-service 502 burst (distractor) happens 70 min before
+// `now` — clearly BEFORE both deploys and self-resolved.
+
+const HISTORY_WINDOW_MS = 2 * 60 * 60 * 1000;
+const SCRAPE_INTERVAL_MS = 120 * 1000;
+const DEPLOY_AGO_MS = 45 * 60 * 1000;
+const ROLLOUT_STAGGER_MS = 2 * 60 * 1000;
+const BURST_AGO_MS = 70 * 60 * 1000;
+const BURST_DURATION_MS = 5 * 60 * 1000;
+
+const POD_COUNT = 6;
+const CANARY_POD_COUNT = 3;
+
+const OLD_VERSION = '1.43.1';
+const NEW_VERSION = '2.0.0-rc1';
+
+// Innocent payment-service rollout (distractor): starts 58 min ago, one pod
+// per minute (6 pods), completion event 52 min ago — 7 min before checkout's
+// first pod flip, where the errors actually start.
+const PAYMENT_DEPLOY_AGO_MS = 58 * 60 * 1000;
+const PAYMENT_ROLLOUT_STAGGER_MS = 60 * 1000;
+const PAYMENT_COMPLETE_AGO_MS = 52 * 60 * 1000;
+const PAYMENT_POD_COUNT = 6;
+const PAYMENT_OLD_VERSION = '3.6.2';
+const PAYMENT_NEW_VERSION = '3.7.0';
+
+// ─── Failure model ──────────────────────────────────────────────────────────
+// ~30% of checkouts apply a promo code; half of the promo picks are
+// fixed-amount (the kind that lacks `percentOff`), and those ALWAYS fail on
+// 2.0.0-rc1. With 3/6 pods updated: 0.5 * 0.3 * 0.5 ≈ 7.5% overall checkout
+// error rate.
+
+const PROMO_FRACTION = 0.3;
+const FIXED_PROMO_SHARE = 0.5; // share of promo picks that are fixed-amount
+// Uneven-share catalogs: the failing set isn't a trivial "2 of 4".
+const PERCENT_PROMO_MIX = [
+  { value: 'SAVE10', weight: 40 },
+  { value: 'VIP20', weight: 25 },
+  { value: 'WELCOME15', weight: 20 },
+  { value: 'SPRING25', weight: 15 },
+] as const;
+const FIXED_PROMO_MIX = [
+  { value: 'FREESHIP', weight: 45 },
+  { value: 'FLAT5', weight: 40 },
+  { value: 'GIFT10', weight: 15 },
+] as const;
+const BASELINE_ERROR_RATE = 0.003;
+
+// Defect spans carry the same generic status message as baseline noise —
+// the pod × promo cross-tab (not a label) separates them.
+const GENERIC_STATUS_MESSAGE = 'internal error';
+const DEFECT_STACK = [
+  "TypeError: Cannot read properties of undefined (reading 'percentOff')",
+  '    at applyPromotion (/app/handlers/promotion.js:87:31)',
+  '    at processCheckout (/app/handlers/checkout.js:214:19)',
+  '    at async CheckoutController.create (/app/controllers/checkout.js:52:9)',
+  '    at async /app/middleware/route.js:31:7',
+].join('\n');
+// Error-sampling: only every Nth defect hit logs the full stack trace
+// (deterministic modulo — the count is exact at every volumeFactor). The
+// rest emit this generic trace-correlated failure line.
+const STACK_SAMPLE_EVERY = 7;
+const GENERIC_FAILURE_BODY =
+  'Unhandled error processing POST /api/checkout (500); request aborted';
+
+// Deploy-introduced benign WARN flood: new-build pods emit this from their
+// flip time at a rate ~10x the sampled stack traces. It steps at the SAME
+// boundary as the real errors but is topically unrelated and benign.
+const DEPRECATION_BODY =
+  'DeprecationWarning: legacy session-cookie format detected; ' +
+  'session-store v1 support is removed in 3.0. ' +
+  'Set checkout.session.store=v2 to silence this warning.';
+const DEPRECATION_FLOOD_TOTAL = 6_000;
+
+// ─── Metric constants ───────────────────────────────────────────────────────
+
+const LATENCY_BOUNDS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000];
+const CHECKOUT_REQS_PER_SCRAPE = 200;
+
+// ─── Volumes ────────────────────────────────────────────────────────────────
+// Trace/log floor is the load-bearing signal here, so it's richer than
+// metric-saturation's — but still modest enough to seed quickly. Planted
+// anomaly volumes (burst spans, rollout logs) stay fixed.
+
+const TOTAL_TRACES = 400_000;
+const TOTAL_LOGS = 800_000;
+const BURST_SPAN_COUNT = 150;
+const BURST_LOG_COUNT = 30;
+
+// Traffic mix across the trace floor (weights are relative).
+const TRAFFIC_MIX = [
+  { value: 'checkout', weight: 37 },
+  { value: 'cart', weight: 31 },
+  { value: 'order', weight: 24 },
+  { value: 'reco', weight: 8 },
+] as const;
+
+// Log-floor mix. checkout-api chatter + proxy access/probe + neighbor ops +
+// the constant-rate caught-exception decoy (an "error-looking" pattern whose
+// rate does NOT change at the deploy — real errors do).
+const LOG_MIX = [
+  { value: 'cache_hit', weight: 30 },
+  { value: 'envoy', weight: 25 },
+  { value: 'health_probe', weight: 10 },
+  { value: 'inventory_ops', weight: 15 },
+  { value: 'reco_ops', weight: 10 },
+  { value: 'caught_exception', weight: 10 },
+] as const;
+
+type Rng = GenerateContext['rng'];
+
+// ─── Rollout model ──────────────────────────────────────────────────────────
+
+/** Time pod `pod` flips to NEW_VERSION (Infinity = never — rollout paused). */
+function podFlipMs(nowMs: number, pod: number): number {
+  if (pod >= CANARY_POD_COUNT) return Number.POSITIVE_INFINITY;
+  return nowMs - DEPLOY_AGO_MS + pod * ROLLOUT_STAGGER_MS;
+}
+
+function versionForPod(nowMs: number, pod: number, t: number): string {
+  return t >= podFlipMs(nowMs, pod) ? NEW_VERSION : OLD_VERSION;
+}
+
+/** Time payment pod `pod` flips (innocent rollout — all 6 complete). */
+function paymentPodFlipMs(nowMs: number, pod: number): number {
+  return nowMs - PAYMENT_DEPLOY_AGO_MS + pod * PAYMENT_ROLLOUT_STAGGER_MS;
+}
+
+function paymentVersionForPod(nowMs: number, pod: number, t: number): string {
+  return t >= paymentPodFlipMs(nowMs, pod)
+    ? PAYMENT_NEW_VERSION
+    : PAYMENT_OLD_VERSION;
+}
+
+/** Fraction of pods on NEW_VERSION at `t`. */
+function updatedPodFraction(nowMs: number, t: number): number {
+  let updated = 0;
+  for (let pod = 0; pod < POD_COUNT; pod++) {
+    if (t >= podFlipMs(nowMs, pod)) updated++;
+  }
+  return updated / POD_COUNT;
+}
+
+/** Expected fraction of checkout requests failing at `t` (aggregate view). */
+function checkoutFailureFraction(nowMs: number, t: number): number {
+  return updatedPodFraction(nowMs, t) * PROMO_FRACTION * FIXED_PROMO_SHARE;
+}
+
+// ─── Metric generation (corroborating only — keyed by service, NOT version) ─
+
+function generateMetrics(rng: Rng, nowMs: number): MetricBatch {
+  const windowStart = nowMs - HISTORY_WINDOW_MS;
+  const scrapeCount = Math.floor(HISTORY_WINDOW_MS / SCRAPE_INTERVAL_MS);
+
+  const gauge: GaugeMetricRow[] = [];
+  const sum: SumMetricRow[] = [];
+  const histogram: HistogramMetricRow[] = [];
+
+  // Deliberately NO service.version / pod split in metric resource
+  // attributes: the aggregate error-rate step is visible, but the pod
+  // cross-tab (the actual diagnosis) is not reconstructable from metrics.
+  const subjectResource: Record<string, string> = {
+    'service.name': SUBJECT_SERVICE,
+    'service.namespace': 'production',
+    'k8s.namespace.name': 'production',
+    'k8s.deployment.name': SUBJECT_SERVICE,
+  };
+  const neighborResource: Record<string, string> = {
+    'service.name': NEIGHBOR_SERVICE,
+    'service.namespace': 'production',
+    'k8s.namespace.name': 'production',
+    'k8s.deployment.name': NEIGHBOR_SERVICE,
+  };
+
+  let cum2xx = 0;
+  let cum5xx = 0;
+
+  for (let i = 0; i < scrapeCount; i++) {
+    const t = windowStart + i * SCRAPE_INTERVAL_MS;
+    const failFrac = checkoutFailureFraction(nowMs, t);
+
+    // ── Gauges: flat, healthy infra (rules out saturation) ───────────────
+    gauge.push(
+      makeGauge({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'system.cpu.utilization',
+        metricUnit: '1',
+        metricDescription: 'CPU utilization (0-1)',
+        value: Number(rng.range(0.22, 0.34).toFixed(3)),
+        resourceAttributes: subjectResource,
+        attributes: { state: 'used' },
+      }),
+    );
+    gauge.push(
+      makeGauge({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'process.memory.usage',
+        metricUnit: 'By',
+        metricDescription: 'Process resident memory',
+        value: Math.round(rng.range(470, 540) * 1024 * 1024),
+        resourceAttributes: subjectResource,
+        attributes: {},
+      }),
+    );
+
+    // ── Gauge red herring: noisy-but-benign neighbor queue depth ─────────
+    // Wobbles (with occasional spikes) across the WHOLE window — visually
+    // alarming, uncorrelated with the incident.
+    const spiky = rng.next() < 0.06;
+    gauge.push(
+      makeGauge({
+        timeUnixMs: t,
+        serviceName: NEIGHBOR_SERVICE,
+        metricName: 'inventory.sync.queue.depth',
+        metricUnit: '{jobs}',
+        metricDescription: 'Pending jobs in the inventory sync queue',
+        value: spiky ? rng.intRange(150, 400) : rng.intRange(0, 90),
+        resourceAttributes: neighborResource,
+        attributes: { queue: 'inventory-sync' },
+      }),
+    );
+
+    // ── Requests this scrape: OK vs failed checkout calls ────────────────
+    const reqs = CHECKOUT_REQS_PER_SCRAPE;
+    const baselineFail = rng.next() < reqs * BASELINE_ERROR_RATE ? 1 : 0;
+    const fails = Math.max(baselineFail, Math.round(reqs * failFrac));
+    const oks = reqs - fails;
+
+    // ── Histogram: request-duration by status (delta temporality) ────────
+    const okSamples: number[] = [];
+    for (let s = 0; s < oks; s++) okSamples.push(rng.range(30, 280));
+    histogram.push(
+      makeHistogram({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'http.server.request.duration',
+        metricUnit: 'ms',
+        metricDescription: 'HTTP server request duration',
+        aggregationTemporality: 1,
+        ...bucketize(okSamples, LATENCY_BOUNDS_MS),
+        explicitBounds: [...LATENCY_BOUNDS_MS],
+        resourceAttributes: subjectResource,
+        attributes: {
+          'http.route': '/api/checkout',
+          'http.response.status_code': '200',
+        },
+      }),
+    );
+    if (fails > 0) {
+      // Defect requests fail FAST (TypeError thrown before any I/O).
+      const errSamples: number[] = [];
+      for (let s = 0; s < fails; s++) errSamples.push(rng.range(6, 40));
+      histogram.push(
+        makeHistogram({
+          timeUnixMs: t,
+          serviceName: SUBJECT_SERVICE,
+          metricName: 'http.server.request.duration',
+          metricUnit: 'ms',
+          metricDescription: 'HTTP server request duration',
+          aggregationTemporality: 1,
+          ...bucketize(errSamples, LATENCY_BOUNDS_MS),
+          explicitBounds: [...LATENCY_BOUNDS_MS],
+          resourceAttributes: subjectResource,
+          attributes: {
+            'http.route': '/api/checkout',
+            'http.response.status_code': '500',
+          },
+        }),
+      );
+    }
+
+    // ── Sums: cumulative request counters by status class ────────────────
+    cum2xx += oks;
+    cum5xx += fails;
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'http.server.request.count',
+        metricDescription: 'Cumulative HTTP requests served',
+        value: cum2xx,
+        resourceAttributes: subjectResource,
+        attributes: { 'http.route': '/api/checkout', status_class: '2xx' },
+      }),
+    );
+    sum.push(
+      makeSum({
+        timeUnixMs: t,
+        serviceName: SUBJECT_SERVICE,
+        metricName: 'http.server.request.count',
+        metricDescription: 'Cumulative HTTP requests served',
+        value: cum5xx,
+        resourceAttributes: subjectResource,
+        attributes: { 'http.route': '/api/checkout', status_class: '5xx' },
+      }),
+    );
+  }
+
+  return { gauge, sum, histogram };
+}
+
+// ─── Scenario ───────────────────────────────────────────────────────────────
+
+// Turn budget: the agent can COUNT its tool calls but cannot observe
+// wall-clock time, so the hard cap must be low enough to bind BEFORE the
+// wall-clock limit (~9-11s per tool call ⇒ 26 turns fits inside the 300s
+// default --timeout).
+const DEPLOY_MAX_TURNS = 26;
+// Soft answer checkpoint shown in the prompt's TURN BUDGET line — showing
+// the HARD cap there would instruct the agent to exhaust the entire
+// budget before answering.
+const SOFT_ANSWER_TURN_MARGIN = 8;
+
+// Scenario-local budget-discipline note, appended after the shared
+// investigation prompt. Phrased in tool-call counts, not minutes — the
+// agent cannot observe elapsed wall time. The metrics signalsNote stays
+// byte-identical to metric-saturation's (adoption parity).
+const BUDGET_NOTE = `
+HARD BUDGETS: this run has a hard tool-call cap a few calls above the
+soft checkpoint in the TURN BUDGET above, AND a hard wall-clock limit of
+roughly five minutes. Neither budget waits for an unfinished
+investigation — when either runs out, whatever you last wrote IS your
+answer. You cannot see the wall clock; the only budget you can track is
+your own tool-call count, so budget by COUNTING TOOL CALLS:
+- Prefer aggregating queries over reading individual events.
+- At the soft checkpoint, STOP opening new lines of investigation and
+  write the best-supported conclusion from the evidence you already have.
+- Reserve the final turn for the answer — never let a verification query
+  be your last action. An answer grounded in partial evidence scores; an
+  unfinished investigation with no written answer scores zero.`;
+
+// Judge preamble (third consistency round). Scenario-local override:
+// identical to the default "evaluating an SRE investigation" preamble in
+// grading/judgePrompt.ts plus the SCORE ONLY WHAT IS WRITTEN block.
+// Without it, judging truncated runs is a coin flip: two near-identical
+// mid-investigation notes ("let me verify one last detail") in the same
+// batch scored 0.98 and 0.02 — the 0.98 judge hallucinated the diagnosis
+// from the ground-truth facts and credited claims the candidate never
+// wrote.
+const JUDGE_PREAMBLE = `You are evaluating an SRE investigation. You will receive:
+- the scenario question (what the candidate was asked)
+- the ground-truth facts (the planted answer the candidate did NOT see)
+- a rubric with weighted criteria
+- the candidate's final answer (anonymized — tool names and product brands have been redacted so you cannot tell which tool the candidate used)
+
+For each rubric criterion, output an integer score from 0 to 5 plus a one-sentence rationale. Do not consider tool choice, query syntax, or implementation details — score only the quality of the candidate's final answer relative to the ground truth.
+
+SCORE ONLY WHAT IS WRITTEN. Credit a claim only if the candidate's answer
+states it explicitly — never because the ground-truth facts contain it or
+because the candidate seemed about to conclude it. Some answers are
+truncated mid-investigation: a progress note, a plan, or a statement of
+intent ("let me verify one more thing", "I now have the complete picture")
+with no actual diagnosis. Such an answer scores 0 on every criterion
+except conciseness (at most 1), no matter how promising the investigation
+looked.
+
+Return STRICT JSON of shape:
+{ "scores": { "<criterion_id>": { "score": N, "rationale": "..." } } }
+No prose outside the JSON. Include every criterion id from the rubric.`;
+
+export const deployRegressionScenario: Scenario = {
+  name: 'deploy-regression',
+  agentPrompt: groundTruth.agentPrompt,
+  // See DEPLOY_MAX_TURNS above: high enough for the mandatory steps
+  // (blinded entry, pod cross-tab + rollout-event join, promo-code
+  // inference, two co-timed deploys), low enough that the observable
+  // turn budget binds before the unobservable 300s wall clock.
+  maxTurns: DEPLOY_MAX_TURNS,
+  description:
+    'checkout-api staged rollout regression: 2.0.0-rc1 canary (3/6 pods) throws a TypeError in applyPromotion on fixed-amount promo codes -> ~7% checkout 500s. No service.version stamping — the smoking gun is a k8s.pod.name cross-tab joined against rollout event logs; the TypeError stack is error-sampled (~1-in-7) and the trigger has no promo-type label. Metrics (latency histogram, 5xx sum, flat CPU/memory gauges) only corroborate — measures organic metric-tool adoption. Distractors: innocent completed payment-service rollout minutes earlier, deploy-introduced DeprecationWarning flood stepping at the same boundary, healthy payment spans, constant NonFatalRetryableError noise, pre-deploy recommendation-service 502 burst, noisy-but-benign queue-depth gauge. Consistency rounds: dedicated disjoint node pools per service (no accidental host-overlap confounder); 26-turn hard cap with a soft answer checkpoint (~18) shown in the prompt so the observable turn budget binds before the invisible 300s wall clock; a count-your-tool-calls budget note; and a truncation-strict judge preamble (interim notes score 0 — no ground-truth fill-in). Difficulty lives in the excellence-tier rubric.',
+  buildSystemPrompt: ctx => {
+    // Show a SOFT checkpoint in the TURN BUDGET line, not the hard cap —
+    // the harness still enforces ctx.maxTurns. Tracks a CLI --max-turns
+    // override so the checkpoint stays proportional.
+    const softAnswerTurn = Math.max(
+      10,
+      (ctx.maxTurns ?? DEPLOY_MAX_TURNS) - SOFT_ANSWER_TURN_MARGIN,
+    );
+    return (
+      buildInvestigationSystemPrompt(
+        'deploy-regression',
+        ctx.anchorTimeIso,
+        ctx.variant,
+        softAnswerTurn,
+        {
+          // Byte-identical to metric-saturation's note: discoverability is
+          // held constant between the two scenarios, so the adoption delta
+          // measures inclination, not awareness.
+          signalsNote:
+            '- Metrics: a HyperDX metric source is available (gauge, sum, ' +
+            'histogram, exponential histogram, and summary). Use the metric ' +
+            'tools to explore it alongside traces and logs.',
+        },
+      ) + BUDGET_NOTE
+    );
+  },
+  judgeSystemPreamble: JUDGE_PREAMBLE,
+  *generate(ctx): Iterable<ScenarioBatch> {
+    const { rng, nowMs } = ctx;
+    const factor = ctx.volumeFactor ?? 1;
+    const batchSize = ctx.batchSize ?? 10_000;
+    const windowStart = nowMs - HISTORY_WINDOW_MS;
+
+    // Metrics first (fixed volume — corroboration never scales).
+    const metrics = generateMetrics(rng, nowMs);
+    yield { traces: [], logs: [], metrics };
+
+    // checkout-api gets a fixed 6-pod pool. The fleet does NOT
+    // stamp service.version into OTel resources — the pod identity
+    // (k8s.pod.name) is the only per-pod dimension; the rollout event logs
+    // are what tie pods to versions. The pods are pinned to one namespace/
+    // region (a single deployment — no accidental coarse proxy split via
+    // namespace or region group-bys). The defect stack is Node, so pin the
+    // SDK language.
+    const pinDeployment = (r: Record<string, string>) => ({
+      ...r,
+      'service.namespace': 'production',
+      'k8s.namespace.name': 'production',
+      'deployment.environment.name': 'production',
+      'cloud.region': 'us-east-1',
+    });
+    // Each controlled pool gets a DEDICATED node pool, one pod per node.
+    // The generic buildResourcePool assigns nodes from a shared 4-name
+    // list, which made payment's rollout look like it landed "on the same
+    // hosts" as the checkout errors — an accidental cross-service
+    // confounder (and wall-clock sink) we never designed. Disjoint,
+    // service-prefixed node names remove the correlation; a node-level
+    // group-by now just mirrors the pod split instead of inventing a
+    // noisy-neighbor story.
+    const pinNode = (
+      attrs: Record<string, string>,
+      poolName: string,
+    ): Record<string, string> => {
+      const node = `gke-prod-${poolName}-${rng.hex(8)}-${rng.hex(4)}`;
+      return { ...attrs, 'k8s.node.name': node, 'host.name': node };
+    };
+    const checkoutPods = buildResourcePool({
+      rng,
+      services: [SUBJECT_SERVICE],
+      instancesPerService: POD_COUNT,
+    })[SUBJECT_SERVICE].map(r => {
+      const attrs = pinNode(
+        pinDeployment({ ...r, 'telemetry.sdk.language': 'nodejs' }),
+        'checkout',
+      );
+      delete attrs['service.version'];
+      return attrs;
+    });
+    const checkoutPodResource = (pod: number): Record<string, string> =>
+      checkoutPods[pod];
+
+    // payment-service gets a controlled 6-pod pool whose service.version
+    // flips per its own (innocent, completed) rollout — it DOES stamp
+    // versions, so its new build is provably healthy.
+    const paymentPods = buildResourcePool({
+      rng,
+      services: [PAYMENT_SERVICE],
+      instancesPerService: PAYMENT_POD_COUNT,
+    })[PAYMENT_SERVICE].map(r => pinNode(pinDeployment(r), 'payment'));
+    const paymentPodResource = (
+      pod: number,
+      t: number,
+    ): Record<string, string> => ({
+      ...paymentPods[pod],
+      'service.version': paymentVersionForPod(nowMs, pod, t),
+    });
+
+    const resourcePool = buildResourcePool({
+      rng,
+      services: [PROXY_SERVICE, NEIGHBOR_SERVICE, RECO_SERVICE],
+      instancesPerService: 12,
+    });
+
+    // ── Trace floor + planted defect ──────────────────────────────────────
+    const totalTraces = Math.max(50, Math.round(TOTAL_TRACES * factor));
+    const traces: TraceRow[] = [];
+    const plantedLogs: LogRow[] = [];
+    let defectCount = 0;
+
+    for (let i = 0; i < totalTraces; i++) {
+      const t = spreadTimestamp(i, totalTraces, windowStart, HISTORY_WINDOW_MS);
+      const kind = rng.weightedPick(TRAFFIC_MIX);
+
+      if (kind === 'reco') {
+        traces.push(
+          makeSpan({
+            rng,
+            timestampMs: t,
+            traceId: newTraceId(rng),
+            spanId: newSpanId(rng),
+            spanName: 'recommendation.score',
+            spanKind: 'SPAN_KIND_SERVER',
+            serviceName: RECO_SERVICE,
+            durationNs: msToNs(rng.range(8, 120)),
+            resourceAttributes: pickResource(rng, resourcePool, RECO_SERVICE),
+            spanAttributes: {
+              'http.route': '/api/recommendations',
+              'http.request.method': 'GET',
+              'http.response.status_code': '200',
+            },
+          }),
+        );
+      } else {
+        const pod = rng.intRange(0, POD_COUNT);
+        const version = versionForPod(nowMs, pod, t);
+        const resourceAttributes = checkoutPodResource(pod);
+
+        const isCheckout = kind === 'checkout';
+        const route = isCheckout
+          ? '/api/checkout'
+          : kind === 'cart'
+            ? '/api/cart'
+            : '/api/order';
+        const method = isCheckout ? 'POST' : 'GET';
+        const spanName = `${method} ${route}`;
+
+        // Promo attribution (checkout only) and the planted defect. The
+        // span carries only the promo CODE — no type label; the fixed-vs-
+        // percent distinction must be inferred from the failing set + the
+        // percentOff stack trace.
+        let promoCode: string | undefined;
+        let promoIsFixed = false;
+        if (isCheckout && rng.next() < PROMO_FRACTION) {
+          if (rng.next() < FIXED_PROMO_SHARE) {
+            promoCode = rng.weightedPick(FIXED_PROMO_MIX);
+            promoIsFixed = true;
+          } else {
+            promoCode = rng.weightedPick(PERCENT_PROMO_MIX);
+          }
+        }
+        const defectHit = isCheckout && version === NEW_VERSION && promoIsFixed;
+        const baselineErr = !defectHit && rng.next() < BASELINE_ERROR_RATE;
+
+        const durationMs = defectHit
+          ? rng.range(6, 40) // TypeError thrown before any I/O — fails fast
+          : baselineErr
+            ? rng.range(200, 1500)
+            : isCheckout
+              ? rng.range(30, 280)
+              : rng.range(8, 120);
+
+        const traceId = newTraceId(rng);
+        const spanId = newSpanId(rng);
+        traces.push(
+          makeSpan({
+            rng,
+            timestampMs: t,
+            traceId,
+            spanId,
+            spanName,
+            spanKind: 'SPAN_KIND_SERVER',
+            serviceName: SUBJECT_SERVICE,
+            durationNs: msToNs(durationMs),
+            statusCode:
+              defectHit || baselineErr ? 'STATUS_CODE_ERROR' : 'STATUS_CODE_OK',
+            statusMessage:
+              defectHit || baselineErr ? GENERIC_STATUS_MESSAGE : '',
+            resourceAttributes,
+            spanAttributes: {
+              'http.route': route,
+              'http.request.method': method,
+              'http.response.status_code':
+                defectHit || baselineErr ? '500' : '200',
+              ...(isCheckout
+                ? {
+                    'checkout.cart_items': String(rng.intRange(1, 12)),
+                    'checkout.total_cents': String(rng.intRange(499, 89999)),
+                  }
+                : {}),
+              ...(promoCode ? { 'checkout.promo_code': promoCode } : {}),
+            },
+          }),
+        );
+
+        // Trace-correlated defect logs. Error-sampled: every Nth defect hit
+        // logs the full stack trace that NAMES the bug; the rest log a
+        // generic failure line (no TypeError, no promotion).
+        if (defectHit) {
+          defectCount++;
+          const sampled = defectCount % STACK_SAMPLE_EVERY === 1;
+          plantedLogs.push(
+            makeLog({
+              timestampMs: t + rng.intRange(1, 30),
+              traceId,
+              spanId,
+              serviceName: SUBJECT_SERVICE,
+              severityText: 'ERROR',
+              body: sampled ? DEFECT_STACK : GENERIC_FAILURE_BODY,
+              resourceAttributes,
+              logAttributes: sampled
+                ? {
+                    'event.name': 'checkout.unhandled_exception',
+                    'error.kind': 'TypeError',
+                    'code.function.name': 'applyPromotion',
+                    'checkout.promo_code': promoCode!,
+                    'http.route': '/api/checkout',
+                    'log.iostream': 'stderr',
+                    logtag: 'F',
+                  }
+                : {
+                    'event.name': 'checkout.request_failed',
+                    'http.route': '/api/checkout',
+                    'http.response.status_code': '500',
+                    'log.iostream': 'stderr',
+                    logtag: 'F',
+                  },
+            }),
+          );
+        }
+
+        // Healthy payment-service child span for successful checkouts —
+        // the "blame the dependency" decoy stays visibly healthy (on BOTH
+        // sides of its own innocent rollout). Failed checkouts never reach
+        // payment (promotion is applied first).
+        if (isCheckout && !defectHit && !baselineErr && rng.next() < 0.85) {
+          const paymentPod = rng.intRange(0, PAYMENT_POD_COUNT);
+          traces.push(
+            makeSpan({
+              rng,
+              timestampMs: t + rng.intRange(2, 20),
+              traceId,
+              spanId: newSpanId(rng),
+              parentSpanId: spanId,
+              spanName: 'payment.authorize',
+              spanKind: 'SPAN_KIND_SERVER',
+              serviceName: PAYMENT_SERVICE,
+              durationNs: msToNs(rng.range(20, 120)),
+              resourceAttributes: paymentPodResource(paymentPod, t),
+              spanAttributes: {
+                'payment.provider': rng.pick(['stripe', 'adyen', 'braintree']),
+                'payment.method': rng.pick(['card', 'wallet', 'bank']),
+                'http.response.status_code': '200',
+              },
+            }),
+          );
+        }
+      }
+
+      if (traces.length >= batchSize) {
+        yield { traces: traces.splice(0, traces.length), logs: [] };
+      }
+      if (plantedLogs.length >= batchSize) {
+        yield { traces: [], logs: plantedLogs.splice(0, plantedLogs.length) };
+      }
+    }
+    if (traces.length)
+      yield { traces: traces.splice(0, traces.length), logs: [] };
+
+    // ── Distractor: pre-deploy recommendation-service 502 burst ──────────
+    // Fixed volume (planted anomaly). Starts 70 min ago, self-resolves in
+    // ~5 min — disjoint from both deploys in time and service.
+    const burstStart = nowMs - BURST_AGO_MS;
+    for (let i = 0; i < BURST_SPAN_COUNT; i++) {
+      const t =
+        burstStart +
+        Math.floor((i / BURST_SPAN_COUNT) * (BURST_DURATION_MS - 2000)) +
+        rng.intRange(0, 1500);
+      traces.push(
+        makeSpan({
+          rng,
+          timestampMs: t,
+          traceId: newTraceId(rng),
+          spanId: newSpanId(rng),
+          spanName: 'recommendation.score',
+          spanKind: 'SPAN_KIND_SERVER',
+          serviceName: RECO_SERVICE,
+          durationNs: msToNs(rng.range(1, 12)),
+          statusCode: 'STATUS_CODE_ERROR',
+          statusMessage:
+            'upstream connect error or disconnect/reset before headers (connection termination)',
+          resourceAttributes: pickResource(rng, resourcePool, RECO_SERVICE),
+          spanAttributes: {
+            'http.route': '/api/recommendations',
+            'http.request.method': 'GET',
+            'http.response.status_code': '502',
+          },
+        }),
+      );
+    }
+    yield { traces: traces.splice(0, traces.length), logs: [] };
+
+    // ── Log floor ─────────────────────────────────────────────────────────
+    const totalLogs = Math.max(50, Math.round(TOTAL_LOGS * factor));
+    const logs: LogRow[] = [];
+    for (let i = 0; i < totalLogs; i++) {
+      const t = spreadTimestamp(
+        i,
+        totalLogs,
+        windowStart,
+        HISTORY_WINDOW_MS,
+        60_000,
+      );
+      const kind = rng.weightedPick(LOG_MIX);
+      let service: string;
+      let resourceAttributes: Record<string, string>;
+      let body: string;
+      let attrs: Record<string, string>;
+      let sevText: string;
+
+      if (kind === 'cache_hit' || kind === 'caught_exception') {
+        service = SUBJECT_SERVICE;
+        const pod = rng.intRange(0, POD_COUNT);
+        resourceAttributes = checkoutPodResource(pod);
+        const tmpl =
+          kind === 'cache_hit'
+            ? cacheHitLog({ rng, nowMs: t })
+            : caughtExceptionLog({ rng, nowMs: t });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = tmpl.level;
+      } else if (kind === 'envoy' || kind === 'health_probe') {
+        service = PROXY_SERVICE;
+        resourceAttributes = pickResource(rng, resourcePool, PROXY_SERVICE);
+        const tmpl =
+          kind === 'envoy'
+            ? envoyAccessLog({ rng, nowMs: t })
+            : upstreamHealthProbeLog({ rng, nowMs: t });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = 'info';
+      } else {
+        service = kind === 'inventory_ops' ? NEIGHBOR_SERVICE : RECO_SERVICE;
+        resourceAttributes = pickResource(rng, resourcePool, service);
+        const tmpl = serviceOpsDebugLog({
+          rng,
+          nowMs: t,
+          serviceName: service as
+            | 'inventory-service'
+            | 'recommendation-service',
+        });
+        body = tmpl.body;
+        attrs = tmpl.attrs;
+        sevText = tmpl.level;
+      }
+
+      logs.push(
+        makeLog({
+          timestampMs: t,
+          serviceName: service,
+          severityText: normalizeSeverityText(sevText),
+          body,
+          resourceAttributes,
+          logAttributes: { ...attrs, _severity_raw: sevText },
+        }),
+      );
+      if (logs.length >= batchSize) {
+        yield { traces: [], logs: logs.splice(0, logs.length) };
+      }
+    }
+
+    // ── Distractor: deploy-introduced benign DeprecationWarning flood ────
+    // Emitted ONLY by new-build pods, each from its own flip time — the
+    // total rate steps up at the exact same boundaries as the real errors,
+    // but the pattern is WARN, has no trace correlation, and is topically
+    // unrelated. Scales with volumeFactor at a fixed ~10x multiple of the
+    // sampled stack-trace count, so it outranks the confession in any
+    // pattern ranking.
+    const floodCount = Math.max(
+      30,
+      Math.round(DEPRECATION_FLOOD_TOTAL * factor),
+    );
+    for (let i = 0; i < floodCount; i++) {
+      const pod = i % CANARY_POD_COUNT;
+      const flip = podFlipMs(nowMs, pod);
+      const t = flip + Math.floor(rng.range(0, nowMs - flip));
+      logs.push(
+        makeLog({
+          timestampMs: t,
+          serviceName: SUBJECT_SERVICE,
+          severityText: 'WARN',
+          body: DEPRECATION_BODY,
+          resourceAttributes: checkoutPodResource(pod),
+          logAttributes: {
+            'event.name': 'runtime.deprecation',
+            'code.function.name': 'loadSessionCookie',
+            'log.iostream': 'stderr',
+            logtag: 'F',
+          },
+        }),
+      );
+      if (logs.length >= batchSize) {
+        yield { traces: [], logs: logs.splice(0, logs.length) };
+      }
+    }
+
+    // ── Planted rollout events (fixed volume) ─────────────────────────────
+    // Innocent payment-service rollout: starts BEFORE checkout's, completes
+    // 6/6, and its service is provably healthy on both versions.
+    const paymentDeployMs = nowMs - PAYMENT_DEPLOY_AGO_MS;
+    plantedLogs.push(
+      makeLog({
+        timestampMs: paymentDeployMs,
+        serviceName: PAYMENT_SERVICE,
+        severityText: 'INFO',
+        body: `Deployment payment-service rolling update started: version ${PAYMENT_OLD_VERSION} -> ${PAYMENT_NEW_VERSION} (target ${PAYMENT_POD_COUNT} replicas)`,
+        resourceAttributes: {
+          'service.name': PAYMENT_SERVICE,
+          'k8s.deployment.name': PAYMENT_SERVICE,
+        },
+        logAttributes: {
+          'event.name': 'deployment.rollout',
+          'service.version': PAYMENT_NEW_VERSION,
+        },
+      }),
+    );
+    for (let pod = 0; pod < PAYMENT_POD_COUNT; pod++) {
+      plantedLogs.push(
+        makeLog({
+          timestampMs: paymentPodFlipMs(nowMs, pod),
+          serviceName: PAYMENT_SERVICE,
+          severityText: 'INFO',
+          body: `Pod ${paymentPods[pod]['k8s.pod.name']} updated to version ${PAYMENT_NEW_VERSION} (${pod + 1}/${PAYMENT_POD_COUNT} pods updated)`,
+          resourceAttributes: paymentPodResource(
+            pod,
+            paymentPodFlipMs(nowMs, pod),
+          ),
+          logAttributes: {
+            'event.name': 'deployment.rollout',
+            'service.version': PAYMENT_NEW_VERSION,
+            'k8s.pod.name': paymentPods[pod]['k8s.pod.name'],
+          },
+        }),
+      );
+    }
+    plantedLogs.push(
+      makeLog({
+        timestampMs: nowMs - PAYMENT_COMPLETE_AGO_MS,
+        serviceName: PAYMENT_SERVICE,
+        severityText: 'INFO',
+        body: `Rollout payment-service completed: ${PAYMENT_POD_COUNT}/${PAYMENT_POD_COUNT} pods updated to version ${PAYMENT_NEW_VERSION}`,
+        resourceAttributes: {
+          'service.name': PAYMENT_SERVICE,
+          'k8s.deployment.name': PAYMENT_SERVICE,
+        },
+        logAttributes: {
+          'event.name': 'deployment.rollout',
+          'service.version': PAYMENT_NEW_VERSION,
+        },
+      }),
+    );
+
+    // checkout-api rollout: the guilty one. The event bodies/attributes are
+    // the ONLY place pod names and versions are tied together (spans carry
+    // no service.version) — this is the intended join.
+    const deployMs = nowMs - DEPLOY_AGO_MS;
+    plantedLogs.push(
+      makeLog({
+        timestampMs: deployMs,
+        serviceName: SUBJECT_SERVICE,
+        severityText: 'INFO',
+        body: `Deployment checkout-api rolling update started: version ${OLD_VERSION} -> ${NEW_VERSION} (target ${POD_COUNT} replicas)`,
+        resourceAttributes: {
+          'service.name': SUBJECT_SERVICE,
+          'k8s.deployment.name': SUBJECT_SERVICE,
+        },
+        logAttributes: {
+          'event.name': 'deployment.rollout',
+          'service.version': NEW_VERSION,
+        },
+      }),
+    );
+    for (let pod = 0; pod < CANARY_POD_COUNT; pod++) {
+      plantedLogs.push(
+        makeLog({
+          timestampMs: podFlipMs(nowMs, pod),
+          serviceName: SUBJECT_SERVICE,
+          severityText: 'INFO',
+          body: `Pod ${checkoutPods[pod]['k8s.pod.name']} updated to version ${NEW_VERSION} (${pod + 1}/${POD_COUNT} pods updated)`,
+          resourceAttributes: checkoutPodResource(pod),
+          logAttributes: {
+            'event.name': 'deployment.rollout',
+            'service.version': NEW_VERSION,
+            'k8s.pod.name': checkoutPods[pod]['k8s.pod.name'],
+          },
+        }),
+      );
+    }
+    plantedLogs.push(
+      makeLog({
+        timestampMs: deployMs + CANARY_POD_COUNT * ROLLOUT_STAGGER_MS,
+        serviceName: SUBJECT_SERVICE,
+        severityText: 'INFO',
+        body: `Rollout checkout-api paused at ${CANARY_POD_COUNT}/${POD_COUNT} pods (canary observation window)`,
+        resourceAttributes: {
+          'service.name': SUBJECT_SERVICE,
+          'k8s.deployment.name': SUBJECT_SERVICE,
+        },
+        logAttributes: {
+          'event.name': 'deployment.rollout',
+          'service.version': NEW_VERSION,
+        },
+      }),
+    );
+
+    // ── Distractor: burst-adjacent WARN logs (fixed volume) ───────────────
+    for (let i = 0; i < BURST_LOG_COUNT; i++) {
+      const t =
+        burstStart +
+        Math.floor((i / BURST_LOG_COUNT) * (BURST_DURATION_MS - 2000)) +
+        rng.intRange(0, 1500);
+      logs.push(
+        makeLog({
+          timestampMs: t,
+          serviceName: RECO_SERVICE,
+          severityText: 'WARN',
+          body: 'upstream connect error or disconnect/reset before headers (connection termination)',
+          resourceAttributes: pickResource(rng, resourcePool, RECO_SERVICE),
+          logAttributes: {
+            'event.name': 'upstream.connect_error',
+            'http.response.status_code': '502',
+          },
+        }),
+      );
+    }
+
+    if (logs.length || plantedLogs.length) {
+      yield { traces: [], logs: [...logs, ...plantedLogs] };
+    }
+  },
+  groundTruth,
+};

--- a/packages/hdx-eval/src/scenarios/deploy-regression/generate.ts
+++ b/packages/hdx-eval/src/scenarios/deploy-regression/generate.ts
@@ -36,9 +36,11 @@
  *   - Gauge     inventory.sync.queue.depth (inventory-service) : noisy but
  *     benign across the whole window — a metric red herring.
  *
- * The scenario measures ORGANIC metric-tool adoption via the transcript
- * rubric: the agent doesn't need the metric tools, so reaching for them is
- * the adoption signal (contrast with metric-saturation, where it's forced).
+ * The scenario measures ORGANIC metric adoption via the adoption rubric:
+ * a tool call counts when its input args name a target metric (any tool —
+ * dedicated metric tools and raw SQL against the metrics tables score the
+ * same). The agent doesn't need the metrics, so reaching for them is the
+ * adoption signal (contrast with metric-saturation, where it's forced).
  *
  * Distractors: an INNOCENT completed payment-service rollout minutes before
  * checkout's (the "blame the other deploy" trap), a deploy-introduced

--- a/packages/hdx-eval/src/scenarios/deploy-regression/ground-truth.json
+++ b/packages/hdx-eval/src/scenarios/deploy-regression/ground-truth.json
@@ -1,0 +1,192 @@
+{
+  "scenario": "deploy-regression",
+  "agentPrompt": "Support has been fielding a growing trickle of 'something went wrong at checkout' reports — order completions are down a few percent versus normal for this time of day. Figure out what's going on and explain the mechanism.",
+  "expected": {
+    "affectedService": "checkout-api",
+    "rootCause": "A defective staged rollout of checkout-api 2.0.0-rc1. Three of six pods updated (one every ~2 min starting 45 min ago), then the rollout was paused for canary observation. The new build's rewritten promotion handler assumes every promo code has a percentOff field, so fixed-amount promo codes (FREESHIP, FLAT5, GIFT10) throw TypeError: Cannot read properties of undefined (reading 'percentOff') in applyPromotion and the request 500s. Roughly 7-8% of checkouts fail overall — but ONLY on the three updated pods and ONLY for fixed-amount promo codes. The three pods still on 1.43.1 stay at baseline. checkout-api telemetry carries no service.version resource attribute, so the split must be reconstructed at the pod level and joined against the rollout events.",
+    "mechanismChain": [
+      "POST /api/checkout 500s begin exactly at the first pod flip (45 min ago) and step up twice more as the second and third canary pods flip (~2 min apart) — the error onset is staggered, matching a rolling update, not a single cutover.",
+      "Grouping failed POST /api/checkout spans by k8s.pod.name shows the failures confined to exactly 3 of 6 pods (~15% error rate each); the other 3 pods stay at baseline (~0.3%). Spans carry NO service.version, so the pod split is the only per-pod dimension.",
+      "Deployment rollout events (INFO logs, event.name deployment.rollout) name exactly those 3 pods updating to 2.0.0-rc1 (rolling update 1.43.1 -> 2.0.0-rc1, paused at 3/6 for canary observation) — the join that ties the failing pods to the new build is the smoking gun.",
+      "Every failed checkout carries a fixed-amount promo code (FREESHIP, FLAT5, or GIFT10) in checkout.promo_code; percent codes (SAVE10, VIP20, WELCOME15, SPRING25) and no-promo checkouts succeed on every pod — the failure is confined to the fixed-amount promo path. There is no promo-type label; the fixed-vs-percent distinction is inferred from the failing set.",
+      "Trace-correlated ERROR logs carry the defect's stack trace — TypeError: Cannot read properties of undefined (reading 'percentOff') at applyPromotion (/app/handlers/promotion.js) — naming the exact code path the new build broke. The stack is error-sampled (~1-in-7 failures); the rest log a generic 'Unhandled error processing POST /api/checkout' line."
+    ],
+    "loadBearingSignal": "traces+logs",
+    "whyMetricsNotRequired": "The complete diagnosis — onset time, error-rate step, pod split, defect identity, and the promo-code trigger — is recoverable from traces (k8s.pod.name + http.response.status_code + checkout.promo_code span attributes) and logs (deployment.rollout events naming the updated pods + the sampled TypeError stack trace, trace-correlated to the failing spans). The planted metrics only mirror the aggregate error-rate step (http.server.request.duration{500} histogram, http.server.request.count{5xx} sum) and rule out infra saturation (flat CPU/memory gauges); they are keyed by service, not pod or version, so they cannot reveal the pod split or the defect. Ignoring the metric tools entirely is a valid solve path.",
+    "metricsRole": {
+      "histogram": "http.server.request.duration on checkout-api split by http.response.status_code: the 500-series count steps up at the deploy — corroborates the onset, adds nothing traces don't show.",
+      "sum": "http.server.request.count{status_class=5xx} (cumulative): slope changes at the deploy — same corroboration as a rate.",
+      "gauge": "system.cpu.utilization and process.memory.usage on checkout-api stay flat and healthy — rules out infra saturation as an alternative cause. inventory.sync.queue.depth on inventory-service is a noisy-but-benign red herring.",
+      "adoptionNote": "This scenario measures ORGANIC metric-tool adoption: the transcript checks record whether the agent reaches for metric tools it does not strictly need. Contrast with metric-saturation, where metric-tool use is forced by the scenario design."
+    }
+  },
+  "distractors": [
+    {
+      "kind": "innocent completed deploy (blame-the-other-rollout trap)",
+      "service": "payment-service",
+      "minutesAgo": 58,
+      "whyNotRootCause": "payment-service rolled 3.6.2 -> 3.7.0 starting 58 min ago and completed 6/6 pods by 52 min ago — 7 minutes BEFORE the checkout errors begin. It is the louder deploy (completed, not paused) and sits closest to the onset, but payment.authorize spans are error-free and fast on BOTH its versions, and failed checkouts never reach payment at all. 'A deploy happened around then' cannot attribute blame; only the checkout-api pod split can."
+    },
+    {
+      "kind": "deploy-introduced benign WARN flood (new-pattern-at-the-boundary trap)",
+      "service": "checkout-api",
+      "pattern": "DeprecationWarning: legacy session-cookie format detected (runtime.deprecation)",
+      "whyNotRootCause": "The new 2.0.0-rc1 build also emits a high-rate DeprecationWarning from each updated pod starting exactly at its flip — the flood's rate steps up at the SAME boundaries as the real errors and dwarfs the sampled TypeError stack traces in volume. But it is WARN severity, has no trace correlation to any failed request, and is topically unrelated (session cookies, not promotions). A new pattern appearing at the incident boundary is not automatically the cause."
+    },
+    {
+      "kind": "healthy dependency (blame-the-payment-service decoy)",
+      "service": "payment-service",
+      "whyNotRootCause": "payment.authorize child spans stay fast (20-120ms) and error-free throughout the window, before and after its own rollout. Failed checkouts never even reach payment — the TypeError is thrown in promotion handling first. 'Checkout fails' pattern-matches to 'payments are down', but the payment dependency is provably healthy; blaming it is a calibration failure."
+    },
+    {
+      "kind": "constant-rate caught-exception noise",
+      "service": "checkout-api",
+      "pattern": "NonFatalRetryableError (caught) worker stack traces",
+      "whyNotRootCause": "An error-severity log pattern that exists at the SAME steady rate before and after the deploy, is marked handled=true, and has no trace correlation to failed checkouts. Real incident errors change rate at the incident boundary — this one doesn't."
+    },
+    {
+      "kind": "pre-deploy 502 burst on a neighbor",
+      "service": "recommendation-service",
+      "minutesAgo": 70,
+      "durationMinutes": 5,
+      "whyNotRootCause": "A brief upstream-connect-error burst (HTTP 502) that starts 70 min ago — BEFORE both deploys — and self-resolves within ~5 minutes. Different service, disjoint time window, no causal link to checkout failures that begin 25 minutes later."
+    },
+    {
+      "kind": "noisy-but-benign metric",
+      "service": "inventory-service",
+      "metric": "inventory.sync.queue.depth (gauge)",
+      "whyNotRootCause": "A queue-depth gauge that wobbles (with occasional spikes to ~400) across the ENTIRE two-hour window, on a service that isn't in the checkout path's failure chain. It looks alarming on a chart but is uncorrelated with the incident onset — a metric red herring testing that metric presence doesn't derail a traces/logs-solvable investigation."
+    },
+    {
+      "kind": "infra saturation (ruled out)",
+      "service": "checkout-api",
+      "whyNotRootCause": "CPU (~28%) and process memory (~500MB) stay flat and healthy through the incident. The failure is a code defect, not resource exhaustion — and the fail-fast (6-40ms) error spans corroborate that nothing is starved or queueing."
+    }
+  ],
+  "rubric": {
+    "programmatic": [
+      ["names_affected_service", 1, "checkout-api"],
+      [
+        "blames_the_deploy",
+        3,
+        "2\\.0\\.0-rc1|(deploy|roll[- ]?out|release|canary|new (version|build))[^.\\n]{0,60}?(regress|defect|bug|introduc|caus|broke|break|fault|bad)|(bad|faulty|broken|buggy|defective)[^.\\n]{0,25}?(deploy|release|version|build|rollout)|(caused by|due to|because of)[^.\\n]{0,40}?(deploy|rollout|release|new version)"
+      ],
+      [
+        "names_defect_mechanism",
+        2,
+        "TypeError|applyPromotion|cannot read propert|(missing|undefined|absent|lacks?|without|no)[^.\\n]{0,30}?percent[-_ ]?off|percent[-_ ]?off[^.\\n]{0,40}?(field|property|attribute|undefined|missing|does(?: not|n['’]t) exist)|(field|property|attribute)[^.\\n]{0,30}?percent[-_ ]?off"
+      ],
+      [
+        "names_fixed_amount_trigger",
+        1,
+        "fixed[- ]?(amount|value|dollar|price|discount)|flat[- ]?(rate|amount|discount)|non[- ]?percent(age)?|(FREESHIP|FLAT5|GIFT10)[^\\n]{0,100}?(FREESHIP|FLAT5|GIFT10)"
+      ],
+      [
+        "cites_pod_split",
+        2,
+        "(3|three)\\s*(of|/|out of)\\s*(the )?(6|six)[^.\\n]{0,30}?pods|(only|exclusively|confined to|solely|limited to|isolated to)[^.\\n]{0,60}?(updated|new|canary|flipped|rolled|rc1)[^.\\n]{0,25}?pods|(updated|canary|flipped|new-build|rc1) pods[^.\\n]{0,60}?(fail|error|500)|(old|other|remaining|un-?updated|non-?updated)[^.\\n]{0,20}?pods[^.\\n]{0,60}?(clean|healthy|fine|unaffected|baseline|no (errors|failures)|zero)|k8s\\.pod\\.name|(2\\.0\\.0-rc1[^\\n]{0,140}?1\\.43\\.1)|(1\\.43\\.1[^\\n]{0,140}?2\\.0\\.0-rc1)"
+      ],
+      [
+        "cites_rollout_event_join",
+        2,
+        "deployment\\.rollout|(rollout|deploy(ment)?)[- ]?(event|log)s?[^.\\n]{0,80}?(pod|name|2\\.0\\.0-rc1)|pods?[^.\\n]{0,70}?(named|listed|logged|recorded|identified|announced|shown)[^.\\n]{0,50}?(rollout|deploy)|updated to (version |v)?2\\.0\\.0-rc1|(pod|per[- ]pod)[- ]flip|flip (time|timestamp)s?|(match|matches|matched|matching|exactly the)[^.\\n]{0,60}?(rollout|deploy(ment)?)[- ]?(event|log)"
+      ],
+      [
+        "names_rollout_pause_or_partial",
+        1,
+        "pause[ds]?|3\\s*/\\s*6|(3|three) (of|out of) (the )?(6|six)|half (of )?the (pods|fleet|replicas)|partial(ly)? (roll|deploy|updat)|staged roll|canary"
+      ],
+      [
+        "names_staggered_onset",
+        2,
+        "stagger|(three|3|two|2)[- ]step|step(ped|s)?([- ]| )up (at|as|with) each|one pod at a time|pod[- ]by[- ]pod|every ~?2 ?min|2[- ]min(ute)?s? (interval|stagger|apart)|(ramp|increas|step)[^.\\n]{0,50}?(as|with) (each|every) (pod|flip|replica)|(each|every) pod (flip|updat)[^.\\n]{0,50}?(ramp|increas|step|jump)"
+      ],
+      [
+        "notes_error_sampling",
+        2,
+        "1[- ]?in[- ]?7|one in (every )?seven|error[- ]?sampl|(stack( |-)?trace|stack|TypeError)[^.\\n]{0,80}?(sampl|only (a |a small )?(fraction|subset|minority)|not (every|all)|1\\/7)|(fraction|subset|minority|only some)[^.\\n]{0,60}?(log|carr|emit|contain|includ)[^.\\n]{0,50}?(stack|TypeError)|(most|majority|bulk|rest) of[^.\\n]{0,60}?(failures|errors|500s)[^.\\n]{0,70}?(generic|request_failed|no stack|without (a |the )?stack)|request_failed[^\\n]{0,150}?unhandled_exception|unhandled_exception[^\\n]{0,150}?request_failed"
+      ],
+      [
+        "quantifies_impact",
+        1,
+        "(error|fail|500|checkout)[^.\\n]{0,80}?~?\\s?(?<![\\d.])([678]|1[3-7])(\\.\\d+)?\\s?%|~?\\s?(?<![\\d.])([678]|1[3-7])(\\.\\d+)?\\s?%[^.\\n]{0,80}?(error|fail|500|checkout)|(baseline|error)[^.\\n]{0,40}?0\\.[2-5]\\s?%|0\\.[2-5]\\s?%[^.\\n]{0,40}?(baseline|error)"
+      ],
+      [
+        "rules_out_payment_deploy",
+        1,
+        "payment[- ]service(['’]s)?[^\\n]{0,60}?(deploy|roll[- ]?out|release|update|3\\.7\\.0)[^\\n]{0,120}?(healthy|error[- ]?free|no (new )?errors|zero errors|0 errors|clean|innocent|benign|unrelated|not the (cause|culprit|issue|problem)|ruled? out|red herring|coinciden|completed (well |just )?before|finished before|predates)|(deploy|roll[- ]?out|release|3\\.7\\.0)[^\\n]{0,50}?payment[^\\n]{0,120}?(healthy|error[- ]?free|innocent|benign|unrelated|ruled? out|not the cause|red herring|coinciden)|payment[^\\n]{0,80}?(healthy|error[- ]?free|no errors|0 errors|zero errors)[^\\n]{0,80}?(both|either|old and new|before and after)[^\\n]{0,30}?(version|rollout|build)|(never|don['’]t|doesn['’]t|not) (even )?reach(es|ed|ing)?[^\\n]{0,40}?payment"
+      ],
+      [
+        "rules_out_deprecation_flood",
+        1,
+        "(deprecat|session[- ]?(cookie|store))[^\\n]{0,120}?(benign|harmless|cosmetic|noise|noisy|red herring|unrelated|not (the )?(cause|culprit|related)|no trace|not correlated|uncorrelated|never correlated|warning[- ]only|warn[- ](only|severity|level)|only a warning|ruled? out|coinciden|distract)|(benign|harmless|red herring|noise|cosmetic|unrelated|ruled? out)[^\\n]{0,80}?(deprecat|session[- ]?(cookie|store))"
+      ],
+      [
+        "false_blame_payment",
+        2,
+        "(?<!\\b(no|not|never|whether|if|unlikely|doubt\\w*|possib\\w*|potential\\w*|candidate|hypothes\\w*|suspect\\w*|might|may|could|appear\\w*|look\\w*|seem\\w*|rul\\w*|dismiss\\w*|eliminat\\w*|exonerat\\w*)\\b[^.?!\\n]{0,24})(?<!n['’]t )(root cause|caused by|due to|because of|culprit|the (issue|problem|cause) is)(?:(?!not |no evidence |no sign|n['’]t |rul(e|ed|ing)|unrelated|healthy|innocent|clean|error[- ]?free|look|appear|seem|might|could|may|possib|suspect|hypothes|whether|initial|unlikely|doubt)[^.?!\\n]){0,60}?payment[- ](service|gateway|provider)(?![^.!\\n]{0,120}\\?)",
+        true
+      ],
+      [
+        "false_blame_payment_deploy",
+        2,
+        "(?<!\\b(no|not|never|whether|if|unlikely|doubt\\w*|possib\\w*|potential\\w*|candidate|hypothes\\w*|suspect\\w*|might|may|could|appear\\w*|look\\w*|seem\\w*|rul\\w*|dismiss\\w*|eliminat\\w*|exonerat\\w*)\\b[^.?!\\n]{0,24})(?<!n['’]t )(root cause|caused by|due to|because of|culprit|the (issue|problem|cause) is)(?:(?!not |no evidence |no sign|n['’]t |rul(e|ed|ing)|unrelated|healthy|innocent|clean|error[- ]?free|look|appear|seem|might|could|may|possib|suspect|hypothes|whether|initial|unlikely|doubt)[^.?!\\n]){0,80}?payment[- ]service[^.?!\\n]{0,50}?(deploy|roll[- ]?out|release|update|3\\.7\\.0)(?![^.!\\n]{0,120}\\?)|(?<!\\b(no|not|never|whether|if|unlikely|doubt\\w*|possib\\w*|potential\\w*|candidate|hypothes\\w*|suspect\\w*|might|may|could|appear\\w*|look\\w*|seem\\w*|rul\\w*|dismiss\\w*|eliminat\\w*|exonerat\\w*)\\b[^.?!\\n]{0,24})(?<!n['’]t )payment[- ]service(['’]s)?[^.?!\\n]{0,25}?(deploy|roll[- ]?out|release|new version|3\\.7\\.0)(?:(?!not |no evidence |no sign|n['’]t |rul(e|ed|ing)|unrelated|healthy|innocent|clean|error[- ]?free|look|appear|seem|might|could|may|possib|suspect|hypothes|whether|initial|unlikely|doubt)[^.?!\\n]){0,60}?\\b(caus|broke|regress|introduc|fault|blame|responsible)(?![^.!\\n]{0,120}\\?)",
+        true
+      ],
+      [
+        "false_blame_deprecation",
+        2,
+        "(?<!\\b(no|not|never|whether|if|unlikely|doubt\\w*|possib\\w*|potential\\w*|candidate|hypothes\\w*|suspect\\w*|might|may|could|appear\\w*|look\\w*|seem\\w*|rul\\w*|dismiss\\w*|eliminat\\w*|exonerat\\w*)\\b[^.?!\\n]{0,24})(?<!n['’]t )(root cause|caused by|due to|because of|culprit|the (issue|problem|cause) is)(?:(?!not |no evidence |no sign|n['’]t |rul(e|ed|ing)|unrelated|healthy|innocent|clean|error[- ]?free|look|appear|seem|might|could|may|possib|suspect|hypothes|whether|initial|unlikely|doubt|benign|harmless|cosmetic|nois|red herring|distract)[^.?!\\n]){0,80}?(deprecat|session[- ]?(cookie|store))(?![^.!\\n]{0,120}\\?)|(?<!\\b(no|not|never|whether|if|unlikely|doubt\\w*|possib\\w*|potential\\w*|candidate|hypothes\\w*|suspect\\w*|might|may|could|appear\\w*|look\\w*|seem\\w*|rul\\w*|dismiss\\w*|eliminat\\w*|exonerat\\w*)\\b[^.?!\\n]{0,24})(?<!n['’]t )(deprecation|session[- ]?(cookie|store))(?:(?!not |no evidence |no sign|n['’]t |rul(e|ed|ing)|unrelated|healthy|innocent|clean|error[- ]?free|look|appear|seem|might|could|may|possib|suspect|hypothes|whether|initial|unlikely|doubt|benign|harmless|cosmetic|nois|red herring|distract)[^.?!\\n]){0,60}?\\b(caus(e[sd]?|ing)|broke|breaking|responsible for|behind the)(?![^.!\\n]{0,120}\\?)",
+        true
+      ],
+      [
+        "false_blame_infra",
+        2,
+        "(?<!not )(?<!n['’]t )(?<!never )(root cause|caused by|due to|because of|the (issue|problem|cause) is)(?:(?!not |no evidence |n['’]t |rul(e|ed|ing)|unrelated)[^.\\n]){0,60}?(cpu|memory|oom|out of memory|resource (exhaust|saturat)|disk|node pressure)",
+        true
+      ],
+      [
+        "false_blame_neighbor",
+        2,
+        "(?<!not )(?<!n['’]t )(?<!never )(root cause|caused by|due to|because of|the (issue|problem|cause) is)(?:(?!not |no evidence |n['’]t |rul(e|ed|ing)|unrelated)[^.\\n]){0,60}?(recommendation-service|502 burst|queue[ ._-]?depth|inventory-service)",
+        true
+      ]
+    ],
+    "transcript": [
+      [
+        "used_metric_tool",
+        1,
+        "clickstack_(list_metrics|describe_metric)|clickstack_(timeseries|table)[^\\n]*metricType"
+      ],
+      [
+        "queried_checkout_metrics",
+        1,
+        "(clickstack_describe_metric|clickstack_(timeseries|table)(?=[^\\n]*metricType))[^\\n]*(http[\\s._]server[\\s._]request|checkout)"
+      ]
+    ],
+    "judge": {
+      "criteria": [
+        {
+          "id": "correctness",
+          "weight": 3,
+          "description": "Did the answer identify the root cause: the defective checkout-api 2.0.0-rc1 staged rollout, whose promotion handler throws a TypeError (undefined percentOff in applyPromotion) on fixed-amount promo codes on the updated pods? CAP at 4 unless the mechanism also includes the rollout TIMELINE — staggered per-pod flips (~2 min apart), paused at 3/6 for canary. 5 = the complete chain: paused rollout -> fixed-amount promo checkouts on those pods throw the TypeError -> ~7% checkout 500s, onset tied to the pod flips. 'There was a deploy' or 'the new version is broken' without the promo-code trigger caps at 2."
+        },
+        {
+          "id": "evidence_grounding",
+          "weight": 3,
+          "description": "Is the conclusion grounded in the pod-level cross-tab? Telemetry carries NO service.version, so a strong answer reconstructs the split: failures confined to exactly the 3 pods the deployment.rollout events name as updated to 2.0.0-rc1 (other 3 stay at baseline), only fixed-amount promo codes (FREESHIP/FLAT5/GIFT10) fail, and the trace-correlated TypeError/applyPromotion stack names the broken code path. CAP at 3 unless the answer does BOTH: (a) makes the rollout-event join EXPLICIT — ties the specific failing pods to 2.0.0-rc1 — AND (b) dates the error onset at the first pod flip (not merely 'after a deploy'). 5 additionally requires quantified error rates (~15% per bad pod vs ~0.3% baseline, or ~7-8% overall) AND noting the TypeError stack is error-sampled (most failures log a generic request-failed line); join + accurate onset without both caps at 4. Corroborating metrics cannot substitute for the pod/promo cross-tab."
+        },
+        {
+          "id": "calibration",
+          "weight": 2,
+          "description": "Did the answer avoid the traps? (a) the payment-service 3.7.0 rollout is innocent — payment.authorize is healthy on both versions and failed checkouts never reach payment; (b) the DeprecationWarning (session-cookie) flood from the new build is benign WARN noise with no trace correlation to the 500s; (c) the recommendation-service 502 burst predates both deploys and self-resolved; (d) the constant-rate NonFatalRetryableError logs are handled noise; (e) CPU/memory are flat — not infra saturation; (f) the inventory.sync.queue.depth gauge is noisy but uncorrelated. Blaming any of these scores 1-2. CAP at 3 unless BOTH co-timed traps — (a) and (b) — are explicitly addressed (not merely omitted). CAP at 4 unless each is dismissed WITH its evidence. 5 = both dismissed with evidence plus the background distractors handled."
+        },
+        {
+          "id": "conciseness",
+          "weight": 1,
+          "description": "Was the answer concise, well-structured, and free of filler or unnecessary speculation?"
+        }
+      ]
+    }
+  }
+}

--- a/packages/hdx-eval/src/scenarios/deploy-regression/ground-truth.json
+++ b/packages/hdx-eval/src/scenarios/deploy-regression/ground-truth.json
@@ -17,7 +17,7 @@
       "histogram": "http.server.request.duration on checkout-api split by http.response.status_code: the 500-series count steps up at the deploy — corroborates the onset, adds nothing traces don't show.",
       "sum": "http.server.request.count{status_class=5xx} (cumulative): slope changes at the deploy — same corroboration as a rate.",
       "gauge": "system.cpu.utilization and process.memory.usage on checkout-api stay flat and healthy — rules out infra saturation as an alternative cause. inventory.sync.queue.depth on inventory-service is a noisy-but-benign red herring.",
-      "adoptionNote": "This scenario measures ORGANIC metric-tool adoption: the transcript checks record whether the agent reaches for metric tools it does not strictly need. Contrast with metric-saturation, where metric-tool use is forced by the scenario design."
+      "adoptionNote": "This scenario measures ORGANIC metric adoption: the adoption checks record whether any tool call's input args name the target metrics (regardless of which tool — a dedicated metric tool and raw SQL against the metrics tables both count), even though the agent does not strictly need metrics here. Contrast with metric-saturation, where metric use is forced by the scenario design."
     }
   },
   "distractors": [
@@ -152,17 +152,22 @@
         true
       ]
     ],
-    "transcript": [
-      [
-        "used_metric_tool",
-        1,
-        "clickstack_(list_metrics|describe_metric)|clickstack_(timeseries|table)[^\\n]*metricType"
-      ],
-      [
-        "queried_checkout_metrics",
-        1,
-        "(clickstack_describe_metric|clickstack_(timeseries|table)(?=[^\\n]*metricType))[^\\n]*(http[\\s._]server[\\s._]request|checkout)"
-      ]
+    "adoption": [
+      {
+        "id": "queried_target_metric",
+        "weight": 1,
+        "metrics": [
+          "http.server.request.duration",
+          "http.server.request.count",
+          "system.cpu.utilization",
+          "process.memory.usage"
+        ]
+      },
+      {
+        "id": "queried_checkout_http_metrics",
+        "weight": 1,
+        "metrics": ["http.server.request.duration", "http.server.request.count"]
+      }
     ],
     "judge": {
       "criteria": [

--- a/packages/hdx-eval/src/scenarios/index.ts
+++ b/packages/hdx-eval/src/scenarios/index.ts
@@ -1,4 +1,5 @@
 import { dashboardBuildScenario } from './dashboard-build/generate';
+import { deployRegressionScenario } from './deploy-regression/generate';
 import { errorRootCauseScenario } from './error-root-cause/generate';
 import { latencySpikeScenario } from './latency-spike/generate';
 import { metricSaturationScenario } from './metric-saturation/generate';
@@ -9,6 +10,7 @@ import type { Scenario } from './types';
 
 export const SCENARIOS: Record<string, Scenario> = {
   [dashboardBuildScenario.name]: dashboardBuildScenario,
+  [deployRegressionScenario.name]: deployRegressionScenario,
   [errorRootCauseScenario.name]: errorRootCauseScenario,
   [latencySpikeScenario.name]: latencySpikeScenario,
   [metricSaturationScenario.name]: metricSaturationScenario,

--- a/packages/hdx-eval/src/scenarios/metric-saturation/ground-truth.json
+++ b/packages/hdx-eval/src/scenarios/metric-saturation/ground-truth.json
@@ -130,27 +130,35 @@
         true
       ]
     ],
-    "transcript": [
-      [
-        "used_metric_tool",
-        1,
-        "clickstack_(list_metrics|describe_metric)|clickstack_(timeseries|table)[^\\n]*metricType"
-      ],
-      [
-        "described_jvm_memory_metric",
-        1,
-        "(clickstack_describe_metric|clickstack_(timeseries|table)(?=[^\\n]*metricType))[^\\n]*process[\\s._]runtime[\\s._]jvm[\\s._]memory"
-      ],
-      [
-        "described_gc_pause_metric",
-        1,
-        "(clickstack_describe_metric|clickstack_(timeseries|table)(?=[^\\n]*metricType))[^\\n]*(gc[\\s._]?pause|jvm[\\s._]gc)"
-      ],
-      [
-        "grouped_memory_by_pod_or_pool",
-        1,
-        "clickstack_(timeseries|table)(?=[^\\n]*metricType)(?=[^\\n]*(jvm[\\s._]memory|memory[\\s._]used))[^\\n]*(pool|pod)"
-      ]
+    "adoption": [
+      {
+        "id": "queried_target_metric",
+        "weight": 1,
+        "metrics": [
+          "process.runtime.jvm.memory.used",
+          "jvm.gc.pause",
+          "jvm.gc.collections",
+          "k8s.pod.restarts",
+          "jvm.threads.count",
+          "system.cpu.utilization"
+        ]
+      },
+      {
+        "id": "queried_jvm_memory_metric",
+        "weight": 1,
+        "metrics": ["process.runtime.jvm.memory.used"]
+      },
+      {
+        "id": "queried_gc_metric",
+        "weight": 1,
+        "metrics": ["jvm.gc.pause", "jvm.gc.collections"]
+      },
+      {
+        "id": "grouped_memory_by_pod_or_pool",
+        "weight": 1,
+        "metrics": ["process.runtime.jvm.memory.used"],
+        "alsoPattern": "pool|pod"
+      }
     ],
     "judge": {
       "criteria": [


### PR DESCRIPTION
# feat(evals): add deploy-regression scenario (measure organic metric tool adoption)

## Why

`metric-saturation` measures whether an agent can use metric tools when the scenario **forces** it to. `deploy-regression` measures the complement: **organic** metric adoption — the incident is fully solvable from traces + logs, the planted metrics only corroborate, and the adoption rubric records whether the agent reaches for metrics it doesn't strictly need, without letting that inflate the outcome score.

## Summary

- **Scenario**: `checkout-api` staged rollout of `2.0.0-rc1` pauses at 3/6 pods; the new build throws a `TypeError` on fixed-amount promo codes (`FREESHIP`, `FLAT5`, `GIFT10`) → ~7-8% of checkouts 500, only on updated pods, only for fixed-amount codes.
- **Nothing pre-labeled**: no `service.version` stamping — the smoking gun is a `k8s.pod.name` cross-tab on failed checkouts joined against the `deployment.rollout` event logs; promo type has no label and the TypeError stack is error-sampled (~1-in-7).
- **Calibration traps**: two co-timed ones (an innocent completed payment-service rollout minutes before the onset, and a deploy-introduced benign DeprecationWarning flood stepping at the same boundaries as the errors) plus background distractors (healthy payment child spans, constant caught-exception noise, pre-deploy 502 burst, noisy-but-benign queue-depth gauge).
- **Metrics corroborate only** (keyed by service, not pod/version): they confirm the onset but cannot reveal the pod split or the defect — ignoring metrics entirely is a valid solve path, which is what makes measured adoption organic.
- **Also included**: eval-viewer "copy batch name" button next to the batch picker.

## Adoption grading: args-based metric-key matching (updated per review)

Per review feedback, the adoption rubric no longer pattern-matches on **tool names** (the old regexes hard-coded `clickstack_*`, so the ClickHouse arm could never score above 0% even when it investigated the same metrics via SQL). It is now **arm-agnostic and args-only**:

- Each scenario's `ground-truth.json` declares target metric keys per check (`{ id, weight, metrics: string[], alsoPattern? }`); the rubric block is renamed `transcript` → `adoption` to match `GradeRecord.adoption`.
- A check is satisfied when **some single tool call's input args** name one of the check's metrics — full dotted keys, separator-tolerant (`jvm.gc.pause` ≡ `jvm_gc_pause`, case-insensitive). Tool names and tool outputs are excluded from the matched text, so prose like `Body LIKE '%gc pause%'` in a log search does not count. `alsoPattern` (e.g. `pool|pod` for the group-by check) must match the **same call's** args.
- Behavior changes: raw SQL naming a target metric now **counts** (the point of the fix); a bare `list_metrics` call with no metric name in its args no longer does — adoption now means "engaged with a target metric by name", not "touched a metric tool".
- Adoption's place in the pipeline is unchanged: opt-in per scenario, reported separately, **excluded from the combined score**. Check ids were renamed to match the new semantics (`used_metric_tool` → `queried_target_metric`, etc.).

## Eval results

Both batches graded with the args-based adoption rubric. N=3 per arm, so treat per-arm deltas as directional.

### claude-opus-4-6

| Metric | hyperdx | clickhouse | Δ (clickhouse) |
|---|---|---|---|
| Combined score | **68%** | 55% | -13pp |
| Programmatic | 70% | 60% | -10pp |
| Judge mean (weighted) | 76% | 64% | -11pp |
| Adoption (organic metric use) | 0% | 0% | — |
| Tool calls (mean) | 17.7 | 20.0 | +2.3 |
| Wall clock (s, mean) | 196.9 | 183.9 | -13.0 |
| Termination | final_answer 3/3 | final_answer 2/3, max_turns 1/3 | — |
| N | 3 | 3 | — |

### claude-fable-5

| Metric | hyperdx | clickhouse | Δ (clickhouse) |
|---|---|---|---|
| Combined score | **86%** | 84% | -1pp |
| Programmatic | 79% | 75% | -5pp |
| Judge mean (weighted) | 90% | 90% | +1pp |
| Adoption (organic metric use) | 0% | 0% | — |
| Tool calls (mean) | 12.0 | 16.7 | +4.7 |
| Wall clock (s, mean) | 202.2 | 161.7 | -40.5 |
| Termination | final_answer 3/3 | final_answer 3/3 | — |
| N | 3 | 3 | — |

- **The organic-adoption readout**: 0% on both arms with **both models** — even the newer fable-5 never names a target metric key in any tool call's args on either arm. With traces/logs sufficient, agents genuinely skip metrics entirely (not an artifact of the old tool-name matching); this is the baseline future MCP ergonomics changes can move.
- fable-5 lifts both arms to near-parity (86% vs 84% combined) with cleaner runs: zero tool errors, fewer tool calls, and both arms nail the core findings (`blames_the_deploy`, `cites_pod_split`, `names_fixed_amount_trigger` all 100%); remaining misses are the hard corroboration checks (`cites_rollout_event_join`, `rules_out_payment_deploy`, `notes_error_sampling`).
- On opus, hyperdx leads on both programmatic and judge scores; clickhouse dropped points on core findings (`names_fixed_amount_trigger` 33% vs 100%) and had one run hit max_turns. Trap calibration is clean on both arms and both models (all false-blame negatives 100%).

### References

- Linear Issue: Closes HDX-4787
- Related PRs: https://github.com/hyperdxio/hyperdx/pull/2717
