### PR TITLE
feat(app): edit multiple notification channels on alerts

### DIFF
--- a/.changeset/alert-multi-channel-ui.md
+++ b/.changeset/alert-multi-channel-ui.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': minor
+---
+
+Alert forms for saved searches and dashboard tiles can now send to several webhooks. Add or remove notification channels inline (up to 10); webhooks already chosen by the alert are greyed out in the other pickers, since duplicates are rejected.

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -146,7 +146,6 @@ const AlertForm = ({
 
   const groupBy = useWatch({ control, name: 'groupBy' });
   const thresholdType = useWatch({ control, name: 'thresholdType' });
-  const channelType = useWatch({ control, name: 'channels.0.type' });
   const interval = useWatch({ control, name: 'interval' });
   const scheduleOffsetMinutes = useWatch({
     control,
@@ -301,11 +300,7 @@ const AlertForm = ({
           <Text size="xxs" opacity={0.5} mb={4}>
             Send to
           </Text>
-          <AlertChannelForm
-            control={control}
-            type={channelType}
-            channelsName="channels"
-          />
+          <AlertChannelForm control={control} channelsName="channels" />
           <AlertNoteField control={control} name="note" />
           {groupBy &&
             (thresholdType === AlertThresholdType.BELOW ||

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -16,7 +16,7 @@ import {
   SearchConditionLanguage,
   validateAlertScheduleOffsetMinutes,
   validateAlertThresholdMax,
-  zAlertChannel,
+  zAlertChannels,
 } from '@hyperdx/common-utils/dist/types';
 import {
   Accordion,
@@ -53,6 +53,7 @@ import {
   ALERT_THRESHOLD_TYPE_OPTIONS,
   intervalToMinutes,
   normalizeNoOpAlertScheduleFields,
+  toAlertChannels,
 } from '@/utils/alerts';
 
 import { AlertNoteField } from './components/AlertNoteField';
@@ -76,7 +77,7 @@ const SavedSearchAlertFormSchema = z
     scheduleOffsetMinutes: z.number().int().min(0).default(0),
     scheduleStartAt: scheduleStartAtSchema,
     thresholdType: z.nativeEnum(AlertThresholdType),
-    channel: zAlertChannel,
+    channels: zAlertChannels,
     // nullish() (not optional()): persisted alerts store this as null, which
     // optional() would reject.
     numConsecutiveWindows: z.number().int().min(1).nullish(),
@@ -123,6 +124,7 @@ const AlertForm = ({
     defaultValues: defaultValues
       ? {
           ...defaultValues,
+          channels: toAlertChannels(defaultValues),
           scheduleOffsetMinutes: defaultValues.scheduleOffsetMinutes ?? 0,
           scheduleStartAt: defaultValues.scheduleStartAt ?? null,
           // Persisted null -> undefined for the NumberInput.
@@ -136,10 +138,7 @@ const AlertForm = ({
           scheduleStartAt: null,
           thresholdType: AlertThresholdType.ABOVE,
           source: AlertSource.SAVED_SEARCH,
-          channel: {
-            type: 'webhook',
-            webhookId: '',
-          },
+          channels: [{ type: 'webhook', webhookId: '' }],
           note: null,
         },
     resolver: zodResolver(SavedSearchAlertFormSchema),
@@ -147,7 +146,7 @@ const AlertForm = ({
 
   const groupBy = useWatch({ control, name: 'groupBy' });
   const thresholdType = useWatch({ control, name: 'thresholdType' });
-  const channelType = useWatch({ control, name: 'channel.type' });
+  const channelType = useWatch({ control, name: 'channels.0.type' });
   const interval = useWatch({ control, name: 'interval' });
   const scheduleOffsetMinutes = useWatch({
     control,
@@ -178,7 +177,10 @@ const AlertForm = ({
             // this form was opened with. This binds the submission to the
             // originally-edited alert rather than whatever the parent's alerts
             // list happens to index at submit time.
-            { ...data, id: defaultValues?.id },
+            // `channel` is cleared (JSON drops undefined): the API derives it
+            // from channels[0], and echoing a stale value back would conflict
+            // with an edited list.
+            { ...data, channel: undefined, id: defaultValues?.id },
             defaultValues,
             {
               preserveExplicitScheduleOffsetMinutes:
@@ -264,7 +266,7 @@ const AlertForm = ({
             </Text>
             <Controller
               control={control}
-              name="channel.type"
+              name="channels.0.type"
               render={({ field }) => (
                 <NativeSelect
                   data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -301,7 +301,11 @@ const AlertForm = ({
           <Text size="xxs" opacity={0.5} mb={4}>
             Send to
           </Text>
-          <AlertChannelForm control={control} type={channelType} />
+          <AlertChannelForm
+            control={control}
+            type={channelType}
+            channelsName="channels"
+          />
           <AlertNoteField control={control} name="note" />
           {groupBy &&
             (thresholdType === AlertThresholdType.BELOW ||

--- a/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
@@ -134,8 +134,10 @@ describe('DBSearchPageAlertModal', () => {
     const alertTab = await screen.findByRole('tab', { name: /Alert 2/ });
     fireEvent.click(alertTab);
 
-    const saveButton = await screen.findByText('Save Alert');
-    fireEvent.click(saveButton.closest('button') as HTMLButtonElement);
+    const saveButton = await screen.findByRole('button', {
+      name: 'Save Alert',
+    });
+    fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(updateAlertMutateAsync).toHaveBeenCalledTimes(1);
@@ -161,8 +163,10 @@ describe('DBSearchPageAlertModal', () => {
     const alertTab = await screen.findByRole('tab', { name: /Alert 2/ });
     fireEvent.click(alertTab);
 
-    const saveButton = await screen.findByText('Save Alert');
-    fireEvent.click(saveButton.closest('button') as HTMLButtonElement);
+    const saveButton = await screen.findByRole('button', {
+      name: 'Save Alert',
+    });
+    fireEvent.click(saveButton);
 
     await waitFor(() => {
       expect(updateAlertMutateAsync).toHaveBeenCalledTimes(1);

--- a/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
@@ -151,4 +151,27 @@ describe('DBSearchPageAlertModal', () => {
     );
     expect(createAlertMutateAsync).not.toHaveBeenCalled();
   });
+
+  // The submitted payload must not carry the legacy singular `channel`: the API
+  // rejects it when it disagrees with the edited channels list, and these
+  // fixtures are legacy channel-only alerts.
+  it('submits channels and drops the legacy channel field', async () => {
+    renderModal();
+
+    const alertTab = await screen.findByRole('tab', { name: /Alert 2/ });
+    fireEvent.click(alertTab);
+
+    const saveButton = await screen.findByText('Save Alert');
+    fireEvent.click(saveButton.closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(updateAlertMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = updateAlertMutateAsync.mock.calls[0][0];
+    expect(payload.channel).toBeUndefined();
+    expect(payload.channels).toEqual([
+      { type: 'webhook', webhookId: 'webhook-id' },
+    ]);
+  });
 });

--- a/packages/app/src/components/Alerts.tsx
+++ b/packages/app/src/components/Alerts.tsx
@@ -1,19 +1,33 @@
 import { useMemo } from 'react';
 import {
+  ArrayPath,
   Control,
   Controller,
+  FieldArray,
   FieldValues,
   Path,
-  useController,
+  useFieldArray,
+  useWatch,
 } from 'react-hook-form';
 import { Label, ReferenceArea, ReferenceLine } from 'recharts';
 import {
   type AlertChannelType,
   AlertThresholdType,
+  MAX_ALERT_CHANNELS,
   WebhookService,
 } from '@hyperdx/common-utils/dist/types';
-import { Button, ComboboxData, Group, Modal, Select } from '@mantine/core';
+import {
+  ActionIcon,
+  Button,
+  ComboboxData,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Text,
+} from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { IconPlus, IconTrash, IconWebhook } from '@tabler/icons-react';
 
 import api from '@/api';
 import { WebhookForm } from '@/components/TeamSettings/WebhookForm';
@@ -23,27 +37,37 @@ type Webhook = {
   name: string;
 };
 
-const WebhookChannelForm = <T extends FieldValues>({
-  control,
-  name,
-}: {
-  control?: Control<T>;
-  name?: string;
-}) => {
-  const { data: webhooks, refetch: refetchWebhooks } = api.useWebhooks([
+const useAlertWebhooks = () =>
+  api.useWebhooks([
     WebhookService.Slack,
     WebhookService.Generic,
     WebhookService.IncidentIO,
   ]);
-  const [opened, { open, close }] = useDisclosure(false);
+
+const WebhookChannelForm = <T extends FieldValues>({
+  control,
+  name,
+  onRemove,
+  takenWebhookIds,
+}: {
+  control?: Control<T>;
+  name?: string;
+  onRemove?: () => void;
+  /** Webhooks already chosen by the alert's other channels. */
+  takenWebhookIds?: string[];
+}) => {
+  const { data: webhooks } = useAlertWebhooks();
 
   const hasWebhooks = Array.isArray(webhooks?.data) && webhooks.data.length > 0;
 
   const options = useMemo<ComboboxData>(() => {
+    const taken = new Set(takenWebhookIds ?? []);
     const webhookOptions =
       webhooks?.data.map((sw: Webhook) => ({
         value: sw._id,
         label: sw.name,
+        // The API rejects duplicate channels, so don't offer one twice.
+        disabled: taken.has(sw._id),
       })) || [];
 
     return [
@@ -54,55 +78,142 @@ const WebhookChannelForm = <T extends FieldValues>({
       },
       ...webhookOptions,
     ];
-  }, [webhooks]);
+  }, [webhooks, takenWebhookIds]);
 
-  const { field } = useController({
+  return (
+    <Group gap="md" align="flex-start" wrap="nowrap">
+      <Controller
+        control={control}
+        name={name! as Path<T>}
+        render={({ field, fieldState }) => (
+          <Select
+            data-testid="select-webhook"
+            comboboxProps={{
+              withinPortal: false,
+            }}
+            required
+            size="xs"
+            flex={1}
+            placeholder={
+              hasWebhooks ? 'Select a Webhook' : 'No Webhooks available'
+            }
+            data={options}
+            {...field}
+            error={fieldState.error?.message}
+          />
+        )}
+      />
+      {onRemove && (
+        <ActionIcon
+          data-testid="remove-webhook-channel-button"
+          aria-label="Remove notification channel"
+          size="md"
+          variant="danger"
+          onClick={onRemove}
+        >
+          <IconTrash size={14} />
+        </ActionIcon>
+      )}
+    </Group>
+  );
+};
+
+export const AlertChannelForm = <T extends FieldValues>({
+  control,
+  type,
+  namePrefix = '',
+}: {
+  control: Control<T>;
+  type: AlertChannelType;
+  namePrefix?: string;
+}) => {
+  const channelsName = `${namePrefix}channels` as ArrayPath<T>;
+  const { fields, append, remove, update } = useFieldArray<T>({
     control,
-    name: name! as Path<T>,
+    name: channelsName,
   });
+  // `fields` holds the values from the last render, so watch for the live ones
+  // the duplicate check needs.
+  const channels = useWatch({
+    control,
+    name: channelsName as unknown as Path<T>,
+  }) as { webhookId?: string }[] | undefined;
+  const { refetch: refetchWebhooks } = useAlertWebhooks();
+  const [opened, { open, close }] = useDisclosure(false);
 
+  const selectedWebhookIds = useMemo(
+    () => (channels ?? []).map(c => c?.webhookId ?? ''),
+    [channels],
+  );
+
+  const newChannel = () =>
+    ({ type: 'webhook', webhookId: '' }) as FieldArray<T, ArrayPath<T>>;
+
+  // A webhook created from here lands in the first empty row, or a new one if
+  // every row is already filled — so the user never has to re-pick it.
   const handleWebhookCreated = async (webhookId?: string) => {
     await refetchWebhooks();
     if (webhookId) {
-      field.onChange(webhookId);
-      field.onBlur();
+      const emptyIndex = selectedWebhookIds.findIndex(id => !id);
+      const value = { type: 'webhook', webhookId } as FieldArray<
+        T,
+        ArrayPath<T>
+      >;
+      if (emptyIndex >= 0) {
+        update(emptyIndex, value);
+      } else if (fields.length < MAX_ALERT_CHANNELS) {
+        append(value);
+      }
     }
     close();
   };
 
+  if (type !== 'webhook') {
+    return null;
+  }
+
   return (
-    <div>
-      <Group gap="md" justify="space-between" align="flex-start">
-        <Controller
+    <Stack gap="xs">
+      {fields.map((field, index) => (
+        <WebhookChannelForm
+          key={field.id}
           control={control}
-          name={name! as Path<T>}
-          render={({ field, fieldState }) => (
-            <Select
-              data-testid="select-webhook"
-              comboboxProps={{
-                withinPortal: false,
-              }}
-              required
-              size="xs"
-              flex={1}
-              placeholder={
-                hasWebhooks ? 'Select a Webhook' : 'No Webhooks available'
-              }
-              data={options}
-              {...field}
-              error={fieldState.error?.message}
-            />
+          name={`${namePrefix}channels.${index}.webhookId`}
+          takenWebhookIds={selectedWebhookIds.filter(
+            (id, i) => i !== index && !!id,
           )}
+          // A single channel is not removable: an alert with no target would
+          // fire into the void, and the API rejects it anyway.
+          onRemove={fields.length > 1 ? () => remove(index) : undefined}
         />
+      ))}
+      <Group gap="xs">
+        <Button
+          data-testid="add-alert-channel-button"
+          size="xs"
+          variant="subtle"
+          color="gray"
+          leftSection={<IconPlus size={14} />}
+          disabled={fields.length >= MAX_ALERT_CHANNELS}
+          onClick={() => append(newChannel())}
+        >
+          Add another channel
+        </Button>
         <Button
           data-testid="add-new-webhook-button"
           size="xs"
           variant="subtle"
           color="gray"
+          leftSection={<IconWebhook size={14} />}
           onClick={open}
         >
           Add New Incoming Webhook
         </Button>
+        {fields.length >= MAX_ALERT_CHANNELS && (
+          <Text size="xs" opacity={0.5}>
+            Limit of {MAX_ALERT_CHANNELS} channels reached
+          </Text>
+        )}
       </Group>
 
       <Modal
@@ -116,29 +227,8 @@ const WebhookChannelForm = <T extends FieldValues>({
       >
         <WebhookForm onClose={close} onSuccess={handleWebhookCreated} />
       </Modal>
-    </div>
+    </Stack>
   );
-};
-
-export const AlertChannelForm = <T extends FieldValues>({
-  control,
-  type,
-  namePrefix = '',
-}: {
-  control: Control<T>;
-  type: AlertChannelType;
-  namePrefix?: string;
-}) => {
-  if (type === 'webhook') {
-    return (
-      <WebhookChannelForm
-        control={control}
-        name={`${namePrefix}channel.webhookId`}
-      />
-    );
-  }
-
-  return null;
 };
 
 export const getAlertReferenceLines = ({

--- a/packages/app/src/components/Alerts.tsx
+++ b/packages/app/src/components/Alerts.tsx
@@ -96,6 +96,9 @@ export const AlertChannelForm = <T extends FieldValues>({
           <WebhookChannelForm
             control={control}
             namePrefix={`${channelsName}.${index}.`}
+            takenWebhookIds={selectedWebhookIds.filter(
+              (id, i) => i !== index && !!id,
+            )}
           />
           {/* A single channel is not removable: an alert with no target
               would fire into the void, and the API rejects it anyway. */}

--- a/packages/app/src/components/Alerts.tsx
+++ b/packages/app/src/components/Alerts.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import {
   ArrayPath,
   Control,
-  Controller,
   FieldArray,
   FieldValues,
   Path,
@@ -16,28 +15,13 @@ import {
   MAX_ALERT_CHANNELS,
   WebhookService,
 } from '@hyperdx/common-utils/dist/types';
-import {
-  ActionIcon,
-  Button,
-  ComboboxData,
-  Group,
-  Modal,
-  Select,
-  Stack,
-  Text,
-} from '@mantine/core';
+import { ActionIcon, Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconPlus, IconTrash, IconWebhook } from '@tabler/icons-react';
 
 import api from '@/api';
+import { WebhookChannelForm } from '@/components/alerts/WebhookChannelForm';
 import { WebhookForm } from '@/components/TeamSettings/WebhookForm';
-import { getWebhookChannelIcon } from '@/utils/webhookIcons';
-
-type Webhook = {
-  _id: string;
-  name: string;
-  service?: string;
-};
 
 const useAlertWebhooks = () =>
   api.useWebhooks([
@@ -46,106 +30,15 @@ const useAlertWebhooks = () =>
     WebhookService.IncidentIO,
   ]);
 
-const WebhookChannelForm = <T extends FieldValues>({
-  control,
-  name,
-  onRemove,
-  takenWebhookIds,
-}: {
-  control?: Control<T>;
-  name?: string;
-  onRemove?: () => void;
-  /** Webhooks already chosen by the alert's other channels. */
-  takenWebhookIds?: string[];
-}) => {
-  const { data: webhooks } = useAlertWebhooks();
-
-  const hasWebhooks = Array.isArray(webhooks?.data) && webhooks.data.length > 0;
-
-  const options = useMemo<ComboboxData>(() => {
-    const taken = new Set(takenWebhookIds ?? []);
-    const webhookOptions =
-      webhooks?.data.map((sw: Webhook) => ({
-        value: sw._id,
-        label: sw.name,
-        // The API rejects duplicate channels, so don't offer one twice.
-        disabled: taken.has(sw._id),
-      })) || [];
-
-    return [
-      {
-        value: '',
-        label: 'Select a Webhook',
-        disabled: true,
-      },
-      ...webhookOptions,
-    ];
-  }, [webhooks, takenWebhookIds]);
-
-  // Which destination a webhook posts to matters when picking one, and the
-  // name alone doesn't say. Keyed by id so the option renderer can look it up.
-  const serviceById = useMemo(
-    () =>
-      new Map<string, string | undefined>(
-        (webhooks?.data ?? []).map((sw: Webhook) => [sw._id, sw.service]),
-      ),
-    [webhooks],
-  );
-
-  return (
-    <Group gap="md" align="flex-start" wrap="nowrap">
-      <Controller
-        control={control}
-        name={name! as Path<T>}
-        render={({ field, fieldState }) => (
-          <Select
-            data-testid="select-webhook"
-            comboboxProps={{
-              withinPortal: false,
-            }}
-            required
-            size="xs"
-            flex={1}
-            placeholder={
-              hasWebhooks ? 'Select a Webhook' : 'No Webhooks available'
-            }
-            data={options}
-            leftSection={
-              field.value ? (
-                getWebhookChannelIcon(serviceById.get(field.value))
-              ) : (
-                <IconWebhook size={16} />
-              )
-            }
-            renderOption={({ option }) =>
-              option.value ? (
-                <Group gap="xs" wrap="nowrap">
-                  {getWebhookChannelIcon(serviceById.get(option.value))}
-                  <span>{option.label}</span>
-                </Group>
-              ) : (
-                <span>{option.label}</span>
-              )
-            }
-            {...field}
-            error={fieldState.error?.message}
-          />
-        )}
-      />
-      {onRemove && (
-        <ActionIcon
-          data-testid="remove-webhook-channel-button"
-          aria-label="Remove notification channel"
-          size="md"
-          variant="danger"
-          onClick={onRemove}
-        >
-          <IconTrash size={14} />
-        </ActionIcon>
-      )}
-    </Group>
-  );
-};
+// react-hook-form's `FieldArray<T, ArrayPath<T>>` depends on the caller's
+// generic form type, which TypeScript can't verify a plain object literal
+// against here. Centralized so that unavoidable assertion exists once
+// instead of at every call site.
+function makeWebhookChannel<T extends FieldValues>(
+  webhookId: string,
+): FieldArray<T, ArrayPath<T>> {
+  return { type: 'webhook', webhookId } as FieldArray<T, ArrayPath<T>>;
+}
 
 export const AlertChannelForm = <T extends FieldValues>({
   control,
@@ -174,8 +67,7 @@ export const AlertChannelForm = <T extends FieldValues>({
     [channels],
   );
 
-  const newChannel = () =>
-    ({ type: 'webhook', webhookId: '' }) as FieldArray<T, ArrayPath<T>>;
+  const newChannel = () => makeWebhookChannel<T>('');
 
   // A webhook created from here lands in the first empty row, or a new one if
   // every row is already filled — so the user never has to re-pick it.
@@ -183,10 +75,7 @@ export const AlertChannelForm = <T extends FieldValues>({
     await refetchWebhooks();
     if (webhookId) {
       const emptyIndex = selectedWebhookIds.findIndex(id => !id);
-      const value = { type: 'webhook', webhookId } as FieldArray<
-        T,
-        ArrayPath<T>
-      >;
+      const value = makeWebhookChannel<T>(webhookId);
       if (emptyIndex >= 0) {
         update(emptyIndex, value);
       } else if (fields.length < MAX_ALERT_CHANNELS) {
@@ -203,17 +92,25 @@ export const AlertChannelForm = <T extends FieldValues>({
   return (
     <Stack gap="xs">
       {fields.map((field, index) => (
-        <WebhookChannelForm
-          key={field.id}
-          control={control}
-          name={`${channelsName}.${index}.webhookId`}
-          takenWebhookIds={selectedWebhookIds.filter(
-            (id, i) => i !== index && !!id,
+        <Group key={field.id} gap="md" align="flex-start" wrap="nowrap">
+          <WebhookChannelForm
+            control={control}
+            namePrefix={`${channelsName}.${index}.`}
+          />
+          {/* A single channel is not removable: an alert with no target
+              would fire into the void, and the API rejects it anyway. */}
+          {fields.length > 1 && (
+            <ActionIcon
+              data-testid="remove-webhook-channel-button"
+              aria-label="Remove notification channel"
+              size="md"
+              variant="danger"
+              onClick={() => remove(index)}
+            >
+              <IconTrash size={14} />
+            </ActionIcon>
           )}
-          // A single channel is not removable: an alert with no target would
-          // fire into the void, and the API rejects it anyway.
-          onRemove={fields.length > 1 ? () => remove(index) : undefined}
-        />
+        </Group>
       ))}
       <Group gap="xs">
         <Button

--- a/packages/app/src/components/Alerts.tsx
+++ b/packages/app/src/components/Alerts.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-hook-form';
 import { Label, ReferenceArea, ReferenceLine } from 'recharts';
 import {
-  type AlertChannelType,
   AlertThresholdType,
   MAX_ALERT_CHANNELS,
   WebhookService,
@@ -42,11 +41,9 @@ function makeWebhookChannel<T extends FieldValues>(
 
 export const AlertChannelForm = <T extends FieldValues>({
   control,
-  type,
   channelsName,
 }: {
   control: Control<T>;
-  type: AlertChannelType;
   /** Path of the alert's channels array, e.g. "channels" or "alert.channels". */
   channelsName: ArrayPath<T> & Path<T>;
 }) => {
@@ -55,9 +52,9 @@ export const AlertChannelForm = <T extends FieldValues>({
     name: channelsName,
   });
   // `fields` holds the values from the last render, so watch for the live ones
-  // the duplicate check needs.
+  // the duplicate check (and the per-row type discriminant below) need.
   const channels = useWatch({ control, name: channelsName }) as
-    | { webhookId?: string }[]
+    | { type?: string | null; webhookId?: string }[]
     | undefined;
   const { refetch: refetchWebhooks } = useAlertWebhooks();
   const [opened, { open, close }] = useDisclosure(false);
@@ -85,36 +82,42 @@ export const AlertChannelForm = <T extends FieldValues>({
     close();
   };
 
-  if (type !== 'webhook') {
-    return null;
-  }
-
   return (
     <Stack gap="xs">
-      {fields.map((field, index) => (
-        <Group key={field.id} gap="md" align="flex-start" wrap="nowrap">
-          <WebhookChannelForm
-            control={control}
-            namePrefix={`${channelsName}.${index}.`}
-            takenWebhookIds={selectedWebhookIds.filter(
-              (id, i) => i !== index && !!id,
+      {fields.map((field, index) => {
+        // The discriminant is per-row, not per-array: a downstream fork can
+        // mix channel types (e.g. webhook + email) in one alert. A row whose
+        // type this repo doesn't render (anything but webhook) is skipped so
+        // the rest of the list still works.
+        const channelType = channels?.[index]?.type;
+        if (channelType !== 'webhook') {
+          return null;
+        }
+        return (
+          <Group key={field.id} gap="md" align="flex-start" wrap="nowrap">
+            <WebhookChannelForm
+              control={control}
+              namePrefix={`${channelsName}.${index}.`}
+              takenWebhookIds={selectedWebhookIds.filter(
+                (id, i) => i !== index && !!id,
+              )}
+            />
+            {/* A single channel is not removable: an alert with no target
+                would fire into the void, and the API rejects it anyway. */}
+            {fields.length > 1 && (
+              <ActionIcon
+                data-testid="remove-webhook-channel-button"
+                aria-label="Remove notification channel"
+                size="md"
+                variant="danger"
+                onClick={() => remove(index)}
+              >
+                <IconTrash size={14} />
+              </ActionIcon>
             )}
-          />
-          {/* A single channel is not removable: an alert with no target
-              would fire into the void, and the API rejects it anyway. */}
-          {fields.length > 1 && (
-            <ActionIcon
-              data-testid="remove-webhook-channel-button"
-              aria-label="Remove notification channel"
-              size="md"
-              variant="danger"
-              onClick={() => remove(index)}
-            >
-              <IconTrash size={14} />
-            </ActionIcon>
-          )}
-        </Group>
-      ))}
+          </Group>
+        );
+      })}
       <Group gap="xs">
         <Button
           data-testid="add-alert-channel-button"

--- a/packages/app/src/components/Alerts.tsx
+++ b/packages/app/src/components/Alerts.tsx
@@ -31,10 +31,12 @@ import { IconPlus, IconTrash, IconWebhook } from '@tabler/icons-react';
 
 import api from '@/api';
 import { WebhookForm } from '@/components/TeamSettings/WebhookForm';
+import { getWebhookChannelIcon } from '@/utils/webhookIcons';
 
 type Webhook = {
   _id: string;
   name: string;
+  service?: string;
 };
 
 const useAlertWebhooks = () =>
@@ -80,6 +82,16 @@ const WebhookChannelForm = <T extends FieldValues>({
     ];
   }, [webhooks, takenWebhookIds]);
 
+  // Which destination a webhook posts to matters when picking one, and the
+  // name alone doesn't say. Keyed by id so the option renderer can look it up.
+  const serviceById = useMemo(
+    () =>
+      new Map<string, string | undefined>(
+        (webhooks?.data ?? []).map((sw: Webhook) => [sw._id, sw.service]),
+      ),
+    [webhooks],
+  );
+
   return (
     <Group gap="md" align="flex-start" wrap="nowrap">
       <Controller
@@ -98,6 +110,23 @@ const WebhookChannelForm = <T extends FieldValues>({
               hasWebhooks ? 'Select a Webhook' : 'No Webhooks available'
             }
             data={options}
+            leftSection={
+              field.value ? (
+                getWebhookChannelIcon(serviceById.get(field.value))
+              ) : (
+                <IconWebhook size={16} />
+              )
+            }
+            renderOption={({ option }) =>
+              option.value ? (
+                <Group gap="xs" wrap="nowrap">
+                  {getWebhookChannelIcon(serviceById.get(option.value))}
+                  <span>{option.label}</span>
+                </Group>
+              ) : (
+                <span>{option.label}</span>
+              )
+            }
             {...field}
             error={fieldState.error?.message}
           />
@@ -121,23 +150,22 @@ const WebhookChannelForm = <T extends FieldValues>({
 export const AlertChannelForm = <T extends FieldValues>({
   control,
   type,
-  namePrefix = '',
+  channelsName,
 }: {
   control: Control<T>;
   type: AlertChannelType;
-  namePrefix?: string;
+  /** Path of the alert's channels array, e.g. "channels" or "alert.channels". */
+  channelsName: ArrayPath<T> & Path<T>;
 }) => {
-  const channelsName = `${namePrefix}channels` as ArrayPath<T>;
   const { fields, append, remove, update } = useFieldArray<T>({
     control,
     name: channelsName,
   });
   // `fields` holds the values from the last render, so watch for the live ones
   // the duplicate check needs.
-  const channels = useWatch({
-    control,
-    name: channelsName as unknown as Path<T>,
-  }) as { webhookId?: string }[] | undefined;
+  const channels = useWatch({ control, name: channelsName }) as
+    | { webhookId?: string }[]
+    | undefined;
   const { refetch: refetchWebhooks } = useAlertWebhooks();
   const [opened, { open, close }] = useDisclosure(false);
 
@@ -178,7 +206,7 @@ export const AlertChannelForm = <T extends FieldValues>({
         <WebhookChannelForm
           key={field.id}
           control={control}
-          name={`${namePrefix}channels.${index}.webhookId`}
+          name={`${channelsName}.${index}.webhookId`}
           takenWebhookIds={selectedWebhookIds.filter(
             (id, i) => i !== index && !!id,
           )}

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -483,6 +483,38 @@ describe('convertSavedChartConfigToFormState', () => {
     expect(result.configType).toBe('builder');
   });
 
+  // Clearing the legacy singular `channel` on load is what stops a stale value
+  // being submitted alongside an edited channels list, which the API rejects.
+  it('normalises a legacy channel-only tile alert onto channels', () => {
+    const config: BuilderSavedChartConfig = {
+      source: 'source-1',
+      displayType: DisplayType.Line,
+      select: [seriesItem],
+      where: '',
+      alert: {
+        threshold: 1,
+        thresholdType: AlertThresholdType.ABOVE,
+        interval: '5m',
+        channel: { type: 'webhook', webhookId: 'w1' },
+      },
+    };
+    const result = convertSavedChartConfigToFormState(config);
+    expect(result.alert?.channel).toBeUndefined();
+    expect(result.alert?.channels).toEqual([
+      { type: 'webhook', webhookId: 'w1' },
+    ]);
+  });
+
+  it('leaves a config without an alert untouched', () => {
+    const config: BuilderSavedChartConfig = {
+      source: 'source-1',
+      displayType: DisplayType.Line,
+      select: [seriesItem],
+      where: '',
+    };
+    expect(convertSavedChartConfigToFormState(config).alert).toBeUndefined();
+  });
+
   it('maps array select to series with aggConditionLanguage defaulted', () => {
     const selectItem = {
       aggFn: 'count' as const,

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -34,6 +34,7 @@ import {
   buildVariableCompletions,
   toMacroCompletion,
 } from '@/components/SQLEditor/variableCompletions';
+import { toAlertChannels } from '@/utils/alerts';
 
 import { ChartEditorFormState } from './types';
 
@@ -391,6 +392,16 @@ export function convertSavedChartConfigToFormState(
 ): ChartEditorFormState {
   return {
     ...config,
+    // Normalise the alert's channels up front: tile alerts saved before
+    // multi-channel support only carry the singular `channel`. Clearing it
+    // here keeps a stale value from being submitted alongside an edited list.
+    ...(config.alert != null && {
+      alert: {
+        ...config.alert,
+        channel: undefined,
+        channels: toAlertChannels(config.alert),
+      },
+    }),
     configType: isPromqlSavedChartConfig(config)
       ? 'promql'
       : isRawSqlSavedChartConfig(config)

--- a/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
@@ -250,7 +250,7 @@ export function TileAlertEditor({
           <AlertChannelForm
             control={control}
             type={alertChannelType}
-            namePrefix="alert."
+            channelsName="alert.channels"
           />
           <AlertNoteField
             control={control}

--- a/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
@@ -64,7 +64,7 @@ export function TileAlertEditor({
 }) {
   const [opened, { toggle }] = useDisclosure(true);
 
-  const alertChannelType = useWatch({ control, name: 'alert.channel.type' });
+  const alertChannelType = useWatch({ control, name: 'alert.channels.0.type' });
   const alertThresholdType = useWatch({ control, name: 'alert.thresholdType' });
   const alertThreshold = useWatch({ control, name: 'alert.threshold' });
   const alertThresholdMax = useWatch({ control, name: 'alert.thresholdMax' });
@@ -214,7 +214,7 @@ export function TileAlertEditor({
             </Text>
             <Controller
               control={control}
-              name="alert.channel.type"
+              name="alert.channels.0.type"
               render={({ field }) => (
                 <NativeSelect
                   data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}

--- a/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
@@ -64,7 +64,6 @@ export function TileAlertEditor({
 }) {
   const [opened, { toggle }] = useDisclosure(true);
 
-  const alertChannelType = useWatch({ control, name: 'alert.channels.0.type' });
   const alertThresholdType = useWatch({ control, name: 'alert.thresholdType' });
   const alertThreshold = useWatch({ control, name: 'alert.threshold' });
   const alertThresholdMax = useWatch({ control, name: 'alert.thresholdMax' });
@@ -247,11 +246,7 @@ export function TileAlertEditor({
           <Text size="xxs" opacity={0.5} mb={4} mt="sm">
             Send to
           </Text>
-          <AlertChannelForm
-            control={control}
-            type={alertChannelType}
-            channelsName="alert.channels"
-          />
+          <AlertChannelForm control={control} channelsName="alert.channels" />
           <AlertNoteField
             control={control}
             name="alert.note"

--- a/packages/app/src/components/__tests__/AlertChannelForm.test.tsx
+++ b/packages/app/src/components/__tests__/AlertChannelForm.test.tsx
@@ -26,9 +26,17 @@ jest.mock('@/components/TeamSettings/WebhookForm', () => ({
   WebhookForm: () => <div data-testid="webhook-form" />,
 }));
 
+type Channel = { type: 'webhook'; webhookId: string };
+
 type FormValues = {
-  channels: { type: 'webhook'; webhookId: string }[];
+  channels: Channel[];
 };
+
+// A channel type this repo doesn't render (e.g. a downstream fork's email
+// channel). `value: any` (rather than an `as` cast) keeps this off the
+// no-unsafe-type-assertion budget while still producing a value shaped like
+// this form's channel type for the harness below.
+const foreignChannel = (value: any): Channel => value;
 
 const ONE_EMPTY_CHANNEL: FormValues['channels'] = [
   { type: 'webhook', webhookId: '' },
@@ -42,13 +50,7 @@ const Harness = ({
   const { control } = useForm<FormValues>({
     defaultValues: { channels: initial },
   });
-  return (
-    <AlertChannelForm
-      control={control}
-      type="webhook"
-      channelsName="channels"
-    />
-  );
+  return <AlertChannelForm control={control} channelsName="channels" />;
 };
 
 // jsdom has no layout, and Mantine's combobox scrolls the active option.
@@ -112,6 +114,20 @@ describe('AlertChannelForm', () => {
     expect(beta.closest('[data-combobox-option]')).not.toHaveAttribute(
       'data-combobox-disabled',
     );
+  });
+
+  it('renders nothing for a row of a type this repo does not handle, but keeps the rest of the list working', () => {
+    renderWithMantine(
+      <Harness
+        initial={[
+          foreignChannel({ type: 'email', emailRecipients: ['ops@x.test'] }),
+          { type: 'webhook', webhookId: 'w1' },
+        ]}
+      />,
+    );
+
+    // Only the webhook row renders a channel picker.
+    expect(rows()).toHaveLength(1);
   });
 
   it('stops offering more channels at the cap', async () => {

--- a/packages/app/src/components/__tests__/AlertChannelForm.test.tsx
+++ b/packages/app/src/components/__tests__/AlertChannelForm.test.tsx
@@ -1,0 +1,133 @@
+import { useForm } from 'react-hook-form';
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+
+import { AlertChannelForm } from '@/components/Alerts';
+
+const WEBHOOKS = [
+  { _id: 'w1', name: 'Alpha Hook', service: WebhookService.Slack },
+  { _id: 'w2', name: 'Beta Hook', service: WebhookService.Generic },
+  { _id: 'w3', name: 'Gamma Hook', service: WebhookService.IncidentIO },
+];
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useWebhooks: () => ({
+      data: { data: WEBHOOKS },
+      refetch: jest.fn().mockResolvedValue({ data: { data: WEBHOOKS } }),
+    }),
+  },
+}));
+
+// The creation modal pulls in the whole webhook settings form; the channel
+// picker's own behaviour is what's under test here.
+jest.mock('@/components/TeamSettings/WebhookForm', () => ({
+  WebhookForm: () => <div data-testid="webhook-form" />,
+}));
+
+type FormValues = {
+  channels: { type: 'webhook'; webhookId: string }[];
+};
+
+const ONE_EMPTY_CHANNEL: FormValues['channels'] = [
+  { type: 'webhook', webhookId: '' },
+];
+
+const Harness = ({
+  initial = ONE_EMPTY_CHANNEL,
+}: {
+  initial?: FormValues['channels'];
+}) => {
+  const { control } = useForm<FormValues>({
+    defaultValues: { channels: initial },
+  });
+  return (
+    <AlertChannelForm
+      control={control}
+      type="webhook"
+      channelsName="channels"
+    />
+  );
+};
+
+// jsdom has no layout, and Mantine's combobox scrolls the active option.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+const rows = () => screen.getAllByTestId('select-webhook');
+
+describe('AlertChannelForm', () => {
+  it('starts with a single row that cannot be removed', () => {
+    renderWithMantine(<Harness />);
+
+    expect(rows()).toHaveLength(1);
+    // An alert with no target would fire into the void, so the last row stays.
+    expect(
+      screen.queryByTestId('remove-webhook-channel-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('adds and removes channel rows', async () => {
+    renderWithMantine(<Harness />);
+
+    fireEvent.click(screen.getByTestId('add-alert-channel-button'));
+    await waitFor(() => expect(rows()).toHaveLength(2));
+
+    // With more than one row, each becomes removable.
+    const removeButtons = screen.getAllByTestId(
+      'remove-webhook-channel-button',
+    );
+    expect(removeButtons).toHaveLength(2);
+
+    fireEvent.click(removeButtons[0]);
+    await waitFor(() => expect(rows()).toHaveLength(1));
+    expect(
+      screen.queryByTestId('remove-webhook-channel-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables a webhook already chosen by another channel', async () => {
+    renderWithMantine(
+      <Harness
+        initial={[
+          { type: 'webhook', webhookId: 'w1' },
+          { type: 'webhook', webhookId: '' },
+        ]}
+      />,
+    );
+
+    // Open the empty row's dropdown.
+    fireEvent.click(rows()[1]);
+
+    const listbox = await screen.findByRole('listbox');
+    const alpha = within(listbox).getByText('Alpha Hook');
+    const beta = within(listbox).getByText('Beta Hook');
+
+    // The API rejects duplicate channels, so the taken one must not be pickable.
+    expect(alpha.closest('[data-combobox-option]')).toHaveAttribute(
+      'data-combobox-disabled',
+    );
+    expect(beta.closest('[data-combobox-option]')).not.toHaveAttribute(
+      'data-combobox-disabled',
+    );
+  });
+
+  it('stops offering more channels at the cap', async () => {
+    renderWithMantine(
+      <Harness
+        initial={Array.from({ length: 10 }, (_, i) => ({
+          type: 'webhook' as const,
+          webhookId: `w${i}`,
+        }))}
+      />,
+    );
+
+    expect(rows()).toHaveLength(10);
+    expect(screen.getByTestId('add-alert-channel-button')).toBeDisabled();
+    expect(
+      screen.getByText(/Limit of 10 channels reached/),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/alerts/EditAlertModal.tsx
+++ b/packages/app/src/components/alerts/EditAlertModal.tsx
@@ -10,9 +10,11 @@ import {
   AlertThresholdType,
   isRangeThresholdType,
   scheduleStartAtSchema,
+  validateAlertChannelSelection,
   validateAlertScheduleOffsetMinutes,
   validateAlertThresholdMax,
   zAlertChannel,
+  zAlertChannels,
 } from '@hyperdx/common-utils/dist/types';
 import {
   Accordion,
@@ -40,6 +42,7 @@ import { useSource } from '@/source';
 import { useBrandDisplayName } from '@/theme/ThemeProvider';
 import type { AlertsPageItem } from '@/types';
 import { optionsToSelectData } from '@/utils';
+import { toAlertChannels } from '@/utils/alerts';
 import {
   ALERT_CHANNEL_OPTIONS,
   ALERT_INTERVAL_OPTIONS,
@@ -61,12 +64,14 @@ const EditAlertFormSchema = z
     scheduleOffsetMinutes: z.number().int().min(0).default(0),
     scheduleStartAt: scheduleStartAtSchema,
     thresholdType: z.nativeEnum(AlertThresholdType),
-    channel: zAlertChannel,
+    channel: zAlertChannel.optional(),
+    channels: zAlertChannels.optional(),
     // nullish() (not optional()): persisted alerts store this as null, which
     // optional() would reject.
     numConsecutiveWindows: z.number().int().min(1).nullish(),
   })
   .passthrough()
+  .superRefine(validateAlertChannelSelection)
   .superRefine(validateAlertScheduleOffsetMinutes)
   .superRefine(validateAlertThresholdMax);
 
@@ -90,10 +95,14 @@ function alertToFormValues(alert: AlertsPageItem): Alert {
         : typeof alert.scheduleStartAt === 'string'
           ? alert.scheduleStartAt
           : alert.scheduleStartAt.toISOString(),
-    channel: {
-      type: 'webhook' as const,
-      webhookId: alert.channel.webhookId ?? '',
-    },
+    // AlertsPageItem types a channel loosely (type?: string | null) while the
+    // form carries the strict Alert shape. Copy channels through rather than
+    // rebuilding them, so a fork's extra channel fields survive an edit; only
+    // webhookId is coerced, because the picker needs a string.
+    channels: toAlertChannels(alert).map(c => ({
+      ...c,
+      webhookId: c.webhookId ?? '',
+    })) as Alert['channels'],
     name: alert.name ?? null,
     message: alert.message ?? null,
     note: alert.note ?? null,
@@ -174,7 +183,6 @@ export function EditAlertModal({
   const thresholdType = useWatch({ control, name: 'thresholdType' });
   const threshold = useWatch({ control, name: 'threshold' });
   const thresholdMax = useWatch({ control, name: 'thresholdMax' });
-  const channelType = useWatch({ control, name: 'channel.type' });
   const interval = useWatch({ control, name: 'interval' });
   const groupBy = useWatch({ control, name: 'groupBy' });
   const scheduleOffsetMinutes = useWatch({
@@ -362,7 +370,7 @@ export function EditAlertModal({
             </Text>
             <Controller
               control={control}
-              name="channel.type"
+              name="channels.0.type"
               render={({ field }) => (
                 <NativeSelect
                   data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}
@@ -401,7 +409,7 @@ export function EditAlertModal({
           <Text size="xxs" opacity={0.5} mb={4}>
             Send to
           </Text>
-          <AlertChannelForm control={control} type={channelType} />
+          <AlertChannelForm control={control} channelsName="channels" />
           <AlertNoteField control={control} name="note" />
           {!isTileAlert &&
             groupBy &&

--- a/packages/app/src/components/alerts/WebhookChannelForm.tsx
+++ b/packages/app/src/components/alerts/WebhookChannelForm.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import { Control, Controller, useWatch } from 'react-hook-form';
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import { ComboboxData, Group, Select } from '@mantine/core';
+import { IconWebhook } from '@tabler/icons-react';
+
+import api from '@/api';
+import { getWebhookChannelIcon } from '@/utils/webhookIcons';
+
+type Webhook = {
+  _id: string;
+  name: string;
+  service?: string;
+};
+
+// The channels array path this channel belongs to, derived from a
+// `namePrefix` like "channels.0." -> "channels", so sibling channels can be
+// watched for already-chosen webhooks without an extra prop.
+const channelsArrayPath = (namePrefix: string) =>
+  namePrefix.replace(/\.\d+\.$/, '');
+
+export const WebhookChannelForm = ({
+  control,
+  namePrefix = '',
+}: {
+  control: Control<any>;
+  namePrefix?: string;
+}) => {
+  const { data: webhooks } = api.useWebhooks([
+    WebhookService.Slack,
+    WebhookService.Generic,
+    WebhookService.IncidentIO,
+  ]);
+
+  const hasWebhooks = Array.isArray(webhooks?.data) && webhooks.data.length > 0;
+
+  const webhookIdField = `${namePrefix}webhookId`;
+  const currentWebhookId = useWatch({ control, name: webhookIdField });
+  const siblingChannels: unknown = useWatch({
+    control,
+    name: channelsArrayPath(namePrefix),
+  });
+
+  // Webhooks already chosen by the alert's other channels. The API rejects
+  // duplicate channels, so don't offer one twice.
+  const takenWebhookIds = useMemo(() => {
+    const channels = Array.isArray(siblingChannels) ? siblingChannels : [];
+    return new Set(
+      channels
+        .map((c: { webhookId?: unknown }) => c?.webhookId)
+        .filter(
+          (id): id is string =>
+            typeof id === 'string' && !!id && id !== currentWebhookId,
+        ),
+    );
+  }, [siblingChannels, currentWebhookId]);
+
+  const options = useMemo<ComboboxData>(() => {
+    const webhookOptions =
+      webhooks?.data.map((sw: Webhook) => ({
+        value: sw._id,
+        label: sw.name,
+        disabled: takenWebhookIds.has(sw._id),
+      })) || [];
+
+    return [
+      {
+        value: '',
+        label: 'Select a Webhook',
+        disabled: true,
+      },
+      ...webhookOptions,
+    ];
+  }, [webhooks, takenWebhookIds]);
+
+  // Which destination a webhook posts to matters when picking one, and the
+  // name alone doesn't say. Keyed by id so the option renderer can look it up.
+  const serviceById = useMemo(
+    () =>
+      new Map<string, string | undefined>(
+        (webhooks?.data ?? []).map((sw: Webhook) => [sw._id, sw.service]),
+      ),
+    [webhooks],
+  );
+
+  return (
+    <Controller
+      control={control}
+      name={webhookIdField}
+      render={({ field, fieldState }) => (
+        <Select
+          data-testid="select-webhook"
+          comboboxProps={{
+            withinPortal: false,
+          }}
+          required
+          size="xs"
+          flex={1}
+          placeholder={
+            hasWebhooks ? 'Select a Webhook' : 'No Webhooks available'
+          }
+          data={options}
+          leftSection={
+            field.value ? (
+              getWebhookChannelIcon(serviceById.get(field.value))
+            ) : (
+              <IconWebhook size={16} />
+            )
+          }
+          renderOption={({ option }) =>
+            option.value ? (
+              <Group gap="xs" wrap="nowrap">
+                {getWebhookChannelIcon(serviceById.get(option.value))}
+                <span>{option.label}</span>
+              </Group>
+            ) : (
+              <span>{option.label}</span>
+            )
+          }
+          {...field}
+          error={fieldState.error?.message}
+        />
+      )}
+    />
+  );
+};

--- a/packages/app/src/components/alerts/WebhookChannelForm.tsx
+++ b/packages/app/src/components/alerts/WebhookChannelForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Control, Controller, useWatch } from 'react-hook-form';
+import { Control, Controller } from 'react-hook-form';
 import { WebhookService } from '@hyperdx/common-utils/dist/types';
 import { ComboboxData, Group, Select } from '@mantine/core';
 import { IconWebhook } from '@tabler/icons-react';
@@ -13,18 +13,19 @@ type Webhook = {
   service?: string;
 };
 
-// The channels array path this channel belongs to, derived from a
-// `namePrefix` like "channels.0." -> "channels", so sibling channels can be
-// watched for already-chosen webhooks without an extra prop.
-const channelsArrayPath = (namePrefix: string) =>
-  namePrefix.replace(/\.\d+\.$/, '');
+// Stable reference so omitting `takenWebhookIds` doesn't create a new array
+// (and re-render loop) on every render.
+const NO_TAKEN_WEBHOOK_IDS: string[] = [];
 
 export const WebhookChannelForm = ({
   control,
   namePrefix = '',
+  takenWebhookIds = NO_TAKEN_WEBHOOK_IDS,
 }: {
   control: Control<any>;
   namePrefix?: string;
+  /** Webhooks already chosen by the alert's other channels. */
+  takenWebhookIds?: string[];
 }) => {
   const { data: webhooks } = api.useWebhooks([
     WebhookService.Slack,
@@ -35,32 +36,15 @@ export const WebhookChannelForm = ({
   const hasWebhooks = Array.isArray(webhooks?.data) && webhooks.data.length > 0;
 
   const webhookIdField = `${namePrefix}webhookId`;
-  const currentWebhookId = useWatch({ control, name: webhookIdField });
-  const siblingChannels: unknown = useWatch({
-    control,
-    name: channelsArrayPath(namePrefix),
-  });
-
-  // Webhooks already chosen by the alert's other channels. The API rejects
-  // duplicate channels, so don't offer one twice.
-  const takenWebhookIds = useMemo(() => {
-    const channels = Array.isArray(siblingChannels) ? siblingChannels : [];
-    return new Set(
-      channels
-        .map((c: { webhookId?: unknown }) => c?.webhookId)
-        .filter(
-          (id): id is string =>
-            typeof id === 'string' && !!id && id !== currentWebhookId,
-        ),
-    );
-  }, [siblingChannels, currentWebhookId]);
 
   const options = useMemo<ComboboxData>(() => {
+    const taken = new Set(takenWebhookIds);
     const webhookOptions =
       webhooks?.data.map((sw: Webhook) => ({
         value: sw._id,
         label: sw.name,
-        disabled: takenWebhookIds.has(sw._id),
+        // The API rejects duplicate channels, so don't offer one twice.
+        disabled: taken.has(sw._id),
       })) || [];
 
     return [

--- a/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
@@ -151,7 +151,8 @@ describe('EditAlertModal', () => {
         groupBy: 'ServiceName',
         threshold: 3,
         interval: '5m',
-        channel: { type: 'webhook', webhookId: 'webhook-id' },
+        // A legacy single-channel alert saves as the plural list.
+        channels: [{ type: 'webhook', webhookId: 'webhook-id' }],
         // Fields the form doesn't edit must be carried through — the PUT
         // clears any that are omitted.
         name: 'My alert',

--- a/packages/app/src/utils/__tests__/alerts.test.ts
+++ b/packages/app/src/utils/__tests__/alerts.test.ts
@@ -3,6 +3,13 @@ import {
   toAlertChannels,
 } from '@/utils/alerts';
 
+// A channel shape this repo doesn't define -- e.g. a downstream fork's email
+// channel, or a webhook channel carrying `webhookService`/`slackChannelId`/
+// `severity`. `value: any` (rather than an `as` cast) keeps this off the
+// no-unsafe-type-assertion budget while still producing a value typed as the
+// generic channel type `toAlertChannels` accepts.
+const foreignChannel = (value: any): { type?: string | null } => value;
+
 describe('normalizeNoOpAlertScheduleFields', () => {
   it('drops no-op schedule fields for pre-migration alerts', () => {
     const normalized = normalizeNoOpAlertScheduleFields(
@@ -117,5 +124,41 @@ describe('toAlertChannels', () => {
     expect(toAlertChannels()).toEqual([wh('')]);
     expect(toAlertChannels({})).toEqual([wh('')]);
     expect(toAlertChannels({ channel: { type: null } })).toEqual([wh('')]);
+  });
+
+  // The invariant guard: this repo only defines webhook channels, but a
+  // downstream fork adds others. toAlertChannels must copy them by
+  // reference, not project them onto webhook-shaped fields.
+  it('keeps an email-shaped channel intact', () => {
+    const exotic = foreignChannel({
+      type: 'email',
+      emailRecipients: ['ops@example.test'],
+    });
+
+    expect(toAlertChannels({ channels: [exotic] })).toEqual([exotic]);
+  });
+
+  it('keeps webhookService, slackChannelId and severity on a webhook channel', () => {
+    const exotic = foreignChannel({
+      type: 'webhook',
+      webhookId: 'w1',
+      webhookService: 'slack',
+      slackChannelId: 'C123',
+      severity: 'critical',
+    });
+
+    expect(toAlertChannels({ channels: [exotic] })).toEqual([exotic]);
+  });
+
+  it('keeps both entries in a mixed webhook + email list', () => {
+    const email = foreignChannel({
+      type: 'email',
+      emailRecipients: ['ops@example.test'],
+    });
+
+    expect(toAlertChannels({ channels: [wh('a'), email] })).toEqual([
+      wh('a'),
+      email,
+    ]);
   });
 });

--- a/packages/app/src/utils/__tests__/alerts.test.ts
+++ b/packages/app/src/utils/__tests__/alerts.test.ts
@@ -1,4 +1,7 @@
-import { normalizeNoOpAlertScheduleFields } from '@/utils/alerts';
+import {
+  normalizeNoOpAlertScheduleFields,
+  toAlertChannels,
+} from '@/utils/alerts';
 
 describe('normalizeNoOpAlertScheduleFields', () => {
   it('drops no-op schedule fields for pre-migration alerts', () => {
@@ -91,5 +94,28 @@ describe('normalizeNoOpAlertScheduleFields', () => {
     expect(normalized).toEqual({
       scheduleStartAt: null,
     });
+  });
+});
+
+describe('toAlertChannels', () => {
+  const wh = (id: string) => ({ type: 'webhook' as const, webhookId: id });
+
+  it('prefers the channels array', () => {
+    expect(
+      toAlertChannels({ channel: wh('legacy'), channels: [wh('a'), wh('b')] }),
+    ).toEqual([wh('a'), wh('b')]);
+  });
+
+  it('falls back to the legacy singular channel', () => {
+    expect(toAlertChannels({ channel: wh('legacy') })).toEqual([wh('legacy')]);
+    expect(toAlertChannels({ channel: wh('legacy'), channels: [] })).toEqual([
+      wh('legacy'),
+    ]);
+  });
+
+  it('always returns at least one row for the form to render', () => {
+    expect(toAlertChannels()).toEqual([wh('')]);
+    expect(toAlertChannels({})).toEqual([wh('')]);
+    expect(toAlertChannels({ channel: { type: null } })).toEqual([wh('')]);
   });
 });

--- a/packages/app/src/utils/alerts.ts
+++ b/packages/app/src/utils/alerts.ts
@@ -128,16 +128,36 @@ export const ALERT_CHANNEL_OPTIONS: Record<AlertChannelType, string> = {
   webhook: 'Webhook',
 };
 
+const EMPTY_ALERT_CHANNEL = { type: 'webhook', webhookId: '' } as const;
+
+/**
+ * Form value for an alert's notification channels. Alerts saved before
+ * multi-channel support only carry the singular `channel`, and the form always
+ * needs at least one row to render.
+ */
+export function toAlertChannels(alert?: {
+  channel?: { type?: string | null; webhookId?: string } | null;
+  channels?: { type?: string | null; webhookId?: string }[] | null;
+}): { type: 'webhook'; webhookId: string }[] {
+  const source =
+    alert?.channels != null && alert.channels.length > 0
+      ? alert.channels
+      : alert?.channel != null
+        ? [alert.channel]
+        : [];
+  const channels = source
+    .filter(c => c.type === 'webhook')
+    .map(c => ({ type: 'webhook' as const, webhookId: c.webhookId ?? '' }));
+  return channels.length > 0 ? channels : [{ ...EMPTY_ALERT_CHANNEL }];
+}
+
 export const DEFAULT_TILE_ALERT: z.infer<typeof ChartAlertBaseSchema> = {
   threshold: 1,
   thresholdType: AlertThresholdType.ABOVE,
   interval: '5m',
   scheduleOffsetMinutes: 0,
   scheduleStartAt: null,
-  channel: {
-    type: 'webhook',
-    webhookId: '',
-  },
+  channels: [{ ...EMPTY_ALERT_CHANNEL }],
   note: null,
 };
 

--- a/packages/app/src/utils/alerts.ts
+++ b/packages/app/src/utils/alerts.ts
@@ -134,21 +134,21 @@ const EMPTY_ALERT_CHANNEL = { type: 'webhook', webhookId: '' } as const;
  * Form value for an alert's notification channels. Alerts saved before
  * multi-channel support only carry the singular `channel`, and the form always
  * needs at least one row to render.
+ *
+ * A downstream fork defines channel types this repo doesn't (e.g. email).
+ * Channels are copied through untouched rather than rebuilt field-by-field,
+ * so saving an alert here never destroys fields this repo doesn't know about.
  */
-export function toAlertChannels(alert?: {
-  channel?: { type?: string | null; webhookId?: string } | null;
-  channels?: { type?: string | null; webhookId?: string }[] | null;
-}): { type: 'webhook'; webhookId: string }[] {
-  const source =
-    alert?.channels != null && alert.channels.length > 0
-      ? alert.channels
-      : alert?.channel != null
-        ? [alert.channel]
-        : [];
-  const channels = source
-    .filter(c => c.type === 'webhook')
-    .map(c => ({ type: 'webhook' as const, webhookId: c.webhookId ?? '' }));
-  return channels.length > 0 ? channels : [{ ...EMPTY_ALERT_CHANNEL }];
+export function toAlertChannels<T extends { type?: string | null }>(alert?: {
+  channel?: T | null;
+  channels?: T[] | null;
+}): T[] | [typeof EMPTY_ALERT_CHANNEL] {
+  const source = alert?.channels?.length
+    ? alert.channels
+    : alert?.channel != null && alert.channel.type != null
+      ? [alert.channel]
+      : [];
+  return source.length > 0 ? source : [{ ...EMPTY_ALERT_CHANNEL }];
 }
 
 export const DEFAULT_TILE_ALERT: z.infer<typeof ChartAlertBaseSchema> = {


### PR DESCRIPTION
Lets the alert forms edit the full list of notification channels. Until now the API supported several channels but both forms still edited a single one, so saving from the UI would silently drop the rest.


https://github.com/user-attachments/assets/d435ad1e-12d5-4c04-a62b-c9f9c172d9f2



## What changed

Saved search and dashboard tile alerts both edit the plural `channels` list through the shared `AlertChannelForm`. Channels can be added and removed inline up to the API's limit of 10, and each row shows the webhook's service icon so the destination is visible without opening webhook settings.

A webhook already used by the alert is disabled in the other pickers, since duplicates are rejected server-side.

Alerts saved before multi-channel support are normalised on load, and the legacy `channel` field is cleared on submit so a stale value can never conflict with an edited list.

## Key decisions

**The last channel row is not removable.** An alert with no target would fire into the void, and the API rejects it anyway, so the remove control only appears once there are two or more rows.

**A webhook created from the picker fills the first empty row.** Otherwise the user would create a webhook and then have to find and select it manually.

**`AlertChannelForm` takes the field path rather than a string prefix.** Callers pass `channels` or `alert.channels` directly, which types correctly and removes two generic-boundary casts.

## Impact

Closes the UI overwrite hazard documented as a known limitation until now: editing a multi-channel alert in the app now preserves its channels.

<details>
<summary>Implementation detail</summary>

The picker is a `useFieldArray` with a `useWatch` on the array — `fields` holds last-render values, so the live ones are needed for the duplicate check.

Component tests cover adding and removing rows, the last row staying non-removable, duplicate disabling across rows, and the cap disabling the add button. `toAlertChannels` has unit coverage for both document vintages.

Verification: 2745 app unit tests.

</details>

