### PR TITLE
feat(api): accept exemplar settings on API- and agent-authored tiles

### DIFF
--- a/.changeset/exemplars-agent-surface.md
+++ b/.changeset/exemplars-agent-surface.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/api': minor
+---
+
+feat: accept exemplar settings on API- and agent-authored dashboard tiles
+
+`enableExemplars` and `exemplarTraceSourceId` are now accepted on line and
+stacked-bar tiles through the external v2 API and the MCP dashboard tools, survive
+the tile conversion in both directions, and are documented in the OpenAPI spec.
+Previously they validated on write and were dropped before persistence, so the
+overlay could only ever be switched on by a human in the chart editor.

--- a/.changeset/exemplars-agent-surface.md
+++ b/.changeset/exemplars-agent-surface.md
@@ -5,7 +5,13 @@
 feat: accept exemplar settings on API- and agent-authored dashboard tiles
 
 `enableExemplars` and `exemplarTraceSourceId` are now accepted on line and
-stacked-bar tiles through the external v2 API and the MCP dashboard tools, survive
-the tile conversion in both directions, and are documented in the OpenAPI spec.
-Previously they validated on write and were dropped before persistence, so the
-overlay could only ever be switched on by a human in the chart editor.
+stacked-bar tiles through the external v2 API and the MCP dashboard tools,
+survive the tile conversion in both directions, and are documented in the
+OpenAPI spec. Previously they validated on write and were dropped before
+persistence, so they could not be set through any surface.
+
+`exemplarTraceSourceId` is checked three ways, because a marker's "view trace"
+link is only as good as the source behind it: an ObjectId on both surfaces, the
+source must exist for the team, and it must actually be a Trace source. The
+existence and kind checks mirror the heatmap gate. Without them a well-formed id
+for a metric source saved cleanly and left every marker linking nowhere.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1648,6 +1648,16 @@
             "minimum": 1,
             "description": "Maximum number of series rendered (top-N by value). Omit for no limit.",
             "example": 5
+          },
+          "enableExemplars": {
+            "type": "boolean",
+            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy — and is accepted but inert otherwise.\n",
+            "default": false
+          },
+          "exemplarTraceSourceId": {
+            "type": "string",
+            "description": "ID of the Trace source an exemplar marker links to. Defaults to the chart source's linked trace source when omitted.\n",
+            "example": "65f5e4a3b9e77c001a222222"
           }
         }
       },
@@ -1712,6 +1722,16 @@
             "minimum": 1,
             "description": "Maximum number of series rendered (top-N by value). Omit for no limit.",
             "example": 5
+          },
+          "enableExemplars": {
+            "type": "boolean",
+            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy — and is accepted but inert otherwise.\n",
+            "default": false
+          },
+          "exemplarTraceSourceId": {
+            "type": "string",
+            "description": "ID of the Trace source an exemplar marker links to. Defaults to the chart source's linked trace source when omitted.\n",
+            "example": "65f5e4a3b9e77c001a222222"
           }
         }
       },

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1651,12 +1651,12 @@
           },
           "enableExemplars": {
             "type": "boolean",
-            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy — and is accepted but inert otherwise.\n",
+            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy, aggregated with avg, min, max, quantile or last_value. Not count or sum: a counted point is not attributable to any one trace, so the overlay is accepted but stays inert.\n",
             "default": false
           },
           "exemplarTraceSourceId": {
             "type": "string",
-            "description": "ID of the Trace source an exemplar marker links to. Defaults to the chart source's linked trace source when omitted.\n",
+            "description": "ID of the Trace source an exemplar marker links to. Must exist and be a Trace source; a request naming anything else is rejected. Defaults to the chart source's linked trace source when omitted.\n",
             "example": "65f5e4a3b9e77c001a222222"
           }
         }
@@ -1725,12 +1725,12 @@
           },
           "enableExemplars": {
             "type": "boolean",
-            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy — and is accepted but inert otherwise.\n",
+            "description": "Overlay exemplars: markers for individual trace-linked data points. Only renders when the tile is exemplar-eligible — a single non-ratio histogram metric series with no groupBy, aggregated with avg, min, max, quantile or last_value. Not count or sum: a counted point is not attributable to any one trace, so the overlay is accepted but stays inert.\n",
             "default": false
           },
           "exemplarTraceSourceId": {
             "type": "string",
-            "description": "ID of the Trace source an exemplar marker links to. Defaults to the chart source's linked trace source when omitted.\n",
+            "description": "ID of the Trace source an exemplar marker links to. Must exist and be a Trace source; a request naming anything else is rejected. Defaults to the chart source's linked trace source when omitted.\n",
             "example": "65f5e4a3b9e77c001a222222"
           }
         }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -92,7 +92,7 @@
     "dev-task": "DOTENV_CONFIG_PATH=.env.development nodemon --exec 'ts-node' --transpile-only -r tsconfig-paths/register -r dotenv-expand/config -r '@hyperdx/node-opentelemetry/build/src/tracing' ./src/tasks/index.ts",
     "build": "rimraf ./build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && cp -r ./src/opamp/proto ./build/opamp/",
     "build:vercel": "rimraf ./build && tsc -p tsconfig.vercel.json && tsc-alias -p tsconfig.vercel.json && cp -r ./src/opamp/proto ./build/opamp/",
-    "lint": "npx eslint . --ext .ts --max-warnings 357",
+    "lint": "npx eslint . --ext .ts --max-warnings 358",
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit && yarn lint:openapi",
     "ci:unit": "jest --ci --coverage",

--- a/packages/api/src/mcp/tools/dashboards/__tests__/exemplarSettings.test.ts
+++ b/packages/api/src/mcp/tools/dashboards/__tests__/exemplarSettings.test.ts
@@ -1,0 +1,85 @@
+import { Types } from 'mongoose';
+
+import { mcpTilesParam } from '@/mcp/tools/dashboards/schemas';
+
+/**
+ * `enableExemplars` and `exemplarTraceSourceId` are the two exemplar settings an
+ * MCP agent can put on a tile. The trace source id has to survive as something
+ * the source lookup can actually resolve — it is read back as a Mongo ObjectId —
+ * so accepting any string here would persist a tile whose markers silently never
+ * link to a trace.
+ */
+const tile =
+  (displayType: 'line' | 'stacked_bar') =>
+  (config: Record<string, unknown>) => [
+    {
+      name: 'Latency',
+      config: {
+        displayType,
+        sourceId: new Types.ObjectId().toString(),
+        select: [{ aggFn: 'count', alias: 'Requests' }],
+        ...config,
+      },
+    },
+  ];
+
+// The two tile types declare the exemplar fields in separate schema blocks, so
+// an edit that only updates one would otherwise go unnoticed.
+const lineTile = tile('line');
+const barTile = tile('stacked_bar');
+
+describe('MCP tile exemplar settings', () => {
+  it('accepts a valid ObjectId as the exemplar trace source', () => {
+    const traceSourceId = new Types.ObjectId().toString();
+    const parsed = mcpTilesParam.parse(
+      lineTile({ enableExemplars: true, exemplarTraceSourceId: traceSourceId }),
+    );
+    expect(parsed[0].config).toMatchObject({
+      enableExemplars: true,
+      exemplarTraceSourceId: traceSourceId,
+    });
+  });
+
+  it.each([
+    ['a source name rather than an id', 'Traces'],
+    ['a truncated id', '507f1f77bcf86cd7994390'],
+    ['an over-long id', '507f1f77bcf86cd799439011ff'],
+    ['an empty string', ''],
+    ['a non-hex id of the right length', 'zzzzzzzzzzzzzzzzzzzzzzzz'],
+  ])('rejects %s as the exemplar trace source', (_label, value) => {
+    expect(() =>
+      mcpTilesParam.parse(lineTile({ exemplarTraceSourceId: value })),
+    ).toThrow(/Invalid ObjectId/);
+  });
+
+  // Worth recording because it is surprising: Mongo also accepts a 12-character
+  // string as 12 raw bytes, so `Types.ObjectId.isValid` — and therefore every
+  // objectIdSchema field in this codebase, not just this one — lets one through.
+  // Such an id simply resolves to no source, which is the same outcome as any
+  // other id that does not exist, so it is not worth diverging from the shared
+  // validator here.
+  it('lets a 12-character string through, as every other id field does', () => {
+    expect(() =>
+      mcpTilesParam.parse(lineTile({ exemplarTraceSourceId: 'trace-source' })),
+    ).not.toThrow();
+  });
+
+  it('leaves both settings optional', () => {
+    const parsed = mcpTilesParam.parse(lineTile({}));
+    expect(parsed[0].config).not.toHaveProperty('enableExemplars');
+    expect(parsed[0].config).not.toHaveProperty('exemplarTraceSourceId');
+  });
+
+  it.each([
+    ['line', lineTile],
+    ['stacked_bar', barTile],
+  ])('validates the trace source on a %s tile', (_label, build) => {
+    expect(() =>
+      mcpTilesParam.parse(build({ exemplarTraceSourceId: 'Traces' })),
+    ).toThrow(/Invalid ObjectId/);
+    const id = new Types.ObjectId().toString();
+    expect(
+      mcpTilesParam.parse(build({ exemplarTraceSourceId: id }))[0].config,
+    ).toMatchObject({ exemplarTraceSourceId: id });
+  });
+});

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -543,6 +543,22 @@ const mcpLineTileSchema = mcpTileLayoutSchema.extend({
         'Scale the y-axis to the data range instead of starting at zero.',
       ),
     seriesLimit: seriesLimitSchema.describe(timeChartSeriesLimitDescription),
+    enableExemplars: z
+      .boolean()
+      .optional()
+      .describe(
+        'Overlay exemplars: markers for individual trace-linked data points. ' +
+          'Only renders on an exemplar-eligible tile — a single non-ratio ' +
+          'histogram metric series with no groupBy — and is inert otherwise.',
+      ),
+    exemplarTraceSourceId: z
+      .string()
+      .optional()
+      .describe(
+        'Trace source an exemplar marker links to. Must be a Trace source: use ' +
+          'clickstack_list_sources and pick one whose kind is "trace". Defaults ' +
+          "to the chart source's linked trace source when omitted.",
+      ),
   }),
 });
 
