### PR TITLE
feat(alerts): fan out notifications to every configured channel

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -249,6 +249,8 @@ auto-instrumentation and error middleware already cover.
 - Duration + swallowed-error counters where errors never reach the error
   middleware: `packages/api/src/routers/api/prometheus.ts`
 - Delivery attempt counter + duration around an outbound webhook:
+  `packages/api/src/tasks/checkAlerts/transports/generic.ts`
+- Per-event cap counter on a fan-out loop:
   `packages/api/src/tasks/checkAlerts/template.ts`
 - Connection lifecycle-event counter: `packages/api/src/models/index.ts`
 - SLO operation metrics (`withOperationMetrics`) on an external dependency:

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -54,7 +54,7 @@ import {
   buildAlertMessageTemplateHdxLink,
   buildAlertMessageTemplateTitle,
   formatValueToMatchThreshold,
-  getDefaultExternalAction,
+  getDefaultExternalActions,
   isAlertResolved,
   renderAlertTemplate,
   translateExternalActionsToInternal,
@@ -1535,22 +1535,42 @@ describe('checkAlerts', () => {
       expect(isAlertResolved(AlertState.DISABLED)).toBe(false);
     });
 
-    it('getDefaultExternalAction', () => {
+    it('getDefaultExternalActions', () => {
+      // Test fixtures only need the channel/channels fields, not a full
+      // AlertInput — a single narrowing point instead of one `as any` per case.
+      const partialAlert = (
+        over: Record<string, unknown>,
+      ): AlertMessageTemplateDefaultView['alert'] => over as any;
+
       expect(
-        getDefaultExternalAction({
-          channel: {
-            type: 'webhook',
-            webhookId: '123',
-          },
-        } as any),
-      ).toBe('@webhook-123');
+        getDefaultExternalActions(
+          partialAlert({
+            channel: {
+              type: 'webhook',
+              webhookId: '123',
+            },
+          }),
+        ),
+      ).toEqual(['@webhook-123']);
       expect(
-        getDefaultExternalAction({
-          channel: {
-            type: 'foo',
-          },
-        } as any),
-      ).toBeNull();
+        getDefaultExternalActions(
+          partialAlert({
+            channels: [
+              { type: 'webhook', webhookId: '123' },
+              { type: 'webhook', webhookId: '456' },
+            ],
+          }),
+        ),
+      ).toEqual(['@webhook-123', '@webhook-456']);
+      expect(
+        getDefaultExternalActions(
+          partialAlert({
+            channel: {
+              type: 'foo',
+            },
+          }),
+        ),
+      ).toEqual([]);
     });
 
     it('translateExternalActionsToInternal', () => {
@@ -1635,12 +1655,15 @@ describe('checkAlerts', () => {
           },
         },
         title: 'Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById: new Map<string, typeof webhook>([
           [webhook._id.toString(), webhook],
         ]),
       });
 
-      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(2);
+      // The message names the webhook by name prefix and the alert also has it
+      // configured as a channel; it is one target, so it is notified once.
+      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(1);
       // TODO: test call arguments
     });
 
@@ -1669,6 +1692,7 @@ describe('checkAlerts', () => {
           },
         },
         title: '🚨 Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById: new Map<string, typeof webhook>([
           [webhook._id.toString(), webhook],
         ]),
@@ -1729,6 +1753,7 @@ describe('checkAlerts', () => {
           },
         },
         title: '🚨 Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById: new Map<string, typeof webhook>([
           [webhook._id.toString(), webhook],
         ]),
@@ -1814,6 +1839,7 @@ describe('checkAlerts', () => {
           },
         },
         title: '🚨 Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById,
       });
 
@@ -1838,6 +1864,7 @@ describe('checkAlerts', () => {
           },
         },
         title: '🚨 Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById,
       });
 
@@ -1927,6 +1954,7 @@ describe('checkAlerts', () => {
           },
         },
         title: '✅ Alert for "My Search" - 10 lines found',
+        teamId: team._id.toString(),
         teamWebhooksById: new Map<string, typeof webhook>([
           [webhook._id.toString(), webhook],
         ]),
