### PR TITLE
feat: Hide unsupported aggregate functions for histogram metrics

### DIFF
--- a/.changeset/hide-histogram-agg-fns.md
+++ b/.changeset/hide-histogram-agg-fns.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Hide unsupported aggregation functions for Histogram metrics in the chart builder

--- a/packages/app/src/components/AggFnSelect.tsx
+++ b/packages/app/src/components/AggFnSelect.tsx
@@ -7,6 +7,18 @@ import { AGG_FNS } from '@/ChartUtils';
 
 type AggFnValues = (typeof AGG_FNS)[number]['value'];
 
+// aggFn form values that are supported for histogram metrics.
+export const HISTOGRAM_SUPPORTED_AGG_FNS: string[] = ['count', 'quantile'];
+
+// Displayed versions of the supported aggregation functions for histogram metrics.
+const HISTOGRAM_SUPPORTED_AGG_FNS_DISPLAY: AggFnValues[] = [
+  'count',
+  'p99',
+  'p95',
+  'p90',
+  'p50',
+];
+
 type OnChangeValue =
   | { aggFn?: AggFnValues }
   | { aggFn: 'quantile'; level: number };
@@ -45,6 +57,15 @@ function AggFnSelect({
     // Only show 'increase' when the source is a Sum (counter) metric.
     if (metricType !== MetricsDataType.Sum) {
       opts = opts.filter(fn => fn.value !== 'increase');
+    }
+    // Filter out unsupported aggregation functions for histogram metrics.
+    if (
+      metricType === MetricsDataType.Histogram ||
+      metricType === MetricsDataType.ExponentialHistogram
+    ) {
+      opts = opts.filter(fn =>
+        HISTOGRAM_SUPPORTED_AGG_FNS_DISPLAY.includes(fn.value),
+      );
     }
     return opts;
   }, [hideCustom, metricType]);

--- a/packages/app/src/components/DBEditTimeChartForm/ChartSeriesEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartSeriesEditor.tsx
@@ -32,7 +32,10 @@ import {
 } from '@tabler/icons-react';
 
 import { AGG_FNS } from '@/ChartUtils';
-import { AggFnSelectControlled } from '@/components/AggFnSelect';
+import {
+  AggFnSelectControlled,
+  HISTOGRAM_SUPPORTED_AGG_FNS,
+} from '@/components/AggFnSelect';
 import {
   ChartEditorFormState,
   SavedChartConfigWithSelectArray,
@@ -136,6 +139,21 @@ export function ChartSeriesEditor({
       metricType === MetricsDataType.Sum;
     if (!isSumMetric && aggFn === 'increase') {
       setValue(`${namePrefix}aggFn`, 'sum');
+    }
+  }, [tableSource?.kind, metricType, aggFn, namePrefix, setValue]);
+
+  // Histogram and exponential histogram metrics only support 'count' and
+  // 'quantile' aggregations. Reset any unsupported aggFn to a default, valid one
+  useEffect(() => {
+    const isHistogramMetric =
+      tableSource?.kind === SourceKind.Metric &&
+      (metricType === MetricsDataType.Histogram ||
+        metricType === MetricsDataType.ExponentialHistogram);
+    if (
+      isHistogramMetric &&
+      !HISTOGRAM_SUPPORTED_AGG_FNS.includes(aggFn ?? '')
+    ) {
+      setValue(`${namePrefix}aggFn`, 'count');
     }
   }, [tableSource?.kind, metricType, aggFn, namePrefix, setValue]);
 

--- a/packages/app/src/components/__tests__/AggFnSelect.test.tsx
+++ b/packages/app/src/components/__tests__/AggFnSelect.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { MetricsDataType } from '@hyperdx/common-utils/dist/types';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AggFnSelectControlled } from '@/components/AggFnSelect';
+
+// Mantine's Combobox calls scrollIntoView when its dropdown opens; jsdom lacks it.
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+function Harness({
+  metricType,
+  hideCustom = true,
+}: {
+  metricType?: MetricsDataType;
+  hideCustom?: boolean;
+}) {
+  const { control } = useForm({
+    defaultValues: { aggFn: 'count', level: 0.95 },
+  });
+  return (
+    <AggFnSelectControlled
+      aggFnName="aggFn"
+      quantileLevelName="level"
+      defaultValue="count"
+      control={control}
+      hideCustom={hideCustom}
+      metricType={metricType}
+    />
+  );
+}
+
+const openSelect = async () => {
+  const input = screen.getByTestId('agg-fn-select');
+  await userEvent.click(input);
+};
+
+describe('AggFnSelect', () => {
+  it('shows the full aggregation list for gauge metrics', async () => {
+    renderWithMantine(<Harness metricType={MetricsDataType.Gauge} />);
+    await openSelect();
+
+    expect(await screen.findByText('Count of Events')).toBeInTheDocument();
+    expect(screen.getByText('Average')).toBeInTheDocument();
+    expect(screen.getByText('Sum')).toBeInTheDocument();
+    expect(screen.getByText('Maximum')).toBeInTheDocument();
+    expect(screen.getByText('Minimum')).toBeInTheDocument();
+    expect(screen.getByText('95th Percentile')).toBeInTheDocument();
+  });
+
+  it('shows the Increase option only for Sum metrics', async () => {
+    renderWithMantine(<Harness metricType={MetricsDataType.Sum} />);
+    await openSelect();
+
+    expect(await screen.findByText('Increase')).toBeInTheDocument();
+  });
+
+  it('does not show Increase for gauge metrics', async () => {
+    renderWithMantine(<Harness metricType={MetricsDataType.Gauge} />);
+    await openSelect();
+
+    await screen.findByText('Count of Events');
+    expect(screen.queryByText('Increase')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['histogram', MetricsDataType.Histogram],
+    ['exponential histogram', MetricsDataType.ExponentialHistogram],
+  ])('hides unsupported aggregations for %s metrics', async (_label, type) => {
+    renderWithMantine(<Harness metricType={type} />);
+    await openSelect();
+
+    // Supported for histogram metrics: count + quantiles.
+    expect(await screen.findByText('Count of Events')).toBeInTheDocument();
+    expect(screen.getByText('99th Percentile')).toBeInTheDocument();
+    expect(screen.getByText('95th Percentile')).toBeInTheDocument();
+    expect(screen.getByText('90th Percentile')).toBeInTheDocument();
+    expect(screen.getByText('Median')).toBeInTheDocument();
+
+    // Unsupported aggregations should be hidden.
+    expect(screen.queryByText('Average')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sum')).not.toBeInTheDocument();
+    expect(screen.queryByText('Maximum')).not.toBeInTheDocument();
+    expect(screen.queryByText('Minimum')).not.toBeInTheDocument();
+    expect(screen.queryByText('Count Distinct')).not.toBeInTheDocument();
+    expect(screen.queryByText('Any')).not.toBeInTheDocument();
+    expect(screen.queryByText('Increase')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

This PR hides the unsupported aggregation functions for histogram and exponential histogram metrics in the chart builder. Previously, the user could select them and would then see an error when running the query or saving the tile.

https://github.com/user-attachments/assets/d280418f-dcbf-4022-93d1-027e468eac41

## Testing in Preview

1. View a histogram metric
2. Observe the available agg functions

Linear Issue: Closes HDX-4991