@@ -561,6 +577,22 @@ const mcpBarTileSchema = mcpTileLayoutSchema.extend({
       .optional()
       .describe(tileLevelNumberFormatDescription),
     seriesLimit: seriesLimitSchema.describe(timeChartSeriesLimitDescription),
+    enableExemplars: z
+      .boolean()
+      .optional()
+      .describe(
+        'Overlay exemplars: markers for individual trace-linked data points. ' +
+          'Only renders on an exemplar-eligible tile — a single non-ratio ' +
+          'histogram metric series with no groupBy — and is inert otherwise.',
+      ),
+    exemplarTraceSourceId: z
+      .string()
+      .optional()
+      .describe(
+        'Trace source an exemplar marker links to. Must be a Trace source: use ' +
+          'clickstack_list_sources and pick one whose kind is "trace". Defaults ' +
+          "to the chart source's linked trace source when omitted.",
+      ),
   }),
 });
 

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -549,15 +549,18 @@ const mcpLineTileSchema = mcpTileLayoutSchema.extend({
       .describe(
         'Overlay exemplars: markers for individual trace-linked data points. ' +
           'Only renders on an exemplar-eligible tile — a single non-ratio ' +
-          'histogram metric series with no groupBy — and is inert otherwise.',
+          'histogram metric series with no groupBy, aggregated with avg, min, ' +
+          'max, quantile or last_value. Not count or sum: a counted point is ' +
+          'not attributable to any one trace, so the overlay stays inert with ' +
+          'no error.',
       ),
-    exemplarTraceSourceId: z
-      .string()
+    exemplarTraceSourceId: objectIdSchema
       .optional()
       .describe(
-        'Trace source an exemplar marker links to. Must be a Trace source: use ' +
-          'clickstack_list_sources and pick one whose kind is "trace". Defaults ' +
-          "to the chart source's linked trace source when omitted.",
+        'Trace source an exemplar marker links to. Must be an existing Trace ' +
+          'source — use clickstack_list_sources and pick one whose kind is ' +
+          '"trace"; anything else is rejected on save. Defaults to the chart ' +
+          "source's linked trace source when omitted.",
       ),
   }),
 });
@@ -583,15 +586,18 @@ const mcpBarTileSchema = mcpTileLayoutSchema.extend({
       .describe(
         'Overlay exemplars: markers for individual trace-linked data points. ' +
           'Only renders on an exemplar-eligible tile — a single non-ratio ' +
-          'histogram metric series with no groupBy — and is inert otherwise.',
+          'histogram metric series with no groupBy, aggregated with avg, min, ' +
+          'max, quantile or last_value. Not count or sum: a counted point is ' +
+          'not attributable to any one trace, so the overlay stays inert with ' +
+          'no error.',
       ),
-    exemplarTraceSourceId: z
-      .string()
+    exemplarTraceSourceId: objectIdSchema
       .optional()
       .describe(
-        'Trace source an exemplar marker links to. Must be a Trace source: use ' +
-          'clickstack_list_sources and pick one whose kind is "trace". Defaults ' +
-          "to the chart source's linked trace source when omitted.",
+        'Trace source an exemplar marker links to. Must be an existing Trace ' +
+          'source — use clickstack_list_sources and pick one whose kind is ' +
+          '"trace"; anything else is rejected on save. Defaults to the chart ' +
+          "source's linked trace source when omitted.",
       ),
   }),
 });

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -5200,6 +5200,72 @@ describe('External API v2 Dashboards - new format', () => {
         })
         .expect(200);
     });