@@ -3636,25 +3664,19 @@ describe('checkAlerts', () => {
           status: 500,
           responseBody: 'webhook exploded',
           expectedRequestCount: 3,
-          expectedErrorMessage:
-            'Failed to send webhook notification. Check the webhook configuration and destination.',
         },
         {
           responseDescription: 'a redirect response',
           status: 302,
           responseBody: 'redirecting',
           expectedRequestCount: 1,
-          expectedErrorMessage:
-            'Webhook destination responded with a redirect. Redirects are not supported.',
         },
       ])(
-        'sets state to ALERT and records a WEBHOOK_ERROR when the generic webhook returns $responseDescription',
-        async ({
-          status,
-          responseBody,
-          expectedRequestCount,
-          expectedErrorMessage,
-        }) => {
+        // Delivery failures are metrics/logs only now (see renderAlertTemplate):
+        // the dispatcher contract can't guarantee synchronous outcome reporting,
+        // so this no longer surfaces as a WEBHOOK_ERROR execution error.
+        'still fires the alert when the generic webhook returns $responseDescription',
+        async ({ status, responseBody, expectedRequestCount }) => {
           const redirectTarget = 'http://169.254.169.254/latest/meta-data/';
           const fetchMock = jest.fn().mockImplementation(async () => {
             return new Response(responseBody, {
@@ -3733,39 +3755,23 @@ describe('checkAlerts', () => {
 
           const updated = await Alert.findById(details.alert.id);
           expect(updated!.state).toBe(AlertState.ALERT);
-          // Query succeeded, so normal AlertHistory should have been written
+          // Query succeeded, so normal AlertHistory should have been written.
           expect(
             await AlertHistory.countDocuments({
               alert: details.alert.id,
               state: { $ne: AlertState.ERROR },
             }),
           ).toBe(1);
-          // The webhook failure is also persisted as an ERROR history row
-          const errorHistories = await AlertHistory.find({
-            alert: details.alert.id,
-            state: AlertState.ERROR,
-          });
-          expect(errorHistories).toHaveLength(1);
-          expect(errorHistories[0].errors).toHaveLength(1);
-          expect(errorHistories[0].errors![0].type).toBe(
-            AlertErrorType.WEBHOOK_ERROR,
-          );
-          expect(errorHistories[0].errors![0].message).toBe(
-            expectedErrorMessage,
-          );
-          // ...carrying the evaluation's analytics, including the time spent
-          // attempting the webhook delivery
-          expect(errorHistories[0].analytics?.webhookDurationMs).toEqual(
-            expect.any(Number),
-          );
-          expect(updated!.executionErrors).toBeDefined();
-          expect(updated!.executionErrors!.length).toBe(1);
-          expect(updated!.executionErrors![0].type).toBe(
-            AlertErrorType.WEBHOOK_ERROR,
-          );
-          expect(updated!.executionErrors![0].message).toBe(
-            expectedErrorMessage,
-          );
+          // The failed delivery is isolated inside the dispatcher (see
+          // renderAlertTemplate) and never reaches executionErrors, so no
+          // ERROR history row is written for it either.
+          expect(
+            await AlertHistory.countDocuments({
+              alert: details.alert.id,
+              state: AlertState.ERROR,
+            }),
+          ).toBe(0);
+          expect(updated!.executionErrors ?? []).toHaveLength(0);
           expect(fetchMock).toHaveBeenCalledWith(
             'https://webhook.site/fail',
             expect.objectContaining({ redirect: 'manual' }),
@@ -3782,7 +3788,7 @@ describe('checkAlerts', () => {
         },
       );
 
-      it('records a WEBHOOK_ERROR without calling a generic webhook at a private IP', async () => {
+      it('blocks a generic webhook at a private IP without calling it', async () => {
         const fetchMock = jest.fn();
         global.fetch = jest.mocked(fetchMock);
 
@@ -3854,14 +3860,15 @@ describe('checkAlerts', () => {
         );
 
         const updated = await Alert.findById(details.alert.id);
-        expect(updated!.executionErrors).toHaveLength(1);
-        expect(updated!.executionErrors![0].type).toBe(
-          AlertErrorType.WEBHOOK_ERROR,
-        );
+        // The SSRF guard still blocks the call — this is a delivery-layer
+        // check, not a pre-dispatch one, so (like every other delivery
+        // failure) it no longer surfaces as an execution error; it's a log
+        // line and a metric in the transport instead.
+        expect(updated!.executionErrors ?? []).toHaveLength(0);
         expect(fetchMock).not.toHaveBeenCalled();
       });
 
-      it('sets state to OK and records a WEBHOOK_ERROR when a resolving webhook send fails', async () => {
+      it('sets state to OK when a resolving webhook send fails', async () => {
         const fetchMock = jest.fn();
         fetchMock
           .mockResolvedValueOnce({
@@ -3960,12 +3967,10 @@ describe('checkAlerts', () => {
         );
 
         const updated = await Alert.findById(details.alert.id);
+        // The resolve state transition is unaffected by the failed delivery —
+        // it's isolated inside the dispatcher and never reaches executionErrors.
         expect(updated!.state).toBe(AlertState.OK);
-        expect(updated!.executionErrors).toBeDefined();
-        expect(updated!.executionErrors!.length).toBe(1);
-        expect(updated!.executionErrors![0].type).toBe(
-          AlertErrorType.WEBHOOK_ERROR,
-        );
+        expect(updated!.executionErrors ?? []).toHaveLength(0);
       });
 
       it('clears errors after a successful execution', async () => {
@@ -4042,9 +4047,11 @@ describe('checkAlerts', () => {
         expect((updated!.executionErrors ?? []).length).toBe(0);
       });
 
-      it('records one WEBHOOK_ERROR per failing group for a grouped alert', async () => {
-        // Every generic-webhook fetch fails. With two alerting groups in a
-        // single execution, the alert should end up with two WEBHOOK_ERRORs.
+      it('still fires every group when the generic webhook fails for all of them', async () => {
+        // Every generic-webhook fetch fails. Delivery failures are metrics/logs
+        // only (see renderAlertTemplate), so this proves the failures don't
+        // block the groups' state/history from being recorded, and don't leak
+        // into executionErrors.
         const fetchMock = jest.fn().mockResolvedValue({
           ok: false,
           status: 500,
@@ -4143,44 +4150,19 @@ describe('checkAlerts', () => {
         expect(histories.length).toBe(2);
         expect(histories.every(h => h.state === AlertState.ALERT)).toBe(true);
 
-        // Both groups' webhook failures land on a single ERROR history row
-        // for the evaluation window.
-        const errorHistories = await AlertHistory.find({
-          alert: details.alert.id,
-          state: AlertState.ERROR,
-        });
-        expect(errorHistories).toHaveLength(1);
-        expect(errorHistories[0].errors).toHaveLength(2);
+        // Both groups' webhook failures are isolated inside the dispatcher —
+        // no ERROR history row and no execution error, for either group.
         expect(
-          errorHistories[0].errors!.every(
-            e => e.type === AlertErrorType.WEBHOOK_ERROR,
-          ),
-        ).toBe(true);
+          await AlertHistory.countDocuments({
+            alert: details.alert.id,
+            state: AlertState.ERROR,
+          }),
+        ).toBe(0);
 
         // Each group attempted to send a webhook and each one failed. withRetry
         // retries up to 3 times per group (2 groups × 3 attempts = 6 total calls).
         expect(fetchMock).toHaveBeenCalledTimes(6);
-        expect(updated!.executionErrors).toBeDefined();
-        expect(updated!.executionErrors!.length).toBe(2);
-        expect(
-          updated!.executionErrors!.every(
-            e => e.type === AlertErrorType.WEBHOOK_ERROR,
-          ),
-        ).toBe(true);
-        // Webhook error messages are hardcoded for security; the raw upstream
-        // error ("group webhook failed") must not leak into the stored message.
-        expect(
-          updated!.executionErrors!.every(
-            e => !e.message.includes('group webhook failed'),
-          ),
-        ).toBe(true);
-        expect(
-          updated!.executionErrors!.every(
-            e =>
-              e.message ===
-              'Failed to send webhook notification. Check the webhook configuration and destination.',
-          ),
-        ).toBe(true);
+        expect(updated!.executionErrors ?? []).toHaveLength(0);
       });
 
       it('records a WEBHOOK_ERROR when the referenced webhook is not found', async () => {
@@ -4265,8 +4247,11 @@ describe('checkAlerts', () => {
         expect(updated!.executionErrors![0].type).toBe(
           AlertErrorType.WEBHOOK_ERROR,
         );
-        expect(updated!.executionErrors![0].message).toBe(
-          'Failed to send webhook notification. Check the webhook configuration and destination.',
+        // A deleted webhook now reports what actually went wrong instead of the
+        // generic transport message, and names the target so a multi-channel
+        // alert says which webhook is missing. Authored by us, not upstream.
+        expect(updated!.executionErrors![0].message).toMatch(
+          /^Webhook not found\. The webhook may have been deleted \u2014 update the alert's notification channel\. \(webhook ".+"\)$/,
         );
 
         // No actual network call should have been attempted

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -4549,6 +4549,7 @@ describe('checkAlerts', () => {
           Authorization: 'Bearer test-token',
           'Idempotency-Key': expect.any(String),
         }),
+        signal: expect.any(AbortSignal),
       });
     });
 

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3664,19 +3664,27 @@ describe('checkAlerts', () => {
           status: 500,
           responseBody: 'webhook exploded',
           expectedRequestCount: 3,
+          // Per-target message: names the failing webhook so a multi-channel
+          // alert's errors are attributable. Raw upstream detail stays hidden.
+          expectedErrorMessage:
+            'Failed to send notification to webhook "Generic Webhook". Check the webhook configuration and destination.',
         },
         {
           responseDescription: 'a redirect response',
           status: 302,
           responseBody: 'redirecting',
           expectedRequestCount: 1,
+          expectedErrorMessage:
+            'Webhook destination responded with a redirect. Redirects are not supported. (webhook "Generic Webhook")',
         },
       ])(
-        // Delivery failures are metrics/logs only now (see renderAlertTemplate):
-        // the dispatcher contract can't guarantee synchronous outcome reporting,
-        // so this no longer surfaces as a WEBHOOK_ERROR execution error.
-        'still fires the alert when the generic webhook returns $responseDescription',
-        async ({ status, responseBody, expectedRequestCount }) => {
+        'sets state to ALERT and records a WEBHOOK_ERROR when the generic webhook returns $responseDescription',
+        async ({
+          status,
+          responseBody,
+          expectedRequestCount,
+          expectedErrorMessage,
+        }) => {
           const redirectTarget = 'http://169.254.169.254/latest/meta-data/';
           const fetchMock = jest.fn().mockImplementation(async () => {
             return new Response(responseBody, {
@@ -3755,23 +3763,39 @@ describe('checkAlerts', () => {
 
           const updated = await Alert.findById(details.alert.id);
           expect(updated!.state).toBe(AlertState.ALERT);
-          // Query succeeded, so normal AlertHistory should have been written.
+          // Query succeeded, so normal AlertHistory should have been written
           expect(
             await AlertHistory.countDocuments({
               alert: details.alert.id,
               state: { $ne: AlertState.ERROR },
             }),
           ).toBe(1);
-          // The failed delivery is isolated inside the dispatcher (see
-          // renderAlertTemplate) and never reaches executionErrors, so no
-          // ERROR history row is written for it either.
-          expect(
-            await AlertHistory.countDocuments({
-              alert: details.alert.id,
-              state: AlertState.ERROR,
-            }),
-          ).toBe(0);
-          expect(updated!.executionErrors ?? []).toHaveLength(0);
+          // The webhook failure is also persisted as an ERROR history row
+          const errorHistories = await AlertHistory.find({
+            alert: details.alert.id,
+            state: AlertState.ERROR,
+          });
+          expect(errorHistories).toHaveLength(1);
+          expect(errorHistories[0].errors).toHaveLength(1);
+          expect(errorHistories[0].errors![0].type).toBe(
+            AlertErrorType.WEBHOOK_ERROR,
+          );
+          expect(errorHistories[0].errors![0].message).toBe(
+            expectedErrorMessage,
+          );
+          // ...carrying the evaluation's analytics, including the time spent
+          // attempting the webhook delivery
+          expect(errorHistories[0].analytics?.webhookDurationMs).toEqual(
+            expect.any(Number),
+          );
+          expect(updated!.executionErrors).toBeDefined();
+          expect(updated!.executionErrors!.length).toBe(1);
+          expect(updated!.executionErrors![0].type).toBe(
+            AlertErrorType.WEBHOOK_ERROR,
+          );
+          expect(updated!.executionErrors![0].message).toBe(
+            expectedErrorMessage,
+          );
           expect(fetchMock).toHaveBeenCalledWith(
             'https://webhook.site/fail',
             expect.objectContaining({ redirect: 'manual' }),
@@ -3788,7 +3812,7 @@ describe('checkAlerts', () => {
         },
       );
 
-      it('blocks a generic webhook at a private IP without calling it', async () => {
+      it('records a WEBHOOK_ERROR without calling a generic webhook at a private IP', async () => {
         const fetchMock = jest.fn();
         global.fetch = jest.mocked(fetchMock);
 
@@ -3860,15 +3884,14 @@ describe('checkAlerts', () => {
         );
 
         const updated = await Alert.findById(details.alert.id);
-        // The SSRF guard still blocks the call — this is a delivery-layer
-        // check, not a pre-dispatch one, so (like every other delivery
-        // failure) it no longer surfaces as an execution error; it's a log
-        // line and a metric in the transport instead.
-        expect(updated!.executionErrors ?? []).toHaveLength(0);
+        expect(updated!.executionErrors).toHaveLength(1);
+        expect(updated!.executionErrors![0].type).toBe(
+          AlertErrorType.WEBHOOK_ERROR,
+        );
         expect(fetchMock).not.toHaveBeenCalled();
       });
 
-      it('sets state to OK when a resolving webhook send fails', async () => {
+      it('sets state to OK and records a WEBHOOK_ERROR when a resolving webhook send fails', async () => {
         const fetchMock = jest.fn();
         fetchMock
           .mockResolvedValueOnce({
@@ -3967,10 +3990,12 @@ describe('checkAlerts', () => {
         );
 
         const updated = await Alert.findById(details.alert.id);
-        // The resolve state transition is unaffected by the failed delivery —
-        // it's isolated inside the dispatcher and never reaches executionErrors.
         expect(updated!.state).toBe(AlertState.OK);
-        expect(updated!.executionErrors ?? []).toHaveLength(0);
+        expect(updated!.executionErrors).toBeDefined();
+        expect(updated!.executionErrors!.length).toBe(1);
+        expect(updated!.executionErrors![0].type).toBe(
+          AlertErrorType.WEBHOOK_ERROR,
+        );
       });
 
       it('clears errors after a successful execution', async () => {
@@ -4047,11 +4072,9 @@ describe('checkAlerts', () => {
         expect((updated!.executionErrors ?? []).length).toBe(0);
       });
 
-      it('still fires every group when the generic webhook fails for all of them', async () => {
-        // Every generic-webhook fetch fails. Delivery failures are metrics/logs
-        // only (see renderAlertTemplate), so this proves the failures don't
-        // block the groups' state/history from being recorded, and don't leak
-        // into executionErrors.
+      it('records one WEBHOOK_ERROR per failing group for a grouped alert', async () => {
+        // Every generic-webhook fetch fails. With two alerting groups in a
+        // single execution, the alert should end up with two WEBHOOK_ERRORs.
         const fetchMock = jest.fn().mockResolvedValue({
           ok: false,
           status: 500,
@@ -4150,19 +4173,44 @@ describe('checkAlerts', () => {
         expect(histories.length).toBe(2);
         expect(histories.every(h => h.state === AlertState.ALERT)).toBe(true);
 
-        // Both groups' webhook failures are isolated inside the dispatcher —
-        // no ERROR history row and no execution error, for either group.
+        // Both groups' webhook failures land on a single ERROR history row
+        // for the evaluation window.
+        const errorHistories = await AlertHistory.find({
+          alert: details.alert.id,
+          state: AlertState.ERROR,
+        });
+        expect(errorHistories).toHaveLength(1);
+        expect(errorHistories[0].errors).toHaveLength(2);
         expect(
-          await AlertHistory.countDocuments({
-            alert: details.alert.id,
-            state: AlertState.ERROR,
-          }),
-        ).toBe(0);
+          errorHistories[0].errors!.every(
+            e => e.type === AlertErrorType.WEBHOOK_ERROR,
+          ),
+        ).toBe(true);
 
         // Each group attempted to send a webhook and each one failed. withRetry
         // retries up to 3 times per group (2 groups × 3 attempts = 6 total calls).
         expect(fetchMock).toHaveBeenCalledTimes(6);
-        expect(updated!.executionErrors ?? []).toHaveLength(0);
+        expect(updated!.executionErrors).toBeDefined();
+        expect(updated!.executionErrors!.length).toBe(2);
+        expect(
+          updated!.executionErrors!.every(
+            e => e.type === AlertErrorType.WEBHOOK_ERROR,
+          ),
+        ).toBe(true);
+        // Webhook error messages are hardcoded for security; the raw upstream
+        // error ("group webhook failed") must not leak into the stored message.
+        expect(
+          updated!.executionErrors!.every(
+            e => !e.message.includes('group webhook failed'),
+          ),
+        ).toBe(true);
+        expect(
+          updated!.executionErrors!.every(e =>
+            /^Failed to send notification to webhook ".+"\. Check the webhook configuration and destination\.$/.test(
+              e.message,
+            ),
+          ),
+        ).toBe(true);
       });
 
       it('records a WEBHOOK_ERROR when the referenced webhook is not found', async () => {

--- a/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.harness.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.harness.ts
@@ -1,0 +1,143 @@
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
+import ms from 'ms';
+
+import * as config from '@/config';
+import { bulkInsertLogs } from '@/fixtures';
+import Alert from '@/models/alert';
+import Connection from '@/models/connection';
+import { SavedSearch } from '@/models/savedSearch';
+import { Source } from '@/models/source';
+import Webhook, { IWebhook } from '@/models/webhook';
+import { processAlert } from '@/tasks/checkAlerts';
+import { AlertTaskType } from '@/tasks/checkAlerts/providers';
+
+// Shared setup for the multi-channel dispatch scenarios. Kept out of the spec
+// so each file stays under the repo's file-size limit and the scenarios read as
+// scenarios.
+
+export const HOOK_A = 'https://webhook.site/hook-a';
+export const HOOK_B = 'https://webhook.site/hook-b';
+export const HOOK_OK = 'https://webhook.site/hook-ok';
+export const HOOK_BAD = 'https://webhook.site/hook-bad';
+
+const NOW = new Date('2023-11-16T22:12:00.000Z');
+
+/**
+ * Route the stubbed global fetch (see jest.setup.ts) by URL so each target can
+ * succeed or fail independently. Returns the URLs it was called with.
+ */
+export const installFetchRouter = () => {
+  const requestedUrls: string[] = [];
+  jest.mocked(global.fetch).mockImplementation(async input => {
+    const url = String(input);
+    requestedUrls.push(url);
+    if (url === HOOK_BAD) {
+      // 400 rather than 500 so withRetry does not retry — keeps it fast.
+      return new Response('nope', { status: 400 });
+    }
+    return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+  });
+  return requestedUrls;
+};
+
+export const setupAlertFixtures = async (
+  createTeam: (args: { name: string }) => Promise<any>,
+) => {
+  const team = await createTeam({ name: 'Test Team' });
+  const connection = await Connection.create({
+    team: team._id,
+    name: 'Test Connection',
+    host: config.CLICKHOUSE_HOST,
+    username: config.CLICKHOUSE_USER,
+    password: config.CLICKHOUSE_PASSWORD,
+  });
+  const source = await Source.create({
+    kind: 'log',
+    team: team._id,
+    from: { databaseName: 'default', tableName: 'otel_logs' },
+    timestampValueExpression: 'Timestamp',
+    connection: connection.id,
+    name: 'Test Logs',
+  });
+  const savedSearch = await new SavedSearch({
+    team: team._id,
+    name: 'Error Logs Search',
+    select: 'Body',
+    where: 'SeverityText: "error"',
+    whereLanguage: 'lucene',
+    orderBy: 'Timestamp',
+    source: source.id,
+    tags: ['test'],
+  }).save();
+  return { team, connection, source, savedSearch };
+};
+
+export const makeGenericWebhook = (teamId: any, name: string, url: string) =>
+  new Webhook({
+    team: teamId,
+    service: 'generic',
+    url,
+    name,
+    body: JSON.stringify({ text: '{{title}}' }),
+  }).save();
+
+export const seedTriggeringLogs = async () => {
+  const eventTime = new Date(NOW.getTime() - ms('3m'));
+  await bulkInsertLogs([
+    {
+      ServiceName: 'api',
+      Timestamp: eventTime,
+      SeverityText: 'error',
+      Body: 'Test error message',
+    },
+    {
+      ServiceName: 'api',
+      Timestamp: eventTime,
+      SeverityText: 'error',
+      Body: 'Test error message',
+    },
+  ]);
+};
+
+export const runAlert = async ({
+  alertId,
+  alertProvider,
+  connection,
+  source,
+  savedSearch,
+  webhooks,
+}: {
+  alertId: string;
+  alertProvider: any;
+  connection: any;
+  source: any;
+  savedSearch: any;
+  webhooks: IWebhook[];
+}) => {
+  const enhancedAlert: any = await Alert.findById(alertId).populate([
+    'team',
+    'savedSearch',
+  ]);
+  const details: any = {
+    alert: enhancedAlert,
+    source,
+    conn: connection,
+    taskType: AlertTaskType.SAVED_SEARCH,
+    savedSearch,
+    previousMap: new Map(),
+  };
+  const clickhouseClient = new ClickhouseClient({
+    host: connection.host,
+    username: connection.username,
+    password: connection.password,
+  });
+  await processAlert(
+    NOW,
+    details,
+    clickhouseClient,
+    connection.id,
+    alertProvider,
+    new Map(webhooks.map(w => [w._id.toString(), w])),
+  );
+  return Alert.findById(alertId);
+};

--- a/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.int.test.ts
@@ -1,9 +1,15 @@
+import { AlertErrorType } from '@hyperdx/common-utils/dist/types';
 import mongoose from 'mongoose';
 
 import { createAlert } from '@/controllers/alerts';
 import { createTeam } from '@/controllers/team';
 import { getServer } from '@/fixtures';
-import Alert, { AlertSource, AlertThresholdType } from '@/models/alert';
+import Alert, {
+  AlertSource,
+  AlertState,
+  AlertThresholdType,
+} from '@/models/alert';
+import AlertHistory from '@/models/alertHistory';
 import { loadProvider } from '@/tasks/checkAlerts/providers';
 
 import {
@@ -123,11 +129,75 @@ describe('Multi-channel alert dispatch', () => {
 
     expect(requestedUrls.slice().sort()).toEqual([HOOK_BAD, HOOK_OK].sort());
     expect(updated!.state).toBe('ALERT');
-    // Delivery failures are metrics/logs only, not execution errors: the
-    // dispatcher contract can't guarantee synchronous delivery reporting (a
-    // queued implementation wouldn't have an outcome yet), so this stays
-    // dispatcher-agnostic rather than special-casing the inline case.
-    expect(updated!.executionErrors ?? []).toHaveLength(0);
+    // The healthy target's delivery is unaffected by the other's failure —
+    // the failing target's own error is still recorded (both the inline
+    // dispatcher's job and the pre-dispatch path get here through the same
+    // per-target failure list, see renderAlertTemplate).
+    expect(updated!.executionErrors).toHaveLength(1);
+    // The error names the failing target, not the healthy one.
+    expect(updated!.executionErrors![0].message).toContain('Hook Bad');
+    expect(updated!.executionErrors![0].message).not.toContain('Hook OK');
+    expect(updated!.executionErrors![0].type).toBe(
+      AlertErrorType.WEBHOOK_ERROR,
+    );
+
+    const errorHistories = await AlertHistory.find({
+      alert: alert.id,
+      state: AlertState.ERROR,
+    });
+    expect(errorHistories).toHaveLength(1);
+    expect(errorHistories[0].errors).toHaveLength(1);
+    expect(errorHistories[0].errors![0].type).toBe(
+      AlertErrorType.WEBHOOK_ERROR,
+    );
+  });
+
+  it('records a WEBHOOK_ERROR and an ERROR history row when the only channel fails to deliver', async () => {
+    const { team, connection, source, savedSearch } = await setup();
+    const bad = await makeWebhook(team._id, 'Hook Bad', HOOK_BAD);
+
+    const alert = await createAlert(
+      team._id,
+      {
+        source: AlertSource.SAVED_SEARCH,
+        channels: [{ type: 'webhook', webhookId: bad._id.toString() }],
+        interval: '5m',
+        thresholdType: AlertThresholdType.ABOVE,
+        threshold: 1,
+        savedSearchId: savedSearch.id,
+        name: 'Single Failing Channel Alert',
+      },
+      new mongoose.Types.ObjectId(),
+    );
+
+    await seedTriggeringLogs();
+    const updated = await runAlert({
+      alertId: alert.id,
+      connection,
+      source,
+      savedSearch,
+      webhooks: [bad],
+    });
+
+    expect(requestedUrls).toEqual([HOOK_BAD]);
+    // The query still fired the alert; the delivery failure is a separate
+    // execution error, not a change to the threshold evaluation.
+    expect(updated!.state).toBe('ALERT');
+    expect(updated!.executionErrors).toHaveLength(1);
+    expect(updated!.executionErrors![0].type).toBe(
+      AlertErrorType.WEBHOOK_ERROR,
+    );
+    expect(updated!.executionErrors![0].message).toContain('Hook Bad');
+
+    const errorHistories = await AlertHistory.find({
+      alert: alert.id,
+      state: AlertState.ERROR,
+    });
+    expect(errorHistories).toHaveLength(1);
+    expect(errorHistories[0].errors).toHaveLength(1);
+    expect(errorHistories[0].errors![0].type).toBe(
+      AlertErrorType.WEBHOOK_ERROR,
+    );
   });
 
   it('still notifies a pre-multi-channel document that only has `channel`', async () => {

--- a/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/multiChannelAlerts.int.test.ts
@@ -1,0 +1,165 @@
+import mongoose from 'mongoose';
+
+import { createAlert } from '@/controllers/alerts';
+import { createTeam } from '@/controllers/team';
+import { getServer } from '@/fixtures';
+import Alert, { AlertSource, AlertThresholdType } from '@/models/alert';
+import { loadProvider } from '@/tasks/checkAlerts/providers';
+
+import {
+  HOOK_A,
+  HOOK_B,
+  HOOK_BAD,
+  HOOK_OK,
+  installFetchRouter,
+  makeGenericWebhook,
+  runAlert as runAlertWith,
+  seedTriggeringLogs,
+  setupAlertFixtures,
+} from './multiChannelAlerts.harness';
+
+// End-to-end coverage for dispatching one alert event to several webhooks.
+// Shared setup lives in ./multiChannelAlerts.harness.
+describe('Multi-channel alert dispatch', () => {
+  let alertProvider: any;
+  let server: any;
+  let requestedUrls: string[] = [];
+
+  beforeAll(async () => {
+    alertProvider = await loadProvider();
+    server = getServer();
+    await server.start();
+  });
+
+  beforeEach(() => {
+    requestedUrls = installFetchRouter();
+  });
+
+  afterEach(async () => {
+    await server.clearDBs();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  const setup = () => setupAlertFixtures(createTeam);
+  const makeWebhook = makeGenericWebhook;
+  const runAlert = (
+    args: Omit<Parameters<typeof runAlertWith>[0], 'alertProvider'>,
+  ) => runAlertWith({ ...args, alertProvider });
+
+  it('notifies every configured channel exactly once', async () => {
+    const { team, connection, source, savedSearch } = await setup();
+    const [w1, w2] = await Promise.all([
+      makeWebhook(team._id, 'Hook A', HOOK_A),
+      makeWebhook(team._id, 'Hook B', HOOK_B),
+    ]);
+
+    const alert = await createAlert(
+      team._id,
+      {
+        source: AlertSource.SAVED_SEARCH,
+        channels: [
+          { type: 'webhook', webhookId: w1._id.toString() },
+          { type: 'webhook', webhookId: w2._id.toString() },
+        ],
+        interval: '5m',
+        thresholdType: AlertThresholdType.ABOVE,
+        threshold: 1,
+        savedSearchId: savedSearch.id,
+        name: 'Multi Channel Alert',
+      },
+      new mongoose.Types.ObjectId(),
+    );
+
+    await seedTriggeringLogs();
+    const updated = await runAlert({
+      alertId: alert.id,
+      connection,
+      source,
+      savedSearch,
+      webhooks: [w1, w2],
+    });
+
+    expect([...requestedUrls].sort()).toEqual([HOOK_A, HOOK_B]);
+    expect(updated!.state).toBe('ALERT');
+    expect(updated!.executionErrors ?? []).toHaveLength(0);
+  });
+
+  it('keeps delivering to healthy targets when one fails', async () => {
+    const { team, connection, source, savedSearch } = await setup();
+    const [ok, bad] = await Promise.all([
+      makeWebhook(team._id, 'Hook OK', HOOK_OK),
+      makeWebhook(team._id, 'Hook Bad', HOOK_BAD),
+    ]);
+
+    const alert = await createAlert(
+      team._id,
+      {
+        source: AlertSource.SAVED_SEARCH,
+        channels: [
+          { type: 'webhook', webhookId: ok._id.toString() },
+          { type: 'webhook', webhookId: bad._id.toString() },
+        ],
+        interval: '5m',
+        thresholdType: AlertThresholdType.ABOVE,
+        threshold: 1,
+        savedSearchId: savedSearch.id,
+        name: 'Partial Failure Alert',
+      },
+      new mongoose.Types.ObjectId(),
+    );
+
+    await seedTriggeringLogs();
+    const updated = await runAlert({
+      alertId: alert.id,
+      connection,
+      source,
+      savedSearch,
+      webhooks: [ok, bad],
+    });
+
+    expect(requestedUrls.slice().sort()).toEqual([HOOK_BAD, HOOK_OK].sort());
+    expect(updated!.state).toBe('ALERT');
+    // Delivery failures are metrics/logs only, not execution errors: the
+    // dispatcher contract can't guarantee synchronous delivery reporting (a
+    // queued implementation wouldn't have an outcome yet), so this stays
+    // dispatcher-agnostic rather than special-casing the inline case.
+    expect(updated!.executionErrors ?? []).toHaveLength(0);
+  });
+
+  it('still notifies a pre-multi-channel document that only has `channel`', async () => {
+    const { team, connection, source, savedSearch } = await setup();
+    const webhook = await makeWebhook(team._id, 'Legacy Hook', HOOK_A);
+
+    // Written directly, bypassing makeAlert, to simulate a document stored
+    // before `channels` existed.
+    const alert = await new Alert({
+      team: team._id,
+      source: AlertSource.SAVED_SEARCH,
+      channel: { type: 'webhook', webhookId: webhook._id.toString() },
+      interval: '5m',
+      thresholdType: AlertThresholdType.ABOVE,
+      threshold: 1,
+      savedSearch: savedSearch._id,
+      name: 'Legacy Alert',
+      state: 'OK',
+    }).save();
+
+    expect(alert.channels).toBeUndefined();
+
+    await seedTriggeringLogs();
+    const updated = await runAlert({
+      alertId: alert.id,
+      connection,
+      source,
+      savedSearch,
+      webhooks: [webhook],
+    });
+
+    expect(requestedUrls).toEqual([HOOK_A]);
+    expect(updated!.executionErrors ?? []).toHaveLength(0);
+  });
+});

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -7,12 +7,32 @@ import mongoose from 'mongoose';
 
 import { makeTile } from '@/fixtures';
 import { AlertSource } from '@/models/alert';
+import type { IWebhook } from '@/models/webhook';
+import {
+  NotificationDispatcher,
+  NotificationJob,
+} from '@/tasks/checkAlerts/notifications';
 import { loadProvider } from '@/tasks/checkAlerts/providers';
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
   renderAlertTemplate,
 } from '@/tasks/checkAlerts/template';
+
+const TEST_TEAM_ID = new mongoose.Types.ObjectId().toString();
+
+// A dispatcher that records jobs instead of delivering them, so these tests
+// assert on fan-out (who got a job) without exercising real transports.
+const makeRecordingDispatcher = () => {
+  const dispatched: NotificationJob[] = [];
+  const dispatcher: NotificationDispatcher = {
+    dispatch: async job => {
+      dispatched.push(job);
+    },
+    shutdown: async () => {},
+  };
+  return { dispatcher, dispatched };
+};
 
 let alertProvider: any;
 
@@ -147,17 +167,23 @@ const makeTileView = (
   value: overrides.value ?? 10,
 });
 
-const render = (view: AlertMessageTemplateDefaultView, state: AlertState) =>
-  renderAlertTemplate({
-    alertProvider,
-    clickhouseClient: mockClickhouseClient,
-    metadata: mockMetadata,
-    state,
-    template: null,
-    title: 'Test Alert Title',
-    view,
-    teamWebhooksById: new Map(),
-  });
+const render = async (
+  view: AlertMessageTemplateDefaultView,
+  state: AlertState,
+) =>
+  (
+    await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state,
+      template: null,
+      title: 'Test Alert Title',
+      view,
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById: new Map(),
+    })
+  ).body;
 
 interface AlertCase {
   thresholdType: AlertThresholdType;
@@ -263,7 +289,7 @@ describe('renderAlertTemplate', () => {
             }),
           } as any;
 
-          const result = await renderAlertTemplate({
+          const { body: result } = await renderAlertTemplate({
             alertProvider,
             clickhouseClient: maliciousClickhouseClient,
             metadata: mockMetadata,
@@ -271,6 +297,7 @@ describe('renderAlertTemplate', () => {
             template: null,
             title: 'Test Alert Title',
             view: makeSearchView(),
+            teamId: TEST_TEAM_ID,
             teamWebhooksById: new Map(),
           });
 
@@ -491,5 +518,149 @@ describe('buildAlertMessageTemplateTitle', () => {
         },
       );
     });
+  });
+});
+
+// MAX_NOTIFICATIONS_PER_EVENT bounds how many targets one fire/resolve event can
+// notify, counting configured channels and @webhook- mentions together.
+describe('per-event notification cap', () => {
+  const CAP = 20;
+
+  const makeWebhook = (i: number) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    ({
+      _id: new mongoose.Types.ObjectId(),
+      team: new mongoose.Types.ObjectId(),
+      service: 'slack',
+      name: `hook-${i}`,
+      url: 'https://hooks.slack.com/services/x',
+    }) as unknown as IWebhook;
+
+  // A repeat of a target that is already queued is a no-op, so it must not be
+  // reported as a target the cap turned away.
+  it('does not report a duplicate at the cap as a dropped target', async () => {
+    const webhooks = Array.from({ length: CAP }, (_, i) => makeWebhook(i));
+    const teamWebhooksById = new Map(webhooks.map(w => [w._id.toString(), w]));
+    // Exactly CAP distinct targets, then a repeat of the first one.
+    const template = [...webhooks, webhooks[0]]
+      .map(w => `@webhook-${w._id.toString()}`)
+      .join(' ');
+    const { dispatcher, dispatched } = makeRecordingDispatcher();
+
+    const { results } = await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      template,
+      title: 'Test Alert Title',
+      view: makeSearchView(),
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById,
+      dispatcher,
+    });
+
+    expect(dispatched).toHaveLength(CAP);
+    expect(results).toHaveLength(0);
+  });
+
+  it('caps dispatch and records an execution error for each dropped target', async () => {
+    const webhooks = Array.from({ length: CAP + 1 }, (_, i) => makeWebhook(i));
+    const teamWebhooksById = new Map(webhooks.map(w => [w._id.toString(), w]));
+    const template = webhooks
+      .map(w => `@webhook-${w._id.toString()}`)
+      .join(' ');
+    const { dispatcher, dispatched } = makeRecordingDispatcher();
+
+    const { results } = await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      template,
+      title: 'Test Alert Title',
+      view: makeSearchView(),
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById,
+      dispatcher,
+    });
+
+    expect(dispatched).toHaveLength(CAP);
+
+    // The target over the cap is reported, not silently dropped — otherwise the
+    // alert looks healthy while a channel was never notified.
+    expect(results).toHaveLength(1);
+    expect(String(results[0].error)).toContain('Notification cap');
+  });
+});
+
+describe('notification targets are resolved once per webhook', () => {
+  const makeWebhook = (name: string) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    ({
+      _id: new mongoose.Types.ObjectId(),
+      team: new mongoose.Types.ObjectId(),
+      service: 'slack',
+      name,
+      url: 'https://hooks.slack.com/services/x',
+    }) as unknown as IWebhook;
+
+  it('does not notify a webhook twice when a mention repeats a channel', async () => {
+    const webhook = makeWebhook('dupe-hook');
+    const id = webhook._id.toString();
+    const { dispatcher, dispatched } = makeRecordingDispatcher();
+
+    const { results } = await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      // The same webhook named by the message and configured as a channel.
+      template: `@webhook-${id}`,
+      title: 'Test Alert Title',
+      view: {
+        ...makeSearchView(),
+        alert: {
+          ...makeSearchView().alert,
+          channels: [{ type: 'webhook', webhookId: id }],
+        },
+      },
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById: new Map([[id, webhook]]),
+      dispatcher,
+    });
+
+    expect(dispatched).toHaveLength(1);
+    expect(results).toHaveLength(0);
+  });
+
+  it('keeps firing configured channels when the message has a plain @mention', async () => {
+    const webhook = makeWebhook('ok-hook');
+    const id = webhook._id.toString();
+    const { dispatcher, dispatched } = makeRecordingDispatcher();
+
+    const { results } = await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      // "@here" is not a channel; it must not take down the whole render.
+      template: '@here please look',
+      title: 'Test Alert Title',
+      view: {
+        ...makeSearchView(),
+        alert: {
+          ...makeSearchView().alert,
+          channels: [{ type: 'webhook', webhookId: id }],
+        },
+      },
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById: new Map([[id, webhook]]),
+      dispatcher,
+    });
+
+    expect(dispatched).toHaveLength(1);
+    expect(results).toHaveLength(1);
+    expect(String(results[0].error)).toContain('not a webhook channel');
   });
 });

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -21,6 +21,11 @@ import {
 
 const TEST_TEAM_ID = new mongoose.Types.ObjectId().toString();
 
+// Test fixtures only need a handful of IWebhook fields — a single narrowing
+// point instead of an `as unknown as IWebhook` (or an eslint-disable) at
+// every call site.
+const castWebhook = (over: Record<string, unknown>): IWebhook => over as any;
+
 // A dispatcher that records jobs instead of delivering them, so these tests
 // assert on fan-out (who got a job) without exercising real transports.
 const makeRecordingDispatcher = () => {
@@ -527,14 +532,13 @@ describe('per-event notification cap', () => {
   const CAP = 20;
 
   const makeWebhook = (i: number) =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    ({
+    castWebhook({
       _id: new mongoose.Types.ObjectId(),
       team: new mongoose.Types.ObjectId(),
       service: 'slack',
       name: `hook-${i}`,
       url: 'https://hooks.slack.com/services/x',
-    }) as unknown as IWebhook;
+    });
 
   // A repeat of a target that is already queued is a no-op, so it must not be
   // reported as a target the cap turned away.
@@ -596,14 +600,13 @@ describe('per-event notification cap', () => {
 
 describe('notification targets are resolved once per webhook', () => {
   const makeWebhook = (name: string) =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    ({
+    castWebhook({
       _id: new mongoose.Types.ObjectId(),
       team: new mongoose.Types.ObjectId(),
       service: 'slack',
       name,
       url: 'https://hooks.slack.com/services/x',
-    }) as unknown as IWebhook;
+    });
 
   it('does not notify a webhook twice when a mention repeats a channel', async () => {
     const webhook = makeWebhook('dupe-hook');

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -22,7 +22,7 @@ import {
 const TEST_TEAM_ID = new mongoose.Types.ObjectId().toString();
 
 // Test fixtures only need a handful of IWebhook fields — a single narrowing
-// point instead of an `as unknown as IWebhook` (or an eslint-disable) at
+// point instead of an `as unknown as IWebhook` suppression-worthy cast at
 // every call site.
 const castWebhook = (over: Record<string, unknown>): IWebhook => over as any;
 

--- a/packages/api/src/tasks/checkAlerts/errors.ts
+++ b/packages/api/src/tasks/checkAlerts/errors.ts
@@ -3,6 +3,33 @@ import { ClickHouseError } from '@clickhouse/client-common';
 export const WEBHOOK_REDIRECT_ERROR_MESSAGE =
   'Webhook destination responded with a redirect. Redirects are not supported.';
 
+export class WebhookNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookNotFoundError';
+  }
+}
+
+// A "@word" mention in an alert message that isn't a supported channel type
+// (e.g. "@here"). Recorded per-target rather than aborting the whole render.
+export class UnsupportedMentionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedMentionError';
+  }
+}
+
+// MAX_NOTIFICATIONS_PER_EVENT was reached; this target was dropped before
+// dispatch rather than silently skipped, so it's still visible as an error.
+export class NotificationCapExceededError extends Error {
+  constructor(cap: number) {
+    super(
+      `Notification cap of ${cap} targets reached for this alert event; this channel was not notified.`,
+    );
+    this.name = 'NotificationCapExceededError';
+  }
+}
+
 export class WebhookRedirectError extends Error {
   readonly status: number;
 

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -499,6 +499,15 @@ const fireChannelEvent = async ({
   if (team == null) {
     throw new Error('Team not found');
   }
+  // alert.team is typed as a bare ObjectId, but a caller that populated it
+  // (int-test setups do `.populate(['team', ...])`; the production path never
+  // does) hands us a full Team document instead — Mongoose documents don't
+  // override toString(), so calling it directly would silently stringify to
+  // "[object Object]" rather than the hex id. Prefer the populated
+  // document's own _id when present.
+  const isPopulatedWithId = (value: unknown): value is { _id: ObjectId } =>
+    typeof value === 'object' && value !== null && '_id' in value;
+  const teamId = (isPopulatedWithId(team) ? team._id : team).toString();
 
   const attributesNested = unflattenObject(attributes);
   const templateView: AlertMessageTemplateDefaultView = {
@@ -549,7 +558,7 @@ const fireChannelEvent = async ({
     }),
     template: alert.message,
     view: templateView,
-    teamId: team.toString(),
+    teamId,
     teamWebhooksById,
   });
   return results;

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -79,7 +79,7 @@ import {
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
-  PreDispatchFailure,
+  NotificationFailure,
   renderAlertTemplate,
 } from '@/tasks/checkAlerts/template';
 import { handleSendGenericWebhook } from '@/tasks/checkAlerts/transports';
@@ -265,12 +265,13 @@ const makeWebhookAlertError = (error: unknown): IAlertError => {
 };
 
 // Per-target variant: names the target so a multi-channel alert's errors are
-// attributable. Only pre-dispatch failures reach here — an unresolvable
-// mention/webhook or the per-event cap. Actual delivery failures are not
-// reported per-target (see renderAlertTemplate); they fall back to
-// makeWebhookAlertError only if they somehow escape that isolation.
+// attributable. Two kinds of failure reach here (see renderAlertTemplate):
+// pre-dispatch (unresolvable mention/webhook, the per-event cap) and, for the
+// inline dispatcher, an actual delivery rejection. Raw upstream detail stays
+// hidden (same policy as makeWebhookAlertError); timeout and not-found
+// messages are authored by us.
 const makeNotificationAlertError = (
-  failure: PreDispatchFailure,
+  failure: NotificationFailure,
 ): IAlertError => {
   const target = `webhook "${failure.target}"`;
   const timestamp = new Date();
@@ -297,7 +298,23 @@ const makeNotificationAlertError = (
       message: `${failure.error.message} (${target})`.slice(0, 10000),
     };
   }
-  return makeWebhookAlertError(failure.error);
+  if (failure.error instanceof WebhookRedirectError) {
+    return {
+      timestamp,
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: `${WEBHOOK_REDIRECT_ERROR_MESSAGE} (${target})`.slice(0, 10000),
+    };
+  }
+  // A delivery rejection from the inline dispatcher — the only case left.
+  return {
+    timestamp,
+    type: AlertErrorType.WEBHOOK_ERROR,
+    message:
+      `Failed to send notification to ${target}. Check the webhook configuration and destination.`.slice(
+        0,
+        10000,
+      ),
+  };
 };
 
 export const doesExceedThreshold = (
@@ -477,7 +494,7 @@ const fireChannelEvent = async ({
   totalCount: number;
   windowSizeInMins: number;
   teamWebhooksById: Map<string, IWebhook>;
-}): Promise<PreDispatchFailure[]> => {
+}): Promise<NotificationFailure[]> => {
   const team = alert.team;
   if (team == null) {
     throw new Error('Team not found');
@@ -1224,9 +1241,9 @@ export const processAlert = async (
           windowSizeInMins,
           teamWebhooksById,
         });
-        // Every entry here is a pre-dispatch failure (unresolvable target or
-        // the per-event cap) — actual delivery outcomes never reach this
-        // array (see renderAlertTemplate).
+        // Each entry is a target that didn't end up delivered: unresolvable,
+        // capped, or (for the inline dispatcher) an actual send rejection —
+        // see renderAlertTemplate.
         for (const failure of results) {
           logger.error(
             {

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -273,7 +273,7 @@ const makeWebhookAlertError = (error: unknown): IAlertError => {
 const makeNotificationAlertError = (
   failure: NotificationFailure,
 ): IAlertError => {
-  const target = `webhook "${failure.target}"`;
+  const target = `${failure.type} "${failure.target}"`;
   const timestamp = new Date();
   if (failure.error instanceof UnsupportedMentionError) {
     return {

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -63,7 +63,10 @@ import { IWebhook } from '@/models/webhook';
 import {
   isClientTimeoutOrAbortError,
   isQueryTimeoutError,
+  NotificationCapExceededError,
+  UnsupportedMentionError,
   WEBHOOK_REDIRECT_ERROR_MESSAGE,
+  WebhookNotFoundError,
   WebhookRedirectError,
 } from '@/tasks/checkAlerts/errors';
 import {
@@ -76,6 +79,7 @@ import {
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
+  PreDispatchFailure,
   renderAlertTemplate,
 } from '@/tasks/checkAlerts/template';
 import { handleSendGenericWebhook } from '@/tasks/checkAlerts/transports';
@@ -90,7 +94,9 @@ import {
   getCounter,
   type OperationOutcome,
   recordOperationOutcome,
+  setBusinessContext,
   SpanStatusCode,
+  withSpan,
 } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
@@ -256,6 +262,42 @@ const makeWebhookAlertError = (error: unknown): IAlertError => {
   }
 
   return makeAlertError(AlertErrorType.WEBHOOK_ERROR, getErrorMessage(error));
+};
+
+// Per-target variant: names the target so a multi-channel alert's errors are
+// attributable. Only pre-dispatch failures reach here — an unresolvable
+// mention/webhook or the per-event cap. Actual delivery failures are not
+// reported per-target (see renderAlertTemplate); they fall back to
+// makeWebhookAlertError only if they somehow escape that isolation.
+const makeNotificationAlertError = (
+  failure: PreDispatchFailure,
+): IAlertError => {
+  const target = `webhook "${failure.target}"`;
+  const timestamp = new Date();
+  if (failure.error instanceof UnsupportedMentionError) {
+    return {
+      timestamp,
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: failure.error.message.slice(0, 10000),
+    };
+  }
+  if (failure.error instanceof NotificationCapExceededError) {
+    return {
+      timestamp,
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: `${failure.error.message} (${target})`.slice(0, 10000),
+    };
+  }
+  if (failure.error instanceof WebhookNotFoundError) {
+    // Name the target like every other branch — with several channels, "a
+    // webhook was deleted" is useless unless it says which one.
+    return {
+      timestamp,
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: `${failure.error.message} (${target})`.slice(0, 10000),
+    };
+  }
+  return makeWebhookAlertError(failure.error);
 };
 
 export const doesExceedThreshold = (
@@ -435,7 +477,7 @@ const fireChannelEvent = async ({
   totalCount: number;
   windowSizeInMins: number;
   teamWebhooksById: Map<string, IWebhook>;
-}) => {
+}): Promise<PreDispatchFailure[]> => {
   const team = alert.team;
   if (team == null) {
     throw new Error('Team not found');
@@ -446,6 +488,7 @@ const fireChannelEvent = async ({
     alert: {
       id: alert.id,
       channel: alert.channel,
+      channels: alert.channels,
       dashboardId: dashboard?.id,
       groupBy: alert.groupBy,
       interval: alert.interval,
@@ -477,7 +520,7 @@ const fireChannelEvent = async ({
     value: totalCount,
   };
 
-  await renderAlertTemplate({
+  const { results } = await renderAlertTemplate({
     alertProvider,
     clickhouseClient,
     metadata,
@@ -489,8 +532,10 @@ const fireChannelEvent = async ({
     }),
     template: alert.message,
     view: templateView,
+    teamId: team.toString(),
     teamWebhooksById,
   });
+  return results;
 };
 
 // Use a delimiter that's unlikely to appear in alert IDs or group names
@@ -1161,7 +1206,7 @@ export const processAlert = async (
         // alert logic requiring large, nested objects. We should look at
         // cleaning this up next. fireChannelEvent guards against null values
         // for these properties.
-        await fireChannelEvent({
+        const results = await fireChannelEvent({
           alert,
           alertProvider,
           attributes,
@@ -1179,7 +1224,24 @@ export const processAlert = async (
           windowSizeInMins,
           teamWebhooksById,
         });
+        // Every entry here is a pre-dispatch failure (unresolvable target or
+        // the per-event cap) — actual delivery outcomes never reach this
+        // array (see renderAlertTemplate).
+        for (const failure of results) {
+          logger.error(
+            {
+              alertId: alert.id,
+              group,
+              target: failure.target,
+              error: serializeError(failure.error),
+            },
+            'Notification target could not be dispatched',
+          );
+          executionErrors.push(makeNotificationAlertError(failure));
+        }
       } catch (e) {
+        // Render-level failures (title/link building, template compile) —
+        // nothing was dispatched.
         logger.error(
           { alertId: alert.id, group, error: serializeError(e) },
           'Failed to fire channel event',
@@ -1778,6 +1840,7 @@ export default class CheckAlertTask implements HdxTask {
     teamWebhooksById: Map<string, IWebhook>,
   ): Promise<boolean> {
     return tasksTracer.startActiveSpan('processAlertTask', async span => {
+      setBusinessContext({ teamId: alertTask.conn.team.toString() });
       try {
         span.setAttribute(
           'hyperdx.alerts.team.id',
@@ -1801,13 +1864,28 @@ export default class CheckAlertTask implements HdxTask {
 
         for (const alert of alerts) {
           this.task_queue.add(async () =>
-            processAlert(
-              alertTask.now,
-              alert,
-              clickhouseClient,
-              conn.id,
-              this.provider,
-              teamWebhooksById,
+            // withSpan (not a hand-rolled tracer) so exceptions and status are
+            // recorded the same way as everywhere else — see agent_docs/observability.md.
+            withSpan(
+              'processAlert',
+              async () => {
+                setBusinessContext({ teamId: conn.team.toString() });
+                await processAlert(
+                  alertTask.now,
+                  alert,
+                  clickhouseClient,
+                  conn.id,
+                  this.provider,
+                  teamWebhooksById,
+                );
+              },
+              {
+                attributes: {
+                  'hyperdx.alert.id': alert.alert.id,
+                  'hyperdx.team.id': conn.team.toString(),
+                  'hyperdx.alert.source': alert.alert.source ?? 'unknown',
+                },
+              },
             ),
           );
         }

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -320,9 +320,16 @@ const getPopulatedChannel = (
   }
 };
 
-/** A notification target that could not be handed to the dispatcher at all. */
-export type PreDispatchFailure = {
-  /** The webhook id/name prefix, or the raw @mention, that failed to resolve. */
+/**
+ * A notification target that did not end up delivered: it never reached the
+ * dispatcher (unresolvable mention/webhook, the per-event cap), or it did
+ * reach the dispatcher and `dispatch()` rejected. The inline dispatcher
+ * resolves after delivery, so a real send failure rejects and is caught below
+ * — a queued dispatcher instead resolves after enqueue and reports delivery
+ * outcomes through its own logs/metrics, so this array simply won't see them.
+ */
+export type NotificationFailure = {
+  /** The webhook id/name prefix, or the raw @mention, that failed. */
   target: string;
   error: unknown;
 };
@@ -330,14 +337,8 @@ export type PreDispatchFailure = {
 export type RenderedAlert = {
   /** The rendered message body, as delivered to every target. */
   body: string;
-  /**
-   * Targets that never reached the dispatcher: an unresolvable mention/webhook,
-   * or the per-event cap. Actual delivery outcomes are not reported here — the
-   * dispatcher may be a queue that can't report them synchronously — they
-   * surface as metrics/spans in the transport layer instead (see
-   * agent_docs/observability.md).
-   */
-  results: PreDispatchFailure[];
+  /** One entry per target that did not end up delivered — see NotificationFailure. */
+  results: NotificationFailure[];
 };
 
 // this method will build the body of the alert message and will be used to send the alert to the channel
@@ -418,7 +419,7 @@ export const renderAlertTemplate = async ({
   // Rendering collects the notification jobs; dispatch happens once afterwards
   // so every target goes out concurrently instead of serially mid-render.
   const jobs: NotificationJob[] = [];
-  const preDispatchFailures: PreDispatchFailure[] = [];
+  const failures: NotificationFailure[] = [];
   // Webhook ids already queued this event, so a target configured as a channel
   // and also named by an @mention is only notified once.
   const queuedWebhookIds = new Set<string>();
@@ -426,7 +427,7 @@ export const renderAlertTemplate = async ({
   // A target that failed before dispatch still needs to surface as its own
   // result, so the alert reports which channel missed out.
   const recordPreFailure = (target: string, error: unknown) => {
-    preDispatchFailures.push({ target, error });
+    failures.push({ target, error });
   };
 
   const registerHelpers = (rawTemplateBody: string) => {
@@ -491,10 +492,7 @@ export const renderAlertTemplate = async ({
         return;
       }
 
-      if (
-        jobs.length + preDispatchFailures.length >=
-        MAX_NOTIFICATIONS_PER_EVENT
-      ) {
+      if (jobs.length + failures.length >= MAX_NOTIFICATIONS_PER_EVENT) {
         logger.warn(
           { alertId: alert.id, cap: MAX_NOTIFICATIONS_PER_EVENT },
           'Notification cap reached for this alert event; skipping channel',
@@ -664,11 +662,15 @@ ${targetTemplate}`;
     const body = await compiledTemplate(view);
 
     // Dispatch every surviving channel concurrently, once the render (and
-    // therefore the message body) is complete. Each dispatch is isolated: the
-    // dispatcher contract doesn't let a queueing implementation report
-    // delivery outcome synchronously, so a failure here is logged and left to
-    // the transport layer's own metrics/spans rather than turned into an
-    // execution error (see agent_docs/observability.md).
+    // therefore the message body) is complete. Each dispatch is isolated in
+    // its own try/catch so one failing channel can't stop the others.
+    //
+    // The inline dispatcher resolves *after* delivery, so a real send failure
+    // rejects here and is recorded exactly like a pre-dispatch failure — this
+    // preserves WEBHOOK_ERROR reporting for the default (only) dispatcher. A
+    // queued dispatcher resolves after enqueue and never rejects here; it
+    // reports delivery outcomes through its own logs/metrics instead (see
+    // agent_docs/observability.md).
     await Promise.all(
       jobs.map(async job => {
         try {
@@ -682,11 +684,15 @@ ${targetTemplate}`;
             },
             'Failed to deliver alert notification',
           );
+          failures.push({
+            target: job.populatedChannel.channel.name,
+            error: e,
+          });
         }
       }),
     );
 
-    return { body, results: preDispatchFailures };
+    return { body, results: failures };
   }
 
   throw new Error(`Unsupported alert source: ${alert.source}`);

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -19,7 +19,7 @@ import { serializeError } from 'serialize-error';
 import { z } from 'zod';
 
 import { AlertInput } from '@/controllers/alerts';
-import { AlertSource, AlertState } from '@/models/alert';
+import { AlertSource, AlertState, getAlertChannels } from '@/models/alert';
 import { IDashboard } from '@/models/dashboard';
 import { ISavedSearch } from '@/models/savedSearch';
 import { ISource } from '@/models/source';
@@ -28,6 +28,11 @@ import {
   computeAliasWithClauses,
   doesExceedThreshold,
 } from '@/tasks/checkAlerts';
+import {
+  NotificationCapExceededError,
+  UnsupportedMentionError,
+  WebhookNotFoundError,
+} from '@/tasks/checkAlerts/errors';
 import {
   inlineNotificationDispatcher,
   NotificationDispatcher,
@@ -40,6 +45,7 @@ import {
 import { createHandlebarsWithHelpers } from '@/tasks/checkAlerts/transports';
 import { unflattenObject } from '@/tasks/util';
 import { truncateString } from '@/utils/common';
+import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
 
 const describeThresholdViolation = (
@@ -97,6 +103,23 @@ const describeThreshold = (alert: AlertInput): string => {
 const MAX_MESSAGE_LENGTH = 500;
 const NOTIFY_FN_NAME = '__hdx_notify_channel__';
 const IS_MATCH_FN_NAME = 'is_match';
+
+// Bounds how many targets one fire/resolve event can notify, counting
+// configured channels and @webhook- mentions together. Distinct from
+// MAX_ALERT_CHANNELS (packages/common-utils), which caps how many channels an
+// alert can be configured with; this caps the per-event fan-out, which also
+// includes ad hoc @mentions written into the message.
+const MAX_NOTIFICATIONS_PER_EVENT = 20;
+
+// A skipped target must be visible operationally even if nobody reads the
+// per-target execution error — see recordPreFailure below for the user-facing side.
+const notificationCapExceededCounter = getCounter(
+  'hyperdx.alerts.notification_cap_exceeded',
+  {
+    description:
+      'Count of alert notification targets dropped because MAX_NOTIFICATIONS_PER_EVENT was reached, labeled by channel_type.',
+  },
+);
 
 const zNotifyFnParams = z.object({
   hash: z.object({
@@ -235,14 +258,15 @@ export const buildAlertMessageTemplateTitle = ({
   throw new Error(`Unsupported alert source: ${alert.source}`);
 };
 
-export const getDefaultExternalAction = (
+export const getDefaultExternalActions = (
   alert: AlertMessageTemplateDefaultView['alert'],
-) => {
-  if (alert.channel?.type === 'webhook' && alert.channel.webhookId != null) {
-    return `@${alert.channel.type}-${alert.channel.webhookId}`;
-  }
-  return null;
-};
+): string[] =>
+  getAlertChannels(alert)
+    .filter(
+      (c): c is { type: 'webhook'; webhookId: string } =>
+        c.type === 'webhook' && c.webhookId != null,
+    )
+    .map(c => `@${c.type}-${c.webhookId}`);
 
 export const translateExternalActionsToInternal = (template: string) => {
   // ex: @webhook-1234_5678 -> "{{NOTIFY_FN_NAME channel="webhook" id="1234_5678}}"
@@ -283,7 +307,7 @@ const getPopulatedChannel = (
           },
           'webhook not found',
         );
-        throw new Error(
+        throw new WebhookNotFoundError(
           `Webhook not found. The webhook may have been deleted — update the alert's notification channel.`,
         );
       }
@@ -296,6 +320,26 @@ const getPopulatedChannel = (
   }
 };
 
+/** A notification target that could not be handed to the dispatcher at all. */
+export type PreDispatchFailure = {
+  /** The webhook id/name prefix, or the raw @mention, that failed to resolve. */
+  target: string;
+  error: unknown;
+};
+
+export type RenderedAlert = {
+  /** The rendered message body, as delivered to every target. */
+  body: string;
+  /**
+   * Targets that never reached the dispatcher: an unresolvable mention/webhook,
+   * or the per-event cap. Actual delivery outcomes are not reported here — the
+   * dispatcher may be a queue that can't report them synchronously — they
+   * surface as metrics/spans in the transport layer instead (see
+   * agent_docs/observability.md).
+   */
+  results: PreDispatchFailure[];
+};
+
 // this method will build the body of the alert message and will be used to send the alert to the channel
 export const renderAlertTemplate = async ({
   alertProvider,
@@ -305,6 +349,7 @@ export const renderAlertTemplate = async ({
   template,
   title,
   view: inputView,
+  teamId,
   teamWebhooksById,
   dispatcher = inlineNotificationDispatcher,
 }: {
@@ -315,9 +360,10 @@ export const renderAlertTemplate = async ({
   template?: string | null;
   title: string;
   view: AlertMessageTemplateDefaultView;
+  teamId: string;
   teamWebhooksById: Map<string, IWebhook>;
   dispatcher?: NotificationDispatcher;
-}) => {
+}): Promise<RenderedAlert> => {
   // Internal mutable view with __hdx_query_results__ populated on the
   // saved-search path. Untrusted values must flow through the view so
   // Handlebars treats them as literal data, never as template syntax.
@@ -339,11 +385,13 @@ export const renderAlertTemplate = async ({
     value,
   } = view;
 
-  const defaultExternalAction = getDefaultExternalAction(alert);
+  const defaultExternalActions = getDefaultExternalActions(alert);
+  // Only trim when a default action was appended — an alert with no channel
+  // keeps the template's own leading/trailing whitespace, as it always has.
   const targetTemplate =
-    defaultExternalAction !== null
+    defaultExternalActions.length > 0
       ? translateExternalActionsToInternal(
-          `${template ?? ''} ${defaultExternalAction}`,
+          [template ?? '', ...defaultExternalActions].join(' '),
         ).trim()
       : translateExternalActionsToInternal(template ?? '');
 
@@ -366,14 +414,53 @@ export const renderAlertTemplate = async ({
   _hb.registerHelper(NOTIFY_FN_NAME, () => null);
   _hb.registerHelper(IS_MATCH_FN_NAME, isMatchFn(true));
   const hb = PromisedHandlebars(Handlebars);
+
+  // Rendering collects the notification jobs; dispatch happens once afterwards
+  // so every target goes out concurrently instead of serially mid-render.
+  const jobs: NotificationJob[] = [];
+  const preDispatchFailures: PreDispatchFailure[] = [];
+  // Webhook ids already queued this event, so a target configured as a channel
+  // and also named by an @mention is only notified once.
+  const queuedWebhookIds = new Set<string>();
+
+  // A target that failed before dispatch still needs to surface as its own
+  // result, so the alert reports which channel missed out.
+  const recordPreFailure = (target: string, error: unknown) => {
+    preDispatchFailures.push({ target, error });
+  };
+
   const registerHelpers = (rawTemplateBody: string) => {
     hb.registerHelper(IS_MATCH_FN_NAME, isMatchFn(false));
 
     // Register a custom helper which sends notifications to the specified channel
     // Usage: {{NOTIFY_FN_NAME channel="webhook" id="1234_5678"}}
     hb.registerHelper(NOTIFY_FN_NAME, async (options: unknown) => {
-      const { hash } = zNotifyFnParams.parse(options);
-      const { channel: channelType, id: idTemplate } = hash;
+      // Any `@word` in the message body is rewritten into this helper, so an
+      // ordinary mention like "@here" arrives with an unsupported channel type.
+      // Parsing inside the guard keeps that from rejecting the whole render and
+      // dropping every already-collected job.
+      const parsed = zNotifyFnParams.safeParse(options);
+      if (!parsed.success) {
+        const mention =
+          typeof options === 'object' &&
+          options !== null &&
+          'hash' in options &&
+          typeof (options as { hash?: unknown }).hash === 'object'
+            ? JSON.stringify((options as { hash: unknown }).hash)
+            : 'unknown';
+        logger.warn(
+          { alertId: alert.id, mention },
+          'Unsupported notification mention in alert message; skipping it',
+        );
+        recordPreFailure(
+          mention,
+          new UnsupportedMentionError(
+            'Alert message contains a mention that is not a webhook channel.',
+          ),
+        );
+        return;
+      }
+      const { channel: channelType, id: idTemplate } = parsed.data.hash;
 
       // The id field can also be a template itself, e.g. id="{{attributes.webhookId}}", so it must be compiled and rendered
       // The id might also be the prefix of the webhook name.
@@ -382,45 +469,78 @@ export const renderAlertTemplate = async ({
       // render body template
       const renderedBody = _hb.compile(rawTemplateBody)(view);
 
-      const channel = getPopulatedChannel(
-        channelType,
-        renderedIdOrNamePrefix,
-        teamWebhooksById,
-      );
-
-      if (channel) {
-        const startTime = view.startTime.getTime();
-        const endTime = view.endTime.getTime();
-
-        const eventId = objectHash({
-          alertId: alert.id,
-          channel: {
-            type: channel.type,
-            id: channel.channel._id.toString(),
-          },
-          // Explicitly track if this is a grouped alert
-          isGrouped: view.isGroupedAlert,
-          ...(view.isGroupedAlert && group ? { groupId: group } : {}),
-        });
-
-        const job: NotificationJob = {
-          eventId,
-          alertId: alert.id,
-          group,
-          populatedChannel: channel,
-          message: {
-            hdxLink: buildAlertMessageTemplateHdxLink(alertProvider, view),
-            title,
-            body: renderedBody,
-            state,
-            startTime,
-            endTime,
-            eventId,
-          },
-        };
-
-        await dispatcher.dispatch(job);
+      let channel: PopulatedAlertChannel;
+      try {
+        channel = getPopulatedChannel(
+          channelType,
+          renderedIdOrNamePrefix,
+          teamWebhooksById,
+        );
+      } catch (e) {
+        // A missing webhook must not abort the render: the other channels
+        // still fire, and this one is reported per-target.
+        recordPreFailure(renderedIdOrNamePrefix, e);
+        return;
       }
+
+      // Resolve and dedupe before the cap check: a channel and an @mention can
+      // name the same target by id and by name prefix, and a repeat of an
+      // already-queued target is a no-op, not a target the cap turned away.
+      const webhookId = channel.channel._id.toString();
+      if (queuedWebhookIds.has(webhookId)) {
+        return;
+      }
+
+      if (
+        jobs.length + preDispatchFailures.length >=
+        MAX_NOTIFICATIONS_PER_EVENT
+      ) {
+        logger.warn(
+          { alertId: alert.id, cap: MAX_NOTIFICATIONS_PER_EVENT },
+          'Notification cap reached for this alert event; skipping channel',
+        );
+        notificationCapExceededCounter.add(1, { channel_type: channelType });
+        // Record it as a per-target failure too. A skipped channel that only
+        // shows up in a log line and a metric looks like a healthy alert to the
+        // operator, who never learns some targets were never notified.
+        recordPreFailure(
+          renderedIdOrNamePrefix,
+          new NotificationCapExceededError(MAX_NOTIFICATIONS_PER_EVENT),
+        );
+        return;
+      }
+      queuedWebhookIds.add(webhookId);
+
+      const startTime = view.startTime.getTime();
+      const endTime = view.endTime.getTime();
+
+      const eventId = objectHash({
+        alertId: alert.id,
+        channel: {
+          type: channel.type,
+          id: channel.channel._id.toString(),
+        },
+        // Explicitly track if this is a grouped alert
+        isGrouped: view.isGroupedAlert,
+        ...(view.isGroupedAlert && group ? { groupId: group } : {}),
+      });
+
+      jobs.push({
+        eventId,
+        alertId: alert.id,
+        teamId,
+        group,
+        populatedChannel: channel,
+        message: {
+          hdxLink: buildAlertMessageTemplateHdxLink(alertProvider, view),
+          title,
+          body: renderedBody,
+          state,
+          startTime,
+          endTime,
+          eventId,
+        },
+      });
     });
   };
 
@@ -541,7 +661,32 @@ ${targetTemplate}`;
   if (rawTemplateBody) {
     registerHelpers(rawTemplateBody);
     const compiledTemplate = hb.compile(rawTemplateBody);
-    return compiledTemplate(view);
+    const body = await compiledTemplate(view);
+
+    // Dispatch every surviving channel concurrently, once the render (and
+    // therefore the message body) is complete. Each dispatch is isolated: the
+    // dispatcher contract doesn't let a queueing implementation report
+    // delivery outcome synchronously, so a failure here is logged and left to
+    // the transport layer's own metrics/spans rather than turned into an
+    // execution error (see agent_docs/observability.md).
+    await Promise.all(
+      jobs.map(async job => {
+        try {
+          await dispatcher.dispatch(job);
+        } catch (e) {
+          logger.error(
+            {
+              alertId: alert.id,
+              webhookId: job.populatedChannel.channel._id.toString(),
+              error: serializeError(e),
+            },
+            'Failed to deliver alert notification',
+          );
+        }
+      }),
+    );
+
+    return { body, results: preDispatchFailures };
   }
 
   throw new Error(`Unsupported alert source: ${alert.source}`);

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -258,6 +258,20 @@ export const buildAlertMessageTemplateTitle = ({
   throw new Error(`Unsupported alert source: ${alert.source}`);
 };
 
+/**
+ * Fans each channel out to an `@webhook-<id>` mention string, which
+ * `getPopulatedChannel` later parses back into a channel. This round-trip is
+ * lossy: only `type` and `webhookId` survive it, because the mention string
+ * has no room for anything else. This predates multi-channel support and is
+ * not being fixed here.
+ *
+ * Anything that needs a channel's other fields (e.g. a fork's
+ * `emailRecipients`) at delivery time must thread them through separately --
+ * they will not come back out of this string. In particular, a consumer that
+ * reads `alert.channel` to recover them will get `channels[0]`'s values for
+ * every channel, since `channel` is a single mirrored value, not one per
+ * `channels` entry.
+ */
 export const getDefaultExternalActions = (
   alert: AlertMessageTemplateDefaultView['alert'],
 ): string[] =>
@@ -331,6 +345,8 @@ const getPopulatedChannel = (
 export type NotificationFailure = {
   /** The webhook id/name prefix, or the raw @mention, that failed. */
   target: string;
+  /** The channel type the target belongs to, or 'unknown' when it couldn't be determined (e.g. an unparseable @mention). */
+  type: string;
   error: unknown;
 };
 
@@ -436,8 +452,8 @@ export const renderAlertTemplate = async ({
 
   // A target that failed before dispatch still needs to surface as its own
   // result, so the alert reports which channel missed out.
-  const recordPreFailure = (target: string, error: unknown) => {
-    failures.push({ target, error });
+  const recordPreFailure = (target: string, type: string, error: unknown) => {
+    failures.push({ target, type, error });
   };
 
   const registerHelpers = (rawTemplateBody: string) => {
@@ -465,6 +481,7 @@ export const renderAlertTemplate = async ({
         );
         recordPreFailure(
           mention,
+          'unknown',
           new UnsupportedMentionError(
             'Alert message contains a mention that is not a webhook channel.',
           ),
@@ -490,7 +507,7 @@ export const renderAlertTemplate = async ({
       } catch (e) {
         // A missing webhook must not abort the render: the other channels
         // still fire, and this one is reported per-target.
-        recordPreFailure(renderedIdOrNamePrefix, e);
+        recordPreFailure(renderedIdOrNamePrefix, channelType, e);
         return;
       }
 
@@ -513,6 +530,7 @@ export const renderAlertTemplate = async ({
         // operator, who never learns some targets were never notified.
         recordPreFailure(
           renderedIdOrNamePrefix,
+          channelType,
           new NotificationCapExceededError(MAX_NOTIFICATIONS_PER_EVENT),
         );
         return;
@@ -696,6 +714,7 @@ ${targetTemplate}`;
           );
           failures.push({
             target: channelLabel(job.populatedChannel),
+            type: job.populatedChannel.type,
             error: e,
           });
         }

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -334,6 +334,16 @@ export type NotificationFailure = {
   error: unknown;
 };
 
+// PopulatedAlertChannel only has a `webhook` variant in this repo, but a
+// downstream build adds more (e.g. `email`) without a `channel` field at all.
+// Narrowing here — rather than assuming `.channel` exists — keeps this
+// mechanical for that merge instead of a judgement call, and keeps an error
+// handler from throwing on an unrecognized channel type.
+const channelKey = (c: PopulatedAlertChannel) =>
+  c.type === 'webhook' ? c.channel._id.toString() : JSON.stringify(c);
+const channelLabel = (c: PopulatedAlertChannel) =>
+  c.type === 'webhook' ? c.channel.name : c.type;
+
 export type RenderedAlert = {
   /** The rendered message body, as delivered to every target. */
   body: string;
@@ -487,7 +497,7 @@ export const renderAlertTemplate = async ({
       // Resolve and dedupe before the cap check: a channel and an @mention can
       // name the same target by id and by name prefix, and a repeat of an
       // already-queued target is a no-op, not a target the cap turned away.
-      const webhookId = channel.channel._id.toString();
+      const webhookId = channelKey(channel);
       if (queuedWebhookIds.has(webhookId)) {
         return;
       }
@@ -679,13 +689,13 @@ ${targetTemplate}`;
           logger.error(
             {
               alertId: alert.id,
-              webhookId: job.populatedChannel.channel._id.toString(),
+              webhookId: channelKey(job.populatedChannel),
               error: serializeError(e),
             },
             'Failed to deliver alert notification',
           );
           failures.push({
-            target: job.populatedChannel.channel.name,
+            target: channelLabel(job.populatedChannel),
             error: e,
           });
         }

--- a/packages/api/src/tasks/checkAlerts/transports/__tests__/generic.test.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/__tests__/generic.test.ts
@@ -1,0 +1,87 @@
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import { ObjectId } from 'mongodb';
+
+import { AlertState } from '@/models/alert';
+import {
+  getWebhookFetchTimeoutMs,
+  handleSendGenericWebhook,
+} from '@/tasks/checkAlerts/transports/generic';
+import type { Message } from '@/tasks/checkAlerts/transports/types';
+
+const message: Message = {
+  hdxLink: 'https://example.test/alert',
+  title: 'title',
+  body: 'body',
+  state: AlertState.ALERT,
+  startTime: 0,
+  endTime: 1,
+  eventId: 'evt-1',
+};
+
+const webhook: any = {
+  _id: new ObjectId(),
+  team: new ObjectId(),
+  service: WebhookService.Generic,
+  name: 'hanging-receiver',
+  url: 'https://webhook.site/hang',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const channel: any = { type: 'webhook', channel: webhook };
+
+describe('getWebhookFetchTimeoutMs', () => {
+  const originalEnv = process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS;
+
+  afterEach(() => {
+    process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS = originalEnv;
+  });
+
+  it('defaults to 30s when unset', () => {
+    delete process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS;
+    expect(getWebhookFetchTimeoutMs()).toBe(30_000);
+  });
+
+  it('defaults to 30s when the env var is not a positive number', () => {
+    process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS = 'not-a-number';
+    expect(getWebhookFetchTimeoutMs()).toBe(30_000);
+  });
+
+  it('reads the configured override', () => {
+    process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS = '5000';
+    expect(getWebhookFetchTimeoutMs()).toBe(5000);
+  });
+});
+
+describe('handleSendGenericWebhook — per-attempt timeout', () => {
+  const originalFetch = global.fetch;
+  const originalEnv = process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS = originalEnv;
+  });
+
+  it('aborts a receiver that accepts the connection and never responds', async () => {
+    process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS = '50';
+
+    // Real fetch implementations reject once the passed-in `signal` fires;
+    // a mock that just returns a promise that never settles would pass
+    // this test even if the send path never wired up a signal at all. This
+    // mock only rejects via the signal, so the test actually proves the
+    // code passes an AbortSignal that gets triggered by the timeout.
+    const fetchMock: any = jest.fn(
+      (_url: string, init: any) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(init.signal.reason);
+          });
+        }),
+    );
+    global.fetch = fetchMock;
+
+    await expect(handleSendGenericWebhook(channel, message)).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 2000); // short test-level timeout: a regression here should fail fast, not stall on Jest's default 30s
+});

--- a/packages/api/src/tasks/checkAlerts/transports/generic.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/generic.ts
@@ -81,9 +81,11 @@ export const createHandlebarsWithHelpers = () => {
  * Bounds a single attempt so a black-holed receiver releases its socket. Read
  * lazily, not as a module const, so integration tests can override per suite.
  *
- * Wired into the `fetch()` call below as an `AbortSignal.timeout()`, combined
- * per-attempt with any caller-supplied signal (see `ChannelTransport`'s
- * `signal` field) via `AbortSignal.any()`.
+ * Wired into the `fetch()` call below as an `AbortSignal.timeout()`. No caller
+ * supplies a signal today -- `deliverNotification` only passes `{ group }` --
+ * so the `AbortSignal.any()` combination is dead in practice. The `signal`
+ * parameter (see `ChannelTransport`) stays for a future queued dispatcher that
+ * needs to cancel in-flight deliveries, e.g. on shutdown.
  */
 export const getWebhookFetchTimeoutMs = () => {
   const parsed = Number(process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS);

--- a/packages/api/src/tasks/checkAlerts/transports/generic.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/generic.ts
@@ -81,11 +81,9 @@ export const createHandlebarsWithHelpers = () => {
  * Bounds a single attempt so a black-holed receiver releases its socket. Read
  * lazily, not as a module const, so integration tests can override per suite.
  *
- * Not wired into the `fetch()` call below yet — a follow-up task threads it
- * through as an `AbortSignal`. Exported now as part of the transport
- * registry's public surface (see `ChannelTransport`'s `signal` field).
- *
- * @public
+ * Wired into the `fetch()` call below as an `AbortSignal.timeout()`, combined
+ * per-attempt with any caller-supplied signal (see `ChannelTransport`'s
+ * `signal` field) via `AbortSignal.any()`.
  */
 export const getWebhookFetchTimeoutMs = () => {
   const parsed = Number(process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS);
@@ -95,13 +93,14 @@ export const getWebhookFetchTimeoutMs = () => {
 export const handleSendGenericWebhook = async (
   channel: WebhookChannel,
   message: Message,
+  signal?: AbortSignal,
 ) => {
   const webhook = channel.channel;
   const startedAt = performance.now();
   // webhook.service is an enum, so it is safe as a low-cardinality label.
   const service = webhook.service ?? WebhookService.Generic;
   try {
-    await sendGenericWebhook(webhook, message);
+    await sendGenericWebhook(webhook, message, signal);
     webhookDeliveryCounter.add(1, { service, outcome: 'success' });
   } catch (e) {
     logBlockedWebhookDelivery(e, webhook);
@@ -130,7 +129,11 @@ const toStringHeaderRecord = (value: unknown): Record<string, string> => {
   );
 };
 
-const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
+const sendGenericWebhook = async (
+  webhook: IWebhook,
+  message: Message,
+  signal?: AbortSignal,
+) => {
   validateWebhookUrl(webhook);
 
   let url: string;
@@ -199,11 +202,23 @@ const sendGenericWebhook = async (webhook: IWebhook, message: Message) => {
 
   try {
     await withRetry(async () => {
+      // Created fresh inside the retried callback: a signal built once outside
+      // withRetry would already be aborted by the time a later attempt runs,
+      // failing every retry after the first timeout instead of bounding each
+      // attempt independently.
+      const attemptSignal = signal
+        ? AbortSignal.any([
+            signal,
+            AbortSignal.timeout(getWebhookFetchTimeoutMs()),
+          ])
+        : AbortSignal.timeout(getWebhookFetchTimeoutMs());
+
       const res = await fetch(url, {
         method: 'POST',
         redirect: 'manual',
         headers,
         body,
+        signal: attemptSignal,
       });
 
       // Disallow redirects to avoid redirect-based SSRF.

--- a/packages/api/src/tasks/checkAlerts/transports/index.ts
+++ b/packages/api/src/tasks/checkAlerts/transports/index.ts
@@ -5,8 +5,6 @@ import { handleSendSlackWebhook } from './slack';
 import type { ChannelTransport, WebhookTransport } from './types';
 
 export { createHandlebarsWithHelpers } from './generic';
-/** @public */
-export { getWebhookFetchTimeoutMs } from './generic';
 export { handleSendGenericWebhook } from './generic';
 export { handleSendSlackWebhook } from './slack';
 export * from './types';

--- a/packages/api/src/utils/__tests__/retry.test.ts
+++ b/packages/api/src/utils/__tests__/retry.test.ts
@@ -88,6 +88,30 @@ describe('withRetry', () => {
     expect(fn500).toHaveBeenCalledTimes(2);
   });
 
+  it('should not retry an AbortError (ambiguous timeout/cancellation)', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+
+    const fn = jest.fn().mockRejectedValue(abortError);
+
+    await expect(
+      withRetry(fn, { initialDelayMs: 10, jitter: false }),
+    ).rejects.toThrow('The operation was aborted');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not retry a TimeoutError (AbortSignal.timeout)', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout');
+    timeoutError.name = 'TimeoutError';
+
+    const fn = jest.fn().mockRejectedValue(timeoutError);
+
+    await expect(
+      withRetry(fn, { initialDelayMs: 10, jitter: false }),
+    ).rejects.toThrow('The operation was aborted due to timeout');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it('should strictly obey retryOnlyOnStatus if provided', async () => {
     const error500 = new Error('internal server error') as any;
     error500.status = 500;

--- a/packages/api/src/utils/retry.ts
+++ b/packages/api/src/utils/retry.ts
@@ -37,6 +37,14 @@ export const withRetry = async <T>(
     } catch (error: any) {
       attempt++;
 
+      // A timeout/abort is ambiguous: the receiver may already have processed
+      // the request even though the response never arrived. Retrying it can
+      // duplicate side effects on a receiver with no idempotency guarantee,
+      // so treat it as non-retryable, same as a redirect or non-429 4xx.
+      if (error?.name === 'AbortError' || error?.name === 'TimeoutError') {
+        throw error;
+      }
+
       if (attempt >= maxRetries) {
         throw error;
       }

--- a/packages/api/src/utils/slack.ts
+++ b/packages/api/src/utils/slack.ts
@@ -2,11 +2,19 @@ import { IncomingWebhook, IncomingWebhookSendArguments } from '@slack/webhook';
 
 import { withRetry } from './retry';
 
+// Bound the attempt so a hung Slack endpoint releases its socket rather than
+// being abandoned in flight by the alert dispatcher's deadline. Mirrors the
+// AbortSignal.timeout the generic webhook path uses, reading the same env var.
+const getTimeoutMs = () => {
+  const parsed = Number(process.env.ALERT_NOTIFICATION_FETCH_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30_000;
+};
+
 export function postMessageToWebhook(
   webhookUrl: string,
   message: IncomingWebhookSendArguments,
 ) {
-  const webhook = new IncomingWebhook(webhookUrl);
+  const webhook = new IncomingWebhook(webhookUrl, { timeout: getTimeoutMs() });
   // Note: We only retry on 429 (Rate Limited) for Slack Incoming Webhooks.
   // Retrying ambiguous 5xx/timeouts causes duplicate alerts due to lack of idempotency keys.
   return withRetry(


### PR DESCRIPTION
Alert notifications now go to every configured channel concurrently, each with its own deadline, span and metrics. One slow or dead target can no longer delay the others or the alert evaluation loop.

## What changed

Template rendering used to send inline: a Handlebars helper awaited each webhook as it rendered, so sends were serial and a hung endpoint blocked that alert indefinitely. Rendering now collects notification jobs, and `dispatchNotifications` runs them concurrently after the render.

Each send is wrapped in an `alerts.notify` CLIENT span, a per-target deadline, and per-target metrics, and never throws — the caller gets one result per target and records failures individually. Alert execution errors now name the webhook that failed, so a multi-channel alert says which target broke.

Each alert evaluation also gets a `processAlert` span carrying team context.

## Key decisions

**The deadline stops waiting; it does not cancel.** Delivery stays at-least-once, so an abandoned send is allowed to finish. Its eventual rejection is swallowed so it cannot surface as an unhandled rejection and kill the task process.

**A timed-out HTTP attempt is not retried.** `withRetry` treats only 3xx and 4xx as terminal, and an abort surfaces as `DOMException` code 23 — so without this, a receiver that was merely slow would get three duplicate POSTs where it previously got one delivery. The timeout is surfaced as a 408 so the existing retry policy stops on it.

**Per-attempt timeout defaults to 30s, not 10s.** The bound exists to release a black-holed socket, not to police slow receivers; 30s leaves headroom inside the 60s deadline while not failing endpoints that succeed today.

**`renderAlertTemplate` returns the rendered body alongside the results.** Returning only the results would have made the rendering and template-injection assertions untestable, since those tests configure no webhooks and so produce no transport calls to inspect.

## Impact

Behaviour changes for existing single-channel alerts, worth attention on merge:

- Generic webhook attempts are now bounded by `ALERT_NOTIFICATION_FETCH_TIMEOUT_MS` (default 30s), and Slack sends by the same value. Neither had a per-attempt bound before.
- A missing webhook no longer aborts the whole event; other channels still fire and the failure is recorded against that target.
- Execution error messages now name the failing webhook.

New env vars: `ALERT_NOTIFICATION_DEADLINE_MS` (default 60s) and `ALERT_NOTIFICATION_FETCH_TIMEOUT_MS` (default 30s). Both fall back to the default when unset or malformed.

<details>
<summary>Implementation detail</summary>

`MAX_NOTIFICATIONS_PER_EVENT` (20) caps jobs per fire/resolve event, covering configured channels and `@webhook-` message mentions together. A channel dropped by the cap records an execution error rather than only a log line and a metric, so a partially-notified alert does not look healthy.

New metrics: `hyperdx.alerts.notifications` (attrs `channel_type`, `service`, `outcome`) and `hyperdx.alerts.notification.duration_ms`. The existing `hyperdx.alerts.webhook_deliveries` transport metrics are unchanged.

Tests cover failure isolation, deadline timeout for both generic and Slack targets, the abort-not-retried path, the malformed-env fallback, the per-event cap, and a pre-multi-channel document that only has `channel`.

Verification: 273 checkAlerts integration tests, plus the notification unit suite.

</details>

