### PR TITLE
feat(alerts): model and schema groundwork for multiple notification channels

### DIFF
--- a/.changeset/alert-multi-channel-schemas.md
+++ b/.changeset/alert-multi-channel-schemas.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/common-utils': minor
+---
+
+Add plural alert notification channel schemas: `zAlertChannels` (1–10 entries), `MAX_ALERT_CHANNELS`, and a shared `channel`/`channels` cross-field validator, ahead of multi-channel alert support in the API.

--- a/packages/api/src/controllers/__tests__/alerts.test.ts
+++ b/packages/api/src/controllers/__tests__/alerts.test.ts
@@ -1,0 +1,31 @@
+import { makeAlert } from '@/controllers/alerts';
+import { AlertChannel, AlertThresholdType } from '@/models/alert';
+
+// A channel type this repo doesn't define -- see
+// models/__tests__/alert.test.ts for why. `value: any` (rather than an `as`
+// cast) keeps this off the no-unsafe-type-assertion budget while still
+// producing a value typed as AlertChannel for the call below.
+const foreignChannel = (value: any): AlertChannel => value;
+
+describe('makeAlert', () => {
+  // makeAlert mirrors channels[0] into `channel` for readers that predate
+  // multi-channel support. That mirroring must stay opaque: a downstream
+  // fork's channel types must survive verbatim, not get projected onto
+  // webhook-shaped fields.
+  it('mirrors channels[0] into channel verbatim, preserving fields this repo does not define', () => {
+    const exotic = foreignChannel({
+      type: 'email',
+      emailRecipients: ['ops@example.test'],
+    });
+
+    const result = makeAlert({
+      interval: '5m',
+      threshold: 1,
+      thresholdType: AlertThresholdType.ABOVE,
+      channels: [exotic],
+    });
+
+    expect(result.channel).toEqual(exotic);
+    expect(result.channels).toEqual([exotic]);
+  });
+});

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -129,7 +129,12 @@ export const validateAlertInput = async (
   }
 };
 
-const makeAlert = (alert: AlertInput, userId?: ObjectId): Partial<IAlert> => {
+// Exported for unit testing the channel-mirroring invariant (see
+// controllers/__tests__/alerts.test.ts) -- otherwise only used internally.
+export const makeAlert = (
+  alert: AlertInput,
+  userId?: ObjectId,
+): Partial<IAlert> => {
   // Preserve existing DB value when scheduleStartAt is omitted from updates
   // (undefined), while still allowing explicit clears via null.
   const hasScheduleStartAt = alert.scheduleStartAt !== undefined;

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -7,7 +7,12 @@ import { groupBy } from 'lodash';
 import { z } from 'zod';
 
 import type { ObjectId } from '@/models';
-import Alert, { AlertSource, IAlert } from '@/models/alert';
+import Alert, {
+  AlertChannel,
+  AlertSource,
+  getAlertChannels,
+  IAlert,
+} from '@/models/alert';
 import Dashboard, { IDashboard } from '@/models/dashboard';
 import { ISavedSearch, SavedSearch } from '@/models/savedSearch';
 import { IUser } from '@/models/user';
@@ -18,6 +23,7 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
 export type AlertInput = Omit<
   IAlert,
   | 'id'
+  | 'channel'
   | 'scheduleStartAt'
   | 'savedSearchId'
   | 'createdAt'
@@ -27,6 +33,9 @@ export type AlertInput = Omit<
   | 'state'
 > & {
   id?: string;
+  // Exactly one of channel/channels is provided (enforced by alertSchema);
+  // `channels` flows in optionally via IAlert.
+  channel?: AlertChannel;
   // Replace the Date-type fields from IAlert
   scheduleStartAt?: string | null;
   // Replace the ObjectId-type fields from IAlert
@@ -44,7 +53,12 @@ export const validateAlertInput = async (
   teamId: ObjectId,
   alertInput: Pick<
     AlertInput,
-    'source' | 'dashboardId' | 'tileId' | 'savedSearchId' | 'channel'
+    | 'source'
+    | 'dashboardId'
+    | 'tileId'
+    | 'savedSearchId'
+    | 'channel'
+    | 'channels'
   >,
 ) => {
   if (alertInput.source === AlertSource.TILE) {
@@ -94,17 +108,24 @@ export const validateAlertInput = async (
     }
   }
 
-  if (alertInput.channel.type === 'webhook') {
-    validateObjectId(alertInput.channel.webhookId, 'Invalid webhook ID');
+  const channels = getAlertChannels(alertInput);
+  if (channels.length === 0) {
+    throw new Api400Error('At least one notification channel is required');
+  }
 
-    if (
-      (await Webhook.findOne({
-        _id: alertInput.channel.webhookId,
-        team: teamId,
-      })) == null
-    ) {
-      throw new Api400Error('Webhook not found');
-    }
+  const webhookIds = channels
+    .filter(c => c.type === 'webhook')
+    .map(c => c.webhookId);
+  for (const webhookId of webhookIds) {
+    validateObjectId(webhookId, 'Invalid webhook ID');
+  }
+  const uniqueIds = [...new Set(webhookIds)];
+  const found = await Webhook.countDocuments({
+    _id: { $in: uniqueIds },
+    team: teamId,
+  });
+  if (found !== uniqueIds.length) {
+    throw new Api400Error('Webhook not found');
   }
 };
 
@@ -124,9 +145,14 @@ const makeAlert = (alert: AlertInput, userId?: ObjectId): Partial<IAlert> => {
         : alert.scheduleOffsetMinutes;
   const isSavedSearch = alert.source === AlertSource.SAVED_SEARCH;
   const isTile = alert.source === AlertSource.TILE;
+  const channels = getAlertChannels(alert);
 
   return {
-    channel: alert.channel,
+    // `channels` is canonical; `channel` mirrors channels[0] so readers that
+    // predate multi-channel support (older task runners mid-rollout) still
+    // notify the first target.
+    channel: channels[0] ?? { type: null },
+    channels,
     interval: alert.interval,
     ...(normalizedScheduleOffsetMinutes != null && {
       scheduleOffsetMinutes: normalizedScheduleOffsetMinutes,

--- a/packages/api/src/models/__tests__/alert.test.ts
+++ b/packages/api/src/models/__tests__/alert.test.ts
@@ -1,0 +1,23 @@
+import { getAlertChannels } from '@/models/alert';
+
+describe('getAlertChannels', () => {
+  const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+  it('prefers the channels array when present', () => {
+    expect(
+      getAlertChannels({ channel: wh('legacy'), channels: [wh('a'), wh('b')] }),
+    ).toEqual([wh('a'), wh('b')]);
+  });
+
+  it('falls back to the legacy singular channel', () => {
+    expect(getAlertChannels({ channel: wh('legacy') })).toEqual([wh('legacy')]);
+    expect(getAlertChannels({ channel: wh('legacy'), channels: [] })).toEqual([
+      wh('legacy'),
+    ]);
+  });
+
+  it('returns empty for null-type or missing channels', () => {
+    expect(getAlertChannels({ channel: { type: null } })).toEqual([]);
+    expect(getAlertChannels({})).toEqual([]);
+  });
+});

--- a/packages/api/src/models/__tests__/alert.test.ts
+++ b/packages/api/src/models/__tests__/alert.test.ts
@@ -1,4 +1,10 @@
-import { getAlertChannels } from '@/models/alert';
+import { AlertChannel, getAlertChannels } from '@/models/alert';
+
+// A channel type this repo doesn't define -- e.g. a downstream fork's email
+// channel carrying an `emailRecipients` array. `value: any` (rather than an
+// `as` cast) keeps this off the no-unsafe-type-assertion budget while still
+// producing a value typed as AlertChannel for the calls below.
+const foreignChannel = (value: any): AlertChannel => value;
 
 describe('getAlertChannels', () => {
   const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
@@ -19,5 +25,26 @@ describe('getAlertChannels', () => {
   it('returns empty for null-type or missing channels', () => {
     expect(getAlertChannels({ channel: { type: null } })).toEqual([]);
     expect(getAlertChannels({})).toEqual([]);
+  });
+
+  // The invariant guard: this repo only defines webhook channels, but a
+  // downstream fork adds others. getAlertChannels must copy them by
+  // reference, not project them onto webhook-shaped fields.
+  it('copies a channels[] entry opaquely, preserving fields this repo does not define', () => {
+    const exotic = foreignChannel({
+      type: 'email',
+      emailRecipients: ['ops@example.test'],
+    });
+
+    expect(getAlertChannels({ channels: [exotic] })).toEqual([exotic]);
+  });
+
+  it('copies the legacy singular channel opaquely when it is a foreign type', () => {
+    const exotic = foreignChannel({
+      type: 'email',
+      emailRecipients: ['ops@example.test'],
+    });
+
+    expect(getAlertChannels({ channel: exotic })).toEqual([exotic]);
   });
 });

--- a/packages/api/src/models/alert.ts
+++ b/packages/api/src/models/alert.ts
@@ -50,6 +50,24 @@ export type AlertChannel =
       type: null;
     };
 
+/**
+ * Resolve an alert's notification channels regardless of document vintage:
+ * documents written before multi-channel support only have the singular
+ * `channel`. Writers keep `channel` mirrored to `channels[0]`.
+ */
+export const getAlertChannels = (alert: {
+  channel?: AlertChannel | null;
+  channels?: AlertChannel[] | null;
+}): AlertChannel[] => {
+  if (alert.channels != null && alert.channels.length > 0) {
+    return alert.channels;
+  }
+  if (alert.channel != null && alert.channel.type != null) {
+    return [alert.channel];
+  }
+  return [];
+};
+
 export enum AlertSource {
   SAVED_SEARCH = 'saved_search',
   TILE = 'tile',
@@ -58,6 +76,7 @@ export enum AlertSource {
 export interface IAlert {
   id: string;
   channel: AlertChannel;
+  channels?: AlertChannel[];
   interval: AlertInterval;
   scheduleOffsetMinutes?: number;
   scheduleStartAt?: Date | null;
@@ -146,6 +165,10 @@ const AlertSchema = new Schema<IAlert>(
       required: false,
     },
     channel: Schema.Types.Mixed, // slack, email, etc
+    // Canonical list of notification channels. `channel` above is kept in
+    // sync (first entry) so pre-multi-channel readers keep working.
+    // `default: undefined` stops Mongoose materialising [] on old documents.
+    channels: { type: [Schema.Types.Mixed], default: undefined },
     state: {
       type: String,
       enum: AlertState,

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -263,6 +263,65 @@ describe('dashboard router', () => {
     expect(storedAlert?.groupBy).toBeNull();
   });
 
+  // A tile alert must always end up with a resolvable notification target.
+  // Making `channel` optional briefly let a channels-only tile alert through
+  // this path and persist with nothing to notify.
+  it('persists a resolvable target for a channels-only tile alert', async () => {
+    const dashboard = await agent
+      .post('/dashboards')
+      .send({
+        name: 'Test Dashboard',
+        tiles: [
+          makeTile({
+            alert: {
+              channels: [
+                { type: 'webhook' as const, webhookId: webhook._id.toString() },
+              ],
+              interval: '12h' as const,
+              threshold: 1,
+              thresholdType: AlertThresholdType.ABOVE,
+            },
+          }),
+        ],
+        tags: [],
+      })
+      .expect(200);
+
+    const storedAlert = await Alert.findOne({
+      team: team._id,
+      dashboard: dashboard.body.id,
+      source: AlertSource.TILE,
+    });
+    expect(storedAlert).not.toBeNull();
+    expect(storedAlert?.channels).toEqual([
+      { type: 'webhook', webhookId: webhook._id.toString() },
+    ]);
+    // The legacy mirror is what pre-multi-channel readers dispatch from.
+    expect(storedAlert?.channel).toEqual({
+      type: 'webhook',
+      webhookId: webhook._id.toString(),
+    });
+  });
+
+  it('rejects a tile alert with no notification channel', async () => {
+    await agent
+      .post('/dashboards')
+      .send({
+        name: 'Test Dashboard',
+        tiles: [
+          makeTile({
+            alert: {
+              interval: '12h' as const,
+              threshold: 1,
+              thresholdType: AlertThresholdType.ABOVE,
+            },
+          }),
+        ],
+        tags: [],
+      })
+      .expect(400);
+  });
+
   it('alerts are created when updating dashboard (adding alert to tile)', async () => {
     const mockAlert = makeMockAlert(webhook._id.toString());
     const dashboard = await agent

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -238,7 +238,7 @@ export const buildAlertMessageTemplateTitle = ({
 export const getDefaultExternalAction = (
   alert: AlertMessageTemplateDefaultView['alert'],
 ) => {
-  if (alert.channel.type === 'webhook' && alert.channel.webhookId != null) {
+  if (alert.channel?.type === 'webhook' && alert.channel.webhookId != null) {
     return `@${alert.channel.type}-${alert.channel.webhookId}`;
   }
   return null;

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -19,9 +19,12 @@ import {
   scheduleStartAtSchema,
   SearchConditionLanguageSchema as whereLanguageSchema,
   tagsSchema,
+  validateAlertChannelSelection,
   validateAlertScheduleOffsetMinutes,
   validateAlertThresholdMax,
   WebhookService,
+  zAlertChannel,
+  zAlertChannels,
 } from '@hyperdx/common-utils/dist/types';
 import { Types } from 'mongoose';
 import { z } from 'zod';
@@ -647,11 +650,6 @@ export const externalDashboardTileListSchema = z
 // ==============================
 // Alerts
 // ==============================
-const zChannel = z.object({
-  type: z.literal('webhook'),
-  webhookId: z.string().min(1),
-});
-
 const zSavedSearchAlert = z.object({
   source: z.literal(AlertSource.SAVED_SEARCH),
   groupBy: z.string().nullish(),
@@ -666,7 +664,8 @@ const zTileAlert = z.object({
 
 export const alertSchema = z
   .object({
-    channel: zChannel,
+    channel: zAlertChannel.optional(),
+    channels: zAlertChannels.optional(),
     interval: z.enum(['1m', '5m', '15m', '30m', '1h', '6h', '12h', '1d']),
     scheduleOffsetMinutes: z.number().int().min(0).max(1439).optional(),
     scheduleStartAt: scheduleStartAtSchema,
@@ -680,6 +679,7 @@ export const alertSchema = z
     numConsecutiveWindows: z.number().int().min(1).nullish(),
   })
   .and(zSavedSearchAlert.or(zTileAlert))
+  .superRefine(validateAlertChannelSelection)
   .superRefine(validateAlertScheduleOffsetMinutes)
   .superRefine(validateAlertThresholdMax);
 

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -588,7 +588,7 @@ export const DBSearchPageAlertModal = ({
             {(savedSearch?.alerts || []).map((alert, index) => (
               <Tabs.Tab key={alert.id} value={`${index}`}>
                 <Group gap="xs">
-                  {getWebhookChannelIcon(alert.channel.type)}
+                  {getWebhookChannelIcon(alert.channel?.type)}
                   Alert {index + 1}
                   <AlertStatusIcon alerts={[alert]} />
                 </Group>

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+  AlertSchema,
   MAX_ALERT_CHANNELS,
   SavedChartConfigSchema,
   validateAlertChannelSelection,
@@ -100,5 +101,45 @@ describe('tile alerts embedded in a saved chart config', () => {
         tile({ ...baseAlert, channel: { type: 'webhook', webhookId: 'w1' } }),
       ).success,
     ).toBe(true);
+  });
+});
+
+// The rule above is exercised through a hand-built RefinementCtx; these drive
+// it through a real parse, which is how the API actually reaches it.
+describe('AlertSchema channel selection', () => {
+  const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+  const savedSearchAlert = (channelFields: Record<string, unknown>) => ({
+    source: 'saved_search',
+    savedSearchId: '65f5e4a3b9e77c001a345678',
+    interval: '5m',
+    threshold: 1,
+    thresholdType: 'above',
+    ...channelFields,
+  });
+
+  const parse = (channelFields: Record<string, unknown>) =>
+    AlertSchema.safeParse(savedSearchAlert(channelFields)).success;
+
+  it('accepts either field alone, and both when they agree', () => {
+    expect(parse({ channel: wh('a') })).toBe(true);
+    expect(parse({ channels: [wh('a'), wh('b')] })).toBe(true);
+    expect(parse({ channel: wh('a'), channels: [wh('a'), wh('b')] })).toBe(
+      true,
+    );
+  });
+
+  it('rejects the invalid combinations', () => {
+    expect(parse({})).toBe(false);
+    expect(parse({ channel: wh('a'), channels: [wh('b')] })).toBe(false);
+    expect(parse({ channels: [wh('a'), wh('a')] })).toBe(false);
+    expect(parse({ channels: [] })).toBe(false);
+    expect(
+      parse({
+        channels: Array.from({ length: MAX_ALERT_CHANNELS + 1 }, (_, i) =>
+          wh(`w${i}`),
+        ),
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -34,11 +34,19 @@ describe('alert channel schemas', () => {
     ).toBe(false);
   });
 
-  it('requires exactly one of channel / channels', () => {
+  it('requires at least one of channel / channels', () => {
     expect(refine({ channel: wh('a') })).toHaveLength(0);
     expect(refine({ channels: [wh('a')] })).toHaveLength(0);
     expect(refine({})).toHaveLength(1);
+  });
+
+  // Responses carry both fields, so a GET-then-PUT client echoes both back.
+  it('accepts channel + channels when they agree, rejects a mismatch', () => {
+    expect(
+      refine({ channel: wh('a'), channels: [wh('a'), wh('b')] }),
+    ).toHaveLength(0);
     expect(refine({ channel: wh('a'), channels: [wh('b')] })).toHaveLength(1);
+    expect(refine({ channel: wh('a'), channels: [] })).toHaveLength(1);
   });
 
   it('rejects duplicate channels', () => {

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   MAX_ALERT_CHANNELS,
+  SavedChartConfigSchema,
   validateAlertChannelSelection,
   zAlertChannels,
 } from '@/types';
@@ -52,5 +53,52 @@ describe('alert channel schemas', () => {
   it('rejects duplicate channels', () => {
     expect(refine({ channels: [wh('a'), wh('a')] })).toHaveLength(1);
     expect(refine({ channels: [wh('a'), wh('b')] })).toHaveLength(0);
+  });
+});
+
+// Tile alerts are validated through the saved-chart-config schema, not the
+// API's alertSchema, so the "must have a target" rule has to hold here too --
+// an alert saved with no channel fires and notifies nobody.
+describe('tile alerts embedded in a saved chart config', () => {
+  const tile = (alert: Record<string, unknown>) => ({
+    name: 'Tile',
+    displayType: 'line',
+    connection: '65f5e4a3b9e77c001a789012',
+    source: '65f5e4a3b9e77c001a789013',
+    select: [],
+    where: '',
+    whereLanguage: 'lucene',
+    alert,
+  });
+
+  const baseAlert = {
+    threshold: 1,
+    thresholdType: 'above',
+    interval: '5m',
+  };
+
+  it('rejects a tile alert with no channel and no channels', () => {
+    expect(SavedChartConfigSchema.safeParse(tile(baseAlert)).success).toBe(
+      false,
+    );
+  });
+
+  it('accepts a tile alert with channels', () => {
+    expect(
+      SavedChartConfigSchema.safeParse(
+        tile({
+          ...baseAlert,
+          channels: [{ type: 'webhook', webhookId: 'w1' }],
+        }),
+      ).success,
+    ).toBe(true);
+  });
+
+  it('accepts a legacy tile alert with only the singular channel', () => {
+    expect(
+      SavedChartConfigSchema.safeParse(
+        tile({ ...baseAlert, channel: { type: 'webhook', webhookId: 'w1' } }),
+      ).success,
+    ).toBe(true);
   });
 });

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -55,6 +55,41 @@ describe('alert channel schemas', () => {
     expect(refine({ channels: [wh('a'), wh('a')] })).toHaveLength(1);
     expect(refine({ channels: [wh('a'), wh('b')] })).toHaveLength(0);
   });
+
+  // This repo only defines a webhook channel, but a downstream fork's wider
+  // union (e.g. an `email` variant with `emailRecipients`, no `webhookId`)
+  // must not collapse to the same key just because it's not webhook-shaped.
+  it('keys non-webhook-shaped channels on their full contents, not webhookId', () => {
+    const email = (recipients: string[]) => ({
+      type: 'email',
+      emailRecipients: recipients,
+    });
+
+    // Two distinct email channels both have `webhookId: undefined` -- a
+    // webhookId-based key would collide them as duplicates.
+    expect(
+      refine({ channels: [email(['a@x.com']), email(['b@x.com'])] }),
+    ).toHaveLength(0);
+    // A real duplicate (same recipients) is still caught.
+    expect(
+      refine({ channels: [email(['a@x.com']), email(['a@x.com'])] }),
+    ).toHaveLength(1);
+
+    // A genuine disagreement between `channel` and `channels[0]` must not
+    // read as agreement just because both are webhookId-less.
+    expect(
+      refine({
+        channel: email(['a@x.com']),
+        channels: [email(['b@x.com'])],
+      }),
+    ).toHaveLength(1);
+    expect(
+      refine({
+        channel: email(['a@x.com']),
+        channels: [email(['a@x.com'])],
+      }),
+    ).toHaveLength(0);
+  });
 });
 
 // Tile alerts are validated through the saved-chart-config schema, not the

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+import {
+  MAX_ALERT_CHANNELS,
+  validateAlertChannelSelection,
+  zAlertChannels,
+} from '@/types';
+
+const refine = (input: Parameters<typeof validateAlertChannelSelection>[0]) => {
+  const issues: z.ZodIssue[] = [];
+  const ctx = {
+    addIssue: (issue: z.ZodIssue) => issues.push(issue),
+    path: [],
+  } as unknown as z.RefinementCtx;
+  validateAlertChannelSelection(input, ctx);
+  return issues;
+};
+
+describe('alert channel schemas', () => {
+  const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+  it('zAlertChannels accepts 1..MAX_ALERT_CHANNELS entries', () => {
+    expect(zAlertChannels.safeParse([wh('a')]).success).toBe(true);
+    expect(
+      zAlertChannels.safeParse(
+        Array.from({ length: MAX_ALERT_CHANNELS }, (_, i) => wh(`w${i}`)),
+      ).success,
+    ).toBe(true);
+    expect(zAlertChannels.safeParse([]).success).toBe(false);
+    expect(
+      zAlertChannels.safeParse(
+        Array.from({ length: MAX_ALERT_CHANNELS + 1 }, (_, i) => wh(`w${i}`)),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('requires exactly one of channel / channels', () => {
+    expect(refine({ channel: wh('a') })).toHaveLength(0);
+    expect(refine({ channels: [wh('a')] })).toHaveLength(0);
+    expect(refine({})).toHaveLength(1);
+    expect(refine({ channel: wh('a'), channels: [wh('b')] })).toHaveLength(1);
+  });
+
+  it('rejects duplicate channels', () => {
+    expect(refine({ channels: [wh('a'), wh('a')] })).toHaveLength(1);
+    expect(refine({ channels: [wh('a'), wh('b')] })).toHaveLength(0);
+  });
+});

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -902,6 +902,20 @@ export const ChartAlertBaseSchema = AlertBaseObjectSchema.extend({
   threshold: z.number(),
 });
 
+// Tile alerts embedded in a saved chart config are validated through
+// SavedChartConfigSchema, not through the API's alertSchema, so the channel rule
+// has to be attached here as well. Without it, making `channel` optional would
+// let a tile alert be saved through the dashboards endpoint with no target at
+// all — it would fire and notify nobody. Only the channel rule is applied (not
+// the schedule/threshold refinements), so existing saved dashboards that never
+// passed those checks keep parsing.
+const AlertBaseChannelCheckedSchema = AlertBaseObjectSchema.superRefine(
+  validateAlertChannelSelection,
+);
+const ChartAlertBaseChannelCheckedSchema = ChartAlertBaseSchema.superRefine(
+  validateAlertChannelSelection,
+);
+
 const ChartAlertBaseValidatedSchema = ChartAlertBaseSchema.superRefine(
   validateAlertScheduleOffsetMinutes,
 )
@@ -1623,8 +1637,8 @@ const BuilderSavedChartConfigWithoutAlertSchema = z
 const BuilderSavedChartConfigSchema =
   BuilderSavedChartConfigWithoutAlertSchema.extend({
     alert: z.union([
-      AlertBaseSchema.optional(),
-      ChartAlertBaseSchema.optional(),
+      AlertBaseChannelCheckedSchema.optional(),
+      ChartAlertBaseChannelCheckedSchema.optional(),
     ]),
   });
 
@@ -1640,8 +1654,8 @@ const RawSqlSavedChartConfigWithoutAlertSchema =
 const RawSqlSavedChartConfigSchema =
   RawSqlSavedChartConfigWithoutAlertSchema.extend({
     alert: z.union([
-      AlertBaseSchema.optional(),
-      ChartAlertBaseSchema.optional(),
+      AlertBaseChannelCheckedSchema.optional(),
+      ChartAlertBaseChannelCheckedSchema.optional(),
     ]),
   });
 
@@ -1653,8 +1667,8 @@ const PromqlSavedChartConfigWithoutAlertSchema =
 const PromqlSavedChartConfigSchema =
   PromqlSavedChartConfigWithoutAlertSchema.extend({
     alert: z.union([
-      AlertBaseSchema.optional(),
-      ChartAlertBaseSchema.optional(),
+      AlertBaseChannelCheckedSchema.optional(),
+      ChartAlertBaseChannelCheckedSchema.optional(),
     ]),
   });
 

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1,3 +1,4 @@
+import objectHash from 'object-hash';
 import { z } from 'zod';
 
 // Basic Enums
@@ -710,13 +711,23 @@ export const zAlertChannels = z
     `An alert supports at most ${MAX_ALERT_CHANNELS} notification channels`,
   );
 
-const alertChannelKey = (channel: { type?: unknown; webhookId?: unknown }) =>
-  `${String(channel.type)}:${String(channel.webhookId)}`;
+/**
+ * Identifies a channel by its full contents, not just `type` + `webhookId`.
+ * Two channels of a type this repo doesn't define (e.g. a downstream fork's
+ * `email` channel) both key as `"email:undefined"` under a webhook-shaped
+ * key, so a legitimate pair reads as a duplicate and a genuine disagreement
+ * reads as agreement. Hashing the whole object avoids assuming any particular
+ * field set.
+ */
+export const alertChannelKey = (channel: Record<string, unknown>) =>
+  objectHash(channel);
 
 /**
- * Cross-field rule shared by every alert input schema (internal API, external
- * v2 API): at least one of the legacy singular `channel` or the plural
- * `channels` must be provided, and `channels` must not contain duplicates.
+ * Cross-field rule shared by every alert input schema in this repo (internal
+ * API, external v2 API) — the MCP tool schema has its own hand-rolled copy of
+ * this check, not this one: at least one of the legacy singular `channel` or
+ * the plural `channels` must be provided, and `channels` must not contain
+ * duplicates.
  *
  * Both may be sent together only when they agree — `channel` must equal
  * `channels[0]`. Responses carry both fields, so read-modify-write clients
@@ -726,8 +737,8 @@ const alertChannelKey = (channel: { type?: unknown; webhookId?: unknown }) =>
  */
 export const validateAlertChannelSelection = (
   alert: {
-    channel?: { type?: unknown; webhookId?: unknown } | null;
-    channels?: { type: string; webhookId: string }[];
+    channel?: Record<string, unknown> | null;
+    channels?: Record<string, unknown>[];
   },
   ctx: z.RefinementCtx,
 ) => {
@@ -756,7 +767,7 @@ export const validateAlertChannelSelection = (
       return;
     }
   }
-  const keys = (alert.channels ?? []).map(c => `${c.type}:${c.webhookId}`);
+  const keys = (alert.channels ?? []).map(alertChannelKey);
   if (new Set(keys).size !== keys.length) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -700,6 +700,48 @@ export const zAlertChannel = z.object({
   webhookId: z.string().nonempty("Webhook ID can't be empty"),
 });
 
+export const MAX_ALERT_CHANNELS = 10;
+
+export const zAlertChannels = z
+  .array(zAlertChannel)
+  .min(1, 'At least one notification channel is required')
+  .max(
+    MAX_ALERT_CHANNELS,
+    `An alert supports at most ${MAX_ALERT_CHANNELS} notification channels`,
+  );
+
+/**
+ * Cross-field rule shared by every alert input schema (internal API, external
+ * v2 API): exactly one of the legacy singular `channel` or the plural
+ * `channels` must be provided, and `channels` must not contain duplicates.
+ */
+export const validateAlertChannelSelection = (
+  alert: {
+    channel?: unknown;
+    channels?: { type: string; webhookId: string }[];
+  },
+  ctx: z.RefinementCtx,
+) => {
+  const hasChannel = alert.channel != null;
+  const hasChannels = alert.channels != null;
+  if (hasChannel === hasChannels) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['channels'],
+      message: 'Provide exactly one of "channel" or "channels"',
+    });
+    return;
+  }
+  const keys = (alert.channels ?? []).map(c => `${c.type}:${c.webhookId}`);
+  if (new Set(keys).size !== keys.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['channels'],
+      message: 'Duplicate notification channels are not allowed',
+    });
+  }
+};
+
 export const zSavedSearchAlert = z.object({
   source: z.literal(AlertSource.SAVED_SEARCH),
   groupBy: z.string().optional(),
@@ -806,7 +848,8 @@ export const AlertBaseObjectSchema = z.object({
   threshold: z.number(),
   thresholdType: z.nativeEnum(AlertThresholdType),
   thresholdMax: z.number().optional(),
-  channel: zAlertChannel,
+  channel: zAlertChannel.optional(),
+  channels: zAlertChannels.optional(),
   state: z.nativeEnum(AlertState).optional(),
   name: z.string().min(1).max(512).nullish(),
   message: z.string().min(1).max(4096).nullish(),
@@ -827,7 +870,9 @@ export const AlertBaseSchema = AlertBaseObjectSchema;
 
 const AlertBaseValidatedSchema = AlertBaseObjectSchema.superRefine(
   validateAlertScheduleOffsetMinutes,
-).superRefine(validateAlertThresholdMax);
+)
+  .superRefine(validateAlertThresholdMax)
+  .superRefine(validateAlertChannelSelection);
 
 export const ChartAlertBaseSchema = AlertBaseObjectSchema.extend({
   threshold: z.number(),
@@ -835,7 +880,9 @@ export const ChartAlertBaseSchema = AlertBaseObjectSchema.extend({
 
 const ChartAlertBaseValidatedSchema = ChartAlertBaseSchema.superRefine(
   validateAlertScheduleOffsetMinutes,
-).superRefine(validateAlertThresholdMax);
+)
+  .superRefine(validateAlertThresholdMax)
+  .superRefine(validateAlertChannelSelection);
 
 export const AlertSchema = z.union([
   z.intersection(AlertBaseValidatedSchema, zSavedSearchAlert),
@@ -2250,6 +2297,13 @@ export type AssistantResponseConfigSchema = z.infer<
 // --------------------------
 
 // Alerts
+// Looser than zAlertChannel: a page item echoes whatever was persisted, which
+// includes rows written before multi-channel that have a null type and no webhook.
+const alertsPageItemChannelSchema = z.object({
+  type: z.string().optional().nullable(),
+  webhookId: z.string().optional(),
+});
+
 export const AlertsPageItemSchema = z.object({
   _id: z.string(),
   interval: AlertIntervalSchema,
@@ -2258,10 +2312,8 @@ export const AlertsPageItemSchema = z.object({
   threshold: z.number(),
   thresholdMax: z.number().optional(),
   thresholdType: z.nativeEnum(AlertThresholdType),
-  channel: z.object({
-    type: z.string().optional().nullable(),
-    webhookId: z.string().optional(),
-  }),
+  channel: alertsPageItemChannelSchema,
+  channels: z.array(alertsPageItemChannelSchema).optional(),
   state: z.nativeEnum(AlertState).optional(),
   source: z.nativeEnum(AlertSource).optional(),
   dashboardId: z.string().optional(),

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -710,27 +710,51 @@ export const zAlertChannels = z
     `An alert supports at most ${MAX_ALERT_CHANNELS} notification channels`,
   );
 
+const alertChannelKey = (channel: { type?: unknown; webhookId?: unknown }) =>
+  `${String(channel.type)}:${String(channel.webhookId)}`;
+
 /**
  * Cross-field rule shared by every alert input schema (internal API, external
- * v2 API): exactly one of the legacy singular `channel` or the plural
+ * v2 API): at least one of the legacy singular `channel` or the plural
  * `channels` must be provided, and `channels` must not contain duplicates.
+ *
+ * Both may be sent together only when they agree — `channel` must equal
+ * `channels[0]`. Responses carry both fields, so read-modify-write clients
+ * echo both back untouched; rejecting that outright would break every
+ * GET-then-PUT caller. A genuine disagreement is still an error rather than a
+ * silent precedence rule, so no client can be surprised about which one won.
  */
 export const validateAlertChannelSelection = (
   alert: {
-    channel?: unknown;
+    channel?: { type?: unknown; webhookId?: unknown } | null;
     channels?: { type: string; webhookId: string }[];
   },
   ctx: z.RefinementCtx,
 ) => {
   const hasChannel = alert.channel != null;
   const hasChannels = alert.channels != null;
-  if (hasChannel === hasChannels) {
+  if (!hasChannel && !hasChannels) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['channels'],
-      message: 'Provide exactly one of "channel" or "channels"',
+      message: 'Provide either "channel" or "channels"',
     });
     return;
+  }
+  if (hasChannel && hasChannels) {
+    const first = alert.channels?.[0];
+    if (
+      first == null ||
+      alertChannelKey(alert.channel!) !== alertChannelKey(first)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['channels'],
+        message:
+          'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"',
+      });
+      return;
+    }
   }
   const keys = (alert.channels ?? []).map(c => `${c.type}:${c.webhookId}`);
   if (new Set(keys).size !== keys.length) {


### PR DESCRIPTION
Adds the shared Zod schemas and the Mongoose field that let an alert hold several notification channels instead of one. Nothing reads the new field yet.

## What changed

`zAlertChannels` (1 to `MAX_ALERT_CHANNELS`, currently 10) and a shared cross-field rule that both API layers chain into their alert input schemas. `channel` becomes optional on `AlertBaseObjectSchema`, with the new rule enforcing that an alert still has a target.

The Mongoose model gains a canonical `channels` array, and `getAlertChannels` resolves an alert's targets regardless of when the document was written.

## Key decisions

**`channels` is canonical, `channel` is kept and mirrored.** Storing both means a task runner from before this change still notifies the first target during a rolling upgrade, and a downgrade doesn't strand alerts. No data migration: `getAlertChannels` handles both vintages, and `default: undefined` stops Mongoose materialising an empty array on old documents.

**Both fields may be sent together when they agree.** The rule started as a strict exactly-one-of, but responses carry both fields, so any read-modify-write client would echo both back and get a 400 — the API's own response would not have been a valid request body. Sending both is now accepted when `channel` matches `channels[0]`, and a genuine disagreement is still rejected rather than resolved by a silent precedence rule.

**Only the channel rule is applied to tile alerts.** Tile alerts embedded in a saved chart config validate through `SavedChartConfigSchema` rather than the API's `alertSchema`, so the rule had to be attached there too. It deliberately does not pull in the schedule and threshold refinements, which have never run on that path — adding them could reject dashboards that parse today.

## Impact

Single-channel payloads remain valid unchanged. `channel` going optional required one defensive fix in the app (`alert.channel?.type`), where the helper already handled a missing value.

<details>
<summary>Implementation detail</summary>

`getAlertChannels` prefers a non-empty `channels`, falls back to `channel` when its type is non-null, and otherwise returns empty.

The tile-alert rule is pinned by a test that fails without it: `SavedChartConfigSchema` rejects a tile alert carrying neither field, and accepts both the plural and legacy-singular forms.

Verification: 1693 common-utils unit tests, 669 API unit tests, 265 dashboard integration tests.

</details>

