### PR TITLE
fix(api): key the external API rate limiter on the access key

### DIFF
--- a/.changeset/rate-limit-per-access-key.md
+++ b/.changeset/rate-limit-per-access-key.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/api': patch
+---
+
+Key the external API and MCP rate limiters on the access key, not the raw
+`Authorization` header
+
+`validateUserAccessKey` accepts any text before `Bearer `, so a single access
+key authenticates under unlimited header spellings. The limiter bucketed on the
+header value, so varying that prefix handed each request a fresh quota. Requests
+that carry no usable access key now fall back to the client IP.

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -77,16 +77,16 @@ export function handleAuthError(
   res.redirect(303, `${config.FRONTEND_REDIRECT_BASE}/login?err=${returnErr}`);
 }
 
+export function getAccessKeyFromRequest(req: Request): string | undefined {
+  return req.headers.authorization?.split('Bearer ')[1];
+}
+
 export async function validateUserAccessKey(
   req: Request,
   res: Response,
   next: NextFunction,
 ) {
-  const authHeader = req.headers.authorization;
-  if (!authHeader) {
-    return res.sendStatus(401);
-  }
-  const key = authHeader.split('Bearer ')[1];
+  const key = getAccessKeyFromRequest(req);
   if (!key) {
     return res.sendStatus(401);
   }

--- a/packages/api/src/utils/__tests__/rateLimiter.test.ts
+++ b/packages/api/src/utils/__tests__/rateLimiter.test.ts
@@ -1,0 +1,46 @@
+import express from 'express';
+import request from 'supertest';
+
+import rateLimiter, { rateLimiterKeyGenerator } from '@/utils/rateLimiter';
+
+describe('rateLimiterKeyGenerator', () => {
+  const buildApp = () => {
+    const app = express();
+    app.use(
+      rateLimiter({
+        windowMs: 60 * 1000,
+        max: 2,
+        keyGenerator: rateLimiterKeyGenerator,
+      }),
+      (_req: express.Request, res: express.Response) => res.sendStatus(200),
+    );
+    return app;
+  };
+
+  const get = (app: express.Application, authorization: string) =>
+    request(app).get('/').set('Authorization', authorization);
+
+  it('counts one access key against one bucket whatever precedes Bearer', async () => {
+    const app = buildApp();
+
+    expect((await get(app, 'Bearer key-a')).status).toBe(200);
+    expect((await get(app, 'Bearer key-a')).status).toBe(200);
+    expect((await get(app, 'xBearer key-a')).status).toBe(429);
+  });
+
+  it('gives each access key its own bucket', async () => {
+    const app = buildApp();
+
+    expect((await get(app, 'Bearer key-a')).status).toBe(200);
+    expect((await get(app, 'Bearer key-a')).status).toBe(200);
+    expect((await get(app, 'Bearer key-b')).status).toBe(200);
+  });
+
+  it('falls back to the request IP when the header carries no access key', async () => {
+    const app = buildApp();
+
+    expect((await get(app, 'Basic dXNlcjph')).status).toBe(200);
+    expect((await get(app, 'Basic dXNlcjpi')).status).toBe(200);
+    expect((await get(app, 'Basic dXNlcjpj')).status).toBe(429);
+  });
+});

--- a/packages/api/src/utils/rateLimiter.ts
+++ b/packages/api/src/utils/rateLimiter.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import rateLimit, { Options } from 'express-rate-limit';
 
+import { getAccessKeyFromRequest } from '@/middleware/auth';
+
 export const rateLimiterKeyGenerator = (req: express.Request): string => {
-  return req.headers.authorization ?? req.ip ?? 'unknown';
+  return getAccessKeyFromRequest(req) || req.ip || 'unknown';
 };
 
 export default (config?: Partial<Options>) => {


### PR DESCRIPTION
## Summary

Addresses the first half of #2775.

`validateUserAccessKey` reads the credential as `authHeader.split('Bearer ')[1]`,
so anything before `Bearer ` is ignored — `Bearer K` and `xBearer K` authenticate
as the same key. `rateLimiterKeyGenerator` bucketed on the raw `Authorization`
header, so rotating that prefix handed each request a fresh quota.

Against the real `/api/v2/alerts` limiter (`max: 100`/min), 120 requests carrying
one access key, prefix rotated on the last 20:

| | first 429 at | total 429s |
|---|---|---|
| before | never | 0 |
| after | request 101 | 20 |

The MCP router shares the same generator.

The key generator now derives the credential through the same helper the auth
middleware uses, so the two can't drift again. For authenticated requests this
relabels buckets rather than re-partitioning them: one key still maps to one
bucket. A header with no usable access key now falls back to the client IP
instead of getting its own bucket, which only tightens the limit; those requests
are 401'd by auth anyway, and on the MCP `GET`/`DELETE` handlers they hit the
limiter before any auth at all. I left the `Bearer ` parse itself loose so auth
behaviour is byte-identical; if you'd rather reject `xBearer K` outright I'll
tighten it to a strict prefix match instead.

`packages/api/src/utils/__tests__/rateLimiter.test.ts` pins both directions: a
rotated prefix hits the same bucket, unauthenticated header values share the IP
bucket, and distinct access keys still get distinct buckets. Verified the first
two fail on `main` without the source change and pass with it.

`packages/api` unit suite and `make ci-lint` are green locally. I did not run the
integration suite — the `otel-collector` image won't build in my environment.

The other half of #2775, the missing limiter on `POST /login/password`, is left
out: it needs a policy call on window/limit that I'd rather you make. Happy to
follow up.

### Screenshots or video

N/A — non-UI change.

### How to test on Vercel preview

N/A — non-UI change.

### References

- Linear Issue: N/A — external contribution. GitHub issue: #2775
- Related PRs: none
