### PR TITLE
fix(api): preserve not-found result when loading dashboards

### DIFF
--- a/.changeset/bright-dashboard-not-found.md
+++ b/.changeset/bright-dashboard-not-found.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+Return a not-found response when updating a missing dashboard.

--- a/packages/api/src/controllers/dashboard.ts
+++ b/packages/api/src/controllers/dashboard.ts
@@ -149,9 +149,13 @@ export async function getDashboard(dashboardId: string, teamId: ObjectId) {
     getDashboardAlertsByTile(teamId, dashboardId),
   ]);
 
+  if (_dashboard == null) {
+    return null;
+  }
+
   return healLegacyDashboardTileColors({
-    ..._dashboard?.toJSON(),
-    tiles: _dashboard?.tiles.map(t => ({
+    ..._dashboard.toJSON(),
+    tiles: _dashboard.tiles.map(t => ({
       ...t,
       config: { ...t.config, alert: alerts[t.id]?.[0] },
     })),

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -216,6 +216,13 @@ describe('dashboard router', () => {
     );
   });
 
+  it('returns 404 when patching a missing dashboard', async () => {
+    await agent
+      .patch(`/dashboards/${new mongoose.Types.ObjectId()}`)
+      .send({ name: 'Missing Dashboard' })
+      .expect(404);
+  });
+
   it('can delete a dashboard', async () => {
     const dashboard = await agent
       .post('/dashboards')


### PR DESCRIPTION
## Summary

`getDashboard` decorated a missing database record into a truthy object, so the existing PATCH not-found guard was skipped and the request ended as a 500.

Return `null` before decorating a missing dashboard, restoring the existing 404 behavior for the route and the controller.

## Testing

- `yarn nx run @hyperdx/api:ci:unit --skip-nx-cache`
- `yarn nx run @hyperdx/api:ci:lint --skip-nx-cache`
- `yarn prettier --check packages/api/src/controllers/dashboard.ts packages/api/src/routers/api/__tests__/dashboard.int.test.ts .changeset/bright-dashboard-not-found.md`
- API dashboard integration regression running locally