### PR TITLE
fix(ci): close a bot-author bypass in PR triage introduced by #2820

### DIFF
--- a/.github/scripts/__tests__/pr-triage-classify.test.js
+++ b/.github/scripts/__tests__/pr-triage-classify.test.js
@@ -383,10 +383,33 @@ describe('determineTier', () => {
     });
 
     it('release branch carrying real source code is NOT short-circuited', () => {
-      assert.equal(classify('github-actions', 'changeset-release/main', [
+      // Deliberately non-critical code: an auth.ts case would pass even if the
+      // release guard were deleted, since auth is Tier 4 either way.
+      assert.notEqual(classify('github-actions', 'changeset-release/main', [
         makeFile('packages/otel-collector/package.json', 1, 1),
-        makeFile('packages/api/src/middleware/auth.ts', 40, 10),  // not a release artifact
-      ]), 4);
+        makeFile('packages/app/src/App.tsx', 600, 300),  // not a release artifact
+      ]), 1);
+    });
+
+    it('github-actions gets no blanket bot escape — only the release path', () => {
+      // .github/workflows/claude.yml runs with secrets.GITHUB_TOKEN, so PRs the
+      // agent opens are authored by github-actions. A blanket bot escape would
+      // drop a 900-line agent PR to Tier 1 auto-merge.
+      const files = [makeFile('packages/app/src/App.tsx', 600, 300)];
+      assert.equal(classify('github-actions', 'chore/codegen', files), 3);
+      assert.equal(classify('github-actions[bot]', 'chore/codegen', files), 3);
+      assert.equal(
+        classify('github-actions', 'chore/codegen', files),
+        classify('alice', 'chore/codegen', files),
+        'a bot-authored PR must tier the same as the identical human one'
+      );
+    });
+
+    it('dependabot keeps its blanket escape', () => {
+      assert.equal(classify('dependabot[bot]', 'dependabot/npm/lodash', [
+        makeFile('package.json', 5, 3),
+        makeFile('packages/api/package.json', 2, 2),
+      ]), 1);
     });
 
     it('release-artifact files outside a release branch classify normally', () => {
@@ -590,6 +613,25 @@ describe('determineTier', () => {
         makeFile('packages/api/src/routers/external-api/v2/alerts.ts', 7, 3),
         makeFile('packages/api/src/services/alerts.ts', 12, 4),     // PR #2595 pattern
       ]), 3);
+    });
+
+    it('grazing counts churn in buckets excluded from prodLines', () => {
+      // Workflows, Actions scripts and hdx-eval are excluded from prodLines for
+      // tiering, but they are still code a reviewer has to read — they must not
+      // let a large PR pass itself off as a graze.
+      assert.equal(classify('alice', 'infra/ch-and-ci', [
+        makeFile('docker/clickhouse/local/users.xml', 3, 2),
+        makeFile('.github/workflows/deploy-staging.yml', 700, 0),
+      ]), 4);
+      assert.equal(classify('alice', 'feat/evals-and-config', [
+        makeFile('packages/api/src/config.ts', 3, 2),
+        makeFile('packages/hdx-eval/src/big.ts', 5000, 0),
+      ]), 4);
+      // Lockfile churn is unreadable and does not count against a graze
+      assert.equal(classify('alice', 'chore/bump', [
+        makeFile('packages/api/src/config.ts', 3, 2),
+        makeFile('yarn.lock', 4000, 3000),
+      ]), 2);
     });
 
     it('grazing stops at the bounds — either bound alone is not enough', () => {
@@ -818,6 +860,28 @@ describe('buildTierComment', () => {
       buildTierComment(2, agent).replace(/claude\/thing/g, 'feat/thing'),
       buildTierComment(2, base)
     );
+  });
+
+  it('does not call a workflow-only Tier 4 PR "docs / images / lock files"', () => {
+    // main.yml is both trivial and infra-critical, so allFilesTrivial is true
+    // while the PR escalates on pipeline churn. The two must not both render.
+    const infraCriticalFiles = [makeFile('.github/workflows/main.yml', 30, 5)];
+    const body = buildTierComment(4, makeSignals({
+      criticalFiles: infraCriticalFiles,
+      infraCriticalFiles,
+      infraCriticalLines: 35,
+      infraCriticalEscalates: true,
+      allFilesTrivial: true,
+      prodFiles: [],
+      prodLines: 0,
+    }));
+    assert.ok(body.includes('delivery pipeline substantially modified'));
+    assert.ok(!body.includes('All files are docs'), 'contradictory trigger must be suppressed');
+    assert.ok(body.includes('Critical-path lines changed: 35'), 'stats must not report 0 churn');
+  });
+
+  it('does not throw on a fixture claiming a graze with no core-critical files', () => {
+    assert.doesNotThrow(() => buildTierComment(2, makeSignals({ grazesCoreCritical: true })));
   });
 
   it('shows test line count in stats when non-zero', () => {

--- a/.github/scripts/pr-triage-classify.js
+++ b/.github/scripts/pr-triage-classify.js
@@ -117,11 +117,21 @@ const CROSS_LAYER_MIN_LINES = 100;
 // evidence as anyone else's — what the diff touches and how big it is. Keying off
 // a `claude/` prefix only penalised the tools that advertise themselves, while
 // equally agent-written `cursor/` branches sailed past.
-const BOT_AUTHORS = [
-  'dependabot', 'dependabot[bot]',
-  'github-actions', 'github-actions[bot]',
-];
+// Authors whose PRs are trivial by construction — a dependency bump is a
+// lockfile and a manifest, whatever its line count.
+const BOT_AUTHORS = ['dependabot', 'dependabot[bot]'];
+
+// The account the changesets action runs as. Deliberately NOT in BOT_AUTHORS:
+// `github-actions` also authors every PR opened by .github/workflows/claude.yml,
+// which runs with secrets.GITHUB_TOKEN. A blanket bot escape here would drop
+// agent-authored PRs of any size straight to Tier 1. Only the narrow
+// release-artifact path below short-circuits for this account.
+const RELEASE_BOT_AUTHORS = ['github-actions', 'github-actions[bot]'];
 const RELEASE_BRANCH_PREFIX = 'changeset-release/';
+
+// Lockfiles are enormous and unreadable; they never count toward "how much is
+// there to review".
+const LOCKFILE_PATTERN = /^(yarn\.lock|package-lock\.json)$/;
 
 const TIER_LABELS = {
   1: { name: 'review/tier-1', color: '0E8A16', description: 'Trivial — auto-merge candidate once CI passes' },
@@ -217,12 +227,24 @@ function computeSignals(pr, filesRes) {
   const coreCriticalLines  = churn(coreCriticalFiles);
   const infraCriticalLines = churn(infraCriticalFiles);
 
+  // Everything a reviewer actually has to read. Unlike prodLines this keeps
+  // workflows, Actions scripts and internal-tooling packages in: they are
+  // excluded from tiering but are still real code, and a five-line config.ts
+  // edit shipped alongside 5000 lines of hdx-eval is not a PR that merely
+  // grazes anything.
+  const reviewableLines = churn(
+    criticalCandidates.filter(f => !LOCKFILE_PATTERN.test(f.filename))
+  );
+
   // A small edit to a core-critical path inside an otherwise small PR reviews
-  // like any other small change, so let it fall through to normal sizing.
+  // like any other small change, so let it fall through to normal sizing. Both
+  // size bounds are checked so neither a large excluded bucket nor a large
+  // production diff can sneak through.
   const grazesCoreCritical =
     coreCriticalFiles.length > 0 &&
     coreCriticalLines <= CORE_CRITICAL_GRAZE_LINES &&
-    prodLines <= GRAZE_MAX_PROD_LINES;
+    prodLines <= GRAZE_MAX_PROD_LINES &&
+    reviewableLines <= GRAZE_MAX_PROD_LINES;
 
   const infraCriticalEscalates = infraCriticalLines >= INFRA_CRITICAL_MIN_LINES;
 
@@ -239,7 +261,7 @@ function computeSignals(pr, filesRes) {
   // on the entire file set, so real code pushed onto a release branch still
   // classifies on its merits.
   const isReleaseArtifactPR =
-    isBotAuthor &&
+    (isBotAuthor || RELEASE_BOT_AUTHORS.includes(author)) &&
     branchName.startsWith(RELEASE_BRANCH_PREFIX) &&
     filesRes.length > 0 &&
     filesRes.every(f => isReleaseArtifactFile(f.filename));
@@ -265,7 +287,8 @@ function computeSignals(pr, filesRes) {
     author, branchName,
     prodFiles, prodLines, testLines,
     criticalFiles, securityCriticalFiles, coreCriticalFiles, infraCriticalFiles,
-    coreCriticalLines, infraCriticalLines, grazesCoreCritical, infraCriticalEscalates,
+    coreCriticalLines, infraCriticalLines, reviewableLines,
+    grazesCoreCritical, infraCriticalEscalates,
     internalToolingFiles,
     isBotAuthor, allFilesTrivial, isReleaseArtifactPR,
     touchesApiModels, touchesFrontend, touchesBackend, touchesSharedUtils,
@@ -323,6 +346,7 @@ function buildTierComment(tier, signals) {
 
   const info = TIER_INFO[tier];
   const fileList = files => files.map(f => `    - \`${f.filename}\``).join('\n');
+  const criticalChurn = criticalFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0);
 
   // Assembles the final body from whatever `triggers` and `contextSignals` hold
   // at call time, so an early return can skip the context block.
@@ -341,6 +365,10 @@ function buildTierComment(tier, signals) {
     '',
     `- Production files changed: ${prodFiles.length}`,
     `- Production lines changed: ${prodLines}${testLines > 0 ? ` (+ ${testLines} in test files, excluded from tier calculation)` : ''}`,
+    // Workflow files are both trivial and infra-critical, so a PR can escalate
+    // on churn that never reaches prodLines. Show it rather than report 0.
+    ...(criticalChurn > 0 && criticalChurn !== prodLines
+      ? [`- Critical-path lines changed: ${criticalChurn}`] : []),
     `- Branch: \`${branchName}\``,
     `- Author: ${author}`,
     '',
@@ -370,7 +398,12 @@ function buildTierComment(tier, signals) {
     triggers.push(`**Diff size**: ${prodLines} production lines changed (Tier 2 max: < ${TIER2_MAX_LINES})`);
   }
   if (isBotAuthor && !isReleaseArtifactPR) triggers.push(`**Bot author**: \`${author}\``);
-  if (allFilesTrivial && !isBotAuthor) triggers.push('**All files are docs / images / lock files**');
+  // Guarded on criticalFiles: a workflow file is both trivial and infra-critical,
+  // so without this a main.yml rewrite claimed to be "docs / images / lock files"
+  // in the same breath as escalating on 35 lines of pipeline churn.
+  if (allFilesTrivial && !isBotAuthor && criticalFiles.length === 0) {
+    triggers.push('**All files are docs / images / lock files**');
+  }
   if (isCrossLayer) {
     const layers = [
       touchesFrontend    && 'frontend (`packages/app`)',
@@ -390,8 +423,8 @@ function buildTierComment(tier, signals) {
   // for automated releases, where none of it is actionable.
   const contextSignals = [];
   if (isReleaseArtifactPR) return render();
-  if (grazesCoreCritical) {
-    contextSignals.push(`grazes a critical path (${coreCriticalLines} lines in \`${coreCriticalFiles[0].filename}\`) but the whole PR is only ${prodLines} production lines, so it is tiered on size`);
+  if (grazesCoreCritical && coreCriticalFiles.length > 0) {
+    contextSignals.push(`grazes a critical path (${coreCriticalLines} lines in \`${coreCriticalFiles[0].filename}\`) inside a ${prodLines}-line PR, so it is tiered on size`);
   }
   if (infraCriticalFiles.length > 0 && !infraCriticalEscalates) {
     contextSignals.push(`touches background tasks or the delivery pipeline lightly (${infraCriticalLines} lines, under the ${INFRA_CRITICAL_MIN_LINES}-line bar for Tier 4)`);


### PR DESCRIPTION
## Summary

Follow-up to #2820, which merged before these fixes landed. That PR added `github-actions` to `BOT_AUTHORS` so changeset release PRs could short-circuit to Tier 1, but the blanket bot escape in `determineTier` fires just after the critical gate — so **any** `github-actions` PR got Tier 1 regardless of size (a 900-line diff scored Tier 1 where the identical diff from a human scored Tier 3), and `.github/workflows/claude.yml` runs with `secrets.GITHUB_TOKEN`, so every PR the agent opens carries that login. This splits the lists so dependabot keeps its blanket escape while `github-actions` reaches Tier 1 only through the narrow release-artifact path. It also adds a second size bound to the graze rule, which previously compared only against `prodLines` and so let a 5-line `config.ts` edit shipped with 5000 lines of `hdx-eval` pass as a graze, and stops a `main.yml`-only Tier 4 PR from rendering "All files are docs / images / lock files" above a stats block reporting zero churn.

Tier distribution over the last 250 merged PRs is unchanged (T2 51%, T4 17%); the suite grows to 103 tests, including a regression test asserting a bot-authored PR tiers identically to the same diff from a human.

### How to test on Vercel preview

N/A — non-UI change. Covered by `node --test .github/scripts/__tests__/pr-triage-classify.test.js`, which the PR Triage workflow runs as a gate before any labelling.

### References

- Linear Issue:
- Related PRs: #2820 (introduced the regression)