### PR TITLE
feat(api): accept and return multiple alert notification channels

### DIFF
--- a/.changeset/alert-multi-channel-api.md
+++ b/.changeset/alert-multi-channel-api.md
@@ -3,3 +3,5 @@
 ---
 
 Alerts can be configured with multiple notification channels (up to 10 webhooks) via the new `channels` field on the v2 external API, internal API, and the MCP `clickstack_save_alert` tool. The legacy singular `channel` field is still accepted on input and mirrored in responses, so existing integrations keep working unchanged.
+
+Note that alert updates are a full replace, not a merge. A client that sends only the legacy `channel` field when updating an alert that has several channels will reduce it to that one channel — fetch the alert and resend the complete `channels` array to preserve them.

--- a/.changeset/alert-multi-channel-api.md
+++ b/.changeset/alert-multi-channel-api.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': minor
+---
+
+Alerts can be configured with multiple notification channels (up to 10 webhooks) via the new `channels` field on the v2 external API, internal API, and the MCP `clickstack_save_alert` tool. The legacy singular `channel` field is still accepted on input and mirrored in responses, so existing integrations keep working unchanged.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -394,7 +394,7 @@
           },
           {
             "type": "object",
-            "description": "At least one of \"channel\" or \"channels\" must be provided. Sending both is allowed only when \"channel\" matches the first entry of \"channels\", so a response body can be echoed back unchanged. Responses always include both, with \"channel\" mirroring the first entry of \"channels\".\n",
+            "description": "At least one of \"channel\" or \"channels\" must be provided. Sending both is allowed only when \"channel\" matches the first entry of \"channels\", so a response body can be echoed back unchanged. Responses always include both, with \"channel\" mirroring the first entry of \"channels\". Updates replace the alert's configuration rather than merging it: sending only the legacy \"channel\" field for an alert that has several channels reduces it to that one channel. Fetch the alert and resend the complete \"channels\" array to preserve them.\n",
             "required": [
               "threshold",
               "interval",

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -204,6 +204,15 @@
           "propertyName": "type"
         }
       },
+      "AlertChannels": {
+        "type": "array",
+        "description": "Notification channels to trigger when the alert fires or resolves. Between 1 and 10 channels; duplicates are rejected.\n",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/AlertChannel"
+        }
+      },
       "Alert": {
         "type": "object",
         "properties": {
@@ -273,7 +282,11 @@
           },
           "channel": {
             "$ref": "#/components/schemas/AlertChannel",
-            "description": "Alert notification channel configuration."
+            "description": "First notification channel, mirrored from \"channels\" for pre-multi-channel clients."
+          },
+          "channels": {
+            "$ref": "#/components/schemas/AlertChannels",
+            "description": "All notification channels to trigger when the alert fires or resolves."
           },
           "name": {
             "type": "string",
@@ -365,11 +378,11 @@
           },
           {
             "type": "object",
+            "description": "At least one of \"channel\" or \"channels\" must be provided. Sending both is allowed only when \"channel\" matches the first entry of \"channels\", so a response body can be echoed back unchanged. Responses always include both, with \"channel\" mirroring the first entry of \"channels\".\n",
             "required": [
               "threshold",
               "interval",
-              "thresholdType",
-              "channel"
+              "thresholdType"
             ]
           }
         ]
@@ -381,11 +394,11 @@
           },
           {
             "type": "object",
+            "description": "At least one of \"channel\" or \"channels\" must be provided. Sending both is allowed only when \"channel\" matches the first entry of \"channels\", so a response body can be echoed back unchanged. Responses always include both, with \"channel\" mirroring the first entry of \"channels\".\n",
             "required": [
               "threshold",
               "interval",
-              "thresholdType",
-              "channel"
+              "thresholdType"
             ]
           }
         ]
@@ -5179,6 +5192,27 @@
                     "name": "Error Spike Alert",
                     "message": "Error rate has exceeded 100 in the last hour",
                     "numConsecutiveWindows": 3
+                  }
+                },
+                "multiChannelAlert": {
+                  "summary": "Create an alert that notifies several webhooks",
+                  "value": {
+                    "savedSearchId": "65f5e4a3b9e77c001a345678",
+                    "threshold": 10,
+                    "interval": "5m",
+                    "source": "saved_search",
+                    "thresholdType": "above",
+                    "channels": [
+                      {
+                        "type": "webhook",
+                        "webhookId": "65f5e4a3b9e77c001a789012"
+                      },
+                      {
+                        "type": "webhook",
+                        "webhookId": "65f5e4a3b9e77c001a789013"
+                      }
+                    ],
+                    "name": "Error Spike Alert"
                   }
                 }
               }

--- a/packages/api/src/mcp/__tests__/alerts.int.test.ts
+++ b/packages/api/src/mcp/__tests__/alerts.int.test.ts
@@ -1,4 +1,7 @@
-import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import {
+  MAX_ALERT_CHANNELS,
+  SourceKind,
+} from '@hyperdx/common-utils/dist/types';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 import * as config from '@/config';
@@ -603,6 +606,34 @@ describe('MCP Alert Tools', () => {
 
         expect(result.isError).toBe(true);
       });
+
+      // The MCP surface enforces the channel cap through the MCP SDK's own
+      // Zod .max() parsing of the tool's inputSchema -- a protocol-level check
+      // that runs before validateSaveAlertInput ever sees the payload. That is
+      // a different enforcement path from the HTTP routers' superRefine (see
+      // the "over the cap" case in routers/external-api/__tests__/alerts.int.test.ts),
+      // so it needs its own coverage.
+      it('should reject more than MAX_ALERT_CHANNELS channels', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const many = Array.from({ length: MAX_ALERT_CHANNELS + 1 }, (_, i) => ({
+          type: 'webhook' as const,
+          webhookId: `fake-webhook-id-${i}`,
+        }));
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channels: many,
+        });
+
+        expect(result.isError).toBe(true);
+        const text = getFirstText(result);
+        expect(text).toContain('channels');
+        expect(text).toContain(String(MAX_ALERT_CHANNELS));
+      });
     });
 
     describe('update', () => {
@@ -647,6 +678,77 @@ describe('MCP Alert Tools', () => {
         expect(output.name).toBe('Updated Name');
         expect(output.threshold).toBe(200);
         expect(output.interval).toBe('15m');
+      });
+
+      // The update path above only exercises the legacy singular `channel`;
+      // full-replace semantics on the agent surface are otherwise unverified.
+      it('replaces the full channels array on update, keeping the legacy channel mirror in sync', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const [w1, w2, w3, w4] = await Promise.all([
+          Webhook.create({
+            team: team._id,
+            name: 'mcp-update-1',
+            service: WebhookService.Generic,
+            url: 'https://example.com/webhook',
+          }),
+          Webhook.create({
+            team: team._id,
+            name: 'mcp-update-2',
+            service: WebhookService.Generic,
+            url: 'https://example.com/webhook',
+          }),
+          Webhook.create({
+            team: team._id,
+            name: 'mcp-update-3',
+            service: WebhookService.Generic,
+            url: 'https://example.com/webhook',
+          }),
+          Webhook.create({
+            team: team._id,
+            name: 'mcp-update-4',
+            service: WebhookService.Generic,
+            url: 'https://example.com/webhook',
+          }),
+        ]);
+
+        const created = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channels: [
+            { type: 'webhook', webhookId: w1._id.toString() },
+            { type: 'webhook', webhookId: w2._id.toString() },
+          ],
+          name: 'Multi Channel Alert For Update',
+        });
+        expect(created.isError).toBeFalsy();
+        const createdOutput = JSON.parse(getFirstText(created));
+
+        const newChannels = [
+          { type: 'webhook', webhookId: w3._id.toString() },
+          { type: 'webhook', webhookId: w4._id.toString() },
+        ];
+        const updated = await callTool(client, 'clickstack_save_alert', {
+          id: createdOutput.id,
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channels: newChannels,
+          name: 'Multi Channel Alert For Update',
+        });
+
+        expect(updated.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(updated));
+        expect(output.channels).toEqual(newChannels);
+        expect(output.channel).toEqual(newChannels[0]);
+
+        const persisted = await Alert.findById(createdOutput.id);
+        expect(persisted?.channels).toEqual(newChannels);
+        expect(persisted?.channel).toEqual(newChannels[0]);
       });
 
       it('should clear source-specific fields when both source field groups are provided', async () => {

--- a/packages/api/src/mcp/__tests__/alerts.int.test.ts
+++ b/packages/api/src/mcp/__tests__/alerts.int.test.ts
@@ -510,6 +510,101 @@ describe('MCP Alert Tools', () => {
       });
     });
 
+    describe('multiple channels', () => {
+      const namedWebhook = (name: string) =>
+        Webhook.create({
+          team: team._id,
+          name,
+          service: WebhookService.Generic,
+          url: 'https://example.com/webhook',
+        });
+
+      it('should create an alert with several channels', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const [w1, w2] = await Promise.all([
+          namedWebhook('mcp-multi-1'),
+          namedWebhook('mcp-multi-2'),
+        ]);
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channels: [
+            { type: 'webhook', webhookId: w1._id.toString() },
+            { type: 'webhook', webhookId: w2._id.toString() },
+          ],
+          name: 'MCP Multi Channel Alert',
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.channels).toEqual([
+          { type: 'webhook', webhookId: w1._id.toString() },
+          { type: 'webhook', webhookId: w2._id.toString() },
+        ]);
+        expect(output.channel).toEqual({
+          type: 'webhook',
+          webhookId: w1._id.toString(),
+        });
+      });
+
+      it('should reject channel and channels that disagree', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const [w1, w2] = await Promise.all([
+          namedWebhook('mcp-mismatch-1'),
+          namedWebhook('mcp-mismatch-2'),
+        ]);
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channel: { type: 'webhook', webhookId: w1._id.toString() },
+          channels: [{ type: 'webhook', webhookId: w2._id.toString() }],
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain('must match the first entry');
+      });
+
+      it('should reject duplicate channels', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const webhook = await namedWebhook('mcp-dupe');
+        const ch = { type: 'webhook', webhookId: webhook._id.toString() };
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channels: [ch, ch],
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain('Duplicate');
+      });
+
+      it('should reject a payload with neither channel nor channels', async () => {
+        const savedSearch = await createTestSavedSearch();
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+        });
+
+        expect(result.isError).toBe(true);
+      });
+    });
+
     describe('update', () => {
       it('should update an existing alert', async () => {
         const savedSearch = await createTestSavedSearch();

--- a/packages/api/src/mcp/tools/alerts/__tests__/schemas.test.ts
+++ b/packages/api/src/mcp/tools/alerts/__tests__/schemas.test.ts
@@ -1,0 +1,84 @@
+import {
+  McpSaveAlertInput,
+  validateSaveAlertInput,
+} from '@/mcp/tools/alerts/schemas';
+
+// A channel shape wider than this schema's `{ type, webhookId }` -- e.g. a
+// downstream channel type carrying an extra field. `value: any` (rather than
+// an `as` cast) keeps this off the no-unsafe-type-assertion budget while
+// still producing a value typed as a channel for the calls below.
+type Channel = NonNullable<McpSaveAlertInput['channel']>;
+const foreignChannel = (value: any): Channel => value;
+
+const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+const baseInput: Omit<McpSaveAlertInput, 'channel' | 'channels'> = {
+  source: 'saved_search',
+  savedSearchId: 'saved-search-1',
+  threshold: 1,
+  thresholdType: 'above',
+  interval: '5m',
+};
+
+describe('validateSaveAlertInput channel comparison', () => {
+  it('accepts channel and channels[0] that are genuinely equal', () => {
+    const result = validateSaveAlertInput({
+      ...baseInput,
+      channel: wh('a'),
+      channels: [wh('a')],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('rejects channel and channels[0] that disagree on webhookId', () => {
+    const result = validateSaveAlertInput({
+      ...baseInput,
+      channel: wh('a'),
+      channels: [wh('b')],
+    });
+
+    expect(result).toContain('must match');
+  });
+
+  it('rejects channel and channels[0] that disagree on a field other than webhookId', () => {
+    // Same webhookId, different label. The old webhookId-only comparison
+    // would have called these equal.
+    const result = validateSaveAlertInput({
+      ...baseInput,
+      channel: foreignChannel({
+        type: 'webhook',
+        webhookId: 'a',
+        label: 'Primary',
+      }),
+      channels: [
+        foreignChannel({ type: 'webhook', webhookId: 'a', label: 'Secondary' }),
+      ],
+    });
+
+    expect(result).toContain('must match');
+  });
+
+  it('rejects duplicate entries within channels', () => {
+    const result = validateSaveAlertInput({
+      ...baseInput,
+      channels: [wh('a'), wh('a')],
+    });
+
+    expect(result).toContain('Duplicate');
+  });
+
+  it('accepts channels entries that are genuinely different, including a pair differing only outside webhookId', () => {
+    // Same webhookId, different label. The old webhookId-only comparison
+    // would have wrongly collapsed these into a duplicate.
+    const result = validateSaveAlertInput({
+      ...baseInput,
+      channels: [
+        foreignChannel({ type: 'webhook', webhookId: 'a', label: 'Primary' }),
+        foreignChannel({ type: 'webhook', webhookId: 'a', label: 'Secondary' }),
+      ],
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/api/src/mcp/tools/alerts/saveAlert.ts
+++ b/packages/api/src/mcp/tools/alerts/saveAlert.ts
@@ -25,14 +25,16 @@ import {
 } from './schemas';
 
 /**
- * Convert the flat MCP channel object into the discriminated-union
- * `AlertChannel` that the controller layer expects.
+ * Convert the flat MCP channel objects into the discriminated-union
+ * `AlertChannel[]` that the controller layer expects. `channel` and `channels`
+ * are already checked to agree by validateSaveAlertInput.
  */
-function toAlertChannel(ch: McpSaveAlertInput['channel']): AlertChannel {
-  return {
-    type: 'webhook',
-    webhookId: ch.webhookId,
-  };
+function toAlertChannels(input: McpSaveAlertInput): AlertChannel[] {
+  const flat = input.channels ?? (input.channel ? [input.channel] : []);
+  return flat.map(c => ({
+    type: 'webhook' as const,
+    webhookId: c.webhookId,
+  }));
 }
 
 export function registerSaveAlert({
@@ -68,12 +70,12 @@ export function registerSaveAlert({
       }
 
       // Build the alert input matching the shape expected by controllers.
-      const channel = toAlertChannel(input.channel);
       const source =
         input.source === 'tile' ? AlertSource.TILE : AlertSource.SAVED_SEARCH;
       const alertInput: AlertInput = {
         source,
-        channel,
+        // `channel` is omitted; makeAlert mirrors it from channels[0].
+        channels: toAlertChannels(input),
         interval: input.interval,
         threshold: input.threshold,
         thresholdType: input.thresholdType as AlertThresholdType,

--- a/packages/api/src/mcp/tools/alerts/saveAlert.ts
+++ b/packages/api/src/mcp/tools/alerts/saveAlert.ts
@@ -14,28 +14,11 @@ import {
   mcpUserError,
   validateObjectId,
 } from '@/mcp/utils/errors';
-import { type AlertChannel, AlertSource } from '@/models/alert';
+import { AlertSource } from '@/models/alert';
 import { BaseError } from '@/utils/errors';
 import { translateAlertDocumentToExternalAlert } from '@/utils/externalApi';
 
-import {
-  type McpSaveAlertInput,
-  mcpSaveAlertSchema,
-  validateSaveAlertInput,
-} from './schemas';
-
-/**
- * Convert the flat MCP channel objects into the discriminated-union
- * `AlertChannel[]` that the controller layer expects. `channel` and `channels`
- * are already checked to agree by validateSaveAlertInput.
- */
-function toAlertChannels(input: McpSaveAlertInput): AlertChannel[] {
-  const flat = input.channels ?? (input.channel ? [input.channel] : []);
-  return flat.map(c => ({
-    type: 'webhook' as const,
-    webhookId: c.webhookId,
-  }));
-}
+import { mcpSaveAlertSchema, validateSaveAlertInput } from './schemas';
 
 export function registerSaveAlert({
   context,
@@ -79,7 +62,7 @@ export function registerSaveAlert({
       const alertInput: AlertInput = {
         source,
         // `channel` is omitted; makeAlert mirrors it from channels[0].
-        channels: toAlertChannels(input),
+        channels: input.channels ?? (input.channel ? [input.channel] : []),
         interval: input.interval,
         threshold: input.threshold,
         thresholdType: input.thresholdType as AlertThresholdType,

--- a/packages/api/src/mcp/tools/alerts/saveAlert.ts
+++ b/packages/api/src/mcp/tools/alerts/saveAlert.ts
@@ -52,7 +52,11 @@ export function registerSaveAlert({
       description:
         'Create a new alert (omit id) or update an existing one (provide id). ' +
         'Alerts monitor a saved search or dashboard tile and fire when the ' +
-        'metric crosses a threshold. A webhook notification channel is required.',
+        'metric crosses a threshold. At least one webhook notification channel ' +
+        'is required: pass "channels" for 1-10 targets, or the legacy singular ' +
+        '"channel" for one. Updates replace the alert configuration rather than ' +
+        'merging it, so read the alert first and resend its full "channels" ' +
+        'array to avoid dropping channels you did not mean to remove.',
       inputSchema: mcpSaveAlertSchema,
     },
     async input => {

--- a/packages/api/src/mcp/tools/alerts/schemas.ts
+++ b/packages/api/src/mcp/tools/alerts/schemas.ts
@@ -2,6 +2,7 @@ import {
   ALERT_INTERVAL_TO_MINUTES,
   type AlertInterval,
   isRangeThresholdType,
+  MAX_ALERT_CHANNELS,
 } from '@hyperdx/common-utils/dist/types';
 import { z } from 'zod';
 
@@ -98,7 +99,15 @@ export const mcpSaveAlertSchema = z.object({
     .describe('Absolute UTC anchor for window alignment (ISO 8601).'),
 
   // Channel
-  channel: mcpAlertChannelSchema,
+  channel: mcpAlertChannelSchema.optional(),
+  channels: z
+    .array(mcpAlertChannelSchema)
+    .min(1)
+    .max(MAX_ALERT_CHANNELS)
+    .optional()
+    .describe(
+      `Notification channels (1-${MAX_ALERT_CHANNELS}). Provide this or "channel"; if both, "channel" must match the first entry.`,
+    ),
 
   // Metadata
   name: z
@@ -122,6 +131,24 @@ export type McpSaveAlertInput = z.infer<typeof mcpSaveAlertSchema>;
 // Returns a human-readable error string, or null when valid.
 // ---------------------------------------------------------------------------
 export function validateSaveAlertInput(data: McpSaveAlertInput): string | null {
+  // Channel selection. Mirrors validateAlertChannelSelection in common-utils:
+  // both fields may be sent when they agree, so a response can be echoed back.
+  const hasChannel = data.channel != null;
+  const hasChannels = data.channels != null;
+  if (!hasChannel && !hasChannels) {
+    return 'Provide either "channel" or "channels"';
+  }
+  if (hasChannel && hasChannels) {
+    const first = data.channels?.[0];
+    if (first == null || first.webhookId !== data.channel?.webhookId) {
+      return 'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"';
+    }
+  }
+  const webhookIds = (data.channels ?? []).map(c => c.webhookId);
+  if (new Set(webhookIds).size !== webhookIds.length) {
+    return 'Duplicate notification channels are not allowed';
+  }
+
   // Source-specific required fields
   if (data.source === 'tile') {
     if (!data.dashboardId) {

--- a/packages/api/src/mcp/tools/alerts/schemas.ts
+++ b/packages/api/src/mcp/tools/alerts/schemas.ts
@@ -1,7 +1,7 @@
 import {
   ALERT_INTERVAL_TO_MINUTES,
-  alertChannelKey,
   type AlertInterval,
+  checkAlertChannelSelection,
   isRangeThresholdType,
   MAX_ALERT_CHANNELS,
 } from '@hyperdx/common-utils/dist/types';
@@ -132,25 +132,19 @@ export type McpSaveAlertInput = z.infer<typeof mcpSaveAlertSchema>;
 // Returns a human-readable error string, or null when valid.
 // ---------------------------------------------------------------------------
 export function validateSaveAlertInput(data: McpSaveAlertInput): string | null {
-  // Channel selection. Mirrors validateAlertChannelSelection in common-utils:
-  // both fields may be sent when they agree, so a response can be echoed back.
-  const hasChannel = data.channel != null;
-  const hasChannels = data.channels != null;
-  if (!hasChannel && !hasChannels) {
-    return 'Provide either "channel" or "channels"';
-  }
-  if (hasChannel && hasChannels) {
-    const first = data.channels?.[0];
-    if (
-      first == null ||
-      alertChannelKey(first) !== alertChannelKey(data.channel!)
-    ) {
-      return 'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"';
+  // Channel selection rule shared with every other alert input schema in this
+  // repo (see checkAlertChannelSelection in common-utils); reported here as a
+  // plain string since this validator has no ZodIssueCode to add to.
+  const channelSelection = checkAlertChannelSelection(data);
+  if (!channelSelection.ok) {
+    switch (channelSelection.code) {
+      case 'missing':
+        return 'Provide either "channel" or "channels"';
+      case 'mismatch':
+        return 'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"';
+      case 'duplicate':
+        return 'Duplicate notification channels are not allowed';
     }
-  }
-  const keys = (data.channels ?? []).map(alertChannelKey);
-  if (new Set(keys).size !== keys.length) {
-    return 'Duplicate notification channels are not allowed';
   }
 
   // Source-specific required fields

--- a/packages/api/src/mcp/tools/alerts/schemas.ts
+++ b/packages/api/src/mcp/tools/alerts/schemas.ts
@@ -1,5 +1,6 @@
 import {
   ALERT_INTERVAL_TO_MINUTES,
+  alertChannelKey,
   type AlertInterval,
   isRangeThresholdType,
   MAX_ALERT_CHANNELS,
@@ -140,12 +141,15 @@ export function validateSaveAlertInput(data: McpSaveAlertInput): string | null {
   }
   if (hasChannel && hasChannels) {
     const first = data.channels?.[0];
-    if (first == null || first.webhookId !== data.channel?.webhookId) {
+    if (
+      first == null ||
+      alertChannelKey(first) !== alertChannelKey(data.channel!)
+    ) {
       return 'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"';
     }
   }
-  const webhookIds = (data.channels ?? []).map(c => c.webhookId);
-  if (new Set(webhookIds).size !== webhookIds.length) {
+  const keys = (data.channels ?? []).map(alertChannelKey);
+  if (new Set(keys).size !== keys.length) {
     return 'Duplicate notification channels are not allowed';
   }
 

--- a/packages/api/src/routers/api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/alerts.int.test.ts
@@ -1484,4 +1484,169 @@ describe('alerts router', () => {
       );
     });
   });
+  describe('multiple notification channels', () => {
+    const makeSavedSearch = () =>
+      SavedSearch.create({
+        name: 'Test Saved Search',
+        source: new mongoose.Types.ObjectId(),
+        team: team._id,
+      });
+
+    const secondWebhook = () =>
+      Webhook.create({
+        name: 'Second Webhook',
+        service: WebhookService.Slack,
+        url: 'https://hooks.slack.com/second',
+        team: team._id,
+      });
+
+    const baseInput = (savedSearchId: string) => ({
+      ...makeSavedSearchAlertInput({ savedSearchId }),
+      channel: undefined,
+    });
+
+    it('creates an alert with several channels and persists all of them', async () => {
+      const [savedSearch, other] = await Promise.all([
+        makeSavedSearch(),
+        secondWebhook(),
+      ]);
+
+      const created = await agent
+        .post('/alerts')
+        .send({
+          ...baseInput(savedSearch._id.toString()),
+          channels: [
+            { type: 'webhook', webhookId: webhook._id.toString() },
+            { type: 'webhook', webhookId: other._id.toString() },
+          ],
+        })
+        .expect(200);
+
+      // POST echoes the created document, and the list endpoint returns
+      // webhookIds too so edit surfaces can prefill the channel.
+      expect(created.body.data.channels).toEqual([
+        { type: 'webhook', webhookId: webhook._id.toString() },
+        { type: 'webhook', webhookId: other._id.toString() },
+      ]);
+
+      const stored = await Alert.findById(created.body.data._id);
+      expect(stored!.channels).toEqual([
+        { type: 'webhook', webhookId: webhook._id.toString() },
+        { type: 'webhook', webhookId: other._id.toString() },
+      ]);
+      // Legacy mirror keeps pre-multi-channel readers working.
+      expect(stored!.channel).toEqual({
+        type: 'webhook',
+        webhookId: webhook._id.toString(),
+      });
+    });
+
+    it('exposes channels for a legacy single-channel alert', async () => {
+      const savedSearch = await makeSavedSearch();
+      const created = await agent
+        .post('/alerts')
+        .send(
+          makeSavedSearchAlertInput({
+            savedSearchId: savedSearch._id.toString(),
+            webhookId: webhook._id.toString(),
+          }),
+        )
+        .expect(200);
+
+      const list = await agent.get('/alerts').expect(200);
+      const alert = list.body.data.find(
+        (a: { _id: string }) => a._id === created.body.data._id,
+      );
+      expect(alert.channels).toEqual([
+        { type: 'webhook', webhookId: webhook._id.toString() },
+      ]);
+    });
+
+    it('round-trips a multi-channel alert through PUT without losing channels', async () => {
+      const [savedSearch, other] = await Promise.all([
+        makeSavedSearch(),
+        secondWebhook(),
+      ]);
+      const channels = [
+        { type: 'webhook', webhookId: webhook._id.toString() },
+        { type: 'webhook', webhookId: other._id.toString() },
+      ];
+
+      const created = await agent
+        .post('/alerts')
+        .send({ ...baseInput(savedSearch._id.toString()), channels })
+        .expect(200);
+
+      await agent
+        .put(`/alerts/${created.body.data._id}`)
+        .send({
+          ...baseInput(savedSearch._id.toString()),
+          channels,
+          threshold: 42,
+        })
+        .expect(200);
+
+      const stored = await Alert.findById(created.body.data._id);
+      expect(stored!.channels).toHaveLength(2);
+      expect(stored!.threshold).toBe(42);
+    });
+
+    it('rejects invalid channel combinations', async () => {
+      const [savedSearch, other] = await Promise.all([
+        makeSavedSearch(),
+        secondWebhook(),
+      ]);
+      const base = baseInput(savedSearch._id.toString());
+      const ch = { type: 'webhook', webhookId: webhook._id.toString() };
+
+      // neither channel nor channels
+      await agent.post('/alerts').send(base).expect(400);
+
+      // channel disagrees with channels[0]
+      await agent
+        .post('/alerts')
+        .send({
+          ...base,
+          channel: ch,
+          channels: [{ type: 'webhook', webhookId: other._id.toString() }],
+        })
+        .expect(400);
+
+      // duplicates
+      await agent
+        .post('/alerts')
+        .send({ ...base, channels: [ch, ch] })
+        .expect(400);
+
+      // over the cap
+      await agent
+        .post('/alerts')
+        .send({
+          ...base,
+          channels: Array.from({ length: 11 }, () => ({
+            type: 'webhook',
+            webhookId: randomMongoId(),
+          })),
+        })
+        .expect(400);
+
+      // a webhook belonging to another team, hidden among valid ones
+      const foreign = await Webhook.create({
+        name: 'Foreign Webhook',
+        service: WebhookService.Slack,
+        url: 'https://hooks.slack.com/foreign',
+        team: new mongoose.Types.ObjectId(),
+      });
+      await agent
+        .post('/alerts')
+        .send({
+          ...base,
+          channels: [
+            ch,
+            { type: 'webhook', webhookId: foreign._id.toString() },
+          ],
+        })
+        .expect(400);
+    });
+  });
 });

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -26,6 +26,7 @@ import {
   updateAlert,
   validateAlertInput,
 } from '@/controllers/alerts';
+import { getAlertChannels } from '@/models/alert';
 import { IAlertHistory } from '@/models/alertHistory';
 import { PreSerialized, sendJson } from '@/utils/serialization';
 import { alertSchema, objectIdSchema } from '@/utils/zod';
@@ -54,6 +55,7 @@ const formatAlertResponse = (
     // prefill the notification channel; webhook ids are already visible to
     // team members via GET /webhooks.
     channel: pick(alert.channel, ['type', 'webhookId']),
+    channels: getAlertChannels(alert).map(c => pick(c, ['type', 'webhookId'])),
     ...(alert.dashboard && {
       dashboardId: alert.dashboard._id,
       dashboard: {

--- a/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
@@ -1545,7 +1545,7 @@ describe('External API Alerts', () => {
         .send({ ...base, channels: [ch, ch] })
         .expect(400);
       // over the cap
-      const many = Array.from({ length: 11 }, (_, i) => ({
+      const many = Array.from({ length: 11 }, () => ({
         type: 'webhook',
         webhookId: new ObjectId().toString(),
       }));

--- a/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
@@ -1489,6 +1489,42 @@ describe('External API Alerts', () => {
       expect(after.body.data.threshold).toBe(42);
     });
 
+    // Updates are a full replace, not a merge. A client that predates
+    // `channels` sends only `channel`, which reduces the alert to that one
+    // target -- documented behaviour, pinned here so it can't change silently.
+    it('collapses to one channel when a legacy client sends only `channel`', async () => {
+      const [w1, w2] = await Promise.all([
+        makeWebhookNamed('legacy-1'),
+        makeWebhookNamed('legacy-2'),
+      ]);
+      const base = await baseSavedSearchAlert();
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channels: [
+            { type: 'webhook', webhookId: w1._id.toString() },
+            { type: 'webhook', webhookId: w2._id.toString() },
+          ],
+        })
+        .expect(200);
+      expect(created.body.data.channels).toHaveLength(2);
+
+      await authRequest('put', `${ALERTS_BASE_URL}/${created.body.data.id}`)
+        .send({
+          ...base,
+          channel: { type: 'webhook', webhookId: w1._id.toString() },
+        })
+        .expect(200);
+
+      const after = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(after.body.data.channels).toEqual([
+        { type: 'webhook', webhookId: w1._id.toString() },
+      ]);
+    });
+
     it('rejects invalid channel combinations', async () => {
       const webhook = await createTestWebhook();
       const base = await baseSavedSearchAlert();

--- a/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
@@ -232,6 +232,12 @@ describe('External API Alerts', () => {
             type: 'webhook',
             webhookId: expect.any(String),
           },
+          channels: [
+            {
+              type: 'webhook',
+              webhookId: expect.any(String),
+            },
+          ],
           teamId: expect.any(String),
           tileId: expect.any(String),
           dashboardId: expect.any(String),
@@ -1387,6 +1393,142 @@ describe('External API Alerts', () => {
       ).expect(200);
 
       expect(getResponse.body.data.numConsecutiveWindows).toBeNull();
+    });
+  });
+  describe('Multiple notification channels', () => {
+    const makeWebhookNamed = async (name: string) =>
+      await Webhook.findOneAndUpdate(
+        { name, service: WebhookService.Slack, team: team._id },
+        {
+          name,
+          service: WebhookService.Slack,
+          url: 'https://hooks.slack.com/test',
+          team: team._id,
+        },
+        { upsert: true, new: true },
+      );
+
+    const baseSavedSearchAlert = async () => {
+      const savedSearch = await createTestSavedSearch();
+      return {
+        source: 'saved_search',
+        savedSearchId: savedSearch._id.toString(),
+        interval: '5m',
+        threshold: 1,
+        thresholdType: 'above',
+      };
+    };
+
+    it('creates an alert with multiple channels and echoes both shapes', async () => {
+      const [w1, w2] = await Promise.all([
+        makeWebhookNamed('multi-1'),
+        makeWebhookNamed('multi-2'),
+      ]);
+      const base = await baseSavedSearchAlert();
+      const resp = await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channels: [
+            { type: 'webhook', webhookId: w1._id.toString() },
+            { type: 'webhook', webhookId: w2._id.toString() },
+          ],
+        })
+        .expect(200);
+      expect(resp.body.data.channels).toEqual([
+        { type: 'webhook', webhookId: w1._id.toString() },
+        { type: 'webhook', webhookId: w2._id.toString() },
+      ]);
+      // Legacy field mirrors the first entry for pre-multi-channel clients.
+      expect(resp.body.data.channel).toEqual({
+        type: 'webhook',
+        webhookId: w1._id.toString(),
+      });
+    });
+
+    it('legacy single-channel payloads still work and gain channels in the response', async () => {
+      const webhook = await createTestWebhook();
+      const base = await baseSavedSearchAlert();
+      const resp = await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channel: { type: 'webhook', webhookId: webhook._id.toString() },
+        })
+        .expect(200);
+      expect(resp.body.data.channels).toEqual([
+        { type: 'webhook', webhookId: webhook._id.toString() },
+      ]);
+    });
+
+    it('round-trips a multi-channel alert through PUT unchanged', async () => {
+      const [w1, w2] = await Promise.all([
+        makeWebhookNamed('rt-1'),
+        makeWebhookNamed('rt-2'),
+      ]);
+      const base = await baseSavedSearchAlert();
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channels: [
+            { type: 'webhook', webhookId: w1._id.toString() },
+            { type: 'webhook', webhookId: w2._id.toString() },
+          ],
+        })
+        .expect(200);
+
+      // Echo the response body straight back, as a read-modify-write client
+      // would: it carries both `channel` and `channels`.
+      await authRequest('put', `${ALERTS_BASE_URL}/${created.body.data.id}`)
+        .send({ ...created.body.data, ...base, threshold: 42 })
+        .expect(200);
+
+      const after = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(after.body.data.channels).toHaveLength(2);
+      expect(after.body.data.threshold).toBe(42);
+    });
+
+    it('rejects invalid channel combinations', async () => {
+      const webhook = await createTestWebhook();
+      const base = await baseSavedSearchAlert();
+      const ch = { type: 'webhook', webhookId: webhook._id.toString() };
+      // channel disagrees with channels[0]
+      const other = await makeWebhookNamed('mismatch-1');
+      await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channel: ch,
+          channels: [{ type: 'webhook', webhookId: other._id.toString() }],
+        })
+        .expect(400);
+      // neither
+      await authRequest('post', ALERTS_BASE_URL).send(base).expect(400);
+      // duplicates
+      await authRequest('post', ALERTS_BASE_URL)
+        .send({ ...base, channels: [ch, ch] })
+        .expect(400);
+      // over the cap
+      const many = Array.from({ length: 11 }, (_, i) => ({
+        type: 'webhook',
+        webhookId: new ObjectId().toString(),
+      }));
+      await authRequest('post', ALERTS_BASE_URL)
+        .send({ ...base, channels: many })
+        .expect(400);
+      // cross-team webhook hidden among valid ones
+      const otherTeamWebhook = await createTestWebhook({
+        teamId: new ObjectId(),
+      });
+      await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          ...base,
+          channels: [
+            ch,
+            { type: 'webhook', webhookId: otherTeamWebhook._id.toString() },
+          ],
+        })
+        .expect(400);
     });
   });
 });

--- a/packages/api/src/routers/external-api/v2/alerts.ts
+++ b/packages/api/src/routers/external-api/v2/alerts.ts
@@ -116,6 +116,15 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *         - $ref: '#/components/schemas/AlertChannelWebhook'
  *       discriminator:
  *         propertyName: type
+ *     AlertChannels:
+ *       type: array
+ *       description: >
+ *         Notification channels to trigger when the alert fires or resolves.
+ *         Between 1 and 10 channels; duplicates are rejected.
+ *       minItems: 1
+ *       maxItems: 10
+ *       items:
+ *         $ref: '#/components/schemas/AlertChannel'
  *     Alert:
  *       type: object
  *       properties:
@@ -174,7 +183,10 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *           example: "above"
  *         channel:
  *           $ref: '#/components/schemas/AlertChannel'
- *           description: Alert notification channel configuration.
+ *           description: First notification channel, mirrored from "channels" for pre-multi-channel clients.
+ *         channels:
+ *           $ref: '#/components/schemas/AlertChannels'
+ *           description: All notification channels to trigger when the alert fires or resolves.
  *         name:
  *           type: string
  *           description: Human-friendly alert name.
@@ -243,21 +255,29 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *       allOf:
  *         - $ref: '#/components/schemas/Alert'
  *         - type: object
+ *           description: >
+ *             At least one of "channel" or "channels" must be provided. Sending both is
+ *             allowed only when "channel" matches the first entry of "channels", so a
+ *             response body can be echoed back unchanged. Responses always include both,
+ *             with "channel" mirroring the first entry of "channels".
  *           required:
  *             - threshold
  *             - interval
  *             - thresholdType
- *             - channel
  *
  *     UpdateAlertRequest:
  *       allOf:
  *         - $ref: '#/components/schemas/Alert'
  *         - type: object
+ *           description: >
+ *             At least one of "channel" or "channels" must be provided. Sending both is
+ *             allowed only when "channel" matches the first entry of "channels", so a
+ *             response body can be echoed back unchanged. Responses always include both,
+ *             with "channel" mirroring the first entry of "channels".
  *           required:
  *             - threshold
  *             - interval
  *             - thresholdType
- *             - channel
  *
  *     AlertResponseEnvelope:
  *       type: object
@@ -513,6 +533,20 @@ router.get(
  *                 name: "Error Spike Alert"
  *                 message: "Error rate has exceeded 100 in the last hour"
  *                 numConsecutiveWindows: 3
+ *             multiChannelAlert:
+ *               summary: Create an alert that notifies several webhooks
+ *               value:
+ *                 savedSearchId: "65f5e4a3b9e77c001a345678"
+ *                 threshold: 10
+ *                 interval: "5m"
+ *                 source: "saved_search"
+ *                 thresholdType: "above"
+ *                 channels:
+ *                   - type: "webhook"
+ *                     webhookId: "65f5e4a3b9e77c001a789012"
+ *                   - type: "webhook"
+ *                     webhookId: "65f5e4a3b9e77c001a789013"
+ *                 name: "Error Spike Alert"
  *     responses:
  *       '200':
  *         description: Successfully created alert

--- a/packages/api/src/routers/external-api/v2/alerts.ts
+++ b/packages/api/src/routers/external-api/v2/alerts.ts
@@ -274,6 +274,10 @@ import { alertSchema, objectIdSchema } from '@/utils/zod';
  *             allowed only when "channel" matches the first entry of "channels", so a
  *             response body can be echoed back unchanged. Responses always include both,
  *             with "channel" mirroring the first entry of "channels".
+ *             Updates replace the alert's configuration rather than merging it: sending
+ *             only the legacy "channel" field for an alert that has several channels
+ *             reduces it to that one channel. Fetch the alert and resend the complete
+ *             "channels" array to preserve them.
  *           required:
  *             - threshold
  *             - interval

--- a/packages/api/src/utils/__tests__/externalApi.test.ts
+++ b/packages/api/src/utils/__tests__/externalApi.test.ts
@@ -1,12 +1,19 @@
 import { Types } from 'mongoose';
 
 import {
+  type AlertChannel,
   type AlertDocument,
   AlertSource,
   AlertState,
   AlertThresholdType,
 } from '@/models/alert';
 import { translateAlertDocumentToExternalAlert } from '@/utils/externalApi';
+
+// A channel type this repo doesn't define -- see
+// models/__tests__/alert.test.ts for why. `value: any` (rather than an `as`
+// cast) keeps this off the no-unsafe-type-assertion budget while still
+// producing a value typed as AlertChannel for the call below.
+const foreignChannel = (value: any): AlertChannel => value;
 
 const createAlertDocument = (
   overrides: Partial<Record<string, unknown>> = {},
@@ -95,6 +102,28 @@ describe('utils/externalApi', () => {
       const translated = translateAlertDocumentToExternalAlert(alert);
 
       expect(translated.numConsecutiveWindows).toBe(3);
+    });
+  });
+
+  describe('channel mirroring', () => {
+    // translateAlertDocumentToExternalAlert mirrors channels[0] into
+    // `channel`, same as makeAlert (controllers/__tests__/alerts.test.ts).
+    // That mirroring must stay opaque: a downstream fork's channel types
+    // must survive verbatim, not get projected onto webhook-shaped fields.
+    it('mirrors channels[0] into channel verbatim, preserving fields this repo does not define', () => {
+      const exotic = foreignChannel({
+        type: 'email',
+        emailRecipients: ['ops@example.test'],
+      });
+      const alert = createAlertDocument({
+        channel: undefined,
+        channels: [exotic],
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.channel).toEqual(exotic);
+      expect(translated.channels).toEqual([exotic]);
     });
   });
 });

--- a/packages/api/src/utils/__tests__/externalApi.test.ts
+++ b/packages/api/src/utils/__tests__/externalApi.test.ts
@@ -125,5 +125,24 @@ describe('utils/externalApi', () => {
       expect(translated.channel).toEqual(exotic);
       expect(translated.channels).toEqual([exotic]);
     });
+
+    // A legacy `{type: null}` channel is a real, persistable state older
+    // fixtures exercise, but it satisfies neither the `AlertChannels`
+    // (minItems: 1) nor the `AlertChannel` oneOf in openapi.json. Omit both
+    // fields rather than emit a shape that contradicts this API's own
+    // contract.
+    it('omits channel and channels when no channel resolves', () => {
+      const alert = createAlertDocument({
+        channel: { type: null },
+        channels: undefined,
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.channel).toBeUndefined();
+      expect(translated.channels).toBeUndefined();
+      expect('channel' in translated).toBe(false);
+      expect('channels' in translated).toBe(false);
+    });
   });
 });

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -253,8 +253,8 @@ export type ExternalAlert = {
   thresholdType: AlertThresholdType;
   source?: string;
   state: AlertState;
-  channel: AlertChannel;
-  channels: AlertChannel[];
+  channel?: AlertChannel;
+  channels?: AlertChannel[];
   teamId: string;
   tileId?: string;
   dashboardId?: string;
@@ -358,8 +358,12 @@ export function translateAlertDocumentToExternalAlert(
     thresholdType: alertObj.thresholdType,
     source: alertObj.source,
     state: alertObj.state,
-    channel: channels[0] ?? { type: null },
-    channels,
+    // Omit both fields when no channel resolves (e.g. a legacy `{type: null}`
+    // channel) instead of emitting `channels: []` alongside a null-typed
+    // `channel` -- that shape violates this API's own OpenAPI contract
+    // (`AlertChannels` requires minItems: 1, and `AlertChannel`'s oneOf has no
+    // branch for `{type: null}`).
+    ...(channels.length > 0 && { channel: channels[0], channels }),
     teamId: alertObj.team.toString(),
     tileId: alertObj.tileId ?? undefined,
     dashboardId: alertObj.dashboard?.toString(),

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -18,6 +18,7 @@ import {
   AlertDocument,
   AlertInterval,
   AlertState,
+  getAlertChannels,
   IAlert,
 } from '@/models/alert';
 import type { DashboardDocument } from '@/models/dashboard';
@@ -253,6 +254,7 @@ export type ExternalAlert = {
   source?: string;
   state: AlertState;
   channel: AlertChannel;
+  channels: AlertChannel[];
   teamId: string;
   tileId?: string;
   dashboardId?: string;
@@ -337,6 +339,8 @@ export function translateAlertDocumentToExternalAlert(
     ? alert.toJSON()
     : { ...alert };
 
+  const channels = getAlertChannels(alertObj);
+
   // Copy all fields, renaming _id to id, ensuring ObjectId's are strings
   const result = {
     id: alertObj._id.toString(),
@@ -354,7 +358,8 @@ export function translateAlertDocumentToExternalAlert(
     thresholdType: alertObj.thresholdType,
     source: alertObj.source,
     state: alertObj.state,
-    channel: alertObj.channel,
+    channel: channels[0] ?? { type: null },
+    channels,
     teamId: alertObj.team.toString(),
     tileId: alertObj.tileId ?? undefined,
     dashboardId: alertObj.dashboard?.toString(),

--- a/packages/common-utils/src/__tests__/alertChannels.test.ts
+++ b/packages/common-utils/src/__tests__/alertChannels.test.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   AlertSchema,
+  checkAlertChannelSelection,
   MAX_ALERT_CHANNELS,
   SavedChartConfigSchema,
   validateAlertChannelSelection,
@@ -17,6 +18,51 @@ const refine = (input: Parameters<typeof validateAlertChannelSelection>[0]) => {
   validateAlertChannelSelection(input, ctx);
   return issues;
 };
+
+// checkAlertChannelSelection is the Zod-independent rule that
+// validateAlertChannelSelection (below) wraps, and that the MCP tool's
+// hand-rolled validator (packages/api/src/mcp/tools/alerts/schemas.ts) calls
+// directly. Covering it here pins the classification both callers depend on.
+describe('checkAlertChannelSelection', () => {
+  const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+  it('returns ok when exactly one of channel / channels is provided', () => {
+    expect(checkAlertChannelSelection({ channel: wh('a') })).toEqual({
+      ok: true,
+    });
+    expect(checkAlertChannelSelection({ channels: [wh('a')] })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('returns "missing" when neither is provided', () => {
+    expect(checkAlertChannelSelection({})).toEqual({
+      ok: false,
+      code: 'missing',
+    });
+  });
+
+  it('returns "mismatch" when channel disagrees with channels[0]', () => {
+    expect(
+      checkAlertChannelSelection({ channel: wh('a'), channels: [wh('b')] }),
+    ).toEqual({ ok: false, code: 'mismatch' });
+  });
+
+  it('returns ok when channel agrees with channels[0]', () => {
+    expect(
+      checkAlertChannelSelection({
+        channel: wh('a'),
+        channels: [wh('a'), wh('b')],
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('returns "duplicate" when channels contains a repeated entry', () => {
+    expect(
+      checkAlertChannelSelection({ channels: [wh('a'), wh('a')] }),
+    ).toEqual({ ok: false, code: 'duplicate' });
+  });
+});
 
 describe('alert channel schemas', () => {
   const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -723,17 +723,74 @@ export const alertChannelKey = (channel: Record<string, unknown>) =>
   objectHash(channel);
 
 /**
- * Cross-field rule shared by every alert input schema in this repo (internal
- * API, external v2 API) — the MCP tool schema has its own hand-rolled copy of
- * this check, not this one: at least one of the legacy singular `channel` or
- * the plural `channels` must be provided, and `channels` must not contain
- * duplicates.
+ * Why a channel selection is rejected. Zod-independent so both the
+ * superRefine below and the MCP tool's hand-rolled validator (which has no
+ * ZodIssueCode to report through) can turn this into their own error shape.
+ */
+export type AlertChannelSelectionErrorCode =
+  | 'missing'
+  | 'mismatch'
+  | 'duplicate';
+
+export type AlertChannelSelectionResult =
+  | { ok: true }
+  | { ok: false; code: AlertChannelSelectionErrorCode };
+
+/**
+ * Cross-field rule shared by every alert input in this repo (internal API,
+ * external v2 API, MCP `clickstack_save_alert`): at least one of the legacy
+ * singular `channel` or the plural `channels` must be provided, and
+ * `channels` must not contain duplicates.
  *
  * Both may be sent together only when they agree — `channel` must equal
  * `channels[0]`. Responses carry both fields, so read-modify-write clients
  * echo both back untouched; rejecting that outright would break every
  * GET-then-PUT caller. A genuine disagreement is still an error rather than a
  * silent precedence rule, so no client can be surprised about which one won.
+ *
+ * Pure and throw-free by design: callers own how the failure is reported
+ * (Zod issue, MCP error string, …), this only classifies it.
+ */
+export const checkAlertChannelSelection = (alert: {
+  channel?: Record<string, unknown> | null;
+  channels?: Record<string, unknown>[];
+}): AlertChannelSelectionResult => {
+  const hasChannel = alert.channel != null;
+  const hasChannels = alert.channels != null;
+  if (!hasChannel && !hasChannels) {
+    return { ok: false, code: 'missing' };
+  }
+  if (hasChannel && hasChannels) {
+    const first = alert.channels?.[0];
+    if (
+      first == null ||
+      alertChannelKey(alert.channel!) !== alertChannelKey(first)
+    ) {
+      return { ok: false, code: 'mismatch' };
+    }
+  }
+  const keys = (alert.channels ?? []).map(alertChannelKey);
+  if (new Set(keys).size !== keys.length) {
+    return { ok: false, code: 'duplicate' };
+  }
+  return { ok: true };
+};
+
+const alertChannelSelectionMessages: Record<
+  AlertChannelSelectionErrorCode,
+  string
+> = {
+  missing: 'Provide either "channel" or "channels"',
+  mismatch:
+    'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"',
+  duplicate: 'Duplicate notification channels are not allowed',
+};
+
+/**
+ * Zod superRefine wrapper around {@link checkAlertChannelSelection}, shared by
+ * every alert input schema in this repo (internal API, external v2 API) — the
+ * MCP tool schema calls checkAlertChannelSelection directly, since its runtime
+ * validator has no ZodIssueCode to report through.
  */
 export const validateAlertChannelSelection = (
   alert: {
@@ -742,37 +799,12 @@ export const validateAlertChannelSelection = (
   },
   ctx: z.RefinementCtx,
 ) => {
-  const hasChannel = alert.channel != null;
-  const hasChannels = alert.channels != null;
-  if (!hasChannel && !hasChannels) {
+  const result = checkAlertChannelSelection(alert);
+  if (!result.ok) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['channels'],
-      message: 'Provide either "channel" or "channels"',
-    });
-    return;
-  }
-  if (hasChannel && hasChannels) {
-    const first = alert.channels?.[0];
-    if (
-      first == null ||
-      alertChannelKey(alert.channel!) !== alertChannelKey(first)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['channels'],
-        message:
-          'When both "channel" and "channels" are provided, "channel" must match the first entry of "channels"',
-      });
-      return;
-    }
-  }
-  const keys = (alert.channels ?? []).map(alertChannelKey);
-  if (new Set(keys).size !== keys.length) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['channels'],
-      message: 'Duplicate notification channels are not allowed',
+      message: alertChannelSelectionMessages[result.code],
     });
   }
 };


### PR DESCRIPTION
Exposes multi-channel alerts through the v2 external API, the internal API, and the MCP `clickstack_save_alert` tool. Writes accept a `channels` array, and every alert response carries both `channels` and the legacy `channel`.

## What changed

`alertSchema` (shared by `/api/alerts` and `/api/v2/alerts`) takes `channel` and/or `channels`, replacing its local channel definition with the shared one from common-utils.

`validateAlertInput` checks every referenced webhook exists and belongs to the team in a single query instead of one per channel. `makeAlert` persists the canonical `channels` array with `channel` mirrored to `channels[0]`.

v2 responses gain `channels`; the internal API also returns `channels` but masks `webhookId` to `{type}`, matching the existing policy for `channel`. OpenAPI documents the new shape and the input rule.

The MCP tool accepts `channels` with hand-rolled cross-field validation, since the MCP SDK cannot serialise `ZodEffects`.

## Key decisions

**Updates replace rather than merge.** A client that sends only the legacy `channel` when updating a multi-channel alert reduces it to that one target. Merging would make channels unremovable by legacy clients, so the behaviour stands and is documented in the changeset, the OpenAPI update schema, and the MCP tool description.

**Bulk webhook check by count.** `countDocuments({_id: {$in: uniqueIds}, team})` compared against the deduplicated id count. A cross-team or non-existent id can only lower the count, so it still rejects — and ids are validated as ObjectIds before reaching `$in`.

## Impact

Additive for existing consumers: `channel` is still accepted on input and present on every response. `channel` was removed from the `required` list of the create and update request schemas, since either field now satisfies the requirement.

Editing a multi-channel alert in the app still replaces `channels` with the single UI-selected channel, until the alert forms support the full list.

<details>
<summary>Implementation detail</summary>

The round-trip case is covered end to end: a response body is PUT back unchanged and the alert keeps both channels. Rejections are covered for a channel/channels mismatch, neither field, duplicates, exceeding the cap, and a cross-team webhook hidden among valid ones — on both the external and internal routes, and on the MCP tool.

Verification: 52 external-api, 43 internal, 31 MCP integration tests; `yarn lint:openapi` clean.

</details>

