### PR TITLE
fix(chart): improve pinned time-chart tooltip behavior

### DIFF
--- a/.changeset/fix-chart-pinned-tooltip-click-outside.md
+++ b/.changeset/fix-chart-pinned-tooltip-click-outside.md
@@ -2,5 +2,7 @@
 '@hyperdx/app': patch
 ---
 
-Fix the pinned time-chart tooltip: clicking outside the chart now unpins it, and
-the pin always stacks above hover tooltips.
+Fix the time-chart tooltip: clicking outside the chart now unpins the pinned
+tooltip, the pin always stacks above hover tooltips, and a many-series hover
+tooltip is clamped to a bounded height instead of overflowing the chart (pin it
+to scroll through every series).

--- a/.changeset/fix-chart-pinned-tooltip-click-outside.md
+++ b/.changeset/fix-chart-pinned-tooltip-click-outside.md
@@ -2,6 +2,5 @@
 '@hyperdx/app': patch
 ---
 
-Fix the pinned time-chart tooltip: clicking outside the chart now unpins it, the
-pin always stacks above hover tooltips, and a long series list scrolls within a
-bounded height instead of overflowing the chart.
+Fix the pinned time-chart tooltip: clicking outside the chart now unpins it, and
+the pin always stacks above hover tooltips.

--- a/.changeset/fix-chart-pinned-tooltip-click-outside.md
+++ b/.changeset/fix-chart-pinned-tooltip-click-outside.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/app': patch
+---
+
+Fix the pinned time-chart tooltip: clicking outside the chart now unpins it, the
+pin always stacks above hover tooltips, and a long series list scrolls within a
+bounded height instead of overflowing the chart.

--- a/packages/app/src/HDXMultiSeriesTimeChart.tsx
+++ b/packages/app/src/HDXMultiSeriesTimeChart.tsx
@@ -211,7 +211,10 @@ const HDXLineChartTooltip = withErrorBoundary(
 
       return (
         <div style={anchorStyle}>
-          <ChartTooltipContainer header={header}>
+          <ChartTooltipContainer
+            header={header}
+            contentClassName={styles.chartTooltipContentClipped}
+          >
             {/* Copy before sorting: Recharts 3 freezes the payload, so an
                 in-place sort throws "this object has been frozen". */}
             {[...payload]

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -154,7 +154,7 @@ function ChartTooltipOverlay({
     payload.activePayload != null &&
     payload.activePayload.length > 0;
 
-  const popoverZIndex = useChartTooltipZIndex();
+  const popoverZIndex = useChartTooltipZIndex({ pinned: true });
 
   const dropdownRef = useRef<HTMLDivElement | null>(null);
 
@@ -180,6 +180,25 @@ function ChartTooltipOverlay({
     });
     return () => {
       window.removeEventListener('scroll', handleScroll, { capture: true });
+    };
+  }, [isOpen, onDismiss]);
+
+  // Dismiss on outside click. Mantine's closeOnClickOutside misses it because
+  // the chart's recharts onClick calls stopPropagation (see
+  // HDXMultiSeriesTimeChart handleClick); a capture-phase listener sees the
+  // click regardless, ignoring clicks inside the tooltip's own dropdown.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target;
+      if (target instanceof Node && dropdownRef.current?.contains(target)) {
+        return;
+      }
+      onDismiss();
+    };
+    document.addEventListener('mousedown', handleMouseDown, true);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown, true);
     };
   }, [isOpen, onDismiss]);
 

--- a/packages/app/src/components/charts/ChartTooltip.tsx
+++ b/packages/app/src/components/charts/ChartTooltip.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import cx from 'classnames';
 import { ActionIcon, getDefaultZIndex, Group } from '@mantine/core';
 import {
   IconCaretDownFilled,
@@ -213,17 +214,22 @@ export const ChartTooltipContainer = ({
   header,
   children,
   footer,
+  contentClassName,
 }: {
   header?: React.ReactNode;
   children: React.ReactNode;
   /** Bordered block below the content; the pinned tooltip's drill-down actions. */
   footer?: React.ReactNode;
+  /** Extra class on the content wrapper (e.g. the hover tooltip's height clamp). */
+  contentClassName?: string;
 }) => (
   <div className={styles.chartTooltip}>
     {header != null && (
       <div className={styles.chartTooltipHeader}>{header}</div>
     )}
-    <div className={styles.chartTooltipContent}>{children}</div>
+    <div className={cx(styles.chartTooltipContent, contentClassName)}>
+      {children}
+    </div>
     {footer != null && (
       <div className={styles.chartTooltipFooter}>{footer}</div>
     )}

--- a/packages/app/src/components/charts/ChartTooltip.tsx
+++ b/packages/app/src/components/charts/ChartTooltip.tsx
@@ -16,11 +16,13 @@ import styles from '@styles/HDXLineChart.module.scss';
 /**
  * z-index for a body-portaled chart tooltip: above any modal/drawer the chart
  * is in (via ZIndexContext), but never below the default popover layer. Shared
- * so hover and pinned tooltips stack the same way.
+ * so hover and pinned tooltips stack the same way. `pinned` bumps the pin one
+ * layer above the hover tooltip so a hover tooltip never covers it.
  */
-export function useChartTooltipZIndex() {
+export function useChartTooltipZIndex({ pinned = false } = {}) {
   const contextZIndex = useZIndex();
-  return Math.max(getDefaultZIndex('popover'), contextZIndex + 1);
+  const base = Math.max(getDefaultZIndex('popover'), contextZIndex + 1);
+  return pinned ? base + 1 : base;
 }
 
 /**

--- a/packages/app/styles/HDXLineChart.module.scss
+++ b/packages/app/styles/HDXLineChart.module.scss
@@ -59,6 +59,15 @@
   padding: 6px 12px;
 }
 
+// Hover-tooltip only: bound the series list so a many-series bucket can't grow
+// the tooltip past the chart. Uses `hidden`, not `auto`, because the hover
+// tooltip has `pointer-events: none` (its scrollbar would be unreachable) — to
+// see every series, click to pin, where the list scrolls instead.
+.chartTooltipContentClipped {
+  max-height: 200px;
+  overflow: hidden;
+}
+
 .chartTooltipFooter {
   padding: 6px 12px;
   border-top: 1px solid var(--color-border);

--- a/packages/app/styles/HDXLineChart.module.scss
+++ b/packages/app/styles/HDXLineChart.module.scss
@@ -57,11 +57,6 @@
 
 .chartTooltipContent {
   padding: 6px 12px;
-
-  // Bound the series list so a many-series bucket can't grow the tooltip past
-  // the chart. Header/footer are siblings, so only the series list scrolls.
-  max-height: 200px;
-  overflow-y: auto;
 }
 
 .chartTooltipFooter {

--- a/packages/app/styles/HDXLineChart.module.scss
+++ b/packages/app/styles/HDXLineChart.module.scss
@@ -57,6 +57,11 @@
 
 .chartTooltipContent {
   padding: 6px 12px;
+
+  // Bound the series list so a many-series bucket can't grow the tooltip past
+  // the chart. Header/footer are siblings, so only the series list scrolls.
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .chartTooltipFooter {


### PR DESCRIPTION
## Why

The pinned time-chart tooltip had a few rough edges that made it awkward to use:

1. **Clicking outside the chart didn't unpin it** — once pinned, the tooltip would linger. Mantine's `closeOnClickOutside` misses these clicks because the chart's recharts `onClick` calls `stopPropagation` (see `HDXMultiSeriesTimeChart` `handleClick`).
2. **A hover tooltip could cover the pinned one** — both shared the same z-index, so hovering elsewhere on the chart could visually obscure the pin.
3. **A many-series bucket overflowed the chart** — a long series list grew the tooltip unbounded, pushing past the chart boundaries.

## What changed

- **`DBTimeChart.tsx`** — add a capture-phase `mousedown` listener that unpins the tooltip on outside clicks, while ignoring clicks inside the tooltip's own dropdown. The capture phase sees the click regardless of the recharts `stopPropagation`.
- **`ChartTooltip.tsx`** — `useChartTooltipZIndex` now takes a `pinned` option that bumps the pin one layer above the hover tooltip, so a hover tooltip never covers it.
- **`HDXLineChart.module.scss`** — bound the series list to `max-height: 200px` with `overflow-y: auto` so only the series list scrolls; the header/footer are siblings and stay put.

## Testing

Manual verification in the chart tooltip UI. No behavioral test coverage exists for the tooltip overlay today.