### PR TITLE
fix(common-utils): escape LIKE metacharacters in search terms

### DIFF
--- a/.changeset/escape-like-metacharacters-in-search.md
+++ b/.changeset/escape-like-metacharacters-in-search.md
@@ -1,0 +1,10 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+Treat `_` and `%` in a search term as literal characters, not LIKE wildcards
+
+Search terms were interpolated straight into the ILIKE pattern, so ClickHouse
+read their `_` and `%` as wildcards. `ServiceName:user_service` also matched
+`user-service` and `user.service`, and the negated `-ServiceName:user_service`
+dropped those same rows. Token-index lookups still receive the raw term.

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -619,6 +619,50 @@ describe('CustomSchemaSQLSerializerV2 - json', () => {
       expect(sql).toContain("concatWithSeparator(';',Body,Message)");
     });
   });
+
+  describe('LIKE metacharacters in search terms', () => {
+    const escapingCases = [
+      {
+        lucene: 'ServiceName:user_service',
+        sql: "((ServiceName ILIKE '%user\\\\_service%'))",
+      },
+      {
+        lucene: 'ServiceName:100%',
+        sql: "((ServiceName ILIKE '%100\\\\%%'))",
+      },
+      {
+        lucene: '-ServiceName:user_service',
+        sql: "((ServiceName NOT ILIKE '%user\\\\_service%'))",
+      },
+      {
+        lucene: 'LogAttributes.error_code:5_0',
+        sql: "((`LogAttributes`['error_code'] ILIKE '%5\\\\_0%' AND indexHint(mapContains(`LogAttributes`, 'error_code'))))",
+      },
+      {
+        lucene: 'ResourceAttributesJSON.error:a_b',
+        sql: "((toString(`ResourceAttributesJSON`.`error`) ILIKE '%a\\\\_b%'))",
+      },
+      {
+        lucene: 'user_*',
+        sql: "((lower(Body) LIKE lower('user\\\\_%')))",
+      },
+    ];
+
+    it.each(escapingCases)(
+      'escapes wildcards in "$lucene"',
+      async ({ lucene, sql }) => {
+        const builder = new SearchQueryBuilder(lucene, serializer);
+        expect(await builder.build()).toBe(sql);
+      },
+    );
+
+    it('escapes the LIKE fallback but leaves the tokens raw', async () => {
+      const builder = new SearchQueryBuilder('user_service', serializer);
+      expect(await builder.build()).toBe(
+        "((hasToken(lower(Body), lower('user')) AND hasToken(lower(Body), lower('service')) AND (lower(Body) LIKE lower('%user\\\\_service%'))))",
+      );
+    });
+  });
 });
 
 describe('CustomSchemaSQLSerializerV2 - bloom_filter tokens() indices', () => {

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -51,6 +51,11 @@ export function parse(query: string): lucene.AST {
   return lucene.parse(encodeSpecialTokens(query));
 }
 
+/** Escape the LIKE/ILIKE metacharacters `\`, `%` and `_` so a term matches literally */
+function escapeLikePattern(term: string): string {
+  return term.replace(/[\\%_]/g, '\\$&');
+}
+
 function buildMapContains(mapField: string) {
   const path = parseKeyPath(mapField);
   if (path.length < 2) return undefined;
@@ -817,7 +822,7 @@ function renderArrayFieldExpression({
         ])
       : SqlString.format(`${prefix}arrayExists(el -> el[?] ILIKE ?, ?)`, [
           mapKey,
-          `%${term}%`,
+          `%${escapeLikePattern(term)}%`,
           SqlString.raw(column),
         ]);
   }
@@ -836,7 +841,7 @@ function renderArrayFieldExpression({
         ])
       : SqlString.format(
           `${prefix}arrayExists(el -> toString(el.??) ILIKE ?, ?)`,
-          [mapKey, `%${term}%`, SqlString.raw(column)],
+          [mapKey, `%${escapeLikePattern(term)}%`, SqlString.raw(column)],
         );
   }
 
@@ -854,7 +859,7 @@ function renderArrayFieldExpression({
         )
       : SqlString.format(
           `${prefix}arrayExists(el -> ${stringifiedElement} ILIKE ?, ?)`,
-          [`%${term}%`, SqlString.raw(column)],
+          [`%${escapeLikePattern(term)}%`, SqlString.raw(column)],
         );
 }
 
@@ -1399,7 +1404,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     } else if (propertyType === JSDataType.JSON) {
       return SqlString.format(
         `(${columnJSON?.string} ${isNegatedField ? 'NOT ' : ''}ILIKE ?${expressionPostfix})`,
-        [`%${term}%`],
+        [`%${escapeLikePattern(term)}%`],
       );
     }
 
