### PR TITLE
fix(app): don't infer metric tables for sources that already have tables

### DIFF
--- a/.changeset/metrics-source-no-infer-when-tables-defined.md
+++ b/.changeset/metrics-source-no-infer-when-tables-defined.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Don't auto-infer metric tables when editing a metrics source that already has tables configured. Schema inference now only runs for brand-new sources, so an existing source with a missing table (e.g. exponential histogram) no longer appears populated with values that were never saved.

--- a/docker/clickhouse/local/init-db-e2e.sh
+++ b/docker/clickhouse/local/init-db-e2e.sh
@@ -10,6 +10,9 @@ if [ "$BETA_CH_OTEL_JSON_SCHEMA_ENABLED" = "true" ]; then
 fi
 
 DATABASE=${HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE:-default}
+# Second database used by the metric-table inference tests; keep in sync with
+# E2E_ALT_METRICS_DATABASE in packages/app/tests/e2e/utils/constants.ts.
+ALT_METRICS_DATABASE=e2e_alt_metrics
 
 clickhouse client -n <<EOFSQL
 CREATE DATABASE IF NOT EXISTS ${DATABASE};
@@ -241,6 +244,20 @@ PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
 TTL toDate(TimeUnix) + toIntervalDay(30)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+-- A second database holding its own OTEL metric tables, so E2E tests can
+-- switch a metrics source's Database dropdown to a different database and
+-- assert that table inference re-runs for the newly selected one. Structures
+-- are copied from the tables above so the tables pass the source form's
+-- metric-schema validation. Left empty — the inference these tables exercise
+-- reads schemas, not rows.
+CREATE DATABASE IF NOT EXISTS ${ALT_METRICS_DATABASE};
+
+CREATE TABLE IF NOT EXISTS ${ALT_METRICS_DATABASE}.alt_otel_metrics_gauge
+AS ${DATABASE}.e2e_otel_metrics_gauge;
+
+CREATE TABLE IF NOT EXISTS ${ALT_METRICS_DATABASE}.alt_otel_metrics_sum
+AS ${DATABASE}.e2e_otel_metrics_sum;
 
 -- Materialized view rollup for traces, used by E2E tests covering MV
 -- acceleration. The target table pre-aggregates Duration over 1-minute

