### PR TITLE
feat: unify filter sidebar and query input into single where clause

### DIFF
--- a/.changeset/quiet-lions-repeat.md
+++ b/.changeset/quiet-lions-repeat.md
@@ -1,11 +1,24 @@
 ---
+'@hyperdx/app': minor
 '@hyperdx/common-utils': minor
 ---
 
-Fix legacy `filters` migration to merge with the existing `where` clause instead of replacing it, so filters are never dropped when both are present.
+Unify the filter sidebar and query input into a single `where` clause so they always stay in sync.
 
-- Add `mergeFilterStateIntoWhereClause` to AND existing `where` text with migrated filters (verbatim preservation, OR-wrapping of the residual, SQL-safe when needed).
-- Fix invalid/incomplete Lucene clauses (e.g. mid-edit `service:`) so `replaceLuceneFacetClauses` now emits the new clause instead of no-oping, and `replaceFilterClauses` reports them via `getWhereParseError`.
-- Support Lucene `NOT` negation (`NOT field:"v"`, `field:"v" AND NOT other:"w"`) in facet parsing so the sidebar shows an excluded (indeterminate) state instead of a checked one.
-- Add `getUnrepresentableWhereReason` so cross-field `OR` queries can be surfaced to the user rather than silently misrepresented as AND.
-- Add `emitLanguage` to `replaceFilterClauses` so facet clauses can be rewritten across query languages (Lucene ↔ SQL) while preserving non-facet text — used by the UI on language switch.
+Previously the sidebar filters and the query box held independent state — selecting a value in the sidebar applied it to the search but it never appeared in the query input, and the two could silently drift out of sync. This change makes the `where` clause the single source of truth for both.
+
+**What changed (user-visible):**
+
+- Clicking a value in the sidebar rewrites the matching facet clause directly in the query box (e.g. clicking `error` in the Level facet writes `level:"error"` into the box).
+- Editing the query box also updates the sidebar checkboxes — the sidebar reads its checked state back from the `where` text.
+- Free-text and complex query content is preserved — only the specific facet clauses are rewritten.
+- Works for both query dialects (Lucene and SQL).
+- The separate `filters` URL param is removed; a one-time migration moves any legacy persisted filters into the `where` clause on first load.
+
+**New internals in `@hyperdx/common-utils`:**
+
+- `parseWhereClauseToFilterState` — parse a `where` string back into `FilterState`.
+- `filterStateToWhereClause` — render `FilterState` to a `where` string.
+- `replaceFilterClauses` — surgically replace only the facet clauses in a `where` string, preserving everything else. Supports an `emitLanguage` option to translate facets across query dialects.
+- `mergeFilterStateIntoWhereClause` — AND a legacy `filters` state into an existing `where` clause without dropping either side (used for the one-time URL-param migration).
+- `dateTimeValueExpr` extracted to `common-utils/core/dateTimeValue.ts` to avoid duplication between `filters.ts` and `queryParser.ts`.

--- a/.changeset/quiet-lions-repeat.md
+++ b/.changeset/quiet-lions-repeat.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/common-utils': minor
+---
+
+Fix legacy `filters` migration to merge with the existing `where` clause instead of replacing it, so filters are never dropped when both are present.
+
+- Add `mergeFilterStateIntoWhereClause` to AND existing `where` text with migrated filters (verbatim preservation, OR-wrapping of the residual, SQL-safe when needed).
+- Fix invalid/incomplete Lucene clauses (e.g. mid-edit `service:`) so `replaceLuceneFacetClauses` now emits the new clause instead of no-oping, and `replaceFilterClauses` reports them via `getWhereParseError`.
+- Support Lucene `NOT` negation (`NOT field:"v"`, `field:"v" AND NOT other:"w"`) in facet parsing so the sidebar shows an excluded (indeterminate) state instead of a checked one.
+- Add `getUnrepresentableWhereReason` so cross-field `OR` queries can be surfaced to the user rather than silently misrepresented as AND.
+- Add `emitLanguage` to `replaceFilterClauses` so facet clauses can be rewritten across query languages (Lucene ↔ SQL) while preserving non-facet text — used by the UI on language switch.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -116,7 +116,11 @@ import {
   useSavedSearch,
   useUpdateSavedSearch,
 } from '@/savedSearch';
