### PR TITLE
feat: Warn on missing params/macros in SQL Editor

### DIFF
--- a/.changeset/warn-raw-sql-macros.md
+++ b/.changeset/warn-raw-sql-macros.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/common-utils': patch
+---
+
+feat: Warn on missing params/macros in SQL Editor

--- a/packages/api/src/mcp/tools/dashboards/validation.ts
+++ b/packages/api/src/mcp/tools/dashboards/validation.ts
@@ -1,7 +1,7 @@
 import {
+  getSourceDependentMacrosUsed,
   hasMacro,
   INTERVAL_MACROS,
-  SOURCE_DEPENDENT_MACROS,
   TIME_RANGE_MACROS,
 } from '@hyperdx/common-utils/dist/macros';
 
@@ -29,11 +29,11 @@ export function getRawSqlTilesMissingRequiredSource(
       return;
     }
     const { sqlTemplate } = tile.config;
-    // SOURCE_DEPENDENT_MACROS are bare names ('filters', 'sourceTable') for
-    // hasMacro; surface them in the user-facing `$__name` form.
-    const macros = SOURCE_DEPENDENT_MACROS.filter(macro =>
-      hasMacro(sqlTemplate, macro),
-    ).map(macro => `$__${macro}`);
+    // getSourceDependentMacrosUsed returns bare names ('filters',
+    // 'sourceTable'); surface them in the user-facing `$__name` form.
+    const macros = getSourceDependentMacrosUsed(sqlTemplate).map(
+      macro => `$__${macro}`,
+    );
     if (macros.length > 0) {
       offending.push({
         tile: tile.name?.trim() || `tile #${index + 1}`,

--- a/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
@@ -162,20 +162,17 @@ export default function RawSqlChartEditor({
     };
   }, [debouncedRawSqlConfig]);
 
-  const { chartErrors, chartWarnings, sqlValidationAlertColor } =
+  const { chartErrors, chartWarnings, sqlValidationAlertVariant } =
     useMemo(() => {
       const { errors, warnings } = validateRawSqlChartConfig(
         debouncedRawSqlConfig,
         { isDashboardTile: isDashboardForm },
       );
 
-      const sqlValidationAlertColor =
-        errors.length > 0 ? 'red' : warnings.length > 0 ? 'yellow' : undefined;
-
       return {
         chartErrors: errors,
         chartWarnings: warnings,
-        sqlValidationAlertColor,
+        sqlValidationAlertVariant: errors.length > 0 ? 'danger' : 'warning',
       };
     }, [debouncedRawSqlConfig, isDashboardForm]);
 
@@ -350,7 +347,7 @@ export default function RawSqlChartEditor({
         <div className={resizeStyles.resizeYHandle} onMouseDown={startResize} />
       </Box>
       {(chartErrors.length > 0 || chartWarnings.length > 0) && (
-        <Alert color={sqlValidationAlertColor} py="xs">
+        <Alert variant={sqlValidationAlertVariant} py="xs">
           <List size="xs" spacing={2}>
             {chartErrors.map(message => (
               <List.Item key={message}>Error: {message}</List.Item>

--- a/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
@@ -6,6 +6,7 @@ import {
 } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   displayTypeSupportsRawSqlAlerts,
+  validateRawSqlChartConfig,
   validateRawSqlForAlert,
 } from '@hyperdx/common-utils/dist/core/utils';
 import { MACRO_SUGGESTIONS } from '@hyperdx/common-utils/dist/macros';
@@ -17,7 +18,17 @@ import {
   isMetricSource,
   isTraceSource,
 } from '@hyperdx/common-utils/dist/types';
-import { Box, Button, Group, Stack, Text, Tooltip } from '@mantine/core';
+import {
+  Alert,
+  Box,
+  Button,
+  Group,
+  List,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconBell, IconHelpCircle } from '@tabler/icons-react';
 
 import { ConnectionSelectControlled } from '@/components/ConnectionSelect';
@@ -132,19 +143,41 @@ export default function RawSqlChartEditor({
         sqlTemplate: sqlTemplate ?? '',
         connection: connection ?? '',
         from: sourceObject?.from,
+        metricTables:
+          sourceObject && isMetricSource(sourceObject)
+            ? sourceObject.metricTables
+            : undefined,
         displayType,
       }) satisfies RawSqlChartConfig,
-    [sqlTemplate, connection, sourceObject?.from, displayType],
+    [sqlTemplate, connection, sourceObject, displayType],
   );
 
+  const [debouncedRawSqlConfig] = useDebouncedValue(rawSqlConfig, 300);
+
   const { alertErrorMessage, alertWarningMessage } = useMemo(() => {
-    const { errors, warnings } = validateRawSqlForAlert(rawSqlConfig);
+    const { errors, warnings } = validateRawSqlForAlert(debouncedRawSqlConfig);
     return {
-      alertErrorMessage: errors.length > 0 ? errors.join('. ') : undefined,
-      alertWarningMessage:
-        warnings.length > 0 ? warnings.join('. ') : undefined,
+      alertErrorMessage: errors.length > 0 ? errors.join(' ') : undefined,
+      alertWarningMessage: warnings.length > 0 ? warnings.join(' ') : undefined,
     };
-  }, [rawSqlConfig]);
+  }, [debouncedRawSqlConfig]);
+
+  const { chartErrors, chartWarnings, sqlValidationAlertColor } =
+    useMemo(() => {
+      const { errors, warnings } = validateRawSqlChartConfig(
+        debouncedRawSqlConfig,
+        { isDashboardTile: isDashboardForm },
+      );
+
+      const sqlValidationAlertColor =
+        errors.length > 0 ? 'red' : warnings.length > 0 ? 'yellow' : undefined;
+
+      return {
+        chartErrors: errors,
+        chartWarnings: warnings,
+        sqlValidationAlertColor,
+      };
+    }, [debouncedRawSqlConfig, isDashboardForm]);
 
   const prevSource = usePrevious(source);
   const prevConnection = usePrevious(connection);
@@ -316,6 +349,18 @@ export default function RawSqlChartEditor({
         />
         <div className={resizeStyles.resizeYHandle} onMouseDown={startResize} />
       </Box>
+      {(chartErrors.length > 0 || chartWarnings.length > 0) && (
+        <Alert color={sqlValidationAlertColor} py="xs">
+          <List size="xs" spacing={2}>
+            {chartErrors.map(message => (
+              <List.Item key={message}>Error: {message}</List.Item>
+            ))}
+            {chartWarnings.map(message => (
+              <List.Item key={message}>Warning: {message}</List.Item>
+            ))}
+          </List>
+        </Alert>
+      )}
       {alert && (
         <TileAlertEditor
           control={control}

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -397,7 +397,7 @@ export const validateChartForm = (
     if (alertErrors.length > 0) {
       errors.push({
         path: `sqlTemplate`,
-        message: alertErrors.join('. '),
+        message: alertErrors.join(' '),
       });
     }
   }

--- a/packages/common-utils/src/__tests__/macros.test.ts
+++ b/packages/common-utils/src/__tests__/macros.test.ts
@@ -1,4 +1,8 @@
-import { hasMacro, replaceMacros } from '@/macros';
+import {
+  getSourceDependentMacrosUsed,
+  hasMacro,
+  replaceMacros,
+} from '@/macros';
 import type { MetricTable } from '@/types';
 
 const ALL_METRIC_TABLES: MetricTable = {
@@ -24,6 +28,34 @@ describe('hasMacro', () => {
 
   it('detects macros that take arguments', () => {
     expect(hasMacro('WHERE $__timeFilter(ts)', 'timeFilter')).toBe(true);
+  });
+});
+
+describe('getSourceDependentMacrosUsed', () => {
+  it('returns an empty array when no source-dependent macros are used', () => {
+    expect(
+      getSourceDependentMacrosUsed('SELECT * WHERE $__timeFilter(ts)'),
+    ).toEqual([]);
+  });
+
+  it('detects $__filters', () => {
+    expect(getSourceDependentMacrosUsed('SELECT * WHERE $__filters')).toEqual([
+      'filters',
+    ]);
+  });
+
+  it('detects $__sourceTable', () => {
+    expect(
+      getSourceDependentMacrosUsed('SELECT * FROM $__sourceTable'),
+    ).toEqual(['sourceTable']);
+  });
+
+  it('detects both when used together', () => {
+    expect(
+      getSourceDependentMacrosUsed(
+        'SELECT * FROM $__sourceTable WHERE $__filters',
+      ),
+    ).toEqual(['filters', 'sourceTable']);
   });
 });
 

--- a/packages/common-utils/src/__tests__/validateRawSqlChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/validateRawSqlChartConfig.test.ts
@@ -1,0 +1,339 @@
+import { validateRawSqlChartConfig } from '@/core/utils';
+import { DisplayType, RawSqlChartConfig } from '@/types';
+
+function config(overrides: Partial<RawSqlChartConfig>): RawSqlChartConfig {
+  return {
+    configType: 'sql',
+    sqlTemplate: 'SELECT count() FROM $__sourceTable',
+    connection: 'test-connection',
+    from: { databaseName: 'default', tableName: 'otel_logs' },
+    displayType: DisplayType.Table,
+    ...overrides,
+  } as RawSqlChartConfig;
+}
+
+describe('validateRawSqlChartConfig', () => {
+  it('errors when a time-series display type is missing an interval param/macro', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Line,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(errors).toEqual([
+      'SQL must include an interval parameter or macro (e.g. $__interval_s) for this display type.',
+    ]);
+  });
+
+  it('does not require an interval param/macro for non-time-series display types', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Table,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('does not error when a time-series display type includes an interval macro', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Line,
+        sqlTemplate:
+          'SELECT $__timeInterval(ts), count() FROM $__sourceTable WHERE $__timeFilter(ts) GROUP BY 1',
+      }),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('warns when start/end date params or macros are missing', () => {
+    const { warnings } = validateRawSqlChartConfig(
+      config({ sqlTemplate: 'SELECT count() FROM $__sourceTable' }),
+    );
+    expect(warnings).toContain(
+      'SQL should include start and end date parameters or macros (e.g. $__timeFilter) so this chart respects the selected time range.',
+    );
+  });
+
+  it('does not warn about the date range when a time-range macro is present', () => {
+    const { warnings } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(warnings).not.toContain(
+      'SQL should include start and end date parameters or macros (e.g. $__timeFilter) so this chart respects the selected time range.',
+    );
+  });
+
+  it('does not warn about missing $__filters/$__sourceTable when requireSourceMacros is false', () => {
+    const { warnings } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate: 'SELECT count() FROM logs WHERE $__timeFilter(ts)',
+      }),
+      { isDashboardTile: false },
+    );
+    expect(warnings).not.toContain(
+      'SQL should include the $__sourceTable macro so this tile queries its configured source.',
+    );
+    expect(warnings).not.toContain(
+      'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+    );
+  });
+
+  it('warns about missing $__filters/$__sourceTable when requireSourceMacros is true', () => {
+    const { warnings } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate: 'SELECT count() FROM logs WHERE $__timeFilter(ts)',
+      }),
+      { isDashboardTile: true },
+    );
+    expect(warnings).toContain(
+      'SQL should include the $__sourceTable macro so this tile queries its configured source.',
+    );
+    expect(warnings).toContain(
+      'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+    );
+  });
+
+  it('does not warn about missing source macros when they are present', () => {
+    const { warnings } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts) AND $__filters',
+      }),
+      { isDashboardTile: true },
+    );
+    expect(warnings).not.toContain(
+      'SQL should include the $__sourceTable macro so this tile queries its configured source.',
+    );
+    expect(warnings).not.toContain(
+      'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+    );
+  });
+
+  it('errors when $__sourceTable is used but no source is selected', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        from: undefined,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(errors).toContain(
+      'SQL uses $__sourceTable but no source is selected — select a source so this macro can resolve correctly.',
+    );
+  });
+
+  it('errors naming both macros when $__filters and $__sourceTable are both used without a source', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        from: undefined,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts) AND $__filters',
+      }),
+    );
+    expect(errors).toContain(
+      'SQL uses $__filters and $__sourceTable but no source is selected — select a source so these macros can resolve correctly.',
+    );
+  });
+
+  it('does not error about a missing source when no source-dependent macros are used', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        from: undefined,
+        sqlTemplate: 'SELECT count() FROM logs WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(errors.some(e => e.includes('no source is selected'))).toBe(false);
+  });
+
+  it('does not error about a missing source when a source is selected', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        from: { databaseName: 'default', tableName: 'otel_logs' },
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+      }),
+    );
+    expect(errors.some(e => e.includes('no source is selected'))).toBe(false);
+  });
+
+  it('does not throw when $__sourceTable( has an unmatched paren', () => {
+    expect(() =>
+      validateRawSqlChartConfig(
+        config({
+          displayType: DisplayType.Line,
+          sqlTemplate: 'SELECT * FROM $__sourceTable(',
+        }),
+        { isDashboardTile: true },
+      ),
+    ).not.toThrow();
+  });
+
+  it('does not throw when $__filters( has an unmatched paren', () => {
+    expect(() =>
+      validateRawSqlChartConfig(
+        config({
+          displayType: DisplayType.Line,
+          sqlTemplate: 'SELECT * WHERE $__filters(',
+        }),
+        { isDashboardTile: true },
+      ),
+    ).not.toThrow();
+  });
+
+  it('degrades to no errors/warnings (instead of throwing) when the sqlTemplate is unparseable', () => {
+    const result = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Line,
+        sqlTemplate: 'SELECT $__sourceTable( FROM logs',
+      }),
+      { isDashboardTile: true },
+    );
+    expect(result).toEqual({ errors: [], warnings: [] });
+  });
+
+  it('does not throw when $__sourceTable( has an unmatched paren and no source is selected', () => {
+    expect(() =>
+      validateRawSqlChartConfig(
+        config({
+          from: undefined,
+          sqlTemplate: 'SELECT * FROM $__sourceTable(',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('reports the missing-interval error for a metric $__sourceTable(type) macro when metricTables is provided', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Line,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+        metricTables: {
+          gauge: 'otel_metrics_gauge',
+          histogram: 'otel_metrics_histogram',
+          sum: 'otel_metrics_sum',
+          summary: 'otel_metrics_summary',
+          'exponential histogram': 'otel_metrics_exponential_histogram',
+        },
+      }),
+    );
+    // With metricTables, replaceMacros can resolve $__sourceTable(gauge), so
+    // getRawSqlTimeRangeStatus succeeds and correctly reports the interval
+    // macro that this Line-chart query is missing, instead of silently
+    // skipping the check.
+    expect(errors).toEqual([
+      'SQL must include an interval parameter or macro (e.g. $__interval_s) for this display type.',
+    ]);
+  });
+
+  it('silently skips that same interval error when metricTables is missing, but still reports the source-type mismatch', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        displayType: DisplayType.Line,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+        metricTables: undefined,
+      }),
+    );
+    // Same query as above, minus metricTables: replaceMacros now throws
+    // resolving $__sourceTable(gauge), so getRawSqlTimeRangeStatus returns
+    // null and the missing-interval error is NOT reported, even though the
+    // interval macro is equally missing here. The source-type mismatch
+    // check doesn't depend on macro resolution, so it still fires.
+    expect(errors).toEqual([
+      'SQL uses $__sourceTable(<metricType>) but the selected source is not a metrics source — use a bare $__sourceTable instead.',
+    ]);
+    expect(errors).not.toContain(
+      'SQL must include an interval parameter or macro (e.g. $__interval_s) for this display type.',
+    );
+  });
+
+  it('errors when a non-metrics source uses $__sourceTable(<metricType>)', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+        metricTables: undefined,
+      }),
+    );
+    expect(errors).toContain(
+      'SQL uses $__sourceTable(<metricType>) but the selected source is not a metrics source — use a bare $__sourceTable instead.',
+    );
+  });
+
+  it('errors when a metrics source uses a bare $__sourceTable', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+        metricTables: {
+          gauge: 'otel_metrics_gauge',
+          histogram: 'otel_metrics_histogram',
+          sum: 'otel_metrics_sum',
+          summary: 'otel_metrics_summary',
+          'exponential histogram': 'otel_metrics_exponential_histogram',
+        },
+      }),
+    );
+    expect(errors).toContain(
+      'SQL uses a bare $__sourceTable but the selected source is a metrics source — specify a metric type, e.g. $__sourceTable(gauge).',
+    );
+  });
+
+  it('does not error when a non-metrics source uses a bare $__sourceTable', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable WHERE $__timeFilter(ts)',
+        metricTables: undefined,
+      }),
+    );
+    expect(errors.some(e => e.includes('is not a metrics source'))).toBe(false);
+  });
+
+  it('does not error when a metrics source uses $__sourceTable(<metricType>)', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+        metricTables: {
+          gauge: 'otel_metrics_gauge',
+          histogram: 'otel_metrics_histogram',
+          sum: 'otel_metrics_sum',
+          summary: 'otel_metrics_summary',
+          'exponential histogram': 'otel_metrics_exponential_histogram',
+        },
+      }),
+    );
+    expect(errors.some(e => e.includes('specify a metric type'))).toBe(false);
+  });
+
+  it('does not report a source-type mismatch when no source is selected', () => {
+    const { errors } = validateRawSqlChartConfig(
+      config({
+        from: undefined,
+        sqlTemplate:
+          'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+        metricTables: undefined,
+      }),
+    );
+    expect(errors.some(e => e.includes('is not a metrics source'))).toBe(false);
+    // The "no source selected" check takes over instead.
+    expect(errors).toContain(
+      'SQL uses $__sourceTable but no source is selected — select a source so this macro can resolve correctly.',
+    );
+  });
+
+  it('returns no errors/warnings for a non-raw-sql config', () => {
+    const result = validateRawSqlChartConfig({
+      configType: 'metric',
+    } as unknown as RawSqlChartConfig);
+    expect(result).toEqual({ errors: [], warnings: [] });
+  });
+});

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -7,7 +7,12 @@ import { z } from 'zod';
 export { default as objectHash } from 'object-hash';
 
 import { isBuilderSavedChartConfig, isRawSqlSavedChartConfig } from '@/guards';
