### PR TITLE
refactor(alerts): extract notification transports behind a registry

### DIFF
--- a/packages/api/src/routers/api/__tests__/webhooks.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/webhooks.int.test.ts
@@ -3,7 +3,7 @@ import { Types } from 'mongoose';
 import { getLoggedInAgent, getServer } from '@/fixtures';
 import Alert from '@/models/alert';
 import Webhook, { WebhookService } from '@/models/webhook';
-import * as template from '@/tasks/checkAlerts/template';
+import * as notifications from '@/tasks/checkAlerts/notifications';
 
 const MOCK_WEBHOOK = {
   name: 'Test Webhook',
@@ -1221,10 +1221,10 @@ describe('webhooks router', () => {
 
     beforeEach(() => {
       genericSpy = jest
-        .spyOn(template, 'handleSendGenericWebhook')
+        .spyOn(notifications, 'handleSendGenericWebhook')
         .mockResolvedValue(undefined);
       slackSpy = jest
-        .spyOn(template, 'handleSendSlackWebhook')
+        .spyOn(notifications, 'handleSendSlackWebhook')
         .mockResolvedValue(undefined);
     });
 

--- a/packages/api/src/routers/api/__tests__/webhooks.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/webhooks.int.test.ts
@@ -3,7 +3,7 @@ import { Types } from 'mongoose';
 import { getLoggedInAgent, getServer } from '@/fixtures';
 import Alert from '@/models/alert';
 import Webhook, { WebhookService } from '@/models/webhook';
-import * as notifications from '@/tasks/checkAlerts/notifications';
+import * as transports from '@/tasks/checkAlerts/transports';
 
 const MOCK_WEBHOOK = {
   name: 'Test Webhook',
@@ -1221,10 +1221,10 @@ describe('webhooks router', () => {
 
     beforeEach(() => {
       genericSpy = jest
-        .spyOn(notifications, 'handleSendGenericWebhook')
+        .spyOn(transports, 'handleSendGenericWebhook')
         .mockResolvedValue(undefined);
       slackSpy = jest
-        .spyOn(notifications, 'handleSendSlackWebhook')
+        .spyOn(transports, 'handleSendSlackWebhook')
         .mockResolvedValue(undefined);
     });
 
@@ -1258,7 +1258,7 @@ describe('webhooks router', () => {
 
       // The outbound call should receive the real URL and headers
       expect(genericSpy).toHaveBeenCalledTimes(1);
-      const sentWebhook = genericSpy.mock.calls[0][0];
+      const sentWebhook = genericSpy.mock.calls[0][0].channel;
       expect(sentWebhook.url).toBe(realUrl);
       expect(sentWebhook.headers.toJSON()).toEqual({
         Authorization: 'Bearer real-secret',
@@ -1289,7 +1289,7 @@ describe('webhooks router', () => {
 
       // The outbound call should receive the attacker URL and literal ****
       // (NOT the stored real secret)
-      const sentWebhook = genericSpy.mock.calls[0][0];
+      const sentWebhook = genericSpy.mock.calls[0][0].channel;
       expect(sentWebhook.url).toBe('https://attacker.example.com/capture');
       expect(sentWebhook.headers.toJSON()).toEqual({
         Authorization: '****',
@@ -1383,7 +1383,7 @@ describe('webhooks router', () => {
         .expect(200);
 
       expect(genericSpy).toHaveBeenCalledTimes(1);
-      const sentWebhook = genericSpy.mock.calls[0][0];
+      const sentWebhook = genericSpy.mock.calls[0][0].channel;
       expect(sentWebhook.url).toBe('https://example.com/webhook');
     });
 

--- a/packages/api/src/routers/api/webhooks.ts
+++ b/packages/api/src/routers/api/webhooks.ts
@@ -17,7 +17,7 @@ import Webhook, { WebhookService } from '@/models/webhook';
 import {
   handleSendGenericWebhook,
   handleSendSlackWebhook,
-} from '@/tasks/checkAlerts/notifications';
+} from '@/tasks/checkAlerts/transports';
 import { isDuplicateKeyError } from '@/utils/errors';
 import {
   validateWebhookUrl,
@@ -470,13 +470,15 @@ router.post(
         eventId: 'test-event-id',
       };
 
+      const testChannel = { type: 'webhook' as const, channel: testWebhook };
+
       if (service === WebhookService.Slack) {
-        await handleSendSlackWebhook(testWebhook, testMessage);
+        await handleSendSlackWebhook(testChannel, testMessage);
       } else if (
         service === WebhookService.Generic ||
         service === WebhookService.IncidentIO
       ) {
-        await handleSendGenericWebhook(testWebhook, testMessage);
+        await handleSendGenericWebhook(testChannel, testMessage);
       } else {
         return res.status(400).json({
           message: 'Unsupported webhook service type',

--- a/packages/api/src/routers/api/webhooks.ts
+++ b/packages/api/src/routers/api/webhooks.ts
@@ -17,7 +17,7 @@ import Webhook, { WebhookService } from '@/models/webhook';
 import {
   handleSendGenericWebhook,
   handleSendSlackWebhook,
-} from '@/tasks/checkAlerts/template';
+} from '@/tasks/checkAlerts/notifications';
 import { isDuplicateKeyError } from '@/utils/errors';
 import {
   validateWebhookUrl,

--- a/packages/api/src/tasks/checkAlerts/__tests__/notifications.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/notifications.test.ts
@@ -1,0 +1,31 @@
+import { InlineNotificationDispatcher } from '@/tasks/checkAlerts/notifications';
+
+// The dispatcher forwards this opaque, so its shape doesn't matter for these
+// tests — only that dispatch()/shutdown() behave per the documented contract.
+const fakeJob: any = {};
+
+describe('InlineNotificationDispatcher', () => {
+  it('resolves after the deliver fn resolves', async () => {
+    const order: string[] = [];
+    const dispatcher = new InlineNotificationDispatcher(async () => {
+      order.push('delivered');
+    });
+    await dispatcher.dispatch(fakeJob);
+    order.push('dispatch-returned');
+    expect(order).toEqual(['delivered', 'dispatch-returned']);
+  });
+
+  it('propagates a delivery rejection to the caller', async () => {
+    const dispatcher = new InlineNotificationDispatcher(async () => {
+      throw new Error('webhook exploded');
+    });
+    await expect(dispatcher.dispatch(fakeJob)).rejects.toThrow(
+      'webhook exploded',
+    );
+  });
+
+  it('shutdown resolves immediately — nothing is buffered', async () => {
+    const dispatcher = new InlineNotificationDispatcher(async () => {});
+    await expect(dispatcher.shutdown(1000)).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/tasks/checkAlerts/errors.ts
+++ b/packages/api/src/tasks/checkAlerts/errors.ts
@@ -13,6 +13,18 @@ export class WebhookRedirectError extends Error {
   }
 }
 
+// Carries the destination's HTTP status alongside its response body so
+// callers can log/classify without an `as any` assertion on a plain Error.
+export class WebhookResponseError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'WebhookResponseError';
+    this.status = status;
+  }
+}
+
 // @clickhouse/client (Node) rejects with these exact messages when the
 // configured request_timeout elapses or the request is aborted. See
 // clickhouse-js packages/client-node/src/connection/socket_pool.ts.

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -66,6 +66,7 @@ import {
   WEBHOOK_REDIRECT_ERROR_MESSAGE,
   WebhookRedirectError,
 } from '@/tasks/checkAlerts/errors';
+import { handleSendGenericWebhook } from '@/tasks/checkAlerts/notifications';
 import {
   AlertDetails,
   AlertProvider,
@@ -76,7 +77,6 @@ import {
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
-  handleSendGenericWebhook,
   renderAlertTemplate,
 } from '@/tasks/checkAlerts/template';
 import { tasksTracer } from '@/tasks/tracer';

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -66,7 +66,6 @@ import {
   WEBHOOK_REDIRECT_ERROR_MESSAGE,
   WebhookRedirectError,
 } from '@/tasks/checkAlerts/errors';
-import { handleSendGenericWebhook } from '@/tasks/checkAlerts/notifications';
 import {
   AlertDetails,
   AlertProvider,
@@ -79,6 +78,7 @@ import {
   buildAlertMessageTemplateTitle,
   renderAlertTemplate,
 } from '@/tasks/checkAlerts/template';
+import { handleSendGenericWebhook } from '@/tasks/checkAlerts/transports';
 import { tasksTracer } from '@/tasks/tracer';
 import { CheckAlertsTaskArgs, HdxTask } from '@/tasks/types';
 import {

--- a/packages/api/src/tasks/checkAlerts/notifications.ts
+++ b/packages/api/src/tasks/checkAlerts/notifications.ts
@@ -1,0 +1,267 @@
+import { objectHash } from '@hyperdx/common-utils/dist/core/utils';
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import Handlebars from 'handlebars';
+import { performance } from 'perf_hooks';
+import { serializeError } from 'serialize-error';
+
+import { AlertState } from '@/models/alert';
+import { IWebhook } from '@/models/webhook';
+import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
+import { PopulatedAlertChannel } from '@/tasks/checkAlerts/providers';
+import { escapeJsonString } from '@/tasks/util';
+import { getCounter, getHistogram } from '@/utils/instrumentation';
+import logger from '@/utils/logger';
+import { withRetry } from '@/utils/retry';
+import * as slack from '@/utils/slack';
+import {
+  validateWebhookUrl,
+  WebhookUrlValidationError,
+} from '@/utils/validators';
+
+// Webhook delivery is the last (and most failure-prone) hop of an alert. It
+// happens in the background task, so failures only show up in logs today.
+// `service` and `outcome` are bounded enums (see agent_docs/observability.md).
+const webhookDeliveryCounter = getCounter('hyperdx.alerts.webhook_deliveries', {
+  description:
+    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, error).',
+});
+const webhookDeliveryDuration = getHistogram(
+  'hyperdx.alerts.webhook_delivery.duration_ms',
+  {
+    description:
+      'Duration of an alert webhook delivery attempt, labeled by service.',
+    unit: 'ms',
+  },
+);
+
+const logBlockedWebhookDelivery = (error: unknown, webhook: IWebhook) => {
+  if (error instanceof WebhookUrlValidationError) {
+    logger.warn(
+      {
+        error: serializeError(error),
+        webhook: {
+          id: webhook._id.toString(),
+          team: webhook.team.toString(),
+        },
+      },
+      'Blocked alert webhook delivery',
+    );
+  }
+};
+
+// Fallback body for a generic/incidentio webhook persisted without one. Mirrors
+// the default template the UI form applies (WebhookForm.tsx) so a webhook
+// created via the API/MCP (where body is optional) still fires with a sensible
+// payload instead of crashing Handlebars.compile on an undefined template.
+const DEFAULT_GENERIC_WEBHOOK_BODY_TEMPLATE =
+  '{"text": "{{title}} | {{body}} | {{link}} | {{state}} | {{startTime}} | {{endTime}} | {{eventId}}"}';
+
+/**
+ * Creates a Handlebars instance with common helpers registered.
+ * Use this to ensure consistent helper availability across all template rendering.
+ */
+export const createHandlebarsWithHelpers = () => {
+  const hb = Handlebars.create();
+  // Register eq helper for conditional checks (e.g., {{#if (eq state "ALERT")}})
+  hb.registerHelper('eq', (a, b) => a === b);
+  return hb;
+};
+
+export interface Message {
+  hdxLink: string;
+  title: string;
+  body: string;
+  state: AlertState;
+  startTime: number;
+  endTime: number;
+  eventId: string;
+}
+
+export const notifyChannel = async ({
+  channel,
+  message,
+}: {
+  channel: PopulatedAlertChannel;
+  message: Message;
+}) => {
+  switch (channel.type) {
+    case 'webhook': {
+      const webhook = channel.channel;
+      // TODO: migrate to use handleSendGenericWebhook so templates can be used
+      if (webhook.service === WebhookService.Slack) {
+        await handleSendSlackWebhook(webhook, message);
+      } else if (
+        webhook.service === WebhookService.Generic ||
+        webhook.service === WebhookService.IncidentIO
+      ) {
+        await handleSendGenericWebhook(webhook, message);
+      }
+      break;
+    }
+    default:
+      throw new Error(`Unsupported channel type: ${channel.type}`);
+  }
+};
+
+export const handleSendSlackWebhook = async (
+  webhook: IWebhook,
+  message: Message,
+) => {
+  const startedAt = performance.now();
+  try {
+    validateWebhookUrl(webhook);
+
+    await slack.postMessageToWebhook(webhook.url, {
+      text: message.title,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
+          },
+        },
+      ],
+    });
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'success',
+    });
+  } catch (e) {
+    logBlockedWebhookDelivery(e, webhook);
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'error',
+    });
+    throw e;
+  } finally {
+    webhookDeliveryDuration.record(performance.now() - startedAt, {
+      service: WebhookService.Slack,
+    });
+  }
+};
+
+export const handleSendGenericWebhook = async (
+  webhook: IWebhook,
+  message: Message,
+) => {
+  const startedAt = performance.now();
+  // webhook.service is an enum, so it is safe as a low-cardinality label.
+  const service = webhook.service ?? WebhookService.Generic;
+  try {
+    await sendGenericWebhook(webhook, message);
+    webhookDeliveryCounter.add(1, { service, outcome: 'success' });
+  } catch (e) {
+    logBlockedWebhookDelivery(e, webhook);
+    webhookDeliveryCounter.add(1, { service, outcome: 'error' });
+    throw e;
+  } finally {
+    webhookDeliveryDuration.record(performance.now() - startedAt, { service });
+  }
+};
+
+const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
+  validateWebhookUrl(webhook);
+
+  let url: string;
+  // user input of queryParams is disabled on the frontend for now
+  if (webhook.queryParams) {
+    // user may have included params in both the url and the query params
+    // so they should be merged
+    const tmpURL = new URL(webhook.url);
+    for (const [key, value] of Object.entries(webhook.queryParams.toJSON())) {
+      tmpURL.searchParams.append(key, value);
+    }
+
+    url = tmpURL.toString();
+  } else {
+    // if there are no query params given, just use the url
+    url = webhook.url;
+  }
+
+  // HEADERS
+  // TODO: handle real webhook security and signage after v0
+  // X-HyperDX-Signature FROM PRIVATE SHA-256 HMAC, time based nonces, caching functionality etc
+
+  const headers = {
+    'Content-Type': 'application/json', // default, will be overwritten if user has set otherwise
+    ...(webhook.headers?.toJSON() ?? {}),
+    // Stable per-alert key for receivers that honour Idempotency-Key; delivery is at-least-once.
+    'Idempotency-Key': objectHash({
+      eventId: message.eventId,
+      startTime: message.startTime,
+      endTime: message.endTime,
+      state: message.state,
+    }),
+  };
+  // BODY
+  let body = '';
+  try {
+    const handlebars = createHandlebarsWithHelpers();
+
+    // Handlebars.compile throws on undefined; the API/MCP create paths allow an
+    // absent body (the UI form applies the default). An explicit "" is honored.
+    const bodyTemplate =
+      webhook.body == null
+        ? DEFAULT_GENERIC_WEBHOOK_BODY_TEMPLATE
+        : webhook.body;
+
+    body = handlebars.compile(bodyTemplate, {
+      noEscape: true,
+    })({
+      body: escapeJsonString(message.body),
+      endTime: message.endTime,
+      eventId: message.eventId,
+      link: escapeJsonString(message.hdxLink),
+      startTime: message.startTime,
+      state: message.state,
+      title: escapeJsonString(message.title),
+    });
+  } catch (e) {
+    logger.error(
+      {
+        error: serializeError(e),
+      },
+      'Failed to compile generic webhook body',
+    );
+    throw new Error('Failed to build webhook request body', { cause: e });
+  }
+
+  try {
+    await withRetry(async () => {
+      const res = await fetch(url, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: headers as Record<string, string>,
+        body,
+      });
+
+      // Disallow redirects to avoid redirect-based SSRF.
+      if (res.status >= 300 && res.status < 400) {
+        logger.error(
+          { webhookId: webhook._id.toString(), teamId: webhook.team },
+          'Webhook request was redirected, which is not allowed',
+        );
+        throw new WebhookRedirectError(res.status);
+      }
+
+      if (!res.ok) {
+        const errorText = await res.text();
+        const err = new Error(errorText) as any;
+        err.status = res.status;
+        throw err;
+      }
+
+      return res;
+    });
+  } catch (e) {
+    logger.error(
+      {
+        error: serializeError(e),
+      },
+      'Failed to send generic webhook message',
+    );
+    // rethrow so that it can be recorded in alert errors
+    throw e;
+  }
+};

--- a/packages/api/src/tasks/checkAlerts/notifications.ts
+++ b/packages/api/src/tasks/checkAlerts/notifications.ts
@@ -1,0 +1,70 @@
+import type {
+  Message,
+  PopulatedAlertChannel,
+} from '@/tasks/checkAlerts/transports';
+import { deliverToChannel } from '@/tasks/checkAlerts/transports';
+
+/**
+ * Alert notification dispatch seam.
+ *
+ * Evaluation produces fully rendered NotificationJobs; a NotificationDispatcher
+ * owns delivery. `eventId` is the idempotency key, so a queueing dispatcher can
+ * deduplicate without re-deriving it.
+ */
+export type NotificationJob = {
+  /** Idempotency key: objectHash(alertId, channel, group). */
+  eventId: string;
+  alertId?: string;
+  teamId?: string;
+  group?: string;
+  /**
+   * Named `populatedChannel`, not `channel`, deliberately: a downstream build
+   * carries both a serializable channel *reference* and the resolved document,
+   * and reusing `channel` for the resolved one collides with that.
+   */
+  populatedChannel: PopulatedAlertChannel;
+  message: Message;
+};
+
+export type NotificationDeliverFn = (job: NotificationJob) => Promise<void>;
+
+/**
+ * dispatch() contract: the inline implementation resolves after delivery, so
+ * errors propagate to the caller. Queueing implementations resolve after
+ * enqueue; their errors surface in their own logs and metrics.
+ */
+export interface NotificationDispatcher {
+  dispatch(job: NotificationJob): Promise<void>;
+  /** Flush anything pending, giving up after deadlineMs. */
+  shutdown(deadlineMs: number): Promise<void>;
+}
+
+/**
+ * The default delivery implementation, wired to the transports registry. A
+ * downstream dispatcher composes this rather than calling `deliverToChannel`
+ * directly, so it stays swappable in one place.
+ *
+ * @public
+ */
+export const deliverNotification: NotificationDeliverFn = async job => {
+  await deliverToChannel(job.populatedChannel, job.message, {
+    group: job.group,
+  });
+};
+
+/** Delivers synchronously so errors flow into the caller's executionErrors. */
+export class InlineNotificationDispatcher implements NotificationDispatcher {
+  constructor(private readonly deliver: NotificationDeliverFn) {}
+
+  async dispatch(job: NotificationJob): Promise<void> {
+    await this.deliver(job);
+  }
+
+  async shutdown(_deadlineMs: number): Promise<void> {
+    // Nothing buffered.
+  }
+}
+
+export const inlineNotificationDispatcher = new InlineNotificationDispatcher(
+  deliverNotification,
+);

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -29,14 +29,13 @@ import {
   doesExceedThreshold,
 } from '@/tasks/checkAlerts';
 import {
-  createHandlebarsWithHelpers,
-  Message,
-  notifyChannel,
-} from '@/tasks/checkAlerts/notifications';
-import {
   AlertProvider,
   PopulatedAlertChannel,
 } from '@/tasks/checkAlerts/providers';
+import {
+  createHandlebarsWithHelpers,
+  deliverToChannel,
+} from '@/tasks/checkAlerts/transports';
 import { unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
 import logger from '@/utils/logger';
@@ -183,7 +182,7 @@ export const buildAlertMessageTemplateHdxLink = (
     });
   }
 
-  throw new Error(`Unsupported alert source: ${(alert as any).source}`);
+  throw new Error(`Unsupported alert source: ${alert.source}`);
 };
 
 export const buildAlertMessageTemplateTitle = ({
@@ -231,7 +230,7 @@ export const buildAlertMessageTemplateTitle = ({
     return `${emoji}${baseTitle}`;
   }
 
-  throw new Error(`Unsupported alert source: ${(alert as any).source}`);
+  throw new Error(`Unsupported alert source: ${alert.source}`);
 };
 
 export const getDefaultExternalAction = (
@@ -400,9 +399,9 @@ export const renderAlertTemplate = async ({
           ...(view.isGroupedAlert && group ? { groupId: group } : {}),
         });
 
-        await notifyChannel({
+        await deliverToChannel(
           channel,
-          message: {
+          {
             hdxLink: buildAlertMessageTemplateHdxLink(alertProvider, view),
             title,
             body: renderedBody,
@@ -411,7 +410,8 @@ export const renderAlertTemplate = async ({
             endTime,
             eventId,
           },
-        });
+          { group },
+        );
       }
     });
   };
@@ -536,5 +536,5 @@ ${targetTemplate}`;
     return compiledTemplate(view);
   }
 
-  throw new Error(`Unsupported alert source: ${(alert as any).source}`);
+  throw new Error(`Unsupported alert source: ${alert.source}`);
 };

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -29,13 +29,15 @@ import {
   doesExceedThreshold,
 } from '@/tasks/checkAlerts';
 import {
+  inlineNotificationDispatcher,
+  NotificationDispatcher,
+  NotificationJob,
+} from '@/tasks/checkAlerts/notifications';
+import {
   AlertProvider,
   PopulatedAlertChannel,
 } from '@/tasks/checkAlerts/providers';
-import {
-  createHandlebarsWithHelpers,
-  deliverToChannel,
-} from '@/tasks/checkAlerts/transports';
+import { createHandlebarsWithHelpers } from '@/tasks/checkAlerts/transports';
 import { unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
 import logger from '@/utils/logger';
@@ -304,6 +306,7 @@ export const renderAlertTemplate = async ({
   title,
   view: inputView,
   teamWebhooksById,
+  dispatcher = inlineNotificationDispatcher,
 }: {
   alertProvider: AlertProvider;
   clickhouseClient: ClickhouseClient;
@@ -313,6 +316,7 @@ export const renderAlertTemplate = async ({
   title: string;
   view: AlertMessageTemplateDefaultView;
   teamWebhooksById: Map<string, IWebhook>;
+  dispatcher?: NotificationDispatcher;
 }) => {
   // Internal mutable view with __hdx_query_results__ populated on the
   // saved-search path. Untrusted values must flow through the view so
@@ -399,9 +403,12 @@ export const renderAlertTemplate = async ({
           ...(view.isGroupedAlert && group ? { groupId: group } : {}),
         });
 
-        await deliverToChannel(
-          channel,
-          {
+        const job: NotificationJob = {
+          eventId,
+          alertId: alert.id,
+          group,
+          populatedChannel: channel,
+          message: {
             hdxLink: buildAlertMessageTemplateHdxLink(alertProvider, view),
             title,
             body: renderedBody,
@@ -410,8 +417,9 @@ export const renderAlertTemplate = async ({
             endTime,
             eventId,
           },
-          { group },
-        );
+        };
+
+        await dispatcher.dispatch(job);
       }
     });
   };

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -10,12 +10,10 @@ import {
   isRangeThresholdType,
   pickSampleWeightExpressionProps,
   SourceKind,
-  WebhookService,
   zAlertChannelType,
 } from '@hyperdx/common-utils/dist/types';
 import Handlebars, { HelperOptions } from 'handlebars';
 import _ from 'lodash';
-import { performance } from 'perf_hooks';
 import PromisedHandlebars from 'promised-handlebars';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
@@ -30,52 +28,18 @@ import {
   computeAliasWithClauses,
   doesExceedThreshold,
 } from '@/tasks/checkAlerts';
-import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
+import {
+  createHandlebarsWithHelpers,
+  Message,
+  notifyChannel,
+} from '@/tasks/checkAlerts/notifications';
 import {
   AlertProvider,
   PopulatedAlertChannel,
 } from '@/tasks/checkAlerts/providers';
-import { escapeJsonString, unflattenObject } from '@/tasks/util';
+import { unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
-import { getCounter, getHistogram } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
-import { withRetry } from '@/utils/retry';
-import * as slack from '@/utils/slack';
-import {
-  validateWebhookUrl,
-  WebhookUrlValidationError,
-} from '@/utils/validators';
-
-// Webhook delivery is the last (and most failure-prone) hop of an alert. It
-// happens in the background task, so failures only show up in logs today.
-// `service` and `outcome` are bounded enums (see agent_docs/observability.md).
-const webhookDeliveryCounter = getCounter('hyperdx.alerts.webhook_deliveries', {
-  description:
-    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, error).',
-});
-const webhookDeliveryDuration = getHistogram(
-  'hyperdx.alerts.webhook_delivery.duration_ms',
-  {
-    description:
-      'Duration of an alert webhook delivery attempt, labeled by service.',
-    unit: 'ms',
-  },
-);
-
-const logBlockedWebhookDelivery = (error: unknown, webhook: IWebhook) => {
-  if (error instanceof WebhookUrlValidationError) {
-    logger.warn(
-      {
-        error: serializeError(error),
-        webhook: {
-          id: webhook._id.toString(),
-          team: webhook.team.toString(),
-        },
-      },
-      'Blocked alert webhook delivery',
-    );
-  }
-};
 
 const describeThresholdViolation = (
   thresholdType: AlertThresholdType,
@@ -133,24 +97,6 @@ const MAX_MESSAGE_LENGTH = 500;
 const NOTIFY_FN_NAME = '__hdx_notify_channel__';
 const IS_MATCH_FN_NAME = 'is_match';
 
-// Fallback body for a generic/incidentio webhook persisted without one. Mirrors
-// the default template the UI form applies (WebhookForm.tsx) so a webhook
-// created via the API/MCP (where body is optional) still fires with a sensible
-// payload instead of crashing Handlebars.compile on an undefined template.
-const DEFAULT_GENERIC_WEBHOOK_BODY_TEMPLATE =
-  '{"text": "{{title}} | {{body}} | {{link}} | {{state}} | {{startTime}} | {{endTime}} | {{eventId}}"}';
-
-/**
- * Creates a Handlebars instance with common helpers registered.
- * Use this to ensure consistent helper availability across all template rendering.
- */
-const createHandlebarsWithHelpers = () => {
-  const hb = Handlebars.create();
-  // Register eq helper for conditional checks (e.g., {{#if (eq state "ALERT")}})
-  hb.registerHelper('eq', (a, b) => a === b);
-  return hb;
-};
-
 const zNotifyFnParams = z.object({
   hash: z.object({
     channel: zAlertChannelType,
@@ -172,16 +118,6 @@ export type AlertMessageTemplateDefaultView = {
   startTime: Date;
   value: number;
 };
-
-interface Message {
-  hdxLink: string;
-  title: string;
-  body: string;
-  state: AlertState;
-  startTime: number;
-  endTime: number;
-  eventId: string;
-}
 
 export const isAlertResolved = (state?: AlertState): boolean => {
   return state === AlertState.OK;
@@ -212,195 +148,6 @@ export const formatValueToMatchThreshold = (
     maximumFractionDigits: decimalPlaces,
     useGrouping: false,
   }).format(value);
-};
-
-const notifyChannel = async ({
-  channel,
-  message,
-}: {
-  channel: PopulatedAlertChannel;
-  message: Message;
-}) => {
-  switch (channel.type) {
-    case 'webhook': {
-      const webhook = channel.channel;
-      // TODO: migrate to use handleSendGenericWebhook so templates can be used
-      if (webhook.service === WebhookService.Slack) {
-        await handleSendSlackWebhook(webhook, message);
-      } else if (
-        webhook.service === WebhookService.Generic ||
-        webhook.service === WebhookService.IncidentIO
-      ) {
-        await handleSendGenericWebhook(webhook, message);
-      }
-      break;
-    }
-    default:
-      throw new Error(`Unsupported channel type: ${channel.type}`);
-  }
-};
-
-export const handleSendSlackWebhook = async (
-  webhook: IWebhook,
-  message: Message,
-) => {
-  const startedAt = performance.now();
-  try {
-    validateWebhookUrl(webhook);
-
-    await slack.postMessageToWebhook(webhook.url, {
-      text: message.title,
-      blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
-          },
-        },
-      ],
-    });
-    webhookDeliveryCounter.add(1, {
-      service: WebhookService.Slack,
-      outcome: 'success',
-    });
-  } catch (e) {
-    logBlockedWebhookDelivery(e, webhook);
-    webhookDeliveryCounter.add(1, {
-      service: WebhookService.Slack,
-      outcome: 'error',
-    });
-    throw e;
-  } finally {
-    webhookDeliveryDuration.record(performance.now() - startedAt, {
-      service: WebhookService.Slack,
-    });
-  }
-};
-
-export const handleSendGenericWebhook = async (
-  webhook: IWebhook,
-  message: Message,
-) => {
-  const startedAt = performance.now();
-  // webhook.service is an enum, so it is safe as a low-cardinality label.
-  const service = webhook.service ?? WebhookService.Generic;
-  try {
-    await sendGenericWebhook(webhook, message);
-    webhookDeliveryCounter.add(1, { service, outcome: 'success' });
-  } catch (e) {
-    logBlockedWebhookDelivery(e, webhook);
-    webhookDeliveryCounter.add(1, { service, outcome: 'error' });
-    throw e;
-  } finally {
-    webhookDeliveryDuration.record(performance.now() - startedAt, { service });
-  }
-};
-
-const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
-  validateWebhookUrl(webhook);
-
-  let url: string;
-  // user input of queryParams is disabled on the frontend for now
-  if (webhook.queryParams) {
-    // user may have included params in both the url and the query params
-    // so they should be merged
-    const tmpURL = new URL(webhook.url);
-    for (const [key, value] of Object.entries(webhook.queryParams.toJSON())) {
-      tmpURL.searchParams.append(key, value);
-    }
-
-    url = tmpURL.toString();
-  } else {
-    // if there are no query params given, just use the url
-    url = webhook.url;
-  }
-
-  // HEADERS
-  // TODO: handle real webhook security and signage after v0
-  // X-HyperDX-Signature FROM PRIVATE SHA-256 HMAC, time based nonces, caching functionality etc
-
-  const headers = {
-    'Content-Type': 'application/json', // default, will be overwritten if user has set otherwise
-    ...(webhook.headers?.toJSON() ?? {}),
-    // Stable per-alert key for receivers that honour Idempotency-Key; delivery is at-least-once.
-    'Idempotency-Key': objectHash({
-      eventId: message.eventId,
-      startTime: message.startTime,
-      endTime: message.endTime,
-      state: message.state,
-    }),
-  };
-  // BODY
-  let body = '';
-  try {
-    const handlebars = createHandlebarsWithHelpers();
-
-    // Handlebars.compile throws on undefined; the API/MCP create paths allow an
-    // absent body (the UI form applies the default). An explicit "" is honored.
-    const bodyTemplate =
-      webhook.body == null
-        ? DEFAULT_GENERIC_WEBHOOK_BODY_TEMPLATE
-        : webhook.body;
-
-    body = handlebars.compile(bodyTemplate, {
-      noEscape: true,
-    })({
-      body: escapeJsonString(message.body),
-      endTime: message.endTime,
-      eventId: message.eventId,
-      link: escapeJsonString(message.hdxLink),
-      startTime: message.startTime,
-      state: message.state,
-      title: escapeJsonString(message.title),
-    });
-  } catch (e) {
-    logger.error(
-      {
-        error: serializeError(e),
-      },
-      'Failed to compile generic webhook body',
-    );
-    throw new Error('Failed to build webhook request body', { cause: e });
-  }
-
-  try {
-    await withRetry(async () => {
-      const res = await fetch(url, {
-        method: 'POST',
-        redirect: 'manual',
-        headers: headers as Record<string, string>,
-        body,
-      });
-
-      // Disallow redirects to avoid redirect-based SSRF.
-      if (res.status >= 300 && res.status < 400) {
-        logger.error(
-          { webhookId: webhook._id.toString(), teamId: webhook.team },
-          'Webhook request was redirected, which is not allowed',
-        );
-        throw new WebhookRedirectError(res.status);
-      }
-
-      if (!res.ok) {
-        const errorText = await res.text();
-        const err = new Error(errorText) as any;
-        err.status = res.status;
-        throw err;
-      }
-
-      return res;
-    });
-  } catch (e) {
-    logger.error(
-      {
-        error: serializeError(e),
-      },
-      'Failed to send generic webhook message',
-    );
-    // rethrow so that it can be recorded in alert errors
-    throw e;
-  }
 };
 
 export const buildAlertMessageTemplateHdxLink = (

--- a/packages/api/src/tasks/checkAlerts/transports/__tests__/registry.test.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/__tests__/registry.test.ts
@@ -1,0 +1,35 @@
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+
+import { deliverToChannel } from '@/tasks/checkAlerts/transports';
+import type { Message } from '@/tasks/checkAlerts/transports/types';
+
+const message: Message = {
+  hdxLink: 'https://example.test/alert',
+  title: 'title',
+  body: 'body',
+  state: 'ALERT' as Message['state'],
+  startTime: 0,
+  endTime: 1,
+  eventId: 'evt-1',
+};
+
+describe('deliverToChannel', () => {
+  it('throws on an unknown channel type', async () => {
+    await expect(
+      deliverToChannel({ type: 'carrier-pigeon' } as never, message, {}),
+    ).rejects.toThrow('Unsupported channel type: carrier-pigeon');
+  });
+
+  it('throws on an unknown webhook service', async () => {
+    await expect(
+      deliverToChannel(
+        {
+          type: 'webhook',
+          channel: { service: 'fax' as WebhookService } as never,
+        } as never,
+        message,
+        {},
+      ),
+    ).rejects.toThrow('Unsupported webhook service: fax');
+  });
+});

--- a/packages/api/src/tasks/checkAlerts/transports/generic.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/generic.ts
@@ -4,15 +4,19 @@ import Handlebars from 'handlebars';
 import { performance } from 'perf_hooks';
 import { serializeError } from 'serialize-error';
 
-import { AlertState } from '@/models/alert';
 import { IWebhook } from '@/models/webhook';
-import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
-import { PopulatedAlertChannel } from '@/tasks/checkAlerts/providers';
+import {
+  WebhookRedirectError,
+  WebhookResponseError,
+} from '@/tasks/checkAlerts/errors';
+import type {
+  Message,
+  WebhookChannel,
+} from '@/tasks/checkAlerts/transports/types';
 import { escapeJsonString } from '@/tasks/util';
 import { getCounter, getHistogram } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 import { withRetry } from '@/utils/retry';
-import * as slack from '@/utils/slack';
 import {
   validateWebhookUrl,
   WebhookUrlValidationError,
@@ -21,11 +25,14 @@ import {
 // Webhook delivery is the last (and most failure-prone) hop of an alert. It
 // happens in the background task, so failures only show up in logs today.
 // `service` and `outcome` are bounded enums (see agent_docs/observability.md).
-const webhookDeliveryCounter = getCounter('hyperdx.alerts.webhook_deliveries', {
-  description:
-    'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, error).',
-});
-const webhookDeliveryDuration = getHistogram(
+export const webhookDeliveryCounter = getCounter(
+  'hyperdx.alerts.webhook_deliveries',
+  {
+    description:
+      'Count of alert webhook delivery attempts, labeled by service (slack, generic, incidentio) and outcome (success, error).',
+  },
+);
+export const webhookDeliveryDuration = getHistogram(
   'hyperdx.alerts.webhook_delivery.duration_ms',
   {
     description:
@@ -34,7 +41,10 @@ const webhookDeliveryDuration = getHistogram(
   },
 );
 
-const logBlockedWebhookDelivery = (error: unknown, webhook: IWebhook) => {
+export const logBlockedWebhookDelivery = (
+  error: unknown,
+  webhook: IWebhook,
+) => {
   if (error instanceof WebhookUrlValidationError) {
     logger.warn(
       {
@@ -67,84 +77,26 @@ export const createHandlebarsWithHelpers = () => {
   return hb;
 };
 
-export interface Message {
-  hdxLink: string;
-  title: string;
-  body: string;
-  state: AlertState;
-  startTime: number;
-  endTime: number;
-  eventId: string;
-}
-
-export const notifyChannel = async ({
-  channel,
-  message,
-}: {
-  channel: PopulatedAlertChannel;
-  message: Message;
-}) => {
-  switch (channel.type) {
-    case 'webhook': {
-      const webhook = channel.channel;
-      // TODO: migrate to use handleSendGenericWebhook so templates can be used
-      if (webhook.service === WebhookService.Slack) {
-        await handleSendSlackWebhook(webhook, message);
-      } else if (
-        webhook.service === WebhookService.Generic ||
-        webhook.service === WebhookService.IncidentIO
-      ) {
-        await handleSendGenericWebhook(webhook, message);
-      }
-      break;
-    }
-    default:
-      throw new Error(`Unsupported channel type: ${channel.type}`);
-  }
-};
-
-export const handleSendSlackWebhook = async (
-  webhook: IWebhook,
-  message: Message,
-) => {
-  const startedAt = performance.now();
-  try {
-    validateWebhookUrl(webhook);
-
-    await slack.postMessageToWebhook(webhook.url, {
-      text: message.title,
-      blocks: [
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
-          },
-        },
-      ],
-    });
-    webhookDeliveryCounter.add(1, {
-      service: WebhookService.Slack,
-      outcome: 'success',
-    });
-  } catch (e) {
-    logBlockedWebhookDelivery(e, webhook);
-    webhookDeliveryCounter.add(1, {
-      service: WebhookService.Slack,
-      outcome: 'error',
-    });
-    throw e;
-  } finally {
-    webhookDeliveryDuration.record(performance.now() - startedAt, {
-      service: WebhookService.Slack,
-    });
-  }
+/**
+ * Bounds a single attempt so a black-holed receiver releases its socket. Read
+ * lazily, not as a module const, so integration tests can override per suite.
+ *
+ * Not wired into the `fetch()` call below yet — a follow-up task threads it
+ * through as an `AbortSignal`. Exported now as part of the transport
+ * registry's public surface (see `ChannelTransport`'s `signal` field).
+ *
+ * @public
+ */
+export const getWebhookFetchTimeoutMs = () => {
+  const parsed = Number(process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30_000;
 };
 
 export const handleSendGenericWebhook = async (
-  webhook: IWebhook,
+  channel: WebhookChannel,
   message: Message,
 ) => {
+  const webhook = channel.channel;
   const startedAt = performance.now();
   // webhook.service is an enum, so it is safe as a low-cardinality label.
   const service = webhook.service ?? WebhookService.Generic;
@@ -158,6 +110,24 @@ export const handleSendGenericWebhook = async (
   } finally {
     webhookDeliveryDuration.record(performance.now() - startedAt, { service });
   }
+};
+
+// `webhook.headers` is a Mongoose map; `.toJSON()` types as a plain object or
+// a `Map` depending on how it's called (see IWebhook), and the schema
+// restricts values to strings, but nothing enforces that at the type level.
+// Narrow explicitly instead of asserting so a stray non-string value is
+// dropped rather than sent as `[object Object]`. A real `Map` yields no
+// entries here, matching how `Object.entries`/spread already treat one (its
+// data lives outside its own enumerable properties).
+const toStringHeaderRecord = (value: unknown): Record<string, string> => {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
 };
 
 const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
@@ -183,9 +153,9 @@ const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
   // TODO: handle real webhook security and signage after v0
   // X-HyperDX-Signature FROM PRIVATE SHA-256 HMAC, time based nonces, caching functionality etc
 
-  const headers = {
+  const headers: Record<string, string> = {
     'Content-Type': 'application/json', // default, will be overwritten if user has set otherwise
-    ...(webhook.headers?.toJSON() ?? {}),
+    ...toStringHeaderRecord(webhook.headers?.toJSON()),
     // Stable per-alert key for receivers that honour Idempotency-Key; delivery is at-least-once.
     'Idempotency-Key': objectHash({
       eventId: message.eventId,
@@ -232,7 +202,7 @@ const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
       const res = await fetch(url, {
         method: 'POST',
         redirect: 'manual',
-        headers: headers as Record<string, string>,
+        headers,
         body,
       });
 
@@ -247,9 +217,7 @@ const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
 
       if (!res.ok) {
         const errorText = await res.text();
-        const err = new Error(errorText) as any;
-        err.status = res.status;
-        throw err;
+        throw new WebhookResponseError(errorText, res.status);
       }
 
       return res;

--- a/packages/api/src/tasks/checkAlerts/transports/index.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/index.ts
@@ -1,0 +1,64 @@
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+
+import { handleSendGenericWebhook } from './generic';
+import { handleSendSlackWebhook } from './slack';
+import type { ChannelTransport, WebhookTransport } from './types';
+
+export { createHandlebarsWithHelpers } from './generic';
+/** @public */
+export { getWebhookFetchTimeoutMs } from './generic';
+export { handleSendGenericWebhook } from './generic';
+export { handleSendSlackWebhook } from './slack';
+export * from './types';
+
+/**
+ * Webhook services registered against a transport. A downstream build adds a
+ * new `WebhookService` here rather than editing `deliverWebhook`'s dispatch.
+ *
+ * @public
+ */
+export const webhookTransports: Partial<
+  Record<WebhookService, WebhookTransport>
+> = {
+  [WebhookService.Slack]: handleSendSlackWebhook,
+  [WebhookService.Generic]: handleSendGenericWebhook,
+  [WebhookService.IncidentIO]: handleSendGenericWebhook,
+};
+
+const deliverWebhook: ChannelTransport = async (channel, message, ctx) => {
+  if (channel.type !== 'webhook') {
+    throw new Error(`Unsupported channel type: ${channel.type}`);
+  }
+  const transport =
+    webhookTransports[channel.channel.service ?? WebhookService.Generic];
+  if (!transport) {
+    throw new Error(
+      `Unsupported webhook service: ${channel.channel.service ?? WebhookService.Generic}`,
+    );
+  }
+  await transport(channel, message, ctx.signal);
+};
+
+/**
+ * Channel type is the first key and webhook service the second. OSS has one
+ * channel type today, so the indirection looks unnecessary — it is what lets a
+ * downstream build add a whole channel type (EE's email) as one entry instead
+ * of patching the delivery path.
+ *
+ * @public
+ */
+export const channelTransports: Record<string, ChannelTransport> = {
+  webhook: deliverWebhook,
+};
+
+export const deliverToChannel: ChannelTransport = async (
+  channel,
+  message,
+  ctx,
+) => {
+  const transport = channelTransports[channel.type];
+  if (!transport) {
+    throw new Error(`Unsupported channel type: ${channel.type}`);
+  }
+  await transport(channel, message, ctx);
+};

--- a/packages/api/src/tasks/checkAlerts/transports/slack.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/slack.ts
@@ -1,0 +1,53 @@
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import { performance } from 'perf_hooks';
+
+import {
+  logBlockedWebhookDelivery,
+  webhookDeliveryCounter,
+  webhookDeliveryDuration,
+} from '@/tasks/checkAlerts/transports/generic';
+import type {
+  Message,
+  WebhookChannel,
+} from '@/tasks/checkAlerts/transports/types';
+import * as slack from '@/utils/slack';
+import { validateWebhookUrl } from '@/utils/validators';
+
+export const handleSendSlackWebhook = async (
+  channel: WebhookChannel,
+  message: Message,
+) => {
+  const webhook = channel.channel;
+  const startedAt = performance.now();
+  try {
+    validateWebhookUrl(webhook);
+
+    await slack.postMessageToWebhook(webhook.url, {
+      text: message.title,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*<${message.hdxLink} | ${message.title}>*\n${message.body}`,
+          },
+        },
+      ],
+    });
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'success',
+    });
+  } catch (e) {
+    logBlockedWebhookDelivery(e, webhook);
+    webhookDeliveryCounter.add(1, {
+      service: WebhookService.Slack,
+      outcome: 'error',
+    });
+    throw e;
+  } finally {
+    webhookDeliveryDuration.record(performance.now() - startedAt, {
+      service: WebhookService.Slack,
+    });
+  }
+};

--- a/packages/api/src/tasks/checkAlerts/transports/types.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/types.ts
@@ -1,0 +1,38 @@
+import { AlertState } from '@/models/alert';
+import type { PopulatedAlertChannel } from '@/tasks/checkAlerts/providers';
+
+// Re-exported so consumers import channel types from one place.
+export type { PopulatedAlertChannel };
+
+export interface Message {
+  hdxLink: string;
+  title: string;
+  body: string;
+  state: AlertState;
+  startTime: number;
+  endTime: number;
+  eventId: string;
+}
+
+export type WebhookChannel = Extract<
+  PopulatedAlertChannel,
+  { type: 'webhook' }
+>;
+
+/** Sends one rendered message over one webhook service. Rejections mean delivery failed. */
+export type WebhookTransport = (
+  channel: WebhookChannel,
+  message: Message,
+  signal?: AbortSignal,
+) => Promise<void>;
+
+/**
+ * Sends one rendered message to one channel type. Keyed on channel type, not
+ * webhook service, so a new channel type is an added entry rather than an edit
+ * to the delivery switch.
+ */
+export type ChannelTransport = (
+  channel: PopulatedAlertChannel,
+  message: Message,
+  ctx: { group?: string; signal?: AbortSignal },
+) => Promise<void>;


### PR DESCRIPTION
## Why

Notification delivery was a single `if/else` chain over `WebhookService`. Adding a new webhook service meant editing that chain; adding a whole new *channel type* meant editing it and everything around it.

This replaces the chain with a registry keyed on **channel type first, webhook service second**, so both kinds of extension become an added entry rather than an edit to shared code.

The double keying looks like unnecessary indirection given this repo has exactly one channel type today. That is deliberate and is the point of the change — it is the seam a downstream build extends without touching these lines. There is a comment in `transports/index.ts` saying so, aimed at the next person tempted to flatten it.

## What changed

- `checkAlerts/notifications.ts` is split into `checkAlerts/transports/{types,slack,generic,index}.ts` and deleted. The name is deliberately freed — a follow-up PR reuses it for the notification job and dispatcher contract, which is a different concern entirely.
- New `deliverToChannel(channel, message, ctx)` resolves channel type then webhook service, throwing `Unsupported channel type: <t>` / `Unsupported webhook service: <s>`.
- Webhook transports now take the populated channel rather than a bare `IWebhook`, so a transport can read per-channel fields without a signature change later.
- `WebhookResponseError` carries the destination's HTTP status, replacing an `as any` on a plain `Error`. `retry.ts` reads `.status` unchanged.

## Not a behaviour change

`checkAlerts.int.test.ts` (277) and `renderAlertTemplate.int.test.ts` (74) pass **unmodified** — that is the gate. `webhooks.int.test.ts` needed 3 assertion updates (`.calls[0][0].url` -> `.channel.url`), a direct consequence of the transport signature.

`getWebhookFetchTimeoutMs` is exported without a caller: the fetch wiring arrives with the PR that removes the per-event deadline, and landing it here would change behaviour this PR is asserting it does not change.