### PR TITLE
fix: Prevent long attribute values from painting over the key column

### DIFF
--- a/.changeset/span-attributes-key-column-overlap.md
+++ b/.changeset/span-attributes-key-column-overlap.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Prevent long attribute values from painting over the key column in the JSON attributes viewer

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -270,21 +270,6 @@ export function RowOverviewPanel({
           </Accordion.Item>
         )}
 
-        {hasSpanEvents && (
-          <Accordion.Item value="spanEvents">
-            <Accordion.Control>
-              <Text size="sm" ps={contentPx}>
-                Span Events
-              </Text>
-            </Accordion.Control>
-            <Accordion.Panel>
-              <Box px={contentPx}>
-                <SpanEventsSubpanel spanEvents={firstRow?.__hdx_span_events} />
-              </Box>
-            </Accordion.Panel>
-          </Accordion.Item>
-        )}
-
         {Object.keys(topLevelAttributes).length > 0 && (
           <Accordion.Item value="topLevelAttributes">
             <Accordion.Control>
@@ -326,12 +311,12 @@ export function RowOverviewPanel({
         {hasSpanEvents && (
           <Accordion.Item value="spanEvents">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 Span Events
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box ps={contentPx}>
                 <SpanEventsSubpanel spanEvents={firstRow?.__hdx_span_events} />
               </Box>
             </Accordion.Panel>

--- a/packages/app/src/components/HyperJson.module.scss
+++ b/packages/app/src/components/HyperJson.module.scss
@@ -9,8 +9,10 @@
 }
 
 .withTabulate {
-  .key {
-    min-width: 150px;
+  .keyContainer {
+    // `min()` keeps the floor inside the 50% cap so the key
+    // column also can't overflow into the value column in narrow panels.
+    min-width: min(150px, 50%);
   }
 }
 


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

Prevents long attributes overlapping keys. Also removes a duplicate Span Events section.

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->

| Before | After |
| :----- | :---- |
|    <img width="303" height="275" alt="Screenshot 2026-08-05 at 10 18 52" src="https://github.com/user-attachments/assets/5a95dff2-25ec-43a6-8964-a435f0621daf" /> |  <img width="306" height="356" alt="Screenshot 2026-08-05 at 10 19 13" src="https://github.com/user-attachments/assets/a4bebd6f-e0f2-475b-a64d-53022b7aea9a" />  |

### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** <!-- e.g. /chart, /dashboards/[id] --> `/search`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5001
- Related PRs: https://github.com/hyperdxio/hyperdx/pull/2693
