### PR TITLE
feat(mcp): reject persisted histogram tiles with unsupported aggFns in query_tile

### DIFF
--- a/.changeset/mcp-histogram-query-tile-guard.md
+++ b/.changeset/mcp-histogram-query-tile-guard.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+MCP: reject execution of persisted dashboard tiles whose metric config uses an aggregation function its metric kind does not support (e.g. avg/sum/min/max on a histogram or exponential histogram). `clickstack_query_tile` now validates the tile's metric select items with the same rules the query and save/patch tools apply, returning an actionable error instead of an opaque ClickHouse render failure for tiles created outside MCP validation (REST/UI/legacy).

--- a/packages/api/src/mcp/__tests__/dashboards/queryTile.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/queryTile.int.test.ts
@@ -10,7 +10,9 @@ import {
   seedExponentialHistogramMetric,
 } from '@/fixtures';
 import { callTool, getFirstText } from '@/mcp/__tests__/mcpTestUtils';
+import Dashboard from '@/models/dashboard';
 import { Source } from '@/models/source';
+import { convertToInternalTileConfig } from '@/routers/external-api/v2/utils/dashboards';
 
 import { setupDashboardTests } from './setup';
 
@@ -184,6 +186,64 @@ describe('MCP Dashboard Tools - clickstack_query_tile', () => {
     });
 
     expect(result.isError).toBeFalsy();
+  });
+
+  it('rejects a persisted histogram tile that uses an unsupported aggFn', async () => {
+    // Seed a tile directly (bypassing MCP save-time validation) to mimic a
+    // tile created via REST/UI/legacy before histogram aggFn rules existed:
+    // a histogram metric aggregated with "avg", which the renderer cannot
+    // translate. clickstack_query_tile must reject it with an actionable
+    // error instead of surfacing an opaque ClickHouse render failure.
+    const metricSource = await Source.create({
+      kind: SourceKind.Metric,
+      team: ctx.team._id,
+      from: { databaseName: DEFAULT_DATABASE, tableName: '' },
+      metricTables: {
+        [MetricsDataType.Histogram.toLowerCase()]:
+          DEFAULT_METRICS_TABLE.HISTOGRAM,
+      },
+      timestampValueExpression: 'TimeUnix',
+      connection: ctx.connection._id,
+      name: 'Legacy Histogram Metrics',
+    });
+
+    const internalTile = convertToInternalTileConfig({
+      id: 'legacy-histogram-avg',
+      x: 0,
+      y: 0,
+      w: 6,
+      h: 3,
+      name: 'Legacy Histogram Avg',
+      config: {
+        displayType: 'line',
+        sourceId: metricSource._id.toString(),
+        select: [
+          {
+            aggFn: 'avg',
+            metricType: MetricsDataType.Histogram,
+            metricName: 'histogram.legacy',
+            valueExpression: 'Value',
+            where: '',
+          },
+        ],
+      },
+    });
+
+    const dashboard = await new Dashboard({
+      name: 'Legacy Histogram Dashboard',
+      tiles: [internalTile],
+      team: ctx.team._id,
+    }).save();
+
+    const result = await callTool(ctx.client!, 'clickstack_query_tile', {
+      dashboardId: dashboard._id.toString(),
+      tileId: 'legacy-histogram-avg',
+      startTime: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      endTime: new Date().toISOString(),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toContain('Histogram metrics only support');
   });
 
   // Regression: a metric source rendered as a categorical (bar/pie) tile with a

--- a/packages/api/src/mcp/__tests__/dashboards/validation.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/validation.test.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 import { mcpTilesParam } from '@/mcp/tools/dashboards/schemas';
 import {
+  getMetricTileAggFnErrors,
   getRawSqlMissingSourceError,
   getRawSqlTileMacroWarnings,
   getRawSqlTilesMissingRequiredSource,
@@ -65,6 +66,171 @@ function makeSqlTile(overrides: {
     },
   } as ExternalDashboardTileWithId;
 }
+
+function makeBuilderTile(
+  select: Record<string, unknown>[],
+  overrides: { name?: string; displayType?: string } = {},
+): ExternalDashboardTileWithId {
+  return {
+    id: 'builder-tile',
+    x: 0,
+    y: 0,
+    w: 12,
+    h: 4,
+    name: overrides.name ?? 'Builder Tile',
+    config: {
+      displayType: overrides.displayType ?? 'line',
+      sourceId,
+      select,
+    },
+  } as unknown as ExternalDashboardTileWithId;
+}
+
+describe('getMetricTileAggFnErrors', () => {
+  it('flags a histogram metric using an unsupported aggFn (avg)', () => {
+    const errors = getMetricTileAggFnErrors([
+      makeBuilderTile(
+        [
+          {
+            aggFn: 'avg',
+            metricType: 'histogram',
+            metricName: 'http.server.duration',
+            valueExpression: 'Value',
+          },
+        ],
+        { name: 'Bad Histogram' },
+      ),
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Bad Histogram');
+    expect(errors[0]).toContain('select[0].aggFn');
+    expect(errors[0]).toContain('Histogram metrics only support');
+  });
+
+  it('flags an exponential histogram metric using sum', () => {
+    const errors = getMetricTileAggFnErrors([
+      makeBuilderTile([
+        {
+          aggFn: 'sum',
+          metricType: 'exponential histogram',
+          metricName: 'http.server.duration',
+          valueExpression: 'Value',
+        },
+      ]),
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Exponential histogram metrics only support');
+  });
+
+  it('accepts a histogram metric using quantile with a level', () => {
+    expect(
+      getMetricTileAggFnErrors([
+        makeBuilderTile([
+          {
+            aggFn: 'quantile',
+            level: 0.95,
+            metricType: 'histogram',
+            metricName: 'http.server.duration',
+            valueExpression: 'Value',
+          },
+        ]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('accepts a histogram metric using count', () => {
+    expect(
+      getMetricTileAggFnErrors([
+        makeBuilderTile([
+          {
+            aggFn: 'count',
+            metricType: 'histogram',
+            metricName: 'http.server.duration',
+          },
+        ]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('accepts a gauge metric using avg', () => {
+    expect(
+      getMetricTileAggFnErrors([
+        makeBuilderTile([
+          {
+            aggFn: 'avg',
+            metricType: 'gauge',
+            metricName: 'system.memory.usage',
+            valueExpression: 'Value',
+          },
+        ]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('ignores non-metric (log/trace) select items', () => {
+    expect(
+      getMetricTileAggFnErrors([
+        makeBuilderTile([
+          { aggFn: 'avg', valueExpression: 'Duration', where: '' },
+        ]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('ignores raw SQL tiles', () => {
+    expect(
+      getMetricTileAggFnErrors([
+        makeSqlTile({
+          sqlTemplate: 'SELECT avg(Value) FROM otel_metrics_histogram',
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('falls back to a positional label when the tile has no name', () => {
+    const errors = getMetricTileAggFnErrors([
+      makeBuilderTile(
+        [
+          {
+            aggFn: 'max',
+            metricType: 'histogram',
+            metricName: 'http.server.duration',
+            valueExpression: 'Value',
+          },
+        ],
+        { name: '' },
+      ),
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('tile #1');
+  });
+
+  it('collects errors across multiple select items and tiles', () => {
+    const errors = getMetricTileAggFnErrors([
+      makeBuilderTile(
+        [
+          {
+            aggFn: 'quantile',
+            level: 0.95,
+            metricType: 'histogram',
+            metricName: 'ok.metric',
+            valueExpression: 'Value',
+          },
+          {
+            aggFn: 'min',
+            metricType: 'histogram',
+            metricName: 'bad.metric',
+            valueExpression: 'Value',
+          },
+        ],
+        { name: 'Mixed' },
+      ),
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Mixed');
+    expect(errors[0]).toContain('select[1].aggFn');
+  });
+});
 
 describe('getRawSqlTilesMissingRequiredSource', () => {
   it('flags a raw SQL tile that uses $__filters without a sourceId', () => {

--- a/packages/api/src/mcp/tools/dashboards/queryTile.ts
+++ b/packages/api/src/mcp/tools/dashboards/queryTile.ts
@@ -7,7 +7,10 @@ import Dashboard from '@/models/dashboard';
 import { convertToExternalDashboard } from '@/routers/external-api/v2/utils/dashboards';
 import { objectIdSchema } from '@/utils/zod';
 
-import { getRawSqlTileMacroWarnings } from './validation';
+import {
+  getMetricTileAggFnErrors,
+  getRawSqlTileMacroWarnings,
+} from './validation';
 
 export function registerQueryTile({
   context,
@@ -66,6 +69,16 @@ export function registerQueryTile({
         return mcpUserError(
           `Tile not found: ${tileId}. Available tile IDs: ${externalDashboard.tiles.map(t => t.id).join(', ')}`,
         );
+      }
+
+      // Guard against executing a tile whose persisted metric config uses an
+      // aggFn its metric kind does not support (e.g. avg/sum/min/max on a
+      // histogram). Such tiles can exist when created outside MCP validation
+      // (REST/UI/legacy); running them would surface an opaque ClickHouse
+      // render error instead of an actionable message.
+      const metricAggFnErrors = getMetricTileAggFnErrors([tile]);
+      if (metricAggFnErrors.length > 0) {
+        return mcpUserError(metricAggFnErrors.join('\n'));
       }
 
       const result = await runConfigTile(

--- a/packages/api/src/mcp/tools/dashboards/validation.ts
+++ b/packages/api/src/mcp/tools/dashboards/validation.ts
@@ -5,6 +5,7 @@ import {
   TIME_RANGE_MACROS,
 } from '@hyperdx/common-utils/dist/macros';
 
+import { getMetricSelectIssues } from '@/mcp/tools/query/schemas';
 import {
   isConfigTile,
   isRawSqlExternalTileConfig,
@@ -65,6 +66,70 @@ export function getRawSqlMissingSourceError(
     '(call clickstack_list_sources to find it), or remove the macro if the query reads ' +
     `from multiple tables: ${list}`
   );
+}
+
+/**
+ * Validate the metric aggregation constraints of every builder tile's select
+ * items, reusing the same `getMetricSelectIssues` rules the query and
+ * save/patch tools apply at input time. This is the guard for tiles that were
+ * persisted BEFORE those rules existed, or through non-MCP paths (REST/UI/
+ * legacy) — e.g. a histogram metric with aggFn "avg"/"sum"/"min"/"max", which
+ * the ClickHouse renderer cannot translate.
+ *
+ * Only metric select items (those carrying a `metricType`) are inspected;
+ * log/trace items, raw SQL tiles, heatmaps, and string-`select` tiles are
+ * skipped. Returns one human-readable error per offending item, or an empty
+ * array when all tiles are valid.
+ */
+export function getMetricTileAggFnErrors(
+  tiles: ExternalDashboardTileWithId[],
+): string[] {
+  const errors: string[] = [];
+  tiles.forEach((tile, index) => {
+    if (!isConfigTile(tile) || isRawSqlExternalTileConfig(tile.config)) {
+      return;
+    }
+    // Builder tiles (line/stacked_bar/table/number/pie/bar) carry an array of
+    // structured select items. Search/event_patterns use a string `select` and
+    // heatmaps use a single object without an aggFn — neither is a metric
+    // aggregation, so `Array.isArray` filters them out.
+    const select = (tile.config as { select?: unknown }).select;
+    if (!Array.isArray(select)) {
+      return;
+    }
+    const label = tile.name?.trim() || `tile #${index + 1}`;
+    select.forEach((rawItem, selectIndex) => {
+      if (!rawItem || typeof rawItem !== 'object') {
+        return;
+      }
+      const item = rawItem as Record<string, unknown>;
+      // Only metric select items can violate metric-kind aggFn rules.
+      if (typeof item.metricType !== 'string') {
+        return;
+      }
+      const issues = getMetricSelectIssues({
+        aggFn: typeof item.aggFn === 'string' ? item.aggFn : undefined,
+        metricType: item.metricType,
+        metricName:
+          typeof item.metricName === 'string' ? item.metricName : undefined,
+        // The external tile schema stores the Prometheus-style gauge delta as
+        // `periodAggFn: 'delta'`; map it back to the `isDelta` flag the shared
+        // validator understands.
+        isDelta: item.periodAggFn === 'delta',
+        level: typeof item.level === 'number' ? item.level : undefined,
+        valueExpression:
+          typeof item.valueExpression === 'string'
+            ? item.valueExpression
+            : undefined,
+      });
+      for (const issue of issues) {
+        errors.push(
+          `${label} select[${selectIndex}].${issue.path.join('.')}: ${issue.message}`,
+        );
+      }
+    });
+  });
+  return errors;
 }
 
 /** Raw SQL display types that plot a value over time. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Histogram and exponential histogram metrics only support `count` and `quantile` aggregations in the ClickHouse renderer. The MCP query and dashboard save/patch tools already reject invalid aggFns for these metric kinds at input time (added in #2705 via `getMetricSelectIssues`). This mirrors the chart-builder UI change that hides those options.

The one remaining MCP gap was **`clickstack_query_tile`**: it loads and executes an already-persisted tile without re-validating it. A tile created outside MCP validation — via the REST API, the UI (pre-dating the UI guard), or legacy data — could hold a histogram metric with `avg`/`sum`/`min`/`max`, and running it surfaced an opaque ClickHouse render error (`"<aggFn> is not supported for histograms currently"`) instead of an actionable message.

## What changed

- **`mcp/tools/dashboards/validation.ts`**: Added `getMetricTileAggFnErrors(tiles)`, which walks each builder tile's `select` items and reuses the existing `getMetricSelectIssues` rules. It inspects only metric select items (those carrying a `metricType`), maps the persisted `periodAggFn: 'delta'` back to the `isDelta` flag, and skips raw SQL / search / heatmap / log / trace items. Returns one human-readable error per offending item.
- **`mcp/tools/dashboards/queryTile.ts`**: Before executing a tile, `clickstack_query_tile` now runs `getMetricTileAggFnErrors([tile])` and returns an `mcpUserError` when the persisted config is invalid, instead of letting the query fail opaquely downstream.

No change to the already-validated surfaces (`clickstack_timeseries`, `clickstack_table`, `clickstack_save_dashboard`, `clickstack_patch_dashboard`) — those continue to reject invalid histogram aggFns at input time.

## Testing

- Unit: `packages/api/src/mcp/__tests__/dashboards/validation.test.ts` — added coverage for `getMetricTileAggFnErrors` (histogram/exp-histogram rejection of avg/sum/min/max, acceptance of quantile+level and count, gauge unaffected, non-metric/raw-SQL items ignored, positional labels, multi-item collection). 30/30 passing.
- Integration: `packages/api/src/mcp/__tests__/dashboards/queryTile.int.test.ts` — added a test that seeds a histogram tile with `avg` directly into MongoDB (bypassing MCP save validation) and asserts `clickstack_query_tile` rejects it with `"Histogram metrics only support …"`. 15/15 passing (`make dev-int FILE=queryTile`).
- `yarn tsc --noEmit` (packages/api) — clean. `yarn lint:fix` — no errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-4991](https://linear.app/clickhouse/issue/HDX-4991/hide-unsupported-agg-functions-for-histogram-metrics)

<div><a href="https://cursor.com/agents/bc-24db5690-7545-4cfa-9d80-ff39f92126a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24db5690-7545-4cfa-9d80-ff39f92126a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

