### PR TITLE
fix(common-utils): detect timestamp types that carry a timezone or wrapper

### DIFF
--- a/.changeset/timestamp-type-detection-spellings.md
+++ b/.changeset/timestamp-type-detection-spellings.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+Detect ClickHouse timestamp types that carry a timezone or a type wrapper
+
+`DateTime('UTC')` was not classified as a DateTime, so a source whose timestamp
+column listed both a `Date` partition column and a `DateTime` column bucketed
+charts on the `Date` — collapsing a whole day into one bar at midnight. The time
+filter also only wrapped bounds in `toDate()` for an exact `Date` type, so a
+`Date32` or `Nullable(Date)` column was compared against a DateTime bound and
+lost the whole start day.

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -2281,6 +2281,35 @@ describe('renderChartConfig', () => {
         `(date >= toDate(fromUnixTimestamp64Milli(${dateRange[0].getTime()})) AND date <= toDate(fromUnixTimestamp64Milli(${dateRange[1].getTime()})))`,
       );
     });
+
+    it.each(['Date32', 'Nullable(Date)', 'LowCardinality(Date)'])(
+      'wraps a %s column in toDate() and keeps the bounds inclusive',
+      async type => {
+        mockMetadata.getColumn.mockImplementation(
+          async () => ({ type }) as ColumnMeta,
+        );
+
+        const dateRange: [Date, Date] = [
+          new Date('2025-02-12 03:53:38Z'),
+          new Date('2025-02-12 04:08:38Z'),
+        ];
+
+        const actual = await timeFilterExpr({
+          timestampValueExpression: 'date',
+          dateRangeEndInclusive: false,
+          dateRangeStartInclusive: false,
+          dateRange,
+          connectionId: 'test-connection',
+          databaseName: 'default',
+          tableName: 'target_table',
+          metadata: mockMetadata,
+        });
+
+        expect(parameterizedQueryToSql(actual)).toBe(
+          `(date >= toDate(fromUnixTimestamp64Milli(${dateRange[0].getTime()})) AND date <= toDate(fromUnixTimestamp64Milli(${dateRange[1].getTime()})))`,
+        );
+      },
+    );
   });
 
   it('should not generate invalid SQL when primary key wraps toStartOfInterval', async () => {
@@ -3411,6 +3440,51 @@ describe('renderChartConfig', () => {
       // WHERE clause should still reference both columns for partition pruning.
       expect(sql).toContain('EventDate');
       expect(sql).toContain('EventTime');
+    });
+
+    it('picks the DateTime token when its type carries a timezone', async () => {
+      mockMetadata.getColumn = jest
+        .fn()
+        .mockImplementation(async ({ column }: { column: string }) => {
+          if (column === 'EventDate')
+            return { name: 'EventDate', type: 'Date' };
+          if (column === 'EventTime')
+            return { name: 'EventTime', type: "DateTime('UTC')" };
+          return undefined;
+        });
+
+      const config: ChartConfigWithOptDateRange = {
+        displayType: DisplayType.Line,
+        connection: 'test-connection',
+        from: { databaseName: 'default', tableName: 'logs' },
+        select: [
+          {
+            aggFn: 'count',
+            valueExpression: '',
+            aggCondition: '',
+            aggConditionLanguage: 'sql',
+          },
+        ],
+        where: '',
+        whereLanguage: 'sql',
+        timestampValueExpression: 'EventDate, EventTime',
+        dateRange: [
+          new Date('2026-05-27T00:00:00Z'),
+          new Date('2026-05-27T12:00:00Z'),
+        ],
+        granularity: '1 minute',
+        limit: { limit: 10 },
+      };
+
+      const generated = await renderChartConfig(
+        config,
+        mockMetadata,
+        undefined,
+      );
+      const sql = parameterizedQueryToSql(generated);
+
+      expect(sql).toContain('toStartOfInterval(toDateTime(EventTime),');
+      expect(sql).not.toContain('toStartOfInterval(toDateTime(EventDate),');
     });
 
     it('all-Date input falls back to the first token (and warns)', async () => {

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -2998,6 +2998,34 @@ describe('utils', () => {
       ).toBe('EventTime');
     });
 
+    it('DateTime with an explicit timezone still classifies as DateTime', async () => {
+      const metadata = makeMetadata({
+        EventDate: 'Date',
+        EventTime: "DateTime('UTC')",
+      });
+      expect(
+        await pickBucketTimestampColumn({
+          timestampValueExpression: 'EventDate, EventTime',
+          metadata,
+          ...opts,
+        }),
+      ).toBe('EventTime');
+    });
+
+    it('Nullable(DateTime) with an explicit timezone still classifies as DateTime', async () => {
+      const metadata = makeMetadata({
+        EventDate: 'Date',
+        EventTime: "Nullable(DateTime('Europe/Berlin'))",
+      });
+      expect(
+        await pickBucketTimestampColumn({
+          timestampValueExpression: 'EventDate, EventTime',
+          metadata,
+          ...opts,
+        }),
+      ).toBe('EventTime');
+    });
+
     it('higher DateTime64 precision wins over lower', async () => {
       const metadata = makeMetadata({
         TsMs: 'DateTime64(3)',

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -3,6 +3,7 @@ import * as SQLParser from 'node-sql-parser';
 import SqlString from 'sqlstring';
 
 import { ChSql, chSql, concatChSql, wrapChSqlIfNotEmpty } from '@/clickhouse';
+import { stripTypeWrappers } from '@/core/eventDeltas';
 import {
   GROUP_ALIAS,
   translateExponentialHistogram,
@@ -953,7 +954,9 @@ export async function timeFilterExpr({
         ? chSql`${toStartOf.function}(${rawEndBound}${toStartOf.formattedRemainingArgs})`
         : rawEndBound;
 
-      const isDateType = columnMeta?.type === 'Date' || isToDateExpr;
+      const isDateType =
+        /^Date(?:32)?$/i.test(stripTypeWrappers(columnMeta?.type ?? '')) ||
+        isToDateExpr;
 
       // toStartOf* and Date filters must stay inclusive — strict < on a rounded value drops a whole interval
       const startOp =

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -134,7 +134,8 @@ function classifyTimestampType(type: string | undefined): {
   if (/^Date(?:32)?$/i.test(inner)) {
     return { kind: 'date', precision: -1 };
   }
-  if (/^DateTime$/i.test(inner)) {
+  // DateTime[('<timezone>')]
+  if (/^DateTime$/i.test(inner) || /^DateTime\('[^']*'\)$/i.test(inner)) {
     return { kind: 'datetime', precision: 0 };
   }
   // DateTime64(<precision>[, '<timezone>'])


### PR DESCRIPTION
## Summary

`classifyTimestampType` (`core/utils.ts`) matched `/^DateTime$/` with no timezone group, while its `DateTime64` sibling has one. So a column declared `DateTime('UTC')` — the spelling ClickHouse itself reports in `system.columns` — is not seen as a datetime. With `timestampValueExpression = "EventDate, EventTime"` (a `Date` partition column plus the real timestamp), `pickBucketTimestampColumn` finds no DateTime token and falls back to the first one:

| `EventTime` type | bucket column |
| :--- | :--- |
| `DateTime` | `EventTime` |
| `DateTime('UTC')` | **`EventDate`** |
| `DateTime64(3, 'UTC')` | `EventTime` |
| `Nullable(DateTime('UTC'))` | **`EventDate`** |

A 1-minute Line chart then emits `toStartOfInterval(toDateTime(EventDate), INTERVAL 1 minute)`, so a whole day collapses into one bar at midnight UTC — the HDX-4371 symptom that helper was added to prevent.

Same root cause one call site over, and the narrower half: `timeFilterExpr` used `columnMeta?.type === 'Date'`, an exact match, so a `Date32` or `Nullable(Date)` column skipped the `toDate()` wrapper on the bounds. That is not merely less prunable — on ClickHouse 26.7.1:

```
toDate32('2026-05-27') >= fromUnixTimestamp64Milli(toInt64(1779876000000))         -> 0
toDate32('2026-05-27') >= toDate(fromUnixTimestamp64Milli(toInt64(1779876000000))) -> 1
```

so a same-day range over such a column returns zero rows. `filters.ts` already matches these spellings with word boundaries; only this one site did not. Happy to split it into its own PR if you would rather keep this to the timezone fix.

The fix accepts `DateTime('<tz>')` alongside bare `DateTime`, and runs the type through the existing `stripTypeWrappers` before the `Date`/`Date32` check.

Six regression tests across `utils.test.ts` and `renderChartConfig.test.ts`; I confirmed all six fail with the source change reverted and pass with it. `packages/common-utils` is green (1593 tests) and `make ci-lint` is clean.

### Screenshots or video

N/A — no UI change.

### How to test on Vercel preview

N/A — non-UI change.

### References

- Related: HDX-4371, which added `pickBucketTimestampColumn`
