### PR TITLE
fix(api): return 404 for missing alert updates

### DIFF
--- a/.changeset/alert-update-not-found.md
+++ b/.changeset/alert-update-not-found.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+Return 404 when updating a missing alert.

--- a/packages/api/src/routers/api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/alerts.int.test.ts
@@ -127,6 +127,55 @@ describe('alerts router', () => {
     expect(allAlerts.body.data[0].threshold).toBe(10);
   });
 
+  it('returns 404 when updating an alert that does not exist', async () => {
+    const dashboard = await agent
+      .post('/dashboards')
+      .send(MOCK_DASHBOARD)
+      .expect(200);
+
+    await agent
+      .put(`/alerts/${randomMongoId()}`)
+      .send(
+        makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+        }),
+      )
+      .expect(404);
+  });
+
+  it("returns 404 when updating another team's alert", async () => {
+    const dashboard = await agent
+      .post('/dashboards')
+      .send(MOCK_DASHBOARD)
+      .expect(200);
+    const otherTeamAlert = await Alert.create({
+      team: randomMongoId(),
+      channel: {
+        type: 'webhook',
+        webhookId: webhook._id.toString(),
+      },
+      interval: '15m',
+      threshold: 8,
+      thresholdType: AlertThresholdType.ABOVE,
+      source: AlertSource.TILE,
+      dashboard: dashboard.body.id,
+      tileId: dashboard.body.tiles[0].id,
+    });
+
+    await agent
+      .put(`/alerts/${otherTeamAlert._id.toString()}`)
+      .send(
+        makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+        }),
+      )
+      .expect(404);
+  });
+
   it('round-trips note through create, update, and clear', async () => {
     const dashboard = await agent
       .post('/dashboards')

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -247,9 +247,11 @@ router.put(
       const { id } = req.params;
       const alertInput = req.body;
       await validateAlertInput(teamId, alertInput);
-      res.json({
-        data: await updateAlert(id, teamId, alertInput),
-      });
+      const alert = await updateAlert(id, teamId, alertInput);
+      if (alert == null) {
+        return res.sendStatus(404);
+      }
+      return res.json({ data: alert });
     } catch (e) {
       next(e);
     }


### PR DESCRIPTION
## Summary

- Return 404 when an internal alert update target is missing.
- Avoid returning 200 with a null alert for missing or cross-team IDs.
- Add regression coverage for both cases.

## Checks

- `yarn workspace @hyperdx/api tsc --noEmit`
- Targeted ESLint
- Prettier check
- `yarn workspace @hyperdx/api build`