### PR TITLE
docs: enforce sentence case for UI text

### DIFF
--- a/.cursor/rules/ui-sentence-case.mdc
+++ b/.cursor/rules/ui-sentence-case.mdc
@@ -1,0 +1,37 @@
+---
+description: Enforce sentence case (not Title Case) for user-facing UI text in the app
+globs: packages/app/src/**/*.tsx
+alwaysApply: false
+---
+
+# UI text: sentence case
+
+All user-facing text uses **sentence case** — capitalize only the **first word**
+and any proper nouns/acronyms. Never use Title Case. Applies to labels, buttons,
+tab/menu items, headings, modal/section titles, placeholders, tooltips, table
+column headers, empty states, and toast copy.
+
+```tsx
+// ❌ BAD — Title Case
+<Text>Data Source</Text>
+<TextInput label="Chart Name" />
+<Button>Add Series</Button>
+<Menu.Item>Delete Dashboard</Menu.Item>
+
+// ✅ GOOD — sentence case
+<Text>Data source</Text>
+<TextInput label="Chart name" />
+<Button>Add series</Button>
+<Menu.Item>Delete dashboard</Menu.Item>
+```
+
+**Preserve proper nouns, product names, and acronyms** wherever they appear —
+sentence case only touches the surrounding words: HyperDX, ClickHouse,
+ClickStack, OpenTelemetry/OTel, Lucene, SQL, PromQL, MongoDB, Kubernetes, JSON,
+CSV, URL, ID, API, MCP, CPU, P95. E.g. `Search your events w/ Lucene`,
+`Edit SQL`, `View in ClickHouse`.
+
+Only sentence-case **static UI chrome**. Render dynamic/user data (column names,
+tag values, log/trace content, user-typed source/dashboard names) verbatim.
+
+Source of truth: `agent_docs/code_style.md` → "UI text: use sentence case".

--- a/agent_docs/code_style.md
+++ b/agent_docs/code_style.md
@@ -159,6 +159,35 @@ The variant → token mapping is centralized in `packages/app/src/theme/themes/s
 
 **Title copy**: Treat `title` as a short headline (like `Title` in the UI). Do **not** end it with a period. Use `description` for full sentences, which should use normal punctuation including a trailing period when appropriate. Match listing pages (e.g. dashboards and saved searches use parallel phrasing such as “No matching … yet” / “No … yet” without dots).
 
+## UI text: use sentence case
+
+All user-facing text uses **sentence case** — capitalize only the **first word**
+and any proper nouns/acronyms. Do **not** use Title Case (capitalizing every
+significant word).
+
+This applies to every string a user reads: field labels, buttons, tab/menu
+items, headings, section titles, modal titles, placeholders, tooltips, table
+column headers, empty states, and toast/notification copy.
+
+| Title Case (avoid) | Sentence case (use) |
+|--------------------|---------------------|
+| `Data Source`      | `Data source`       |
+| `Chart Name`       | `Chart name`        |
+| `Add Series`       | `Add series`        |
+| `Count of Events`  | `Count of events`   |
+| `Save Changes`     | `Save changes`      |
+| `Delete Dashboard` | `Delete dashboard`  |
+
+**Keep the original casing of proper nouns, product names, and acronyms**
+anywhere in the string — sentence case only changes the words around them:
+HyperDX, ClickHouse, ClickStack, OpenTelemetry/OTel, Lucene, SQL, PromQL,
+MongoDB, Kubernetes, JSON, CSV, URL, ID, API, MCP, CPU, P95. For example:
+`Search your events w/ Lucene`, `Edit SQL`, `Copy as cURL`, `View in ClickHouse`.
+
+Only sentence-case **static UI chrome**. Never rewrite dynamic/user data (column
+names, tag values, log/trace content, source or dashboard names a user typed) —
+render those verbatim.
+
 ## Semantic design tokens (prefer over raw Mantine colors)
 
 The UI is built with **Mantine components**, but **colors and surfaces** should follow the **semantic CSS custom properties** in our themes (`--color-*`, etc.), not ad-hoc Mantine palette values. Those tokens are defined in `packages/app/src/theme/themes/**/_tokens.scss`, align with a **Click UI**–style system, and keep HyperDX and ClickStack visually consistent. They are the path toward a shared design system even while Mantine remains the component layer.


### PR DESCRIPTION
## Summary

Establishes **sentence case** (not Title Case) as the convention for all user-facing UI text, so labels read `Data source` / `Chart name` rather than `Data Source` / `Chart Name` (see the chart builder for current inconsistencies).

- Adds a "UI text: use sentence case" section to `agent_docs/code_style.md` — the source of truth, with a before/after table, a proper-noun/acronym exception list (HyperDX, ClickHouse, SQL, Lucene, …), and a static-chrome-only scope so dynamic/user data is never rewritten.
- Adds a Cursor rule `.cursor/rules/ui-sentence-case.mdc` scoped to `packages/app/src/**/*.tsx` so the convention is automatically in context when authoring or reviewing UI strings, with concrete good/bad examples.

## Why

The app mixes sentence case and Title Case in UI copy. Rather than a noisy ESLint rule (which would fight proper nouns, acronyms, and user data), this documents the convention and gives the agent a scoped rule to apply it at authoring/review time.

## Notes

- Docs + tooling only — no runtime/package changes, so no changeset.
- Follow-up (not in this PR): apply the convention to existing violations in the chart builder (`Chart Name`, `Data Source`, `Add Series`, `Count of Events`) and update the corresponding test expectations.

## Test plan

- [ ] Confirm the new section renders correctly in `agent_docs/code_style.md`.
- [ ] Confirm the rule appears/activates when editing files under `packages/app/src/**/*.tsx`.

Made with [Cursor](https://cursor.com)