### PR TITLE
fix(app): fix timepicker zindex over chart toolpit

### DIFF
--- a/.changeset/fix-timepicker-zindex-over-chart-tooltip.md
+++ b/.changeset/fix-timepicker-zindex-over-chart-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Prevent chart hover tooltips from rendering over the date range picker

--- a/packages/app/src/components/TimePicker/TimePicker.tsx
+++ b/packages/app/src/components/TimePicker/TimePicker.tsx
@@ -8,6 +8,7 @@ import {
   Card,
   CloseButton,
   Divider,
+  getDefaultZIndex,
   Group,
   Popover,
   ScrollArea,
@@ -268,6 +269,7 @@ const TimePickerComponent = ({
       closeOnEscape
       opened={opened}
       onClose={close}
+      zIndex={getDefaultZIndex('popover') + 2}
     >
       <Popover.Target>
         <TextInput


### PR DESCRIPTION
## Summary

Prevent chart hover tooltips from rendering over the date range picker

The date picker's zIndex is set to the default popover z-index + 2, so it beats both the hover and pinned chart tooltips

fixes #2782 

### Screenshots or video

https://github.com/user-attachments/assets/f02a17da-fa58-4e6c-aca4-8d39e0e03fd0

How to test on Vercel preview

Preview routes: /search

Steps:

1. Click the time range button at the top of the page (e.g. "Last 15 minutes") to open the time picker.
2. Leave the time picker open, and hover the mouse over the small histogram chart at the top of the page, at a spot where it overlaps the open time picker.
3. Verify the time picker popover (showing the "Time range" / "Around a time" tabs and the relative-time list) stays fully visible and is not covered by the chart's hover tooltip.