-import { replaceMacros } from '@/macros';
+import {
+  getSourceDependentMacrosUsed,
+  getSourceTableMacroArgCounts,
+  hasMacro,
+  replaceMacros,
+} from '@/macros';
 import { QUERY_PARAMS, RawSqlQueryParam } from '@/rawSqlParams';
 import {
   BuilderChartConfig,
@@ -1333,6 +1338,45 @@ export function displayTypeSupportsPromQLAlerts(
   return displayType ? false : false;
 }
 
+/**
+ * Resolves the chart's macros and reports which raw-SQL time-range/interval
+ * query params are present in the resolved SQL. Shared by
+ * `validateRawSqlForAlert` and `validateRawSqlChartConfig`, which each build
+ * their own error/warning messages from this on top.
+ *
+ * Returns `null` if the config isn't raw SQL or macro resolution fails
+ * (`replaceMacros` throws frequently while a user is still typing).
+ */
+function getRawSqlTimeRangeStatus(chartConfig: RawSqlChartConfig): {
+  isTimeSeries: boolean;
+  hasInterval: boolean;
+  hasTimeFilter: boolean;
+} | null {
+  try {
+    if (!isRawSqlSavedChartConfig(chartConfig)) {
+      return null;
+    }
+
+    const sql = replaceMacros(chartConfig);
+
+    return {
+      isTimeSeries: isTimeSeriesDisplayType(chartConfig.displayType),
+      hasInterval:
+        sql.includes(
+          QUERY_PARAMS[RawSqlQueryParam.intervalMilliseconds].name,
+        ) || sql.includes(QUERY_PARAMS[RawSqlQueryParam.intervalSeconds].name),
+      hasTimeFilter:
+        sql.includes(
+          QUERY_PARAMS[RawSqlQueryParam.startDateMilliseconds].name,
+        ) &&
+        sql.includes(QUERY_PARAMS[RawSqlQueryParam.endDateMilliseconds].name),
+    };
+  } catch {
+    // replaceMacros will often fail as users type in the SQL template
+    return null;
+  }
+}
+
 export function validateRawSqlForAlert(chartConfig: RawSqlChartConfig): {
   errors: string[];
   warnings: string[];
@@ -1340,47 +1384,114 @@ export function validateRawSqlForAlert(chartConfig: RawSqlChartConfig): {
   const errors: string[] = [];
   const warnings: string[] = [];
 
-  try {
-    if (!isRawSqlSavedChartConfig(chartConfig)) {
-      return { errors, warnings };
-    }
+  if (!isRawSqlSavedChartConfig(chartConfig)) {
+    return { errors, warnings };
+  }
 
-    if (!displayTypeSupportsRawSqlAlerts(chartConfig.displayType)) {
+  if (!displayTypeSupportsRawSqlAlerts(chartConfig.displayType)) {
+    errors.push(
+      `Display type ${chartConfig.displayType} does not support raw SQL alerts.`,
+    );
+  }
+
+  const status = getRawSqlTimeRangeStatus(chartConfig);
+  if (status) {
+    // Interval params are only required for time-series display types (Line, StackedBar).
+    // Number charts don't use interval bucketing.
+    if (status.isTimeSeries && !status.hasInterval) {
       errors.push(
-        `Display type ${chartConfig.displayType} does not support raw SQL alerts.`,
+        `SQL used for alerts must include an interval parameter or macro.`,
       );
     }
 
-    const sql = replaceMacros(chartConfig);
-
-    // Interval params are only required for time-series display types (Line, StackedBar).
-    // Number charts don't use interval bucketing.
-    if (isTimeSeriesDisplayType(chartConfig.displayType)) {
-      const hasInterval =
-        sql.includes(
-          QUERY_PARAMS[RawSqlQueryParam.intervalMilliseconds].name,
-        ) || sql.includes(QUERY_PARAMS[RawSqlQueryParam.intervalSeconds].name);
-      if (!hasInterval) {
-        errors.push(
-          `SQL used for alerts must include an interval parameter or macro.`,
-        );
-      }
-    }
-
-    const hasTimeFilter =
-      sql.includes(QUERY_PARAMS[RawSqlQueryParam.startDateMilliseconds].name) &&
-      sql.includes(QUERY_PARAMS[RawSqlQueryParam.endDateMilliseconds].name);
-    if (!hasTimeFilter) {
+    if (!status.hasTimeFilter) {
       warnings.push(
         `SQL used for alerts should include start and end date parameters or macros.`,
       );
     }
+  }
 
-    return { errors, warnings };
-  } catch {
-    // replaceMacros will often fail as users type in the SQL template
+  return { errors, warnings };
+}
+
+/**
+ * General-purpose raw SQL chart validation, surfaced in the chart editor
+ * regardless of whether an alert is configured.
+ */
+export function validateRawSqlChartConfig(
+  chartConfig: RawSqlChartConfig,
+  { isDashboardTile = false }: { isDashboardTile?: boolean } = {},
+): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!isRawSqlSavedChartConfig(chartConfig)) {
     return { errors, warnings };
   }
+
+  try {
+    const status = getRawSqlTimeRangeStatus(chartConfig);
+    if (status) {
+      if (status.isTimeSeries && !status.hasInterval) {
+        errors.push(
+          'SQL must include an interval parameter or macro (e.g. $__interval_s) for this display type.',
+        );
+      }
+
+      if (!status.hasTimeFilter) {
+        warnings.push(
+          'SQL should include start and end date parameters or macros (e.g. $__timeFilter) so this chart respects the selected time range.',
+        );
+      }
+    }
+
+    if (isDashboardTile) {
+      if (!hasMacro(chartConfig.sqlTemplate, 'sourceTable')) {
+        warnings.push(
+          'SQL should include the $__sourceTable macro so this tile queries its configured source.',
+        );
+      }
+      if (!hasMacro(chartConfig.sqlTemplate, 'filters')) {
+        warnings.push(
+          'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+        );
+      }
+    }
+
+    // $__filters/$__sourceTable only resolve correctly once a source is
+    // selected, regardless of dashboard-tile vs. chart-explorer context.
+    if (!chartConfig.from) {
+      const usedMacros = getSourceDependentMacrosUsed(chartConfig.sqlTemplate);
+      if (usedMacros.length > 0) {
+        errors.push(
+          `SQL uses ${usedMacros.map(m => `$__${m}`).join(' and ')} but no source is selected — select a source so ${usedMacros.length > 1 ? 'these macros' : 'this macro'} can resolve correctly.`,
+        );
+      }
+    } else {
+      // A metric type argument is required for a metrics source and
+      // disallowed otherwise — a mismatch here fails at query time.
+      const argCounts = getSourceTableMacroArgCounts(chartConfig.sqlTemplate);
+      const isMetricsSource = !!chartConfig.metricTables;
+
+      if (argCounts.some(count => count > 0) && !isMetricsSource) {
+        errors.push(
+          'SQL uses $__sourceTable(<metricType>) but the selected source is not a metrics source — use a bare $__sourceTable instead.',
+        );
+      }
+
+      if (argCounts.some(count => count === 0) && isMetricsSource) {
+        errors.push(
+          'SQL uses a bare $__sourceTable but the selected source is a metrics source — specify a metric type, e.g. $__sourceTable(gauge).',
+        );
+      }
+    }
+  } catch {
+    // hasMacro/getSourceDependentMacrosUsed throw on malformed macro args
+    // (e.g. an unmatched paren) while the user is still typing; fall back to
+    // whatever errors/warnings were already accumulated rather than crash.
+  }
+
+  return { errors, warnings };
 }
 
 export const isTimeSeriesDisplayType = (

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -244,6 +244,25 @@ export function hasMacro(sql: string, name: string): boolean {
   return findMacros(sql, name).length > 0;
 }
 
+/**
+ * Which of SOURCE_DEPENDENT_MACROS are actually referenced in the given SQL.
+ * Shared by callers that need to warn/error when those macros are used
+ * without a source to resolve them against.
+ */
+export function getSourceDependentMacrosUsed(
+  sqlTemplate: string,
+): (typeof SOURCE_DEPENDENT_MACROS)[number][] {
+  return SOURCE_DEPENDENT_MACROS.filter(macro => hasMacro(sqlTemplate, macro));
+}
+
+/**
+ * Argument count for each `$__sourceTable(...)` usage in the SQL — 0 for a
+ * bare `$__sourceTable`, 1 for `$__sourceTable(<metricType>)`.
+ */
+export function getSourceTableMacroArgCounts(sqlTemplate: string): number[] {
+  return findMacros(sqlTemplate, 'sourceTable').map(match => match.args.length);
+}
+
 function findMacros(input: string, name: string): MacroMatch[] {
   // eslint-disable-next-line security/detect-non-literal-regexp
   const pattern = new RegExp(`\\$__${name}\\b`, 'g');


### PR DESCRIPTION
## Summary

This PR adds additional validation to the Raw SQL Chart Editor. Previously, missing macro / param warnings only included the validations that were applied when an alert was added to the tile. Now we surface various missing macro / para warnings and errors regardless of whether an alert has been added.

### Screenshots or video

<img width="1530" height="809" alt="Screenshot 2026-07-28 at 9 34 26 AM" src="https://github.com/user-attachments/assets/5cc4f388-a386-447c-a9ea-fcad832f03ff" />

### How to test on Vercel preview

- Create a raw SQL chart
- Test various queries missing macros or params required/suggested by the display type.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4887
- Related PRs:
