### PR TITLE
chore: Commit automatic lint fixes

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,7 @@
     "build:clickhouse": "NEXT_PUBLIC_THEME=clickstack NEXT_PUBLIC_IS_LOCAL_MODE=true NEXT_PUBLIC_CLICKHOUSE_BUILD=true next build --webpack && node scripts/prepare-clickhouse-build-export.js",
     "run:clickhouse": "test -d out && npx rimraf tmp && mkdir tmp && cp -r out tmp/clickstack && echo 'visit http://localhost:3000/clickstack to start' && npx serve tmp -l 3000 || echo 'run build:clickhouse first'",
     "start": "next start",
-    "lint": "npx eslint . --ext .ts,.tsx --max-warnings 740",
+    "lint": "npx eslint . --ext .ts,.tsx --max-warnings 663",
     "lint:fix": "npx eslint . --ext .ts,.tsx --fix",
     "lint:styles": "stylelint **/*/*.{css,scss}",
     "ci:lint": "yarn lint && yarn tsc --noEmit && yarn lint:styles --quiet",

--- a/packages/app/src/__tests__/SessionSidePanel.test.tsx
+++ b/packages/app/src/__tests__/SessionSidePanel.test.tsx
@@ -40,7 +40,7 @@ jest.mock('nuqs', () => {
   const noop = () => {};
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) =>
       key === 'sessionPanelEvent'
         ? [mockNuqs.sessionPanelEvent, mockNuqs.setSessionPanelEvent]

--- a/packages/app/src/components/__tests__/DBRowSidePanel.missingSource.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.missingSource.test.tsx
@@ -26,7 +26,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,

--- a/packages/app/src/components/__tests__/DBRowSidePanel.rememberedTab.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.rememberedTab.test.tsx
@@ -67,7 +67,7 @@ const mockRow = {
 
 jest.mock('../DBRowDataPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useRowData: () => ({
     data: { data: [mockRow] },
     isLoading: false,
@@ -88,7 +88,7 @@ jest.mock('../DBRowDataPanel', () => ({
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => '__hdx_body',
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSource: () => ({ data: undefined }),
 }));
 
@@ -129,7 +129,7 @@ jest.mock('../ContextSidePanel', () => ({
 
 jest.mock('../DBSessionPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSessionId: () => ({ rumSessionId: undefined, rumServiceName: undefined }),
   DBSessionPanel: () => null,
 }));

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
@@ -24,7 +24,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,
@@ -56,7 +56,7 @@ const LINK = {
 const mockUseRowData = jest.fn();
 jest.mock('../DBRowDataPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useRowData: (args: unknown) => mockUseRowData(args),
   ROW_DATA_ALIASES: {
     DURATION_MS: '__hdx_duration',
@@ -82,14 +82,14 @@ const TRACE_SOURCE = {
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => undefined,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSource: ({ id }: { id: string | null }) =>
     id === 'trace-src' ? { data: TRACE_SOURCE } : { data: undefined },
 }));
 
 jest.mock('../DBSessionPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSessionId: () => ({ rumSessionId: undefined, rumServiceName: undefined }),
   DBSessionPanel: () => null,
 }));

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
@@ -38,7 +38,7 @@ const LINKED_SPAN_NAME = 'consume order.created';
 const mockUseRowData = jest.fn();
 jest.mock('../DBRowDataPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useRowData: (args: unknown) => mockUseRowData(args),
   ROW_DATA_ALIASES: {
     DURATION_MS: '__hdx_duration',
@@ -62,14 +62,14 @@ const TRACE_SOURCE = {
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => undefined,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSource: ({ id }: { id: string | null }) =>
     id === 'trace-src' ? { data: TRACE_SOURCE } : { data: undefined },
 }));
 
 jest.mock('../DBSessionPanel', () => ({
   __esModule: true,
-  // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
   useSessionId: () => ({ rumSessionId: undefined, rumServiceName: undefined }),
   DBSessionPanel: () => null,
 }));

--- a/packages/app/src/components/__tests__/DBRowSidePanel.staleStack.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.staleStack.test.tsx
@@ -26,7 +26,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,

--- a/packages/app/src/hooks/__tests__/useDashboardKioskMode.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardKioskMode.test.tsx
@@ -6,7 +6,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: () => [false, mockSetKioskMode],
   };
 });

--- a/packages/app/src/hooks/__tests__/useSidePanelStack.test.tsx
+++ b/packages/app/src/hooks/__tests__/useSidePanelStack.test.tsx
@@ -24,7 +24,7 @@ jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
   return {
     ...actual,
-    // eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
+
     useQueryState: (key: string, parser?: { defaultValue?: unknown }) => {
       const hasValue = Object.prototype.hasOwnProperty.call(
         mockQueryStore,


### PR DESCRIPTION
## Summary

This PR commits the results of running `make dev-lint` after a lint rule was previously added to the ignore list for test files. This PR also reduces the limit on lint warnings in the app to the current number, after these fixes.

### Screenshots or video

### How to test on Vercel preview

N/A - no behavior changes

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue:
- Related PRs:
