### PR TITLE
fix(ci): drop --bare from the changelog generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,10 +457,18 @@ jobs:
         # --disallowedTools DENIES, and deny beats allow. /proc/self/environ
         # carries the whole environment, including the API key.
         #
-        # --bare skips hooks, plugin sync and CLAUDE.md discovery, and takes
-        # auth strictly from ANTHROPIC_API_KEY. /tmp as the working directory
-        # keeps the checkout — scripts, workflow, git config — outside the
-        # workspace entirely.
+        # Deliberately NOT --bare. It looked like free hardening (no hooks, no
+        # plugin sync, no CLAUDE.md discovery) but it left the model holding
+        # `Read` alone: it never registered the `Write` from --tools, so the
+        # generator printed the body to stdout, wrote no file, and exited 0.
+        # See run 31149802657. On a GitHub-hosted runner it was guarding against
+        # nothing anyway: there is no user settings file and no MCP server for
+        # --setting-sources user to pick up. That stops being true if this job
+        # ever moves to a self-hosted runner, where $HOME persists between jobs —
+        # confine the settings sources then rather than reaching for --bare.
+        #
+        # /tmp as the working directory keeps the checkout — scripts, workflow,
+        # git config — outside the workspace entirely.
         working-directory: /tmp
         run: |
           set -euo pipefail
@@ -480,7 +488,6 @@ jobs:
                 'Read the instructions in /tmp/inputs/instructions.md and follow them exactly to write /tmp/release-notes-body.md for this release.' \
                 | npx --yes @anthropic-ai/claude-code@2.1.220 \
                     --print \
-                    --bare \
                     --setting-sources user \
                     --tools "Read" "Write" \
                     --allowedTools "Read(//tmp/**)" "Edit(//tmp/release-notes-body.md)" \


### PR DESCRIPTION
`--bare`, added in #2830, stopped the changelog generator writing its output.
The flag never registered the `Write` tool that `--tools "Read" "Write"` asks
for, so the model was left with `Read` alone — it reported the blocker, printed
the finished body to stdout, wrote no file, and exited 0. Run
[31149802657](https://github.com/hyperdxio/hyperdx/actions/runs/31149802657).

Removing it is the whole change. The same invocation without `--bare` writes the
file, verified against the pinned `2.1.220` at the real `/tmp` paths.

## Impact

- The draft job should produce a section again on the next push to `main`.
  Re-running the failed run will not do it — a push-triggered run uses the
  workflow file as it was when it triggered.
- Release PR #2770 is currently open without its changelog section. The body
  from the failed run is in that run's log if it is worth pasting in rather than
  waiting for a regeneration; keep the `<!-- hyperdx-release-notes … -->` marker
  intact if you do.

## Background

`--bare` was added on the reasoning that it could only ever narrow what the model
is able to do, so it was safe hardening for a job that processes untrusted text.
It did narrow — it narrowed away the tool the job depends on. It was also the one
flag that could not be exercised locally, because it takes auth strictly from
`ANTHROPIC_API_KEY` and refuses the keychain, so the first real signal was a
failed release run.

On a GitHub-hosted runner it was guarding against nothing: there is no user
settings file and no MCP server for `--setting-sources user` to load. That
changes if this job ever moves to a self-hosted runner, where `$HOME` persists
between jobs — the comment now says to confine the settings sources at that point
rather than reaching for `--bare` again.

The non-empty assertion added in #2830 is what turned this into a clear failure
in the job that ran the model, rather than a blank body surfacing two jobs later
as a validator error naming the wrong step.
