### PR TITLE
feat: Accept source names in addition to IDs in URL Params

### DIFF
--- a/.changeset/all-fields-empty-table-connection-guard.md
+++ b/.changeset/all-fields-empty-table-connection-guard.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Disable invalid autocomplete query while source loads

--- a/.changeset/search-source-name-deeplink.md
+++ b/.changeset/search-source-name-deeplink.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': minor
+---
+
+feat: Accept source names in addition to IDs in URL Params

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -108,6 +108,7 @@ import { TimePicker } from '@/components/TimePicker';
 import { IS_LOCAL_MODE } from '@/config';
 import { useAliasMapFromChartConfig } from '@/hooks/useChartConfig';
 import { useExplainQuery } from '@/hooks/useExplainQuery';
+import { useResolvedSourceParam } from '@/hooks/useResolvedSourceParam';
 import { withAppNav } from '@/layout';
 import {
   useCreateSavedSearch,
@@ -967,7 +968,21 @@ export function DBSearchPage() {
   const paths = window.location.pathname.split('/');
   const savedSearchId = paths.length === 3 ? paths[2] : null;
 
-  const [searchedConfig, setSearchedConfig] = useQueryStates(queryStateMap);
+  const [rawSearchedConfig, setSearchedConfig] = useQueryStates(queryStateMap);
+
+  // `?source=` accepts a source name as well as a source ID. Resolve it to an ID
+  // here. The param is not changed until the user changes the source in the UI.
+  const { source: searchedSource } = useResolvedSourceParam(
+    rawSearchedConfig.source,
+    {
+      kinds: [SourceKind.Log, SourceKind.Trace],
+    },
+  );
+
+  const searchedConfig = useMemo(
+    () => ({ ...rawSearchedConfig, source: searchedSource?.id }),
+    [rawSearchedConfig, searchedSource?.id],
+  );
   const [directTraceId, setDirectTraceId] = useQueryState(
     'traceId',
     parseAsStringEncoded,
@@ -985,10 +1000,6 @@ export function DBSearchPage() {
     'hdx-last-selected-source-id',
     '',
   );
-  const { data: searchedSource } = useSource({
-    id: searchedConfig.source,
-    kinds: [SourceKind.Log, SourceKind.Trace],
-  });
   const directTraceSource =
     directTraceId != null && searchedSource?.kind === SourceKind.Trace
       ? searchedSource
@@ -1057,9 +1068,13 @@ export function DBSearchPage() {
         where: searchedConfig.where || '',
         whereLanguage:
           searchedConfig.whereLanguage ?? getStoredLanguage() ?? 'lucene',
+        // When source is provided in the URL or in the saved search, don't
+        // fallback to the default source.
         source:
           searchedConfig.source ||
-          (savedSearchId || directTraceId ? '' : defaultSourceId),
+          (savedSearchId || directTraceId || rawSearchedConfig.source
+            ? ''
+            : defaultSourceId),
         filters: searchedConfig.filters ?? [],
         orderBy: searchedConfig.orderBy ?? '',
       },
@@ -1138,8 +1153,14 @@ export function DBSearchPage() {
   // been wiped (ex. clicking on the same saved search again)
   useEffect(() => {
     const { source, where, select, whereLanguage, filters } = searchedConfig;
+    // Source is "empty" when it's not present in the URL, not when it cannot be resolved
+    // to an existing source.
     const isSearchConfigEmpty =
-      !source && !where && !select && !whereLanguage && !filters?.length;
+      !rawSearchedConfig.source &&
+      !where &&
+      !select &&
+      !whereLanguage &&
+      !filters?.length;
 
     // Landed on saved search (if we just landed on a searchId route)
     if (
@@ -1177,6 +1198,7 @@ export function DBSearchPage() {
   }, [
     savedSearch,
     searchedConfig,
+    rawSearchedConfig.source,
     setSearchedConfig,
     savedSearchId,
     defaultSourceId,
@@ -1296,6 +1318,26 @@ export function DBSearchPage() {
     // If the user changes the source dropdown, reset the select and orderby fields
     // to match the new source selected
     if (watchedSource !== prevSourceRef.current) {
+      // If the form is just catching up to the source that the search config
+      // already points at, don't reset the select/orderBy/filters - this is just
+      // a resolution from a source name to its ID, not a user-initiated change.
+      // Saved searches are excluded: on `/search/<savedSearchId>` the source is
+      // written to the URL by the saved-search effect, so the form converging on
+      // it is the normal load path, and the body below is what re-applies the
+      // saved search's own select/orderBy.
+      if (
+        savedSearchId == null &&
+        watchedSource &&
+        watchedSource === searchedSource?.id
+      ) {
+        prevSourceRef.current = watchedSource;
+        if (rawSearchedConfig.source !== watchedSource) {
+          // Partial update — the other search params are left as they are.
+          setSearchedConfig({ source: watchedSource });
+        }
+        return;
+      }
+
       prevSourceRef.current = watchedSource;
       const newInputSourceObj = inputSourceObjs?.find(
         s => s.id === watchedSource,
@@ -1331,6 +1373,9 @@ export function DBSearchPage() {
     inputSourceObjs,
     setLastSelectedSourceId,
     debouncedSubmit,
+    searchedSource?.id,
+    rawSearchedConfig.source,
+    setSearchedConfig,
   ]);
 
   const retainCompatibleFilters = useStableCallback((columns: ColumnMeta[]) => {

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -1318,18 +1318,15 @@ export function DBSearchPage() {
     // If the user changes the source dropdown, reset the select and orderby fields
     // to match the new source selected
     if (watchedSource !== prevSourceRef.current) {
-      // If the form is just catching up to the source that the search config
-      // already points at, don't reset the select/orderBy/filters - this is just
-      // a resolution from a source name to its ID, not a user-initiated change.
-      // Saved searches are excluded: on `/search/<savedSearchId>` the source is
-      // written to the URL by the saved-search effect, so the form converging on
-      // it is the normal load path, and the body below is what re-applies the
-      // saved search's own select/orderBy.
-      if (
-        savedSearchId == null &&
-        watchedSource &&
-        watchedSource === searchedSource?.id
-      ) {
+      // Whether the form is only catching up to the source the search config
+      // already points at — a source name resolving to its ID, a saved search's
+      // own source arriving, or history navigation — rather than the user
+      // picking a different source. Either way the URL's other params were
+      // chosen deliberately and must not be rewritten.
+      const isCatchingUpToConfig =
+        !!watchedSource && watchedSource === searchedSource?.id;
+
+      if (isCatchingUpToConfig && savedSearchId == null) {
         prevSourceRef.current = watchedSource;
         if (rawSearchedConfig.source !== watchedSource) {
           // Partial update — the other search params are left as they are.
@@ -1346,18 +1343,26 @@ export function DBSearchPage() {
         // Save the selected source ID to localStorage
         setLastSelectedSourceId(newInputSourceObj.id);
 
-        // If the user isn't in a saved search (or the source is different from the saved search source), reset fields
-        if (savedSearchId == null || savedSearch?.source !== watchedSource) {
-          setValue('select', '');
-          setValue('orderBy', '');
-          // Defer filter clearing: wait until the new source's columns load,
-          // then keep filters whose root column exists on the new schema.
-          pendingFilterReconcileRef.current = watchedSource ?? null;
-          // If the user is in a saved search, prefer the saved search's select/orderBy if available
-        } else {
-          setValue('select', savedSearch?.select ?? '');
-          setValue('orderBy', savedSearch?.orderBy ?? '');
-          // Don't clear filters - we're loading from saved search
+        // Only a real user-initiated source change may reset the query fields. On a saved
+        // search route the form also catches up to the source the URL points at
+        // (the saved-search effect writes it), and resetting there would discard
+        // select/orderBy the link carried — e.g. an unsaved tweak that was
+        // bookmarked or refreshed. The submit below still runs, since that is how
+        // a freshly loaded page pushes its defaults into the search config.
+        if (!isCatchingUpToConfig) {
+          // If the user isn't in a saved search (or the source is different from the saved search source), reset fields
+          if (savedSearchId == null || savedSearch?.source !== watchedSource) {
+            setValue('select', '');
+            setValue('orderBy', '');
+            // Defer filter clearing: wait until the new source's columns load,
+            // then keep filters whose root column exists on the new schema.
+            pendingFilterReconcileRef.current = watchedSource ?? null;
+            // If the user is in a saved search, prefer the saved search's select/orderBy if available
+          } else {
+            setValue('select', savedSearch?.select ?? '');
+            setValue('orderBy', savedSearch?.orderBy ?? '');
+            // Don't clear filters - we're loading from saved search
+          }
         }
         // Push the new source to URL/searchedConfig so the chart re-queries.
         // Debounced so a later filter reconcile (which also submits) collapses

--- a/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
@@ -524,29 +524,41 @@ describe('DBSearchPage direct trace flow', () => {
     );
   });
 
-  it('does not skip the source-change effect on a saved search route', async () => {
+  it('submits on a saved search route without discarding the config the link carried', async () => {
     // On `/search/<savedSearchId>` the source is written to the URL by the
-    // saved-search effect, and the source-change effect is what re-applies the
-    // saved search's own select/orderBy. Treating the form catching up as a
-    // no-op there stops that from happening (HDX saved-search SELECT tests).
+    // saved-search effect, so the form catches up to it on a cold load. The
+    // submit still has to run — that is how a freshly loaded page pushes its
+    // defaults into the search config — but it must not clear `select`, which a
+    // bookmarked or refreshed link may carry (e.g. an unsaved tweak).
     mockDirectTraceId = null;
     mockSourcesLoading = true;
     mockSearchedConfig = {
       source: 'log-source',
       where: '',
-      select: 'Timestamp, Body',
+      select: 'Timestamp, Body, lower(Body) as body_lower',
       whereLanguage: undefined,
       filters: [],
-      orderBy: '',
+      orderBy: 'Timestamp DESC',
     };
-    window.history.pushState({}, '', '/search/saved-1?source=log-source');
+    window.history.pushState(
+      {},
+      '',
+      '/search/saved-1?source=log-source&select=Timestamp%2C%20Body%2C%20lower(Body)%20as%20body_lower&orderBy=Timestamp%20DESC',
+    );
 
     await renderThroughSourceLoad();
 
-    // The full config is submitted (the effect body ran), not the
-    // `{ source }`-only canonicalization used for plain deeplinks.
     expect(mockSetSearchedConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'log-source', where: '' }),
+      expect.objectContaining({
+        source: 'log-source',
+        select: 'Timestamp, Body, lower(Body) as body_lower',
+        orderBy: 'Timestamp DESC',
+      }),
     );
+    // Nothing may land that empties them.
+    for (const [config] of mockSetSearchedConfig.mock.calls) {
+      expect(config).not.toMatchObject({ select: '' });
+      expect(config).not.toMatchObject({ orderBy: '' });
+    }
   });
 });

--- a/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SourceKind } from '@hyperdx/common-utils/dist/types';
-import { screen, waitFor } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import { DBSearchPage } from '@/DBSearchPage';
 
@@ -15,6 +16,9 @@ const mockOnTimeRangeSelect = jest.fn();
 let mockDirectTraceId: string | null = null;
 let mockSearchedConfig: Record<string, any> = {};
 let mockSources: any[] = [];
+// When true, useSources() reports the list as still loading, so tests can
+// exercise what the page does before and after the source list arrives.
+let mockSourcesLoading = false;
 let latestDirectTracePanelProps: Record<string, any> | null = null;
 
 jest.mock('@/layout', () => ({
@@ -76,11 +80,13 @@ jest.mock('@/source', () => ({
   getEventBody: () => 'Body',
   getFirstTimestampValueExpression: () => 'Timestamp',
   useSources: () => ({
-    data: mockSources,
+    data: mockSourcesLoading ? undefined : mockSources,
   }),
   useSource: ({ id }: { id?: string | null }) => ({
-    data: mockSources.find(source => source.id === id),
-    isLoading: false,
+    data: mockSourcesLoading
+      ? undefined
+      : mockSources.find(source => source.id === id),
+    isLoading: mockSourcesLoading,
   }),
 }));
 
@@ -256,6 +262,7 @@ describe('DBSearchPage direct trace flow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     latestDirectTracePanelProps = null;
+    mockSourcesLoading = false;
     mockDirectTraceId = 'trace-123';
     mockSearchedConfig = {
       source: undefined,
@@ -379,5 +386,167 @@ describe('DBSearchPage direct trace flow', () => {
     screen.getByText('close-trace').click();
 
     expect(mockSetDirectTraceId).toHaveBeenCalledWith(null);
+  });
+
+  it('resolves a source *name* in the source param to its id', async () => {
+    mockSearchedConfig = {
+      ...mockSearchedConfig,
+      source: 'Trace Source',
+    };
+    window.history.pushState(
+      {},
+      '',
+      '/search?traceId=trace-123&source=Trace%20Source',
+    );
+
+    renderWithMantine(<DBSearchPage />);
+
+    // The direct trace filter only applies once the param resolves to a real
+    // trace source, so this asserts the name was resolved to its id.
+    await waitFor(() => {
+      expect(mockSetSearchedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'trace-source',
+          where: "TraceId = 'trace-123'",
+          whereLanguage: 'sql',
+        }),
+      );
+    });
+  });
+
+  // Renders through the source-list load so the form's `source` value goes from
+  // empty to the resolved ID, the way a cold page load does. A wrapper (rather
+  // than renderWithMantine) is used so `rerender` keeps the provider tree, and
+  // with it the page's own state and refs.
+  async function renderThroughSourceLoad() {
+    jest.useFakeTimers();
+    const { rerender } = render(<DBSearchPage />, {
+      wrapper: ({ children }) => <MantineProvider>{children}</MantineProvider>,
+    });
+
+    mockSourcesLoading = false;
+    await act(async () => {
+      rerender(<DBSearchPage />);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+    jest.useRealTimers();
+  }
+
+  it('canonicalizes a source name to its id without touching the rest of the config', async () => {
+    mockDirectTraceId = null;
+    mockSourcesLoading = true;
+    mockSearchedConfig = {
+      source: 'Log Source',
+      where: '',
+      select: 'Timestamp, Body',
+      whereLanguage: undefined,
+      filters: [],
+      orderBy: '',
+    };
+    window.history.pushState(
+      {},
+      '',
+      '/search?source=Log%20Source&select=Timestamp%2C%20Body',
+    );
+
+    await renderThroughSourceLoad();
+
+    // The name is replaced by its id, and nothing else: a source-switch would
+    // have cleared select/orderBy/filters and submitted the whole config.
+    expect(mockSetSearchedConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetSearchedConfig).toHaveBeenCalledWith({
+      source: 'log-source',
+    });
+  });
+
+  it('leaves the config alone when the param is already a source id', async () => {
+    mockDirectTraceId = null;
+    mockSourcesLoading = true;
+    mockSearchedConfig = {
+      source: 'log-source',
+      where: '',
+      select: 'Timestamp, Body',
+      whereLanguage: undefined,
+      filters: [],
+      orderBy: '',
+    };
+    window.history.pushState(
+      {},
+      '',
+      '/search?source=log-source&select=Timestamp%2C%20Body',
+    );
+
+    await renderThroughSourceLoad();
+
+    expect(mockSetSearchedConfig).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unresolvable source param alone instead of picking a default', async () => {
+    mockDirectTraceId = null;
+    mockSourcesLoading = true;
+    mockSearchedConfig = {
+      source: 'Deleted Source',
+      where: '',
+      select: '',
+      whereLanguage: undefined,
+      filters: [],
+      orderBy: '',
+    };
+    window.history.pushState({}, '', '/search?source=Deleted%20Source');
+
+    await renderThroughSourceLoad();
+
+    // Neither the default-source effect nor the form fallback may overwrite a
+    // link whose source no longer exists — the user gets a notification and an
+    // empty source picker instead.
+    expect(mockSetSearchedConfig).not.toHaveBeenCalled();
+  });
+
+  it('still selects a default source when there is no source param', async () => {
+    mockDirectTraceId = null;
+    mockSourcesLoading = true;
+    mockSearchedConfig = {
+      source: null,
+      where: '',
+      select: '',
+      whereLanguage: undefined,
+      filters: [],
+      orderBy: '',
+    };
+    window.history.pushState({}, '', '/search');
+
+    await renderThroughSourceLoad();
+
+    expect(mockSetSearchedConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'trace-source' }),
+    );
+  });
+
+  it('does not skip the source-change effect on a saved search route', async () => {
+    // On `/search/<savedSearchId>` the source is written to the URL by the
+    // saved-search effect, and the source-change effect is what re-applies the
+    // saved search's own select/orderBy. Treating the form catching up as a
+    // no-op there stops that from happening (HDX saved-search SELECT tests).
+    mockDirectTraceId = null;
+    mockSourcesLoading = true;
+    mockSearchedConfig = {
+      source: 'log-source',
+      where: '',
+      select: 'Timestamp, Body',
+      whereLanguage: undefined,
+      filters: [],
+      orderBy: '',
+    };
+    window.history.pushState({}, '', '/search/saved-1?source=log-source');
+
+    await renderThroughSourceLoad();
+
+    // The full config is submitted (the effect body ran), not the
+    // `{ source }`-only canonicalization used for plain deeplinks.
+    expect(mockSetSearchedConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'log-source', where: '' }),
+    );
   });
 });

--- a/packages/app/src/hooks/__tests__/useMetadata.test.tsx
+++ b/packages/app/src/hooks/__tests__/useMetadata.test.tsx
@@ -404,6 +404,67 @@ describe('useMultipleAllFields', () => {
 
     expect(result.current.data).toEqual(fieldsA);
   });
+
+  // `tcFromSource` returns an all-empty-strings connection (never undefined)
+  // while the source is still loading, so an unpopulated connection must never
+  // reach `getAllFields` — it would issue `DESCRIBE .` with no connection id.
+  it('should not fetch for an unpopulated table connection', async () => {
+    const getAllFields = jest.spyOn(mockMetadata, 'getAllFields');
+
+    const { result } = renderHook(
+      () =>
+        useMultipleAllFields([
+          { databaseName: '', tableName: '', connectionId: '' },
+        ]),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    expect(getAllFields).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch for an unpopulated table connection even when the caller passes enabled: true', async () => {
+    const getAllFields = jest.spyOn(mockMetadata, 'getAllFields');
+
+    const { result } = renderHook(
+      () =>
+        useMultipleAllFields(
+          [{ databaseName: '', tableName: '', connectionId: '' }],
+          { enabled: true },
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    expect(getAllFields).not.toHaveBeenCalled();
+  });
+
+  it('should still honor a caller opting out with enabled: false', async () => {
+    const getAllFields = jest
+      .spyOn(mockMetadata, 'getAllFields')
+      .mockResolvedValue(fieldsA);
+
+    const { result } = renderHook(
+      () => useMultipleAllFields([tcA], { enabled: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    expect(getAllFields).not.toHaveBeenCalled();
+  });
+
+  it('should fetch a populated table connection when the caller passes enabled: true', async () => {
+    jest.spyOn(mockMetadata, 'getAllFields').mockResolvedValueOnce(fieldsA);
+
+    const { result } = renderHook(
+      () => useMultipleAllFields([tcA], { enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(fieldsA);
+  });
 });
 
 describe('deduplicate2dArray', () => {

--- a/packages/app/src/hooks/__tests__/useResolvedSourceParam.test.tsx
+++ b/packages/app/src/hooks/__tests__/useResolvedSourceParam.test.tsx
@@ -1,0 +1,166 @@
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import { notifications } from '@mantine/notifications';
+import { renderHook } from '@testing-library/react';
+
+import { useResolvedSourceParam } from '@/hooks/useResolvedSourceParam';
+import { useSources } from '@/source';
+
+jest.mock('@mantine/notifications', () => ({
+  notifications: { show: jest.fn() },
+}));
+
+jest.mock('@/source', () => ({
+  useSources: jest.fn(),
+}));
+
+const mockUseSources = jest.mocked(useSources);
+
+const LOGS = { id: 'log-1', name: 'E2E Logs', kind: SourceKind.Log };
+const OTHER_LOGS = { id: 'log-2', name: 'E2E Logs', kind: SourceKind.Log };
+const TRACES = { id: 'trace-1', name: 'E2E Traces', kind: SourceKind.Trace };
+
+function mockSources(sources: unknown[] | undefined) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  mockUseSources.mockReturnValue({ data: sources } as ReturnType<
+    typeof useSources
+  >);
+}
+
+describe('useResolvedSourceParam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves nothing while sources are loading, then resolves the name', () => {
+    mockSources(undefined);
+    const { result, rerender } = renderHook(() =>
+      useResolvedSourceParam('E2E Logs', { kinds: [SourceKind.Log] }),
+    );
+    expect(result.current.source).toBeUndefined();
+
+    mockSources([LOGS, TRACES]);
+    rerender();
+    expect(result.current.source).toBe(LOGS);
+    expect(notifications.show).not.toHaveBeenCalled();
+  });
+
+  it('resolves an ID param directly', () => {
+    mockSources([LOGS, TRACES]);
+    const { result } = renderHook(() => useResolvedSourceParam('trace-1'));
+    expect(result.current.source).toBe(TRACES);
+    expect(notifications.show).not.toHaveBeenCalled();
+  });
+
+  it('warns once when several sources share the matched name', () => {
+    mockSources([LOGS, OTHER_LOGS]);
+    const { result, rerender } = renderHook(() =>
+      useResolvedSourceParam('E2E Logs', { kinds: [SourceKind.Log] }),
+    );
+
+    expect(result.current.source).toBe(LOGS);
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+    expect(notifications.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'ambiguous-source-name-E2E Logs',
+        color: 'yellow',
+      }),
+    );
+
+    rerender();
+    // A background refetch of ['sources'] hands back a new array with equal
+    // contents — the warning must not fire again.
+    mockSources([{ ...LOGS }, { ...OTHER_LOGS }]);
+    rerender();
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves no source for a name of the wrong kind', () => {
+    mockSources([LOGS, TRACES]);
+    const { result } = renderHook(() =>
+      useResolvedSourceParam('E2E Traces', { kinds: [SourceKind.Log] }),
+    );
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it('warns once when the param matches no source', () => {
+    mockSources([LOGS, TRACES]);
+    const { rerender } = renderHook(() =>
+      useResolvedSourceParam('Deleted Logs', { kinds: [SourceKind.Log] }),
+    );
+
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+    expect(notifications.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'source-param-unresolved-Deleted Logs',
+        color: 'yellow',
+        title: 'Source not found',
+      }),
+    );
+
+    rerender();
+    mockSources([{ ...LOGS }, { ...TRACES }]);
+    rerender();
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('says so when the param names a source of the wrong kind', () => {
+    mockSources([LOGS, TRACES]);
+    renderHook(() =>
+      useResolvedSourceParam('trace-1', { kinds: [SourceKind.Log] }),
+    );
+
+    expect(notifications.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'source-param-unresolved-trace-1',
+        title: "Source can't be used here",
+        message: expect.stringContaining('trace source'),
+      }),
+    );
+  });
+
+  it('stays quiet about an unresolved param while sources are loading', () => {
+    mockSources(undefined);
+    const { rerender } = renderHook(() =>
+      useResolvedSourceParam('Deleted Logs', { kinds: [SourceKind.Log] }),
+    );
+    expect(notifications.show).not.toHaveBeenCalled();
+
+    // ...and only warns once the list has actually arrived.
+    mockSources([LOGS, TRACES]);
+    rerender();
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet when there is no param at all', () => {
+    mockSources([LOGS, TRACES]);
+    renderHook(() => useResolvedSourceParam(null, { kinds: [SourceKind.Log] }));
+    renderHook(() => useResolvedSourceParam('', { kinds: [SourceKind.Log] }));
+    expect(notifications.show).not.toHaveBeenCalled();
+  });
+
+  it('resolves no source for a wrong-kind ID', () => {
+    // Parity with useSource's select, so the caller's own fallback applies.
+    mockSources([LOGS, TRACES]);
+    const { result } = renderHook(() =>
+      useResolvedSourceParam('trace-1', { kinds: [SourceKind.Log] }),
+    );
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it('resolves no source for an unknown value', () => {
+    mockSources([LOGS, TRACES]);
+    const { result } = renderHook(() => useResolvedSourceParam('nope'));
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it('keeps a stable return across re-renders so callers can use it as a dep', () => {
+    mockSources([LOGS, TRACES]);
+    const { result, rerender } = renderHook(() =>
+      useResolvedSourceParam('E2E Logs', { kinds: [SourceKind.Log] }),
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+    expect(result.current.source).toBe(LOGS);
+  });
+});

--- a/packages/app/src/hooks/useMetadata.tsx
+++ b/packages/app/src/hooks/useMetadata.tsx
@@ -233,8 +233,13 @@ export function useMultipleAllFields(
 ) {
   const metadata = useMetadataWithSettings();
   const { data: me, isFetched } = api.useMe();
-  const { dateRange, timestampValueExpression, intersect, ...queryOptions } =
-    options ?? {};
+  const {
+    dateRange,
+    timestampValueExpression,
+    intersect,
+    enabled: enabledOption = true,
+    ...queryOptions
+  } = options ?? {};
   return useQuery<Field[]>({
     queryKey: [
       'useMetadata.useMultipleAllFields',
@@ -273,13 +278,14 @@ export function useMultipleAllFields(
         ? intersect2dArray<Field>(fields2d)
         : deduplicate2dArray<Field>(fields2d);
     },
+    ...queryOptions,
     enabled:
+      enabledOption &&
       tableConnections.length > 0 &&
       tableConnections.every(
         tc => !!tc.databaseName && !!tc.tableName && !!tc.connectionId,
       ) &&
       isFetched,
-    ...queryOptions,
   });
 }
 

--- a/packages/app/src/hooks/useResolvedSourceParam.ts
+++ b/packages/app/src/hooks/useResolvedSourceParam.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo } from 'react';
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import { notifications } from '@mantine/notifications';
+
+import { useSources } from '@/source';
+import { resolveSourceParam } from '@/utils/sourceParams';
+
+export type ResolvedSourceParam<T extends TSource = TSource> = {
+  source: T | undefined;
+};
+
+/**
+ * Resolves a page-level source query param that may hold either a source ID
+ * (what the app emits) or a source name, and returns the matched source.
+ *
+ * The hook does not modify the URL. Existing ID-based links are unaffected: IDs
+ * are matched before names.
+ *
+ * Source names which do not match exactly one source are reported via a
+ * Mantine warning notification.
+ */
+export function useResolvedSourceParam<K extends SourceKind>(
+  param: string | null | undefined,
+  opts: { kinds: K[] },
+): ResolvedSourceParam<Extract<TSource, { kind: K }>>;
+export function useResolvedSourceParam(
+  param: string | null | undefined,
+  opts?: { kinds?: SourceKind[] },
+): ResolvedSourceParam;
+
+export function useResolvedSourceParam(
+  paramValue: string | null | undefined,
+  { kinds }: { kinds?: SourceKind[] } = {},
+) {
+  const { data: sources } = useSources();
+  const resolution = resolveSourceParam(paramValue, sources, { kinds });
+
+  const resolvedSource =
+    resolution.status === 'resolved' ? resolution.source : undefined;
+  const ambiguousMatchCount =
+    resolution.status === 'resolved'
+      ? resolution.ambiguousMatchCount
+      : undefined;
+  const ambiguousName =
+    ambiguousMatchCount != null ? resolvedSource?.name : undefined;
+  const unresolvedParamValue =
+    resolution.status === 'not-found' || resolution.status === 'wrong-kind'
+      ? paramValue
+      : undefined;
+  const wrongKindMatch =
+    resolution.status === 'wrong-kind' ? resolution.source.kind : undefined;
+
+  // Warn when the param matches more than one source by name, and the first match is being used.
+  useEffect(() => {
+    if (ambiguousName == null || ambiguousMatchCount == null) return;
+    notifications.show({
+      id: 'ambiguous-source-name-' + ambiguousName,
+      color: 'yellow',
+      title: 'Multiple sources share this name',
+      message: `${ambiguousMatchCount} sources are named "${ambiguousName}". Using the first match — link with the source ID to be unambiguous.`,
+    });
+  }, [ambiguousName, ambiguousMatchCount]);
+
+  // Warn when the param doesn't match a source of the requested kind, or any source at all.
+  useEffect(() => {
+    if (unresolvedParamValue == null) return;
+    notifications.show({
+      id: 'source-param-unresolved-' + unresolvedParamValue,
+      color: 'yellow',
+      title: wrongKindMatch ? "Source can't be used here" : 'Source not found',
+      message: wrongKindMatch
+        ? `"${unresolvedParamValue}" is a ${wrongKindMatch} source, which this page can't show. Pick a source to continue.`
+        : `No source matches "${unresolvedParamValue}". It may have been renamed or deleted — pick a source to continue.`,
+    });
+  }, [unresolvedParamValue, wrongKindMatch]);
+
+  return useMemo(() => ({ source: resolvedSource }), [resolvedSource]);
+}

--- a/packages/app/src/pinnedFilters.ts
+++ b/packages/app/src/pinnedFilters.ts
@@ -32,7 +32,7 @@ export function usePinnedFiltersApi(sourceId: string | null) {
   return useQuery({
     queryKey: pinnedFiltersQueryKey(sourceId),
     queryFn: () => fetchPinnedFilters(sourceId!),
-    enabled: sourceId != null,
+    enabled: !!sourceId,
   });
 }
 

--- a/packages/app/src/utils/__tests__/sourceParams.test.ts
+++ b/packages/app/src/utils/__tests__/sourceParams.test.ts
@@ -1,0 +1,176 @@
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+
+import {
+  resolveSourceParam,
+  SourceForParamResolution,
+} from '@/utils/sourceParams';
+
+const LOGS_1 = { id: 'log-1', name: 'Logs', kind: SourceKind.Log };
+const LOGS_2 = { id: 'log-2', name: 'Logs', kind: SourceKind.Log };
+const TRACES = { id: 'trace-1', name: 'Traces', kind: SourceKind.Trace };
+const OLD_LOGS_DISABLED = {
+  id: 'log-3',
+  name: 'Old Logs',
+  kind: SourceKind.Log,
+  disabled: true,
+};
+// A source whose *ID* collides with another source's name.
+const DECOY = { id: 'Logs', name: 'Decoy', kind: SourceKind.Log };
+
+const SOURCES: SourceForParamResolution[] = [
+  LOGS_1,
+  TRACES,
+  OLD_LOGS_DISABLED,
+  DECOY,
+];
+
+describe('resolveSourceParam', () => {
+  it('reports an empty param', () => {
+    expect(resolveSourceParam(null, SOURCES)).toEqual({ status: 'empty' });
+    expect(resolveSourceParam(undefined, SOURCES)).toEqual({ status: 'empty' });
+    expect(resolveSourceParam('', SOURCES)).toEqual({ status: 'empty' });
+  });
+
+  it('reports pending while sources are loading', () => {
+    expect(resolveSourceParam('Logs', undefined)).toEqual({
+      status: 'pending',
+    });
+  });
+
+  it('resolves an exact ID match', () => {
+    expect(resolveSourceParam('log-1', SOURCES)).toEqual({
+      status: 'resolved',
+      source: LOGS_1,
+    });
+  });
+
+  it('prefers an ID match over a source of the same kind with that name', () => {
+    // 'Logs' is both DECOY's ID and LOGS_1's name — the ID wins.
+    expect(resolveSourceParam('Logs', SOURCES)).toEqual({
+      status: 'resolved',
+      source: DECOY,
+    });
+  });
+
+  it('ignores a wrong-kind ID entirely, so a usable name still resolves', () => {
+    // The param is a trace source's ID *and* a log source's name; on a log-only
+    // page the trace source is filtered out before matching.
+    const sources = [
+      { id: 'Shared', name: 'Traces', kind: SourceKind.Trace },
+      { id: 'log-9', name: 'Shared', kind: SourceKind.Log },
+    ];
+    expect(
+      resolveSourceParam('Shared', sources, { kinds: [SourceKind.Log] }),
+    ).toEqual({ status: 'resolved', source: sources[1] });
+  });
+
+  it('reports a wrong-kind ID along with the source it found', () => {
+    // The caller needs the source to say "that's a trace source", and the
+    // status keeps it out of the resolved path.
+    expect(
+      resolveSourceParam('trace-1', SOURCES, { kinds: [SourceKind.Log] }),
+    ).toEqual({ status: 'wrong-kind', source: TRACES });
+  });
+
+  it('resolves an exact-case name to its source', () => {
+    expect(resolveSourceParam('Traces', SOURCES)).toEqual({
+      status: 'resolved',
+      source: TRACES,
+    });
+  });
+
+  it('prefers the requested kind, and reports a wrong-kind name match', () => {
+    expect(
+      resolveSourceParam('Traces', SOURCES, { kinds: [SourceKind.Trace] }),
+    ).toEqual({
+      status: 'resolved',
+      source: TRACES,
+    });
+
+    // A name that can only mean a source of another kind reports which source
+    // it found, rather than pretending nothing matches.
+    expect(
+      resolveSourceParam('Traces', SOURCES, { kinds: [SourceKind.Log] }),
+    ).toEqual({ status: 'wrong-kind', source: TRACES });
+  });
+
+  it('resolves a name shared across kinds to the requested kind', () => {
+    const logsAndMetrics = [
+      { id: 'metric-1', name: 'Kubernetes', kind: SourceKind.Metric },
+      { id: 'log-9', name: 'Kubernetes', kind: SourceKind.Log },
+    ];
+    expect(
+      resolveSourceParam('Kubernetes', logsAndMetrics, {
+        kinds: [SourceKind.Log],
+      }),
+    ).toEqual({
+      status: 'resolved',
+      source: logsAndMetrics[1],
+    });
+  });
+
+  it('falls back to a case-insensitive name match', () => {
+    expect(resolveSourceParam('traces', SOURCES)).toEqual({
+      status: 'resolved',
+      source: TRACES,
+    });
+  });
+
+  it('prefers an exact-case match over a case-insensitive one', () => {
+    const sources = [
+      { id: 'log-lower', name: 'logs', kind: SourceKind.Log },
+      LOGS_1,
+    ];
+    expect(resolveSourceParam('Logs', sources)).toEqual({
+      status: 'resolved',
+      source: LOGS_1,
+    });
+  });
+
+  it('reports an unknown param as not found', () => {
+    expect(resolveSourceParam('nope', SOURCES)).toEqual({
+      status: 'not-found',
+    });
+  });
+
+  it('picks the lowest ID and reports ambiguity for duplicate names', () => {
+    expect(resolveSourceParam('Logs', [LOGS_1, LOGS_2, TRACES])).toEqual({
+      status: 'resolved',
+      source: LOGS_1,
+      ambiguousMatchCount: 2,
+    });
+  });
+
+  it('picks the same source for an ambiguous name whatever order sources arrive in', () => {
+    // The API gives no ordering guarantee, so the pick can't depend on it.
+    const forwards = resolveSourceParam('Logs', [LOGS_1, LOGS_2]);
+    const backwards = resolveSourceParam('Logs', [LOGS_2, LOGS_1]);
+    expect(backwards).toEqual(forwards);
+    expect(backwards).toEqual({
+      status: 'resolved',
+      source: LOGS_1,
+      ambiguousMatchCount: 2,
+    });
+  });
+
+  it('does not reorder the array it was given', () => {
+    const sources = [LOGS_2, LOGS_1];
+    resolveSourceParam('Logs', sources);
+    expect(sources).toEqual([LOGS_2, LOGS_1]);
+  });
+
+  it('prefers an enabled source over a disabled one without flagging ambiguity', () => {
+    const sources = [{ ...LOGS_2, disabled: true }, LOGS_1];
+    expect(resolveSourceParam('Logs', sources)).toEqual({
+      status: 'resolved',
+      source: LOGS_1,
+    });
+  });
+
+  it('resolves a name matching only disabled sources', () => {
+    expect(resolveSourceParam('Old Logs', SOURCES)).toEqual({
+      status: 'resolved',
+      source: OLD_LOGS_DISABLED,
+    });
+  });
+});

--- a/packages/app/src/utils/sourceParams.ts
+++ b/packages/app/src/utils/sourceParams.ts
@@ -1,0 +1,108 @@
+import { SourceKind } from '@hyperdx/common-utils/dist/types';
+
+/**
+ * Minimal shape needed to resolve a source param. Structural rather than
+ * `TSource` so callers and tests can pass partial fixtures, matching the
+ * convention of `getDefaultSourceId` in DBSearchPage.
+ */
+export type SourceForParamResolution = {
+  id: string;
+  name: string;
+  kind: SourceKind;
+  disabled?: boolean;
+};
+
+/**
+ * Outcome of resolving a source param. Only `resolved` yields a source; the
+ * other states tell the caller *why* there isn't one, which is what separates
+ * "still loading" (say nothing) from a broken link (warn the user).
+ */
+export type SourceParamResolution<T extends SourceForParamResolution> =
+  /** No param to resolve. */
+  | { status: 'empty' }
+  /** The source list hasn't loaded, so nothing can be concluded yet. */
+  | { status: 'pending' }
+  | {
+      status: 'resolved';
+      source: T;
+      /**
+       * Set only when more than one equally-good source shares the matched
+       * name (IDs are unique, so this can only come from a name).
+       */
+      ambiguousMatchCount?: number;
+    }
+  /** The param identifies a real source, but not one of the requested `kinds`. */
+  | { status: 'wrong-kind'; source: T }
+  /** The param matches no source at all — renamed, deleted, or a typo. */
+  | { status: 'not-found' };
+
+/**
+ * Resolve a page-level `?source=`-style query param that may hold either a
+ * source ID (what the app itself always emits) or a human-written source
+ * *name*, so links can be hand-authored: `/search?source=Production%20Logs`.
+ *
+ * Sources of the wrong `kinds` are never matched — not even by ID. Among the
+ * sources with the correct kind, resolve a source as follows:
+ *   1. no param / empty            -> `empty`
+ *   2. sources not loaded yet      -> `pending`
+ *   3. ID match                    -> `resolved`
+ *   4. exact-case name match       -> `resolved`
+ *   5. case-insensitive name match -> `resolved`
+ *   6. no usable match             -> `wrong-kind` when the param does name a
+ *      source this page can't show, otherwise `not-found`
+ *
+ * When more than one source matches by name, prefer enabled sources and then the
+ * lowest ID, so the same link always resolves to the same source no matter what
+ * order the API returns them in.
+ */
+export function resolveSourceParam<T extends SourceForParamResolution>(
+  paramValue: string | null | undefined,
+  sources: T[] | undefined,
+  { kinds }: { kinds?: SourceKind[] } = {},
+): SourceParamResolution<T> {
+  if (paramValue == null || paramValue === '') return { status: 'empty' };
+  if (sources == null) return { status: 'pending' };
+
+  const lowercasedParam = paramValue.toLowerCase();
+  const sourcesWithValidKind = sources.filter(
+    s => !kinds?.length || kinds.includes(s.kind),
+  );
+
+  const matchedById = sourcesWithValidKind.find(s => s.id === paramValue);
+  if (matchedById) return { status: 'resolved', source: matchedById };
+
+  const exactNameMatches = sourcesWithValidKind.filter(
+    s => s.name === paramValue,
+  );
+  const nameMatches = exactNameMatches.length
+    ? exactNameMatches
+    : sourcesWithValidKind.filter(
+        s => s.name.toLowerCase() === lowercasedParam,
+      );
+
+  if (nameMatches.length === 0) {
+    // Nothing this page can show matches. Separate "there is no such source"
+    // from "it exists but is the wrong kind" so the caller can say which.
+    const unusableMatch = sources.find(
+      s => s.id === paramValue || s.name.toLowerCase() === lowercasedParam,
+    );
+    return unusableMatch
+      ? { status: 'wrong-kind', source: unusableMatch }
+      : { status: 'not-found' };
+  }
+
+  // Prefer enabled sources; a disabled one is picked only when it is all there
+  // is (a disabled source's ID in the URL has always resolved).
+  const enabledMatches = nameMatches.filter(s => !s.disabled);
+  const pool = enabledMatches.length ? enabledMatches : nameMatches;
+  // Sort by ID so an ambiguous name resolves to the same source on every load.
+  const picked = pool.sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+  )[0];
+
+  return {
+    status: 'resolved',
+    source: picked,
+    ...(pool.length > 1 ? { ambiguousMatchCount: pool.length } : {}),
+  };
+}

--- a/packages/app/tests/e2e/features/search/saved-search.spec.ts
+++ b/packages/app/tests/e2e/features/search/saved-search.spec.ts
@@ -339,6 +339,65 @@ test.describe('Saved Search Functionality', () => {
   );
 
   test(
+    'should preserve SELECT and ORDER BY carried in a saved search link loaded cold',
+    {},
+    async ({ page }) => {
+      /**
+       * The other SELECT tests reload `page.url().split('?')[0]`, dropping the
+       * query string — so none of them cover a link whose URL config differs
+       * from what the saved search stores, which is what you have after tweaking
+       * SELECT without saving. A bookmark, a shared link, or a plain browser
+       * refresh keeps that query string, and it has to survive a *cold* load,
+       * where the source list isn't cached and the form's source therefore
+       * arrives a render later than the rest of the config.
+       */
+      const savedSelect = 'Timestamp, Body';
+      const tweakedSelect = 'Timestamp, Body, lower(Body) as body_lower';
+      let linkWithTweak: string;
+
+      await test.step('Create a saved search with a plain SELECT', async () => {
+        await searchPage.setCustomSELECT(savedSelect);
+        await searchPage.submitEmptySearch();
+        await searchPage.openSaveSearchModal();
+        await searchPage.savedSearchModal.saveSearchAndWaitForNavigation(
+          'Cold Load Config Test',
+        );
+      });
+
+      await test.step('Tweak SELECT without saving, so the link differs from the saved search', async () => {
+        await searchPage.setCustomSELECT(tweakedSelect);
+        await searchPage.submitEmptySearch();
+        await searchPage.table.waitForRowsToPopulate(true);
+
+        // Keep the query string: it is the thing under test.
+        linkWithTweak = page.url();
+        expect(new URL(linkWithTweak).searchParams.get('select')).toContain(
+          'lower(Body)',
+        );
+      });
+
+      await test.step('Load that link cold, the way a refresh or a new tab does', async () => {
+        await page.goto(linkWithTweak);
+        await expect(page.getByTestId('search-page')).toBeVisible();
+        await searchPage.table.waitForRowsToPopulate(true);
+        // The page submits on a 1s debounce, so give any rewrite time to land
+        // rather than asserting on the pre-rewrite state.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(2000);
+      });
+
+      await test.step('The tweak survives, in the form and in the URL', async () => {
+        await expect(searchPage.getSELECTEditor()).toContainText(
+          'lower(Body) as body_lower',
+        );
+        expect(new URL(page.url()).searchParams.get('select')).toContain(
+          'lower(Body)',
+        );
+      });
+    },
+  );
+
+  test(
     'should preserve default SELECT when saving a search',
     {},
     async ({ page }) => {

--- a/packages/app/tests/e2e/features/source-name-deeplink.spec.ts
+++ b/packages/app/tests/e2e/features/source-name-deeplink.spec.ts
@@ -1,0 +1,169 @@
+import { Page } from '@playwright/test';
+
+import { SearchPage } from '../page-objects/SearchPage';
+import { getSources } from '../utils/api-helpers';
+import { expect, test } from '../utils/base-test';
+import {
+  DEFAULT_LOGS_SOURCE_NAME,
+  DEFAULT_TRACES_SOURCE_NAME,
+} from '../utils/constants';
+
+/**
+ * `?source=` accepts a source name as well as a source ID so links can be
+ * hand-written. Full-stack only: in local mode the fixture sources use their
+ * name as their ID, so a name param would resolve through the ID path and prove
+ * nothing.
+ */
+/**
+ * Waits for a notification carrying `text`. Call this *before* navigating: these
+ * warnings auto-close, so a slow page load can outlast one that was shown while
+ * `goto` was still resolving.
+ */
+function waitForNotification(page: Page, text: string) {
+  return page
+    .locator('.mantine-Notification-root')
+    .filter({ hasText: text })
+    .waitFor({ state: 'visible', timeout: 15000 });
+}
+
+test.describe('Source name deeplinks', { tag: ['@full-stack'] }, () => {
+  let searchPage: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    searchPage = new SearchPage(page);
+  });
+
+  test('opens search with a source name and canonicalizes it to the id', async ({
+    page,
+  }) => {
+    const logSources = await getSources(page, 'log');
+    const logsSource = logSources.find(
+      (s: { name: string }) => s.name === DEFAULT_LOGS_SOURCE_NAME,
+    );
+    expect(logsSource).toBeDefined();
+
+    await page.goto(
+      `/search?source=${encodeURIComponent(DEFAULT_LOGS_SOURCE_NAME)}&select=Timestamp%2C%20Body&orderBy=Timestamp%20DESC`,
+    );
+
+    await expect(searchPage.currentSource).toHaveValue(
+      DEFAULT_LOGS_SOURCE_NAME,
+      { timeout: 10000 },
+    );
+    await searchPage.table.waitForRowsToPopulate();
+
+    // The name is replaced by the ID it resolves to, and nothing else about the
+    // linked config changes — in particular `select` and `orderBy` survive,
+    // which a source switch would have cleared.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('source'), {
+        timeout: 10000,
+      })
+      .toBe(logsSource.id);
+    const params = new URL(page.url()).searchParams;
+    expect(params.get('select')).toBe('Timestamp, Body');
+    expect(params.get('orderBy')).toBe('Timestamp DESC');
+  });
+
+  test('warns when the source exists but is the wrong kind for this page', async ({
+    page,
+  }) => {
+    const metricSources = await getSources(page, 'metric');
+    const metricSourceId: string = metricSources[0].id;
+
+    // Start watching before navigating: the notification auto-closes after a few
+    // seconds, which a slow page load can outlast.
+    const warning = waitForNotification(page, "Source can't be used here");
+    await page.goto(`/search?source=${metricSourceId}`);
+    await warning;
+
+    await expect(searchPage.currentSource).toHaveValue('');
+  });
+
+  test('resolves a source name on a direct trace link', async ({ page }) => {
+    // `/trace/<id>` forwards its query to /search, so the name has to resolve
+    // there for the trace panel to open.
+    await page.goto(
+      `/trace/trace-0?source=${encodeURIComponent(DEFAULT_TRACES_SOURCE_NAME)}`,
+    );
+
+    await expect(page).toHaveURL(/\/search\?.*traceId=trace-0/, {
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole('dialog').getByText('Trace', { exact: true }),
+    ).toBeVisible({ timeout: 10000 });
+    // The panel's "pick a source" empty states mean the param never resolved.
+    await expect(page.getByText('Select a trace source')).toBeHidden();
+    await expect(page.getByText('Trace source not found')).toBeHidden();
+  });
+
+  test('matches a source name case-insensitively', async ({ page }) => {
+    await page.goto(
+      `/search?source=${encodeURIComponent(DEFAULT_LOGS_SOURCE_NAME.toLowerCase())}`,
+    );
+
+    await expect(searchPage.currentSource).toHaveValue(
+      DEFAULT_LOGS_SOURCE_NAME,
+      { timeout: 10000 },
+    );
+    await searchPage.table.waitForRowsToPopulate();
+  });
+
+  test('warns and selects nothing when the source no longer exists', async ({
+    page,
+  }) => {
+    const warning = waitForNotification(page, 'Source not found');
+    await page.goto('/search?source=Deleted%20Source');
+    await warning;
+
+    // No default source is substituted, and the link is left as the user sent it.
+    await expect(searchPage.currentSource).toHaveValue('');
+    expect(new URL(page.url()).searchParams.get('source')).toBe(
+      'Deleted Source',
+    );
+  });
+
+  test('never requests pinned filters for an unresolved source', async ({
+    page,
+  }) => {
+    // The WHERE/SELECT editors and the filter sidebar fetch pinned filters and
+    // facets by source ID. Until `?source=<name>` resolves, the page's form value
+    // still holds the name, and asking the API for it 400s. Bare /search used to
+    // do the same with an empty source.
+    const failed: string[] = [];
+    page.on('response', res => {
+      if (res.url().includes('pinned-filters') && res.status() >= 400) {
+        failed.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await page.goto(
+      `/search?source=${encodeURIComponent(DEFAULT_LOGS_SOURCE_NAME)}`,
+    );
+    await searchPage.table.waitForRowsToPopulate();
+    expect(failed).toEqual([]);
+
+    await page.goto('/search');
+    await searchPage.table.waitForRowsToPopulate();
+    expect(failed).toEqual([]);
+  });
+
+  test('still opens search with a source id', async ({ page }) => {
+    const logSources = await getSources(page, 'log');
+    const logsSource = logSources.find(
+      (s: { name: string }) => s.name === DEFAULT_LOGS_SOURCE_NAME,
+    );
+    expect(logsSource).toBeDefined();
+    const logsSourceId: string = logsSource.id;
+
+    await page.goto(`/search?source=${logsSourceId}`);
+
+    await expect(searchPage.currentSource).toHaveValue(
+      DEFAULT_LOGS_SOURCE_NAME,
+      { timeout: 10000 },
+    );
+    await searchPage.table.waitForRowsToPopulate();
+    expect(page.url()).toContain(`source=${logsSourceId}`);
+  });
+});


### PR DESCRIPTION
## Summary

This PR updates the /search page to accept `source` URL params that identify a source by name, rather than by ID. This is useful when building links into ClickStack against sources that are provisioned dynamically with known name but no known ID.

The hook can be re-used in the future to extend this functionality to additional pages.

### Screenshots or video

https://github.com/user-attachments/assets/d3f5a785-bd8d-48a7-8b4c-d40590f4a1f9

### How to test on Vercel preview

Replace the `/search?source=` param with the name of a source. Try reloading the page, switching sources, navigating to saved searches, missing sources, duplicate sources (ambiguous), metric sources, and correct opening of sidepanels via deeplinks.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Contributes to HDX-4818
- Related PRs:
