### PR TITLE
fix(app): stop refetching next page while search query is in an error state

### DIFF
--- a/.changeset/stop-refetch-on-query-error.md
+++ b/.changeset/stop-refetch-on-query-error.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Stop requesting additional search pages while a query is in an error state. A failed page (for example a ClickHouse query timeout on a slow time window) previously kept `hasNextPage` true, so the table re-issued the failing query and stayed in a loading state that hid the error and reported zero results.

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -686,6 +686,7 @@ export const RawLogTable = memo(
           if (
             scrollHeight - scrollTop - clientHeight < FETCH_NEXT_PAGE_PX &&
             !isLoading &&
+            !isError &&
             hasNextPage
           ) {
             // Cancel refetch is important to ensure we wait for the last fetch to finish
@@ -693,7 +694,7 @@ export const RawLogTable = memo(
           }
         }
       },
-      [fetchNextPage, isLoading, hasNextPage],
+      [fetchNextPage, isLoading, isError, hasNextPage],
     );
 
     //a check on mount and after a fetch to see if the table is already scrolled to the bottom and immediately needs to fetch more data
@@ -887,6 +888,7 @@ export const RawLogTable = memo(
         if (
           dedupedRows.length < MAX_SCROLL_FETCH_LINES &&
           !isLoading &&
+          !isError &&
           hasNextPage
         ) {
           fetchNextPage?.({ cancelRefetch: false });
@@ -908,6 +910,7 @@ export const RawLogTable = memo(
       rowVirtualizer,
       scrolledToHighlightedLine,
       isLoading,
+      isError,
       hasNextPage,
     ]);
 

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -236,6 +236,42 @@ describe('RawLogTable', () => {
 
       await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
     });
+
+    // Searching for a highlighted row that has not been loaded yet also
+    // auto-advances pages. Both auto-advance paths are active in jsdom, so
+    // these two cases pin the highlighted-line guard alongside the scroll one.
+    it('should not search for a highlighted row while the query is in an error state', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          rows={[{ col1: 'value1' }]}
+          highlightedLineId="not-a-loaded-row"
+          isError
+          error={new Error('Timeout exceeded')}
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('should search for a highlighted row when there is no error', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          rows={[{ col1: 'value1' }]}
+          highlightedLineId="not-a-loaded-row"
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
+    });
   });
 });
 

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -194,6 +194,47 @@ describe('RawLogTable', () => {
       const headers = container.querySelectorAll('th');
       expect(headers).toHaveLength(2);
       expect((headers[0] as HTMLElement).style.width).not.toBe('250px');
+    });
+  });
+
+  describe('Error state', () => {
+    const paginationProps = {
+      displayedColumns: ['col1'],
+      rows: [] as Record<string, any>[],
+      isLoading: false,
+      dedupRows: false,
+      hasNextPage: true,
+      onRowDetailsClick: () => {},
+      generateRowId: () => mockRowWhereResult,
+      columnTypeMap: new Map(),
+    };
+
+    it('should not request another page while the query is in an error state', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          isError
+          error={new Error('Timeout exceeded')}
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      // The error must be surfaced instead of silently retrying, otherwise the
+      // table stays in a perpetual loading state showing zero results.
+      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('should still request another page when there is no error', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable {...paginationProps} fetchNextPage={fetchNextPage} />,
+      );
+
+      await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
     });
   });
 });


### PR DESCRIPTION
## Problem

When a windowed search has a page that fails (most commonly a ClickHouse `TIMEOUT_EXCEEDED` on a slow window), `RawLogTable` keeps calling `fetchNextPage`. `hasNextPage` is still `true` after a failed page, and neither auto-advance path checks `isError`:

- `fetchMoreOnBottomReached` - guards on `!isLoading && hasNextPage`
- the highlighted-line effect - guards on `!isLoading && hasNextPage`

Each retry flips `isLoading` back to `true`, which re-triggers the effect (its `useCallback` identity changes) and re-enters the loading render branch. That branch precedes the `isError && error` branch, so:

1. **The error is never shown.** The table sits on "Searched ... Loading results across ..." with `0 Results`, which is indistinguishable from "no matching data". Users conclude the data is missing.
2. **The failing query is re-issued repeatedly**, amplifying load on ClickHouse.

Observed on a real deployment: a single search over a 1-day range issued **80 queries (63 succeeded, 17 timed out) reading 1.09 billion rows**, while the UI reported `0 Results` with no error. The rows the user was looking for were inside the timed-out windows. Confirmed via `system.query_log` (`exception_code = 159`).

## Fix

Add `!isError` to both auto-advance guards (and their dependency arrays). Once the failed page stops being retried, `isLoading` settles and the existing `ChartErrorState` renders, so this fixes the silent-failure UX as well, with no new UI.

## Tests

Added `RawLogTable > Error state` in `DBRowTable.test.tsx`:

- **fails on `main`** (`fetchNextPage` is called once despite `isError`) and passes with this change
- a control test asserts normal pagination still fires when there is no error

`DBRowTable` suite 26/26; `useOffsetPaginatedQuery` + `DBTableChart` + `DBTraceWaterfallChart` 82/82; `tsc --noEmit` and `eslint` clean.

## Related

- #1404 - same failure mode, complementary angle: that issue asks for timeout errors not to wipe out already-loaded rows. This PR deliberately does **not** touch the render ordering (someone has expressed interest in #1404); it only stops the retry loop, which is what makes the error surface at all when there are zero rows.
- #1403 - also about redundant pagination queries, but for the `LIMIT/OFFSET` path rather than error-driven refetch.
