### PR TITLE
chore: move usage stats tracking from Scarf to Reo.dev

### DIFF
--- a/.changeset/reo-usage-beacon.md
+++ b/.changeset/reo-usage-beacon.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+chore: move usage stats tracking to Reo.dev

--- a/packages/app/src/components/AppNav/AppNav.tsx
+++ b/packages/app/src/components/AppNav/AppNav.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import Router, { useRouter } from 'next/router';
+import Script from 'next/script';
 import cx from 'classnames';
 import HyperDX from '@hyperdx/browser';
 import { SavedSearchListApiResponse } from '@hyperdx/common-utils/dist/types';
@@ -57,6 +58,15 @@ import styles from './AppNav.module.scss';
 // Expose the same value Next injected at build time; fall back to package.json for dev tooling
 const APP_VERSION =
   process.env.NEXT_PUBLIC_APP_VERSION ?? packageJson.version ?? 'dev';
+
+// Reo.dev client ID for our usage tracking. USAGE_STATS_ENABLED is the opt-out.
+const REO_CLIENT_ID = '38b2e79cdb32fa7';
+
+declare global {
+  interface Window {
+    Reo?: { init: (options: { clientID: string; source?: string }) => void };
+  }
+}
 
 // Navigation link configuration
 type NavLinkConfig = {
@@ -510,10 +520,17 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
             onClickUserPreferences={openUserPreferences}
             logoutUrl={IS_LOCAL_MODE ? null : `/api/logout`}
           />
-          {meData && meData.usageStatsEnabled && (
-            <img
-              referrerPolicy="no-referrer-when-downgrade"
-              src="https://static.scarf.sh/a.png?x-pxid=bbc99c42-7a75-4eee-9fb9-2b161fc4acd6"
+          {meData?.usageStatsEnabled && (
+            <Script
+              id="reo-beacon"
+              strategy="afterInteractive"
+              src={`https://static.reo.dev/${REO_CLIENT_ID}/reo.js`}
+              onLoad={() => {
+                window.Reo?.init({
+                  clientID: REO_CLIENT_ID,
+                  source: 'internal',
+                });
+              }}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

Replaces the Scarf tracking pixel in the app nav footer with the Reo.dev usage beacon, keeping `USAGE_STATS_ENABLED` as the single opt-out — it still gates both this and the server-side reporter in `packages/api/src/tasks/usageStats.ts`, and local mode is unaffected since `api.useMe()` resolves to `null` there. Reo ships a JS SDK rather than an image pixel, so this loads a script from `static.reo.dev` via `next/script`; the stable `id` adds dedupe that the old `<img>` lacked, as that re-rendered along with `AppNav`. Verified in a browser: the beacon loads, `Reo.init` authenticates and sends events to `api.reo.dev`, it fires exactly once across client-side navigation, and with `USAGE_STATS_ENABLED=false` there are zero `reo.dev` requests. 

### How to test on Vercel preview

N/A — no user-visible UI change, and the preview cannot exercise this. The beacon is gated on `meData?.usageStatsEnabled` from `GET /api/me`, and the preview builds run in `LOCAL_MODE` where `api.useMe()` returns `null` (`packages/app/src/api.ts:296-298`), so the beacon never renders there.

### References

- Linear Issue: N/A
- Related PRs: N/A
