### PR TITLE
fix: Handle per-connection failures in alerts task without exiting

### DIFF
--- a/.changeset/quiet-ads-sing.md
+++ b/.changeset/quiet-ads-sing.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: Handle per-connection failures in alerts task without exiting

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
@@ -11,6 +11,7 @@ import CheckAlertTask from '@/tasks/checkAlerts';
 import {
   AlertDetails,
   AlertProvider,
+  AlertTask,
   AlertTaskType,
   loadProvider,
 } from '@/tasks/checkAlerts/providers';
@@ -327,6 +328,116 @@ describe('CheckAlertTask', () => {
       expect(mockAlertProvider.getWebhooks).toHaveBeenCalledWith(
         team2Id.toString(),
       );
+    });
+
+    describe('when a connection fails', () => {
+      // The task queue runs batches fire-and-forget, and the worker's global
+      // unhandledRejection handler exits the process, so a single failing
+      // ClickHouse connection must not escape as a rejected promise.
+      let unhandledRejections: unknown[];
+      let onUnhandledRejection: (reason: unknown) => void;
+
+      const buildAlertTask = (
+        connId: string,
+        alertId: string,
+        teamId: mongoose.Types.ObjectId,
+      ) =>
+        ({
+          alerts: [
+            {
+              alert: {
+                id: alertId,
+                team: { _id: teamId },
+                source: AlertSource.SAVED_SEARCH,
+                threshold: 10,
+                thresholdType: AlertThresholdType.ABOVE,
+                interval: '5m',
+                channel: { type: 'webhook', webhookId: 'webhook-123' },
+              },
+              source: {
+                id: 'source-123',
+                from: { databaseName: 'default', tableName: 'otel_logs' },
+                timestampValueExpression: 'Timestamp',
+              },
+              taskType: AlertTaskType.SAVED_SEARCH,
+              previousMap: new Map(),
+            },
+          ],
+          conn: {
+            id: connId,
+            _id: new mongoose.Types.ObjectId(),
+            host: config.CLICKHOUSE_HOST,
+            username: config.CLICKHOUSE_USER,
+            password: config.CLICKHOUSE_PASSWORD,
+            name: '',
+            team: teamId,
+          },
+          now: new Date(),
+        }) as unknown as AlertTask;
+
+      beforeEach(() => {
+        unhandledRejections = [];
+        onUnhandledRejection = reason => unhandledRejections.push(reason);
+        process.on('unhandledRejection', onUnhandledRejection);
+
+        const teamId = new mongoose.Types.ObjectId();
+        mockAlertProvider.getAlertTasks.mockResolvedValue([
+          buildAlertTask('conn-broken', 'alert-broken', teamId),
+          buildAlertTask('conn-healthy', 'alert-healthy', teamId),
+        ]);
+        mockAlertProvider.getWebhooks.mockResolvedValue(new Map());
+        mockAlertProvider.getClickHouseClient.mockImplementation(
+          async (conn: any) => {
+            if (conn.id === 'conn-broken') {
+              throw new Error('connect ECONNREFUSED');
+            }
+            return new ClickhouseClient({});
+          },
+        );
+      });
+
+      afterEach(() => {
+        process.off('unhandledRejection', onUnhandledRejection);
+      });
+
+      it('should not produce an unhandled rejection', async () => {
+        const args: CheckAlertsTaskArgs = { taskName: TaskName.CHECK_ALERTS };
+        const task = new CheckAlertTask(args);
+
+        await task.execute();
+        // Let node emit any rejection that is still without a handler.
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(unhandledRejections).toEqual([]);
+      });
+
+      it('should still evaluate alerts on the healthy connections', async () => {
+        const args: CheckAlertsTaskArgs = { taskName: TaskName.CHECK_ALERTS };
+        const task = new CheckAlertTask(args);
+
+        await task.execute();
+
+        expect(mockProcessAlert).toHaveBeenCalledTimes(1);
+        expect(mockProcessAlert).toHaveBeenCalledWith(
+          expect.any(Date),
+          expect.objectContaining({
+            alert: expect.objectContaining({ id: 'alert-healthy' }),
+          }),
+          expect.any(ClickhouseClient),
+          'conn-healthy',
+          mockAlertProvider,
+          expect.any(Map),
+        );
+      });
+
+      it('should not persist an alert error for the failed batch', async () => {
+        const args: CheckAlertsTaskArgs = { taskName: TaskName.CHECK_ALERTS };
+        const task = new CheckAlertTask(args);
+
+        await task.execute();
+
+        expect(mockAlertProvider.recordAlertErrors).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -84,6 +84,7 @@ import {
   getCounter,
   type OperationOutcome,
   recordOperationOutcome,
+  SpanStatusCode,
 } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
@@ -104,6 +105,10 @@ const alertProcessFailuresCounter = getCounter(
       'Count of alert evaluations that threw an unexpected error during processing.',
   },
 );
+const alertBatchFailuresCounter = getCounter('hyperdx.alerts.batch_failures', {
+  description:
+    'Count of alert batches (one per connection) that failed before their alerts could be evaluated, e.g. a ClickHouse connection failure.',
+});
 
 /**
  * Determine if an alert has group-by behavior.
@@ -1648,19 +1653,24 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
     });
   }
 
+  /**
+   * Schedules every alert in one connection's batch onto the task queue.
+   *
+   * @returns true if the batch was scheduled, false if it failed.
+   */
   async processAlertTask(
     alertTask: AlertTask,
     teamWebhooksById: Map<string, IWebhook>,
-  ) {
-    await tasksTracer.startActiveSpan('processAlertTask', async span => {
-      span.setAttribute(
-        'hyperdx.alerts.team.id',
-        alertTask.conn.team.toString(),
-      );
-      span.setAttribute('hyperdx.alerts.connection.id', alertTask.conn.id);
-      span.setAttribute('hyperdx.alerts.batch.size', alertTask.alerts.length);
-
+  ): Promise<boolean> {
+    return tasksTracer.startActiveSpan('processAlertTask', async span => {
       try {
+        span.setAttribute(
+          'hyperdx.alerts.team.id',
+          alertTask.conn.team.toString(),
+        );
+        span.setAttribute('hyperdx.alerts.connection.id', alertTask.conn.id);
+        span.setAttribute('hyperdx.alerts.batch.size', alertTask.alerts.length);
+
         const { alerts, conn } = alertTask;
         logger.info(
           {
@@ -1686,6 +1696,24 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
             ),
           );
         }
+        return true;
+      } catch (e) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: getErrorMessage(e),
+        });
+        span.recordException(e instanceof Error ? e : new Error(String(e)));
+        alertBatchFailuresCounter.add(1);
+        logger.error(
+          {
+            connectionId: alertTask.conn.id,
+            teamId: alertTask.conn.team.toString(),
+            alertCount: alertTask.alerts.length,
+            error: serializeError(e),
+          },
+          'Failed to process alert batch, skipping its alerts for this cycle',
+        );
+        return false;
       } finally {
         span.end();
       }
@@ -1734,12 +1762,16 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
       `Obtained teams and webhooks for all alertTasks`,
     );
 
+    let failedBatchCount = 0;
     for (const task of alertTasks) {
       const teamWebhooksById =
         teamToWebhooks.get(task.conn.team.toString()) ?? new Map();
-      this.task_queue.add(async () =>
-        this.processAlertTask(task, teamWebhooksById),
-      );
+      this.task_queue.add(async () => {
+        const success = await this.processAlertTask(task, teamWebhooksById);
+        if (!success) {
+          failedBatchCount++;
+        }
+      });
     }
     logger.debug(
       {
@@ -1755,6 +1787,8 @@ export default class CheckAlertTask implements HdxTask<CheckAlertsTaskArgs> {
     logger.info(
       {
         args: this.args,
+        taskCount,
+        failedBatchCount,
       },
       'finished processing all tasks on task_queue',
     );


### PR DESCRIPTION
## Summary

This PR wraps the processAlertTask with a try-catch, to ensure that an unhandled rejection (eg. due to a single ClickHouse createConnection failing) does not cause the alerts task to exit prior to processing alerts on other connections.

The number of failed batches is logged, and counted in `hyperdx.alerts.batch_failures`.

Closes #2744 

### Screenshots or video

Before: process crashed due to bad connection URL:

<img width="1585" height="302" alt="Screenshot 2026-07-29 at 1 10 26 PM" src="https://github.com/user-attachments/assets/51640bb2-89a2-4fc8-87db-80e6fd765ab7" />

After: the batch fails, but other connections continue to run

<img width="1511" height="348" alt="Screenshot 2026-07-29 at 1 12 40 PM" src="https://github.com/user-attachments/assets/2f672373-21a7-4878-a4bc-f1cffa6796bc" />
<img width="1277" height="921" alt="Screenshot 2026-07-29 at 1 13 20 PM" src="https://github.com/user-attachments/assets/4d06eb2f-ac7b-44e0-9ea1-541e181a3c74" />


### How to test

Locally, setup alerts on two connections. Update one connection so that it has an invalid URL (so that the clickhouse connection errors on creation). Observe the alert job logs.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4899
- Related PRs:
