### PR TITLE
Keep pinned filters above map groups

### DIFF
--- a/.changeset/calm-facets-order.md
+++ b/.changeset/calm-facets-order.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Preserve pinned filter priority when rendering grouped map fields.

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -881,6 +881,21 @@ function FilterGroupActions({
 
 const voidFunc = () => {};
 
+function orderFacetElements(
+  fragment: React.ReactElement<{
+    children: [React.ReactElement[], React.ReactElement[]];
+  }>,
+  orderedKeys: string[],
+  keyPrefix: string,
+) {
+  const elementsByKey = new Map(
+    fragment.props.children
+      .flat()
+      .map(element => [element.key, element] as const),
+  );
+  return orderedKeys.map(key => elementsByKey.get(`${keyPrefix}${key}`));
+}
+
 export const FilterGroup = ({
   name,
   options,
@@ -1425,7 +1440,8 @@ const DBSearchPageFiltersComponent = ({
     ) => {
       const { keyPrefix = '', isDefaultExpanded: forceExpanded } =
         options ?? {};
-      const { grouped, nonGrouped, ordered } = groupFacetsByBaseName(facets);
+      const { grouped, nonGrouped, orderedKeys } =
+        groupFacetsByBaseName(facets);
 
       const makeValuePins = (key: string): ValuePinHandlers => ({
         onPinClick: (value: string | boolean) => toggleFilterPin(key, value),
@@ -1443,137 +1459,144 @@ const DBSearchPageFiltersComponent = ({
         isSharedFieldPinned: isSharedFieldPinned(key),
       });
 
-      const groupedElements = grouped.map(group => (
-        <NestedFilterGroup
-          key={`${keyPrefix}${group.key}`}
-          data-testid={`${keyPrefix}nested-filter-group-${group.key}`}
-          name={group.key}
-          // sqlKey is the canonical (quoted/bracket) SQL form used wherever
-          // the key becomes raw SQL (distribution query, "Add column"
-          // SELECT); child.key stays clean for the UI.
-          childFilters={group.children.map(child => ({
-            ...child,
-            sqlKey: toQuotedClickHouseKeyExpression(child.key, knownColumns),
-          }))}
-          selectedValues={group.children.reduce((acc, child) => {
-            acc[child.key] = getFilterStateEntry(filterState, child.key) ?? {
-              included: new Set(),
-              excluded: new Set(),
-            };
-            return acc;
-          }, {} as FilterState)}
-          onChange={(key, value) => setFilterValue(key, value)}
-          onClearClick={key => clearFilter(key)}
-          onOnlyClick={(key, value) => setFilterValue(key, value, 'only')}
-          onExcludeClick={(key, value) => setFilterValue(key, value, 'exclude')}
-          onPinClick={(key, value) => toggleFilterPin(key, value)}
-          isPinned={(key, value) => isFilterPinned(key, value)}
-          onSharedPinClick={(key, value) => toggleSharedFilterPin(key, value)}
-          isSharedPinned={(key, value) => isSharedFilterPinned(key, value)}
-          onFieldPinClick={key => toggleFieldPin(key)}
-          isFieldPinned={key => isFieldPinned(key)}
-          onToggleSharedFieldPin={key => toggleSharedFieldPin(key)}
-          isSharedFieldPinned={key => isSharedFieldPinned(key)}
-          showFilterCounts={showFilterCounts}
-          onColumnToggle={onColumnToggle}
-          displayedColumns={displayedColumns}
-          onLoadMore={loadMoreFacetsForKey}
-          loadMoreLoading={group.children.reduce(
-            (acc, child) => {
-              acc[child.key] = loadMoreLoadingKeys.has(child.key);
-              return acc;
-            },
-            {} as Record<string, boolean>,
-          )}
-          hasLoadedMore={group.children.reduce(
-            (acc, child) => {
-              acc[child.key] = extraFacetKeys.has(child.key);
-              return acc;
-            },
-            {} as Record<string, boolean>,
-          )}
-          isDefaultExpanded={
-            forceExpanded ??
-            group.children.some(child => {
-              const entry = getFilterStateEntry(filterState, child.key);
-              return (
-                (entry &&
-                  (entry.included.size > 0 || entry.excluded.size > 0)) ||
-                isFieldPinned(child.key) ||
-                isSharedFieldPinned(child.key)
-              );
-            })
-          }
-          chartConfig={chartConfig}
-          isLive={isLive}
-        />
-      ));
-      const nonGroupedElements = nonGrouped.map(facet => {
-        const facetSqlKey = toQuotedClickHouseKeyExpression(
-          facet.key,
-          knownColumns,
-        );
-        return (
-          <FilterGroup
-            key={`${keyPrefix}${facet.key}`}
-            data-testid={`${keyPrefix}filter-group-${facet.key}`}
-            name={cleanedFacetName(facet.key)}
-            distributionKey={facetSqlKey}
-            showFilterCounts={showFilterCounts}
-            options={facet.value.map(value => ({
-              value,
-              label: value.toString(),
-            }))}
-            optionsLoading={isFacetsLoading}
-            selectedValues={
-              getFilterStateEntry(filterState, facet.key) ?? {
-                included: new Set(),
-                excluded: new Set(),
+      return orderFacetElements(
+        <>
+          {grouped.map(group => (
+            <NestedFilterGroup
+              key={`${keyPrefix}${group.key}`}
+              data-testid={`${keyPrefix}nested-filter-group-${group.key}`}
+              name={group.key}
+              // sqlKey is the canonical (quoted/bracket) SQL form used wherever
+              // the key becomes raw SQL (distribution query, "Add column"
+              // SELECT); child.key stays clean for the UI.
+              childFilters={group.children.map(child => ({
+                ...child,
+                sqlKey: toQuotedClickHouseKeyExpression(
+                  child.key,
+                  knownColumns,
+                ),
+              }))}
+              selectedValues={group.children.reduce((acc, child) => {
+                acc[child.key] = getFilterStateEntry(
+                  filterState,
+                  child.key,
+                ) ?? {
+                  included: new Set(),
+                  excluded: new Set(),
+                };
+                return acc;
+              }, {} as FilterState)}
+              onChange={(key, value) => setFilterValue(key, value)}
+              onClearClick={key => clearFilter(key)}
+              onOnlyClick={(key, value) => setFilterValue(key, value, 'only')}
+              onExcludeClick={(key, value) =>
+                setFilterValue(key, value, 'exclude')
               }
-            }
-            onChange={value => setFilterValue(facet.key, value)}
-            onClearClick={() => clearFilter(facet.key)}
-            onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
-            onExcludeClick={value =>
-              setFilterValue(facet.key, value, 'exclude')
-            }
-            valuePins={makeValuePins(facet.key)}
-            fieldPins={makeFieldPins(facet.key)}
-            onColumnToggle={
-              onColumnToggle ? () => onColumnToggle(facetSqlKey) : undefined
-            }
-            isColumnDisplayed={displayedColumns?.includes(facetSqlKey)}
-            onLoadMore={loadMoreFacetsForKey}
-            loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
-            hasLoadedMore={extraFacetKeys.has(facet.key)}
-            isDefaultExpanded={(() => {
-              const entry = getFilterStateEntry(filterState, facet.key);
-              return (
+              onPinClick={(key, value) => toggleFilterPin(key, value)}
+              isPinned={(key, value) => isFilterPinned(key, value)}
+              onSharedPinClick={(key, value) =>
+                toggleSharedFilterPin(key, value)
+              }
+              isSharedPinned={(key, value) => isSharedFilterPinned(key, value)}
+              onFieldPinClick={key => toggleFieldPin(key)}
+              isFieldPinned={key => isFieldPinned(key)}
+              onToggleSharedFieldPin={key => toggleSharedFieldPin(key)}
+              isSharedFieldPinned={key => isSharedFieldPinned(key)}
+              showFilterCounts={showFilterCounts}
+              onColumnToggle={onColumnToggle}
+              displayedColumns={displayedColumns}
+              onLoadMore={loadMoreFacetsForKey}
+              loadMoreLoading={group.children.reduce(
+                (acc, child) => {
+                  acc[child.key] = loadMoreLoadingKeys.has(child.key);
+                  return acc;
+                },
+                {} as Record<string, boolean>,
+              )}
+              hasLoadedMore={group.children.reduce(
+                (acc, child) => {
+                  acc[child.key] = extraFacetKeys.has(child.key);
+                  return acc;
+                },
+                {} as Record<string, boolean>,
+              )}
+              isDefaultExpanded={
                 forceExpanded ??
-                (isFieldPrimary(tableMetadata, facet.key) ||
-                  isFieldPinned(facet.key) ||
-                  isSharedFieldPinned(facet.key) ||
-                  (entry != null &&
-                    (entry.included.size > 0 ||
-                      entry.excluded.size > 0 ||
-                      entry.range != null)))
-              );
-            })()}
-            chartConfig={chartConfig}
-            isLive={isLive}
-            onRangeChange={range => setFilterRange(facet.key, range)}
-          />
-        );
-      });
-      const elements = [...groupedElements, ...nonGroupedElements];
-      const elementsByFacet = new Map(
-        [...grouped, ...nonGrouped].map((facet, index) => [
-          facet,
-          elements[index],
-        ]),
+                group.children.some(child => {
+                  const entry = getFilterStateEntry(filterState, child.key);
+                  return (
+                    (entry &&
+                      (entry.included.size > 0 || entry.excluded.size > 0)) ||
+                    isFieldPinned(child.key) ||
+                    isSharedFieldPinned(child.key)
+                  );
+                })
+              }
+              chartConfig={chartConfig}
+              isLive={isLive}
+            />
+          ))}
+          {nonGrouped.map(facet => {
+            const facetSqlKey = toQuotedClickHouseKeyExpression(
+              facet.key,
+              knownColumns,
+            );
+            return (
+              <FilterGroup
+                key={`${keyPrefix}${facet.key}`}
+                data-testid={`${keyPrefix}filter-group-${facet.key}`}
+                name={cleanedFacetName(facet.key)}
+                distributionKey={facetSqlKey}
+                showFilterCounts={showFilterCounts}
+                options={facet.value.map(value => ({
+                  value,
+                  label: value.toString(),
+                }))}
+                optionsLoading={isFacetsLoading}
+                selectedValues={
+                  getFilterStateEntry(filterState, facet.key) ?? {
+                    included: new Set(),
+                    excluded: new Set(),
+                  }
+                }
+                onChange={value => setFilterValue(facet.key, value)}
+                onClearClick={() => clearFilter(facet.key)}
+                onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
+                onExcludeClick={value =>
+                  setFilterValue(facet.key, value, 'exclude')
+                }
+                valuePins={makeValuePins(facet.key)}
+                fieldPins={makeFieldPins(facet.key)}
+                onColumnToggle={
+                  onColumnToggle ? () => onColumnToggle(facetSqlKey) : undefined
+                }
+                isColumnDisplayed={displayedColumns?.includes(facetSqlKey)}
+                onLoadMore={loadMoreFacetsForKey}
+                loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
+                hasLoadedMore={extraFacetKeys.has(facet.key)}
+                isDefaultExpanded={(() => {
+                  const entry = getFilterStateEntry(filterState, facet.key);
+                  return (
+                    forceExpanded ??
+                    (isFieldPrimary(tableMetadata, facet.key) ||
+                      isFieldPinned(facet.key) ||
+                      isSharedFieldPinned(facet.key) ||
+                      (entry != null &&
+                        (entry.included.size > 0 ||
+                          entry.excluded.size > 0 ||
+                          entry.range != null)))
+                  );
+                })()}
+                chartConfig={chartConfig}
+                isLive={isLive}
+                onRangeChange={range => setFilterRange(facet.key, range)}
+              />
+            );
+          })}
+        </>,
+        orderedKeys,
+        keyPrefix,
       );
-
-      return <>{ordered.map(facet => elementsByFacet.get(facet))}</>;
     },
     [
       filterState,

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1565,22 +1565,15 @@ const DBSearchPageFiltersComponent = ({
           />
         );
       });
-      const groupedElementsByGroup = new Map(
-        grouped.map((group, index) => [group, groupedElements[index]]),
-      );
-      const nonGroupedElementsByFacet = new Map(
-        nonGrouped.map((facet, index) => [facet, nonGroupedElements[index]]),
+      const elements = [...groupedElements, ...nonGroupedElements];
+      const elementsByFacet = new Map(
+        [...grouped, ...nonGrouped].map((facet, index) => [
+          facet,
+          elements[index],
+        ]),
       );
 
-      return (
-        <>
-          {ordered.map(item =>
-            'children' in item
-              ? groupedElementsByGroup.get(item)
-              : nonGroupedElementsByFacet.get(item),
-          )}
-        </>
-      );
+      return <>{ordered.map(facet => elementsByFacet.get(facet))}</>;
     },
     [
       filterState,

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -470,7 +470,6 @@ const FilterGroupBody = ({
 
   useEffect(() => {
     if (!isLive) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDateRange(chartConfig.dateRange);
     }
   }, [chartConfig.dateRange, isLive]);
@@ -685,7 +684,7 @@ const FilterGroupBody = ({
           isPercentageLoading={isFetchingDistribution}
           percentage={
             showDistributions && distributionData
-              ? distributionData.get(option.value.toString()) ?? 0
+              ? (distributionData.get(option.value.toString()) ?? 0)
               : undefined
           }
         />

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
+import { appendFileSync } from 'node:fs';
 import {
   TableMetadata,
   tcFromSource,
@@ -470,6 +471,7 @@ const FilterGroupBody = ({
 
   useEffect(() => {
     if (!isLive) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDateRange(chartConfig.dateRange);
     }
   }, [chartConfig.dateRange, isLive]);
@@ -684,7 +686,7 @@ const FilterGroupBody = ({
           isPercentageLoading={isFetchingDistribution}
           percentage={
             showDistributions && distributionData
-              ? (distributionData.get(option.value.toString()) ?? 0)
+              ? distributionData.get(option.value.toString()) ?? 0
               : undefined
           }
         />
@@ -1154,7 +1156,6 @@ const DBSearchPageFiltersComponent = ({
 
   useEffect(() => {
     if (!isLive) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDateRange(chartConfig.dateRange);
     }
   }, [chartConfig.dateRange, isLive]);
@@ -1333,7 +1334,16 @@ const DBSearchPageFiltersComponent = ({
 
     // #region agent log
     if (process.env.NODE_ENV === 'test')
-      require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'A,B', location: 'DBSearchPageFilters.tsx:shownFacets', message: 'Facet priority output', data: { keys: _facets.map(facet => facet.key) }, timestamp: Date.now() }) + '\n');
+      appendFileSync(
+        '/opt/cursor/logs/debug.log',
+        JSON.stringify({
+          hypothesisId: 'A,B',
+          location: 'DBSearchPageFilters.tsx:shownFacets',
+          message: 'Facet priority output',
+          data: { keys: _facets.map(facet => facet.key) },
+          timestamp: 0,
+        }) + '\n',
+      );
     // #endregion
     return _facets;
   }, [
@@ -1429,11 +1439,24 @@ const DBSearchPageFiltersComponent = ({
     ) => {
       const { keyPrefix = '', isDefaultExpanded: forceExpanded } =
         options ?? {};
-      const { grouped, nonGrouped } = groupFacetsByBaseName(facets);
+      const { grouped, nonGrouped, ordered } = groupFacetsByBaseName(facets);
 
       // #region agent log
       if (process.env.NODE_ENV === 'test')
-        require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'B', location: 'DBSearchPageFilters.tsx:renderFacetList', message: 'Grouped render partitions', data: { input: facets.map(facet => facet.key), grouped: grouped.map(group => group.key), nonGrouped: nonGrouped.map(facet => facet.key) }, timestamp: Date.now() }) + '\n');
+        appendFileSync(
+          '/opt/cursor/logs/debug.log',
+          JSON.stringify({
+            hypothesisId: 'B',
+            location: 'DBSearchPageFilters.tsx:renderFacetList',
+            message: 'Grouped render partitions',
+            data: {
+              input: facets.map(facet => facet.key),
+              grouped: grouped.map(group => group.key),
+              nonGrouped: nonGrouped.map(facet => facet.key),
+            },
+            timestamp: 0,
+          }) + '\n',
+        );
       // #endregion
       const makeValuePins = (key: string): ValuePinHandlers => ({
         onPinClick: (value: string | boolean) => toggleFilterPin(key, value),
@@ -1451,140 +1474,142 @@ const DBSearchPageFiltersComponent = ({
         isSharedFieldPinned: isSharedFieldPinned(key),
       });
 
+      const groupedElements = grouped.map(group => (
+        <NestedFilterGroup
+          key={`${keyPrefix}${group.key}`}
+          data-testid={`${keyPrefix}nested-filter-group-${group.key}`}
+          name={group.key}
+          // sqlKey is the canonical (quoted/bracket) SQL form used wherever
+          // the key becomes raw SQL (distribution query, "Add column"
+          // SELECT); child.key stays clean for the UI.
+          childFilters={group.children.map(child => ({
+            ...child,
+            sqlKey: toQuotedClickHouseKeyExpression(child.key, knownColumns),
+          }))}
+          selectedValues={group.children.reduce((acc, child) => {
+            acc[child.key] = getFilterStateEntry(filterState, child.key) ?? {
+              included: new Set(),
+              excluded: new Set(),
+            };
+            return acc;
+          }, {} as FilterState)}
+          onChange={(key, value) => setFilterValue(key, value)}
+          onClearClick={key => clearFilter(key)}
+          onOnlyClick={(key, value) => setFilterValue(key, value, 'only')}
+          onExcludeClick={(key, value) => setFilterValue(key, value, 'exclude')}
+          onPinClick={(key, value) => toggleFilterPin(key, value)}
+          isPinned={(key, value) => isFilterPinned(key, value)}
+          onSharedPinClick={(key, value) => toggleSharedFilterPin(key, value)}
+          isSharedPinned={(key, value) => isSharedFilterPinned(key, value)}
+          onFieldPinClick={key => toggleFieldPin(key)}
+          isFieldPinned={key => isFieldPinned(key)}
+          onToggleSharedFieldPin={key => toggleSharedFieldPin(key)}
+          isSharedFieldPinned={key => isSharedFieldPinned(key)}
+          showFilterCounts={showFilterCounts}
+          onColumnToggle={onColumnToggle}
+          displayedColumns={displayedColumns}
+          onLoadMore={loadMoreFacetsForKey}
+          loadMoreLoading={group.children.reduce(
+            (acc, child) => {
+              acc[child.key] = loadMoreLoadingKeys.has(child.key);
+              return acc;
+            },
+            {} as Record<string, boolean>,
+          )}
+          hasLoadedMore={group.children.reduce(
+            (acc, child) => {
+              acc[child.key] = extraFacetKeys.has(child.key);
+              return acc;
+            },
+            {} as Record<string, boolean>,
+          )}
+          isDefaultExpanded={
+            forceExpanded ??
+            group.children.some(child => {
+              const entry = getFilterStateEntry(filterState, child.key);
+              return (
+                (entry &&
+                  (entry.included.size > 0 || entry.excluded.size > 0)) ||
+                isFieldPinned(child.key) ||
+                isSharedFieldPinned(child.key)
+              );
+            })
+          }
+          chartConfig={chartConfig}
+          isLive={isLive}
+        />
+      ));
+      const nonGroupedElements = nonGrouped.map(facet => {
+        const facetSqlKey = toQuotedClickHouseKeyExpression(
+          facet.key,
+          knownColumns,
+        );
+        return (
+          <FilterGroup
+            key={`${keyPrefix}${facet.key}`}
+            data-testid={`${keyPrefix}filter-group-${facet.key}`}
+            name={cleanedFacetName(facet.key)}
+            distributionKey={facetSqlKey}
+            showFilterCounts={showFilterCounts}
+            options={facet.value.map(value => ({
+              value,
+              label: value.toString(),
+            }))}
+            optionsLoading={isFacetsLoading}
+            selectedValues={
+              getFilterStateEntry(filterState, facet.key) ?? {
+                included: new Set(),
+                excluded: new Set(),
+              }
+            }
+            onChange={value => setFilterValue(facet.key, value)}
+            onClearClick={() => clearFilter(facet.key)}
+            onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
+            onExcludeClick={value =>
+              setFilterValue(facet.key, value, 'exclude')
+            }
+            valuePins={makeValuePins(facet.key)}
+            fieldPins={makeFieldPins(facet.key)}
+            onColumnToggle={
+              onColumnToggle ? () => onColumnToggle(facetSqlKey) : undefined
+            }
+            isColumnDisplayed={displayedColumns?.includes(facetSqlKey)}
+            onLoadMore={loadMoreFacetsForKey}
+            loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
+            hasLoadedMore={extraFacetKeys.has(facet.key)}
+            isDefaultExpanded={(() => {
+              const entry = getFilterStateEntry(filterState, facet.key);
+              return (
+                forceExpanded ??
+                (isFieldPrimary(tableMetadata, facet.key) ||
+                  isFieldPinned(facet.key) ||
+                  isSharedFieldPinned(facet.key) ||
+                  (entry != null &&
+                    (entry.included.size > 0 ||
+                      entry.excluded.size > 0 ||
+                      entry.range != null)))
+              );
+            })()}
+            chartConfig={chartConfig}
+            isLive={isLive}
+            onRangeChange={range => setFilterRange(facet.key, range)}
+          />
+        );
+      });
+      const groupedElementsByGroup = new Map(
+        grouped.map((group, index) => [group, groupedElements[index]]),
+      );
+      const nonGroupedElementsByFacet = new Map(
+        nonGrouped.map((facet, index) => [facet, nonGroupedElements[index]]),
+      );
+
       return (
         <>
-          {grouped.map(group => (
-            <NestedFilterGroup
-              key={`${keyPrefix}${group.key}`}
-              data-testid={`${keyPrefix}nested-filter-group-${group.key}`}
-              name={group.key}
-              // sqlKey is the canonical (quoted/bracket) SQL form used wherever
-              // the key becomes raw SQL (distribution query, "Add column"
-              // SELECT); child.key stays clean for the UI.
-              childFilters={group.children.map(child => ({
-                ...child,
-                sqlKey: toQuotedClickHouseKeyExpression(
-                  child.key,
-                  knownColumns,
-                ),
-              }))}
-              selectedValues={group.children.reduce((acc, child) => {
-                acc[child.key] = getFilterStateEntry(
-                  filterState,
-                  child.key,
-                ) ?? {
-                  included: new Set(),
-                  excluded: new Set(),
-                };
-                return acc;
-              }, {} as FilterState)}
-              onChange={(key, value) => setFilterValue(key, value)}
-              onClearClick={key => clearFilter(key)}
-              onOnlyClick={(key, value) => setFilterValue(key, value, 'only')}
-              onExcludeClick={(key, value) =>
-                setFilterValue(key, value, 'exclude')
-              }
-              onPinClick={(key, value) => toggleFilterPin(key, value)}
-              isPinned={(key, value) => isFilterPinned(key, value)}
-              onSharedPinClick={(key, value) =>
-                toggleSharedFilterPin(key, value)
-              }
-              isSharedPinned={(key, value) => isSharedFilterPinned(key, value)}
-              onFieldPinClick={key => toggleFieldPin(key)}
-              isFieldPinned={key => isFieldPinned(key)}
-              onToggleSharedFieldPin={key => toggleSharedFieldPin(key)}
-              isSharedFieldPinned={key => isSharedFieldPinned(key)}
-              showFilterCounts={showFilterCounts}
-              onColumnToggle={onColumnToggle}
-              displayedColumns={displayedColumns}
-              onLoadMore={loadMoreFacetsForKey}
-              loadMoreLoading={group.children.reduce(
-                (acc, child) => {
-                  acc[child.key] = loadMoreLoadingKeys.has(child.key);
-                  return acc;
-                },
-                {} as Record<string, boolean>,
-              )}
-              hasLoadedMore={group.children.reduce(
-                (acc, child) => {
-                  acc[child.key] = extraFacetKeys.has(child.key);
-                  return acc;
-                },
-                {} as Record<string, boolean>,
-              )}
-              isDefaultExpanded={
-                forceExpanded ??
-                group.children.some(child => {
-                  const entry = getFilterStateEntry(filterState, child.key);
-                  return (
-                    (entry &&
-                      (entry.included.size > 0 || entry.excluded.size > 0)) ||
-                    isFieldPinned(child.key) ||
-                    isSharedFieldPinned(child.key)
-                  );
-                })
-              }
-              chartConfig={chartConfig}
-              isLive={isLive}
-            />
-          ))}
-          {nonGrouped.map(facet => {
-            const facetSqlKey = toQuotedClickHouseKeyExpression(
-              facet.key,
-              knownColumns,
-            );
-            return (
-              <FilterGroup
-                key={`${keyPrefix}${facet.key}`}
-                data-testid={`${keyPrefix}filter-group-${facet.key}`}
-                name={cleanedFacetName(facet.key)}
-                distributionKey={facetSqlKey}
-                showFilterCounts={showFilterCounts}
-                options={facet.value.map(value => ({
-                  value,
-                  label: value.toString(),
-                }))}
-                optionsLoading={isFacetsLoading}
-                selectedValues={
-                  getFilterStateEntry(filterState, facet.key) ?? {
-                    included: new Set(),
-                    excluded: new Set(),
-                  }
-                }
-                onChange={value => setFilterValue(facet.key, value)}
-                onClearClick={() => clearFilter(facet.key)}
-                onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
-                onExcludeClick={value =>
-                  setFilterValue(facet.key, value, 'exclude')
-                }
-                valuePins={makeValuePins(facet.key)}
-                fieldPins={makeFieldPins(facet.key)}
-                onColumnToggle={
-                  onColumnToggle ? () => onColumnToggle(facetSqlKey) : undefined
-                }
-                isColumnDisplayed={displayedColumns?.includes(facetSqlKey)}
-                onLoadMore={loadMoreFacetsForKey}
-                loadMoreLoading={loadMoreLoadingKeys.has(facet.key)}
-                hasLoadedMore={extraFacetKeys.has(facet.key)}
-                isDefaultExpanded={(() => {
-                  const entry = getFilterStateEntry(filterState, facet.key);
-                  return (
-                    forceExpanded ??
-                    (isFieldPrimary(tableMetadata, facet.key) ||
-                      isFieldPinned(facet.key) ||
-                      isSharedFieldPinned(facet.key) ||
-                      (entry != null &&
-                        (entry.included.size > 0 ||
-                          entry.excluded.size > 0 ||
-                          entry.range != null)))
-                  );
-                })()}
-                chartConfig={chartConfig}
-                isLive={isLive}
-                onRangeChange={range => setFilterRange(facet.key, range)}
-              />
-            );
-          })}
+          {ordered.map(item =>
+            'children' in item
+              ? groupedElementsByGroup.get(item)
+              : nonGroupedElementsByFacet.get(item),
+          )}
         </>
       );
     },

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1331,6 +1331,10 @@ const DBSearchPageFiltersComponent = ({
       return 0;
     });
 
+    // #region agent log
+    if (process.env.NODE_ENV === 'test')
+      require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'A,B', location: 'DBSearchPageFilters.tsx:shownFacets', message: 'Facet priority output', data: { keys: _facets.map(facet => facet.key) }, timestamp: Date.now() }) + '\n');
+    // #endregion
     return _facets;
   }, [
     facetsWithPinnedValues,
@@ -1427,6 +1431,10 @@ const DBSearchPageFiltersComponent = ({
         options ?? {};
       const { grouped, nonGrouped } = groupFacetsByBaseName(facets);
 
+      // #region agent log
+      if (process.env.NODE_ENV === 'test')
+        require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'B', location: 'DBSearchPageFilters.tsx:renderFacetList', message: 'Grouped render partitions', data: { input: facets.map(facet => facet.key), grouped: grouped.map(group => group.key), nonGrouped: nonGrouped.map(facet => facet.key) }, timestamp: Date.now() }) + '\n');
+      // #endregion
       const makeValuePins = (key: string): ValuePinHandlers => ({
         onPinClick: (value: string | boolean) => toggleFilterPin(key, value),
         isPinned: (value: string | boolean) => isFilterPinned(key, value),

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1301,20 +1301,6 @@ const DBSearchPageFiltersComponent = ({
       return aIsPk && !bIsPk ? -1 : bIsPk && !aIsPk ? 1 : 0;
     });
 
-    // prioritize facets that are pinned (either personal or shared)
-    _facets.sort((a, b) => {
-      const aPinned = isFieldPinned(a.key) || isSharedFieldPinned(a.key);
-      const bPinned = isFieldPinned(b.key) || isSharedFieldPinned(b.key);
-      return aPinned && !bPinned ? -1 : bPinned && !aPinned ? 1 : 0;
-    });
-
-    // among pinned, prioritize shared over personal
-    _facets.sort((a, b) => {
-      const aShared = isSharedFieldPinned(a.key);
-      const bShared = isSharedFieldPinned(b.key);
-      return aShared && !bShared ? -1 : bShared && !aShared ? 1 : 0;
-    });
-
     // prioritize facets that have checked items
     _facets.sort((a, b) => {
       const aChecked = filterState?.[a.key]?.included.size > 0;
@@ -1329,6 +1315,20 @@ const DBSearchPageFiltersComponent = ({
       if (aRange && !bRange) return -1;
       if (!aRange && bRange) return 1;
       return 0;
+    });
+
+    // prioritize facets that are pinned (either personal or shared)
+    _facets.sort((a, b) => {
+      const aPinned = isFieldPinned(a.key) || isSharedFieldPinned(a.key);
+      const bPinned = isFieldPinned(b.key) || isSharedFieldPinned(b.key);
+      return aPinned && !bPinned ? -1 : bPinned && !aPinned ? 1 : 0;
+    });
+
+    // among pinned, prioritize shared over personal
+    _facets.sort((a, b) => {
+      const aShared = isSharedFieldPinned(a.key);
+      const bShared = isSharedFieldPinned(b.key);
+      return aShared && !bShared ? -1 : bShared && !aShared ? 1 : 0;
     });
 
     return _facets;

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
-import { appendFileSync } from 'node:fs';
 import {
   TableMetadata,
   tcFromSource,
@@ -1156,6 +1155,7 @@ const DBSearchPageFiltersComponent = ({
 
   useEffect(() => {
     if (!isLive) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDateRange(chartConfig.dateRange);
     }
   }, [chartConfig.dateRange, isLive]);
@@ -1332,19 +1332,6 @@ const DBSearchPageFiltersComponent = ({
       return 0;
     });
 
-    // #region agent log
-    if (process.env.NODE_ENV === 'test')
-      appendFileSync(
-        '/opt/cursor/logs/debug.log',
-        JSON.stringify({
-          hypothesisId: 'A,B',
-          location: 'DBSearchPageFilters.tsx:shownFacets',
-          message: 'Facet priority output',
-          data: { keys: _facets.map(facet => facet.key) },
-          timestamp: 0,
-        }) + '\n',
-      );
-    // #endregion
     return _facets;
   }, [
     facetsWithPinnedValues,
@@ -1441,23 +1428,6 @@ const DBSearchPageFiltersComponent = ({
         options ?? {};
       const { grouped, nonGrouped, ordered } = groupFacetsByBaseName(facets);
 
-      // #region agent log
-      if (process.env.NODE_ENV === 'test')
-        appendFileSync(
-          '/opt/cursor/logs/debug.log',
-          JSON.stringify({
-            hypothesisId: 'B',
-            location: 'DBSearchPageFilters.tsx:renderFacetList',
-            message: 'Grouped render partitions',
-            data: {
-              input: facets.map(facet => facet.key),
-              grouped: grouped.map(group => group.key),
-              nonGrouped: nonGrouped.map(facet => facet.key),
-            },
-            timestamp: 0,
-          }) + '\n',
-        );
-      // #endregion
       const makeValuePins = (key: string): ValuePinHandlers => ({
         onPinClick: (value: string | boolean) => toggleFilterPin(key, value),
         isPinned: (value: string | boolean) => isFilterPinned(key, value),

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -6,11 +6,6 @@ import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
 import { mergePath } from '@/utils';
 
-type Facet = { key: string; value: (string | boolean)[] };
-type FacetGroup = Facet & {
-  children: (Facet & { propertyPath: string })[];
-};
-
 // Clean ClickHouse expressions to extract clean property paths
 export function cleanClickHouseExpression(key: string): string {
   // Remove toString() wrapper if present
@@ -67,23 +62,35 @@ function isBracketFormMapKey(key: string): boolean {
 // `LogAttributes['time']` refer to the same logical field and must collapse
 // into a single child. When merging, we keep the bracket-form key so
 // `child.key` remains a valid ClickHouse expression for "Load more" SQL.
-export function groupFacetsByBaseName(facets: Facet[]) {
-  const grouped = new Map<string, FacetGroup>();
-  const nonGrouped: Facet[] = [];
-  const ordered: (Facet | FacetGroup)[] = [];
+export function groupFacetsByBaseName(
+  facets: { key: string; value: (string | boolean)[] }[],
+) {
+  const grouped: Map<
+    string,
+    {
+      key: string;
+      value: (string | boolean)[];
+      children: {
+        key: string;
+        value: (string | boolean)[];
+        propertyPath: string;
+      }[];
+    }
+  > = new Map();
+  const nonGrouped: { key: string; value: (string | boolean)[] }[] = [];
+  const orderedKeys: string[] = [];
 
   for (const facet of facets) {
     const parsed = parseMapFieldName(facet.key);
     if (parsed) {
       const { baseName, propertyPath } = parsed;
       if (!grouped.has(baseName)) {
-        const group: FacetGroup = {
+        grouped.set(baseName, {
           key: baseName,
           value: [], // Base name doesn't have direct values
           children: [],
-        };
-        grouped.set(baseName, group);
-        ordered.push(group);
+        });
+        orderedKeys.push(baseName);
       }
       const group = grouped.get(baseName)!;
       const existing = group.children.find(
@@ -111,11 +118,11 @@ export function groupFacetsByBaseName(facets: Facet[]) {
       }
     } else {
       nonGrouped.push(facet);
-      ordered.push(facet);
+      orderedKeys.push(facet.key);
     }
   }
 
-  return { grouped: Array.from(grouped.values()), nonGrouped, ordered };
+  return { grouped: Array.from(grouped.values()), nonGrouped, orderedKeys };
 }
 
 // Look up a filterState entry by either bracket-form or dot-form map sub-key.

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -6,6 +6,11 @@ import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
 import { mergePath } from '@/utils';
 
+type Facet = { key: string; value: (string | boolean)[] };
+type FacetGroup = Facet & {
+  children: (Facet & { propertyPath: string })[];
+};
+
 // Clean ClickHouse expressions to extract clean property paths
 export function cleanClickHouseExpression(key: string): string {
   // Remove toString() wrapper if present
@@ -62,33 +67,23 @@ function isBracketFormMapKey(key: string): boolean {
 // `LogAttributes['time']` refer to the same logical field and must collapse
 // into a single child. When merging, we keep the bracket-form key so
 // `child.key` remains a valid ClickHouse expression for "Load more" SQL.
-export function groupFacetsByBaseName(
-  facets: { key: string; value: (string | boolean)[] }[],
-) {
-  const grouped: Map<
-    string,
-    {
-      key: string;
-      value: (string | boolean)[];
-      children: {
-        key: string;
-        value: (string | boolean)[];
-        propertyPath: string;
-      }[];
-    }
-  > = new Map();
-  const nonGrouped: { key: string; value: (string | boolean)[] }[] = [];
+export function groupFacetsByBaseName(facets: Facet[]) {
+  const grouped = new Map<string, FacetGroup>();
+  const nonGrouped: Facet[] = [];
+  const ordered: (Facet | FacetGroup)[] = [];
 
   for (const facet of facets) {
     const parsed = parseMapFieldName(facet.key);
     if (parsed) {
       const { baseName, propertyPath } = parsed;
       if (!grouped.has(baseName)) {
-        grouped.set(baseName, {
+        const group: FacetGroup = {
           key: baseName,
           value: [], // Base name doesn't have direct values
           children: [],
-        });
+        };
+        grouped.set(baseName, group);
+        ordered.push(group);
       }
       const group = grouped.get(baseName)!;
       const existing = group.children.find(
@@ -116,10 +111,11 @@ export function groupFacetsByBaseName(
       }
     } else {
       nonGrouped.push(facet);
+      ordered.push(facet);
     }
   }
 
-  return { grouped: Array.from(grouped.values()), nonGrouped };
+  return { grouped: Array.from(grouped.values()), nonGrouped, ordered };
 }
 
 // Look up a filterState entry by either bracket-form or dot-form map sub-key.

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import {
   cleanedFacetName,
+  DBSearchPageFilters,
   FilterGroup,
   type FilterGroupProps,
 } from '@/components/DBSearchPageFilters';
@@ -14,6 +15,40 @@ import {
   parseMapFieldName,
 } from '@/components/DBSearchPageFilters/utils';
 import { useGetValuesDistribution } from '@/hooks/useMetadata';
+
+const mockUseFetchFacets = jest.fn();
+
+jest.mock('@/components/DBSearchPageFilters/hooks', () => ({
+  useFetchFacets: () => mockUseFetchFacets(),
+}));
+
+jest.mock('@/pinnedFilters', () => ({
+  usePinnedFiltersApi: () => ({ data: { team: null } }),
+}));
+
+jest.mock('@/searchFilters', () => ({
+  IS_ROOT_SPAN_COLUMN_NAME: 'isRootSpan',
+  usePinnedFilters: () => ({
+    toggleFilterPin: jest.fn(),
+    toggleFieldPin: jest.fn(),
+    isFilterPinned: jest.fn().mockReturnValue(false),
+    isFieldPinned: (field: string) => field === 'ServiceName',
+    getPinnedFields: () => ['ServiceName'],
+    pinnedFilters: {},
+    toggleSharedFieldPin: jest.fn(),
+    isSharedFieldPinned: jest.fn().mockReturnValue(false),
+    toggleSharedFilterPin: jest.fn(),
+    isSharedFilterPinned: jest.fn().mockReturnValue(false),
+    resetPersonalPins: jest.fn(),
+    resetSharedFilters: jest.fn(),
+    hasPersonalPins: true,
+    hasSharedPins: false,
+  }),
+}));
+
+jest.mock('@/source', () => ({
+  useSource: () => ({ data: undefined }),
+}));
 
 describe('cleanClickHouseExpression', () => {
   it('should remove toString wrapper', () => {
@@ -53,7 +88,71 @@ jest.mock('@/hooks/useMetadata', () => ({
   useGetValuesDistribution: jest
     .fn()
     .mockReturnValue({ data: undefined, isFetching: false, error: undefined }),
+  useColumns: jest.fn().mockReturnValue({ data: [] }),
+  useJsonColumns: jest.fn().mockReturnValue({ data: [] }),
+  useTableMetadata: jest.fn().mockReturnValue({ data: undefined }),
 }));
+
+describe('DBSearchPageFilters', () => {
+  it('renders a pinned scalar field before an unpinned map group', () => {
+    mockUseFetchFacets.mockReturnValue({
+      data: {
+        keys: [],
+        keyValues: [
+          {
+            key: "ResourceAttributes['service.name']",
+            value: ['frontend'],
+          },
+          { key: 'ServiceName', value: ['api'] },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+      loadMoreFacetsForKey: jest.fn(),
+      loadMoreLoadingKeys: new Set(),
+      extraFacetKeys: new Set(),
+    });
+
+    renderWithMantine(
+      <DBSearchPageFilters
+        filters={{}}
+        clearFilter={jest.fn()}
+        setFilterValue={jest.fn()}
+        setFilterRange={jest.fn()}
+        isLive={false}
+        chartConfig={{
+          from: {
+            databaseName: 'test_db',
+            tableName: 'test_table',
+          },
+          select: '',
+          where: '',
+          whereLanguage: 'sql',
+          timestampValueExpression: '',
+          connection: 'test_connection',
+          dateRange: [new Date('2024-01-01'), new Date('2024-01-02')],
+        }}
+        analysisMode="results"
+        setAnalysisMode={jest.fn()}
+        sourceId="test-source"
+        showDelta={false}
+        denoiseResults={false}
+        setDenoiseResults={jest.fn()}
+      />,
+    );
+
+    const pinnedField = screen.getByTestId('filter-group-ServiceName');
+    const mapGroup = screen.getByTestId(
+      'nested-filter-group-ResourceAttributes',
+    );
+
+    expect(
+      pinnedField.compareDocumentPosition(mapGroup) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});
 
 describe('cleanedFacetName', () => {
   describe('basic functionality', () => {

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -94,7 +94,7 @@ jest.mock('@/hooks/useMetadata', () => ({
 }));
 
 describe('DBSearchPageFilters', () => {
-  it('renders a pinned scalar field before an unpinned map group', () => {
+  it('renders a pinned scalar field before an active map group', () => {
     mockUseFetchFacets.mockReturnValue({
       data: {
         keys: [],
@@ -116,7 +116,12 @@ describe('DBSearchPageFilters', () => {
 
     renderWithMantine(
       <DBSearchPageFilters
-        filters={{}}
+        filters={{
+          "ResourceAttributes['service.name']": {
+            included: new Set(['frontend']),
+            excluded: new Set(),
+          },
+        }}
         setFilters={jest.fn()}
         clearFilter={jest.fn()}
         clearAllFilters={jest.fn()}

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -117,8 +117,13 @@ describe('DBSearchPageFilters', () => {
     renderWithMantine(
       <DBSearchPageFilters
         filters={{}}
+        setFilters={jest.fn()}
         clearFilter={jest.fn()}
+        clearAllFilters={jest.fn()}
         setFilterValue={jest.fn()}
+        setOnlyFilters={jest.fn()}
+        replaceFilterValue={jest.fn()}
+        retainFiltersByColumns={jest.fn()}
         setFilterRange={jest.fn()}
         isLive={false}
         chartConfig={{

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -147,6 +147,9 @@ describe('DBSearchPageFilters', () => {
       'nested-filter-group-ResourceAttributes',
     );
 
+    // #region agent log
+    require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'C', location: 'DBSearchPageFilters.test.tsx:ordering assertion', message: 'Rendered facet positions', data: { relation: pinnedField.compareDocumentPosition(mapGroup), sameParent: pinnedField.parentElement === mapGroup.parentElement }, timestamp: Date.now() }) + '\n');
+    // #endregion
     expect(
       pinnedField.compareDocumentPosition(mapGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -1,3 +1,4 @@
+import { appendFileSync } from 'node:fs';
 import { UseQueryResult } from '@tanstack/react-query';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -148,7 +149,19 @@ describe('DBSearchPageFilters', () => {
     );
 
     // #region agent log
-    require('fs').appendFileSync('/opt/cursor/logs/debug.log', JSON.stringify({ hypothesisId: 'C', location: 'DBSearchPageFilters.test.tsx:ordering assertion', message: 'Rendered facet positions', data: { relation: pinnedField.compareDocumentPosition(mapGroup), sameParent: pinnedField.parentElement === mapGroup.parentElement }, timestamp: Date.now() }) + '\n');
+    appendFileSync(
+      '/opt/cursor/logs/debug.log',
+      JSON.stringify({
+        hypothesisId: 'C',
+        location: 'DBSearchPageFilters.test.tsx:ordering assertion',
+        message: 'Rendered facet positions',
+        data: {
+          relation: pinnedField.compareDocumentPosition(mapGroup),
+          sameParent: pinnedField.parentElement === mapGroup.parentElement,
+        },
+        timestamp: 0,
+      }) + '\n',
+    );
     // #endregion
     expect(
       pinnedField.compareDocumentPosition(mapGroup) &

--- a/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
+++ b/packages/app/src/components/__tests__/DBSearchPageFilters.test.tsx
@@ -1,4 +1,3 @@
-import { appendFileSync } from 'node:fs';
 import { UseQueryResult } from '@tanstack/react-query';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -148,21 +147,6 @@ describe('DBSearchPageFilters', () => {
       'nested-filter-group-ResourceAttributes',
     );
 
-    // #region agent log
-    appendFileSync(
-      '/opt/cursor/logs/debug.log',
-      JSON.stringify({
-        hypothesisId: 'C',
-        location: 'DBSearchPageFilters.test.tsx:ordering assertion',
-        message: 'Rendered facet positions',
-        data: {
-          relation: pinnedField.compareDocumentPosition(mapGroup),
-          sameParent: pinnedField.parentElement === mapGroup.parentElement,
-        },
-        timestamp: 0,
-      }) + '\n',
-    );
-    // #endregion
     expect(
       pinnedField.compareDocumentPosition(mapGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keep pinned filters above active fields and preserve the existing facet sort when map fields are grouped for display.

A sort-only change is insufficient because the renderer previously emitted every grouped map field before every scalar field. The implementation now adds only an ordered key list to the existing grouping result and reorders the already-rendered elements by those keys.

### Screenshots or video

[minimized_pinned_filter_fix_demo.mp4](https://cursor.com/agents/bc-fef20c6f-2756-4113-8a1a-f15cc6e8704b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fminimized_pinned_filter_fix_demo.mp4)

### How to test on Vercel preview

**Preview routes:** /search

**Steps:**

1. Open a log source containing both a scalar field such as `ServiceName` and a map field such as `LogAttributes`.
2. Select a value under the map field, then pin the scalar field using `Pin for me`.
3. Verify the pinned scalar field moves above the active map group and the map selection remains active.

### Testing

- `yarn jest src/components/__tests__/DBSearchPageFilters.test.tsx src/components/DBSearchPageFilters/utils.test.ts --runInBand --coverage=false` — 87 passed
- `yarn app:lint` — passed
- Manual browser validation — pinning `ServiceName` moves it above active `LogAttributes.test.case` without clearing the selection

### References

- Linear Issue: N/A
- Related PRs: N/A

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fef20c6f-2756-4113-8a1a-f15cc6e8704b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fef20c6f-2756-4113-8a1a-f15cc6e8704b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

