### PR TITLE
fix(app): serialize JSON column filters with dot access (HDX-5085)

### DIFF
--- a/.changeset/fix-json-column-filter-bracket-notation.md
+++ b/.changeset/fix-json-column-filter-bracket-notation.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Fix search page filters on JSON columns generating invalid bracket access. Adding or excluding a value on a sub-key of a JSON-typed column (e.g. `ResourceAttributes.region`) previously serialized to `ResourceAttributes['region']`, which ClickHouse rejects on a JSON column ("First argument for function 'arrayElement' must be array, got 'JSON'"). Sub-keys of JSON columns now serialize with dot access (`ResourceAttributes.\`region\``).

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -29,6 +29,8 @@ import HyperDX from '@hyperdx/browser';
 import {
   ClickHouseQueryError,
   ColumnMeta,
+  filterColumnMetaByType,
+  JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
@@ -1318,6 +1320,20 @@ export function DBSearchPage() {
         : new Set<string>(),
     [inputSourceColumns],
   );
+  // JSON-typed columns for the active source. Sub-key filters on these must
+  // serialize as dot access (`ResourceAttributes.`region``) rather than the
+  // bracket access ClickHouse rejects on a JSON column. HDX-5085.
+  const jsonColumns = useMemo(
+    () =>
+      inputSourceColumns
+        ? new Set(
+            filterColumnMetaByType(inputSourceColumns, [JSDataType.JSON])?.map(
+              c => c.name,
+            ) ?? [],
+          )
+        : new Set<string>(),
+    [inputSourceColumns],
+  );
 
   const watchedSource = useWatch({
     control,
@@ -1353,6 +1369,7 @@ export function DBSearchPage() {
     onFilterChange: handleSetFilters,
     dateTimeColumns,
     knownColumns,
+    jsonColumns,
   });
 
   useEffect(() => {

--- a/packages/app/src/components/DBSearchPageFilters.tsx
+++ b/packages/app/src/components/DBSearchPageFilters.tsx
@@ -1138,6 +1138,12 @@ const DBSearchPageFiltersComponent = ({
   const { data: source } = useSource({ id: sourceId });
   const sourceTableConnection = tcFromSource(source);
   const { data: jsonColumns } = useJsonColumns(sourceTableConnection);
+  // Set form for O(1) membership checks when serializing sub-key filters on
+  // JSON columns to dot access. HDX-5085.
+  const jsonColumnsSet = useMemo(
+    () => new Set(jsonColumns ?? []),
+    [jsonColumns],
+  );
 
   // Special case for live tail
   const [dateRange, setDateRange] = useState<[Date, Date]>(
@@ -1458,6 +1464,7 @@ const DBSearchPageFiltersComponent = ({
                 sqlKey: toQuotedClickHouseKeyExpression(
                   child.key,
                   knownColumns,
+                  jsonColumnsSet,
                 ),
               }))}
               selectedValues={group.children.reduce((acc, child) => {
@@ -1524,6 +1531,7 @@ const DBSearchPageFiltersComponent = ({
             const facetSqlKey = toQuotedClickHouseKeyExpression(
               facet.key,
               knownColumns,
+              jsonColumnsSet,
             );
             return (
               <FilterGroup
@@ -1603,6 +1611,7 @@ const DBSearchPageFiltersComponent = ({
       setFilterRange,
       tableMetadata,
       knownColumns,
+      jsonColumnsSet,
       extraFacetKeys,
     ],
   );

--- a/packages/app/src/components/DBSearchPageFilters/hooks.ts
+++ b/packages/app/src/components/DBSearchPageFilters/hooks.ts
@@ -60,6 +60,13 @@ function useFacets({
   );
   const { data: jsonColumns } = useJsonColumns(tableConnection);
   const { data: mapColumns } = useMapColumns(tableConnection);
+  // Set form for JSON-aware key serialization: sub-keys of JSON columns must
+  // render as dot access rather than the bracket access ClickHouse rejects on a
+  // JSON column. HDX-5085.
+  const jsonColumnsSet = useMemo(
+    () => new Set(jsonColumns ?? []),
+    [jsonColumns],
+  );
 
   const {
     data: allFields,
@@ -135,12 +142,16 @@ function useFacets({
 
     const sqlKeyToUiKey = new Map<string, string>();
     const escapedKeysToFetch = keysToFetch.map(key => {
-      const sqlKey = toQuotedClickHouseKeyExpression(key, knownColumns);
+      const sqlKey = toQuotedClickHouseKeyExpression(
+        key,
+        knownColumns,
+        jsonColumnsSet,
+      );
       sqlKeyToUiKey.set(sqlKey, key);
       return sqlKey;
     });
     return { escapedKeysToFetch, sqlKeyToUiKey };
-  }, [isColumnsLoading, keysToFetch, knownColumns]);
+  }, [isColumnsLoading, keysToFetch, knownColumns, jsonColumnsSet]);
 
   const facetsChartConfig = useMemo(
     () =>
@@ -174,7 +185,11 @@ function useFacets({
   const loadMoreFacetsForKey = useCallback(
     async (key: string): Promise<Facet | undefined> => {
       try {
-        const sqlKey = toQuotedClickHouseKeyExpression(key, knownColumns);
+        const sqlKey = toQuotedClickHouseKeyExpression(
+          key,
+          knownColumns,
+          jsonColumnsSet,
+        );
         if (mode === 'exact') {
           const strippedFilterState: FilterState = { ...filterState };
           delete strippedFilterState[key];
@@ -184,7 +199,11 @@ function useFacets({
               ...chartConfig,
               dateRange,
               filters: filtersToQuery(
-                escapeFilterStateKeys(strippedFilterState, knownColumns),
+                escapeFilterStateKeys(
+                  strippedFilterState,
+                  knownColumns,
+                  jsonColumnsSet,
+                ),
                 { dateTimeColumns },
               ),
             },
@@ -231,6 +250,7 @@ function useFacets({
       chartConfig,
       dateRange,
       knownColumns,
+      jsonColumnsSet,
       source,
       filterState,
       dateTimeColumns,

--- a/packages/app/src/components/DBSearchPageFilters/jsonAddToFilter.pipeline.test.ts
+++ b/packages/app/src/components/DBSearchPageFilters/jsonAddToFilter.pipeline.test.ts
@@ -165,3 +165,79 @@ describe('parsed-JSON "Add to Filters" -> valid SQL pipeline (HDX-4427)', () => 
     expect(entry.included).toEqual(new Set(["O'Brien"]));
   });
 });
+
+// HDX-5085: filtering a sub-key of a *native* JSON column (e.g. from clicking
+// "Add to Filters" then "Exclude" in the sidebar) must serialize as dot access,
+// not the bracket access ClickHouse rejects on a JSON column with "First
+// argument for function 'arrayElement' must be array, got 'JSON'".
+describe('JSON-column sub-key filter -> valid dot-access SQL pipeline (HDX-5085)', () => {
+  // ResourceAttributes is a native JSON column here (unlike the Map columns
+  // above), so its sub-keys must render with dot access.
+  const jsonKnownColumns = new Set(['ResourceAttributes', 'ServiceName']);
+  const jsonColumns = new Set(['ResourceAttributes']);
+
+  const runJsonFilter = (
+    key: string,
+    values: { included?: string[]; excluded?: string[] },
+  ) => {
+    const state: FilterState = {
+      [key]: {
+        included: new Set<string | boolean>(values.included ?? []),
+        excluded: new Set<string | boolean>(values.excluded ?? []),
+      },
+    };
+    return filtersToQuery(
+      escapeFilterStateKeys(state, jsonKnownColumns, jsonColumns),
+    );
+  };
+
+  it('excludes a JSON sub-key value with dot access, not bracket access', () => {
+    expect(
+      runJsonFilter('ResourceAttributes.region', {
+        excluded: ['eu-central-1'],
+      }),
+    ).toEqual([
+      {
+        type: 'sql',
+        condition: "ResourceAttributes.`region` NOT IN ('eu-central-1')",
+      },
+    ]);
+  });
+
+  it('never emits the illegal bracket subscript on a JSON column', () => {
+    const query = runJsonFilter('ResourceAttributes.region', {
+      included: ['us-east-1'],
+      excluded: ['eu-central-1'],
+    });
+    expect(query.length).toBeGreaterThan(0);
+    for (const filter of query) {
+      expect(filter.type).toBe('sql');
+      if (filter.type === 'sql') {
+        expect(filter.condition).not.toContain("ResourceAttributes['");
+        expect(isValidFilterCondition(filter.condition, 'sql')).toBe(true);
+      }
+    }
+  });
+
+  it('renders a nested JSON path with backtick-quoted segments', () => {
+    expect(
+      runJsonFilter('ResourceAttributes.host.name', { included: ['web-1'] }),
+    ).toEqual([
+      {
+        type: 'sql',
+        condition: "ResourceAttributes.`host`.`name` IN ('web-1')",
+      },
+    ]);
+  });
+
+  it('round-trips the JSON sub-key back to its clean dot form', () => {
+    const query = runJsonFilter('ResourceAttributes.region', {
+      excluded: ['eu-central-1'],
+    });
+    const back = parseQuery(query).filters;
+    const restoredKeys = Object.keys(back).map(cleanClickHouseExpression);
+    expect(restoredKeys).toEqual(['ResourceAttributes.region']);
+    const entry = back[Object.keys(back)[0]];
+    expect(entry.excluded).toEqual(new Set(['eu-central-1']));
+  });
+});

--- a/packages/app/src/components/DBSearchPageFilters/utils.test.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.test.ts
@@ -181,6 +181,45 @@ describe('toClickHouseKeyExpression', () => {
     );
   });
 
+  // HDX-5085: a sub-key on a JSON-typed column must serialize as dot access,
+  // not bracket access. ClickHouse rejects `ResourceAttributes['region']` on a
+  // JSON column with "First argument for function 'arrayElement' must be array,
+  // got 'JSON'". When the base column is known to be JSON, emit dot notation
+  // with backtick-quoted segments instead.
+  describe('JSON columns (HDX-5085)', () => {
+    const jsonColumns = new Set(['ResourceAttributes']);
+
+    it('rewrites a dot-form JSON sub-key to dot access, not bracket access', () => {
+      expect(
+        toClickHouseKeyExpression('ResourceAttributes.region', jsonColumns),
+      ).toBe('ResourceAttributes.`region`');
+    });
+
+    it('renders a nested JSON path with each segment backtick-quoted', () => {
+      expect(
+        toClickHouseKeyExpression('ResourceAttributes.host.name', jsonColumns),
+      ).toBe('ResourceAttributes.`host`.`name`');
+    });
+
+    it('still uses bracket form for a Map column not listed as JSON', () => {
+      expect(
+        toClickHouseKeyExpression('LogAttributes.region', jsonColumns),
+      ).toBe("LogAttributes['region']");
+    });
+
+    it('falls back to bracket form when no JSON columns are provided', () => {
+      expect(toClickHouseKeyExpression('ResourceAttributes.region')).toBe(
+        "ResourceAttributes['region']",
+      );
+    });
+
+    it('leaves an already-backtick JSON path unchanged', () => {
+      expect(
+        toClickHouseKeyExpression('ResourceAttributes.`region`', jsonColumns),
+      ).toBe('ResourceAttributes.`region`');
+    });
+  });
+
   // HDX-4427: "Add to Filters" on a value inside parsed JSON from a String
   // column builds a JSONExtract* function call as the filter key. These are
   // already valid ClickHouse expressions and must pass through untouched.
@@ -318,6 +357,43 @@ describe('toQuotedClickHouseKeyExpression', () => {
       expect(
         toQuotedClickHouseKeyExpression("LogAttributes['host.name']", cols),
       ).toBe("LogAttributes['host.name']");
+    });
+  });
+
+  // HDX-5085: a sub-key on a JSON column must serialize as dot access.
+  describe('with jsonColumns (JSON-aware)', () => {
+    const cols = new Set(['ResourceAttributes']);
+    const jsonCols = new Set(['ResourceAttributes']);
+
+    it('renders a JSON sub-key as dot access instead of bracket access', () => {
+      expect(
+        toQuotedClickHouseKeyExpression(
+          'ResourceAttributes.region',
+          cols,
+          jsonCols,
+        ),
+      ).toBe('ResourceAttributes.`region`');
+    });
+
+    it('renders a nested JSON path with backtick-quoted segments', () => {
+      expect(
+        toQuotedClickHouseKeyExpression(
+          'ResourceAttributes.host.name',
+          cols,
+          jsonCols,
+        ),
+      ).toBe('ResourceAttributes.`host`.`name`');
+    });
+
+    it('uses bracket access for a Map column absent from jsonColumns', () => {
+      const mapCols = new Set(['LogAttributes']);
+      expect(
+        toQuotedClickHouseKeyExpression(
+          'LogAttributes.region',
+          mapCols,
+          jsonCols,
+        ),
+      ).toBe("LogAttributes['region']");
     });
   });
 });

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -149,22 +149,33 @@ const isSqlFunctionCallExpression = (key: string): boolean =>
   /^[A-Za-z_]\w*\(/.test(key);
 
 // Coerce a filterState key into a ClickHouse expression suitable for raw SQL.
-// A dot-form Map sub-key like `LogAttributes.host.name` is rewritten to bracket
-// form `LogAttributes['host.name']` via `mergePath` so the conversion stays
-// consistent with the keys produced by the facet-discovery path. Bracket form,
-// backtick-quoted JSON paths, raw SQL function-call expressions
-// (`toString(...)`, `JSONExtractString(...)`), and plain column names are
-// returned unchanged. Use this when handing a filterState key off to a SQL
-// caller (e.g. "Load more" via metadata.getKeyValues), since `setFilterValue`
-// normalizes Map sub-keys to dot form which ClickHouse cannot resolve as map
-// access.
+// A dot-form sub-key like `LogAttributes.host.name` is rewritten via `mergePath`
+// so the conversion stays consistent with the keys produced by the
+// facet-discovery path. Bracket form, backtick-quoted JSON paths, raw SQL
+// function-call expressions (`toString(...)`, `JSONExtractString(...)`), and
+// plain column names are returned unchanged. Use this when handing a filterState
+// key off to a SQL caller (e.g. "Load more" via metadata.getKeyValues), since
+// `setFilterValue` normalizes sub-keys to dot form which ClickHouse cannot
+// resolve as map/JSON access.
 //
-// `parseMapFieldName` already guarantees `parsed.baseName` is a Map (its only
-// callers are the dot-form facet keys that originate from Map columns), so
-// `mergePath` must treat it as one. Without the third argument, a numeric-
-// looking sub-key like `LogAttributes.1` collapses into the Array branch and
-// emits the illegal `LogAttributes[2]`. HDX-4369.
-export function toClickHouseKeyExpression(key: string): string {
+// The base column's type decides the accessor:
+//   - JSON columns take dot access with backtick-quoted segments
+//     (`ResourceAttributes.`region``). ClickHouse rejects bracket subscripts on
+//     a JSON column with "First argument for function 'arrayElement' must be
+//     array, got 'JSON'", so a dot-form key like `ResourceAttributes.region`
+//     must NOT be turned into `ResourceAttributes['region']`. HDX-5085.
+//   - Map columns take bracket access (`LogAttributes['host.name']`). Passing
+//     the base as a Map (rather than letting `mergePath` fall through to its
+//     default branch) also keeps a numeric-looking sub-key like
+//     `LogAttributes.1` from collapsing into the illegal array subscript
+//     `LogAttributes[2]`. HDX-4369.
+//
+// Callers that know the schema should pass `jsonColumns`; otherwise the base is
+// treated as a Map, preserving the historical behavior.
+export function toClickHouseKeyExpression(
+  key: string,
+  jsonColumns: ReadonlySet<string> = new Set(),
+): string {
   if (
     key.includes("['") ||
     key.includes('["') ||
@@ -180,6 +191,13 @@ export function toClickHouseKeyExpression(key: string): string {
   }
   const parsed = parseMapFieldName(key);
   if (!parsed) return key;
+  if (jsonColumns.has(parsed.baseName)) {
+    return mergePath(
+      [parsed.baseName, parsed.propertyPath],
+      [parsed.baseName],
+      [],
+    );
+  }
   return mergePath(
     [parsed.baseName, parsed.propertyPath],
     [],
@@ -205,10 +223,15 @@ function quoteIdentifierIfNeeded(id: string): string {
  * `knownColumns` is the set of real top-level column names on the table. Only
  * keys matching a known column or accessing a map key of a known column will
  * be quoted.
+ *
+ * `jsonColumns` is the set of JSON-typed top-level columns; sub-keys of these
+ * render as dot access (`ResourceAttributes.`region``) rather than bracket
+ * access, since ClickHouse cannot subscript a JSON column. HDX-5085.
  */
 export function toQuotedClickHouseKeyExpression(
   key: string,
   knownColumns: Set<string>,
+  jsonColumns: ReadonlySet<string> = new Set(),
 ): string {
   // A whole-key match against a real column wins: quote the entire name as one
   // identifier (handles flat columns whose name contains dots/hyphens/etc.).
@@ -216,8 +239,9 @@ export function toQuotedClickHouseKeyExpression(
     return quoteIdentifierIfNeeded(key);
   }
 
-  // Normalize dot-form (ResourceAttributes.host.name) to map access form (ResourceAttributes['host.name'])
-  const expr = toClickHouseKeyExpression(key);
+  // Normalize dot-form to the accessor for the base column's type: Map access
+  // (ResourceAttributes['host.name']) or JSON dot access (ResourceAttributes.`region`).
+  const expr = toClickHouseKeyExpression(key, jsonColumns);
 
   // Already quoted: leave untouched
   if (expr.startsWith('`') || expr.startsWith('"')) {

--- a/packages/app/src/searchFilters.tsx
+++ b/packages/app/src/searchFilters.tsx
@@ -22,14 +22,19 @@ export const IS_ROOT_SPAN_COLUMN_NAME = 'isRootSpan';
 // 2. The persisted `Filter[]`: Uses the quoted/bracketed ClickHouse form so it emits
 // valid SQL verbatim. Persisted in URL params, local storage, and MongoDB for saved searches.
 
-// Convert the clean FilterState keys to valid SQL (quoted/bracket) keys.
+// Convert the clean FilterState keys to valid SQL (quoted/bracket/dot) keys.
+// `jsonColumns` lets a sub-key of a JSON column serialize as dot access
+// (`ResourceAttributes.`region``) instead of the illegal bracket access
+// (`ResourceAttributes['region']`) ClickHouse rejects on a JSON column. HDX-5085.
 export const escapeFilterStateKeys = (
   filters: FilterState,
   knownColumns: Set<string>,
+  jsonColumns: ReadonlySet<string> = new Set(),
 ): FilterState => {
   const escaped: FilterState = {};
   for (const [key, value] of Object.entries(filters)) {
-    escaped[toQuotedClickHouseKeyExpression(key, knownColumns)] = value;
+    escaped[toQuotedClickHouseKeyExpression(key, knownColumns, jsonColumns)] =
+      value;
   }
   return escaped;
 };
@@ -83,6 +88,7 @@ export const useSearchPageFilterState = ({
   onFilterChange,
   dateTimeColumns,
   knownColumns,
+  jsonColumns,
 }: {
   searchQuery?: Filter[];
   onFilterChange: (filters: Filter[]) => void;
@@ -93,15 +99,26 @@ export const useSearchPageFilterState = ({
    * (eg. service-name --> `service-name`).
    **/
   knownColumns: Set<string>;
+  /**
+   * JSON-typed top-level column names on the table, used to serialize sub-key
+   * filters as dot access (`ResourceAttributes.`region``) instead of the
+   * bracket access ClickHouse rejects on a JSON column. HDX-5085.
+   **/
+  jsonColumns?: ReadonlySet<string>;
 }) => {
-  // Access knownColumns through a ref so the returned mutators (which depend on
-  // updateFilterQuery) keep stable identities across knownColumns reference
-  // changes. The known columns are only used by the mutators, which are called
-  // on user input, not render, so avoid re-render by using a stable ref.
+  // Access knownColumns/jsonColumns through refs so the returned mutators (which
+  // depend on updateFilterQuery) keep stable identities across reference
+  // changes. These are only used by the mutators, which are called on user
+  // input, not render, so avoid re-render by using stable refs.
   const knownColumnsRef = useRef<Set<string>>(knownColumns);
   useEffect(() => {
     knownColumnsRef.current = knownColumns;
   }, [knownColumns]);
+
+  const jsonColumnsRef = useRef<ReadonlySet<string>>(jsonColumns ?? new Set());
+  useEffect(() => {
+    jsonColumnsRef.current = jsonColumns ?? new Set();
+  }, [jsonColumns]);
 
   // Persisted filters carry canonical (escaped) keys; convert back to the clean
   // keys the sidebar/comparisons use as they enter in-memory FilterState.
@@ -133,6 +150,7 @@ export const useSearchPageFilterState = ({
       const escapedFilters = escapeFilterStateKeys(
         newFilters,
         knownColumnsRef.current,
+        jsonColumnsRef.current,
       );
       onFilterChange(filtersToQuery(escapedFilters, { dateTimeColumns }));
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search page filters on a JSON `ResourceAttributes` (or any JSON-typed) column were being serialized with bracket access — e.g. `ResourceAttributes['region'] NOT IN ('eu-central-1')`. ClickHouse cannot subscript a JSON column, so the query failed with:

> First argument for function 'arrayElement' must be array, got 'JSON' instead

This reproduced by clicking **Add to Filters** and then **Exclude** (or Include) on a value from a JSON column.

### Root cause

Filter keys live in a clean, in-memory `FilterState` (dot form, e.g. `ResourceAttributes.region`) and are converted to raw SQL keys at serialization time by `escapeFilterStateKeys` → `toQuotedClickHouseKeyExpression` → `toClickHouseKeyExpression`. That serialization step had **no knowledge of column types** and unconditionally rewrote every dot-form sub-key to Map bracket form (`Col['key']`). For a Map column that is correct; for a JSON column it produces SQL ClickHouse rejects.

### Fix

Thread the set of JSON-typed columns through the serialization path so a sub-key of a JSON column renders as dot access with backtick-quoted segments (`ResourceAttributes.` + `` `region` ``) instead of bracket access:

- `toClickHouseKeyExpression` / `toQuotedClickHouseKeyExpression` now accept an optional `jsonColumns` set; a JSON base column routes through `mergePath`'s JSON branch. Map columns keep their existing bracket behavior (including the HDX-4369 numeric-sub-key guard).
- `escapeFilterStateKeys` and `useSearchPageFilterState` accept and forward `jsonColumns` (via a ref, matching the existing `knownColumns` pattern).
- `DBSearchPage` derives the JSON column set from the active source's columns and passes it in.
- The sidebar facet-value queries (`DBSearchPageFilters` and its `hooks.ts`) are made JSON-aware too, so facet counts / "Load more" respect an active JSON filter without emitting invalid SQL.

The value round-trips: the persisted `ResourceAttributes.` + `` `region` `` cleans back to `ResourceAttributes.region` in `FilterState`, so re-serialization is stable.

### Tests

- `utils.test.ts`: JSON-aware cases for `toClickHouseKeyExpression` / `toQuotedClickHouseKeyExpression` (dot access, nested paths, fallback to bracket when not JSON / no set provided).
- `jsonAddToFilter.pipeline.test.ts`: end-to-end pipeline coverage for the reported HDX-5085 exclude scenario, asserting the exact corrected condition, that the illegal `ResourceAttributes['` bracket subscript is never emitted, valid-SQL checks, and a `parseQuery` round-trip.

All app unit tests for the affected areas pass (146 tests across 4 suites); `yarn lint` reports 0 errors and `tsc --noEmit` is clean.

### Screenshots or video

N/A — no visual UI changes; this fixes the generated query for JSON-column filters.

### How to test on Vercel preview

**Preview routes:** /search

**Steps:**

1. Open `/search` against a source whose table has a native JSON column (e.g. `ResourceAttributes`).
2. Expand a row, find a JSON sub-attribute (e.g. `ResourceAttributes.region`), and click **Add to Filters**.
3. In the filters sidebar, click **Exclude** on one of that field's values.
4. Verify the results query runs without a ClickHouse `arrayElement`/JSON error, and that the generated SQL uses `ResourceAttributes.` + `` `region` `` (dot access) rather than `ResourceAttributes['region']`.

### References

- Linear Issue: HDX-5085
- Related PRs:

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HDX-5085](https://linear.app/clickhouse/issue/HDX-5085/bug-invalid-filter-query-on-json-column)

<div><a href="https://cursor.com/agents/bc-0f3828b8-abbc-450c-9208-7acf22be9f7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f3828b8-abbc-450c-9208-7acf22be9f7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