--- a/packages/app/src/components/DBTableSelect.tsx
+++ b/packages/app/src/components/DBTableSelect.tsx
@@ -19,6 +19,7 @@ function DBTableSelect({
   size,
   inputRef,
   connectionId,
+  testId,
 }: {
   database: string | undefined;
   connectionId: string | undefined;
@@ -28,6 +29,7 @@ function DBTableSelect({
   inputRef?: React.Ref<HTMLInputElement>;
   name?: string;
   size?: string;
+  testId?: string;
 }) {
   const { data: tables, isLoading: isTablesLoading } = useTablesDirect(
     { database: database ?? '', connectionId: connectionId ?? '' },
@@ -68,6 +70,7 @@ function DBTableSelect({
         ref={inputRef}
         size={size}
         className="flex-grow-1"
+        data-testid={testId}
       />
       <SourceManagementMenu
         hasSelection={!!table}
@@ -87,11 +90,13 @@ function DBTableSelect({
 export function DBTableSelectControlled({
   database,
   connectionId,
+  testId,
   ...props
 }: {
   database?: string;
   size?: string;
   connectionId: string | undefined;
+  testId?: string;
 } & UseControllerProps<any>) {
   const { field } = useController(props);
 
@@ -100,6 +105,7 @@ export function DBTableSelectControlled({
       {...props}
       database={database}
       connectionId={connectionId}
+      testId={testId}
       table={field.value}
       setTable={field.onChange}
       onBlur={field.onBlur} // notify when input is touched/blur

--- a/packages/app/src/components/Sources/SourceForm/MetricTableModelForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/MetricTableModelForm.tsx
@@ -21,7 +21,11 @@ import { DEFAULT_DATABASE, OTEL_CLICKHOUSE_EXPRESSIONS } from './constants';
 import { FormRow } from './FormRow';
 import { TableModelProps } from './types';
 
-export function MetricTableModelForm({ control, setValue }: TableModelProps) {
+export function MetricTableModelForm({
+  control,
+  setValue,
+  hasExistingMetricTables = false,
+}: TableModelProps) {
   const brandName = useBrandDisplayName();
   const { data: team } = api.useTeam();
   const isMetricsSeriesTableEnabled = !!team?.isMetricsSeriesTableEnabled;
@@ -138,6 +142,11 @@ export function MetricTableModelForm({ control, setValue }: TableModelProps) {
   // new db/connection, then never re-fires for that pair. No clearing of old
   // values — switching databases naturally empties the dropdowns since the
   // new table list won't contain the old names.
+  //
+  // Skipped entirely when editing a saved source that already has metric
+  // tables configured: inferring the missing tables there would silently
+  // populate the form with values that aren't actually persisted, hiding the
+  // fact that a table is unsaved until the user clicks Save Source.
   const { data: tablesData } = useTablesDirect(
     { database: databaseName, connectionId: connectionId ?? '' },
     { enabled: !!databaseName && !!connectionId },
@@ -146,6 +155,7 @@ export function MetricTableModelForm({ control, setValue }: TableModelProps) {
   const lastAutofillKeyRef = useRef('');
 
   useEffect(() => {
+    if (hasExistingMetricTables) return; // never infer over a saved source
     const key = `${databaseName}:${connectionId}`;
     if (key === lastAutofillKeyRef.current) return; // already ran for this db
 
@@ -230,6 +240,7 @@ export function MetricTableModelForm({ control, setValue }: TableModelProps) {
     connectionId,
     metadata,
     isMetricsSeriesTableEnabled,
+    hasExistingMetricTables,
   ]);
 
   return (
@@ -251,6 +262,7 @@ export function MetricTableModelForm({ control, setValue }: TableModelProps) {
               database={databaseName}
               control={control}
               name={`metricTables.${metricType.toLowerCase()}`}
+              testId={`metric-table-select-${metricType.toLowerCase()}`}
             />
           </FormRow>
         ))}

--- a/packages/app/src/components/Sources/SourceForm/MetricTableModelForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/MetricTableModelForm.tsx
@@ -19,12 +19,13 @@ import {
 
 import { DEFAULT_DATABASE, OTEL_CLICKHOUSE_EXPRESSIONS } from './constants';
 import { FormRow } from './FormRow';
+import { metricTablesScopeKey } from './sourceFormUtils';
 import { TableModelProps } from './types';
 
 export function MetricTableModelForm({
   control,
   setValue,
-  hasExistingMetricTables = false,
+  savedMetricTablesKey,
 }: TableModelProps) {
   const brandName = useBrandDisplayName();
   const { data: team } = api.useTeam();
@@ -143,10 +144,12 @@ export function MetricTableModelForm({
   // values — switching databases naturally empties the dropdowns since the
   // new table list won't contain the old names.
   //
-  // Skipped entirely when editing a saved source that already has metric
-  // tables configured: inferring the missing tables there would silently
-  // populate the form with values that aren't actually persisted, hiding the
-  // fact that a table is unsaved until the user clicks Save Source.
+  // Skipped for the db/connection pair a saved source's metric tables were
+  // persisted with: inferring the missing tables there would silently populate
+  // the form with values that aren't actually persisted, hiding the fact that a
+  // table is unsaved until the user clicks Save Source. Pointing the form at
+  // another database or connection is a fresh pair, so inference resumes —
+  // there are no saved tables to be confused with for that pair.
   const { data: tablesData } = useTablesDirect(
     { database: databaseName, connectionId: connectionId ?? '' },
     { enabled: !!databaseName && !!connectionId },
@@ -155,8 +158,8 @@ export function MetricTableModelForm({
   const lastAutofillKeyRef = useRef('');
 
   useEffect(() => {
-    if (hasExistingMetricTables) return; // never infer over a saved source
-    const key = `${databaseName}:${connectionId}`;
+    const key = metricTablesScopeKey(databaseName, connectionId);
+    if (key === savedMetricTablesKey) return; // don't infer over saved tables
     if (key === lastAutofillKeyRef.current) return; // already ran for this db
 
     const tableNames = tablesData?.data?.map((t: { name: string }) => t.name);
@@ -240,7 +243,7 @@ export function MetricTableModelForm({
     connectionId,
     metadata,
     isMetricsSeriesTableEnabled,
-    hasExistingMetricTables,
+    savedMetricTablesKey,
   ]);
 
   return (

--- a/packages/app/src/components/Sources/SourceForm/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/SourceForm.tsx
@@ -228,6 +228,22 @@ export function TableSourceForm({
     defaultValue: source?.kind || SourceKind.Log,
   });
 
+  // Whether the saved source already has at least one metric table configured.
+  // Derived from the persisted source (not the live form values) so that
+  // schema-inference autofill can be suppressed and never silently populate
+  // tables that aren't actually saved. See MetricTableModelForm.
+  const hasExistingMetricTables = useMemo(() => {
+    if (!source || source.kind !== SourceKind.Metric) return false;
+    const metricTables = (source as { metricTables?: Record<string, unknown> })
+      .metricTables;
+    return Boolean(
+      metricTables &&
+        Object.values(metricTables).some(
+          value => typeof value === 'string' && value.length > 0,
+        ),
+    );
+  }, [source]);
+
   const createSource = useCreateSource();
   const updateSource = useUpdateSource();
   const deleteSource = useDeleteSource();
@@ -728,7 +744,12 @@ export function TableSourceForm({
           </Button>
         </FormRow>
       </Stack>
-      <TableModelForm control={control} setValue={setValue} kind={kind} />
+      <TableModelForm
+        control={control}
+        setValue={setValue}
+        kind={kind}
+        hasExistingMetricTables={hasExistingMetricTables}
+      />
       <Group justify="flex-end" mt="lg">
         {onCancel && (
           <Button variant="secondary" onClick={onCancel} size="xs">

--- a/packages/app/src/components/Sources/SourceForm/SourceForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/SourceForm.tsx
@@ -68,7 +68,7 @@ import {
   setCorrelationFieldValue,
 } from './correlationFields';
 import { FormRow } from './FormRow';
-import { distinctSections } from './sourceFormUtils';
+import { distinctSections, metricTablesScopeKey } from './sourceFormUtils';
 import { TableModelForm } from './TableModelForm';
 
 export function TableSourceForm({
@@ -228,20 +228,24 @@ export function TableSourceForm({
     defaultValue: source?.kind || SourceKind.Log,
   });
 
-  // Whether the saved source already has at least one metric table configured.
-  // Derived from the persisted source (not the live form values) so that
-  // schema-inference autofill can be suppressed and never silently populate
-  // tables that aren't actually saved. See MetricTableModelForm.
-  const hasExistingMetricTables = useMemo(() => {
-    if (!source || source.kind !== SourceKind.Metric) return false;
-    const metricTables = (source as { metricTables?: Record<string, unknown> })
-      .metricTables;
-    return Boolean(
+  // The database+connection pair the saved source's metric tables belong to,
+  // set only when that source already has at least one metric table
+  // configured. Derived from the persisted source (not the live form values)
+  // so schema-inference autofill can be suppressed for that pair and never
+  // silently populate tables that aren't actually saved — while still
+  // inferring once the user points the form at a different database or
+  // connection.
+  const savedMetricTablesKey = useMemo(() => {
+    if (!source || source.kind !== SourceKind.Metric) return undefined;
+    const metricTables = source.metricTables;
+    const hasExistingMetricTables = Boolean(
       metricTables &&
         Object.values(metricTables).some(
           value => typeof value === 'string' && value.length > 0,
         ),
     );
+    if (!hasExistingMetricTables) return undefined;
+    return metricTablesScopeKey(source.from?.databaseName, source.connection);
   }, [source]);
 
   const createSource = useCreateSource();
@@ -748,7 +752,7 @@ export function TableSourceForm({
         control={control}
         setValue={setValue}
         kind={kind}
-        hasExistingMetricTables={hasExistingMetricTables}
+        savedMetricTablesKey={savedMetricTablesKey}
       />
       <Group justify="flex-end" mt="lg">
         {onCancel && (

--- a/packages/app/src/components/Sources/SourceForm/TableModelForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/TableModelForm.tsx
@@ -18,10 +18,12 @@ export function TableModelForm({
   control,
   setValue,
   kind,
+  hasExistingMetricTables,
 }: {
   control: Control<TSource>;
   setValue: UseFormSetValue<TSource>;
   kind: SourceKind;
+  hasExistingMetricTables?: boolean;
 }) {
   switch (kind) {
     case SourceKind.Log:
@@ -31,7 +33,13 @@ export function TableModelForm({
     case SourceKind.Session:
       return <SessionTableModelForm control={control} setValue={setValue} />;
     case SourceKind.Metric:
-      return <MetricTableModelForm control={control} setValue={setValue} />;
+      return (
+        <MetricTableModelForm
+          control={control}
+          setValue={setValue}
+          hasExistingMetricTables={hasExistingMetricTables}
+        />
+      );
     case SourceKind.Promql:
       return <PromqlTableModelForm control={control} setValue={setValue} />;
   }

--- a/packages/app/src/components/Sources/SourceForm/TableModelForm.tsx
+++ b/packages/app/src/components/Sources/SourceForm/TableModelForm.tsx
@@ -18,12 +18,12 @@ export function TableModelForm({
   control,
   setValue,
   kind,
-  hasExistingMetricTables,
+  savedMetricTablesKey,
 }: {
   control: Control<TSource>;
   setValue: UseFormSetValue<TSource>;
   kind: SourceKind;
-  hasExistingMetricTables?: boolean;
+  savedMetricTablesKey?: string;
 }) {
   switch (kind) {
     case SourceKind.Log:
@@ -37,7 +37,7 @@ export function TableModelForm({
         <MetricTableModelForm
           control={control}
           setValue={setValue}
-          hasExistingMetricTables={hasExistingMetricTables}
+          savedMetricTablesKey={savedMetricTablesKey}
         />
       );
     case SourceKind.Promql:

--- a/packages/app/src/components/Sources/SourceForm/__tests__/MetricTableModelForm.autofill.test.tsx
+++ b/packages/app/src/components/Sources/SourceForm/__tests__/MetricTableModelForm.autofill.test.tsx
@@ -1,0 +1,149 @@
+import { useForm, useWatch } from 'react-hook-form';
+import { MetricsDataType, TSource } from '@hyperdx/common-utils/dist/types';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useTablesDirect } from '@/clickhouse';
+import { DEFAULT_DATABASE } from '@/components/Sources/SourceForm/constants';
+import { MetricTableModelForm } from '@/components/Sources/SourceForm/MetricTableModelForm';
+import { isValidMetricTable } from '@/source';
+
+jest.mock('@/clickhouse', () => ({
+  useTablesDirect: jest.fn(),
+}));
+jest.mock('@/source', () => ({
+  isValidMetricTable: jest.fn(),
+}));
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: { useTeam: () => ({ data: {} }) },
+}));
+// The real hook keeps its metadata instance in state, so it's stable across
+// renders; a fresh instance per render would restart the autofill effect.
+const metadata = {};
+jest.mock('@/hooks/useMetadata', () => ({
+  useMetadataWithSettings: () => metadata,
+}));
+jest.mock('@/hooks/useMetricsSeriesTableAvailability', () => ({
+  useMetricsSeriesTableAvailability: () => ({ status: 'unavailable' }),
+}));
+// The table/source pickers query ClickHouse and Mongo; the inference logic
+// under test only reads and writes form values, so stub them out.
+jest.mock('@/components/DBTableSelect', () => ({
+  DBTableSelectControlled: () => null,
+}));
+jest.mock('@/components/SourceSelect', () => ({
+  SourceSelectControlled: () => null,
+}));
+
+const asMock = (fn: unknown) => fn as jest.Mock;
+
+const OTHER_DB = 'other_db';
+const CONNECTION_ID = 'conn-1';
+const savedKey = `${DEFAULT_DATABASE}:${CONNECTION_ID}`;
+
+// Both databases hold recognizable OTel metric tables, so a match exists either
+// way and only the guard decides whether inference fires. Gauge is the table the
+// saved source already has; sum is the one inference would fill in.
+const TABLES_BY_DB: Record<string, string[]> = {
+  [DEFAULT_DATABASE]: ['otel_metrics_gauge', 'otel_metrics_sum'],
+  [OTHER_DB]: ['other_metrics_gauge', 'other_metrics_sum'],
+};
+
+/**
+ * Stands in for the source form when editing a saved metric source: the gauge
+ * table is set and sum is left empty, so inference has something to fill.
+ * The button switches the database the way the Database dropdown does.
+ */
+function Harness({ savedMetricTablesKey }: { savedMetricTablesKey?: string }) {
+  const { control, setValue } = useForm<TSource>({
+    defaultValues: {
+      connection: CONNECTION_ID,
+      from: { databaseName: DEFAULT_DATABASE, tableName: '' },
+      metricTables: {
+        [MetricsDataType.Gauge]: 'otel_metrics_gauge',
+      },
+    } as Partial<TSource>,
+  });
+  const metricTables = useWatch({ control, name: 'metricTables' });
+
+  return (
+    <>
+      <MetricTableModelForm
+        control={control}
+        setValue={setValue}
+        savedMetricTablesKey={savedMetricTablesKey}
+      />
+      <button onClick={() => setValue('from.databaseName', OTHER_DB)}>
+        switch db
+      </button>
+      <output data-testid="sum">
+        {(metricTables as Record<string, string> | undefined)?.[
+          MetricsDataType.Sum
+        ] ?? ''}
+      </output>
+    </>
+  );
+}
+
+// Inference validates each candidate before writing it, so let effects and
+// their awaited validations settle before asserting nothing happened.
+async function flushInference() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // One stable result object per database, mirroring react-query's referential
+  // stability — a fresh object per render would restart the autofill effect.
+  const results = new Map<string, unknown>();
+  asMock(useTablesDirect).mockImplementation(
+    ({ database }: { database: string }) => {
+      if (!results.has(database)) {
+        results.set(database, {
+          data: {
+            data: (TABLES_BY_DB[database] ?? []).map(name => ({ name })),
+          },
+        });
+      }
+      return results.get(database);
+    },
+  );
+  asMock(isValidMetricTable).mockResolvedValue(true);
+});
+
+describe('MetricTableModelForm metric table inference guard', () => {
+  it('infers the missing table when there are no saved metric tables', async () => {
+    renderWithMantine(<Harness />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('sum')).toHaveTextContent('otel_metrics_sum'),
+    );
+  });
+
+  it('does not infer for the db/connection the saved tables came from', async () => {
+    renderWithMantine(<Harness savedMetricTablesKey={savedKey} />);
+
+    // Identical mocks to the test above, which proves inference does fire for
+    // this database — so an empty sum here is the guard, not an unready form.
+    await flushInference();
+
+    expect(isValidMetricTable).not.toHaveBeenCalled();
+    expect(screen.getByTestId('sum')).toHaveTextContent('');
+  });
+
+  it('resumes inference after the user switches to another database', async () => {
+    renderWithMantine(<Harness savedMetricTablesKey={savedKey} />);
+    await flushInference();
+
+    await userEvent.click(screen.getByRole('button', { name: 'switch db' }));
+
+    // Another database is a different pair from the one the source was saved
+    // with, so there are no saved-but-hidden tables to protect.
+    await waitFor(() =>
+      expect(screen.getByTestId('sum')).toHaveTextContent('other_metrics_sum'),
+    );
+  });
+});

--- a/packages/app/src/components/Sources/SourceForm/sourceFormUtils.ts
+++ b/packages/app/src/components/Sources/SourceForm/sourceFormUtils.ts
@@ -18,3 +18,13 @@ export function distinctSections(sources: TSource[] | undefined): string[] {
   }
   return [...sections].sort((a, b) => a.localeCompare(b));
 }
+
+/**
+ * Identity of a database + connection pair.
+ */
+export function metricTablesScopeKey(
+  databaseName: string | undefined,
+  connectionId: string | undefined,
+): string {
+  return `${databaseName}:${connectionId}`;
+}

--- a/packages/app/src/components/Sources/SourceForm/types.ts
+++ b/packages/app/src/components/Sources/SourceForm/types.ts
@@ -4,4 +4,8 @@ import { TSource } from '@hyperdx/common-utils/dist/types';
 export interface TableModelProps {
   control: Control<TSource>;
   setValue: UseFormSetValue<TSource>;
+  // True when editing a saved metric source that already has at least one
+  // metric table configured. Used to suppress schema-inference autofill so we
+  // never silently fill in tables the user hasn't actually saved.
+  hasExistingMetricTables?: boolean;
 }

--- a/packages/app/src/components/Sources/SourceForm/types.ts
+++ b/packages/app/src/components/Sources/SourceForm/types.ts
@@ -4,8 +4,11 @@ import { TSource } from '@hyperdx/common-utils/dist/types';
 export interface TableModelProps {
   control: Control<TSource>;
   setValue: UseFormSetValue<TSource>;
-  // True when editing a saved metric source that already has at least one
-  // metric table configured. Used to suppress schema-inference autofill so we
-  // never silently fill in tables the user hasn't actually saved.
-  hasExistingMetricTables?: boolean;
+  // `database:connection` key the saved metric source was persisted with, set
+  // only when that source already has at least one metric table configured.
+  // Used to suppress schema-inference autofill for exactly that pair so we
+  // never silently fill in tables the user hasn't actually saved — while still
+  // allowing inference once the user switches to a different database or
+  // connection. Undefined when there's nothing to suppress.
+  savedMetricTablesKey?: string;
 }

--- a/packages/app/tests/e2e/components/SourceFormComponent.ts
+++ b/packages/app/tests/e2e/components/SourceFormComponent.ts
@@ -51,6 +51,25 @@ export class SourceFormComponent {
     return this.page.getByRole('option', { name: tableName, exact: true });
   }
 
+  // --- Database selector ------------------------------------------------
+
+  /**
+   * The form's Database Select. This is the visible combobox (named after its
+   * placeholder); the `from.databaseName` input Mantine renders alongside it is
+   * hidden, so it can be read but not clicked.
+   */
+  getDatabaseSelect(): Locator {
+    return this.page.getByRole('combobox', { name: 'Database' });
+  }
+
+  /** Pick a database from the Database dropdown, as a user would. */
+  async selectDatabase(databaseName: string): Promise<void> {
+    await this.getDatabaseSelect().click();
+    await this.page
+      .getByRole('option', { name: databaseName, exact: true })
+      .click();
+  }
+
   /**
    * Notification shown when the metrics source form auto-detects (infers)
    * metric tables from the selected database's schema.

--- a/packages/app/tests/e2e/components/SourceFormComponent.ts
+++ b/packages/app/tests/e2e/components/SourceFormComponent.ts
@@ -1,9 +1,12 @@
 /**
- * SourceFormComponent - Component for the materialized view configuration section
- * rendered inside the source edit modal (TableSourceForm).
+ * SourceFormComponent - Component for the TableSourceForm (source create/edit).
  *
- * Open the modal first via SearchPage.openEditSourceModal(), then use this
- * component to interact with the MV configuration blocks.
+ * Covers both the materialized view configuration section and the OTEL metrics
+ * table selectors.
+ *
+ * Open the form first via SearchPage.openEditSourceModal() (edit) or
+ * SearchPage.openCreateSourceModal() (create), then use this component to
+ * interact with the form.
  */
 import { expect, Locator, Page } from '@playwright/test';
 
@@ -12,6 +15,56 @@ export class SourceFormComponent {
 
   constructor(page: Page) {
     this.page = page;
+  }
+
+  // --- OTEL metrics table selectors -------------------------------------
+
+  /**
+   * Hidden input backing a metric-table Mantine Select. Its value is the
+   * currently selected ClickHouse table name (empty string when unset).
+   * `metricType` is the lower-cased MetricsDataType key, e.g. 'gauge', 'sum',
+   * or 'exponential histogram'.
+   */
+  getMetricTableInput(metricType: string): Locator {
+    return this.page.locator(`input[name="metricTables.${metricType}"]`);
+  }
+
+  /**
+   * The Mantine Select control (root) for a metric table, targeted via the
+   * data-testid wired in MetricTableModelForm.
+   */
+  getMetricTableSelect(metricType: string): Locator {
+    return this.page.getByTestId(`metric-table-select-${metricType}`);
+  }
+
+  /**
+   * Open a metric-table dropdown. The options only render once the ClickHouse
+   * table list for the selected database has loaded, so awaiting an option
+   * afterwards is a deterministic signal that the table list is available
+   * (and therefore that autofill inference has had its chance to run).
+   */
+  async openMetricTableDropdown(metricType: string): Promise<void> {
+    await this.getMetricTableSelect(metricType).click();
+  }
+
+  getTableOption(tableName: string): Locator {
+    return this.page.getByRole('option', { name: tableName, exact: true });
+  }
+
+  /**
+   * Notification shown when the metrics source form auto-detects (infers)
+   * metric tables from the selected database's schema.
+   */
+  getMetricAutoDetectNotification(): Locator {
+    return this.page.locator('.mantine-Notification-root').filter({
+      hasText: 'Auto-detected metric tables from database.',
+    });
+  }
+
+  async waitForMetricAutoDetectSuccess(): Promise<void> {
+    await expect(this.getMetricAutoDetectNotification()).toBeVisible({
+      timeout: 15000,
+    });
   }
 
   async addMaterializedView(): Promise<void> {

--- a/packages/app/tests/e2e/features/sources.spec.ts
+++ b/packages/app/tests/e2e/features/sources.spec.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_METRICS_SOURCE_NAME,
   DEFAULT_SESSIONS_SOURCE_NAME,
   DEFAULT_TRACES_SOURCE_NAME,
+  E2E_ALT_METRICS_DATABASE,
+  E2E_ALT_METRICS_SUM_TABLE,
   E2E_METRICS_GAUGE_TABLE,
   E2E_METRICS_SUM_TABLE,
   METADATA_MV_LOGS_SOURCE_NAME,
@@ -308,6 +310,45 @@ test.describe('Sources Functionality', { tag: ['@sources'] }, () => {
       // filling it in.
       await expect(sourceForm.getMetricAutoDetectNotification()).toHaveCount(0);
       await expect(sourceForm.getMetricTableInput('sum')).toHaveValue('');
+    },
+  );
+
+  test(
+    'infers metric tables again after switching an existing source to another database',
+    { tag: ['@full-stack'] },
+    async ({ page }) => {
+      const sourcesListPage = new SourcesListPage(page);
+      const sourceForm = new SourceFormComponent(page);
+
+      // Same starting point as the test above: 'E2E Metrics Partial' is saved
+      // against the `default` database with only the gauge table configured,
+      // and inference is suppressed for that database.
+      await sourcesListPage.goto();
+      await sourcesListPage.expandSource(PARTIAL_METRICS_SOURCE_NAME);
+
+      await expect(sourceForm.getMetricTableInput('gauge')).toHaveValue(
+        E2E_METRICS_GAUGE_TABLE,
+      );
+      await expect(sourceForm.getMetricTableInput('sum')).toHaveValue('');
+      await expect(sourceForm.getMetricAutoDetectNotification()).toHaveCount(0);
+
+      // Point the form at a different database. The saved tables belong to
+      // `default`, so nothing here can be confused with them — inference must
+      // resume and fill the empty sum table from the new database's schema.
+      await sourceForm.selectDatabase(E2E_ALT_METRICS_DATABASE);
+
+      await sourceForm.waitForMetricAutoDetectSuccess();
+      await expect(sourceForm.getMetricTableInput('sum')).toHaveValue(
+        E2E_ALT_METRICS_SUM_TABLE,
+      );
+
+      // Inference only fills empty fields, so gauge keeps the value it was
+      // hydrated with rather than being replaced by the new database's gauge
+      // table. Nothing is saved: the form is left without clicking Save, so
+      // the shared fixture source keeps its persisted configuration.
+      await expect(sourceForm.getMetricTableInput('gauge')).toHaveValue(
+        E2E_METRICS_GAUGE_TABLE,
+      );
     },
   );
 

--- a/packages/app/tests/e2e/features/sources.spec.ts
+++ b/packages/app/tests/e2e/features/sources.spec.ts
@@ -1,5 +1,6 @@
 import { SourceFormComponent } from '../components/SourceFormComponent';
 import { SearchPage } from '../page-objects/SearchPage';
+import { SourcesListPage } from '../page-objects/SourcesListPage';
 import { getApiUrl, getSources } from '../utils/api-helpers';
 import { expect, test } from '../utils/base-test';
 import {
@@ -275,12 +276,15 @@ test.describe('Sources Functionality', { tag: ['@sources'] }, () => {
     'does not infer missing metric tables when editing a source that already has tables',
     { tag: ['@full-stack'] },
     async ({ page }) => {
+      const sourcesListPage = new SourcesListPage(page);
       const sourceForm = new SourceFormComponent(page);
 
-      // 'E2E Metrics Partial' is saved with only the gauge table configured;
-      // sum (and the rest) are intentionally left empty.
-      await searchPage.selectSource(PARTIAL_METRICS_SOURCE_NAME);
-      await searchPage.openEditSourceModal();
+      // Metric sources can't be picked on the search page, so edit via the
+      // team "Data" tab, which lists every source and expands its edit form
+      // inline. 'E2E Metrics Partial' is saved with only the gauge table
+      // configured; sum (and the rest) are intentionally left empty.
+      await sourcesListPage.goto();
+      await sourcesListPage.expandSource(PARTIAL_METRICS_SOURCE_NAME);
 
       // Form hydrates from the saved source: gauge is set, sum is empty.
       await expect(sourceForm.getMetricTableInput('gauge')).toHaveValue(

--- a/packages/app/tests/e2e/features/sources.spec.ts
+++ b/packages/app/tests/e2e/features/sources.spec.ts
@@ -1,3 +1,4 @@
+import { SourceFormComponent } from '../components/SourceFormComponent';
 import { SearchPage } from '../page-objects/SearchPage';
 import { getApiUrl, getSources } from '../utils/api-helpers';
 import { expect, test } from '../utils/base-test';
@@ -7,7 +8,9 @@ import {
   DEFAULT_SESSIONS_SOURCE_NAME,
   DEFAULT_TRACES_SOURCE_NAME,
   E2E_METRICS_GAUGE_TABLE,
+  E2E_METRICS_SUM_TABLE,
   METADATA_MV_LOGS_SOURCE_NAME,
+  PARTIAL_METRICS_SOURCE_NAME,
 } from '../utils/constants';
 import { setTeamFlag } from '../utils/db-helpers';
 
@@ -237,6 +240,70 @@ test.describe('Sources Functionality', { tag: ['@sources'] }, () => {
           },
         });
       }
+    },
+  );
+
+  test(
+    'auto-infers and populates metric tables for a brand new source',
+    { tag: ['@full-stack'] },
+    async ({ page }) => {
+      const sourceForm = new SourceFormComponent(page);
+
+      // Open the "Configure New Source" modal and switch to the metrics kind.
+      await searchPage.openCreateSourceModal();
+      await searchPage.selectSourceKind('OTEL Metrics');
+
+      // A brand-new source has no metric tables, so once the default
+      // database's table list loads the form should infer and auto-populate
+      // the metric tables it recognizes. The gauge and sum tables exist in
+      // the seeded E2E ClickHouse database, so both get filled in.
+      await sourceForm.waitForMetricAutoDetectSuccess();
+
+      await expect(sourceForm.getMetricTableInput('gauge')).toHaveValue(
+        E2E_METRICS_GAUGE_TABLE,
+      );
+      await expect(sourceForm.getMetricTableInput('sum')).toHaveValue(
+        E2E_METRICS_SUM_TABLE,
+      );
+
+      // Close without saving to avoid persisting a throwaway source.
+      await page.keyboard.press('Escape');
+    },
+  );
+
+  test(
+    'does not infer missing metric tables when editing a source that already has tables',
+    { tag: ['@full-stack'] },
+    async ({ page }) => {
+      const sourceForm = new SourceFormComponent(page);
+
+      // 'E2E Metrics Partial' is saved with only the gauge table configured;
+      // sum (and the rest) are intentionally left empty.
+      await searchPage.selectSource(PARTIAL_METRICS_SOURCE_NAME);
+      await searchPage.openEditSourceModal();
+
+      // Form hydrates from the saved source: gauge is set, sum is empty.
+      await expect(sourceForm.getMetricTableInput('gauge')).toHaveValue(
+        E2E_METRICS_GAUGE_TABLE,
+      );
+      await expect(sourceForm.getMetricTableInput('sum')).toHaveValue('');
+
+      // Open the sum dropdown to confirm the ClickHouse table list has loaded
+      // and that the sum table IS a valid inference candidate — i.e. without
+      // the guard the form WOULD auto-fill it. (Clicking also waits for the
+      // select to become enabled once tables have loaded.)
+      await sourceForm.openMetricTableDropdown('sum');
+      await expect(
+        sourceForm.getTableOption(E2E_METRICS_SUM_TABLE),
+      ).toBeVisible();
+      await page.keyboard.press('Escape');
+
+      // The guard suppresses inference for a source that already has tables:
+      // no auto-detect notification fires and the sum table stays unset,
+      // making the "unsaved/missing" state visible instead of silently
+      // filling it in.
+      await expect(sourceForm.getMetricAutoDetectNotification()).toHaveCount(0);
+      await expect(sourceForm.getMetricTableInput('sum')).toHaveValue('');
     },
   );
 

--- a/packages/app/tests/e2e/fixtures/e2e-fixtures.json
+++ b/packages/app/tests/e2e/fixtures/e2e-fixtures.json
@@ -147,6 +147,19 @@
       "logSourceId": "E2E Logs"
     },
     {
+      "id": "E2E Metrics Partial",
+      "kind": "metric",
+      "name": "E2E Metrics Partial",
+      "connection": "local",
+      "from": { "databaseName": "default", "tableName": "" },
+      "timestampValueExpression": "TimeUnix",
+      "serviceNameExpression": "ServiceName",
+      "metricTables": {
+        "gauge": "e2e_otel_metrics_gauge"
+      },
+      "resourceAttributesExpression": "ResourceAttributes"
+    },
+    {
       "id": "E2E Sessions",
       "kind": "session",
       "name": "E2E Sessions",

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -115,6 +115,19 @@ export class SearchPage {
     await this.editSourceItem.click();
   }
 
+  async openCreateSourceModal() {
+    await this.sourceActionsMenu.click();
+    await this.createNewSourceItem.click();
+  }
+
+  /**
+   * Select a source data type in the source form by its radio label
+   * (e.g. 'Log', 'Trace', 'OTEL Metrics').
+   */
+  async selectSourceKind(radioLabel: string) {
+    await this.page.getByLabel(radioLabel, { exact: true }).click();
+  }
+
   async sourceModalShowOptionalFields() {
     const optionalFieldsButton = this.page.getByText(
       'Configure Optional Fields',

--- a/packages/app/tests/e2e/page-objects/SourcesListPage.ts
+++ b/packages/app/tests/e2e/page-objects/SourcesListPage.ts
@@ -1,0 +1,37 @@
+/**
+ * SourcesListPage - Page object for the team "Data" tab (/team), which renders
+ * the full list of configured sources and expands an inline TableSourceForm
+ * when a source row is toggled.
+ *
+ * Unlike the search page's source picker, this list includes every source kind
+ * (including metric sources), so it's the way to open the edit form for a
+ * metric source.
+ */
+import { Locator, Page } from '@playwright/test';
+
+export class SourcesListPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/team');
+  }
+
+  /**
+   * The row for a source, matched by its (unique) display name. Each row is
+   * rendered with an `id="source-<id>"` anchor.
+   */
+  sourceRow(name: string): Locator {
+    return this.page.locator('[id^="source-"]').filter({ hasText: name });
+  }
+
+  /**
+   * Expand a source's inline edit form by clicking its chevron toggle.
+   */
+  async expandSource(name: string): Promise<void> {
+    await this.sourceRow(name).getByRole('button').first().click();
+  }
+}

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -51,6 +51,12 @@ export const E2E_TRACES_MV_TABLE = 'e2e_otel_traces_1m';
 export const E2E_SESSIONS_TABLE = 'e2e_hyperdx_sessions';
 export const E2E_METRICS_GAUGE_TABLE = 'e2e_otel_metrics_gauge';
 export const E2E_METRICS_SUM_TABLE = 'e2e_otel_metrics_sum';
+// A second database with its own OTEL metric tables (structure copied from the
+// ones above, no rows), so tests can switch a metrics source to a different
+// database and assert table inference re-runs there.
+export const E2E_ALT_METRICS_DATABASE = 'e2e_alt_metrics';
+export const E2E_ALT_METRICS_GAUGE_TABLE = 'alt_otel_metrics_gauge';
+export const E2E_ALT_METRICS_SUM_TABLE = 'alt_otel_metrics_sum';
 // Table backing the INTERESTING_FILTER_KEYS_SOURCE_NAME source. Created in
 // `docker/clickhouse/local/init-db-e2e.sh` and seeded in `seed-clickhouse.ts`.
 export const E2E_INTERESTING_FILTER_KEYS_TABLE =

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -1,6 +1,10 @@
 export const DEFAULT_SESSIONS_SOURCE_NAME = 'E2E Sessions';
 export const DEFAULT_TRACES_SOURCE_NAME = 'E2E Traces';
 export const DEFAULT_METRICS_SOURCE_NAME = 'E2E Metrics';
+// Metric source with only the gauge table configured (sum/histogram/etc left
+// empty), used to verify the source form does NOT infer the missing tables
+// when the saved source already has metric tables defined.
+export const PARTIAL_METRICS_SOURCE_NAME = 'E2E Metrics Partial';
 export const DEFAULT_LOGS_SOURCE_NAME = 'E2E Logs';
 
 // Log source deliberately left without a correlated metric source, so tests can


### PR DESCRIPTION
## Summary

This PR prevents the metric source inference from occurring when a source already has some metric type tables defined. 

Without this, a user opening a metric source without all tables defined will observe that all tables are set, because they're inferred. The user is unlikely to save the source since it seems like nothing was changed.

The schema inference still runs for new metric sources.

### Screenshots or video

Before

https://github.com/user-attachments/assets/58b73d16-00f4-44fd-b304-74da7de37152

After

https://github.com/user-attachments/assets/7d2832ac-8df8-40b0-8c31-1d7203cac6da

### How to test Locally

Test locally by editing a source without all the metric tables defined.

### References

- Linear Issue: Closes HDX-5006