### PR TITLE
fix(app): stop refetching next page while search query is in an error state

### DIFF
--- a/.changeset/stop-refetch-on-query-error.md
+++ b/.changeset/stop-refetch-on-query-error.md
@@ -1,0 +1,8 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Stop requesting additional search pages while a query is in an error state.
+A failed page (for example a ClickHouse query timeout on a slow time window)
+previously kept `hasNextPage` true, so the table re-issued the failing query and
+stayed in a loading state that hid the error and reported zero results.

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -686,6 +686,7 @@ export const RawLogTable = memo(
           if (
             scrollHeight - scrollTop - clientHeight < FETCH_NEXT_PAGE_PX &&
             !isLoading &&
+            !isError &&
             hasNextPage
           ) {
             // Cancel refetch is important to ensure we wait for the last fetch to finish
@@ -693,7 +694,7 @@ export const RawLogTable = memo(
           }
         }
       },
-      [fetchNextPage, isLoading, hasNextPage],
+      [fetchNextPage, isLoading, isError, hasNextPage],
     );
 
     //a check on mount and after a fetch to see if the table is already scrolled to the bottom and immediately needs to fetch more data
@@ -887,6 +888,7 @@ export const RawLogTable = memo(
         if (
           dedupedRows.length < MAX_SCROLL_FETCH_LINES &&
           !isLoading &&
+          !isError &&
           hasNextPage
         ) {
           fetchNextPage?.({ cancelRefetch: false });
@@ -908,6 +910,7 @@ export const RawLogTable = memo(
       rowVirtualizer,
       scrolledToHighlightedLine,
       isLoading,
+      isError,
       hasNextPage,
     ]);
 

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -221,7 +221,7 @@ describe('RawLogTable', () => {
         />,
       );
 
-      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(await screen.findByTestId('chart-error-state')).toBeTruthy();
       expect(fetchNextPage).not.toHaveBeenCalled();
     });
 
@@ -252,7 +252,7 @@ describe('RawLogTable', () => {
         />,
       );
 
-      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(await screen.findByTestId('chart-error-state')).toBeTruthy();
       expect(fetchNextPage).not.toHaveBeenCalled();
     });
 

--- a/packages/app/src/components/__tests__/DBRowTable.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowTable.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -194,6 +194,81 @@ describe('RawLogTable', () => {
       const headers = container.querySelectorAll('th');
       expect(headers).toHaveLength(2);
       expect((headers[0] as HTMLElement).style.width).not.toBe('250px');
+    });
+  });
+
+  describe('Error state', () => {
+    const paginationProps = {
+      displayedColumns: ['col1'],
+      rows: [] as Record<string, any>[],
+      isLoading: false,
+      dedupRows: false,
+      hasNextPage: true,
+      onRowDetailsClick: () => {},
+      generateRowId: () => mockRowWhereResult,
+      columnTypeMap: new Map(),
+    };
+
+    it('should not request another page while the query is in an error state', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          isError
+          error={new Error('Timeout exceeded')}
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('should still request another page when there is no error', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable {...paginationProps} fetchNextPage={fetchNextPage} />,
+      );
+
+      await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
+    });
+
+    // Looking for a highlighted row that has not been loaded yet also advances
+    // pages. Both auto-advance paths are active in jsdom, so these two cases
+    // pin the highlighted-line guard alongside the scroll one.
+    it('should not look for a highlighted row while the query is in an error state', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          rows={[{ col1: 'value1' }]}
+          highlightedLineId="a-row-that-is-not-loaded"
+          isError
+          error={new Error('Timeout exceeded')}
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      expect(await screen.findByText(/Error loading chart/i)).toBeTruthy();
+      expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('should look for a highlighted row when there is no error', async () => {
+      const fetchNextPage = jest.fn();
+
+      renderWithMantine(
+        <RawLogTable
+          {...paginationProps}
+          rows={[{ col1: 'value1' }]}
+          highlightedLineId="a-row-that-is-not-loaded"
+          fetchNextPage={fetchNextPage}
+        />,
+      );
+
+      await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
     });
   });
 });

--- a/packages/app/src/components/charts/ChartErrorState.tsx
+++ b/packages/app/src/components/charts/ChartErrorState.tsx
@@ -47,6 +47,7 @@ export default function ChartErrorState({
 
   return (
     <div
+      data-testid="chart-error-state"
       className={cx(
         'h-100 w-100 d-flex g-1 flex-column align-items-center text-muted overflow-scroll',
         {


### PR DESCRIPTION
## Summary

When a windowed search has a page that fails (most commonly a ClickHouse `TIMEOUT_EXCEEDED` on a slow window), `RawLogTable` keeps calling `fetchNextPage`. `hasNextPage` is still `true` after a failed page, and neither auto-advance path checks `isError`:

- `fetchMoreOnBottomReached` - guards on `!isLoading && hasNextPage`
- the highlighted-line effect - guards on `!isLoading && hasNextPage`

Each retry flips `isLoading` back to `true`, which re-triggers the effect and re-enters the loading render branch. That branch precedes the `isError && error` branch, so:

1. **The error is never shown.** The table sits on "Searched ... Loading results across ..." with `0 Results`, which is indistinguishable from "no matching data", so users conclude the data is missing.
2. **The failing query is re-issued repeatedly**, amplifying load on ClickHouse.

Measured on a deployment where this happened: a single search over a 1-day range issued 80 queries (63 succeeded, 17 timed out) reading 1.09 billion rows, while the UI reported `0 Results` with no error. The rows being searched for were inside the timed-out windows. Confirmed server-side via `system.query_log` (`exception_code = 159`).

The fix adds `!isError` to both auto-advance guards (and their dependency arrays). Once the failed page stops being retried, `isLoading` settles and the existing `ChartErrorState` renders, so this also fixes the silent-failure UX with no new UI.

### Screenshots or video

No new UI. The only visual change is that the already-existing `ChartErrorState` now becomes reachable in this scenario, instead of the table staying on the loading row indefinitely.

### How to test on Vercel preview

N/A - triggering this requires a query that exceeds `max_execution_time` on a later time window, which is not reproducible against the preview's demo ClickHouse. The behavior is covered by unit tests instead (see below).

### Tests

Added `RawLogTable > Error state` in `DBRowTable.test.tsx`, covering both changed paths:

- `should not request another page while the query is in an error state`
- `should not look for a highlighted row while the query is in an error state`
- plus two control tests asserting normal pagination still fires when there is no error

Both error tests **fail on `main`** (`fetchNextPage` is called despite `isError`) and pass with this change.

Verification run locally: `DBRowTable` 28/28; `DBRowTable` + `useOffsetPaginatedQuery` + `DBTableChart` + `DBTraceWaterfallChart` 110/110; `tsc --noEmit` clean; `eslint` 0 errors; `prettier --check` clean.

### References

- Related: #1404 - same failure mode from a complementary angle: that issue asks for timeout errors not to wipe out already-loaded rows. This PR deliberately does **not** touch the render ordering; it only stops the retry loop, which is what makes the error surface at all when there are zero rows.
- Related: #1403 - also about redundant pagination queries, but for the `LIMIT/OFFSET` path rather than error-driven refetch.