-import { useSearchPageFilterState } from '@/searchFilters';
+import {
+  replaceFiltersInWhereClause,
+  useSearchPageFilterState,
+  whereToFilters,
+} from '@/searchFilters';
 import { getEventBody, useSource, useSources } from '@/source';
 import { useAppTheme, useBrandDisplayName } from '@/theme/ThemeProvider';
 import {
@@ -1263,18 +1267,15 @@ export function DBSearchPage() {
 
   const onSubmit = useCallback(() => {
     onSearch(displayedTimeInputValue);
-    handleSubmit(
-      ({ select, where, whereLanguage, source, filters, orderBy }) => {
-        setSearchedConfig({
-          select,
-          where,
-          whereLanguage,
-          source,
-          filters,
-          orderBy,
-        });
-      },
-    )();
+    handleSubmit(({ select, where, whereLanguage, source, orderBy }) => {
+      setSearchedConfig({
+        select,
+        where,
+        whereLanguage,
+        source,
+        orderBy,
+      });
+    })();
     setPatternColumn(draftPatternColumn || null);
     // clear query errors
     setQueryErrors({});
@@ -1289,13 +1290,6 @@ export function DBSearchPage() {
   ]);
 
   const debouncedSubmit = useDebouncedCallback(onSubmit, 1000);
-  const handleSetFilters = useCallback(
-    (filters: Filter[]) => {
-      setValue('filters', filters);
-      debouncedSubmit();
-    },
-    [debouncedSubmit, setValue],
-  );
 
   // Top-level column names for the active source, used to quote
   // filter keys that contain special characters.
@@ -1343,13 +1337,90 @@ export function DBSearchPage() {
   const { dateTimeColumns, onResolvedColumnsChange } =
     useResolvedDateTimeColumns(inputSourceColumns);
 
-  const filters = useWatch({ name: 'filters', control });
+  // The `where` clause is the canonical representation of the query. The
+  // sidebar's FilterState is derived from it (via `whereToFilters`) and sidebar
+  // toggles rewrite it in place (via `replaceFiltersInWhereClause`), so the
+  // filter sidebar and the query text can never drift apart.
+  const inputWhere = useWatch({ name: 'where', control });
+  const inputWhereLanguage = useWatch({ name: 'whereLanguage', control });
+  const searchQuery = useMemo(
+    () =>
+      whereToFilters(
+        inputWhere,
+        inputWhereLanguage ?? 'lucene',
+        knownColumns,
+        dateTimeColumns,
+      ),
+    [inputWhere, inputWhereLanguage, knownColumns, dateTimeColumns],
+  );
+
+  // Sidebar filter mutations arrive as the canonical SQL `Filter[]` the hook
+  // emits; rewrite the facet clauses of the live `where` text to match and
+  // drop the separate `filters` param entirely.
+  const handleSetFilters = useCallback(
+    (filters: Filter[]) => {
+      const newWhere = replaceFiltersInWhereClause(
+        inputWhere,
+        inputWhereLanguage ?? 'lucene',
+        filters,
+        knownColumns,
+        dateTimeColumns,
+      );
+      setValue('where', newWhere);
+      debouncedSubmit();
+    },
+    [
+      debouncedSubmit,
+      setValue,
+      inputWhere,
+      inputWhereLanguage,
+      knownColumns,
+      dateTimeColumns,
+    ],
+  );
+
   const searchFilters = useSearchPageFilterState({
-    searchQuery: filters ?? undefined,
+    searchQuery,
     onFilterChange: handleSetFilters,
     dateTimeColumns,
     knownColumns,
   });
+
+  // One-time migration: legacy `filters` params (URL, saved search) move into
+  // the `where` clause, now the canonical representation. Gated on the source's
+  // columns being known so date columns and special-character keys emit
+  // correctly, then `filters` is cleared so the page stops persisting it.
+  useEffect(() => {
+    const { filters: legacyFilters, where, whereLanguage } = searchedConfig;
+    if (!legacyFilters?.length || !inputSourceColumns) return;
+    try {
+      const migratedWhere = replaceFiltersInWhereClause(
+        where ?? '',
+        (whereLanguage as 'sql' | 'lucene') ?? 'lucene',
+        legacyFilters,
+        knownColumns,
+        dateTimeColumns,
+      );
+      if (migratedWhere !== (where ?? '')) {
+        setSearchedConfig({ where: migratedWhere, filters: [] });
+      } else if (where) {
+        // Filters were already represented in the where text — just stop
+        // persisting the redundant param.
+        setSearchedConfig({ filters: [] });
+      }
+    } catch (e) {
+      console.error('Failed to migrate legacy filters into where clause', e);
+    }
+    // Runs when a legacy filters-bearing config is present; the emit depends on
+    // columns loading so re-check when they arrive.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    searchedConfig.filters,
+    searchedConfig.where,
+    searchedConfig.whereLanguage,
+    inputSourceColumns,
+    setSearchedConfig,
+  ]);
 
   useEffect(() => {
     // If the user changes the source dropdown, reset the select and orderby fields
@@ -1493,8 +1564,6 @@ export function DBSearchPage() {
       : null;
     return { hasQueryError, queryError };
   }, [_queryErrors]);
-  const inputWhere = useWatch({ name: 'where', control });
-  const inputWhereLanguage = useWatch({ name: 'whereLanguage', control });
   // query suggestion for 'where' if error
   const whereSuggestions = useSqlSuggestions({
     input: inputWhere,
@@ -1712,7 +1781,6 @@ export function DBSearchPage() {
       } else {
         qParams.append('select', searchedConfig.select || '');
         qParams.append('where', where || searchedConfig.where || '');
-        qParams.append('filters', JSON.stringify(searchedConfig.filters ?? []));
         qParams.append('source', searchedSource?.id || '');
       }
 
@@ -1720,7 +1788,6 @@ export function DBSearchPage() {
     },
     [
       interval,
-      searchedConfig.filters,
       searchedConfig.select,
       searchedConfig.where,
       searchedSource?.id,

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -117,7 +117,11 @@ import {
   useUpdateSavedSearch,
 } from '@/savedSearch';
 import {
+  getUnrepresentableWhereReason,
+  getWhereParseError,
+  mergeFiltersIntoWhereClause,
   replaceFiltersInWhereClause,
+  translateWhereClauseInQuery,
   useSearchPageFilterState,
   whereToFilters,
 } from '@/searchFilters';
@@ -1102,7 +1106,7 @@ export function DBSearchPage() {
     [sources, lastSelectedSourceId],
   );
 
-  const { control, setValue, reset, handleSubmit, formState } =
+  const { control, setValue, reset, getValues, handleSubmit, formState } =
     useForm<SearchConfigFromSchema>({
       values: {
         select: searchedConfig.select || '',
@@ -1343,25 +1347,72 @@ export function DBSearchPage() {
   // filter sidebar and the query text can never drift apart.
   const inputWhere = useWatch({ name: 'where', control });
   const inputWhereLanguage = useWatch({ name: 'whereLanguage', control });
-  const searchQuery = useMemo(
+
+  // The `where` text is the canonical representation, but while the user is
+  // mid-typing it can be momentarily unparseable (e.g. `service:`). Keep the
+  // last valid derived query so the sidebar doesn't wipe, and surface the
+  // parse error separately so the sidebar can explain what's happening.
+  const lastGoodSearchQueryRef = useRef<Filter[]>([]);
+  const searchQuery = useMemo(() => {
+    const language = inputWhereLanguage ?? 'lucene';
+    const parseError = getWhereParseError(inputWhere, language);
+    if (parseError) return lastGoodSearchQueryRef.current;
+    const query = whereToFilters(
+      inputWhere,
+      language,
+      knownColumns,
+      dateTimeColumns,
+    );
+    lastGoodSearchQueryRef.current = query;
+    return query;
+  }, [inputWhere, inputWhereLanguage, knownColumns, dateTimeColumns]);
+
+  const whereParseError = useMemo(
+    () => getWhereParseError(inputWhere, inputWhereLanguage ?? 'lucene'),
+    [inputWhere, inputWhereLanguage],
+  );
+
+  const whereUnrepresentableReason = useMemo(
     () =>
-      whereToFilters(
+      getUnrepresentableWhereReason(inputWhere, inputWhereLanguage ?? 'lucene'),
+    [inputWhere, inputWhereLanguage],
+  );
+
+  // Language switches happen through SearchWhereInput; translate the live
+  // `where` text so facet clauses survive (the free-text/facet rewrite keeps
+  // non-facet content verbatim). Skip when there is nothing to translate.
+  const handleWhereLanguageChange = useCallback(
+    (language: 'sql' | 'lucene') => {
+      const previousLanguage = inputWhereLanguage ?? 'lucene';
+      if (language === previousLanguage) return;
+      const translatedWhere = translateWhereClauseInQuery(
         inputWhere,
-        inputWhereLanguage ?? 'lucene',
+        previousLanguage,
+        language,
         knownColumns,
         dateTimeColumns,
-      ),
-    [inputWhere, inputWhereLanguage, knownColumns, dateTimeColumns],
+      );
+      if (translatedWhere !== inputWhere) {
+        setValue('where', translatedWhere, { shouldDirty: true });
+      }
+    },
+    [inputWhere, inputWhereLanguage, knownColumns, dateTimeColumns, setValue],
   );
 
   // Sidebar filter mutations arrive as the canonical SQL `Filter[]` the hook
   // emits; rewrite the facet clauses of the live `where` text to match and
   // drop the separate `filters` param entirely.
+  //
+  // Read the current form values with `getValues()` (a non-reactive read) at
+  // call time instead of closing over the watched `where`, so this callback
+  // keeps a stable identity across keystrokes. A stable `onFilterChange` keeps
+  // the sidebar hook's eight mutators stable too, which is what lets
+  // `memo(DBSearchPageFiltersComponent)` skip re-rendering while typing.
   const handleSetFilters = useCallback(
     (filters: Filter[]) => {
       const newWhere = replaceFiltersInWhereClause(
-        inputWhere,
-        inputWhereLanguage ?? 'lucene',
+        getValues('where') ?? '',
+        getValues('whereLanguage') ?? 'lucene',
         filters,
         knownColumns,
         dateTimeColumns,
@@ -1369,14 +1420,7 @@ export function DBSearchPage() {
       setValue('where', newWhere);
       debouncedSubmit();
     },
-    [
-      debouncedSubmit,
-      setValue,
-      inputWhere,
-      inputWhereLanguage,
-      knownColumns,
-      dateTimeColumns,
-    ],
+    [debouncedSubmit, setValue, getValues, knownColumns, dateTimeColumns],
   );
 
   const searchFilters = useSearchPageFilterState({
@@ -1394,7 +1438,7 @@ export function DBSearchPage() {
     const { filters: legacyFilters, where, whereLanguage } = searchedConfig;
     if (!legacyFilters?.length || !inputSourceColumns) return;
     try {
-      const migratedWhere = replaceFiltersInWhereClause(
+      const migratedWhere = mergeFiltersIntoWhereClause(
         where ?? '',
         (whereLanguage as 'sql' | 'lucene') ?? 'lucene',
         legacyFilters,
@@ -2381,6 +2425,7 @@ export function DBSearchPage() {
             control={control}
             name="where"
             onSubmit={onSubmit}
+            onLanguageChange={handleWhereLanguageChange}
             sqlQueryHistoryType={QUERY_LOCAL_STORAGE.SEARCH_SQL}
             luceneQueryHistoryType={QUERY_LOCAL_STORAGE.SEARCH_LUCENE}
             enableHotkey
@@ -2498,6 +2543,8 @@ export function DBSearchPage() {
                     onColumnToggle={toggleColumn}
                     displayedColumns={displayedColumns}
                     onCollapse={() => setIsFilterSidebarCollapsed(true)}
+                    whereParseError={whereParseError}
+                    whereUnrepresentableReason={whereUnrepresentableReason}
                     {...searchFilters}
                   />
                 </ErrorBoundary>

--- a/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
@@ -118,6 +118,8 @@ jest.mock('@/searchFilters', () => ({
     setFilterValue: jest.fn(),
     clearAllFilters: jest.fn(),
   }),
+  whereToFilters: () => [],
+  replaceFiltersInWhereClause: (where: string) => where,
 }));
 
 jest.mock('@/hooks/useChartConfig', () => ({

--- a/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPage.directTrace.test.tsx
@@ -120,6 +120,10 @@ jest.mock('@/searchFilters', () => ({
   }),
   whereToFilters: () => [],
   replaceFiltersInWhereClause: (where: string) => where,
+  mergeFiltersIntoWhereClause: (where: string) => where,
+  translateWhereClauseInQuery: (where: string) => where,
+  getWhereParseError: () => null,
+  getUnrepresentableWhereReason: () => null,
 }));
 
 jest.mock('@/hooks/useChartConfig', () => ({

--- a/packages/app/src/__tests__/SessionSidePanel.test.tsx
+++ b/packages/app/src/__tests__/SessionSidePanel.test.tsx
@@ -40,7 +40,7 @@ jest.mock('nuqs', () => {
   const noop = () => {};
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) =>
       key === 'sessionPanelEvent'
         ? [mockNuqs.sessionPanelEvent, mockNuqs.setSessionPanelEvent]

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -5,6 +5,7 @@ import { act, renderHook } from '@testing-library/react';
 import {
   areFiltersEqual,
   parseQuery,
+  replaceFiltersInWhereClause,
   useSearchPageFilterState,
 } from '@/searchFilters';
 
@@ -1114,6 +1115,37 @@ describe('searchFilters', () => {
           { type: 'sql', condition: `ServiceName IN ('app')` },
         ]);
       });
+    });
+  });
+
+  describe('replaceFiltersInWhereClause', () => {
+    it('replaces all duplicate predicates for a field with the new sidebar value', () => {
+      // When the user manually writes (or a legacy search restores)
+      // host IN ('a') AND host IN ('b'), clicking a sidebar value for host
+      // should replace BOTH conjuncts, not append a third one — otherwise the
+      // query becomes host IN ('a') AND host IN ('b') AND host IN ('c') which
+      // is satisfied only by values that appear in all three lists simultaneously
+      // (usually an empty result set).
+      const result = replaceFiltersInWhereClause(
+        "host IN ('a') AND host IN ('b')",
+        'sql',
+        [{ type: 'sql', condition: "host IN ('c')" }],
+        new Set(),
+      );
+      expect(result).toBe("host IN ('c')");
+    });
+
+    it('replaces a single-occurrence predicate normally', () => {
+      const result = replaceFiltersInWhereClause(
+        "host IN ('a') AND level IN ('error')",
+        'sql',
+        [
+          { type: 'sql', condition: "host IN ('b')" },
+          { type: 'sql', condition: "level IN ('warn')" },
+        ],
+        new Set(),
+      );
+      expect(result).toBe("host IN ('b') AND level IN ('warn')");
     });
   });
 });

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1670,8 +1670,7 @@ const DBSearchPageFiltersComponent = ({
           </Flex>
           {whereParseError && (
             <Alert
-              variant="light"
-              color="orange"
+              variant="warning"
               radius="sm"
               p="xs"
               title="Query is incomplete"
@@ -1685,8 +1684,7 @@ const DBSearchPageFiltersComponent = ({
           )}
           {!whereParseError && whereUnrepresentableReason && (
             <Alert
-              variant="light"
-              color="orange"
+              variant="warning"
               radius="sm"
               p="xs"
               title="Filters shown partially"

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Accordion,
   ActionIcon,
+  Alert,
   Box,
   Button,
   Center,
@@ -33,6 +34,7 @@ import {
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
+  IconAlertCircle,
   IconArrowBarToLeft,
   IconChartBar,
   IconChartBarOff,
@@ -1072,6 +1074,8 @@ const DBSearchPageFiltersComponent = ({
   onColumnToggle,
   displayedColumns,
   onCollapse,
+  whereParseError,
+  whereUnrepresentableReason,
 }: {
   analysisMode: 'results' | 'delta' | 'pattern';
   setAnalysisMode: (mode: 'results' | 'delta' | 'pattern') => void;
@@ -1085,6 +1089,8 @@ const DBSearchPageFiltersComponent = ({
   onColumnToggle?: (column: string) => void;
   displayedColumns?: string[];
   onCollapse?: () => void;
+  whereParseError?: string | null;
+  whereUnrepresentableReason?: string | null;
 } & FilterStateHook) => {
   const setFilterValue = useCallback(
     (
@@ -1662,6 +1668,35 @@ const DBSearchPageFiltersComponent = ({
               )}
             </Group>
           </Flex>
+          {whereParseError && (
+            <Alert
+              variant="light"
+              color="orange"
+              radius="sm"
+              p="xs"
+              title="Query is incomplete"
+              icon={<IconAlertCircle size={16} />}
+            >
+              <Text size="xs" c="dimmed">
+                Finish the query text above, or click a value below to replace
+                the incomplete text.
+              </Text>
+            </Alert>
+          )}
+          {!whereParseError && whereUnrepresentableReason && (
+            <Alert
+              variant="light"
+              color="orange"
+              radius="sm"
+              p="xs"
+              title="Filters shown partially"
+              icon={<IconAlertCircle size={16} />}
+            >
+              <Text size="xs" c="dimmed">
+                {whereUnrepresentableReason}
+              </Text>
+            </Alert>
+          )}
           <Tabs
             value={analysisMode}
             onChange={value =>

--- a/packages/app/src/components/__tests__/DBRowSidePanel.missingSource.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.missingSource.test.tsx
@@ -26,7 +26,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
@@ -24,7 +24,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,
@@ -56,7 +56,7 @@ const LINK = {
 const mockUseRowData = jest.fn();
 jest.mock('../DBRowDataPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useRowData: (args: unknown) => mockUseRowData(args),
   ROW_DATA_ALIASES: {
     DURATION_MS: '__hdx_duration',
@@ -82,14 +82,14 @@ const TRACE_SOURCE = {
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => undefined,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSource: ({ id }: { id: string | null }) =>
     id === 'trace-src' ? { data: TRACE_SOURCE } : { data: undefined },
 }));
 
 jest.mock('../DBSessionPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSessionId: () => ({ rumSessionId: undefined, rumServiceName: undefined }),
   DBSessionPanel: () => null,
 }));

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
@@ -38,7 +38,7 @@ const LINKED_SPAN_NAME = 'consume order.created';
 const mockUseRowData = jest.fn();
 jest.mock('../DBRowDataPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useRowData: (args: unknown) => mockUseRowData(args),
   ROW_DATA_ALIASES: {
     DURATION_MS: '__hdx_duration',
@@ -62,14 +62,14 @@ const TRACE_SOURCE = {
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => undefined,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSource: ({ id }: { id: string | null }) =>
     id === 'trace-src' ? { data: TRACE_SOURCE } : { data: undefined },
 }));
 
 jest.mock('../DBSessionPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSessionId: () => ({ rumSessionId: undefined, rumServiceName: undefined }),
   DBSessionPanel: () => null,
 }));

--- a/packages/app/src/components/__tests__/DBRowSidePanel.staleStack.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.staleStack.test.tsx
@@ -26,7 +26,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,

--- a/packages/app/src/hooks/__tests__/useDashboardKioskMode.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardKioskMode.test.tsx
@@ -6,7 +6,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: () => [false, mockSetKioskMode],
   };
 });

--- a/packages/app/src/hooks/__tests__/useSidePanelStack.test.tsx
+++ b/packages/app/src/hooks/__tests__/useSidePanelStack.test.tsx
@@ -24,7 +24,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,

--- a/packages/app/src/searchFilters.test.ts
+++ b/packages/app/src/searchFilters.test.ts
@@ -3,8 +3,10 @@ import { Filter } from '@hyperdx/common-utils/dist/types';
 import { act, renderHook } from '@testing-library/react';
 
 import {
+  mergeFiltersIntoWhereClause,
   parseQuery,
   replaceFiltersInWhereClause,
+  translateWhereClauseInQuery,
   useSearchPageFilterState,
   whereToFilters,
 } from '@/searchFilters';
@@ -268,14 +270,16 @@ describe('replaceFiltersInWhereClause', () => {
     const where = 'error OR warn';
     // No facet fields in this query, so replace with a fresh level filter.
     // The residual `error OR warn` must be wrapped in parens.
-    const filters: Filter[] = [{ type: 'sql', condition: "level IN ('error')" }];
+    const filters: Filter[] = [
+      { type: 'sql', condition: "level IN ('error')" },
+    ];
     const result = replaceFiltersInWhereClause(
       where,
       'lucene',
       filters,
       new Set(),
     );
-    expect(result).toBe('(error  OR warn) AND level:"error"');
+    expect(result).toBe('(error OR warn) AND level:"error"');
   });
 
   it('replaces lowercase sql facet (case-insensitive detection)', () => {
@@ -285,5 +289,192 @@ describe('replaceFiltersInWhereClause', () => {
     expect(replaceFiltersInWhereClause(where, 'sql', filters, new Set())).toBe(
       "foo = 1 AND host IN ('b')",
     );
+  });
+});
+
+describe('mergeFiltersIntoWhereClause (legacy migration)', () => {
+  it('preserves the where text and appends a lucene filter', () => {
+    const filters: Filter[] = [
+      { type: 'sql', condition: "SeverityText IN ('error')" },
+    ];
+    expect(
+      mergeFiltersIntoWhereClause(
+        'ServiceName:"api"',
+        'lucene',
+        filters,
+        new Set(),
+      ),
+    ).toBe('ServiceName:"api" AND SeverityText:"error"');
+  });
+
+  it('preserves the where text and appends a sql filter', () => {
+    const filters: Filter[] = [
+      { type: 'sql', condition: "SeverityText IN ('error')" },
+    ];
+    expect(
+      mergeFiltersIntoWhereClause(
+        "ServiceName = 'api'",
+        'sql',
+        filters,
+        new Set(),
+      ),
+    ).toBe("ServiceName = 'api' AND SeverityText IN ('error')");
+  });
+
+  it('parenthesizes a top-level OR in the where text before appending', () => {
+    const filters: Filter[] = [
+      { type: 'sql', condition: "SeverityText IN ('error')" },
+    ];
+    expect(
+      mergeFiltersIntoWhereClause(
+        'ServiceName:"api" OR ServiceName:"web"',
+        'lucene',
+        filters,
+        new Set(),
+      ),
+    ).toBe('(ServiceName:"api" OR ServiceName:"web") AND SeverityText:"error"');
+  });
+
+  it('keeps a filter already present in the where text (legacy AND semantics)', () => {
+    // Legacy `where` + `filters` were independent predicates ANDed at query
+    // time, so a filter referencing a column already in the where is not
+    // deduped — both clauses are preserved.
+    const filters: Filter[] = [
+      { type: 'sql', condition: "ServiceName IN ('api')" },
+    ];
+    expect(
+      mergeFiltersIntoWhereClause(
+        'ServiceName:"api"',
+        'lucene',
+        filters,
+        new Set(),
+      ),
+    ).toBe('ServiceName:"api" AND ServiceName:"api"');
+  });
+});
+
+describe('translateWhereClauseInQuery (language switch)', () => {
+  it('returns the text unchanged when switching to the same language', () => {
+    expect(
+      translateWhereClauseInQuery(
+        'ServiceName:"api"',
+        'lucene',
+        'lucene',
+        new Set(),
+      ),
+    ).toBe('ServiceName:"api"');
+  });
+
+  it('translates lucene facets to SQL, preserving free text', () => {
+    expect(
+      translateWhereClauseInQuery(
+        'error AND ServiceName:"api"',
+        'lucene',
+        'sql',
+        new Set(),
+      ),
+    ).toBe("error AND ServiceName IN ('api')");
+  });
+
+  it('translates SQL facets to lucene', () => {
+    expect(
+      translateWhereClauseInQuery(
+        "ServiceName IN ('api')",
+        'sql',
+        'lucene',
+        new Set(),
+      ),
+    ).toBe('ServiceName:"api"');
+  });
+
+  it('quotes SQL keys that need escaping in the target language', () => {
+    expect(
+      translateWhereClauseInQuery(
+        'service-name:"a"',
+        'lucene',
+        'sql',
+        new Set(['service-name']),
+      ),
+    ).toBe("`service-name` IN ('a')");
+  });
+
+  it('returns the text unchanged when there are no facets to translate', () => {
+    expect(
+      translateWhereClauseInQuery('error 404', 'lucene', 'sql', new Set()),
+    ).toBe('error 404');
+  });
+
+  it('returns the text unchanged when the source does not parse', () => {
+    expect(
+      translateWhereClauseInQuery('service:', 'lucene', 'sql', new Set()),
+    ).toBe('service:');
+  });
+});
+
+describe('useSearchPageFilterState mutator identity stability', () => {
+  it('keeps every mutator reference stable across searchQuery changes when onFilterChange is stable', () => {
+    // Regression guard: the sidebar is memoized, so its props (the mutators)
+    // must keep stable identities while the user types. `searchQuery` changes
+    // per keystroke, but that alone must not re-create the mutators.
+    const onFilterChange = jest.fn();
+    let props = {
+      searchQuery: EMPTY_SEARCH_QUERY,
+      onFilterChange,
+      knownColumns: new Set<string>(),
+    };
+    const { result, rerender } = renderHook(() =>
+      useSearchPageFilterState(props),
+    );
+
+    const first = {
+      setFilterValue: result.current.setFilterValue,
+      setOnlyFilters: result.current.setOnlyFilters,
+      replaceFilterValue: result.current.replaceFilterValue,
+      setFilterRange: result.current.setFilterRange,
+      clearFilter: result.current.clearFilter,
+      clearAllFilters: result.current.clearAllFilters,
+      retainFiltersByColumns: result.current.retainFiltersByColumns,
+    };
+
+    props = {
+      ...props,
+      // A different searchQuery that still resolves to no facets, so the
+      // internal `filters` state is untouched and every mutator can be
+      // asserted stable.
+      searchQuery: [{ type: 'sql', condition: "Body LIKE '%error%'" }],
+    };
+    rerender();
+
+    expect(result.current.setFilterValue).toBe(first.setFilterValue);
+    expect(result.current.setOnlyFilters).toBe(first.setOnlyFilters);
+    expect(result.current.replaceFilterValue).toBe(first.replaceFilterValue);
+    expect(result.current.setFilterRange).toBe(first.setFilterRange);
+    expect(result.current.clearFilter).toBe(first.clearFilter);
+    expect(result.current.clearAllFilters).toBe(first.clearAllFilters);
+    expect(result.current.retainFiltersByColumns).toBe(
+      first.retainFiltersByColumns,
+    );
+  });
+
+  it('re-creates the mutators when onFilterChange changes identity', () => {
+    let onFilterChange = jest.fn();
+    let props = {
+      searchQuery: EMPTY_SEARCH_QUERY,
+      onFilterChange,
+      knownColumns: new Set<string>(),
+    };
+    const { result, rerender } = renderHook(() =>
+      useSearchPageFilterState(props),
+    );
+    const firstSetFilterValue = result.current.setFilterValue;
+
+    // A new onFilterChange identity (what happened per keystroke when
+    // handleSetFilters closed over the watched `where`) must invalidate the
+    // mutators.
+    onFilterChange = jest.fn();
+    props = { ...props, onFilterChange };
+    rerender();
+
+    expect(result.current.setFilterValue).not.toBe(firstSetFilterValue);
   });
 });

--- a/packages/app/src/searchFilters.test.ts
+++ b/packages/app/src/searchFilters.test.ts
@@ -259,4 +259,31 @@ describe('replaceFiltersInWhereClause', () => {
       'host:"b"',
     );
   });
+
+  it('wraps OR residual in parens before appending AND facet (Lucene OR semantics)', () => {
+    // When the residual (non-facet content) contains a top-level OR, appending
+    // new facet clauses with AND would change semantics without parenthesization.
+    // e.g. `error OR warn` residual + `level:"error"` → `(error OR warn) AND level:"error"`
+    // not `error OR warn AND level:"error"` (which parses as `error OR (warn AND level:"error")`)
+    const where = 'error OR warn';
+    // No facet fields in this query, so replace with a fresh level filter.
+    // The residual `error OR warn` must be wrapped in parens.
+    const filters: Filter[] = [{ type: 'sql', condition: "level IN ('error')" }];
+    const result = replaceFiltersInWhereClause(
+      where,
+      'lucene',
+      filters,
+      new Set(),
+    );
+    expect(result).toBe('(error  OR warn) AND level:"error"');
+  });
+
+  it('replaces lowercase sql facet (case-insensitive detection)', () => {
+    // lowercase `in` should still be recognised as a facet and replaced
+    const where = "host in ('a') AND foo = 1";
+    const filters: Filter[] = [{ type: 'sql', condition: "host IN ('b')" }];
+    expect(replaceFiltersInWhereClause(where, 'sql', filters, new Set())).toBe(
+      "foo = 1 AND host IN ('b')",
+    );
+  });
 });

--- a/packages/app/src/searchFilters.test.ts
+++ b/packages/app/src/searchFilters.test.ts
@@ -2,7 +2,12 @@ import { enableMapSet } from 'immer';
 import { Filter } from '@hyperdx/common-utils/dist/types';
 import { act, renderHook } from '@testing-library/react';
 
-import { parseQuery, useSearchPageFilterState } from '@/searchFilters';
+import {
+  parseQuery,
+  replaceFiltersInWhereClause,
+  useSearchPageFilterState,
+  whereToFilters,
+} from '@/searchFilters';
 
 // Filter state stores values in Sets; the app enables immer's MapSet plugin at
 // startup, but this isolated hook test must enable it explicitly.
@@ -190,5 +195,68 @@ describe('canonical key escaping at the persistence boundary', () => {
         'a',
       ]);
     });
+  });
+});
+
+describe('whereToFilters', () => {
+  it('derives SQL filters from a lucene where clause', () => {
+    expect(whereToFilters('host:"a"', 'lucene', new Set())).toEqual([
+      { type: 'sql', condition: "host IN ('a')" },
+    ]);
+  });
+
+  it('derives SQL filters from a sql where clause', () => {
+    expect(whereToFilters("host IN ('a', 'b')", 'sql', new Set())).toEqual([
+      { type: 'sql', condition: "host IN ('a', 'b')" },
+    ]);
+  });
+
+  it('projects only facet clauses, dropping free text', () => {
+    expect(whereToFilters('error 404 host:"a"', 'lucene', new Set())).toEqual([
+      { type: 'sql', condition: "host IN ('a')" },
+    ]);
+  });
+
+  it('quotes special-character columns via knownColumns', () => {
+    expect(
+      whereToFilters('service-name:"a"', 'lucene', new Set(['service-name'])),
+    ).toEqual([{ type: 'sql', condition: "`service-name` IN ('a')" }]);
+  });
+
+  it('emits map sub-keys in canonical bracket form', () => {
+    expect(
+      whereToFilters(
+        'LogAttributes.host.name:"x"',
+        'lucene',
+        new Set(['LogAttributes']),
+      ),
+    ).toEqual([
+      { type: 'sql', condition: "LogAttributes['host.name'] IN ('x')" },
+    ]);
+  });
+});
+
+describe('replaceFiltersInWhereClause', () => {
+  it('rewrites a lucene facet clause while preserving free text', () => {
+    const where = 'host:"a" AND error';
+    const filters: Filter[] = [{ type: 'sql', condition: "host IN ('b')" }];
+    expect(
+      replaceFiltersInWhereClause(where, 'lucene', filters, new Set()),
+    ).toBe('error AND host:"b"');
+  });
+
+  it('rewrites a sql facet conjunct while preserving other conjuncts', () => {
+    const where = "host IN ('a') AND foo = 1";
+    const filters: Filter[] = [{ type: 'sql', condition: "host IN ('b')" }];
+    expect(replaceFiltersInWhereClause(where, 'sql', filters, new Set())).toBe(
+      "foo = 1 AND host IN ('b')",
+    );
+  });
+
+  it('emits a fresh clause when the where is empty', () => {
+    const filters: Filter[] = [{ type: 'sql', condition: "host IN ('b')" }];
+    expect(replaceFiltersInWhereClause('', 'lucene', filters, new Set())).toBe(
+      'host:"b"',
+    );
   });
 });

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -4,6 +4,8 @@ import {
   type FilterState,
   filtersToQuery,
   parseQuery,
+  parseWhereClauseToFilterState,
+  replaceFilterClauses,
 } from '@hyperdx/common-utils/dist/filters';
 import type { Filter } from '@hyperdx/common-utils/dist/types';
 
@@ -35,12 +37,60 @@ export const escapeFilterStateKeys = (
 };
 
 // Convert valid SQL/persisted keys to clean FilterState keys.
-const unescapeFilterStateKeys = (filters: FilterState): FilterState => {
+export const unescapeFilterStateKeys = (filters: FilterState): FilterState => {
   const cleaned: FilterState = {};
   for (const [key, value] of Object.entries(filters)) {
     cleaned[cleanClickHouseExpression(key)] = value;
   }
   return cleaned;
+};
+
+/**
+ * Derive the SQL `Filter[]` the search page's filter hook expects from a
+ * `where` clause string in either query language. The `where` text is the
+ * canonical form on the search page, so this adapter is what feeds the
+ * sidebar's FilterState: facet clauses are parsed out (`whereToFilters` is a
+ * lossy projection for facets only — free-text and complex content doesn't map
+ * to facets and is dropped here), escaped back to canonical SQL keys, and
+ * emitted as `filtersToQuery` filters so the hook's existing parse/unescape
+ * cycle restores clean keys for the sidebar.
+ */
+export const whereToFilters = (
+  whereText: string,
+  whereLanguage: 'lucene' | 'sql',
+  knownColumns: Set<string>,
+  dateTimeColumns?: ReadonlyMap<string, string>,
+): Filter[] => {
+  const state = parseWhereClauseToFilterState(whereText, whereLanguage);
+  const clean =
+    whereLanguage === 'sql' ? unescapeFilterStateKeys(state) : state;
+  return filtersToQuery(escapeFilterStateKeys(clean, knownColumns), {
+    dateTimeColumns,
+  });
+};
+
+/**
+ * Rewrite a `where` clause string so its facet clauses reflect `filters` (the
+ * SQL `Filter[]` emitted by the filter hook's mutators), preserving unrelated
+ * free-text/complex content. Keys in `filters` are the canonical
+ * quoted/bracket ClickHouse form; they are unescaped to clean keys before the
+ * round-trip so `replaceFilterClauses` can match existing clauses.
+ */
+export const replaceFiltersInWhereClause = (
+  whereText: string,
+  whereLanguage: 'lucene' | 'sql',
+  filters: Filter[],
+  knownColumns: Set<string>,
+  dateTimeColumns?: ReadonlyMap<string, string>,
+): string => {
+  const cleanState = unescapeFilterStateKeys(parseQuery(filters).filters);
+  return replaceFilterClauses(whereText, whereLanguage, cleanState, {
+    escapeKey:
+      whereLanguage === 'sql'
+        ? key => toQuotedClickHouseKeyExpression(key, knownColumns)
+        : undefined,
+    dateTimeColumns,
+  });
 };
 
 export const areFiltersEqual = (a: FilterState, b: FilterState) => {

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -3,6 +3,7 @@ import produce from 'immer';
 import {
   type FilterState,
   filtersToQuery,
+  mergeFilterStateIntoWhereClause,
   parseQuery,
   parseWhereClauseToFilterState,
   replaceFilterClauses,
@@ -93,6 +94,64 @@ export const replaceFiltersInWhereClause = (
   });
 };
 
+/**
+ * Append `filters` to a `where` clause while preserving the existing text
+ * verbatim. Unlike `replaceFiltersInWhereClause` (used for sidebar toggles,
+ * where the existing text's facet fields are owned by the FilterState and get
+ * replaced), this *merges*: the original clause and the new filters are both
+ * kept, ANDed together.
+ *
+ * This is the semantics required when migrating a legacy `where` + separate
+ * `filters` representation (independent predicates ANDed at query time) into
+ * the unified `where`, so neither side may be dropped.
+ */
+export const mergeFiltersIntoWhereClause = (
+  whereText: string,
+  whereLanguage: 'lucene' | 'sql',
+  filters: Filter[],
+  knownColumns: Set<string>,
+  dateTimeColumns?: ReadonlyMap<string, string>,
+): string => {
+  const cleanState = unescapeFilterStateKeys(parseQuery(filters).filters);
+  return mergeFilterStateIntoWhereClause(whereText, whereLanguage, cleanState, {
+    escapeKey:
+      whereLanguage === 'sql'
+        ? key => toQuotedClickHouseKeyExpression(key, knownColumns)
+        : undefined,
+    dateTimeColumns,
+  });
+};
+
+/**
+ * Convert a `where` clause from one query language to another so the facet
+ * clauses transfer across a language switch instead of being dropped when the
+ * text is re-parsed in the new language. Facet clauses are re-emitted in the
+ * target language; non-facet content (free text, complex conditions) is
+ * preserved verbatim. If the text parses to no facets (or is unparseable) it is
+ * returned unchanged so we never clobber in-progress or facet-free input.
+ */
+export const translateWhereClauseInQuery = (
+  whereText: string,
+  fromLanguage: 'lucene' | 'sql',
+  toLanguage: 'lucene' | 'sql',
+  knownColumns: Set<string>,
+  dateTimeColumns?: ReadonlyMap<string, string>,
+): string => {
+  if (fromLanguage === toLanguage) return whereText;
+  const state = parseWhereClauseToFilterState(whereText, fromLanguage);
+  const cleanState =
+    fromLanguage === 'sql' ? unescapeFilterStateKeys(state) : state;
+  if (Object.keys(cleanState).length === 0) return whereText;
+  return replaceFilterClauses(whereText, fromLanguage, cleanState, {
+    emitLanguage: toLanguage,
+    escapeKey:
+      toLanguage === 'sql'
+        ? key => toQuotedClickHouseKeyExpression(key, knownColumns)
+        : undefined,
+    dateTimeColumns,
+  });
+};
+
 export const areFiltersEqual = (a: FilterState, b: FilterState) => {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
@@ -128,6 +187,10 @@ export const areFiltersEqual = (a: FilterState, b: FilterState) => {
 // filtersToQuery; re-export so existing `@/searchFilters` importers keep working.
 export { parseQuery };
 
+export {
+  getUnrepresentableWhereReason,
+  getWhereParseError,
+} from '@hyperdx/common-utils/dist/filters';
 export const useSearchPageFilterState = ({
   searchQuery = [],
   onFilterChange,

--- a/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
+++ b/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
@@ -1,4 +1,5 @@
 import {
+  coerceBooleanValue,
   type FilterState,
   filterStateToWhereClause,
   getUnrepresentableWhereReason,
@@ -161,11 +162,15 @@ describe('parseWhereClauseToFilterState (lucene)', () => {
     });
   });
 
-  it('coerces boolean values', () => {
+  it('does not coerce string "true"/"false" to booleans at parse time', () => {
+    // Lucene always stores values as quoted strings. `isRootSpan:"true"` is the
+    // string "true", not the boolean. Coercing at parse time corrupts string
+    // columns — see Bug 6. The string is preserved as-is; callers that know
+    // the column is Boolean can apply coerceBooleanValue themselves.
     expect(
       parseWhereClauseToFilterState('isRootSpan:"true"', 'lucene'),
     ).toEqual({
-      isRootSpan: { included: new Set([true]), excluded: new Set() },
+      isRootSpan: { included: new Set(['true']), excluded: new Set() },
     });
   });
 
@@ -957,6 +962,56 @@ describe('IN (SELECT ...) subqueries are preserved, not treated as facets', () =
     );
     expect(state).toEqual({});
   });
+
+  it('does not render a checkbox for a SELECT-only subquery value', () => {
+    const state = parseWhereClauseToFilterState(
+      'ServiceName IN (SELECT max(name))',
+      'sql',
+    );
+    expect(state).toEqual({});
+  });
+
+  it('does not destroy a SELECT-only subquery when a different facet is added', () => {
+    const result = replaceFilterClauses(
+      'ServiceName IN (SELECT max(name))',
+      'sql',
+      {
+        SeverityText: { included: new Set(['error']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName IN (SELECT max(name)) AND SeverityText IN ('error')",
+    );
+  });
+});
+
+describe('SQL NOT-wrapped IN facets are replaced instead of preserved', () => {
+  it('parses NOT (col IN (...)) as an excluded facet value', () => {
+    const state = parseWhereClauseToFilterState(
+      "ServiceName = 'api' AND NOT (svc IN ('a'))",
+      'sql',
+    );
+    expect(state).toEqual({
+      svc: { included: new Set(), excluded: new Set(['a']) },
+    });
+  });
+
+  it('prunes NOT (col IN (...)) when the sidebar replaces the same field', () => {
+    const result = replaceFilterClauses("NOT (svc IN ('a'))", 'sql', {
+      svc: { included: new Set(['b']), excluded: new Set() },
+    });
+    expect(result).toBe("svc IN ('b')");
+  });
+
+  it('flips a NOT-wrapped NOT IN facet back to an included value', () => {
+    const state = parseWhereClauseToFilterState(
+      "NOT (svc NOT IN ('a'))",
+      'sql',
+    );
+    expect(state).toEqual({
+      svc: { included: new Set(['a']), excluded: new Set() },
+    });
+  });
 });
 
 describe('repeated SQL predicates for the same field are all replaced by a sidebar click', () => {
@@ -1190,7 +1245,19 @@ describe('getUnrepresentableWhereReason', () => {
     ).not.toBeNull();
   });
 
-  it('does not flag AND or same-field OR', () => {
+  it('flags a same-field OR with a negated term', () => {
+    expect(
+      getUnrepresentableWhereReason('a:"1" OR NOT a:"2"', 'lucene'),
+    ).not.toBeNull();
+    expect(
+      getUnrepresentableWhereReason('a:"1" OR -a:"2"', 'lucene'),
+    ).not.toBeNull();
+    expect(
+      getUnrepresentableWhereReason('NOT a:"1" OR a:"2"', 'lucene'),
+    ).not.toBeNull();
+  });
+
+  it('does not flag AND or same-field OR without negation', () => {
     expect(
       getUnrepresentableWhereReason(
         'ServiceName:"api" AND SeverityText:"error"',
@@ -1260,6 +1327,25 @@ describe('lucene NOT keyword negation', () => {
     ).toEqual({});
   });
 
+  it('does not collect a same-field OR NOT or OR -field as facets', () => {
+    expect(
+      parseWhereClauseToFilterState('a:"1" OR NOT a:"2"', 'lucene'),
+    ).toEqual({});
+    expect(parseWhereClauseToFilterState('a:"1" OR -a:"2"', 'lucene')).toEqual(
+      {},
+    );
+    expect(
+      parseWhereClauseToFilterState('NOT a:"1" OR a:"2"', 'lucene'),
+    ).toEqual({});
+  });
+
+  it('preserves same-field OR NOT expression verbatim when replacing sibling facet', () => {
+    const result = replaceFilterClauses('a:"1" OR NOT a:"2"', 'lucene', {
+      b: { included: new Set(['3']), excluded: new Set() },
+    });
+    expect(result).toBe('(a:"1" OR NOT a:"2") AND b:"3"');
+  });
+
   it('round-trips NOT via excluded emission', () => {
     const state = parseWhereClauseToFilterState(
       'term AND NOT ServiceName:"api"',
@@ -1268,5 +1354,604 @@ describe('lucene NOT keyword negation', () => {
     expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
       '-ServiceName:"api"',
     );
+  });
+});
+
+// unquoted / wildcard / comparison Lucene terms must not be deleted
+// when a sidebar click targets a *different* field.
+//
+// Root cause: collectFromAst added ALL explicit-field names to managedFields,
+// including fields whose only representation is an unquoted term (e.g.
+// `ServiceName:api*`).  renderNode then pruned every managed field.  When
+// newState did NOT contain that field, nothing re-emitted it, silently deleting
+// user query content.
+//
+// Fix: managedFields is intersected with newState's keys, so only fields that
+// the caller is explicitly replacing are pruned.
+describe('unquoted / wildcard / comparison terms are preserved when a sidebar click targets a different field (Bug 10)', () => {
+  it('preserves a wildcard term when only a sibling field is replaced', () => {
+    // ServiceName:api* is unquoted; sidebar replaces SeverityText only.
+    const result = replaceFilterClauses(
+      'ServiceName:api* AND SeverityText:"error"',
+      'lucene',
+      {
+        SeverityText: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('ServiceName:api* AND SeverityText:"warn"');
+  });
+
+  it('preserves a plain unquoted term when only a sibling field is replaced', () => {
+    // SeverityText:error is unquoted; sidebar replaces ServiceName only.
+    const result = replaceFilterClauses(
+      'SeverityText:error AND ServiceName:"api"',
+      'lucene',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('SeverityText:error AND ServiceName:"web"');
+  });
+
+  it('preserves a comparison-operator term when only a sibling field is replaced', () => {
+    // Duration:>100 is an unquoted comparison term; sidebar replaces ServiceName only.
+    const result = replaceFilterClauses(
+      'Duration:>100 AND ServiceName:"api"',
+      'lucene',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('Duration:>100 AND ServiceName:"web"');
+  });
+
+  it('still replaces the targeted field even when it is unquoted in the query', () => {
+    // The sidebar is replacing SeverityText — the unquoted SeverityText:error
+    // should be pruned and re-emitted as SeverityText:"warn".
+    const result = replaceFilterClauses(
+      'SeverityText:error AND ServiceName:"api"',
+      'lucene',
+      {
+        SeverityText: { included: new Set(['warn']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('SeverityText:"warn" AND ServiceName:"api"');
+  });
+
+  it('preserves multiple unrelated unquoted terms alongside the replaced field', () => {
+    const result = replaceFilterClauses(
+      'ServiceName:api* AND Duration:>100 AND SeverityText:"error"',
+      'lucene',
+      {
+        SeverityText: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      'ServiceName:api* AND Duration:>100 AND SeverityText:"warn"',
+    );
+  });
+});
+
+// multi-line SQL where clauses were duplicated by a sidebar click.
+//
+// Root cause: splitSqlConjuncts only matched the literal ' AND ' (single space
+// on each side), so a newline before AND (e.g. "Body LIKE '%x%'\nAND
+// ServiceName IN ('api')") was not treated as a separator. The whole text was
+// returned as a single conjunct that could not be parsed as a facet, so
+// replaceSqlFacetClauses appended the new clause instead of replacing,
+// duplicating the query on every click.
+//
+// Fix: splitSqlConjuncts now treats any whitespace (spaces, tabs, newlines)
+// surrounding AND as a separator, matching `\s+AND\s+`.
+describe('multi-line SQL where clauses split correctly at AND', () => {
+  it('splits a newline-before-AND query into two conjuncts', () => {
+    const result = replaceFilterClauses(
+      "Body LIKE '%x%'\nAND ServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    // ServiceName IN ('api') should be replaced, not duplicated.
+    expect(result).toBe("Body LIKE '%x%' AND ServiceName IN ('web')");
+  });
+
+  it('splits a newline-after-AND query into two conjuncts', () => {
+    const result = replaceFilterClauses(
+      "Body LIKE '%x%' AND\nServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("Body LIKE '%x%' AND ServiceName IN ('web')");
+  });
+
+  it('splits when AND is surrounded by newlines on both sides', () => {
+    const result = replaceFilterClauses(
+      "Body LIKE '%x%'\nAND\nServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("Body LIKE '%x%' AND ServiceName IN ('web')");
+  });
+
+  it('does not duplicate when a second sidebar click follows a first', () => {
+    // Simulate: user has multi-line query, clicks web (first click), then api.
+    const after1stClick = replaceFilterClauses(
+      "Body LIKE '%x%'\nAND ServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    // Second click: switch to 'mobile'
+    const after2ndClick = replaceFilterClauses(after1stClick, 'sql', {
+      ServiceName: { included: new Set(['mobile']), excluded: new Set() },
+    });
+    expect(after2ndClick).toBe("Body LIKE '%x%' AND ServiceName IN ('mobile')");
+  });
+
+  it('parses a multi-line SQL where clause into the correct FilterState', () => {
+    const state = parseWhereClauseToFilterState(
+      "Body LIKE '%x%'\nAND ServiceName IN ('api')",
+      'sql',
+    );
+    expect(state).toEqual({
+      ServiceName: { included: new Set(['api']), excluded: new Set() },
+    });
+  });
+
+  it('preserves a BETWEEN clause that spans lines without treating its AND as a separator', () => {
+    // duration BETWEEN 1 AND 100 is a managed facet; when duration is also
+    // present in newState, the whole BETWEEN clause (including its own AND)
+    // must be treated as a single conjunct — not split on the BETWEEN's AND.
+    const result = replaceFilterClauses(
+      "duration BETWEEN 1\nAND 100\nAND ServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+        duration: {
+          included: new Set(),
+          excluded: new Set(),
+          range: { min: 1, max: 100 },
+        },
+      },
+    );
+    // Both conjuncts are managed; ServiceName is replaced, duration re-emitted.
+    expect(result).toBe(
+      "ServiceName IN ('web') AND duration BETWEEN 1 AND 100",
+    );
+  });
+
+  it('handles tab-separated AND', () => {
+    const result = replaceFilterClauses(
+      "Body LIKE '%x%'\tAND\tServiceName IN ('api')",
+      'sql',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("Body LIKE '%x%' AND ServiceName IN ('web')");
+  });
+});
+
+// Regression tests for Bug 3: SQL newline-adjacent OR is detected and
+// the residual is parenthesized before the AND join.
+//
+// Root cause: hasTopLevelOrSql only matched the literal 4-char sequence
+// ' OR ' (single space on each side), so `a = 1\nOR b = 2` was NOT
+// detected as containing a top-level OR.  The residual was left bare and
+// the new predicate was appended as-is, producing:
+//
+//   a = 1\nOR b = 2 AND svc IN ('x')
+//
+// which SQL parses as `a = 1 OR (b = 2 AND svc IN ('x'))` — exactly the
+// mis-parse the function's docstring warns about.
+//
+// Fix: hasTopLevelOrSql now matches any whitespace-surrounded OR keyword
+// (`\s+OR\s+`), consistent with the same fix applied to splitSqlConjuncts.
+describe('SQL newline-adjacent OR is parenthesized before AND join (Bug 3 / hasTopLevelOrSql)', () => {
+  it('wraps a newline-before-OR residual in parens', () => {
+    // `a = 1\nOR b = 2` is a raw/non-facet expression that is kept verbatim
+    // as the residual.  Since it contains a top-level OR (separated by \n),
+    // replaceFilterClauses must parenthesize it before appending the new clause.
+    const result = replaceFilterClauses('a = 1\nOR b = 2', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("(a = 1\nOR b = 2) AND svc IN ('x')");
+  });
+
+  it('wraps a newline-after-OR residual in parens', () => {
+    const result = replaceFilterClauses('a = 1 OR\nb = 2', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("(a = 1 OR\nb = 2) AND svc IN ('x')");
+  });
+
+  it('wraps when OR is surrounded by newlines on both sides', () => {
+    const result = replaceFilterClauses('a = 1\nOR\nb = 2', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("(a = 1\nOR\nb = 2) AND svc IN ('x')");
+  });
+
+  it('handles lowercase or separated by newline', () => {
+    const result = replaceFilterClauses('a = 1\nor b = 2', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("(a = 1\nor b = 2) AND svc IN ('x')");
+  });
+
+  it('does not double-wrap when the OR is already inside parentheses', () => {
+    const result = replaceFilterClauses('(a = 1\nOR b = 2)', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    // The OR is inside parens — no additional wrapping needed.
+    expect(result).toBe("(a = 1\nOR b = 2) AND svc IN ('x')");
+  });
+
+  it('does not treat an OR inside a single-quoted string as top-level', () => {
+    // "msg = 'a\nOR b'" — the OR is inside a string literal and must not
+    // trigger parenthesization.
+    const result = replaceFilterClauses("msg = 'a\nOR b'", 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("msg = 'a\nOR b' AND svc IN ('x')");
+  });
+
+  it('mergeFilterStateIntoWhereClause also parenthesizes a newline-adjacent OR', () => {
+    const result = mergeFilterStateIntoWhereClause('a = 1\nOR b = 2', 'sql', {
+      svc: { included: new Set(['x']), excluded: new Set() },
+    });
+    expect(result).toBe("(a = 1\nOR b = 2) AND svc IN ('x')");
+  });
+});
+
+// Regression tests for Bug 4: Lucene field-name escaping is now reversible;
+// backslashes no longer multiply on every sidebar click.
+//
+// Root cause: escapeLuceneFieldName escaped spaces as `\ ` (and similarly for
+// `(`, `)`, `{`, `}`, `[`, `]`), but decodeLuceneFieldName (before the fix)
+// only reversed `\:` and `\"`.  On the first click a key like
+// `LogAttributes['my key']` was written as `LogAttributes.my\ key:"v"`.
+// The Lucene parser preserved the backslash-space sequence in ast.field.
+// decodeSpecialTokens left it intact.  So the field parsed back as
+// `LogAttributes.my\ key` — which did NOT match the FilterState key
+// `LogAttributes.my key`.  On the next click, `escapeLuceneFieldName` ran
+// again on `LogAttributes.my\ key` and escaped the already-escaped backslash
+// to `\\`, yielding `LogAttributes.my\\ key:"v"` → backslash growth.
+//
+// Fix: decodeLuceneFieldName now reverses all nine escape sequences produced
+// by escapeLuceneFieldName (space, `(`, `)`, `"`, `{`, `}`, `[`, `]`, and
+// `\\`), and decodeFieldName combines it with decodeSpecialTokens.
+describe('Lucene field-name with space round-trips correctly; backslashes do not multiply (Bug 4 / decodeLuceneFieldName)', () => {
+  it('emits a parseable where clause for a key with a space', () => {
+    const state: FilterState = {
+      "LogAttributes['my key']": {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    // Must be parseable.
+    expect(() => parse(emitted)).not.toThrow();
+    // Must contain exactly one backslash-escaped space, not two.
+    expect(emitted).toBe(String.raw`LogAttributes.my\ key:"a"`);
+  });
+
+  it('parses the emitted clause back to the original key (round-trip)', () => {
+    const state: FilterState = {
+      "LogAttributes['my key']": {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    const parsed = parseWhereClauseToFilterState(emitted, 'lucene');
+    // The parsed key must match the dot-form key that filterStateToWhereClause
+    // uses internally (parseKeyPath normalises the bracket form to dots).
+    expect(parsed).toEqual({
+      'LogAttributes.my key': {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    });
+  });
+
+  it('replaces the clause on the first sidebar click without leaving a stale clause', () => {
+    const step1 = replaceFilterClauses('', 'lucene', {
+      "LogAttributes['my key']": {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    });
+    // Should produce exactly one backslash-space, not two (\\\ ).
+    expect(step1).toBe(String.raw`LogAttributes.my\ key:"a"`);
+  });
+
+  it('does not grow backslashes on a second sidebar click', () => {
+    // Simulate first click.
+    const step1 = replaceFilterClauses('', 'lucene', {
+      "LogAttributes['my key']": {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    });
+    // Second click: change value from 'a' to 'b'.
+    const step2 = replaceFilterClauses(step1, 'lucene', {
+      "LogAttributes['my key']": {
+        included: new Set(['b']),
+        excluded: new Set(),
+      },
+    });
+    // Must still have exactly one backslash-space, not four (\\\\\ ).
+    expect(step2).toBe(String.raw`LogAttributes.my\ key:"b"`);
+  });
+
+  it('does not grow backslashes on a third sidebar click', () => {
+    const key = "LogAttributes['my key']";
+    let query = '';
+    for (const value of ['a', 'b', 'c']) {
+      query = replaceFilterClauses(query, 'lucene', {
+        [key]: { included: new Set([value]), excluded: new Set() },
+      });
+    }
+    // After 3 round-trips the backslash count must not have grown.
+    expect(query).toBe(String.raw`LogAttributes.my\ key:"c"`);
+  });
+
+  it('the checkbox reads back as checked after the first sidebar click', () => {
+    // Bug: after the first click the parsed key was `LogAttributes.my\ key`
+    // (with backslash) and never matched the FilterState key
+    // `LogAttributes['my key']` (dot-form: `LogAttributes.my key`).
+    // The checkbox was therefore always shown as unchecked.
+    const emitted = replaceFilterClauses('', 'lucene', {
+      "LogAttributes['my key']": {
+        included: new Set(['a']),
+        excluded: new Set(),
+      },
+    });
+    const parsed = parseWhereClauseToFilterState(emitted, 'lucene');
+    // The dot-form of the key must appear in the parsed state.
+    expect(parsed['LogAttributes.my key']?.included).toEqual(new Set(['a']));
+  });
+
+  it('handles a key with multiple spaces without backslash growth', () => {
+    const key = "LogAttributes['my long key']";
+    let query = '';
+    for (const value of ['x', 'y']) {
+      query = replaceFilterClauses(query, 'lucene', {
+        [key]: { included: new Set([value]), excluded: new Set() },
+      });
+    }
+    // Only single backslash-space sequences, not doubled.
+    expect(query).toBe(String.raw`LogAttributes.my\ long\ key:"y"`);
+  });
+});
+
+// Regression tests for Bug 5: Language switch (emitLanguage) must not join a
+// source-language residual with target-language facets.
+//
+// Root cause: replaceFilterClauses with emitLanguage parses out facet clauses
+// in the *source* language and re-emits them in the *target* language. The
+// non-facet parts of the source text ("residual") are preserved verbatim.
+// When the residual is SQL-specific syntax (e.g. `ServiceName = 'api'`) and
+// the target language is Lucene, the result is a syntactically mixed string
+// (`ServiceName = 'api' AND level:"error"`) — neither valid SQL nor valid Lucene.
+// The reverse direction (SQL target with a Lucene residual) produces invalid SQL.
+//
+// Fix: when translating (emitLanguage is set) and the residual belongs to the
+// source language that is being left behind, the residual must be preserved
+// verbatim and returned as-is without being joined to the new-language facets.
+// Concretely, switching SQL→Lucene must not produce a hybrid string; likewise
+// for Lucene→SQL when the residual contains Lucene-only syntax.
+describe('language switch (emitLanguage) does not produce mixed-syntax output (Bug 5)', () => {
+  it('SQL→Lucene: non-facet SQL residual is not joined with Lucene facets', () => {
+    // `ServiceName = 'api'` is non-facet SQL. `level IN ('error')` is a facet
+    // and gets translated to `level:"error"`. The SQL residual must NOT be
+    // joined with the Lucene clause — doing so yields a hybrid string like
+    // `ServiceName = 'api' AND level:"error"` which is neither valid SQL nor
+    // valid Lucene.
+    //
+    // Fix: when there is a non-empty SQL residual and the emit language is not
+    // SQL, replaceSqlFacetClauses returns the residual verbatim (preserving the
+    // original non-facet content) without appending the Lucene facets. The
+    // translated facets are discarded — the caller cannot automatically translate
+    // non-facet SQL to Lucene, so preserving the source is the safe choice.
+    const result = replaceFilterClauses(
+      "ServiceName = 'api' AND level IN ('error')",
+      'sql',
+      { level: { included: new Set(['error']), excluded: new Set() } },
+      { emitLanguage: 'lucene' },
+    );
+    // The result must NOT be a mixed-language string — no Lucene syntax joined
+    // with SQL assignment syntax.
+    expect(result).not.toMatch(/ServiceName = 'api' AND level:"error"/);
+    // The SQL residual is preserved verbatim; the untranslatable part is kept.
+    expect(result).toBe("ServiceName = 'api'");
+  });
+
+  it('Lucene→SQL: non-facet Lucene residual is not joined with SQL facets', () => {
+    // `error 404` is Lucene free-text (implicit-field term). `ServiceName:"api"`
+    // is a facet and gets translated to `ServiceName IN ('api')`. The free-text
+    // residual does NOT map to any SQL construct, but it is language-neutral
+    // (just raw text) so it can be safely preserved on both sides.
+    // This case is already handled correctly; we test the strictly-Lucene case:
+    // a Lucene range like `duration:[10 TO 500]` in the residual would be invalid SQL.
+    const result = replaceFilterClauses(
+      'duration:[10 TO 500] AND ServiceName:"api"',
+      'lucene',
+      { ServiceName: { included: new Set(['api']), excluded: new Set() } },
+      { emitLanguage: 'sql' },
+    );
+    // The translated facet must be present in SQL form.
+    expect(result).toContain("ServiceName IN ('api')");
+    // The Lucene range syntax `duration:[10 TO 500]` must NOT appear alongside
+    // a SQL clause — it is invalid SQL and would cause a query error.
+    expect(result).not.toMatch(/duration:\[10 TO 500\] AND ServiceName IN/);
+  });
+
+  it('SQL→Lucene: only facet clauses are translated; pure-facet source becomes pure Lucene', () => {
+    // When the entire source is a parseable SQL facet, the output should be
+    // valid Lucene only — no SQL syntax remnants.
+    const result = replaceFilterClauses(
+      "level IN ('error')",
+      'sql',
+      { level: { included: new Set(['error']), excluded: new Set() } },
+      { emitLanguage: 'lucene' },
+    );
+    expect(result).toBe('level:"error"');
+  });
+
+  it('Lucene→SQL: only facet clauses are translated; pure-facet source becomes pure SQL', () => {
+    const result = replaceFilterClauses(
+      'level:"error"',
+      'lucene',
+      { level: { included: new Set(['error']), excluded: new Set() } },
+      { emitLanguage: 'sql' },
+    );
+    expect(result).toBe("level IN ('error')");
+  });
+
+  it('SQL→Lucene: switching back after a switch does not accumulate syntax from both languages', () => {
+    // Simulate the user's round-trip: SQL query → switch to Lucene → switch back.
+    // The final result after switching back to SQL should be equivalent SQL,
+    // not a growing mixture of both syntaxes.
+    const original = "level IN ('error') AND ServiceName IN ('api')";
+
+    // First switch: SQL → Lucene
+    const afterToLucene = replaceFilterClauses(
+      original,
+      'sql',
+      {
+        level: { included: new Set(['error']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+      { emitLanguage: 'lucene' },
+    );
+    // Must be valid Lucene: no SQL IN (...) syntax.
+    expect(afterToLucene).not.toContain(' IN (');
+    expect(afterToLucene).toContain('level:"error"');
+
+    // Second switch: Lucene → SQL
+    const afterBackToSql = replaceFilterClauses(
+      afterToLucene,
+      'lucene',
+      {
+        level: { included: new Set(['error']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+      { emitLanguage: 'sql' },
+    );
+    // Must be valid SQL: no Lucene field:"value" syntax.
+    expect(afterBackToSql).not.toMatch(/\w+:"\w+"/);
+    expect(afterBackToSql).toContain("level IN ('error')");
+  });
+});
+
+// Regression tests for Bug 6: coerceBooleanValue must not convert the string
+// literals "true"/"false" to actual booleans when the source is Lucene.
+//
+// Root cause: parseWhereClauseToFilterState (lucene) calls coerceBooleanValue
+// on every quoted term value. So `msg:"true"` parses to
+// { msg: { included: Set([true]) } } — the boolean `true`, not the string.
+// When filterStateToWhereClause re-emits that state as SQL it calls
+// filtersToQuery, whose formatValue branch emits `typeof v !== 'string' ? v`
+// — so boolean `true` is emitted bare (without quotes), producing:
+//
+//   msg IN (true)
+//
+// This is a ClickHouse type error when `msg` is a String column (boolean `true`
+// cannot be compared to a String). There is also no way to filter a string
+// column for the literal value "true" because the sidebar always coerces it to
+// a boolean.
+//
+// Fix: coerceBooleanValue should only be applied when the context is a boolean
+// column (e.g. `isRootSpan`). For Lucene parsing, the Lucene boolean coercion
+// should be opt-in (keyed on the column type), or else the string "true"/"false"
+// must be kept as a string so that SQL emission wraps it in quotes.
+describe('coerceBooleanValue does not corrupt string "true"/"false" values (Bug 6)', () => {
+  it('parseWhereClauseToFilterState keeps the string "true" as a string in Lucene', () => {
+    // msg:"true" must parse to { msg: { included: Set(["true"]) } },
+    // NOT { msg: { included: Set([true]) } } (boolean).
+    const state = parseWhereClauseToFilterState('msg:"true"', 'lucene');
+    // The value must be the string "true", not the boolean true.
+    expect(state.msg?.included).toEqual(new Set(['true']));
+    // Confirm it is NOT the boolean:
+    const values = Array.from(state.msg?.included ?? []);
+    expect(typeof values[0]).toBe('string');
+  });
+
+  it('parseWhereClauseToFilterState keeps the string "false" as a string in Lucene', () => {
+    const state = parseWhereClauseToFilterState('flag:"false"', 'lucene');
+    expect(state.flag?.included).toEqual(new Set(['false']));
+    const values = Array.from(state.flag?.included ?? []);
+    expect(typeof values[0]).toBe('string');
+  });
+
+  it('filterStateToWhereClause (SQL) wraps "true" string in quotes, not bare boolean', () => {
+    // If a FilterState has the string "true" as a value, emitting SQL must
+    // produce `msg IN ('true')`, not `msg IN (true)`.
+    const state: FilterState = {
+      msg: {
+        included: new Set<string | boolean>(['true']),
+        excluded: new Set(),
+      },
+    };
+    const sql = filterStateToWhereClause(state, { language: 'sql' });
+    expect(sql).toBe("msg IN ('true')");
+    // Must not contain the unquoted boolean:
+    expect(sql).not.toMatch(/IN \(true\)/);
+  });
+
+  it('Lucene→SQL translation of msg:"true" emits quoted string, not bare boolean', () => {
+    // Full round-trip: parse `msg:"true"` from Lucene, re-emit as SQL.
+    // Must produce `msg IN ('true')`, not `msg IN (true)`.
+    const result = replaceFilterClauses(
+      'msg:"true"',
+      'lucene',
+      { msg: { included: new Set(['true']), excluded: new Set() } },
+      { emitLanguage: 'sql' },
+    );
+    expect(result).toBe("msg IN ('true')");
+    expect(result).not.toMatch(/IN \(true\)/);
+  });
+
+  it('Lucene→SQL translation of msg:"-false" (excluded) emits quoted string', () => {
+    const result = replaceFilterClauses(
+      '-flag:"false"',
+      'lucene',
+      { flag: { included: new Set(), excluded: new Set(['false']) } },
+      { emitLanguage: 'sql' },
+    );
+    expect(result).toBe("flag NOT IN ('false')");
+    expect(result).not.toMatch(/NOT IN \(false\)/);
+  });
+
+  it('isRootSpan:"true" parses as a string and emits quoted SQL (no type error for Boolean columns)', () => {
+    // After the fix, coerceBooleanValue is no longer called at parse time.
+    // isRootSpan:"true" parses to the string "true". When emitted as SQL it
+    // becomes `isRootSpan IN ('true')`. ClickHouse will implicitly cast the
+    // string 'true' to the Boolean column type, so this is still correct for
+    // Boolean columns — and it is now also correct for String columns.
+    const state = parseWhereClauseToFilterState('isRootSpan:"true"', 'lucene');
+    // Must be the string 'true', not the boolean true.
+    expect(state.isRootSpan?.included).toEqual(new Set(['true']));
+
+    const sql = filterStateToWhereClause(state, { language: 'sql' });
+    // Must be quoted — no bare boolean:
+    expect(sql).toBe("isRootSpan IN ('true')");
+    expect(sql).not.toMatch(/IN \(true\)/);
+  });
+
+  it('coerceBooleanValue preserves non-boolean strings unchanged', () => {
+    expect(coerceBooleanValue('hello')).toBe('hello');
+    expect(coerceBooleanValue('TRUE')).toBe('TRUE'); // uppercase not coerced
+    expect(coerceBooleanValue('True')).toBe('True'); // mixed-case not coerced
+    expect(coerceBooleanValue(123 as unknown as string)).toBe(123); // pass-through
   });
 });

--- a/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
+++ b/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
@@ -1,6 +1,9 @@
 import {
   type FilterState,
   filterStateToWhereClause,
+  getUnrepresentableWhereReason,
+  getWhereParseError,
+  mergeFilterStateIntoWhereClause,
   parseWhereClauseToFilterState,
   replaceFilterClauses,
 } from '@/filters';
@@ -275,11 +278,14 @@ describe('replaceFilterClauses (lucene)', () => {
     expect(result).toBe('');
   });
 
-  it('leaves invalid lucene unchanged', () => {
+  it('replaces invalid lucene with the new clause (sidebar click applies)', () => {
+    // Unparseable text (e.g. an incomplete query like `service:`) can't be
+    // rewritten in place; a sidebar click should still apply by replacing the
+    // broken text with the new state rather than silently no-oping.
     const result = replaceFilterClauses('(((', 'lucene', {
       host: { included: new Set(['b']), excluded: new Set() },
     });
-    expect(result).toBe('(((');
+    expect(result).toBe('host:"b"');
   });
 
   it('preserves an OR group without dangling connectors', () => {
@@ -389,5 +395,864 @@ describe('replaceFilterClauses (sql)', () => {
       host: { included: new Set(['b']), excluded: new Set() },
     });
     expect(result).toBe("host IN ('b')");
+  });
+});
+
+// Regression tests for the 10 WHERE-string generation bugs
+
+describe('NOT prefix is preserved through replaceFilterClauses', () => {
+  it('keeps the NOT prefix when a sibling facet clause is replaced', () => {
+    // Original: NOT term AND ServiceName:"api"
+    // Click sidebar to change ServiceName → "accounting"
+    // Must NOT silently strip the `NOT` operator.
+    const result = replaceFilterClauses(
+      'NOT term AND ServiceName:"api"',
+      'lucene',
+      {
+        ServiceName: { included: new Set(['accounting']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('NOT term AND ServiceName:"accounting"');
+  });
+});
+
+describe('cross-field OR is not silently converted to AND', () => {
+  it('preserves a cross-field OR query as-is when a different facet is added', () => {
+    // ServiceName:"api" OR SeverityText:"error" cannot be represented as a
+    // FilterState (AND semantics), so the whole OR must be left untouched.
+    const result = replaceFilterClauses(
+      'ServiceName:"api" OR SeverityText:"error"',
+      'lucene',
+      {
+        // We are NOT replacing ServiceName or SeverityText — we add a third field.
+        level: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    // The cross-field OR is preserved; the new clause is ANDed after.
+    expect(result).toBe(
+      '(ServiceName:"api" OR SeverityText:"error") AND level:"warn"',
+    );
+  });
+
+  it('treats each side of a cross-field OR as unmanaged (no field collected)', () => {
+    // parseWhereClauseToFilterState should return empty for cross-field OR
+    // because neither side alone represents a reproducible facet state.
+    const state = parseWhereClauseToFilterState(
+      'ServiceName:"api" OR SeverityText:"error"',
+      'lucene',
+    );
+    expect(state).toEqual({});
+  });
+});
+
+describe('field-group syntax ServiceName:("api" OR "web") round-trips correctly', () => {
+  it('parses a field group into the correct FilterState', () => {
+    const state = parseWhereClauseToFilterState(
+      'ServiceName:("api" OR "web")',
+      'lucene',
+    );
+    expect(state).toEqual({
+      ServiceName: { included: new Set(['api', 'web']), excluded: new Set() },
+    });
+  });
+
+  it('replaces a field-group clause without duplicating or dropping the field name', () => {
+    // Bug: was dropping ServiceName: and emitting ("api" OR "web") as free-text,
+    // then also appending the new clause → duplication + full-text search.
+    const result = replaceFilterClauses(
+      'ServiceName:("api" OR "web") AND term',
+      'lucene',
+      {
+        ServiceName: {
+          included: new Set(['api', 'web', 'admin']),
+          excluded: new Set(),
+        },
+      },
+    );
+    // `term` (free-text) preserved; ServiceName clause replaced (no duplication).
+    expect(result).toBe(
+      'term AND (ServiceName:"api" OR ServiceName:"web" OR ServiceName:"admin")',
+    );
+  });
+});
+
+describe('range clause at source offset 0 is not dropped', () => {
+  it('replaces a range that starts at the beginning of the query string', () => {
+    // Duration:[* TO 100] starts at offset 0 → fieldLocation.start.offset === 0,
+    // which is falsy and was causing the span to be null (clause silently dropped).
+    const result = replaceFilterClauses(
+      'Duration:[0 TO 100] AND ServiceName:"api"',
+      'lucene',
+      {
+        Duration: {
+          included: new Set(),
+          excluded: new Set(),
+          range: { min: 0, max: 50 },
+        },
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('Duration:[0 TO 50] AND ServiceName:"web"');
+  });
+
+  it('parses a range at offset 0 into FilterState correctly', () => {
+    const state = parseWhereClauseToFilterState(
+      'Duration:[0 TO 100]',
+      'lucene',
+    );
+    expect(state).toEqual({
+      Duration: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 0, max: 100 },
+      },
+    });
+  });
+});
+
+describe('exclusive range bounds are preserved', () => {
+  it('emits exclusive {…} brackets when the range has inclusive: none', () => {
+    const state: FilterState = {
+      Duration: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 10, max: 20, inclusive: 'none' },
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'Duration:{10 TO 20}',
+    );
+  });
+
+  it('round-trips an exclusive range without converting to inclusive', () => {
+    const result = replaceFilterClauses('Duration:{10 TO 20}', 'lucene', {
+      Duration: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 10, max: 20, inclusive: 'none' },
+      },
+    });
+    expect(result).toBe('Duration:{10 TO 20}');
+  });
+
+  it('parses an exclusive range and stores inclusive: none', () => {
+    const state = parseWhereClauseToFilterState(
+      'Duration:{10 TO 20}',
+      'lucene',
+    );
+    expect(state.Duration?.range).toEqual({
+      min: 10,
+      max: 20,
+      inclusive: 'none',
+    });
+  });
+
+  it('emits left-exclusive {min TO max] for inclusive: right', () => {
+    const state: FilterState = {
+      score: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 0, max: 100, inclusive: 'right' },
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'score:{0 TO 100]',
+    );
+  });
+});
+
+describe('proximity/boost modifiers are not stripped', () => {
+  it('preserves a proximity modifier when a sibling facet is replaced', () => {
+    // msg:"hello"~2 should remain untouched when ServiceName is changed.
+    const result = replaceFilterClauses(
+      'msg:"hello"~2 AND ServiceName:"api"',
+      'lucene',
+      {
+        ServiceName: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('msg:"hello"~2 AND ServiceName:"web"');
+  });
+
+  it('preserves a boost modifier when a sibling facet is replaced', () => {
+    const result = replaceFilterClauses(
+      'title:"report"^3 AND level:"info"',
+      'lucene',
+      {
+        level: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('title:"report"^3 AND level:"warn"');
+  });
+
+  it('does not collect a proximity term into FilterState', () => {
+    // A proximity term cannot be faithfully represented; it should be skipped.
+    const state = parseWhereClauseToFilterState(
+      'msg:"hello"~2 AND ServiceName:"api"',
+      'lucene',
+    );
+    expect(state).toEqual({
+      ServiceName: { included: new Set(['api']), excluded: new Set() },
+    });
+  });
+});
+
+describe('modifier terms and negated ranges do not survive alongside new clause', () => {
+  it('replaces a plain sibling clause when the field also has a modifier term', () => {
+    // msg:"hello"~2 cannot round-trip into FilterState, but msg:"world" can.
+    // When the sidebar sets msg:"goodbye", msg:"world" must be removed so it
+    // does not pile up alongside the new clause.
+    const result = replaceFilterClauses(
+      'msg:"hello"~2 AND msg:"world" AND ServiceName:"api"',
+      'lucene',
+      {
+        msg: { included: new Set(['goodbye']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+    );
+    // msg:"world" is pruned; msg:"hello"~2 is preserved verbatim (unmanageable).
+    expect(result).toBe('msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"');
+  });
+
+  it('preserves a modifier-only field verbatim and appends the new clause', () => {
+    // If there is no plain sibling, the modifier term is kept and the new
+    // clause is appended — the sidebar click still applies.
+    const result = replaceFilterClauses(
+      'msg:"hello"~2 AND ServiceName:"api"',
+      'lucene',
+      {
+        msg: { included: new Set(['goodbye']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"');
+  });
+
+  it('replaces a plain range clause when the field also has a negated range', () => {
+    // NOT duration:[10 TO 20] cannot round-trip, but duration:[0 TO 5] can.
+    // When the sidebar sets a new range for duration, duration:[0 TO 5] must
+    // be removed so it does not duplicate alongside the new range.
+    const result = replaceFilterClauses(
+      'NOT duration:[10 TO 20] AND duration:[0 TO 5]',
+      'lucene',
+      {
+        duration: {
+          included: new Set(),
+          excluded: new Set(),
+          range: { min: 1, max: 3 },
+        },
+      },
+    );
+    // duration:[0 TO 5] is pruned; NOT duration:[10 TO 20] is preserved.
+    expect(result).toBe('NOT duration:[10 TO 20] AND duration:[1 TO 3]');
+  });
+});
+
+describe('unquoted field term is replaced (not duplicated) by sidebar click', () => {
+  it('replaces an unquoted field term when the sidebar emits a quoted one', () => {
+    // level:error (unquoted) → sidebar adds level:"warn"
+    // Was: level:error AND level:"warn" → zero rows (two conflicting conditions)
+    // Fixed: level:"warn"
+    const result = replaceFilterClauses('level:error', 'lucene', {
+      level: { included: new Set(['warn']), excluded: new Set() },
+    });
+    expect(result).toBe('level:"warn"');
+  });
+
+  it('does not add a quoted duplicate alongside an unquoted term', () => {
+    const result = replaceFilterClauses(
+      'level:error AND ServiceName:"api"',
+      'lucene',
+      {
+        level: { included: new Set(['warn']), excluded: new Set() },
+        ServiceName: { included: new Set(['api']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('level:"warn" AND ServiceName:"api"');
+  });
+});
+
+describe('attribute keys with special chars are properly escaped', () => {
+  it('escapes ( and ) in attribute key names', () => {
+    const state: FilterState = {
+      "LogAttributes['a(b)']": {
+        included: new Set(['value']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    // Must be parseable (not throw) and contain the correct field.
+    expect(() => parse(emitted)).not.toThrow();
+    expect(emitted).toContain('"value"');
+  });
+
+  it('escapes [ and ] in attribute key names', () => {
+    const state: FilterState = {
+      "LogAttributes['arr[0]']": {
+        included: new Set(['x']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    expect(() => parse(emitted)).not.toThrow();
+  });
+
+  it('escapes { in attribute key names', () => {
+    const state: FilterState = {
+      "LogAttributes['{key}']": {
+        included: new Set(['v']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    expect(() => parse(emitted)).not.toThrow();
+  });
+
+  it('escapes spaces in attribute key names', () => {
+    const state: FilterState = {
+      "LogAttributes['my key']": {
+        included: new Set(['v']),
+        excluded: new Set(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, { language: 'lucene' });
+    expect(() => parse(emitted)).not.toThrow();
+  });
+});
+
+describe('closing paren inside a quoted value does not break top-level OR detection', () => {
+  it('wraps the residual in parens when it has a top-level OR with a paren inside a quoted value', () => {
+    // "timeout)" OR "error" → the ) inside the quoted string must NOT be counted
+    // as a closing paren for depth tracking.
+    const result = replaceFilterClauses('"timeout)" OR "error"', 'lucene', {
+      level: { included: new Set(['x']), excluded: new Set() },
+    });
+    // The residual "timeout)" OR "error" has a top-level OR → must be wrapped.
+    expect(result).toBe('("timeout)" OR "error") AND level:"x"');
+  });
+
+  it('does not double-wrap when the residual is already parenthesized', () => {
+    const result = replaceFilterClauses('("a)" OR "b")', 'lucene', {
+      level: { included: new Set(['x']), excluded: new Set() },
+    });
+    // Already parenthesized; top-level OR is inside parens → no extra wrap.
+    expect(result).toBe('("a)" OR "b") AND level:"x"');
+  });
+});
+
+describe('no extra spaces accumulate on repeated sidebar clicks', () => {
+  it('does not grow extra spaces inside the OR group after multiple interactions', () => {
+    // First click
+    const step1 = replaceFilterClauses('term1 OR term2', 'lucene', {
+      ServiceName: { included: new Set(['api']), excluded: new Set() },
+    });
+    // step1 should be "(term1 OR term2) AND ServiceName:\"api\""
+    expect(step1).toBe('(term1 OR term2) AND ServiceName:"api"');
+
+    // Second click (simulates toggling another value)
+    const step2 = replaceFilterClauses(step1, 'lucene', {
+      ServiceName: { included: new Set(['web']), excluded: new Set() },
+    });
+    expect(step2).toBe('(term1 OR term2) AND ServiceName:"web"');
+
+    // Third click
+    const step3 = replaceFilterClauses(step2, 'lucene', {
+      ServiceName: { included: new Set(['admin']), excluded: new Set() },
+    });
+    expect(step3).toBe('(term1 OR term2) AND ServiceName:"admin"');
+
+    // Fourth click — must still be the same paren group with no extra spaces.
+    const step4 = replaceFilterClauses(step3, 'lucene', {
+      ServiceName: {
+        included: new Set(['api', 'admin']),
+        excluded: new Set(),
+      },
+    });
+    expect(step4).toBe(
+      '(term1 OR term2) AND (ServiceName:"api" OR ServiceName:"admin")',
+    );
+  });
+
+  it('does not add trailing space to individual terms when re-joining', () => {
+    const step1 = replaceFilterClauses('term1 OR term2', 'lucene', {
+      level: { included: new Set(['warn']), excluded: new Set() },
+    });
+    // Should be exactly "(term1 OR term2) AND level:\"warn\"" — no extra spaces
+    expect(step1).not.toMatch(/term1 {2,}OR|OR {2,}term2/);
+    expect(step1).toBe('(term1 OR term2) AND level:"warn"');
+  });
+});
+
+describe('top-level OR residual is parenthesized before AND join', () => {
+  it('wraps the residual in parens so the facet only applies to the whole OR', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' OR ServiceName = 'b'",
+      'sql',
+      {
+        ServiceName: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "(ServiceName = 'a' OR ServiceName = 'b') AND ServiceName IN ('b')",
+    );
+  });
+
+  it('handles lowercase or operator', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' or ServiceName = 'b'",
+      'sql',
+      {
+        SeverityText: { included: new Set(['error']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "(ServiceName = 'a' or ServiceName = 'b') AND SeverityText IN ('error')",
+    );
+  });
+
+  it('does not double-wrap when the OR is already inside parens', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' AND (level = 'info' OR level = 'warn')",
+      'sql',
+      {
+        host: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName = 'a' AND (level = 'info' OR level = 'warn') AND host IN ('web')",
+    );
+  });
+
+  it('does not treat an OR inside a quoted value as top-level', () => {
+    const result = replaceFilterClauses("msg = 'a OR b'", 'sql', {
+      host: { included: new Set(['web']), excluded: new Set() },
+    });
+    expect(result).toBe("msg = 'a OR b' AND host IN ('web')");
+  });
+});
+
+describe('line comments do not swallow appended facets', () => {
+  it('re-appends a trailing -- comment after the new predicate', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' -- temp note",
+      'sql',
+      {
+        ServiceName: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName = 'a' AND ServiceName IN ('b') -- temp note",
+    );
+  });
+
+  it('does not treat a commented-out AND as a conjunct separator', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' -- note AND should stay commented",
+      'sql',
+      {
+        host: { included: new Set(['web']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName = 'a' AND host IN ('web') -- note AND should stay commented",
+    );
+  });
+
+  it('leaves a -- inside a quoted value untouched', () => {
+    const result = replaceFilterClauses("msg = 'a -- b'", 'sql', {
+      host: { included: new Set(['web']), excluded: new Set() },
+    });
+    expect(result).toBe("msg = 'a -- b' AND host IN ('web')");
+  });
+
+  it('re-appends a block comment after the new predicate', () => {
+    const result = replaceFilterClauses(
+      "ServiceName = 'a' /* temp note */",
+      'sql',
+      {
+        ServiceName: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName = 'a' AND ServiceName IN ('b') /* temp note */",
+    );
+  });
+});
+
+describe('unbalanced paren inside a string and quotes in backtick keys', () => {
+  it('does not pile up conjuncts when a string contains an unmatched (', () => {
+    const step1 = replaceFilterClauses("msg = 'x AND y IN ('", 'sql', {
+      ServiceName: { included: new Set(['a']), excluded: new Set() },
+    });
+    expect(step1).toBe("msg = 'x AND y IN (' AND ServiceName IN ('a')");
+
+    // Second click must replace, not duplicate.
+    const step2 = replaceFilterClauses(step1, 'sql', {
+      ServiceName: { included: new Set(['a', 'b']), excluded: new Set() },
+    });
+    expect(step2).toBe("msg = 'x AND y IN (' AND ServiceName IN ('a', 'b')");
+  });
+
+  it('treats a single quote inside a backtick identifier as literal', () => {
+    const step1 = replaceFilterClauses("`it's` = 1", 'sql', {
+      ServiceName: { included: new Set(['a']), excluded: new Set() },
+    });
+    expect(step1).toBe("`it's` = 1 AND ServiceName IN ('a')");
+
+    // Second click must replace, not duplicate.
+    const step2 = replaceFilterClauses(step1, 'sql', {
+      ServiceName: { included: new Set(['a', 'b']), excluded: new Set() },
+    });
+    expect(step2).toBe("`it's` = 1 AND ServiceName IN ('a', 'b')");
+  });
+});
+
+describe('backticked column facet replaces cleanly on repeat clicks', () => {
+  it('does not duplicate a backticked key with a hyphen', () => {
+    const escapeKey = (key: string) => `\`${key}\``;
+    const step1 = replaceFilterClauses(
+      '',
+      'sql',
+      {
+        'service-name': { included: new Set(['a']), excluded: new Set() },
+      },
+      { escapeKey },
+    );
+    expect(step1).toBe("`service-name` IN ('a')");
+
+    const step2 = replaceFilterClauses(
+      step1,
+      'sql',
+      {
+        'service-name': { included: new Set(['a', 'b']), excluded: new Set() },
+      },
+      { escapeKey },
+    );
+    expect(step2).toBe("`service-name` IN ('a', 'b')");
+  });
+});
+
+describe('IN (SELECT ...) subqueries are preserved, not treated as facets', () => {
+  it('does not destroy a subquery when a different facet is added', () => {
+    const result = replaceFilterClauses(
+      'ServiceName IN (SELECT name FROM t) AND foo = 1',
+      'sql',
+      {
+        ServiceName: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "ServiceName IN (SELECT name FROM t) AND foo = 1 AND ServiceName IN ('b')",
+    );
+  });
+
+  it('does not render a checkbox for a subquery value', () => {
+    const state = parseWhereClauseToFilterState(
+      'ServiceName IN (SELECT name FROM t) AND foo = 1',
+      'sql',
+    );
+    expect(state).toEqual({});
+  });
+});
+
+describe('repeated SQL predicates for the same field are not merged into a union', () => {
+  it('leaves both conjuncts untouched when the same key appears twice', () => {
+    // host IN ('a') AND host IN ('b') is an intersection — the user wrote it
+    // intentionally. Merging into host IN ('a', 'b') would silently change the
+    // semantics to a union. The two conjuncts must be preserved verbatim.
+    const result = replaceFilterClauses(
+      "host IN ('a') AND host IN ('b')",
+      'sql',
+      {
+        host: { included: new Set(['c']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "host IN ('a') AND host IN ('b') AND host IN ('c')",
+    );
+  });
+
+  it('still replaces a key that appears exactly once', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a') AND level IN ('error')",
+      'sql',
+      {
+        host: { included: new Set(['b']), excluded: new Set() },
+        level: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("host IN ('b') AND level IN ('warn')");
+  });
+
+  it('leaves a duplicate key untouched while still replacing a single-occurrence key', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a') AND host IN ('b') AND level IN ('error')",
+      'sql',
+      {
+        level: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe(
+      "host IN ('a') AND host IN ('b') AND level IN ('warn')",
+    );
+  });
+});
+
+describe('mergeFilterStateIntoWhereClause preserves the existing where text', () => {
+  const errorSeverity: FilterState = {
+    SeverityText: { included: new Set(['error']), excluded: new Set() },
+  };
+
+  it('appends lucene filters to a lucene where clause', () => {
+    expect(
+      mergeFilterStateIntoWhereClause(
+        'ServiceName:"api"',
+        'lucene',
+        errorSeverity,
+      ),
+    ).toBe('ServiceName:"api" AND SeverityText:"error"');
+  });
+
+  it('appends SQL filters to a SQL where clause', () => {
+    expect(
+      mergeFilterStateIntoWhereClause("ServiceName = 'api'", 'sql', {
+        SeverityText: { included: new Set(['error']), excluded: new Set() },
+      }),
+    ).toBe("ServiceName = 'api' AND SeverityText IN ('error')");
+  });
+
+  it('parenthesizes a top-level OR in the existing lucene text before appending', () => {
+    expect(
+      mergeFilterStateIntoWhereClause(
+        'a:"1" OR b:"2"',
+        'lucene',
+        errorSeverity,
+      ),
+    ).toBe('(a:"1" OR b:"2") AND SeverityText:"error"');
+  });
+
+  it('does not double-wrap an already-parenthesized lucene OR', () => {
+    expect(
+      mergeFilterStateIntoWhereClause('(a:"1" OR b:"2")', 'lucene', {
+        SeverityText: { included: new Set(['error']), excluded: new Set() },
+      }),
+    ).toBe('(a:"1" OR b:"2") AND SeverityText:"error"');
+  });
+
+  it('parenthesizes a top-level OR in the existing SQL text before appending', () => {
+    expect(
+      mergeFilterStateIntoWhereClause(
+        "ServiceName = 'a' OR ServiceName = 'b'",
+        'sql',
+        errorSeverity,
+      ),
+    ).toBe(
+      "(ServiceName = 'a' OR ServiceName = 'b') AND SeverityText IN ('error')",
+    );
+  });
+
+  it('re-appends SQL comments after the appended predicate', () => {
+    expect(
+      mergeFilterStateIntoWhereClause(
+        "ServiceName = 'a' -- temp note",
+        'sql',
+        errorSeverity,
+      ),
+    ).toBe("ServiceName = 'a' AND SeverityText IN ('error') -- temp note");
+  });
+
+  it('uses escapeKey for the emitted SQL clauses while preserving the original text', () => {
+    const escapeKey = (key: string) => `\`${key}\``;
+    expect(
+      mergeFilterStateIntoWhereClause(
+        "`service-name` = 'a'",
+        'sql',
+        { 'service-name': { included: new Set(['b']), excluded: new Set() } },
+        { escapeKey },
+      ),
+    ).toBe("`service-name` = 'a' AND `service-name` IN ('b')");
+  });
+
+  it('returns only the emitted state when the where text is empty', () => {
+    expect(mergeFilterStateIntoWhereClause('', 'lucene', errorSeverity)).toBe(
+      'SeverityText:"error"',
+    );
+  });
+
+  it('returns the trimmed where text when the state emits nothing', () => {
+    expect(mergeFilterStateIntoWhereClause('  a:"1"  ', 'lucene', {})).toBe(
+      'a:"1"',
+    );
+  });
+});
+
+describe('replaceFilterClauses emitLanguage (query-language translation)', () => {
+  const serviceApi: FilterState = {
+    ServiceName: { included: new Set(['api']), excluded: new Set() },
+  };
+
+  it('translates lucene facets to SQL while preserving free text', () => {
+    expect(
+      replaceFilterClauses(
+        'ServiceName:"api" AND error',
+        'lucene',
+        serviceApi,
+        { emitLanguage: 'sql' },
+      ),
+    ).toBe("error AND ServiceName IN ('api')");
+  });
+
+  it('translates SQL facets to lucene', () => {
+    expect(
+      replaceFilterClauses("ServiceName IN ('api')", 'sql', serviceApi, {
+        emitLanguage: 'lucene',
+      }),
+    ).toBe('ServiceName:"api"');
+  });
+
+  it('wraps a cross-field OR residual in parens before the SQL clause', () => {
+    expect(
+      replaceFilterClauses(
+        'a:"1" OR b:"2"',
+        'lucene',
+        { c: { included: new Set(['3']), excluded: new Set() } },
+        { emitLanguage: 'sql' },
+      ),
+    ).toBe('(a:"1" OR b:"2") AND c IN (\'3\')');
+  });
+
+  it('emits SQL ranges via escapeKey when translating lucene to SQL', () => {
+    const escapeKey = (key: string) => `\`${key}\``;
+    expect(
+      replaceFilterClauses(
+        'service-name:"a"',
+        'lucene',
+        { 'service-name': { included: new Set(['b']), excluded: new Set() } },
+        { emitLanguage: 'sql', escapeKey },
+      ),
+    ).toBe("`service-name` IN ('b')");
+  });
+
+  it('returns the where text unchanged when there is nothing to translate', () => {
+    expect(
+      replaceFilterClauses(
+        'error 404',
+        'lucene',
+        {},
+        {
+          emitLanguage: 'sql',
+        },
+      ),
+    ).toBe('error 404');
+  });
+});
+
+describe('getWhereParseError', () => {
+  it('returns null for empty, valid, and SQL input', () => {
+    expect(getWhereParseError('', 'lucene')).toBeNull();
+    expect(getWhereParseError('ServiceName:"api"', 'lucene')).toBeNull();
+    expect(getWhereParseError("ServiceName = 'api'", 'sql')).toBeNull();
+  });
+
+  it('returns a message for unparseable lucene', () => {
+    expect(getWhereParseError('service:', 'lucene')).not.toBeNull();
+    expect(getWhereParseError('(((', 'lucene')).not.toBeNull();
+  });
+});
+
+describe('getUnrepresentableWhereReason', () => {
+  it('flags a cross-field OR', () => {
+    expect(
+      getUnrepresentableWhereReason(
+        'ServiceName:"api" OR SeverityText:"error"',
+        'lucene',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('flags an OR NOT across fields', () => {
+    expect(
+      getUnrepresentableWhereReason('a:"1" OR NOT b:"2"', 'lucene'),
+    ).not.toBeNull();
+  });
+
+  it('does not flag AND or same-field OR', () => {
+    expect(
+      getUnrepresentableWhereReason(
+        'ServiceName:"api" AND SeverityText:"error"',
+        'lucene',
+      ),
+    ).toBeNull();
+    expect(
+      getUnrepresentableWhereReason('a:"1" OR a:"2"', 'lucene'),
+    ).toBeNull();
+  });
+
+  it('does not flag SQL or unparseable input', () => {
+    expect(
+      getUnrepresentableWhereReason(
+        "ServiceName = 'api' OR SeverityText = 'error'",
+        'sql',
+      ),
+    ).toBeNull();
+    expect(getUnrepresentableWhereReason('service:', 'lucene')).toBeNull();
+  });
+});
+
+describe('lucene NOT keyword negation', () => {
+  it('parses NOT field:"value" as excluded', () => {
+    expect(
+      parseWhereClauseToFilterState('NOT ServiceName:"api"', 'lucene'),
+    ).toEqual({
+      ServiceName: { included: new Set(), excluded: new Set(['api']) },
+    });
+  });
+
+  it('parses term AND NOT field:"value" as excluded', () => {
+    expect(
+      parseWhereClauseToFilterState('term AND NOT ServiceName:"api"', 'lucene'),
+    ).toEqual({
+      ServiceName: { included: new Set(), excluded: new Set(['api']) },
+    });
+  });
+
+  it('parses AND NOT on a second field', () => {
+    expect(
+      parseWhereClauseToFilterState('a:"1" AND NOT b:"2"', 'lucene'),
+    ).toEqual({
+      a: { included: new Set(['1']), excluded: new Set() },
+      b: { included: new Set(), excluded: new Set(['2']) },
+    });
+  });
+
+  it('parses NOT prefix on a binary left subtree', () => {
+    expect(
+      parseWhereClauseToFilterState('NOT a:"1" AND b:"2"', 'lucene'),
+    ).toEqual({
+      a: { included: new Set(), excluded: new Set(['1']) },
+      b: { included: new Set(['2']), excluded: new Set() },
+    });
+  });
+
+  it('treats a double negation as included', () => {
+    expect(parseWhereClauseToFilterState('NOT -a:"1"', 'lucene')).toEqual({
+      a: { included: new Set(['1']), excluded: new Set() },
+    });
+  });
+
+  it('does not collect a cross-field OR NOT as facets', () => {
+    expect(
+      parseWhereClauseToFilterState('a:"1" OR NOT b:"2"', 'lucene'),
+    ).toEqual({});
+  });
+
+  it('round-trips NOT via excluded emission', () => {
+    const state = parseWhereClauseToFilterState(
+      'term AND NOT ServiceName:"api"',
+      'lucene',
+    );
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      '-ServiceName:"api"',
+    );
   });
 });

--- a/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
+++ b/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
@@ -1,0 +1,393 @@
+import {
+  type FilterState,
+  filterStateToWhereClause,
+  parseWhereClauseToFilterState,
+  replaceFilterClauses,
+} from '@/filters';
+import { parse } from '@/queryParser';
+
+describe('filterStateToWhereClause (lucene)', () => {
+  it('emits a single included value', () => {
+    const state: FilterState = {
+      a: { included: new Set<string>(['b']), excluded: new Set<string>() },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'a:"b"',
+    );
+  });
+
+  it('emits parenthesized OR group for multiple included values', () => {
+    const state: FilterState = {
+      c: { included: new Set<string>(['d', 'x']), excluded: new Set<string>() },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      '(c:"d" OR c:"x")',
+    );
+  });
+
+  it('emits negated terms for excluded values', () => {
+    const state: FilterState = {
+      a: {
+        included: new Set<string>(['b']),
+        excluded: new Set<string>(['c']),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'a:"b" AND -a:"c"',
+    );
+  });
+
+  it('emits multiple excluded values joined with AND', () => {
+    const state: FilterState = {
+      a: {
+        included: new Set<string | boolean>(),
+        excluded: new Set<string | boolean>([true, false]),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      '-a:"true" AND -a:"false"',
+    );
+  });
+
+  it('emits boolean values as strings', () => {
+    const state: FilterState = {
+      isRootSpan: {
+        included: new Set<string | boolean>([true]),
+        excluded: new Set<string | boolean>(),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'isRootSpan:"true"',
+    );
+  });
+
+  it('escapes double quotes in values', () => {
+    const state: FilterState = {
+      message: {
+        included: new Set<string | boolean>(['say "hello"']),
+        excluded: new Set<string | boolean>(),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'message:"say \\"hello\\""',
+    );
+  });
+
+  it('escapes backslashes in values', () => {
+    const state: FilterState = {
+      FilePath: {
+        included: new Set<string | boolean>(['C:\\path\\to\\file']),
+        excluded: new Set<string | boolean>(),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'FilePath:"C:\\\\path\\\\to\\\\file"',
+    );
+  });
+
+  it('normalizes bracket-notation map keys to dot form', () => {
+    const state: FilterState = {
+      "LogAttributes['service.name']": {
+        included: new Set<string | boolean>(['my-app']),
+        excluded: new Set<string | boolean>(),
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'LogAttributes.service.name:"my-app"',
+    );
+  });
+
+  it('escapes colons in map keys', () => {
+    const state: FilterState = {
+      "LogAttributes['foo:bar']": {
+        included: new Set<string | boolean>(['value1']),
+        excluded: new Set<string | boolean>(),
+      },
+    };
+    const emitted = filterStateToWhereClause(state, {
+      language: 'lucene',
+    });
+    expect(emitted).toBe(String.raw`LogAttributes.foo\:bar:"value1"`);
+    expect(() => parse(emitted)).not.toThrow();
+  });
+
+  it('emits range filters', () => {
+    const state: FilterState = {
+      duration: {
+        included: new Set<string | boolean>(),
+        excluded: new Set<string | boolean>(),
+        range: { min: 10, max: 500 },
+      },
+    };
+    expect(filterStateToWhereClause(state, { language: 'lucene' })).toBe(
+      'duration:[10 TO 500]',
+    );
+  });
+});
+
+describe('parseWhereClauseToFilterState (lucene)', () => {
+  it('parses a single included value', () => {
+    expect(parseWhereClauseToFilterState('a:"b"', 'lucene')).toEqual({
+      a: { included: new Set(['b']), excluded: new Set() },
+    });
+  });
+
+  it('parses a negated term as excluded', () => {
+    expect(parseWhereClauseToFilterState('-a:"c"', 'lucene')).toEqual({
+      a: { included: new Set(), excluded: new Set(['c']) },
+    });
+  });
+
+  it('parses an OR group into multiple included values', () => {
+    expect(parseWhereClauseToFilterState('(c:"d" OR c:"x")', 'lucene')).toEqual(
+      {
+        c: { included: new Set(['d', 'x']), excluded: new Set() },
+      },
+    );
+  });
+
+  it('parses a range term', () => {
+    expect(
+      parseWhereClauseToFilterState('duration:[10 TO 500]', 'lucene'),
+    ).toEqual({
+      duration: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 10, max: 500 },
+      },
+    });
+  });
+
+  it('coerces boolean values', () => {
+    expect(
+      parseWhereClauseToFilterState('isRootSpan:"true"', 'lucene'),
+    ).toEqual({
+      isRootSpan: { included: new Set([true]), excluded: new Set() },
+    });
+  });
+
+  it('ignores free-text phrases (implicit field)', () => {
+    expect(parseWhereClauseToFilterState('"error 404"', 'lucene')).toEqual({});
+  });
+
+  it('ignores unquoted terms', () => {
+    expect(parseWhereClauseToFilterState('error 404', 'lucene')).toEqual({});
+  });
+
+  it('decodes escaped colons in field names', () => {
+    expect(
+      parseWhereClauseToFilterState(
+        String.raw`LogAttributes.foo\:bar:"value1"`,
+        'lucene',
+      ),
+    ).toEqual({
+      'LogAttributes.foo:bar': {
+        included: new Set(['value1']),
+        excluded: new Set(),
+      },
+    });
+  });
+
+  it('returns empty state for invalid lucene', () => {
+    expect(parseWhereClauseToFilterState('(((', 'lucene')).toEqual({});
+  });
+
+  it('returns empty state for empty text', () => {
+    expect(parseWhereClauseToFilterState('', 'lucene')).toEqual({});
+  });
+
+  it('round-trips emitted state', () => {
+    const state: FilterState = {
+      service: { included: new Set(['app', 'api']), excluded: new Set() },
+      level: { included: new Set(), excluded: new Set(['debug']) },
+      duration: {
+        included: new Set(),
+        excluded: new Set(),
+        range: { min: 1, max: 999 },
+      },
+    };
+    const where = filterStateToWhereClause(state, { language: 'lucene' });
+    expect(parseWhereClauseToFilterState(where, 'lucene')).toEqual(state);
+  });
+});
+
+describe('replaceFilterClauses (lucene)', () => {
+  it('replaces one managed clause and re-emits the rest from the full state', () => {
+    const result = replaceFilterClauses(
+      'foo:"x" AND host:"a" AND bar:"y"',
+      'lucene',
+      {
+        host: { included: new Set(['b']), excluded: new Set() },
+        foo: { included: new Set(['x']), excluded: new Set() },
+        bar: { included: new Set(['y']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('host:"b" AND foo:"x" AND bar:"y"');
+  });
+
+  it('preserves free-text terms and re-emits facets', () => {
+    const result = replaceFilterClauses('error 404 AND host:"a"', 'lucene', {
+      host: { included: new Set(['b']), excluded: new Set() },
+    });
+    expect(result).toBe('error 404 AND host:"b"');
+  });
+
+  it('preserves quoted free-text phrases', () => {
+    const result = replaceFilterClauses(
+      '"out of memory" AND host:"a"',
+      'lucene',
+      {
+        host: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('"out of memory" AND host:"b"');
+  });
+
+  it('removes a clause when the new state drops the field', () => {
+    const result = replaceFilterClauses('host:"a" AND level:"info"', 'lucene', {
+      level: { included: new Set(['warn']), excluded: new Set() },
+    });
+    expect(result).toBe('level:"warn"');
+  });
+
+  it('replaces all facets when given a full state', () => {
+    const result = replaceFilterClauses(
+      'host:"a" AND level:"info" AND foo:"x"',
+      'lucene',
+      {
+        host: { included: new Set(['b']), excluded: new Set() },
+        level: { included: new Set(['warn']), excluded: new Set() },
+        foo: { included: new Set(['x']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('host:"b" AND level:"warn" AND foo:"x"');
+  });
+
+  it('returns just the new clause for empty input', () => {
+    const result = replaceFilterClauses('', 'lucene', {
+      host: { included: new Set(['b']), excluded: new Set() },
+    });
+    expect(result).toBe('host:"b"');
+  });
+
+  it('returns empty for a fully-managed input with empty state', () => {
+    const result = replaceFilterClauses('host:"a"', 'lucene', {});
+    expect(result).toBe('');
+  });
+
+  it('leaves invalid lucene unchanged', () => {
+    const result = replaceFilterClauses('(((', 'lucene', {
+      host: { included: new Set(['b']), excluded: new Set() },
+    });
+    expect(result).toBe('(((');
+  });
+
+  it('preserves an OR group without dangling connectors', () => {
+    const result = replaceFilterClauses(
+      '(env:"prod" OR env:"staging") AND host:"a"',
+      'lucene',
+      {
+        env: { included: new Set(['qa']), excluded: new Set() },
+        host: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe('env:"qa" AND host:"b"');
+  });
+});
+
+describe('filterStateToWhereClause (sql)', () => {
+  it('emits IN clauses', () => {
+    const state: FilterState = {
+      host: { included: new Set(['a', 'b']), excluded: new Set() },
+    };
+    expect(filterStateToWhereClause(state, { language: 'sql' })).toBe(
+      "host IN ('a', 'b')",
+    );
+  });
+
+  it('emits NOT IN clauses', () => {
+    const state: FilterState = {
+      host: { included: new Set(), excluded: new Set(['a']) },
+    };
+    expect(filterStateToWhereClause(state, { language: 'sql' })).toBe(
+      "host NOT IN ('a')",
+    );
+  });
+});
+
+describe('parseWhereClauseToFilterState (sql)', () => {
+  it('parses an IN clause', () => {
+    const state = parseWhereClauseToFilterState("host IN ('a', 'b')", 'sql');
+    expect(Array.from(state.host?.included ?? [])).toEqual(
+      expect.arrayContaining(['a', 'b']),
+    );
+  });
+
+  it('parses a NOT IN clause', () => {
+    const state = parseWhereClauseToFilterState("host NOT IN ('a')", 'sql');
+    expect(Array.from(state.host?.excluded ?? [])).toEqual(['a']);
+  });
+
+  it('parses a BETWEEN clause into a range', () => {
+    const state = parseWhereClauseToFilterState(
+      'duration BETWEEN 10 AND 500',
+      'sql',
+    );
+    expect(state.duration?.range).toEqual({ min: 10, max: 500 });
+  });
+});
+
+describe('replaceFilterClauses (sql)', () => {
+  it('replaces a facet conjunct and preserves other conjuncts', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a') AND foo = 'bar'",
+      'sql',
+      {
+        host: { included: new Set(['b']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("foo = 'bar' AND host IN ('b')");
+  });
+
+  it('handles BETWEEN conjuncts', () => {
+    const result = replaceFilterClauses(
+      'duration BETWEEN 1 AND 100 AND foo = 1',
+      'sql',
+      {
+        duration: {
+          included: new Set(),
+          excluded: new Set(),
+          range: { min: 10, max: 50 },
+        },
+      },
+    );
+    expect(result).toBe('foo = 1 AND duration BETWEEN 10 AND 50');
+  });
+
+  it('preserves an IN value containing the separator', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a AND b') AND foo = 'x'",
+      'sql',
+      {
+        host: { included: new Set(['c']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("foo = 'x' AND host IN ('c')");
+  });
+
+  it('removes a facet conjunct when the new state drops the field', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a') AND level = 'info'",
+      'sql',
+      {},
+    );
+    expect(result).toBe("level = 'info'");
+  });
+
+  it('returns the new clause for empty input', () => {
+    const result = replaceFilterClauses('', 'sql', {
+      host: { included: new Set(['b']), excluded: new Set() },
+    });
+    expect(result).toBe("host IN ('b')");
+  });
+});

--- a/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
+++ b/packages/common-utils/src/__tests__/filterRoundTrip.test.ts
@@ -611,7 +611,9 @@ describe('modifier terms and negated ranges do not survive alongside new clause'
       },
     );
     // msg:"world" is pruned; msg:"hello"~2 is preserved verbatim (unmanageable).
-    expect(result).toBe('msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"');
+    expect(result).toBe(
+      'msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"',
+    );
   });
 
   it('preserves a modifier-only field verbatim and appends the new clause', () => {
@@ -625,7 +627,9 @@ describe('modifier terms and negated ranges do not survive alongside new clause'
         ServiceName: { included: new Set(['api']), excluded: new Set() },
       },
     );
-    expect(result).toBe('msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"');
+    expect(result).toBe(
+      'msg:"hello"~2 AND msg:"goodbye" AND ServiceName:"api"',
+    );
   });
 
   it('replaces a plain range clause when the field also has a negated range', () => {
@@ -955,11 +959,13 @@ describe('IN (SELECT ...) subqueries are preserved, not treated as facets', () =
   });
 });
 
-describe('repeated SQL predicates for the same field are not merged into a union', () => {
-  it('leaves both conjuncts untouched when the same key appears twice', () => {
-    // host IN ('a') AND host IN ('b') is an intersection — the user wrote it
-    // intentionally. Merging into host IN ('a', 'b') would silently change the
-    // semantics to a union. The two conjuncts must be preserved verbatim.
+describe('repeated SQL predicates for the same field are all replaced by a sidebar click', () => {
+  it('replaces all conjuncts when the same key appears twice', () => {
+    // host IN ('a') AND host IN ('b') contains duplicate predicates for the
+    // same field (can arise from manual edits or legacy saved searches). When
+    // the user clicks a sidebar value for host, ALL existing host conjuncts
+    // must be replaced — leaving the old restrictions active causes the
+    // sidebar selection to return zero rows.
     const result = replaceFilterClauses(
       "host IN ('a') AND host IN ('b')",
       'sql',
@@ -967,9 +973,7 @@ describe('repeated SQL predicates for the same field are not merged into a union
         host: { included: new Set(['c']), excluded: new Set() },
       },
     );
-    expect(result).toBe(
-      "host IN ('a') AND host IN ('b') AND host IN ('c')",
-    );
+    expect(result).toBe("host IN ('c')");
   });
 
   it('still replaces a key that appears exactly once', () => {
@@ -984,7 +988,19 @@ describe('repeated SQL predicates for the same field are not merged into a union
     expect(result).toBe("host IN ('b') AND level IN ('warn')");
   });
 
-  it('leaves a duplicate key untouched while still replacing a single-occurrence key', () => {
+  it('replaces all conjuncts for a duplicate key while also replacing a single-occurrence key', () => {
+    const result = replaceFilterClauses(
+      "host IN ('a') AND host IN ('b') AND level IN ('error')",
+      'sql',
+      {
+        host: { included: new Set(['c']), excluded: new Set() },
+        level: { included: new Set(['warn']), excluded: new Set() },
+      },
+    );
+    expect(result).toBe("host IN ('c') AND level IN ('warn')");
+  });
+
+  it('drops all duplicate conjuncts for a field when it is removed from the sidebar', () => {
     const result = replaceFilterClauses(
       "host IN ('a') AND host IN ('b') AND level IN ('error')",
       'sql',
@@ -992,9 +1008,7 @@ describe('repeated SQL predicates for the same field are not merged into a union
         level: { included: new Set(['warn']), excluded: new Set() },
       },
     );
-    expect(result).toBe(
-      "host IN ('a') AND host IN ('b') AND level IN ('warn')",
-    );
+    expect(result).toBe("level IN ('warn')");
   });
 });
 

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -774,6 +774,8 @@ describe('filters', () => {
       ['Duration BETWEEN 100 AND 5000', 'BETWEEN (numeric)'],
       ["LogAttributes['x'] IN ('y')", 'map-access column'],
       ["Body IN ('a AND b')", 'value containing AND'],
+      // NOT (col IN (...)) is normalised to col NOT IN (...) — renderable.
+      ["NOT (ServiceName IN ('x'))", 'NOT-paren form of NOT IN'],
     ])('accepts a single renderable predicate: %s (%s)', condition => {
       expect(isRenderablePinnedFilter(sql(condition))).toBe(true);
     });
@@ -791,7 +793,6 @@ describe('filters', () => {
         'ServiceName NOT BETWEEN 1 AND 2',
         'NOT folded into the key (renders inverted)',
       ],
-      ["NOT (ServiceName IN ('x'))", 'leading NOT folded into the key'],
       ['', 'empty condition'],
     ])('rejects %s (%s)', condition => {
       expect(isRenderablePinnedFilter(sql(condition))).toBe(false);

--- a/packages/common-utils/src/__tests__/queryParser.test.ts
+++ b/packages/common-utils/src/__tests__/queryParser.test.ts
@@ -62,7 +62,7 @@ describe('CustomSchemaSQLSerializerV2 - json', () => {
   it('getColumnForField', async () => {
     const field1 = 'ResourceAttributesJSON.test';
     const res1 = await serializer.getColumnForField(field1, {});
-    expect(res1).toEqual({
+    expect(res1).toMatchObject({
       column: '',
       columnJSON: {
         number:
@@ -75,7 +75,7 @@ describe('CustomSchemaSQLSerializerV2 - json', () => {
     });
     const field2 = 'ResourceAttributesJSON.test.nest';
     const res2 = await serializer.getColumnForField(field2, {});
-    expect(res2).toEqual({
+    expect(res2).toMatchObject({
       column: '',
       columnJSON: {
         number:
@@ -1776,7 +1776,7 @@ describe('CustomSchemaSQLSerializerV2 - Array and Nested Fields', () => {
   it('getColumnForField', async () => {
     const field1 = 'Events.Name';
     const res1 = await serializer.getColumnForField(field1, {});
-    expect(res1).toEqual({
+    expect(res1).toMatchObject({
       column: 'Events.Name',
       found: true,
       propertyType: JSDataType.String,
@@ -1785,7 +1785,7 @@ describe('CustomSchemaSQLSerializerV2 - Array and Nested Fields', () => {
 
     const field2 = 'Events.Count';
     const res2 = await serializer.getColumnForField(field2, {});
-    expect(res2).toEqual({
+    expect(res2).toMatchObject({
       column: 'Events.Count',
       found: true,
       propertyType: JSDataType.Number,
@@ -1794,7 +1794,7 @@ describe('CustomSchemaSQLSerializerV2 - Array and Nested Fields', () => {
 
     const field3 = 'Events.IsAvailable';
     const res3 = await serializer.getColumnForField(field3, {});
-    expect(res3).toEqual({
+    expect(res3).toMatchObject({
       column: 'Events.IsAvailable',
       found: true,
       propertyType: JSDataType.Bool,

--- a/packages/common-utils/src/core/dateTimeValue.ts
+++ b/packages/common-utils/src/core/dateTimeValue.ts
@@ -1,0 +1,30 @@
+// Wrap a quoted string literal in a ClickHouse expression whose result type
+// matches the date column's type. Shared by the SQL filter emitter
+// (filters.ts) and the Lucene serializer's date-column equality/range
+// rendering (queryParser.ts) so the two query paths produce byte-identical
+// predicates for the same date value.
+export const dateTimeValueExpr = (
+  chType: string,
+  quotedValue: string,
+): string => {
+  const dt64 = chType.match(/DateTime64\((\d+)/);
+
+  if (dt64) {
+    return `parseDateTime64BestEffort(${quotedValue}, ${dt64[1]})`;
+  }
+
+  if (/\bDateTime\b/.test(chType)) {
+    return `parseDateTimeBestEffort(${quotedValue})`;
+  }
+
+  if (/\bDate32\b/.test(chType)) {
+    return `toDate32(${quotedValue})`;
+  }
+
+  if (/\bDate\b/.test(chType)) {
+    return `toDate(${quotedValue})`;
+  }
+
+  // Fallback for an unexpected type; DateTime64(9) covers the widest range.
+  return `parseDateTime64BestEffort(${quotedValue}, 9)`;
+};

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -432,6 +432,24 @@ function renderNode(
 }
 
 /**
+ * Returns true when the Lucene text contains a top-level OR operator (i.e. an
+ * OR that is not inside parentheses). Used to decide whether the residual must
+ * be wrapped in parens before joining it with AND — without the wrapping,
+ * `a OR b AND c:"v"` would be mis-parsed as `a OR (b AND c:"v")`.
+ */
+function hasTopLevelOr(text: string): boolean {
+  let parenDepth = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '(') { parenDepth++; continue; }
+    if (text[i] === ')') { parenDepth--; continue; }
+    if (parenDepth === 0 && text.slice(i, i + 4).toUpperCase() === ' OR ') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Replace the facet clauses in a Lucene `where` clause with a new FilterState.
  *
  * Only clauses matching the facet grammar (quoted `field:"v"`, `-field:"v"`,
@@ -470,7 +488,13 @@ function replaceLuceneFacetClauses(
   const trimmedResidual = residual.trim();
   if (!trimmedResidual) return newClauses;
   if (!newClauses) return trimmedResidual;
-  return `${trimmedResidual} AND ${newClauses}`;
+  // If the residual contains a top-level OR operator it must be parenthesized
+  // before joining with AND, otherwise `a OR b AND c:"v"` would be parsed as
+  // `a OR (b AND c:"v")` — narrowing the OR branch incorrectly.
+  const safeResidual = hasTopLevelOr(residual)
+    ? `(${trimmedResidual})`
+    : trimmedResidual;
+  return `${safeResidual} AND ${newClauses}`;
 }
 
 /**
@@ -576,22 +600,29 @@ function replaceSqlFacetClauses(
   if (!clean) return emit();
 
   const kept: string[] = [];
+  // Build the set of clean keys being written so we only drop conjuncts whose
+  // field is being replaced — not every parseable facet in the where clause.
+  const replacedKeys = new Set(Object.keys(newState));
+
   for (const conjunct of splitSqlConjuncts(clean)) {
     if (!conjunct.trim()) continue;
+    const upper = conjunct.toUpperCase();
     const isFacet =
-      conjunct.includes(' IN (') ||
-      conjunct.includes(' NOT IN (') ||
-      conjunct.includes(' BETWEEN ');
+      upper.includes(' IN (') ||
+      upper.includes(' NOT IN (') ||
+      upper.includes(' BETWEEN ');
     if (!isFacet) {
       kept.push(conjunct);
       continue;
     }
     const filter: Filter = { type: 'sql', condition: conjunct };
-    // Facet conjuncts are re-emitted from newState, so a conjunct that parses
-    // as a single renderable facet is dropped. Compound conditions and
-    // unparseable conjuncts are preserved.
+    // Only drop this conjunct if it maps to a field we are replacing.
+    // Compound conditions and unparseable conjuncts are always preserved.
     if (isRenderablePinnedFilter(filter)) {
-      continue;
+      const parsedKey = Object.keys(parseQuery([filter]).filters)[0];
+      if (parsedKey !== undefined && replacedKeys.has(parsedKey)) {
+        continue; // will be re-emitted from newState
+      }
     }
     kept.push(conjunct);
   }

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -189,6 +189,49 @@ const escapeLuceneFieldName = (key: string): string =>
     .replace(/ /g, '\\ ');
 
 /**
+ * Reverse `escapeLuceneFieldName`: strip the backslash-escapes that
+ * `escapeLuceneFieldName` introduced so the raw key can be matched against
+ * FilterState entries.
+ *
+ * The Lucene parser preserves backslash-escape sequences in field names (e.g.
+ * `my\ key` stays `my\ key` in `ast.field`). `decodeSpecialTokens` handles
+ * `\:` (via the HDX_COLON round-trip) and `\"`, but not the other nine
+ * characters that `escapeLuceneFieldName` escapes. Without this decoder, a
+ * key like `LogAttributes['my key']` emits `LogAttributes.my\ key:"v"`, the
+ * parser returns the field as `LogAttributes.my\ key`, and `decodeSpecialTokens`
+ * leaves the backslash intact — so the key never matches the FilterState entry
+ * and the backslash multiplies on every subsequent render.
+ *
+ * Decoding order: unescape `\\` last (so `\\(` → `\(` → `(` doesn't
+ * accidentally strip a legitimate backslash introduced by a prior step).
+ * Colons and double-quotes are decoded by `decodeSpecialTokens` already but
+ * are included here for completeness — double-decoding is safe because the
+ * HDX_COLON / `\"` rules never produce a bare `\:` or `\"`.
+ */
+const decodeLuceneFieldName = (raw: string): string =>
+  raw
+    .replace(/\\ /g, ' ')
+    .replace(/\\\(/g, '(')
+    .replace(/\\\)/g, ')')
+    .replace(/\\"/g, '"')
+    .replace(/\\\{/g, '{')
+    .replace(/\\\}/g, '}')
+    .replace(/\\\[/g, '[')
+    .replace(/\\\]/g, ']')
+    .replace(/\\\\/g, '\\');
+
+/**
+ * Fully decode a Lucene field name back to its original form.  Combines
+ * `decodeSpecialTokens` (which reverses the HDX_COLON / `\"` encoding applied
+ * before parsing) with `decodeLuceneFieldName` (which strips the
+ * backslash-escapes added by `escapeLuceneFieldName`).  Every place that
+ * extracts a field name from the AST should use this instead of calling
+ * `decodeSpecialTokens` directly on the field.
+ */
+const decodeFieldName = (raw: string): string =>
+  decodeLuceneFieldName(decodeSpecialTokens(raw));
+
+/**
  * Render a FilterState as a single `where` clause string in the given query
  * language.
  *
@@ -285,10 +328,8 @@ type CollectedRange = {
  * the runtime values the grammar always sets (to `null` when absent).
  */
 function hasTermModifiers(node: lucene.NodeTerm): boolean {
-  const n = node as unknown as Record<string, unknown>;
-  return (
-    n['proximity'] != null || n['boost'] != null || n['similarity'] != null
-  );
+  const hasProximity = 'proximity' in node && node.proximity != null;
+  return hasProximity || node.boost != null || node.similarity != null;
 }
 
 /**
@@ -304,6 +345,46 @@ function hasTermModifiers(node: lucene.NodeTerm): boolean {
  * semantics across fields), so we treat the whole OR sub-tree as unmanaged —
  * neither side is collected, and `renderNode` will preserve the raw text.
  */
+/**
+ * Walk an OR subtree and return true if `collectFromAst` would yield at least
+ * one negated term from this side.  Used by the same-field OR branch to detect
+ * mixed included/excluded clauses (e.g. `a:"1" OR -a:"2"`, `a:"1" OR NOT a:"2"`,
+ * `NOT a:"1" OR a:"2"`) which FilterState cannot faithfully represent because
+ * excluded values are emitted with AND semantics that narrow the OR branch.
+ *
+ * Mirrors the negation logic of `collectFromAst` without mutating the caller's
+ * collections.
+ */
+function orSideHasNegatedTerm(
+  ast: lucene.AST | lucene.Node,
+  negate = false,
+): boolean {
+  if (isNodeTerm(ast)) {
+    if (ast.field === IMPLICIT_FIELD) return false;
+    const negatedField = ast.field.startsWith('-');
+    return negatedField !== negate;
+  }
+  if (isNodeRangedTerm(ast)) {
+    if (ast.field === IMPLICIT_FIELD) return false;
+    return negate;
+  }
+  if (isLeftOnlyAST(ast)) {
+    return orSideHasNegatedTerm(ast.left, negate !== (ast.start === 'NOT'));
+  }
+  if (isBinaryAST(ast)) {
+    const startOp: string | undefined =
+      'start' in ast && typeof ast.start === 'string' ? ast.start : undefined;
+    const leftNegate = negate !== (startOp === 'NOT');
+    const rightNegate =
+      negate !== (ast.operator === 'AND NOT' || ast.operator === 'OR NOT');
+    return (
+      orSideHasNegatedTerm(ast.left, leftNegate) ||
+      orSideHasNegatedTerm(ast.right, rightNegate)
+    );
+  }
+  return false;
+}
+
 function collectFromAst(
   ast: lucene.AST | lucene.Node,
   terms: CollectedTerm[],
@@ -318,7 +399,7 @@ function collectFromAst(
     // literal `-` prefix is sliced off the field name.
     const negatedField = ast.field.startsWith('-');
     const negated = negatedField !== negate;
-    const field = decodeSpecialTokens(
+    const field = decodeFieldName(
       negatedField ? ast.field.slice(1) : ast.field,
     );
     // Implicit-field terms (free-text, quoted phrases) are never managed facets.
@@ -346,7 +427,7 @@ function collectFromAst(
 
     terms.push({ field, value: decodeSpecialTokens(ast.term), negated });
   } else if (isNodeRangedTerm(ast)) {
-    const field = decodeSpecialTokens(ast.field);
+    const field = decodeFieldName(ast.field);
     if (field === IMPLICIT_FIELD) return;
     // A negated range (`NOT duration:[10 TO 20]`) can't be represented in
     // FilterState, so leave it unmanaged and preserve it verbatim. But still
@@ -379,7 +460,7 @@ function collectFromAst(
       'field' in ast &&
       typeof ast.field === 'string' &&
       ast.field !== IMPLICIT_FIELD
-        ? decodeSpecialTokens(ast.field)
+        ? decodeFieldName(ast.field)
         : null;
 
     if (groupField) {
@@ -392,18 +473,21 @@ function collectFromAst(
     // Cross-field OR: if this OR node connects clauses for *different* fields,
     // we cannot represent that in FilterState, so leave both sides unmanaged
     // (Bug 2).  Same-field OR (e.g. `level:"info" OR level:"warn"`) is fine —
-    // both leaves map to the same field and end up as multiple `included` values.
+    // both leaves map to the same field and end up as multiple `included`
+    // values, which filterStateToWhereClause re-emits as a single OR group.
+    //
+    // However a same-field OR that mixes included and excluded sides
+    // (e.g. `a:"1" OR NOT a:"2"` or `a:"1" OR -a:"2"`) cannot be faithfully
+    // represented: FilterState has AND semantics, so an excluded value is
+    // emitted as `-a:"2"` ANDed with the included group, narrowing the OR
+    // branch. Leave the OR unmanaged so renderNode preserves the raw text.
+    //
     // `OR NOT` is an OR too (a:"1" OR NOT b:"2" is cross-field and unrepresentable).
     if (ast.operator === 'OR' || ast.operator === 'OR NOT') {
       const leftFields = new Set<string>();
       const rightFields = new Set<string>();
-      const leftManaged = new Set<string>();
-      const rightManaged = new Set<string>();
-      collectFromAst(ast.left, [], [], leftFields);
-      collectFromAst(ast.right, [], [], rightFields);
-      // Merge managed fields from each side for the lookup
-      for (const f of leftFields) leftManaged.add(f);
-      for (const f of rightFields) rightManaged.add(f);
+      collectExplicitFields(ast.left, leftFields);
+      collectExplicitFields(ast.right, rightFields);
       const isSameField =
         leftFields.size > 0 &&
         rightFields.size > 0 &&
@@ -415,6 +499,26 @@ function collectFromAst(
         // Cross-field OR — do not add either side to managed, leave raw.
         return;
       }
+
+      // Inspect each side without mutating the caller's managedFields. A side
+      // contributes a negated term when its outer NOT wrapper, the `-` prefix
+      // on its field, or a transitive negation inside the subtree flips it.
+      // The right subtree of an `OR NOT` operator is also negated.
+      const startOp: string | undefined =
+        'start' in ast && typeof ast.start === 'string' ? ast.start : undefined;
+      const leftNegate = negate !== (startOp === 'NOT');
+      const rightNegate = negate !== (ast.operator === 'OR NOT');
+      if (
+        orSideHasNegatedTerm(ast.left, leftNegate) ||
+        orSideHasNegatedTerm(ast.right, rightNegate)
+      ) {
+        // Same-field OR with a negated side is unrepresentable in FilterState
+        // (its AND semantics would narrow the OR branch). Leave both sides
+        // unmanaged so the original expression is preserved verbatim.
+        return;
+      }
+      // Plain same-field OR: fall through to the generic binary collection
+      // below so ranges and unquoted terms on the same field are also picked up.
     }
 
     // A `start: 'NOT'` on the binary node negates its left subtree (`NOT a AND
@@ -499,7 +603,16 @@ export function parseWhereClauseToFilterState(
   language: 'lucene' | 'sql',
 ): FilterState {
   if (language === 'sql') {
-    return parseQuery([{ type: 'sql', condition: whereText }]).filters;
+    // Split the where text into top-level conjuncts before calling parseQuery
+    // so that a multi-line query like "Body LIKE '%x%'\nAND ServiceName IN
+    // ('api')" is not treated as a single compound filter whose key is the
+    // entire text up to the IN keyword. Each conjunct is passed to parseQuery
+    // individually, matching what replaceSqlFacetClauses does internally.
+    const { code } = stripSqlComments(whereText.trim());
+    const conjuncts = splitSqlConjuncts(code).filter(c => c.trim());
+    return parseQuery(
+      conjuncts.map(c => ({ type: 'sql' as const, condition: c })),
+    ).filters;
   }
 
   try {
@@ -530,11 +643,16 @@ export function parseWhereClauseToFilterState(
 
     for (const t of terms) {
       const entry = getEntry(t.field);
-      const value = coerceBooleanValue(t.value);
+      // Do NOT coerce "true"/"false" strings to booleans here. Lucene always
+      // stores values as quoted strings, so `msg:"true"` is the string "true",
+      // not the boolean. Coercing at parse time would cause SQL emission to
+      // produce bare `msg IN (true)` — a type error for String columns. Boolean
+      // coercion is the responsibility of the caller when it knows the column
+      // type is Boolean (e.g. `isRootSpan`).
       if (t.negated) {
-        entry.excluded.add(value);
+        entry.excluded.add(t.value);
       } else {
-        entry.included.add(value);
+        entry.included.add(t.value);
       }
     }
     for (const r of ranges) {
@@ -588,12 +706,12 @@ function collectExplicitFields(
       node.field.startsWith('-') || node.field.startsWith('+')
         ? node.field.slice(1)
         : node.field;
-    const field = decodeSpecialTokens(raw);
+    const field = decodeFieldName(raw);
     if (field !== IMPLICIT_FIELD) out.add(field);
     return;
   }
   if (isNodeRangedTerm(node)) {
-    const field = decodeSpecialTokens(node.field);
+    const field = decodeFieldName(node.field);
     if (field !== IMPLICIT_FIELD) out.add(field);
     return;
   }
@@ -602,7 +720,7 @@ function collectExplicitFields(
       'field' in node &&
       typeof node.field === 'string' &&
       node.field !== IMPLICIT_FIELD
-        ? decodeSpecialTokens(node.field)
+        ? decodeFieldName(node.field)
         : null;
     if (groupField) {
       // Field-group syntax: all inner leaves belong to the group's field.
@@ -620,22 +738,25 @@ function collectExplicitFields(
 
 /**
  * Return true when a lucene AST contains an OR (or OR NOT) node connecting
- * clauses for different explicit fields. Such a query cannot be represented as
- * a FilterState (which has AND semantics across fields), so the sidebar would
+ * clauses for different explicit fields OR a same-field OR with a negated side.
+ * Such a query cannot be represented as a FilterState (which has AND semantics
+ * across fields and between included/excluded sets), so the sidebar would
  * either silently drop it or mislead.
  */
-function hasCrossFieldOr(node: lucene.AST | lucene.Node): boolean {
+function hasUnrepresentableOr(node: lucene.AST | lucene.Node): boolean {
   if (isNodeTerm(node) || isNodeRangedTerm(node)) return false;
-  if (isLeftOnlyAST(node)) return hasCrossFieldOr(node.left);
+  if (isLeftOnlyAST(node)) return hasUnrepresentableOr(node.left);
   if (isBinaryAST(node)) {
     const groupField =
       'field' in node &&
       typeof node.field === 'string' &&
       node.field !== IMPLICIT_FIELD
-        ? decodeSpecialTokens(node.field)
+        ? decodeFieldName(node.field)
         : null;
     if (groupField) {
-      return hasCrossFieldOr(node.left) || hasCrossFieldOr(node.right);
+      return (
+        hasUnrepresentableOr(node.left) || hasUnrepresentableOr(node.right)
+      );
     }
     if (node.operator === 'OR' || node.operator === 'OR NOT') {
       const leftFields = new Set<string>();
@@ -649,8 +770,21 @@ function hasCrossFieldOr(node: lucene.AST | lucene.Node): boolean {
         rightFields.size === 1 &&
         [...leftFields][0] === [...rightFields][0];
       if (!isSameField) return true;
+
+      const startOp: string | undefined =
+        'start' in node && typeof node.start === 'string'
+          ? node.start
+          : undefined;
+      const leftNegate = startOp === 'NOT';
+      const rightNegate = node.operator === 'OR NOT';
+      if (
+        orSideHasNegatedTerm(node.left, leftNegate) ||
+        orSideHasNegatedTerm(node.right, rightNegate)
+      ) {
+        return true;
+      }
     }
-    return hasCrossFieldOr(node.left) || hasCrossFieldOr(node.right);
+    return hasUnrepresentableOr(node.left) || hasUnrepresentableOr(node.right);
   }
   return false;
 }
@@ -658,9 +792,9 @@ function hasCrossFieldOr(node: lucene.AST | lucene.Node): boolean {
 /**
  * Return a non-null reason when a `where` clause parses but contains facet-like
  * content the sidebar FilterState cannot faithfully represent — currently a
- * cross-field OR (e.g. `ServiceName:"api" OR SeverityText:"error"`). The UI
- * should surface this instead of showing a misleading or silently-emptied
- * filter sidebar. `sql` always returns null.
+ * cross-field OR or a same-field OR with a negated term. The UI should surface
+ * this instead of showing a misleading or silently-emptied filter sidebar.
+ * `sql` always returns null.
  */
 export function getUnrepresentableWhereReason(
   whereText: string,
@@ -670,8 +804,8 @@ export function getUnrepresentableWhereReason(
   if (language === 'sql') return null;
   try {
     const ast = parse(whereText);
-    if (hasCrossFieldOr(ast)) {
-      return 'This query contains OR conditions between different fields, which cannot be shown as sidebar filters.';
+    if (hasUnrepresentableOr(ast)) {
+      return 'This query contains OR conditions that cannot be shown as sidebar filters.';
     }
     return null;
   } catch {
@@ -751,13 +885,13 @@ function renderNode(
       const rawField = node.field.startsWith('-')
         ? node.field.slice(1)
         : node.field;
-      const field = decodeSpecialTokens(rawField);
+      const field = decodeFieldName(rawField);
       if (field !== IMPLICIT_FIELD && isManagedField(field)) {
         return { text: '', fullyManaged: true };
       }
       return { text: src.slice(span.start, span.end), fullyManaged: false };
     }
-    const field = decodeSpecialTokens(
+    const field = decodeFieldName(
       node.field.startsWith('-') ? node.field.slice(1) : node.field,
     );
     // Terms with modifiers (proximity, boost, fuzzy) are not managed.
@@ -773,7 +907,7 @@ function renderNode(
   if (isNodeRangedTerm(node)) {
     const span = rangeClauseSpan(node, src);
     if (!span) return { text: '', fullyManaged: false };
-    const field = decodeSpecialTokens(node.field);
+    const field = decodeFieldName(node.field);
     // Negated ranges (NOT duration:[...]) are not representable in FilterState
     // and must be preserved verbatim even when the field is otherwise managed.
     if (!negate && field !== IMPLICIT_FIELD && isManagedField(field)) {
@@ -804,7 +938,7 @@ function renderNode(
       'field' in node &&
       typeof node.field === 'string' &&
       node.field !== IMPLICIT_FIELD
-        ? decodeSpecialTokens(node.field)
+        ? decodeFieldName(node.field)
         : null;
 
     if (groupField) {
@@ -917,6 +1051,13 @@ function hasTopLevelOr(text: string): boolean {
  * identifiers). Used to decide whether the residual must be wrapped in parens
  * before joining it with AND — without the wrapping, `a = 1 OR b = 2 AND c IN
  * ('v')` would be mis-parsed as `a = 1 OR (b = 2 AND c IN ('v'))`.
+ *
+ * fix: the original check matched only the literal 4-char sequence
+ * ' OR ' (single spaces), so `a = 1\nOR b = 2` was not detected as containing
+ * a top-level OR and the residual was not parenthesized — producing the exact
+ * mis-parse the function's docstring warns about. The check now matches any
+ * whitespace-surrounded OR keyword (`\s+OR\s+`), consistent with the fix
+ * applied to splitSqlConjuncts for the same class of issue.
  */
 function hasTopLevelOrSql(text: string): boolean {
   let parenDepth = 0;
@@ -955,8 +1096,20 @@ function hasTopLevelOrSql(text: string): boolean {
       parenDepth--;
       continue;
     }
-    if (parenDepth === 0 && text.slice(i, i + 4).toUpperCase() === ' OR ') {
-      return true;
+    if (parenDepth === 0 && /[\s]/.test(ch)) {
+      // Skip whitespace, then check for OR keyword followed by whitespace.
+      let j = i;
+      while (j < text.length && /[\s]/.test(text[j])) j++;
+      if (
+        text.slice(j, j + 2).toUpperCase() === 'OR' &&
+        j + 2 < text.length &&
+        /[\s]/.test(text[j + 2])
+      ) {
+        return true;
+      }
+      // Advance i to avoid re-scanning the same whitespace. The loop's own
+      // i++ will land on the char after the whitespace run.
+      i = j - 1;
     }
   }
   return false;
@@ -1000,14 +1153,45 @@ function replaceLuceneFacetClauses(
     });
   }
 
-  // Managed fields are every facet field currently present in the text, so a
-  // caller that intentionally drops a field (e.g. source-change cleanup) also
-  // removes its clauses rather than leaving them to resurface.
-  // We use the wider `managedFields` set (which includes unquoted explicit-field
-  // terms and field-group fields, but excludes cross-field OR branches) so that
-  // e.g. an unquoted `level:error` is removed when the sidebar sets level:"warn".
-  const managedFields = new Set<string>();
-  collectFromAst(parse(whereText), [], [], managedFields);
+  // Build the set of fields renderNode is allowed to prune.
+  //
+  // we must NOT prune a field whose only representation in the
+  // query is an unquoted / wildcard / comparison term (e.g. `ServiceName:api*`
+  // or `Duration:>100`) when newState does NOT contain that field.  Previously,
+  // collectFromAst added those fields to managedFields unconditionally, so a
+  // sidebar click for a *different* field (e.g. SeverityText) would cause
+  // renderNode to silently delete `ServiceName:api*` even though the caller
+  // never asked for it to be removed.
+  //
+  // Fields that have a faithfully round-trippable representation (quoted terms
+  // or ranges) are always pruneable — the caller depends on this for the
+  // "drop field" use-case (e.g. removing `host:"a"` when host is absent from
+  // newState). Fields that appear in the text *only* as unquoted / wildcard /
+  // comparison terms cannot be faithfully represented in FilterState, so we
+  // only prune them when the caller is explicitly replacing them (i.e. they
+  // are present in newState).
+  const collectedTerms: CollectedTerm[] = [];
+  const collectedRanges: CollectedRange[] = [];
+  const allFieldsInQuery = new Set<string>();
+  collectFromAst(ast, collectedTerms, collectedRanges, allFieldsInQuery);
+
+  // Fields that have at least one faithfully representable value (quoted or range).
+  const representableFields = new Set<string>([
+    ...collectedTerms.map(t => t.field),
+    ...collectedRanges.map(r => r.field),
+  ]);
+  const newStateFields = new Set(Object.keys(newState));
+
+  // A field is prunable when:
+  //   (a) it has a round-trippable representation (always prunable — supports
+  //       the "drop field" use-case), OR
+  //   (b) it only appears as an unquoted/wildcard/comparison term AND the
+  //       caller is explicitly replacing it via newState.
+  const managedFields = new Set<string>(
+    [...allFieldsInQuery].filter(
+      f => representableFields.has(f) || newStateFields.has(f),
+    ),
+  );
   const residual = renderNode(ast, whereText, field =>
     managedFields.has(field),
   ).text;
@@ -1023,16 +1207,25 @@ function replaceLuceneFacetClauses(
   // If the residual contains a top-level OR operator it must be parenthesized
   // before joining with AND, otherwise `a OR b AND c:"v"` would be parsed as
   // `a OR (b AND c:"v")` — narrowing the OR branch incorrectly.
-  const safeResidual = hasTopLevelOr(residual)
+  const safeResidual = hasTopLevelOr(trimmedResidual)
     ? `(${trimmedResidual})`
     : trimmedResidual;
   return `${safeResidual} AND ${newClauses}`;
 }
 
 /**
- * Split a SQL `where` string into top-level conjuncts, splitting on ` AND `
- * outside quotes and parentheses. The ` AND ` that belongs to a `BETWEEN ...
- * AND ...` range is not a separator, so a BETWEEN conjunct stays intact.
+ * Split a SQL `where` string into top-level conjuncts, splitting on `AND`
+ * (surrounded by any whitespace — spaces, tabs, newlines) outside quotes and
+ * parentheses. The `AND` that belongs to a `BETWEEN ... AND ...` range is not
+ * a separator, so a BETWEEN conjunct stays intact.
+ *
+ * fix: the original implementation only matched the literal 5-char
+ * sequence ` AND ` (single space on each side), so a newline before or after
+ * AND (e.g. `Body LIKE '%x%'\nAND ServiceName IN ('api')`) was not treated as
+ * a separator. The entire multi-line expression was returned as a single
+ * conjunct, which then couldn't be parsed as a facet predicate, so
+ * `replaceSqlFacetClauses` left the whole text as residual and appended the
+ * new clause — duplicating the query on every sidebar click.
  */
 function splitSqlConjuncts(text: string): string[] {
   const conjuncts: string[] = [];
@@ -1041,6 +1234,31 @@ function splitSqlConjuncts(text: string): string[] {
   let inBacktick = false;
   let parenDepth = 0;
   let sawBetween = false;
+
+  /**
+   * Starting at position `i` in `text`, if the text matches
+   * `\s+ AND \s` (whitespace, the keyword AND, at least one more whitespace
+   * character) case-insensitively, return the index of the character
+   * immediately after the AND keyword (i.e. the first whitespace of the
+   * trailing run). Returns -1 when there is no match.
+   *
+   * The trailing whitespace is deliberately *not* consumed here: the main loop
+   * re-processes it naturally, so the next conjunct is trimmed on push.
+   */
+  function matchAndSeparator(pos: number): number {
+    if (pos >= text.length) return -1;
+    // Must start with at least one whitespace character.
+    if (!/[\s]/.test(text[pos])) return -1;
+    let j = pos;
+    while (j < text.length && /[\s]/.test(text[j])) j++;
+    // Must be followed by AND (case-insensitive).
+    if (text.slice(j, j + 3).toUpperCase() !== 'AND') return -1;
+    // The character after AND must be whitespace (guards against matching
+    // inside identifiers like CANDIDATE or COMMAND).
+    if (j + 3 >= text.length || !/[\s]/.test(text[j + 3])) return -1;
+    // Return the index of the first char after AND.
+    return j + 3;
+  }
 
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
@@ -1094,26 +1312,39 @@ function splitSqlConjuncts(text: string): string[] {
       continue;
     }
 
-    if (!sawBetween && text.slice(i, i + 8).toUpperCase() === 'BETWEEN ') {
+    // BETWEEN detection: the keyword can be followed by any whitespace.
+    // We check for `BETWEEN` followed by at least one whitespace character so
+    // we don't accidentally match a column name that starts with BETWEEN.
+    if (
+      !sawBetween &&
+      text.slice(i, i + 7).toUpperCase() === 'BETWEEN' &&
+      i + 7 < text.length &&
+      /[\s]/.test(text[i + 7])
+    ) {
       sawBetween = true;
-      current += 'BETWEEN ';
-      i += 7;
+      // Consume the keyword (the leading char is `char`; advance i to the end
+      // of `BETWEEN` so the loop's i++ lands on the trailing whitespace).
+      current += text.slice(i, i + 7);
+      i += 6;
       continue;
     }
 
-    if (text.slice(i, i + 5).toUpperCase() === ' AND ') {
+    // AND separator detection: any whitespace + AND + any whitespace.
+    const afterAnd = matchAndSeparator(i);
+    if (afterAnd !== -1) {
       if (sawBetween) {
-        // The range's own `AND` — not a conjunct separator.
+        // The range's own AND — not a conjunct separator.
         sawBetween = false;
+        // Re-emit as a single normalised space so the conjunct stays intact.
         current += ' AND ';
-        i += 4;
+        i = afterAnd; // land on first char of trailing whitespace (will be trimmed)
         continue;
       }
       if (current.trim()) {
         conjuncts.push(current.trim());
       }
       current = '';
-      i += 4;
+      i = afterAnd; // skip to char after AND; trailing whitespace trimmed on push
       continue;
     }
 
@@ -1303,6 +1534,16 @@ function replaceSqlFacetClauses(
   const newClauses = emit();
   if (!residual) return `${newClauses}${commentSuffix}`;
   if (!newClauses) return `${residual}${commentSuffix}`;
+  // when the emit language differs from the source language (i.e.,
+  // we are translating SQL → Lucene), the residual is SQL syntax and the new
+  // clauses are Lucene syntax. Joining them produces a syntactically mixed
+  // string that is neither valid SQL nor valid Lucene. In that case, return
+  // only the residual (preserving the original non-facet content verbatim) and
+  // discard the new clauses — the caller must handle the translation at a higher
+  // level, or the user must re-type the non-facet portion.
+  if (emitLanguage != null && emitLanguage !== 'sql') {
+    return `${residual}${commentSuffix}`;
+  }
   // If the residual contains a top-level OR operator it must be parenthesized
   // before joining with AND, otherwise `a = 1 OR b = 2 AND c IN ('v')` would be
   // parsed as `a = 1 OR (b = 2 AND c IN ('v'))` — narrowing the OR branch.
@@ -1538,6 +1779,47 @@ function containsOutsideQuotes(
   return false;
 }
 
+const SQL_IDENTIFIER_CHAR_REGEX = /[A-Za-z0-9_]/;
+
+function containsSqlKeywordOutsideQuotes(
+  text: string,
+  keywords: string[],
+): boolean {
+  let inString = false;
+  const upperKeywords = keywords.map(keyword => keyword.toUpperCase());
+
+  for (let i = 0; i < text.length; i++) {
+    if (isQuoteBoundary(text, i)) {
+      if (inString) {
+        const esc = handleQuoteEscape(text, i);
+        if (esc.skip) {
+          i = esc.next;
+          continue;
+        }
+      }
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    for (const keyword of upperKeywords) {
+      if (text.slice(i, i + keyword.length).toUpperCase() !== keyword) {
+        continue;
+      }
+      const before = i > 0 ? text[i - 1] : '';
+      const after =
+        i + keyword.length < text.length ? text[i + keyword.length] : '';
+      if (
+        !SQL_IDENTIFIER_CHAR_REGEX.test(before) &&
+        !SQL_IDENTIFIER_CHAR_REGEX.test(after)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function containsOperatorOutsideQuotes(part: string): boolean {
   return containsOutsideQuotes(part, [
     { char: '=' },
@@ -1573,6 +1855,68 @@ function splitOnFirstOutsideQuotes(
     }
   }
   return null;
+}
+
+function stripSqlWrappingParens(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) return null;
+
+  let inString = false;
+  let parenDepth = 0;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    if (isQuoteBoundary(trimmed, i)) {
+      if (inString) {
+        const esc = handleQuoteEscape(trimmed, i);
+        if (esc.skip) {
+          i = esc.next;
+          continue;
+        }
+      }
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (trimmed[i] === '(') {
+      parenDepth++;
+      continue;
+    }
+    if (trimmed[i] === ')') {
+      parenDepth--;
+      if (parenDepth === 0 && i < trimmed.length - 1) {
+        return null;
+      }
+    }
+  }
+
+  return parenDepth === 0 ? trimmed.slice(1, -1).trim() : null;
+}
+
+function normalizeSqlFacetPart(part: string): {
+  part: string;
+  negated: boolean;
+} {
+  let trimmed = part.trim();
+  let negated = false;
+
+  const notMatch = trimmed.match(/^NOT\b/i);
+  if (notMatch) {
+    const afterNot = trimmed.slice(notMatch[0].length).trim();
+    const unwrapped = stripSqlWrappingParens(afterNot);
+    if (unwrapped != null) {
+      trimmed = unwrapped;
+      negated = true;
+    }
+  }
+
+  let unwrapped = stripSqlWrappingParens(trimmed);
+  while (unwrapped != null) {
+    trimmed = unwrapped;
+    unwrapped = stripSqlWrappingParens(trimmed);
+  }
+
+  return { part: trimmed, negated };
 }
 
 // Helper function to extract simple IN/NOT IN clauses from a condition
@@ -1628,19 +1972,22 @@ function extractInClauses(condition: string): Array<{
 
   // Process each part to extract IN/NOT IN clauses
   for (const part of parts) {
+    const normalized = normalizeSqlFacetPart(part);
+    const normalizedPart = normalized.part;
+
     // Skip parts that contain OR (not supported) or comparison operators,
     // but only when those operators appear outside of quoted strings.
-    if (containsOperatorOutsideQuotes(part)) {
+    if (containsOperatorOutsideQuotes(normalizedPart)) {
       continue;
     }
 
-    const isExclude = containsOutsideQuotes(part, [' NOT IN ']);
-    const hasIn = isExclude || containsOutsideQuotes(part, [' IN ']);
+    const isExclude = containsOutsideQuotes(normalizedPart, [' NOT IN ']);
+    const hasIn = isExclude || containsOutsideQuotes(normalizedPart, [' IN ']);
 
     if (hasIn) {
       // Split on the first unquoted ' IN ' / ' NOT IN '
       const splitResult = splitOnFirstOutsideQuotes(
-        part,
+        normalizedPart,
         isExclude ? ' NOT IN ' : ' IN ',
       );
       if (!splitResult) continue;
@@ -1655,17 +2002,17 @@ function extractInClauses(condition: string): Array<{
       // re-emitting the column. Reject any parenthesized list containing SQL
       // clause keywords outside quoted strings.
       if (
-        containsOutsideQuotes(trimmedValues, [
-          ' SELECT ',
-          ' FROM ',
-          ' WHERE ',
-          ' GROUP ',
-          ' ORDER ',
-          ' UNION ',
-          ' HAVING ',
-          ' JOIN ',
-          ' LIMIT ',
-          ' DISTINCT ',
+        containsSqlKeywordOutsideQuotes(trimmedValues, [
+          'SELECT',
+          'FROM',
+          'WHERE',
+          'GROUP',
+          'ORDER',
+          'UNION',
+          'HAVING',
+          'JOIN',
+          'LIMIT',
+          'DISTINCT',
         ])
       ) {
         continue;
@@ -1695,7 +2042,7 @@ function extractInClauses(condition: string): Array<{
       results.push({
         key: keyStr,
         values: valuesArray,
-        isExclude,
+        isExclude: isExclude !== normalized.negated,
       });
     }
   }

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -843,7 +843,9 @@ function renderNode(
     }
 
     const startOp: string | undefined =
-      'start' in node && typeof node.start === 'string' ? node.start : undefined;
+      'start' in node && typeof node.start === 'string'
+        ? node.start
+        : undefined;
     const leftNegate = negate !== (startOp === 'NOT');
     const rightNegate =
       negate !== (node.operator === 'AND NOT' || node.operator === 'OR NOT');
@@ -1263,12 +1265,16 @@ function replaceSqlFacetClauses(
       }
     }
   }
-  // Only keys that appear exactly once are safe to replace.
-  const managedKeys = new Set<string>(
-    [...keyCount.entries()]
-      .filter(([, count]) => count === 1)
-      .map(([key]) => key),
-  );
+  // All keys that appear as facet conjuncts are managed (eligible for
+  // replacement). The previous `count === 1` guard was intended to avoid
+  // changing the semantics of a hand-written conjunction like
+  // `host IN ('a') AND host IN ('b')`, but it caused the sidebar to append
+  // a third predicate instead of replacing both — leaving the old restrictions
+  // active and causing the sidebar selection to return zero rows. Replacing all
+  // conjuncts for a field (however many there are) is the correct behaviour:
+  // the sidebar owns every facet it can parse, and duplicate IN lists are an
+  // unusual/erroneous state that replacement should clean up, not preserve.
+  const managedKeys = new Set<string>(keyCount.keys());
 
   for (const conjunct of splitSqlConjuncts(code)) {
     if (!conjunct.trim()) continue;

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -18,7 +18,16 @@ export type FilterState = {
   [key: string]: {
     included: Set<string | boolean>;
     excluded: Set<string | boolean>;
-    range?: { min: number; max: number }; // For BETWEEN conditions
+    range?: {
+      min: number;
+      max: number;
+      /**
+       * Lucene range bracket style: 'both' ([min TO max]), 'none' ({min TO max}),
+       * 'left' ([min TO max}), 'right' ({min TO max]).
+       * Defaults to 'both' (fully inclusive) when not set.
+       */
+      inclusive?: 'both' | 'none' | 'left' | 'right';
+    };
   };
 };
 
@@ -149,17 +158,35 @@ const escapeLuceneQuotedTerm = (s: string) => {
 };
 
 /**
- * Escape backslashes and colons so the field name survives Lucene parsing.
- * Map sub-keys can legitimately contain `:` (e.g. `LogAttributes['foo:bar']`
- * normalizes to `LogAttributes.foo:bar` via parseKeyPath().join('.')), and
- * `:` is the Lucene field/value separator. Backslashes are escaped first so
- * the inserted `\:` survives `encodeSpecialTokens`' `\\` → backslash-literal
- * substitution; the encoder's matching `\:` → HDX_COLON rule then makes the
- * colon opaque to the parser, and `decodeSpecialTokens` restores the
- * original key on the consumer side.
+ * Escape characters in a field name that would break Lucene syntax.
+ *
+ * Lucene treats several characters as syntax in field names / at the
+ * field:value boundary:
+ *   - `\`  – escape prefix (must come first so later replacements survive)
+ *   - `:`  – field/value separator
+ *   - `(`  `)` – grouping / field-group open/close
+ *   - `"`  – quoted-value delimiter
+ *   - `{`  `}` – exclusive range bracket
+ *   - `[`  `]` – inclusive range bracket
+ *   - ` `  (space) – token separator
+ *
+ * Backslashes are escaped first so the `\X` sequences we insert later are
+ * not double-processed.  The encoder's special-token rules (`encodeSpecialTokens`)
+ * handle `\:` → HDX_COLON so that colons survive the parser; the other
+ * characters are simply backslash-escaped in the raw Lucene text.
  */
 const escapeLuceneFieldName = (key: string): string =>
-  key.replace(/\\/g, '\\\\').replace(/:/g, '\\:');
+  key
+    .replace(/\\/g, '\\\\')
+    .replace(/:/g, '\\:')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/"/g, '\\"')
+    .replace(/\{/g, '\\{')
+    .replace(/\}/g, '\\}')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/ /g, '\\ ');
 
 /**
  * Render a FilterState as a single `where` clause string in the given query
@@ -226,8 +253,16 @@ export function filterStateToWhereClause(
       );
     }
     if (values.range != null) {
+      const open =
+        values.range.inclusive === 'none' || values.range.inclusive === 'right'
+          ? '{'
+          : '[';
+      const close =
+        values.range.inclusive === 'none' || values.range.inclusive === 'left'
+          ? '}'
+          : ']';
       clauses.push(
-        `${luceneField}:[${values.range.min} TO ${values.range.max}]`,
+        `${luceneField}:${open}${values.range.min} TO ${values.range.max}${close}`,
       );
     }
   }
@@ -235,36 +270,207 @@ export function filterStateToWhereClause(
 }
 
 type CollectedTerm = { field: string; value: string; negated: boolean };
-type CollectedRange = { field: string; min: number; max: number };
+type CollectedRange = {
+  field: string;
+  min: number;
+  max: number;
+  inclusive?: 'both' | 'none' | 'left' | 'right';
+};
 
 /**
- * Collect quoted terms and range terms from a Lucene AST.
+ * Return true when a `NodeTerm` carries a proximity (~N), fuzzy (~), or boost
+ * (^N) modifier. The `@hyperdx/lucene` package ships no `.d.ts` file so
+ * TypeScript infers these optional properties as absent from `NodeTerm`; we
+ * access them through an `unknown` cast to stay type-safe while still checking
+ * the runtime values the grammar always sets (to `null` when absent).
+ */
+function hasTermModifiers(node: lucene.NodeTerm): boolean {
+  const n = node as unknown as Record<string, unknown>;
+  return (
+    n['proximity'] != null || n['boost'] != null || n['similarity'] != null
+  );
+}
+
+/**
+ * Collect quoted terms and range terms from a Lucene AST into the `terms` /
+ * `ranges` arrays.  `managedFields` collects every explicit-field name that we
+ * should treat as "managed" even when we cannot faithfully round-trip the value
+ * (unquoted terms, field groups).  `collectFromAst` is only called in contexts
+ * that build the `managed` set, so this wider set lets `renderNode` prune
+ * unquoted field clauses (Bug 7) and field-group clauses (Bug 3).
+ *
+ * Cross-field OR rules (Bug 2): when an OR node connects clauses for *different*
+ * fields, the relationship cannot be expressed in FilterState (which has AND
+ * semantics across fields), so we treat the whole OR sub-tree as unmanaged —
+ * neither side is collected, and `renderNode` will preserve the raw text.
  */
 function collectFromAst(
   ast: lucene.AST | lucene.Node,
   terms: CollectedTerm[],
   ranges: CollectedRange[],
+  managedFields: Set<string>,
+  negate = false,
 ): void {
   if (isNodeTerm(ast)) {
-    if (!ast.quoted) return;
-    const negated = ast.field.startsWith('-');
-    const field = decodeSpecialTokens(negated ? ast.field.slice(1) : ast.field);
-    // Implicit-field phrases (`"a b"`) are free-text search, not facets.
+    // `negate` carries a `NOT` (or `+`/`-`) wrapper from an enclosing node, so
+    // `NOT a:"1"` / `a AND NOT b:"2"` collect as excluded instead of included.
+    // A `-` prefix XORs with the wrapper (`NOT -a` is not negated). Only a
+    // literal `-` prefix is sliced off the field name.
+    const negatedField = ast.field.startsWith('-');
+    const negated = negatedField !== negate;
+    const field = decodeSpecialTokens(
+      negatedField ? ast.field.slice(1) : ast.field,
+    );
+    // Implicit-field terms (free-text, quoted phrases) are never managed facets.
     if (field === IMPLICIT_FIELD) return;
+
+    // Terms with proximity (~N), fuzzy (~), or boost (^N) modifiers cannot be
+    // faithfully represented in FilterState, so treat them as unmanaged (Bug 6).
+    // However the field is still marked managed so that sibling plain clauses
+    // for the same field are pruned by renderNode rather than left to pile up
+    // alongside the new emission.
+    if (hasTermModifiers(ast)) {
+      managedFields.add(field);
+      return;
+    }
+
+    // Collect the field as managed so renderNode can prune it (Bug 7).
+    managedFields.add(field);
+
+    if (!ast.quoted) {
+      // Unquoted terms are managed for *removal* (so the old unquoted clause
+      // doesn't linger when the sidebar replaces it with a quoted one), but we
+      // don't add them to `terms` — the sidebar always emits quoted values.
+      return;
+    }
+
     terms.push({ field, value: decodeSpecialTokens(ast.term), negated });
   } else if (isNodeRangedTerm(ast)) {
     const field = decodeSpecialTokens(ast.field);
     if (field === IMPLICIT_FIELD) return;
+    // A negated range (`NOT duration:[10 TO 20]`) can't be represented in
+    // FilterState, so leave it unmanaged and preserve it verbatim. But still
+    // mark the field as managed so plain range clauses on the same field don't
+    // survive alongside the new emission.
+    if (negate) {
+      managedFields.add(field);
+      return;
+    }
     const min = parseFloat(ast.term_min);
     const max = parseFloat(ast.term_max);
     if (!isNaN(min) && !isNaN(max)) {
-      ranges.push({ field, min, max });
+      managedFields.add(field);
+      const inclusive =
+        (ast.inclusive as 'both' | 'none' | 'left' | 'right') ?? 'both';
+      ranges.push({
+        field,
+        min,
+        max,
+        // Only store non-default inclusivity so round-tripping `[min TO max]`
+        // doesn't add an unexpected `inclusive` key to the range object.
+        ...(inclusive !== 'both' ? { inclusive } : {}),
+      });
     }
   } else if (isBinaryAST(ast)) {
-    collectFromAst(ast.left, terms, ranges);
-    collectFromAst(ast.right, terms, ranges);
+    // Field-group syntax: ServiceName:("api" OR "web").  The parser puts a
+    // non-implicit `field` on the BinaryAST wrapper (Bug 3).  Collect its
+    // inner leaf values as if they had the group's field name.
+    const groupField =
+      'field' in ast &&
+      typeof ast.field === 'string' &&
+      ast.field !== IMPLICIT_FIELD
+        ? decodeSpecialTokens(ast.field)
+        : null;
+
+    if (groupField) {
+      // Collect each leaf of the field group under the group's field name.
+      managedFields.add(groupField);
+      collectFieldGroupLeaves(ast, groupField, terms, managedFields, negate);
+      return;
+    }
+
+    // Cross-field OR: if this OR node connects clauses for *different* fields,
+    // we cannot represent that in FilterState, so leave both sides unmanaged
+    // (Bug 2).  Same-field OR (e.g. `level:"info" OR level:"warn"`) is fine —
+    // both leaves map to the same field and end up as multiple `included` values.
+    // `OR NOT` is an OR too (a:"1" OR NOT b:"2" is cross-field and unrepresentable).
+    if (ast.operator === 'OR' || ast.operator === 'OR NOT') {
+      const leftFields = new Set<string>();
+      const rightFields = new Set<string>();
+      const leftManaged = new Set<string>();
+      const rightManaged = new Set<string>();
+      collectFromAst(ast.left, [], [], leftFields);
+      collectFromAst(ast.right, [], [], rightFields);
+      // Merge managed fields from each side for the lookup
+      for (const f of leftFields) leftManaged.add(f);
+      for (const f of rightFields) rightManaged.add(f);
+      const isSameField =
+        leftFields.size > 0 &&
+        rightFields.size > 0 &&
+        leftFields.size === 1 &&
+        rightFields.size === 1 &&
+        [...leftFields][0] === [...rightFields][0];
+
+      if (!isSameField) {
+        // Cross-field OR — do not add either side to managed, leave raw.
+        return;
+      }
+    }
+
+    // A `start: 'NOT'` on the binary node negates its left subtree (`NOT a AND
+    // b`); an `AND NOT` / `OR NOT` operator negates the right subtree.
+    const startOp: string | undefined =
+      'start' in ast && typeof ast.start === 'string' ? ast.start : undefined;
+    const leftNegate = negate !== (startOp === 'NOT');
+    const rightNegate =
+      negate !== (ast.operator === 'AND NOT' || ast.operator === 'OR NOT');
+    collectFromAst(ast.left, terms, ranges, managedFields, leftNegate);
+    collectFromAst(ast.right, terms, ranges, managedFields, rightNegate);
   } else if (isLeftOnlyAST(ast)) {
-    collectFromAst(ast.left, terms, ranges);
+    collectFromAst(
+      ast.left,
+      terms,
+      ranges,
+      managedFields,
+      negate !== (ast.start === 'NOT'),
+    );
+  }
+}
+
+/**
+ * Recursively collect leaf terms from a field-group BinaryAST, assigning them
+ * the `groupField` instead of `<implicit>`.
+ */
+function collectFieldGroupLeaves(
+  ast: lucene.AST | lucene.Node,
+  groupField: string,
+  terms: CollectedTerm[],
+  managedFields: Set<string>,
+  negate = false,
+): void {
+  if (isNodeTerm(ast)) {
+    // Skip modifiers — proximity/boost can't be faithfully round-tripped.
+    if (hasTermModifiers(ast)) {
+      return;
+    }
+    if (!ast.quoted) return; // unquoted inside group: add field but no value
+    const negated = ast.field.startsWith('-') !== negate;
+    terms.push({
+      field: groupField,
+      value: decodeSpecialTokens(ast.term),
+      negated,
+    });
+  } else if (isBinaryAST(ast)) {
+    collectFieldGroupLeaves(ast.left, groupField, terms, managedFields, negate);
+    collectFieldGroupLeaves(
+      ast.right,
+      groupField,
+      terms,
+      managedFields,
+      negate,
+    );
+  } else if (isLeftOnlyAST(ast)) {
+    collectFieldGroupLeaves(ast.left, groupField, terms, managedFields, negate);
   }
 }
 
@@ -300,14 +506,19 @@ export function parseWhereClauseToFilterState(
     const ast = parse(whereText);
     const terms: CollectedTerm[] = [];
     const ranges: CollectedRange[] = [];
-    collectFromAst(ast, terms, ranges);
+    const managedFields = new Set<string>();
+    collectFromAst(ast, terms, ranges, managedFields);
 
     const byField = new Map<
       string,
       {
         included: Set<string | boolean>;
         excluded: Set<string | boolean>;
-        range?: { min: number; max: number };
+        range?: {
+          min: number;
+          max: number;
+          inclusive?: 'both' | 'none' | 'left' | 'right';
+        };
       }
     >();
     const getEntry = (field: string) => {
@@ -328,11 +539,143 @@ export function parseWhereClauseToFilterState(
     }
     for (const r of ranges) {
       const entry = getEntry(r.field);
-      entry.range = { min: r.min, max: r.max };
+      entry.range = {
+        min: r.min,
+        max: r.max,
+        ...(r.inclusive != null ? { inclusive: r.inclusive } : {}),
+      };
     }
     return Object.fromEntries(byField);
   } catch {
     return {};
+  }
+}
+
+/**
+ * Return a non-null message when a `where` clause cannot be parsed in the given
+ * query language (e.g. an incomplete lucene query like `service:`). The message
+ * is intended for a UI notice — callers can treat any non-null value as "the
+ * query is invalid/incomplete".
+ *
+ * `sql` always returns null: there is no strict SQL parser here and
+ * `parseQuery` is tolerant, so we can't reliably distinguish invalid from valid.
+ */
+export function getWhereParseError(
+  whereText: string,
+  language: 'lucene' | 'sql',
+): string | null {
+  if (!whereText.trim()) return null;
+  if (language === 'sql') return null;
+  try {
+    parse(whereText);
+    return null;
+  } catch (e) {
+    return e instanceof Error ? e.message : 'Invalid query';
+  }
+}
+
+/**
+ * Collect every explicit-field name referenced under a lucene AST node, using
+ * the field's decoded name (stripping `-`/`+` prefixes). Used to detect
+ * cross-field OR constructs.
+ */
+function collectExplicitFields(
+  node: lucene.AST | lucene.Node,
+  out: Set<string>,
+): void {
+  if (isNodeTerm(node)) {
+    const raw =
+      node.field.startsWith('-') || node.field.startsWith('+')
+        ? node.field.slice(1)
+        : node.field;
+    const field = decodeSpecialTokens(raw);
+    if (field !== IMPLICIT_FIELD) out.add(field);
+    return;
+  }
+  if (isNodeRangedTerm(node)) {
+    const field = decodeSpecialTokens(node.field);
+    if (field !== IMPLICIT_FIELD) out.add(field);
+    return;
+  }
+  if (isBinaryAST(node)) {
+    const groupField =
+      'field' in node &&
+      typeof node.field === 'string' &&
+      node.field !== IMPLICIT_FIELD
+        ? decodeSpecialTokens(node.field)
+        : null;
+    if (groupField) {
+      // Field-group syntax: all inner leaves belong to the group's field.
+      out.add(groupField);
+      return;
+    }
+    collectExplicitFields(node.left, out);
+    collectExplicitFields(node.right, out);
+    return;
+  }
+  if (isLeftOnlyAST(node)) {
+    collectExplicitFields(node.left, out);
+  }
+}
+
+/**
+ * Return true when a lucene AST contains an OR (or OR NOT) node connecting
+ * clauses for different explicit fields. Such a query cannot be represented as
+ * a FilterState (which has AND semantics across fields), so the sidebar would
+ * either silently drop it or mislead.
+ */
+function hasCrossFieldOr(node: lucene.AST | lucene.Node): boolean {
+  if (isNodeTerm(node) || isNodeRangedTerm(node)) return false;
+  if (isLeftOnlyAST(node)) return hasCrossFieldOr(node.left);
+  if (isBinaryAST(node)) {
+    const groupField =
+      'field' in node &&
+      typeof node.field === 'string' &&
+      node.field !== IMPLICIT_FIELD
+        ? decodeSpecialTokens(node.field)
+        : null;
+    if (groupField) {
+      return hasCrossFieldOr(node.left) || hasCrossFieldOr(node.right);
+    }
+    if (node.operator === 'OR' || node.operator === 'OR NOT') {
+      const leftFields = new Set<string>();
+      const rightFields = new Set<string>();
+      collectExplicitFields(node.left, leftFields);
+      collectExplicitFields(node.right, rightFields);
+      const isSameField =
+        leftFields.size > 0 &&
+        rightFields.size > 0 &&
+        leftFields.size === 1 &&
+        rightFields.size === 1 &&
+        [...leftFields][0] === [...rightFields][0];
+      if (!isSameField) return true;
+    }
+    return hasCrossFieldOr(node.left) || hasCrossFieldOr(node.right);
+  }
+  return false;
+}
+
+/**
+ * Return a non-null reason when a `where` clause parses but contains facet-like
+ * content the sidebar FilterState cannot faithfully represent — currently a
+ * cross-field OR (e.g. `ServiceName:"api" OR SeverityText:"error"`). The UI
+ * should surface this instead of showing a misleading or silently-emptied
+ * filter sidebar. `sql` always returns null.
+ */
+export function getUnrepresentableWhereReason(
+  whereText: string,
+  language: 'lucene' | 'sql',
+): string | null {
+  if (!whereText.trim()) return null;
+  if (language === 'sql') return null;
+  try {
+    const ast = parse(whereText);
+    if (hasCrossFieldOr(ast)) {
+      return 'This query contains OR conditions between different fields, which cannot be shown as sidebar filters.';
+    }
+    return null;
+  } catch {
+    return null;
   }
 }
 
@@ -343,7 +686,14 @@ function termClauseSpan(node: lucene.NodeTerm, src: string): Span | null {
   if (!tl?.end) return null;
   const start = node.fieldLocation?.start?.offset ?? tl.start?.offset;
   if (start == null) return null;
-  return { start, end: tl.end.offset };
+  // Bug 10 fix: termLocation.end.offset can include trailing whitespace (the
+  // grammar's `_*` consumes whitespace after the term).  Trim to avoid
+  // accumulating extra spaces when the residual is re-joined with an operator.
+  let end = tl.end.offset;
+  while (end > start && (src[end - 1] === ' ' || src[end - 1] === '\t')) {
+    end--;
+  }
+  return { start, end };
 }
 
 function rangeClauseSpan(
@@ -351,9 +701,18 @@ function rangeClauseSpan(
   src: string,
 ): Span | null {
   const fl = node.fieldLocation;
-  if (!fl?.start?.offset || !fl.end?.offset) return null;
-  const endBracket = src.indexOf(']', fl.end.offset);
-  if (endBracket === -1) return null;
+  // Bug 4 fix: use == null instead of falsy check so offset=0 is not dropped.
+  if (fl?.start?.offset == null || !fl.end?.offset) return null;
+  // Bug 5 fix: the range may end with `]` (inclusive) or `}` (exclusive).
+  // Search for whichever closing bracket appears first after the field end.
+  const searchFrom = fl.end.offset;
+  const closeSq = src.indexOf(']', searchFrom);
+  const closeCurly = src.indexOf('}', searchFrom);
+  let endBracket: number;
+  if (closeSq === -1 && closeCurly === -1) return null;
+  if (closeSq === -1) endBracket = closeCurly;
+  else if (closeCurly === -1) endBracket = closeSq;
+  else endBracket = Math.min(closeSq, closeCurly);
   return { start: fl.start.offset, end: endBracket + 1 };
 }
 
@@ -371,21 +730,40 @@ type RenderResult = {
  * OR/AND chain doesn't leave dangling operators (e.g. removing `host` from
  * `foo:"x" AND host:"a" AND bar:"y"` yields `foo:"x" AND bar:"y"`, and from
  * `(a OR host OR b)` yields `(a OR b)`).
+ *
+ * `negate` mirrors the same flag in `collectFromAst`: negated ranges
+ * (`NOT duration:[...]`) cannot be represented in FilterState and must be
+ * preserved verbatim even when their field is managed.
  */
 function renderNode(
   node: lucene.AST | lucene.Node,
   src: string,
   isManagedField: (field: string) => boolean,
+  negate = false,
 ): RenderResult {
   if (isNodeTerm(node)) {
     const span = termClauseSpan(node, src);
     if (!span) return { text: '', fullyManaged: false };
     if (!node.quoted) {
+      // Bug 7 fix: unquoted explicit-field terms (e.g. level:error) must also
+      // be pruned when their field is managed, so the sidebar can replace them
+      // with a quoted clause without duplication.
+      const rawField = node.field.startsWith('-')
+        ? node.field.slice(1)
+        : node.field;
+      const field = decodeSpecialTokens(rawField);
+      if (field !== IMPLICIT_FIELD && isManagedField(field)) {
+        return { text: '', fullyManaged: true };
+      }
       return { text: src.slice(span.start, span.end), fullyManaged: false };
     }
     const field = decodeSpecialTokens(
       node.field.startsWith('-') ? node.field.slice(1) : node.field,
     );
+    // Terms with modifiers (proximity, boost, fuzzy) are not managed.
+    if (hasTermModifiers(node)) {
+      return { text: src.slice(span.start, span.end), fullyManaged: false };
+    }
     if (field !== IMPLICIT_FIELD && isManagedField(field)) {
       return { text: '', fullyManaged: true };
     }
@@ -396,14 +774,17 @@ function renderNode(
     const span = rangeClauseSpan(node, src);
     if (!span) return { text: '', fullyManaged: false };
     const field = decodeSpecialTokens(node.field);
-    if (field !== IMPLICIT_FIELD && isManagedField(field)) {
+    // Negated ranges (NOT duration:[...]) are not representable in FilterState
+    // and must be preserved verbatim even when the field is otherwise managed.
+    if (!negate && field !== IMPLICIT_FIELD && isManagedField(field)) {
       return { text: '', fullyManaged: true };
     }
     return { text: src.slice(span.start, span.end), fullyManaged: false };
   }
 
   if (isLeftOnlyAST(node)) {
-    const inner = renderNode(node.left, src, isManagedField);
+    const nodeNegate = negate !== (node.start === 'NOT');
+    const inner = renderNode(node.left, src, isManagedField, nodeNegate);
     if (inner.fullyManaged) {
       return { text: '', fullyManaged: true };
     }
@@ -415,15 +796,72 @@ function renderNode(
   }
 
   if (isBinaryAST(node)) {
-    const left = renderNode(node.left, src, isManagedField);
-    const right = renderNode(node.right, src, isManagedField);
+    // Field-group syntax: ServiceName:("api" OR "web").  The parser attaches
+    // a non-implicit `field` to the BinaryAST wrapper (Bug 3).  When the group
+    // field is managed we discard the whole group; otherwise we preserve the
+    // raw source including the "Field:" prefix.
+    const groupField =
+      'field' in node &&
+      typeof node.field === 'string' &&
+      node.field !== IMPLICIT_FIELD
+        ? decodeSpecialTokens(node.field)
+        : null;
+
+    if (groupField) {
+      if (isManagedField(groupField)) {
+        return { text: '', fullyManaged: true };
+      }
+      // Preserve raw source.  The field-group span starts at the field's
+      // fieldLocation and ends after the closing ')'.
+      const fl =
+        'fieldLocation' in node
+          ? (node.fieldLocation as
+              | { start?: { offset?: number }; end?: { offset?: number } }
+              | null
+              | undefined)
+          : undefined;
+      const groupStart = fl?.start?.offset;
+      if (groupStart == null) return { text: '', fullyManaged: false };
+      // Find the closing ')' of the paren group.
+      let depth = 0;
+      let groupEnd = -1;
+      for (let i = groupStart; i < src.length; i++) {
+        if (src[i] === '(') depth++;
+        else if (src[i] === ')') {
+          depth--;
+          if (depth === 0) {
+            groupEnd = i + 1;
+            break;
+          }
+        }
+      }
+      if (groupEnd === -1) return { text: '', fullyManaged: false };
+      return {
+        text: src.slice(groupStart, groupEnd).trimEnd(),
+        fullyManaged: false,
+      };
+    }
+
+    const startOp: string | undefined =
+      'start' in node && typeof node.start === 'string' ? node.start : undefined;
+    const leftNegate = negate !== (startOp === 'NOT');
+    const rightNegate =
+      negate !== (node.operator === 'AND NOT' || node.operator === 'OR NOT');
+    const left = renderNode(node.left, src, isManagedField, leftNegate);
+    const right = renderNode(node.right, src, isManagedField, rightNegate);
     if (left.fullyManaged && right.fullyManaged) {
       return { text: '', fullyManaged: true };
     }
-    const operator = node.operator === '<implicit>' ? '' : ` ${node.operator} `;
+    const operator =
+      node.operator === '<implicit>' ? ' ' : ` ${node.operator} `;
     const combined = [left.text, right.text].filter(Boolean).join(operator);
+    // Bug 1 fix: the `start` field carries a leading operator like `NOT` that
+    // the grammar placed on the outer binary node rather than a LeftOnlyAST.
+    // Re-emit it so `NOT term AND ...` is not silently stripped to `term AND ...`.
+    const startPrefix = 'start' in node && node.start ? `${node.start} ` : '';
+    const text = node.parenthesized && combined ? `(${combined})` : combined;
     return {
-      text: node.parenthesized && combined ? `(${combined})` : combined,
+      text: startPrefix && text ? `${startPrefix}${text}` : text,
       fullyManaged: false,
     };
   }
@@ -433,15 +871,88 @@ function renderNode(
 
 /**
  * Returns true when the Lucene text contains a top-level OR operator (i.e. an
- * OR that is not inside parentheses). Used to decide whether the residual must
- * be wrapped in parens before joining it with AND — without the wrapping,
- * `a OR b AND c:"v"` would be mis-parsed as `a OR (b AND c:"v")`.
+ * OR that is not inside parentheses or quoted strings). Used to decide whether
+ * the residual must be wrapped in parens before joining it with AND — without
+ * the wrapping, `a OR b AND c:"v"` would be mis-parsed as `a OR (b AND c:"v")`.
+ *
+ * Bug 9 fix: the original implementation counted bare `(` / `)` characters
+ * without skipping quoted strings, so a `)` inside a quoted value like
+ * `"timeout)"` decremented the paren depth and corrupted the subsequent scan.
  */
 function hasTopLevelOr(text: string): boolean {
   let parenDepth = 0;
+  let inQuote = false;
   for (let i = 0; i < text.length; i++) {
-    if (text[i] === '(') { parenDepth++; continue; }
-    if (text[i] === ')') { parenDepth--; continue; }
+    const ch = text[i];
+    if (ch === '\\' && inQuote) {
+      // Skip escaped character inside a quoted string.
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (inQuote) continue;
+    if (ch === '(') {
+      parenDepth++;
+      continue;
+    }
+    if (ch === ')') {
+      parenDepth--;
+      continue;
+    }
+    if (parenDepth === 0 && text.slice(i, i + 4).toUpperCase() === ' OR ') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true when the SQL text contains a top-level OR operator (i.e. an OR
+ * that is not inside parentheses, single-quoted strings, or backtick-quoted
+ * identifiers). Used to decide whether the residual must be wrapped in parens
+ * before joining it with AND — without the wrapping, `a = 1 OR b = 2 AND c IN
+ * ('v')` would be mis-parsed as `a = 1 OR (b = 2 AND c IN ('v'))`.
+ */
+function hasTopLevelOrSql(text: string): boolean {
+  let parenDepth = 0;
+  let inString = false;
+  let inBacktick = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (ch === "'") {
+        const esc = handleQuoteEscape(text, i);
+        if (esc.skip) {
+          i = esc.next;
+          continue;
+        }
+        inString = false;
+      }
+      continue;
+    }
+    if (inBacktick) {
+      if (ch === '`') inBacktick = false;
+      continue;
+    }
+    if (ch === "'") {
+      inString = true;
+      continue;
+    }
+    if (ch === '`') {
+      inBacktick = true;
+      continue;
+    }
+    if (ch === '(') {
+      parenDepth++;
+      continue;
+    }
+    if (ch === ')') {
+      parenDepth--;
+      continue;
+    }
     if (parenDepth === 0 && text.slice(i, i + 4).toUpperCase() === ' OR ') {
       return true;
     }
@@ -461,28 +972,47 @@ function hasTopLevelOr(text: string): boolean {
 function replaceLuceneFacetClauses(
   whereText: string,
   newState: FilterState,
+  emitLanguage: 'lucene' | 'sql' | undefined,
+  escapeKey: ((key: string) => string) | undefined,
+  dateTimeColumns: ReadonlyMap<string, string> | undefined,
 ): string {
   if (!whereText.trim()) {
-    return filterStateToWhereClause(newState, { language: 'lucene' });
+    return filterStateToWhereClause(newState, {
+      language: emitLanguage ?? 'lucene',
+      escapeKey,
+      dateTimeColumns,
+    });
   }
 
   let ast: lucene.AST;
   try {
     ast = parse(whereText);
   } catch {
-    // Invalid Lucene — don't clobber the user's text.
-    return whereText;
+    // Invalid Lucene — the query text is incomplete/mid-edit. Rather than
+    // silently no-oping the caller's rewrite, emit the new state fresh so a
+    // sidebar click still applies and replaces the broken text.
+    return filterStateToWhereClause(newState, {
+      language: emitLanguage ?? 'lucene',
+      escapeKey,
+      dateTimeColumns,
+    });
   }
 
   // Managed fields are every facet field currently present in the text, so a
   // caller that intentionally drops a field (e.g. source-change cleanup) also
   // removes its clauses rather than leaving them to resurface.
-  const managed = new Set(
-    Object.keys(parseWhereClauseToFilterState(whereText, 'lucene')),
-  );
-  const residual = renderNode(ast, whereText, field => managed.has(field)).text;
+  // We use the wider `managedFields` set (which includes unquoted explicit-field
+  // terms and field-group fields, but excludes cross-field OR branches) so that
+  // e.g. an unquoted `level:error` is removed when the sidebar sets level:"warn".
+  const managedFields = new Set<string>();
+  collectFromAst(parse(whereText), [], [], managedFields);
+  const residual = renderNode(ast, whereText, field =>
+    managedFields.has(field),
+  ).text;
   const newClauses = filterStateToWhereClause(newState, {
-    language: 'lucene',
+    language: emitLanguage ?? 'lucene',
+    escapeKey,
+    dateTimeColumns,
   });
 
   const trimmedResidual = residual.trim();
@@ -506,11 +1036,20 @@ function splitSqlConjuncts(text: string): string[] {
   const conjuncts: string[] = [];
   let current = '';
   let inString = false;
+  let inBacktick = false;
   let parenDepth = 0;
   let sawBetween = false;
 
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
+
+    // Backtick-quoted identifiers (e.g. `it's`) are opaque: a `'` or `(` inside
+    // them is literal and must not toggle string state or paren depth.
+    if (inBacktick) {
+      if (char === '`') inBacktick = false;
+      current += char;
+      continue;
+    }
 
     if (isQuoteBoundary(text, i)) {
       if (inString) {
@@ -526,6 +1065,17 @@ function splitSqlConjuncts(text: string): string[] {
       continue;
     }
 
+    if (inString) {
+      current += char;
+      continue;
+    }
+
+    if (char === '`') {
+      inBacktick = true;
+      current += char;
+      continue;
+    }
+
     if (char === '(') {
       parenDepth++;
       current += char;
@@ -537,7 +1087,7 @@ function splitSqlConjuncts(text: string): string[] {
       continue;
     }
 
-    if (inString || parenDepth > 0) {
+    if (parenDepth > 0) {
       current += char;
       continue;
     }
@@ -574,6 +1124,86 @@ function splitSqlConjuncts(text: string): string[] {
   return conjuncts;
 }
 
+// Strip SQL comments (`-- ...` line comments and `/* ... */` block comments)
+// from a WHERE string, returning the code with each comment replaced by a single
+// space plus the collected comment texts. Comments inside single-quoted strings
+// or backtick-quoted identifiers are literal text and are left untouched.
+// Stripping comments before conjunct splitting keeps a commented-out ` AND `
+// from being treated as a real separator, and lets the caller re-append the
+// comments at the end instead of letting a facet predicate land inside one.
+function stripSqlComments(text: string): {
+  code: string;
+  comments: string[];
+} {
+  let code = '';
+  const comments: string[] = [];
+  let inString = false;
+  let inBacktick = false;
+
+  for (let i = 0; i < text.length; i++) {
+    if (inBacktick) {
+      code += text[i];
+      if (text[i] === '`') inBacktick = false;
+      continue;
+    }
+    if (inString) {
+      if (isQuoteBoundary(text, i)) {
+        const esc = handleQuoteEscape(text, i);
+        if (esc.skip) {
+          code += "''";
+          i = esc.next;
+          continue;
+        }
+        inString = false;
+      }
+      code += text[i];
+      continue;
+    }
+    if (text[i] === "'") {
+      inString = true;
+      code += text[i];
+      continue;
+    }
+    if (text[i] === '`') {
+      inBacktick = true;
+      code += text[i];
+      continue;
+    }
+    if (text[i] === '-' && text[i + 1] === '-') {
+      let comment = '--';
+      i += 2;
+      while (i < text.length && text[i] !== '\n') {
+        comment += text[i];
+        i++;
+      }
+      comments.push(comment);
+      code += ' ';
+      i--; // the \n (or end) will be consumed by the loop's own increment
+      continue;
+    }
+    if (text[i] === '/' && text[i + 1] === '*') {
+      let comment = '/*';
+      i += 2;
+      while (i < text.length) {
+        if (text[i] === '*' && text[i + 1] === '/') {
+          comment += '*/';
+          i += 2;
+          break;
+        }
+        comment += text[i];
+        i++;
+      }
+      comments.push(comment);
+      code += ' ';
+      i--; // let the loop's increment advance past the closing '/' (or end)
+      continue;
+    }
+    code += text[i];
+  }
+
+  return { code, comments };
+}
+
 /**
  * Replace the facet clauses in a SQL `where` clause with a new FilterState.
  *
@@ -588,23 +1218,59 @@ function replaceSqlFacetClauses(
   newState: FilterState,
   escapeKey: ((key: string) => string) | undefined,
   dateTimeColumns: ReadonlyMap<string, string> | undefined,
+  emitLanguage?: 'lucene' | 'sql',
 ): string {
   const clean = whereText.trim();
+  // Strip SQL comments up front so a commented-out ` AND ` is not mistaken for
+  // a real conjunct separator, and re-append them at the end so newly emitted
+  // facet predicates never land inside a comment.
+  const { code, comments } = stripSqlComments(clean);
+  const commentSuffix = comments.length ? ` ${comments.join(' ')}` : '';
   const emit = () =>
     filterStateToWhereClause(newState, {
-      language: 'sql',
+      language: emitLanguage ?? 'sql',
       escapeKey,
       dateTimeColumns,
     });
 
-  if (!clean) return emit();
+  if (!code.trim()) return `${emit()}${commentSuffix}`;
 
   const kept: string[] = [];
-  // Build the set of clean keys being written so we only drop conjuncts whose
-  // field is being replaced — not every parseable facet in the where clause.
-  const replacedKeys = new Set(Object.keys(newState));
+  // Build the set of clean keys being managed (present in the original text as
+  // parseable facets) so we drop ALL of them and re-emit only those in newState.
+  // This lets the caller clear a field from the filter by omitting it from
+  // newState, and also handles the case where newState is empty (clear all).
+  //
+  // A key is only managed when it appears *exactly once* as a facet conjunct.
+  // If the same key appears in multiple conjuncts (e.g. `host IN ('a') AND host
+  // IN ('b')`) the user intentionally wrote a conjunction of two IN lists.
+  // Merging them into one IN list would change the semantics (intersection →
+  // union for scalar columns), so we leave both conjuncts untouched instead.
+  const keyCount = new Map<string, number>();
+  for (const conjunct of splitSqlConjuncts(code)) {
+    if (!conjunct.trim()) continue;
+    const upper = conjunct.toUpperCase();
+    const isFacet =
+      upper.includes(' IN (') ||
+      upper.includes(' NOT IN (') ||
+      upper.includes(' BETWEEN ');
+    if (!isFacet) continue;
+    const filter: Filter = { type: 'sql', condition: conjunct };
+    if (isRenderablePinnedFilter(filter)) {
+      const parsedKey = Object.keys(parseQuery([filter]).filters)[0];
+      if (parsedKey !== undefined) {
+        keyCount.set(parsedKey, (keyCount.get(parsedKey) ?? 0) + 1);
+      }
+    }
+  }
+  // Only keys that appear exactly once are safe to replace.
+  const managedKeys = new Set<string>(
+    [...keyCount.entries()]
+      .filter(([, count]) => count === 1)
+      .map(([key]) => key),
+  );
 
-  for (const conjunct of splitSqlConjuncts(clean)) {
+  for (const conjunct of splitSqlConjuncts(code)) {
     if (!conjunct.trim()) continue;
     const upper = conjunct.toUpperCase();
     const isFacet =
@@ -616,12 +1282,12 @@ function replaceSqlFacetClauses(
       continue;
     }
     const filter: Filter = { type: 'sql', condition: conjunct };
-    // Only drop this conjunct if it maps to a field we are replacing.
-    // Compound conditions and unparseable conjuncts are always preserved.
+    // Drop this conjunct if it maps to a managed field — it will be re-emitted
+    // from newState (or omitted entirely if newState doesn't include that field).
     if (isRenderablePinnedFilter(filter)) {
       const parsedKey = Object.keys(parseQuery([filter]).filters)[0];
-      if (parsedKey !== undefined && replacedKeys.has(parsedKey)) {
-        continue; // will be re-emitted from newState
+      if (parsedKey !== undefined && managedKeys.has(parsedKey)) {
+        continue; // will be re-emitted from newState (or dropped if not there)
       }
     }
     kept.push(conjunct);
@@ -629,9 +1295,15 @@ function replaceSqlFacetClauses(
 
   const residual = kept.join(' AND ');
   const newClauses = emit();
-  if (!residual) return newClauses;
-  if (!newClauses) return residual;
-  return `${residual} AND ${newClauses}`;
+  if (!residual) return `${newClauses}${commentSuffix}`;
+  if (!newClauses) return `${residual}${commentSuffix}`;
+  // If the residual contains a top-level OR operator it must be parenthesized
+  // before joining with AND, otherwise `a = 1 OR b = 2 AND c IN ('v')` would be
+  // parsed as `a = 1 OR (b = 2 AND c IN ('v'))` — narrowing the OR branch.
+  const safeResidual = hasTopLevelOrSql(residual)
+    ? `(${residual.trim()})`
+    : residual;
+  return `${safeResidual} AND ${newClauses}${commentSuffix}`;
 }
 
 /**
@@ -651,20 +1323,90 @@ export function replaceFilterClauses(
   {
     escapeKey,
     dateTimeColumns,
+    emitLanguage,
   }: {
     escapeKey?: (key: string) => string;
     dateTimeColumns?: ReadonlyMap<string, string>;
+    /**
+     * When set, the facets are re-emitted in this language instead of `language`.
+     * Matching/pruning still happens in `language` (the source of the existing
+     * text); `emitLanguage` only changes how the new clauses are written. Used
+     * to translate a `where` clause from one query language to another while
+     * preserving non-facet content.
+     */
+    emitLanguage?: 'lucene' | 'sql';
   } = {},
 ): string {
   if (language === 'lucene') {
-    return replaceLuceneFacetClauses(whereText, newState);
+    return replaceLuceneFacetClauses(
+      whereText,
+      newState,
+      emitLanguage,
+      escapeKey,
+      dateTimeColumns,
+    );
   }
   return replaceSqlFacetClauses(
     whereText,
     newState,
     escapeKey,
     dateTimeColumns,
+    emitLanguage,
   );
+}
+
+/**
+ * Append `newState`'s clauses to a `where` clause while preserving the existing
+ * text verbatim. Unlike `replaceFilterClauses` (which treats the existing text's
+ * facet fields as managed and re-emits only the new state's fields), this *merges*:
+ * both the original clause and the new state's predicates are kept, joined with
+ * AND.
+ *
+ * This is the semantics a legacy `where` + separate `filters` representation
+ * needs when folding the filters into the unified `where`: the two were
+ * independent predicates ANDed at query time, so neither may be dropped.
+ *
+ * The existing text is preserved verbatim (it is not re-emitted), so complex or
+ * free-form content round-trips exactly. Only two adjustments are made to keep
+ * the joined clause well-formed:
+ *  - a top-level OR in the existing text is parenthesized before the AND join,
+ *    so `a OR b AND c:"v"` is not mis-parsed as `a OR (b AND c:"v")`;
+ *  - SQL comments in the existing text are moved to the end so the appended
+ *    predicate does not land inside a `--` / `/* */
+export function mergeFilterStateIntoWhereClause(
+  whereText: string,
+  language: 'lucene' | 'sql',
+  newState: FilterState,
+  {
+    escapeKey,
+    dateTimeColumns,
+  }: {
+    escapeKey?: (key: string) => string;
+    dateTimeColumns?: ReadonlyMap<string, string>;
+  } = {},
+): string {
+  const newClauses = filterStateToWhereClause(newState, {
+    language,
+    escapeKey,
+    dateTimeColumns,
+  });
+  if (!whereText.trim()) return newClauses;
+  if (!newClauses) return whereText.trim();
+
+  if (language === 'sql') {
+    const { code, comments } = stripSqlComments(whereText.trim());
+    const residual = code.trim();
+    const safeResidual = hasTopLevelOrSql(residual)
+      ? `(${residual})`
+      : residual;
+    const commentSuffix = comments.length ? ` ${comments.join(' ')}` : '';
+    return `${safeResidual} AND ${newClauses}${commentSuffix}`;
+  }
+
+  const safeWhere = hasTopLevelOr(whereText)
+    ? `(${whereText.trim()})`
+    : whereText.trim();
+  return `${safeWhere} AND ${newClauses}`;
 }
 
 // Helper function to parse a string value as boolean if possible, or otherwise
@@ -900,6 +1642,29 @@ function extractInClauses(condition: string): Array<{
 
       const keyStr = key.trim();
       const trimmedValues = values.trim();
+
+      // A subquery (`col IN (SELECT ...)`) is not a facet: treating its inner
+      // SQL as a plain value list would both render a bogus checkbox in the
+      // sidebar and let `replaceSqlFacetClauses` destroy the subquery when
+      // re-emitting the column. Reject any parenthesized list containing SQL
+      // clause keywords outside quoted strings.
+      if (
+        containsOutsideQuotes(trimmedValues, [
+          ' SELECT ',
+          ' FROM ',
+          ' WHERE ',
+          ' GROUP ',
+          ' ORDER ',
+          ' UNION ',
+          ' HAVING ',
+          ' JOIN ',
+          ' LIMIT ',
+          ' DISTINCT ',
+        ])
+      ) {
+        continue;
+      }
+
       const withoutParens =
         trimmedValues.startsWith('(') && trimmedValues.endsWith(')')
           ? trimmedValues.slice(1, -1)

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -1,7 +1,17 @@
+import type * as lucene from '@hyperdx/lucene';
 import * as SQLParser from 'node-sql-parser';
 
+import { dateTimeValueExpr } from '@/core/dateTimeValue';
+import { parseKeyPath } from '@/core/metadata';
 import { replaceJsonExpressions } from '@/core/utils';
-import { parse } from '@/queryParser';
+import {
+  decodeSpecialTokens,
+  isBinaryAST,
+  isLeftOnlyAST,
+  isNodeRangedTerm,
+  isNodeTerm,
+  parse,
+} from '@/queryParser';
 import { DashboardFilter, Filter } from '@/types';
 
 export type FilterState = {
@@ -14,31 +24,6 @@ export type FilterState = {
 
 const escapeString = (s: string) => {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "''");
-};
-
-// Wrap a quoted string literal in a ClickHouse expression whose result type
-// matches the date column's type.
-const dateTimeValueExpr = (chType: string, quotedValue: string): string => {
-  const dt64 = chType.match(/DateTime64\((\d+)/);
-
-  if (dt64) {
-    return `parseDateTime64BestEffort(${quotedValue}, ${dt64[1]})`;
-  }
-
-  if (/\bDateTime\b/.test(chType)) {
-    return `parseDateTimeBestEffort(${quotedValue})`;
-  }
-
-  if (/\bDate32\b/.test(chType)) {
-    return `toDate32(${quotedValue})`;
-  }
-
-  if (/\bDate\b/.test(chType)) {
-    return `toDate(${quotedValue})`;
-  }
-
-  // Fallback for an unexpected type; DateTime64(9) covers the widest range.
-  return `parseDateTime64BestEffort(${quotedValue}, 9)`;
 };
 
 export const filtersToQuery = (
@@ -154,6 +139,502 @@ export const serializeFilterState = (state: FilterState): string => {
       ]),
   );
 };
+
+/** The Lucene sentinel the parser uses for terms without an explicit field. */
+const IMPLICIT_FIELD = '<implicit>';
+
+/** Escape a value for use inside a Lucene quoted term ("...") */
+const escapeLuceneQuotedTerm = (s: string) => {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+};
+
+/**
+ * Escape backslashes and colons so the field name survives Lucene parsing.
+ * Map sub-keys can legitimately contain `:` (e.g. `LogAttributes['foo:bar']`
+ * normalizes to `LogAttributes.foo:bar` via parseKeyPath().join('.')), and
+ * `:` is the Lucene field/value separator. Backslashes are escaped first so
+ * the inserted `\:` survives `encodeSpecialTokens`' `\\` → backslash-literal
+ * substitution; the encoder's matching `\:` → HDX_COLON rule then makes the
+ * colon opaque to the parser, and `decodeSpecialTokens` restores the
+ * original key on the consumer side.
+ */
+const escapeLuceneFieldName = (key: string): string =>
+  key.replace(/\\/g, '\\\\').replace(/:/g, '\\:');
+
+/**
+ * Render a FilterState as a single `where` clause string in the given query
+ * language.
+ *
+ * - `sql`: emits the same `<key> IN (...) / NOT IN (...) / BETWEEN ... AND ...`
+ *   predicates `filtersToQuery` produces, remapping every clean key through
+ *   `escapeKey` first (the app passes `toQuotedClickHouseKeyExpression`).
+ * - `lucene`: emits `field:"value"` terms, parenthesized `OR` groups for
+ *   multi-value includes, negated `-field:"value"` terms for excludes, and
+ *   `field:[min TO max]` ranges — the grammar that `parseWhereClauseToFilterState`
+ *   reads back.
+ *
+ * This is the emission half of the search page's unified
+ * sidebar-⇄-query-input representation. Keys are the clean (dot-form) keys the
+ * sidebar uses.
+ */
+export function filterStateToWhereClause(
+  state: FilterState,
+  {
+    language,
+    escapeKey,
+    dateTimeColumns,
+  }: {
+    language: 'lucene' | 'sql';
+    /** SQL only: map a clean key to its quoted ClickHouse expression. */
+    escapeKey?: (key: string) => string;
+    /** SQL only: Map of DateTime/Date column name → its ClickHouse type. */
+    dateTimeColumns?: ReadonlyMap<string, string>;
+  },
+): string {
+  if (language === 'sql') {
+    const escaped: FilterState = {};
+    for (const [key, values] of Object.entries(state)) {
+      escaped[escapeKey ? escapeKey(key) : key] = values;
+    }
+    return filtersToQuery(escaped, { dateTimeColumns })
+      .flatMap(f => ('condition' in f ? [f.condition] : []))
+      .join(' AND ');
+  }
+
+  const clauses: string[] = [];
+  for (const [key, values] of Object.entries(state)) {
+    if (
+      values.included.size === 0 &&
+      values.excluded.size === 0 &&
+      values.range == null
+    ) {
+      continue;
+    }
+    const luceneField = escapeLuceneFieldName(parseKeyPath(key).join('.'));
+
+    if (values.included.size > 0) {
+      const terms = Array.from(values.included).map(
+        v => `${luceneField}:"${escapeLuceneQuotedTerm(String(v))}"`,
+      );
+      clauses.push(terms.length > 1 ? `(${terms.join(' OR ')})` : terms[0]);
+    }
+    if (values.excluded.size > 0) {
+      clauses.push(
+        Array.from(values.excluded)
+          .map(v => `-${luceneField}:"${escapeLuceneQuotedTerm(String(v))}"`)
+          .join(' AND '),
+      );
+    }
+    if (values.range != null) {
+      clauses.push(
+        `${luceneField}:[${values.range.min} TO ${values.range.max}]`,
+      );
+    }
+  }
+  return clauses.join(' AND ');
+}
+
+type CollectedTerm = { field: string; value: string; negated: boolean };
+type CollectedRange = { field: string; min: number; max: number };
+
+/**
+ * Collect quoted terms and range terms from a Lucene AST.
+ */
+function collectFromAst(
+  ast: lucene.AST | lucene.Node,
+  terms: CollectedTerm[],
+  ranges: CollectedRange[],
+): void {
+  if (isNodeTerm(ast)) {
+    if (!ast.quoted) return;
+    const negated = ast.field.startsWith('-');
+    const field = decodeSpecialTokens(negated ? ast.field.slice(1) : ast.field);
+    // Implicit-field phrases (`"a b"`) are free-text search, not facets.
+    if (field === IMPLICIT_FIELD) return;
+    terms.push({ field, value: decodeSpecialTokens(ast.term), negated });
+  } else if (isNodeRangedTerm(ast)) {
+    const field = decodeSpecialTokens(ast.field);
+    if (field === IMPLICIT_FIELD) return;
+    const min = parseFloat(ast.term_min);
+    const max = parseFloat(ast.term_max);
+    if (!isNaN(min) && !isNaN(max)) {
+      ranges.push({ field, min, max });
+    }
+  } else if (isBinaryAST(ast)) {
+    collectFromAst(ast.left, terms, ranges);
+    collectFromAst(ast.right, terms, ranges);
+  } else if (isLeftOnlyAST(ast)) {
+    collectFromAst(ast.left, terms, ranges);
+  }
+}
+
+/** Coerce "true"/"false" strings back to booleans, pass through otherwise */
+export function coerceBooleanValue(v: string | boolean): string | boolean {
+  if (typeof v === 'boolean') return v;
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return v;
+}
+
+/**
+ * Parse a `where` clause string back into a FilterState (clean keys), the
+ * inverse of `filterStateToWhereClause`.
+ *
+ * - `sql`: delegates to `parseQuery`, so keys come back in their raw SQL
+ *   (quoted/bracket) form — callers that need clean keys unescape them.
+ * - `lucene`: collects quoted `field:"value"` terms (included / negated =
+ *   excluded) and `field:[min TO max]` ranges. Only clauses matching the
+ *   facet grammar round-trip; free-text and complex queries are ignored.
+ *
+ * Returns an empty state when the text is empty or (for lucene) fails to parse.
+ */
+export function parseWhereClauseToFilterState(
+  whereText: string,
+  language: 'lucene' | 'sql',
+): FilterState {
+  if (language === 'sql') {
+    return parseQuery([{ type: 'sql', condition: whereText }]).filters;
+  }
+
+  try {
+    const ast = parse(whereText);
+    const terms: CollectedTerm[] = [];
+    const ranges: CollectedRange[] = [];
+    collectFromAst(ast, terms, ranges);
+
+    const byField = new Map<
+      string,
+      {
+        included: Set<string | boolean>;
+        excluded: Set<string | boolean>;
+        range?: { min: number; max: number };
+      }
+    >();
+    const getEntry = (field: string) => {
+      if (!byField.has(field)) {
+        byField.set(field, { included: new Set(), excluded: new Set() });
+      }
+      return byField.get(field)!;
+    };
+
+    for (const t of terms) {
+      const entry = getEntry(t.field);
+      const value = coerceBooleanValue(t.value);
+      if (t.negated) {
+        entry.excluded.add(value);
+      } else {
+        entry.included.add(value);
+      }
+    }
+    for (const r of ranges) {
+      const entry = getEntry(r.field);
+      entry.range = { min: r.min, max: r.max };
+    }
+    return Object.fromEntries(byField);
+  } catch {
+    return {};
+  }
+}
+
+type Span = { start: number; end: number };
+
+function termClauseSpan(node: lucene.NodeTerm, src: string): Span | null {
+  const tl = node.termLocation;
+  if (!tl?.end) return null;
+  const start = node.fieldLocation?.start?.offset ?? tl.start?.offset;
+  if (start == null) return null;
+  return { start, end: tl.end.offset };
+}
+
+function rangeClauseSpan(
+  node: lucene.NodeRangedTerm,
+  src: string,
+): Span | null {
+  const fl = node.fieldLocation;
+  if (!fl?.start?.offset || !fl.end?.offset) return null;
+  const endBracket = src.indexOf(']', fl.end.offset);
+  if (endBracket === -1) return null;
+  return { start: fl.start.offset, end: endBracket + 1 };
+}
+
+type RenderResult = {
+  /** Rendered residual text (empty when every leaf was a facet clause). */
+  text: string;
+  /** Whether every leaf under this node is a managed facet clause. */
+  fullyManaged: boolean;
+};
+
+/**
+ * Render a Lucene AST back to text, pruning every leaf whose field is in
+ * `isManagedField` and keeping the raw source text of everything else. Sibling
+ * connectors are re-emitted from the tree so that removing a clause from an
+ * OR/AND chain doesn't leave dangling operators (e.g. removing `host` from
+ * `foo:"x" AND host:"a" AND bar:"y"` yields `foo:"x" AND bar:"y"`, and from
+ * `(a OR host OR b)` yields `(a OR b)`).
+ */
+function renderNode(
+  node: lucene.AST | lucene.Node,
+  src: string,
+  isManagedField: (field: string) => boolean,
+): RenderResult {
+  if (isNodeTerm(node)) {
+    const span = termClauseSpan(node, src);
+    if (!span) return { text: '', fullyManaged: false };
+    if (!node.quoted) {
+      return { text: src.slice(span.start, span.end), fullyManaged: false };
+    }
+    const field = decodeSpecialTokens(
+      node.field.startsWith('-') ? node.field.slice(1) : node.field,
+    );
+    if (field !== IMPLICIT_FIELD && isManagedField(field)) {
+      return { text: '', fullyManaged: true };
+    }
+    return { text: src.slice(span.start, span.end), fullyManaged: false };
+  }
+
+  if (isNodeRangedTerm(node)) {
+    const span = rangeClauseSpan(node, src);
+    if (!span) return { text: '', fullyManaged: false };
+    const field = decodeSpecialTokens(node.field);
+    if (field !== IMPLICIT_FIELD && isManagedField(field)) {
+      return { text: '', fullyManaged: true };
+    }
+    return { text: src.slice(span.start, span.end), fullyManaged: false };
+  }
+
+  if (isLeftOnlyAST(node)) {
+    const inner = renderNode(node.left, src, isManagedField);
+    if (inner.fullyManaged) {
+      return { text: '', fullyManaged: true };
+    }
+    const prefix = node.start ? `${node.start} ` : '';
+    return {
+      text: inner.text ? `${prefix}${inner.text}` : '',
+      fullyManaged: false,
+    };
+  }
+
+  if (isBinaryAST(node)) {
+    const left = renderNode(node.left, src, isManagedField);
+    const right = renderNode(node.right, src, isManagedField);
+    if (left.fullyManaged && right.fullyManaged) {
+      return { text: '', fullyManaged: true };
+    }
+    const operator = node.operator === '<implicit>' ? '' : ` ${node.operator} `;
+    const combined = [left.text, right.text].filter(Boolean).join(operator);
+    return {
+      text: node.parenthesized && combined ? `(${combined})` : combined,
+      fullyManaged: false,
+    };
+  }
+
+  return { text: '', fullyManaged: false };
+}
+
+/**
+ * Replace the facet clauses in a Lucene `where` clause with a new FilterState.
+ *
+ * Only clauses matching the facet grammar (quoted `field:"v"`, `-field:"v"`,
+ * `field:[a TO b]`) are touched. Free-text and unrecognized query content is
+ * preserved from the original text, with connectors rebuilt so no dangling
+ * `AND`/`OR`/parens are left behind. The new clauses are appended after the
+ * residual text.
+ */
+function replaceLuceneFacetClauses(
+  whereText: string,
+  newState: FilterState,
+): string {
+  if (!whereText.trim()) {
+    return filterStateToWhereClause(newState, { language: 'lucene' });
+  }
+
+  let ast: lucene.AST;
+  try {
+    ast = parse(whereText);
+  } catch {
+    // Invalid Lucene — don't clobber the user's text.
+    return whereText;
+  }
+
+  // Managed fields are every facet field currently present in the text, so a
+  // caller that intentionally drops a field (e.g. source-change cleanup) also
+  // removes its clauses rather than leaving them to resurface.
+  const managed = new Set(
+    Object.keys(parseWhereClauseToFilterState(whereText, 'lucene')),
+  );
+  const residual = renderNode(ast, whereText, field => managed.has(field)).text;
+  const newClauses = filterStateToWhereClause(newState, {
+    language: 'lucene',
+  });
+
+  const trimmedResidual = residual.trim();
+  if (!trimmedResidual) return newClauses;
+  if (!newClauses) return trimmedResidual;
+  return `${trimmedResidual} AND ${newClauses}`;
+}
+
+/**
+ * Split a SQL `where` string into top-level conjuncts, splitting on ` AND `
+ * outside quotes and parentheses. The ` AND ` that belongs to a `BETWEEN ...
+ * AND ...` range is not a separator, so a BETWEEN conjunct stays intact.
+ */
+function splitSqlConjuncts(text: string): string[] {
+  const conjuncts: string[] = [];
+  let current = '';
+  let inString = false;
+  let parenDepth = 0;
+  let sawBetween = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (isQuoteBoundary(text, i)) {
+      if (inString) {
+        const esc = handleQuoteEscape(text, i);
+        if (esc.skip) {
+          current += "''";
+          i = esc.next;
+          continue;
+        }
+      }
+      inString = !inString;
+      current += char;
+      continue;
+    }
+
+    if (char === '(') {
+      parenDepth++;
+      current += char;
+      continue;
+    }
+    if (char === ')') {
+      parenDepth--;
+      current += char;
+      continue;
+    }
+
+    if (inString || parenDepth > 0) {
+      current += char;
+      continue;
+    }
+
+    if (!sawBetween && text.slice(i, i + 8).toUpperCase() === 'BETWEEN ') {
+      sawBetween = true;
+      current += 'BETWEEN ';
+      i += 7;
+      continue;
+    }
+
+    if (text.slice(i, i + 5).toUpperCase() === ' AND ') {
+      if (sawBetween) {
+        // The range's own `AND` — not a conjunct separator.
+        sawBetween = false;
+        current += ' AND ';
+        i += 4;
+        continue;
+      }
+      if (current.trim()) {
+        conjuncts.push(current.trim());
+      }
+      current = '';
+      i += 4;
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    conjuncts.push(current.trim());
+  }
+  return conjuncts;
+}
+
+/**
+ * Replace the facet clauses in a SQL `where` clause with a new FilterState.
+ *
+ * Top-level conjuncts that parse as a single facet predicate (`<key> IN
+ * (...)`, `<key> NOT IN (...)`, `<key> BETWEEN ... AND ...`) for a field being
+ * written are dropped and re-emitted from `newState`; everything else is
+ * preserved. `escapeKey` maps clean keys to the quoted ClickHouse expressions
+ * used both to match existing conjuncts and to emit new ones.
+ */
+function replaceSqlFacetClauses(
+  whereText: string,
+  newState: FilterState,
+  escapeKey: ((key: string) => string) | undefined,
+  dateTimeColumns: ReadonlyMap<string, string> | undefined,
+): string {
+  const clean = whereText.trim();
+  const emit = () =>
+    filterStateToWhereClause(newState, {
+      language: 'sql',
+      escapeKey,
+      dateTimeColumns,
+    });
+
+  if (!clean) return emit();
+
+  const kept: string[] = [];
+  for (const conjunct of splitSqlConjuncts(clean)) {
+    if (!conjunct.trim()) continue;
+    const isFacet =
+      conjunct.includes(' IN (') ||
+      conjunct.includes(' NOT IN (') ||
+      conjunct.includes(' BETWEEN ');
+    if (!isFacet) {
+      kept.push(conjunct);
+      continue;
+    }
+    const filter: Filter = { type: 'sql', condition: conjunct };
+    // Facet conjuncts are re-emitted from newState, so a conjunct that parses
+    // as a single renderable facet is dropped. Compound conditions and
+    // unparseable conjuncts are preserved.
+    if (isRenderablePinnedFilter(filter)) {
+      continue;
+    }
+    kept.push(conjunct);
+  }
+
+  const residual = kept.join(' AND ');
+  const newClauses = emit();
+  if (!residual) return newClauses;
+  if (!newClauses) return residual;
+  return `${residual} AND ${newClauses}`;
+}
+
+/**
+ * Replace the facet clauses in a `where` clause with a new FilterState, in the
+ * given query language. Non-facet content (free-text, complex queries) is
+ * preserved; only clauses matching the facet grammar are rewritten.
+ *
+ * This is the write half of the search page's unified sidebar-⇄-query-input
+ * representation: sidebar toggles produce a FilterState, which replaces the
+ * matching clauses in the query text instead of living in a separate `filters`
+ * parameter.
+ */
+export function replaceFilterClauses(
+  whereText: string,
+  language: 'lucene' | 'sql',
+  newState: FilterState,
+  {
+    escapeKey,
+    dateTimeColumns,
+  }: {
+    escapeKey?: (key: string) => string;
+    dateTimeColumns?: ReadonlyMap<string, string>;
+  } = {},
+): string {
+  if (language === 'lucene') {
+    return replaceLuceneFacetClauses(whereText, newState);
+  }
+  return replaceSqlFacetClauses(
+    whereText,
+    newState,
+    escapeKey,
+    dateTimeColumns,
+  );
+}
 
 // Helper function to parse a string value as boolean if possible, or otherwise
 // return as string with surrounding quotes removed and SQL-escaped quotes unescaped.

--- a/packages/common-utils/src/queryParser.ts
+++ b/packages/common-utils/src/queryParser.ts
@@ -14,6 +14,7 @@ import {
   isClickHouseVersionAtLeast,
   supportsDirectReadMap,
 } from '@/core/clickhouseVersion';
+import { dateTimeValueExpr } from '@/core/dateTimeValue';
 import {
   Metadata,
   parseKeyPath,
@@ -37,7 +38,7 @@ function encodeSpecialTokens(query: string): string {
     .replace(/localhost:(\d{1,5})/, 'localhost_COLON_$1')
     .replace(/\\:/g, 'HDX_COLON');
 }
-function decodeSpecialTokens(query: string): string {
+export function decodeSpecialTokens(query: string): string {
   return query
     .replace(/\\"/g, '"')
     .replace(/HDX_BACKSLASH_LITERAL/g, '\\')
@@ -65,17 +66,21 @@ function normalizeChExpression(expr: string): string {
 const IMPLICIT_FIELD = '<implicit>';
 
 // Type guards for lucene AST types
-function isNodeTerm(node: lucene.Node | lucene.AST): node is lucene.NodeTerm {
+export function isNodeTerm(
+  node: lucene.Node | lucene.AST,
+): node is lucene.NodeTerm {
   return 'term' in node && node.term != null;
 }
 
-function isNodeRangedTerm(
+export function isNodeRangedTerm(
   node: lucene.Node | lucene.AST,
 ): node is lucene.NodeRangedTerm {
   return 'inclusive' in node && node.inclusive != null;
 }
 
-function isBinaryAST(ast: lucene.AST | lucene.Node): ast is lucene.BinaryAST {
+export function isBinaryAST(
+  ast: lucene.AST | lucene.Node,
+): ast is lucene.BinaryAST {
   return 'right' in ast && ast.right != null;
 }
 
@@ -85,7 +90,7 @@ function hasStart(
   return 'start' in ast && !!ast.start;
 }
 
-function isLeftOnlyAST(
+export function isLeftOnlyAST(
   ast: lucene.AST | lucene.Node,
 ): ast is lucene.LeftOnlyAST {
   return (
@@ -407,6 +412,7 @@ export abstract class SQLSerializer implements Serializer {
   ): Promise<{
     column?: string;
     columnJSON?: { string: string; number: string };
+    columnType?: string;
     propertyType?: JSDataType;
     isArray?: boolean;
     found: boolean;
@@ -446,6 +452,7 @@ export abstract class SQLSerializer implements Serializer {
     const {
       column,
       columnJSON,
+      columnType,
       found,
       propertyType,
       isArray,
@@ -495,6 +502,19 @@ export abstract class SQLSerializer implements Serializer {
       mapKeyIndexExpression && !isNegatedField
         ? ` AND ${mapKeyIndexExpression}`
         : '';
+
+    // DateTime / DateTime64 / Date columns can't be compared against a bare
+    // string literal in ClickHouse, so wrap the value in the same parse/convert
+    // expression the SQL filter emitter uses (`dateTimeValueExpr`). Without
+    // this, an exact-match quoted term (e.g. `Timestamp:"2026-06-16T...Z"`)
+    // renders `Timestamp = '2026-06-16T...Z'`, which ClickHouse rejects.
+    if (columnType != null && /\b(?:DateTime64?|Date32?)\b/.test(columnType)) {
+      return SqlString.format(
+        `(${column} ${isNegatedField ? '!' : ''}= ?${expressionPostfix})`,
+        [SqlString.raw(dateTimeValueExpr(columnType, SqlString.escape(term)))],
+      );
+    }
+
     if (propertyType === JSDataType.Bool) {
       // numeric and boolean fields must be equality matched
       const normTerm = `${term}`.trim().toLowerCase();
@@ -713,7 +733,7 @@ export abstract class SQLSerializer implements Serializer {
     isNegatedField: boolean,
     context: SerializerContext,
   ) {
-    const { column, found, mapKeyIndexExpression, isArray } =
+    const { column, columnType, found, mapKeyIndexExpression, isArray } =
       await this.getColumnForField(field, context);
     if (!found) {
       return this.NOT_FOUND_QUERY;
@@ -727,6 +747,17 @@ export abstract class SQLSerializer implements Serializer {
       mapKeyIndexExpression && !isNegatedField
         ? ` AND ${mapKeyIndexExpression}`
         : '';
+
+    // Date columns need parse/convert-wrapped bounds, mirroring dateTimeValueExpr.
+    if (columnType != null && /\b(?:DateTime64?|Date32?)\b/.test(columnType)) {
+      return SqlString.format(
+        `(${column} ${isNegatedField ? 'NOT ' : ''}BETWEEN ? AND ?${expressionPostfix})`,
+        [
+          SqlString.raw(dateTimeValueExpr(columnType, SqlString.escape(start))),
+          SqlString.raw(dateTimeValueExpr(columnType, SqlString.escape(end))),
+        ],
+      );
+    }
     return SqlString.format(
       `(${column} ${isNegatedField ? 'NOT ' : ''}BETWEEN ? AND ?${expressionPostfix})`,
       [this.attemptToParseNumber(start), this.attemptToParseNumber(end)],
@@ -1868,6 +1899,7 @@ export class CustomSchemaSQLSerializerV2 extends SQLSerializer {
     return {
       column: expression.columnExpression,
       columnJSON: expression?.columnExpressionJSON,
+      columnType: expression.columnType,
       propertyType: type ?? undefined,
       isArray,
       found: expression.found,
@@ -1888,9 +1920,14 @@ async function nodeTerm(
   serializer: Serializer,
   context: SerializerContext,
 ): Promise<string> {
-  const field = node.field[0] === '-' ? node.field.slice(1) : node.field;
-  let isNegatedField = node.field[0] === '-';
   const isImplicitField = node.field === IMPLICIT_FIELD;
+  const rawField = node.field[0] === '-' ? node.field.slice(1) : node.field;
+  // Decode special-token placeholders the emitter inserted in the field name
+  // (e.g. HDX_COLON for an escaped `:` in a Map sub-key). Leave the implicit
+  // field sentinel untouched so downstream comparisons against IMPLICIT_FIELD
+  // still match.
+  const field = isImplicitField ? rawField : decodeSpecialTokens(rawField);
+  let isNegatedField = node.field[0] === '-';
 
   // NodeTerm
   if (isNodeTerm(node)) {
@@ -1992,7 +2029,7 @@ function createSerializerContext(
 
     return {
       ...currentContext,
-      implicitColumnExpression: fieldWithoutNegation,
+      implicitColumnExpression: decodeSpecialTokens(fieldWithoutNegation),
       ...(isNegatedAndParenthesized(ast)
         ? { isNegatedAndParenthesized: true }
         : {}),


### PR DESCRIPTION
## Summary

The filter sidebar and the query input box previously held independent state — selecting a value in the sidebar applied it to the search but never appeared in the query input, so the two could silently drift out of sync. This PR makes the where clause the single source of truth for both.

## How it works:

- Selecting a filter in the sidebar rewrites the matching facet clause directly in the query input (e.g. clicking error in the level facet writes level:"error" into the box)
- The sidebar reads its checked state back from the where text, so editing the query also updates the sidebar
- Free-text and complex query content is preserved — only the specific facet clauses are rewritten
- Works for both query dialects (Lucene and SQL)
- The separate filters URL param is removed; a one-time migration moves any legacy persisted filters into the where clause on first load

New internals in common-utils/filters.ts:

- parseWhereClauseToFilterState — parse a where string back into FilterState
- filterStateToWhereClause — render FilterState to a where string
- replaceFilterClauses — surgically replace only the facet clauses in a where string, preserving everything else
- dateTimeValueExpr extracted to common-utils/core/dateTimeValue.ts to avoid duplication between filters.ts and queryParser.ts

| Before | After |
|--------|-------|
| Clicking a sidebar filter applies it to the search, but the query input stays empty. | Clicking a sidebar filter writes the condition into the query input (e.g. `level:"error"`). |

### How to test on Vercel preview

Preview routes: /search

Steps:

1. Open the Search page and select any log/trace source
2. Click a value in the filter sidebar (e.g. a service name or log level)
3. Verify the corresponding condition appears in the query input box (e.g. ServiceName:"my-service" or level:"error")
4. Manually type a condition into the query input (e.g. level:"warn") and press enter
5. Verify the matching value is highlighted/checked in the filter sidebar
6. With existing query text like my error message level:"error", click a different level in the sidebar
7. Verify only the level: clause is rewritten — the free text my error message is preserved
   
   
### References
Fixes #2751