### PR TITLE
fix: encode every URL token in a Lucene search, not just the first

### DIFF
--- a/.changeset/lucene-encode-all-url-tokens.md
+++ b/.changeset/lucene-encode-all-url-tokens.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+fix: Encode every `http://`, `https://` and `localhost:<port>` in a search, not
+just the first
+
+A search naming two or more URLs left the later colons unescaped, so Lucene read
+them as field queries. `http://a.com http://b.com` compiled the second URL to
+`http ILIKE '%//b.com%'` — a predicate on a bare `http` identifier rather than a
+search of the log body.

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -450,6 +450,24 @@ describe('CustomSchemaSQLSerializerV2 - json', () => {
       sql: "(NOT (hasToken(lower(Body), lower('red'))) AND NOT (hasToken(lower(Body), lower('blue'))))",
       english: 'NOT event has whole word red AND NOT event has whole word blue',
     },
+    {
+      lucene: 'http://a.com http://b.com',
+      sql: "((hasToken(lower(Body), lower('http')) AND hasToken(lower(Body), lower('a')) AND hasToken(lower(Body), lower('com')) AND (lower(Body) LIKE lower('%http://a.com%'))) AND (hasToken(lower(Body), lower('http')) AND hasToken(lower(Body), lower('b')) AND hasToken(lower(Body), lower('com')) AND (lower(Body) LIKE lower('%http://b.com%'))))",
+      english:
+        'event has whole word http://a.com AND event has whole word http://b.com',
+    },
+    {
+      lucene: 'https://a.com https://b.com',
+      sql: "((hasToken(lower(Body), lower('https')) AND hasToken(lower(Body), lower('a')) AND hasToken(lower(Body), lower('com')) AND (lower(Body) LIKE lower('%https://a.com%'))) AND (hasToken(lower(Body), lower('https')) AND hasToken(lower(Body), lower('b')) AND hasToken(lower(Body), lower('com')) AND (lower(Body) LIKE lower('%https://b.com%'))))",
+      english:
+        'event has whole word https://a.com AND event has whole word https://b.com',
+    },
+    {
+      lucene: 'localhost:3000 localhost:4000',
+      sql: "((hasToken(lower(Body), lower('localhost')) AND hasToken(lower(Body), lower('3000')) AND (lower(Body) LIKE lower('%localhost:3000%'))) AND (hasToken(lower(Body), lower('localhost')) AND hasToken(lower(Body), lower('4000')) AND (lower(Body) LIKE lower('%localhost:4000%'))))",
+      english:
+        'event has whole word localhost:3000 AND event has whole word localhost:4000',
+    },
   ];
 
   it.each(testCases)(

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -32,18 +32,18 @@ const HAS_ALL_TOKENS_CHUNK_SIZE = 50;
 function encodeSpecialTokens(query: string): string {
   return query
     .replace(/\\\\/g, 'HDX_BACKSLASH_LITERAL')
-    .replace('http://', 'http_COLON_//')
-    .replace('https://', 'https_COLON_//')
-    .replace(/localhost:(\d{1,5})/, 'localhost_COLON_$1')
+    .replace(/http:\/\//g, 'http_COLON_//')
+    .replace(/https:\/\//g, 'https_COLON_//')
+    .replace(/localhost:(\d{1,5})/g, 'localhost_COLON_$1')
     .replace(/\\:/g, 'HDX_COLON');
 }
 function decodeSpecialTokens(query: string): string {
   return query
     .replace(/\\"/g, '"')
     .replace(/HDX_BACKSLASH_LITERAL/g, '\\')
-    .replace('http_COLON_//', 'http://')
-    .replace('https_COLON_//', 'https://')
-    .replace(/localhost_COLON_(\d{1,5})/, 'localhost:$1')
+    .replace(/http_COLON_\/\//g, 'http://')
+    .replace(/https_COLON_\/\//g, 'https://')
+    .replace(/localhost_COLON_(\d{1,5})/g, 'localhost:$1')
     .replace(/HDX_COLON/g, ':');
 }
 


### PR DESCRIPTION
## Problem

`encodeSpecialTokens()` in `packages/common-utils/src/queryParser.ts` shields `http://`, `https://` and `localhost:<port>` from the Lucene parser by rewriting their colons. The three URL rules use `String.replace` with a **string-literal** pattern, which replaces only the first match — so only the first URL in a query is protected. The two neighbouring rules in the same chain (`/\\\\/g` and `/\\:/g`) already use global regexes.

Searching for more than one URL is an ordinary thing to do in a log search box, and it currently misbehaves in three distinct ways:

| Search input | Current result | Expected |
|---|---|---|
| `http://a.com http://b.com` | `... AND (http ILIKE '%//b.com%')` — the second URL becomes a predicate on a bare `http` identifier | both URLs searched against `Body` |
| `https://a.com https://b.com` | `... AND (https ILIKE '%//b.com%')` | both URLs searched against `Body` |
| `localhost:3000 localhost:4000` | `... AND (localhost ILIKE '%4000%')` | both searched against `Body` |
| `http://localhost:3000 http://localhost:4000` | **throws** `SyntaxError: ... but ":" found` | parses, both searched |
| `ServiceName:http://a.com AND foo:http://b.com` | **throws** the same `SyntaxError` | parses, both fields matched |
| `http://a.com/http://b.com` | `(http_COLON_//a.com/http ILIKE '%//b.com%')` — the internal sentinel leaks into the generated SQL as an identifier | one body search for the whole string |

So a two-URL search either silently searches the wrong thing, or fails to parse at all.

## Cause

Lucene treats `foo:bar` as a field query. With only the first occurrence encoded, the second URL's `:` survives into `lucene.parse()`, which reads `http:` as a field name. Checking the AST directly for `http://a.com http://b.com`:

```
main:   right: { field: "http",       term: "//b.com" }
branch: right: { field: "<implicit>", term: "http_COLON_//b.com" }
```

`decodeSpecialTokens()` has the mirror-image problem on the way back out.

## Fix

Make the six affected `replace` calls global, matching the two rules already beside them. No other behaviour changes.

## Tests

Three cases added to the existing `CustomSchemaSQLSerializerV2 - json` table in `queryParser.test.ts`, one per token family. The URL-encoding path had no test coverage before this.

Verified the tests actually catch the bug: with the test rows in place and the change to `queryParser.ts` reverted, **6 tests fail** (3 cases × sql + english); with the change restored, **337 pass**.

- `packages/common-utils`: 25 suites / 1576 tests / 58 snapshots pass
- `make ci-unit`: all 5 packages pass
- `make ci-lint`: all 5 packages pass, 0 errors

The `security/detect-object-injection` warnings in `queryParser.ts` are pre-existing and identical on `main`.

## Alternative considered

The URL rules could be dropped in favour of generally escaping `:` unless it follows a known field name, which would also fix `http://a.com/http://b.com` more principledly. That is a much larger change to the query language's behaviour, so this PR keeps the existing sentinel approach and only corrects the replacement scope. Happy to switch if you would rather go that way.

---

This change was AI-assisted, per the AI-Assisted Development section of `CONTRIBUTING.md`. Every result above was executed, not inferred.