@@ -1421,7 +1426,9 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
           `(lower(?) ${isNegatedField ? 'NOT ' : ''}LIKE lower(?))`,
           [
             SqlString.raw(column),
-            `${prefixWildcard ? '%' : ''}${term}${suffixWildcard ? '%' : ''}`,
+            `${prefixWildcard ? '%' : ''}${escapeLikePattern(term)}${
+              suffixWildcard ? '%' : ''
+            }`,
           ],
         );
       } else if (shouldUseTokenBf) {
@@ -1486,7 +1493,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
               ...hasAllTokensExpressions,
               SqlString.format(`(lower(?) LIKE lower(?))`, [
                 SqlString.raw(column),
-                `%${term}%`,
+                `%${escapeLikePattern(term)}%`,
               ]),
             ].join(' AND ')}${isNegatedField ? ')' : ''})`;
           } else {
@@ -1516,7 +1523,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
               // If there are token separators in the term, try to match the whole term as well
               SqlString.format(`(lower(?) LIKE lower(?))`, [
                 SqlString.raw(column),
-                `%${term}%`,
+                `%${escapeLikePattern(term)}%`,
               ]),
             ].join(' AND ')}${isNegatedField ? ')' : ''})`;
           } else {
@@ -1538,7 +1545,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
             // If there are symbols in the term, try to match the whole term as well
             SqlString.format(`(lower(?) LIKE lower(?))`, [
               SqlString.raw(column),
-              `%${term}%`,
+              `%${escapeLikePattern(term)}%`,
             ]),
           ].join(' AND ')}${isNegatedField ? ')' : ''})`;
         } else {
@@ -1552,7 +1559,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
 
     return SqlString.format(
       `(${column} ${isNegatedField ? 'NOT ' : ''}? ?${expressionPostfix})`,
-      [SqlString.raw('ILIKE'), `%${term}%`],
+      [SqlString.raw('ILIKE'), `%${escapeLikePattern(term)}%`],
     );
   }
 


### PR DESCRIPTION
## Summary

A Lucene field term goes straight into the ILIKE pattern, so ClickHouse reads the term's `_` as any-single-character and its `%` as any-run. `ServiceName:user_service` compiles to `(ServiceName ILIKE '%user_service%')`.

Against a `ServiceName` column holding `user_service`, `user-service`, `user.service`, `billing`, `100% cpu`, `cpu 1000 used` (ClickHouse 26.7):

| Search | Returns | Should return |
| :-- | :-- | :-- |
| `ServiceName:user_service` | user_service, user-service, user.service | user_service |
| `-ServiceName:user_service` | billing, 100% cpu, cpu 1000 used | + user-service, user.service |
| `ServiceName:100%` | 100% cpu, cpu 1000 used | 100% cpu |

The negated form is the worse half — it silently drops rows the user asked to keep. Underscores are common in service names, metric names and attribute keys.

This escapes `\`, `%` and `_` in the LIKE pattern argument at the nine places that build one: the explicit-field ILIKE, the JSON/map/array renderers, the implicit-field `*` branch, and the LIKE fallbacks that sit alongside a token index.

Only the *pattern argument* is escaped. `hasAllTokens()`, `tokens()` and `hasToken()` still get the raw term — escaping the `term` variable instead would emit `hasToken(lower(Body), lower('user\_service'))` and break token search. One test pins that split.

Tests: seven cases in `queryParser.test.ts` — `_`, `%`, the negated form, a map field, a JSON field, the `user_*` wildcard branch, and the token-path/LIKE-fallback split. All seven fail without the source change and pass with it. I also diffed the emitted SQL across 189 metacharacter-free queries before and after: byte-identical.

`packages/common-utils`: 1587 tests passing. `make ci-lint`: 0 errors, warning counts unchanged.

If you'd rather keep `%`/`_` as deliberate user-facing wildcards in field terms, say so and I'll close this — that's a product call.

### Screenshots or video

N/A — non-UI change.

### How to test on Vercel preview

N/A — non-UI change (`packages/common-utils` query compiler).

### References

- Linear Issue: N/A — external contribution, no Linear ticket
- Related PRs: none