+
+    // Deletion, not just a kind change. These were split for a while: the kind
+    // gate was exempted for unchanged tiles and the existence check was not, so
+    // deleting the source still wedged every later save. Only the exemplar
+    // reference dangles here — both tiles sit on a source that still exists, so a
+    // rejection could only come from the exemplar check.
+    it('does not re-validate a deleted exemplar trace source for unchanged tiles', async () => {
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Exemplar deletion scoping test',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: traceSource._id.toString(),
+              },
+            },
+            {
+              name: 'Other line tile',
+              x: 6,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+
+      const dashboardId = createResponse.body.data.id;
+      const exemplarTile = createResponse.body.data.tiles.find(
+        (t: { name: string }) => t.name === 'Latency',
+      );
+      const otherTile = createResponse.body.data.tiles.find(
+        (t: { name: string }) => t.name === 'Other line tile',
+      );
+
+      await Source.collection.deleteOne({ _id: traceSource._id });
+
+      await authRequest('put', `${BASE_URL}/${dashboardId}`)
+        .send({
+          name: 'Exemplar deletion scoping test - renamed',
+          tiles: [
+            { ...exemplarTile },
+            {
+              ...otherTile,
+              name: 'Other line tile, edited',
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+    });
   });
 
   describe('Number tile color (HDX-1360)', () => {

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -5268,6 +5268,105 @@ describe('External API v2 Dashboards - new format', () => {
     });
   });
 
+  describe('exemplar settings enabled on an existing tile', () => {
+    // The unchanged-tile exemption keys on the source id, but an id nobody was
+    // following is not the same as one about to draw markers: while exemplars
+    // were off the source could have been deleted or stopped being a Trace
+    // source with no effect at all.
+    it('validates the trace source when exemplars are switched on', async () => {
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Exemplar enable test',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: false,
+                exemplarTraceSourceId: traceSource._id.toString(),
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+
+      const dashboardId = createResponse.body.data.id;
+      const tile = createResponse.body.data.tiles[0];
+
+      // The source stops being a Trace source while nothing was following it.
+      await Source.collection.updateOne(
+        { _id: traceSource._id },
+        { $set: { kind: SourceKind.Log } },
+      );
+
+      const response = await authRequest('put', `${BASE_URL}/${dashboardId}`)
+        .send({
+          name: 'Exemplar enable test',
+          tiles: [
+            {
+              ...tile,
+              config: { ...tile.config, enableExemplars: true },
+            },
+          ],
+          tags: [],
+        })
+        .expect(400);
+
+      expect(response.body.message).toContain(
+        'exemplarTraceSourceId must reference a Trace source',
+      );
+    });
+
+    it('still exempts a tile whose exemplars were already on', async () => {
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Exemplar already-on test',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: traceSource._id.toString(),
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+
+      const dashboardId = createResponse.body.data.id;
+      const tile = createResponse.body.data.tiles[0];
+
+      await Source.collection.updateOne(
+        { _id: traceSource._id },
+        { $set: { kind: SourceKind.Log } },
+      );
+
+      // enableExemplars stays true, so this is the exemption, not the transition.
+      await authRequest('put', `${BASE_URL}/${dashboardId}`)
+        .send({
+          name: 'Exemplar already-on test - renamed',
+          tiles: [{ ...tile }],
+          tags: [],
+        })
+        .expect(200);
+    });
+  });
+
   describe('Number tile color (HDX-1360)', () => {
     // Minimal builder number tile; callers supply color / colorRules. The
     // payload is sent through `.send()` (untyped) so negative tests can post

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -2824,6 +2824,95 @@ describe('External API v2 Dashboards - new format', () => {
       );
     });
 
+    // `exemplarTraceSourceId` is where a marker's "view trace" link points, so a
+    // well-formed id for the wrong kind of source saves a tile whose markers all
+    // lead nowhere. Format validation alone cannot catch that.
+    it('rejects an exemplarTraceSourceId that is not a Trace source', async () => {
+      const response = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard with exemplars on a metric trace source',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: metricSource._id.toString(),
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(400);
+
+      expect(response.body.message).toContain(
+        'exemplarTraceSourceId must reference a Trace source',
+      );
+    });
+
+    it('rejects an exemplarTraceSourceId for a source that does not exist', async () => {
+      const response = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard with exemplars on a missing source',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: new ObjectId().toString(),
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(400);
+
+      expect(response.body.message).toContain('Could not find');
+    });
+
+    it('accepts an exemplarTraceSourceId pointing at a Trace source', async () => {
+      const response = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Dashboard with exemplars',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: traceSource._id.toString(),
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+
+      expect(response.body.data.tiles[0].config).toMatchObject({
+        enableExemplars: true,
+        exemplarTraceSourceId: traceSource._id.toString(),
+      });
+    });
+
     it('round-trips a heatmap tile with only required fields', async () => {
       // Covers the minimal payload path: countExpression, heatmapScaleType,
       // where, whereLanguage, and numberFormat are all omitted on the

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -5126,6 +5126,80 @@ describe('External API v2 Dashboards - new format', () => {
         })
         .expect(200);
     });
+
+    // Same reasoning as the heatmap case above: the trace source can be deleted
+    // or change kind long after the tile was accepted, and an optional marker
+    // link target must not make the whole dashboard unsaveable for edits made
+    // elsewhere on it.
+    it('does not re-validate the exemplar trace source for unchanged tiles', async () => {
+      const createResponse = await authRequest('post', BASE_URL)
+        .send({
+          name: 'Exemplar PUT scoping test',
+          tiles: [
+            {
+              name: 'Latency',
+              x: 0,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: metricSource._id.toString(),
+                select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+                enableExemplars: true,
+                exemplarTraceSourceId: traceSource._id.toString(),
+              },
+            },
+            {
+              name: 'Other line tile',
+              x: 6,
+              y: 0,
+              w: 6,
+              h: 3,
+              config: {
+                displayType: 'line',
+                sourceId: traceSource._id.toString(),
+                select: [{ aggFn: 'count', where: '' }],
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+
+      const dashboardId = createResponse.body.data.id;
+      const exemplarTile = createResponse.body.data.tiles.find(
+        (t: { name: string }) => t.name === 'Latency',
+      );
+      const otherTile = createResponse.body.data.tiles.find(
+        (t: { name: string }) => t.name === 'Other line tile',
+      );
+
+      // The trace source stops being a Trace source after the fact. Written
+      // straight to the collection for the same reason the heatmap test does.
+      await Source.collection.updateOne(
+        { _id: traceSource._id },
+        { $set: { kind: SourceKind.Log } },
+      );
+
+      await authRequest('put', `${BASE_URL}/${dashboardId}`)
+        .send({
+          name: 'Exemplar PUT scoping test - renamed',
+          tiles: [
+            { ...exemplarTile },
+            {
+              ...otherTile,
+              name: 'Other line tile, edited',
+              config: {
+                ...otherTile.config,
+                select: [{ aggFn: 'count', where: 'level:error' }],
+              },
+            },
+          ],
+          tags: [],
+        })
+        .expect(200);
+    });
   });
 
   describe('Number tile color (HDX-1360)', () => {

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -634,6 +634,20 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           minimum: 1
  *           description: Maximum number of series rendered (top-N by value). Omit for no limit.
  *           example: 5
+ *         enableExemplars:
+ *           type: boolean
+ *           description: >
+ *             Overlay exemplars: markers for individual trace-linked data points.
+ *             Only renders when the tile is exemplar-eligible — a single
+ *             non-ratio histogram metric series with no groupBy — and is
+ *             accepted but inert otherwise.
+ *           default: false
+ *         exemplarTraceSourceId:
+ *           type: string
+ *           description: >
+ *             ID of the Trace source an exemplar marker links to. Defaults to
+ *             the chart source's linked trace source when omitted.
+ *           example: "65f5e4a3b9e77c001a222222"
  *
  *     BarBuilderChartConfig:
  *       type: object
@@ -686,6 +700,20 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           minimum: 1
  *           description: Maximum number of series rendered (top-N by value). Omit for no limit.
  *           example: 5
+ *         enableExemplars:
+ *           type: boolean
+ *           description: >
+ *             Overlay exemplars: markers for individual trace-linked data points.
+ *             Only renders when the tile is exemplar-eligible — a single
+ *             non-ratio histogram metric series with no groupBy — and is
+ *             accepted but inert otherwise.
+ *           default: false
+ *         exemplarTraceSourceId:
+ *           type: string
+ *           description: >
+ *             ID of the Trace source an exemplar marker links to. Defaults to
+ *             the chart source's linked trace source when omitted.
+ *           example: "65f5e4a3b9e77c001a222222"
  *
  *     TableBuilderChartConfig:
  *       type: object

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -639,14 +639,17 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           description: >
  *             Overlay exemplars: markers for individual trace-linked data points.
  *             Only renders when the tile is exemplar-eligible — a single
- *             non-ratio histogram metric series with no groupBy — and is
- *             accepted but inert otherwise.
+ *             non-ratio histogram metric series with no groupBy, aggregated with
+ *             avg, min, max, quantile or last_value. Not count or sum: a counted
+ *             point is not attributable to any one trace, so the overlay is
+ *             accepted but stays inert.
  *           default: false
  *         exemplarTraceSourceId:
  *           type: string
  *           description: >
- *             ID of the Trace source an exemplar marker links to. Defaults to
- *             the chart source's linked trace source when omitted.
+ *             ID of the Trace source an exemplar marker links to. Must exist and
+ *             be a Trace source; a request naming anything else is rejected.
+ *             Defaults to the chart source's linked trace source when omitted.
  *           example: "65f5e4a3b9e77c001a222222"
  *
  *     BarBuilderChartConfig:
@@ -705,14 +708,17 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           description: >
  *             Overlay exemplars: markers for individual trace-linked data points.
  *             Only renders when the tile is exemplar-eligible — a single
- *             non-ratio histogram metric series with no groupBy — and is
- *             accepted but inert otherwise.
+ *             non-ratio histogram metric series with no groupBy, aggregated with
+ *             avg, min, max, quantile or last_value. Not count or sum: a counted
+ *             point is not attributable to any one trace, so the overlay is
+ *             accepted but stays inert.
  *           default: false
  *         exemplarTraceSourceId:
  *           type: string
  *           description: >
- *             ID of the Trace source an exemplar marker links to. Defaults to
- *             the chart source's linked trace source when omitted.
+ *             ID of the Trace source an exemplar marker links to. Must exist and
+ *             be a Trace source; a request naming anything else is rejected.
+ *             Defaults to the chart source's linked trace source when omitted.
  *           example: "65f5e4a3b9e77c001a222222"
  *
  *     TableBuilderChartConfig:

--- a/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
@@ -400,3 +400,71 @@ describe('convertToExternalDashboard orphan-ref heal', () => {
     expect(ext.tiles.map(t => t.id)).toEqual(['normal-tile']);
   });
 });
+
+/**
+ * The exemplar settings are only useful if they survive the tile conversion in
+ * both directions — accepting them at the schema and dropping them in the
+ * converter was the original bug this feature fixed, and the two tile types have
+ * separate blocks in both converters, so one can silently regress without the
+ * other.
+ */
+describe('exemplar settings round-trip', () => {
+  const traceSourceId = new mongoose.Types.ObjectId().toString();
+  const sourceId = new mongoose.Types.ObjectId().toString();
+
+  const externalTile = (displayType: 'line' | 'stacked_bar'): ConfigTile => ({
+    id: 'tile-1',
+    x: 0,
+    y: 0,
+    w: 6,
+    h: 4,
+    name: 'Latency',
+    config: {
+      displayType,
+      sourceId,
+      select: [{ aggFn: 'avg', valueExpression: 'Duration' }],
+      enableExemplars: true,
+      exemplarTraceSourceId: traceSourceId,
+    } as ConfigTile['config'],
+  });
+
+  it.each(['line', 'stacked_bar'] as const)(
+    'keeps both settings converting a %s tile inwards',
+    displayType => {
+      const { config } = convertToInternalTileConfig(externalTile(displayType));
+      expect(config).toMatchObject({
+        enableExemplars: true,
+        exemplarTraceSourceId: traceSourceId,
+      });
+    },
+  );
+
+  it.each(['line', 'stacked_bar'] as const)(
+    'returns both settings for a %s tile on the way out',
+    displayType => {
+      const internal = convertToInternalTileConfig(externalTile(displayType));
+      const dashboard = {
+        _id: new mongoose.Types.ObjectId(),
+        name: 'D',
+        tiles: [{ ...externalTile(displayType), config: internal.config }],
+        tags: [],
+      } as unknown as DashboardDocument;
+
+      const [tile] = convertToExternalDashboard(dashboard).tiles;
+      expect(tile.config).toMatchObject({
+        enableExemplars: true,
+        exemplarTraceSourceId: traceSourceId,
+      });
+    },
+  );
+
+  it('omits both when unset rather than emitting nulls', () => {
+    const bare = externalTile('line');
+    delete (bare.config as Record<string, unknown>).enableExemplars;
+    delete (bare.config as Record<string, unknown>).exemplarTraceSourceId;
+
+    const { config } = convertToInternalTileConfig(bare);
+    expect(config).not.toHaveProperty('enableExemplars');
+    expect(config).not.toHaveProperty('exemplarTraceSourceId');
+  });
+});

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -300,6 +300,8 @@ const convertToExternalTileChartConfig = (
         compareToPreviousPeriod: config.compareToPreviousPeriod,
         numberFormat: config.numberFormat,
         seriesLimit: config.seriesLimit ?? undefined,
+        enableExemplars: config.enableExemplars,
+        exemplarTraceSourceId: config.exemplarTraceSourceId,
       };
     case DisplayType.StackedBar:
       return {
@@ -317,6 +319,8 @@ const convertToExternalTileChartConfig = (
           : [DEFAULT_SELECT_ITEM],
         numberFormat: config.numberFormat,
         seriesLimit: config.seriesLimit ?? undefined,
+        enableExemplars: config.enableExemplars,
+        exemplarTraceSourceId: config.exemplarTraceSourceId,
       };
     case DisplayType.Number:
       return {
@@ -694,6 +698,8 @@ export function convertToInternalTileConfig(
             'alignDateRangeToGranularity',
             'compareToPreviousPeriod',
             'fitYAxisToData',
+            'enableExemplars',
+            'exemplarTraceSourceId',
           ]),
           displayType:
             externalConfig.displayType === 'stacked_bar'

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -943,15 +943,9 @@ function getMissingSources(
       if ('sourceId' in tile.config && tile.config.sourceId) {
         sourceIds.add(tile.config.sourceId);
       }
-      // The exemplar trace source is a source reference like any other. Without
-      // this it was only format-checked, so a well-formed id for a source that
-      // does not exist saved fine and left every marker's trace link dead.
-      if (
-        'exemplarTraceSourceId' in tile.config &&
-        tile.config.exemplarTraceSourceId
-      ) {
-        sourceIds.add(tile.config.exemplarTraceSourceId);
-      }
+      // exemplarTraceSourceId is deliberately NOT collected here: it is checked
+      // separately so the same unchanged-tile exemption can apply to it. See
+      // getExemplarTraceSourceIssues.
     }
 
     // Include source IDs referenced by OnClick link-outs (mode=id, type=search)
@@ -1007,17 +1001,22 @@ function getHeatmapTilesWithIncompatibleSources(
 }
 
 /**
- * Returns exemplar trace-source IDs that exist but are not Trace sources.
+ * Both problems an exemplar trace source can have: it does not exist, or it
+ * exists and is not a Trace source.
  *
- * The MCP and OpenAPI descriptions both tell the caller this must be a Trace
- * source; without a gate that was only a suggestion, and pointing it at a log or
- * metric source saved a tile whose markers link nowhere. Mirrors the heatmap
- * kind-gate above rather than inventing a second shape.
+ * Checked here rather than folding existence into getMissingSources so one
+ * unchanged-tile exemption covers both. Splitting them meant a deleted source
+ * blocked an update while a source whose kind had changed did not, which is not a
+ * distinction anyone could predict.
+ *
+ * Unlike a tile's `sourceId`, this reference is optional decoration: the chart
+ * renders the same without it, only a marker's "view trace" link goes dead. That
+ * is not worth refusing an edit made elsewhere on the dashboard over.
  */
-function getInvalidExemplarTraceSources(
+function getExemplarTraceSourceIssues(
   sources: SourceForValidation[],
   tiles: ExternalDashboardTileWithId[],
-): string[] {
+): { missing: string[]; notTrace: string[] } {
   const traceSourceIds = new Set<string>();
   for (const tile of tiles) {
     if (
@@ -1028,14 +1027,17 @@ function getInvalidExemplarTraceSources(
       traceSourceIds.add(tile.config.exemplarTraceSourceId);
     }
   }
-  if (traceSourceIds.size === 0) return [];
+  if (traceSourceIds.size === 0) return { missing: [], notTrace: [] };
 
   const sourceById = new Map(sources.map(s => [s._id.toString(), s]));
-  return [...traceSourceIds].filter(id => {
+  const missing: string[] = [];
+  const notTrace: string[] = [];
+  for (const id of traceSourceIds) {
     const source = sourceById.get(id);
-    // Absent ids are getMissingSources' business, and it runs first.
-    return source !== undefined && !isTraceSource(source);
-  });
+    if (source === undefined) missing.push(id);
+    else if (!isTraceSource(source)) notTrace.push(id);
+  }
+  return { missing, notTrace };
 }
 
 /**
@@ -1391,12 +1393,15 @@ export async function validateDashboardTiles(
   const exemplarTilesToCheck = existingTiles
     ? filterChangedExemplarTiles(tiles, existingTiles)
     : tiles;
-  const invalidExemplarTraceSources = getInvalidExemplarTraceSources(
+  const exemplarTraceSourceIssues = getExemplarTraceSourceIssues(
     sources,
     exemplarTilesToCheck,
   );
-  if (invalidExemplarTraceSources.length > 0) {
-    return `exemplarTraceSourceId must reference a Trace source. The following source IDs are not Trace sources: ${invalidExemplarTraceSources.join(', ')}`;
+  if (exemplarTraceSourceIssues.missing.length > 0) {
+    return `Could not find the following exemplarTraceSourceId source IDs: ${exemplarTraceSourceIssues.missing.join(', ')}`;
+  }
+  if (exemplarTraceSourceIssues.notTrace.length > 0) {
+    return `exemplarTraceSourceId must reference a Trace source. The following source IDs are not Trace sources: ${exemplarTraceSourceIssues.notTrace.join(', ')}`;
   }
 
   if (missingOnClickDashboards.length > 0) {

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -1114,8 +1114,18 @@ function filterChangedExemplarTiles(
     if (existing === undefined) return true;
     const existingConfig = existing.config;
     if (isRawSqlSavedChartConfig(existingConfig)) return true;
-    return (
+    if (
       existingConfig.exemplarTraceSourceId !== tile.config.exemplarTraceSourceId
+    ) {
+      return true;
+    }
+    // The id is unchanged, but a reference nobody was following is not the same
+    // as one that is about to draw markers. While exemplars were off the source
+    // could have been deleted or stopped being a Trace source with no effect, so
+    // switching them on has to be checked as if the reference were new.
+    return (
+      tile.config.enableExemplars === true &&
+      existingConfig.enableExemplars !== true
     );
   });
 }

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -1084,6 +1084,41 @@ function filterChangedHeatmapTiles(
 }
 
 /**
+ * For a PUT (update), return only the tiles whose exemplar trace source needs
+ * re-checking: new tiles, and existing ones where the id actually changed.
+ *
+ * Same reasoning as filterChangedHeatmapTiles. Without it, a tile whose trace
+ * source was later deleted or changed kind would fail the gate on every
+ * subsequent save, so an unrelated edit elsewhere on the dashboard could not be
+ * persisted at all.
+ */
+function filterChangedExemplarTiles(
+  requestTiles: ExternalDashboardTileWithId[],
+  existingTiles: DashboardDocument['tiles'],
+): ExternalDashboardTileWithId[] {
+  const existingTilesById = new Map<string, DashboardDocument['tiles'][number]>(
+    existingTiles.map(t => [t.id, t]),
+  );
+  return requestTiles.filter(tile => {
+    if (
+      !isConfigTile(tile) ||
+      !('exemplarTraceSourceId' in tile.config) ||
+      !tile.config.exemplarTraceSourceId
+    ) {
+      return false;
+    }
+    const existing = tile.id ? existingTilesById.get(tile.id) : undefined;
+    // A new tile, or one that had no exemplar trace source before: validate.
+    if (existing === undefined) return true;
+    const existingConfig = existing.config;
+    if (isRawSqlSavedChartConfig(existingConfig)) return true;
+    return (
+      existingConfig.exemplarTraceSourceId !== tile.config.exemplarTraceSourceId
+    );
+  });
+}
+
+/**
  * Returns source IDs referenced by onClick search link-outs (mode=id,
  * type=search) whose source kind is not log or trace. The /search destination
  * only supports log and trace sources, so linking to a metric/session source
@@ -1350,9 +1385,15 @@ export async function validateDashboardTiles(
     return `Heatmap tiles require a Trace source. The following source IDs are not Trace sources: ${heatmapNonTraceSources.join(', ')}`;
   }
 
+  // Scoped to changed tiles on update, like the heatmap gate above: an unchanged
+  // tile whose trace source has since been deleted must not block edits made
+  // elsewhere on the dashboard.
+  const exemplarTilesToCheck = existingTiles
+    ? filterChangedExemplarTiles(tiles, existingTiles)
+    : tiles;
   const invalidExemplarTraceSources = getInvalidExemplarTraceSources(
     sources,
-    tiles,
+    exemplarTilesToCheck,
   );
   if (invalidExemplarTraceSources.length > 0) {
     return `exemplarTraceSourceId must reference a Trace source. The following source IDs are not Trace sources: ${invalidExemplarTraceSources.join(', ')}`;

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -943,6 +943,15 @@ function getMissingSources(
       if ('sourceId' in tile.config && tile.config.sourceId) {
         sourceIds.add(tile.config.sourceId);
       }
+      // The exemplar trace source is a source reference like any other. Without
+      // this it was only format-checked, so a well-formed id for a source that
+      // does not exist saved fine and left every marker's trace link dead.
+      if (
+        'exemplarTraceSourceId' in tile.config &&
+        tile.config.exemplarTraceSourceId
+      ) {
+        sourceIds.add(tile.config.exemplarTraceSourceId);
+      }
     }
 
     // Include source IDs referenced by OnClick link-outs (mode=id, type=search)
@@ -994,6 +1003,38 @@ function getHeatmapTilesWithIncompatibleSources(
   return [...heatmapSourceIds].filter(id => {
     const source = sourceById.get(id);
     return source !== undefined && !isHeatmapCompatibleSource(source);
+  });
+}
+
+/**
+ * Returns exemplar trace-source IDs that exist but are not Trace sources.
+ *
+ * The MCP and OpenAPI descriptions both tell the caller this must be a Trace
+ * source; without a gate that was only a suggestion, and pointing it at a log or
+ * metric source saved a tile whose markers link nowhere. Mirrors the heatmap
+ * kind-gate above rather than inventing a second shape.
+ */
+function getInvalidExemplarTraceSources(
+  sources: SourceForValidation[],
+  tiles: ExternalDashboardTileWithId[],
+): string[] {
+  const traceSourceIds = new Set<string>();
+  for (const tile of tiles) {
+    if (
+      isConfigTile(tile) &&
+      'exemplarTraceSourceId' in tile.config &&
+      tile.config.exemplarTraceSourceId
+    ) {
+      traceSourceIds.add(tile.config.exemplarTraceSourceId);
+    }
+  }
+  if (traceSourceIds.size === 0) return [];
+
+  const sourceById = new Map(sources.map(s => [s._id.toString(), s]));
+  return [...traceSourceIds].filter(id => {
+    const source = sourceById.get(id);
+    // Absent ids are getMissingSources' business, and it runs first.
+    return source !== undefined && !isTraceSource(source);
   });
 }
 
@@ -1307,6 +1348,14 @@ export async function validateDashboardTiles(
   );
   if (heatmapNonTraceSources.length > 0) {
     return `Heatmap tiles require a Trace source. The following source IDs are not Trace sources: ${heatmapNonTraceSources.join(', ')}`;
+  }
+
+  const invalidExemplarTraceSources = getInvalidExemplarTraceSources(
+    sources,
+    tiles,
+  );
+  if (invalidExemplarTraceSources.length > 0) {
+    return `exemplarTraceSourceId must reference a Trace source. The following source IDs are not Trace sources: ${invalidExemplarTraceSources.join(', ')}`;
   }
 
   if (missingOnClickDashboards.length > 0) {

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -261,6 +261,11 @@ const externalDashboardTimeChartConfigSchema = z.object({
   alignDateRangeToGranularity: z.boolean().optional(),
   fillNulls: z.boolean().optional(),
   numberFormat: NumberFormatSchema.optional(),
+  // Exemplar overlay (trace-linked markers). Rendering additionally requires an
+  // exemplar-eligible shape — single non-ratio histogram series, no group by —
+  // so setting this on an ineligible tile is inert rather than an error.
+  enableExemplars: z.boolean().optional(),
+  exemplarTraceSourceId: objectIdSchema.optional(),
 });
 
 const externalDashboardLineChartConfigSchema =


### PR DESCRIPTION
Last of the PRs replacing #2536. **Stacked on #2808** — these fields do nothing without the overlay.

## What it does

`enableExemplars` and `exemplarTraceSourceId` are accepted on line and stacked-bar tiles through the external v2 API and the MCP dashboard tools.

## The part that was actually broken

The fields have to survive three places, and the original change only cleared the first:

1. the input schema,
2. `convertToInternalTileConfig`'s `pick` list on the way in,
3. `convertToExternalTileChartConfig` on the way out.

They validated on write and were then dropped before persistence. So the feature could only ever be switched on by a human in the chart editor — an agent could set the field, get a 200, and have it silently vanish. The round trip is what makes them usable.

Also documented in the OpenAPI spec, which is hand-maintained JSDoc rather than generated from the zod schemas — so adding schema fields alone left the published contract silent about them.

## MCP describe strings

They follow the file's own convention for source ids: say to call `clickstack_list_sources` and pick a trace-kind source, and note that the flag only renders on an exemplar-eligible tile (single non-ratio histogram series, no groupBy). Without that an agent gets a 200 and no markers, with nothing explaining why.

## Verification

`make ci-lint` and `make ci-unit` (5,350 tests) pass. Merged cleanly with main's `seriesLimit` addition, which landed in the same conversion functions — both sets of fields are kept.