### PR TITLE
feat(app): filters sidebar for multi-source search

### DIFF
--- a/.changeset/multi-source-filters.md
+++ b/.changeset/multi-source-filters.md
@@ -1,0 +1,10 @@
+---
+'@hyperdx/app': minor
+---
+
+The filters sidebar now works when searching multiple sources. Facet fields
+and values merge across the selected sources, and checking a value filters
+every source that has the field. A source whose table lacks a filtered column
+is excluded from the results with a visible reason on its status chip instead
+of silently returning unfiltered rows. Filter pills and add-to-filter from the
+row side panel work in multi-source mode too.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -101,6 +101,7 @@ import ResourceTerraformPopover from '@/components/Iac/ResourceTerraformPopover'
 import { InputControlled } from '@/components/InputControlled';
 import MultiSourceColumnPicker from '@/components/MultiSourceColumnPicker';
 import MultiSourceRowTableWithSidebar from '@/components/MultiSourceRowTable';
+import MultiSourceSearchFilters from '@/components/MultiSourceSearchFilters';
 import {
   MultiSourceTimeChart,
   MultiSourceTotalCountChart,
@@ -123,6 +124,7 @@ import { useAliasMapFromChartConfig } from '@/hooks/useChartConfig';
 import { useExplainQuery } from '@/hooks/useExplainQuery';
 import {
   resolveExtraColumnsForSource,
+  unresolvedFilterColumns,
   useMultiSourceColumns,
 } from '@/hooks/useMultiSourceSearch';
 import { useResolvedSourceParam } from '@/hooks/useResolvedSourceParam';
@@ -1351,8 +1353,123 @@ export function DBSearchPage() {
     [debouncedSubmit, setValue],
   );
 
+  const watchedSource = useWatch({
+    control,
+    name: 'source',
+    // Watch will reset when changing saved search, so we need to default to the URL
+    defaultValue: searchedConfig.source ?? undefined,
+  });
+
+  // --- Multi-source search: selection & schema state ------------------------
+  // 2+ resolved sources in the ?sources= param engage multi mode: one
+  // independent query pipeline per source, merged client-side. The single
+  // `source` (primary) keeps every existing code path working; multi mode
+  // only swaps what gets rendered below. Declared before the filter-state
+  // hooks so they can work against the union of the selected schemas.
+  const { sources: searchedMultiSources } = useResolvedSourcesParam(
+    rawSearchedConfig.sources,
+    { kinds: ALLOWED_SOURCE_KINDS },
+  );
+  const isMultiSource = searchedMultiSources.length > 1;
+  // Delta/pattern analyses are per-source; multi mode pins the results view.
+  const effectiveAnalysisMode = isMultiSource ? 'results' : analysisMode;
+  // Raw SQL WHERE names concrete columns of a concrete table — reinterpreting
+  // it per source risks silently-wrong results, so multi mode requires Lucene.
+  const isMultiSourceSqlBlocked =
+    isMultiSource &&
+    (searchedConfig.whereLanguage ?? getStoredLanguage() ?? 'lucene') ===
+      'sql' &&
+    !!searchedConfig.where;
+
+  // A hand-authored URL may carry only ?sources=; backfill the primary so the
+  // single-source machinery (form, chart config) has one.
+  useEffect(() => {
+    if (!rawSearchedConfig.source && searchedMultiSources.length > 0) {
+      setSearchedConfig({ source: searchedMultiSources[0].id });
+    }
+  }, [rawSearchedConfig.source, searchedMultiSources, setSearchedConfig]);
+
+  const watchedSources = useWatch({ control, name: 'sources' });
+  const formSourceCount = watchedSources?.length ?? 0;
+  // The multi-select UI stays visible while the user is composing a selection
+  // (even before a second source is added).
+  const [multiPickerOpen, setMultiPickerOpen] = useState(false);
+  const isMultiSelectUI = multiPickerOpen || formSourceCount > 1;
+  const formIsMulti = formSourceCount > 1;
+
+  const enterMultiSourceSelect = useCallback(() => {
+    setValue('sources', watchedSource ? [watchedSource] : []);
+    setMultiPickerOpen(true);
+  }, [setValue, watchedSource]);
+
+  // Keep the primary `source` field in sync with the selection and re-run the
+  // search when the selection changes.
+  const prevWatchedSourcesRef = useRef<string[] | null>(null);
+  useEffect(() => {
+    const current = watchedSources ?? [];
+    const prev = prevWatchedSourcesRef.current;
+    if (prev != null && JSON.stringify(prev) === JSON.stringify(current)) {
+      return;
+    }
+    prevWatchedSourcesRef.current = current;
+    if (prev == null) {
+      // Initial hydration from the URL — nothing changed.
+      return;
+    }
+    if (current.length > 0 && current[0] !== watchedSource) {
+      setValue('source', current[0]);
+    }
+    if ((prev?.length ?? 0) <= 1 && current.length > 1) {
+      // Entering multi mode: the single-source SELECT/ORDER BY strings don't
+      // translate to the canonical multi-source shape.
+      setValue('select', '');
+      setValue('orderBy', '');
+    }
+    debouncedSubmit();
+  }, [watchedSources, watchedSource, setValue, debouncedSubmit]);
+
+  // Collapse the picker back to the single-source select when the user
+  // reduces a real multi selection to one source. Keyed on the >1 → ≤1
+  // transition so it can't fire in the just-opened composing state (picker
+  // open, one source selected, second not yet picked).
+  const prevFormSourceCountRef = useRef(formSourceCount);
+  useEffect(() => {
+    const prev = prevFormSourceCountRef.current;
+    prevFormSourceCountRef.current = formSourceCount;
+    if (prev > 1 && formSourceCount <= 1) {
+      setMultiPickerOpen(false);
+    }
+  }, [formSourceCount]);
+
+  // Per-source top-level columns: powers the add-column picker, the
+  // per-source `column vs NULL` projection for user-picked extras, and
+  // per-source filter resolvability. Driven by the form's draft selection
+  // while composing (so the picker has options before the search is
+  // submitted), falling back to the searched selection.
+  const formMultiSources = useMemo(
+    () =>
+      (watchedSources ?? [])
+        .map(id => inputSourceObjs?.find(s => s.id === id))
+        .filter((s): s is TSource => s != null),
+    [watchedSources, inputSourceObjs],
+  );
+  const {
+    columnsBySourceId,
+    unionColumns,
+    dateTimeColumns: multiDateTimeColumns,
+  } = useMultiSourceColumns(
+    formMultiSources.length > 1
+      ? formMultiSources
+      : isMultiSource
+        ? searchedMultiSources
+        : [],
+  );
+  // --- End multi-source selection & schema state -----------------------------
+
   // Top-level column names for the active source, used to quote
-  // filter keys that contain special characters.
+  // filter keys that contain special characters. In multi mode this is the
+  // union across the selected sources, so filter keys from any of them
+  // escape correctly.
   const { data: inputSourceColumns } = useColumns(
     {
       databaseName: inputSourceObj?.from?.databaseName ?? '',
@@ -1361,20 +1478,19 @@ export function DBSearchPage() {
     },
     { enabled: !!inputSourceObj },
   );
-  const knownColumns = useMemo(
-    () =>
-      inputSourceColumns
-        ? new Set(inputSourceColumns.map(c => c.name))
-        : new Set<string>(),
-    [inputSourceColumns],
-  );
+  const knownColumns = useMemo(() => {
+    if (isMultiSource) {
+      const union = new Set<string>();
+      for (const names of columnsBySourceId.values()) {
+        for (const name of names) union.add(name);
+      }
+      return union;
+    }
+    return inputSourceColumns
+      ? new Set(inputSourceColumns.map(c => c.name))
+      : new Set<string>();
+  }, [inputSourceColumns, isMultiSource, columnsBySourceId]);
 
-  const watchedSource = useWatch({
-    control,
-    name: 'source',
-    // Watch will reset when changing saved search, so we need to default to the URL
-    defaultValue: searchedConfig.source ?? undefined,
-  });
   const prevSourceRef = useRef(watchedSource);
   // Set when the user switches sources via the dropdown. The follow-up
   // effect waits for the new source's columns to load and then drops any
@@ -1397,11 +1513,21 @@ export function DBSearchPage() {
   const { dateTimeColumns, onResolvedColumnsChange } =
     useResolvedDateTimeColumns(inputSourceColumns);
 
+  // In multi mode, date/time-typed filter keys may come from any selected
+  // source's schema.
+  const effectiveDateTimeColumns = useMemo(
+    () =>
+      isMultiSource && multiDateTimeColumns.size > 0
+        ? new Map([...dateTimeColumns, ...multiDateTimeColumns])
+        : dateTimeColumns,
+    [isMultiSource, dateTimeColumns, multiDateTimeColumns],
+  );
+
   const filters = useWatch({ name: 'filters', control });
   const searchFilters = useSearchPageFilterState({
     searchQuery: filters ?? undefined,
     onFilterChange: handleSetFilters,
-    dateTimeColumns,
+    dateTimeColumns: effectiveDateTimeColumns,
     knownColumns,
   });
 
@@ -1539,105 +1665,7 @@ export function DBSearchPage() {
   const { data: chartConfig, isLoading: isChartConfigLoading } =
     useSearchedConfigToChartConfig(chartSearchConfig, defaultSearchConfig);
 
-  // --- Multi-source search -------------------------------------------------
-  // 2+ resolved sources in the ?sources= param engage multi mode: one
-  // independent query pipeline per source, merged client-side. The single
-  // `source` (primary) keeps every existing code path working; multi mode
-  // only swaps what gets rendered below.
-  const { sources: searchedMultiSources } = useResolvedSourcesParam(
-    rawSearchedConfig.sources,
-    { kinds: ALLOWED_SOURCE_KINDS },
-  );
-  const isMultiSource = searchedMultiSources.length > 1;
-  // Delta/pattern analyses are per-source; multi mode pins the results view.
-  const effectiveAnalysisMode = isMultiSource ? 'results' : analysisMode;
-  // Raw SQL WHERE names concrete columns of a concrete table — reinterpreting
-  // it per source risks silently-wrong results, so multi mode requires Lucene.
-  const isMultiSourceSqlBlocked =
-    isMultiSource &&
-    (searchedConfig.whereLanguage ?? getStoredLanguage() ?? 'lucene') ===
-      'sql' &&
-    !!searchedConfig.where;
-
-  // A hand-authored URL may carry only ?sources=; backfill the primary so the
-  // single-source machinery (form, chart config) has one.
-  useEffect(() => {
-    if (!rawSearchedConfig.source && searchedMultiSources.length > 0) {
-      setSearchedConfig({ source: searchedMultiSources[0].id });
-    }
-  }, [rawSearchedConfig.source, searchedMultiSources, setSearchedConfig]);
-
-  const watchedSources = useWatch({ control, name: 'sources' });
-  const formSourceCount = watchedSources?.length ?? 0;
-  // The multi-select UI stays visible while the user is composing a selection
-  // (even before a second source is added).
-  const [multiPickerOpen, setMultiPickerOpen] = useState(false);
-  const isMultiSelectUI = multiPickerOpen || formSourceCount > 1;
-  const formIsMulti = formSourceCount > 1;
-
-  const enterMultiSourceSelect = useCallback(() => {
-    setValue('sources', watchedSource ? [watchedSource] : []);
-    setMultiPickerOpen(true);
-  }, [setValue, watchedSource]);
-
-  // Keep the primary `source` field in sync with the selection and re-run the
-  // search when the selection changes.
-  const prevWatchedSourcesRef = useRef<string[] | null>(null);
-  useEffect(() => {
-    const current = watchedSources ?? [];
-    const prev = prevWatchedSourcesRef.current;
-    if (prev != null && JSON.stringify(prev) === JSON.stringify(current)) {
-      return;
-    }
-    prevWatchedSourcesRef.current = current;
-    if (prev == null) {
-      // Initial hydration from the URL — nothing changed.
-      return;
-    }
-    if (current.length > 0 && current[0] !== watchedSource) {
-      setValue('source', current[0]);
-    }
-    if ((prev?.length ?? 0) <= 1 && current.length > 1) {
-      // Entering multi mode: the single-source SELECT/ORDER BY strings don't
-      // translate to the canonical multi-source shape.
-      setValue('select', '');
-      setValue('orderBy', '');
-    }
-    debouncedSubmit();
-  }, [watchedSources, watchedSource, setValue, debouncedSubmit]);
-
-  // Collapse the picker back to the single-source select when the user
-  // reduces a real multi selection to one source. Keyed on the >1 → ≤1
-  // transition so it can't fire in the just-opened composing state (picker
-  // open, one source selected, second not yet picked).
-  const prevFormSourceCountRef = useRef(formSourceCount);
-  useEffect(() => {
-    const prev = prevFormSourceCountRef.current;
-    prevFormSourceCountRef.current = formSourceCount;
-    if (prev > 1 && formSourceCount <= 1) {
-      setMultiPickerOpen(false);
-    }
-  }, [formSourceCount]);
-
-  // Per-source top-level columns: powers the add-column picker and the
-  // per-source `column vs NULL` projection for user-picked extras. Driven by
-  // the form's draft selection while composing (so the picker has options
-  // before the search is submitted), falling back to the searched selection.
-  const formMultiSources = useMemo(
-    () =>
-      (watchedSources ?? [])
-        .map(id => inputSourceObjs?.find(s => s.id === id))
-        .filter((s): s is TSource => s != null),
-    [watchedSources, inputSourceObjs],
-  );
-  const { columnsBySourceId, unionColumns } = useMultiSourceColumns(
-    formMultiSources.length > 1
-      ? formMultiSources
-      : isMultiSource
-        ? searchedMultiSources
-        : [],
-  );
-
+  // --- Multi-source search: query specs -------------------------------------
   // In multi mode the `select` param holds the extra column names picked by
   // the user (the canonical columns are always projected).
   const multiExtraColumnNames = useMemo(
@@ -1661,13 +1689,46 @@ export function DBSearchPage() {
     [setValue, debouncedSubmit],
   );
 
+  // Sidebar filters apply per source. A source whose table lacks a filtered
+  // column can't answer the filtered search — it's excluded entirely (with a
+  // visible reason on its status chip) rather than silently returning rows
+  // that ignore the filter.
+  const multiSourceFilters = useMemo(
+    () => (isMultiSource ? (searchedConfig.filters ?? []) : []),
+    [isMultiSource, searchedConfig.filters],
+  );
+  const multiDisabledReasons = useMemo(() => {
+    const reasons = new Map<string, string>();
+    if (!isMultiSource || multiSourceFilters.length === 0) return reasons;
+    for (const source of searchedMultiSources) {
+      const missing = unresolvedFilterColumns(
+        multiSourceFilters,
+        columnsBySourceId.get(source.id),
+      );
+      if (missing.length > 0) {
+        reasons.set(
+          source.id,
+          `${source.name} is excluded: the active filter uses ${missing.join(
+            ', ',
+          )}, which it doesn't have`,
+        );
+      }
+    }
+    return reasons;
+  }, [
+    isMultiSource,
+    multiSourceFilters,
+    searchedMultiSources,
+    columnsBySourceId,
+  ]);
+
   const multiSourceStreamSpecs = useMemo(() => {
     if (!isMultiSource || isMultiSourceSqlBlocked) return [];
-    // Extra columns need each source's DESCRIBE to resolve column-vs-NULL;
-    // hold the row queries until they've loaded so we don't fire a throwaway
-    // query per source with every extra projected as NULL.
+    // Extra columns and filters both need each source's DESCRIBE (to resolve
+    // column-vs-NULL and filter resolvability); hold the row queries until
+    // they've loaded so we don't fire throwaway or erroring queries.
     if (
-      multiExtraColumnNames.length > 0 &&
+      (multiExtraColumnNames.length > 0 || multiSourceFilters.length > 0) &&
       columnsBySourceId.size < searchedMultiSources.length
     ) {
       return [];
@@ -1676,12 +1737,14 @@ export function DBSearchPage() {
     const where = searchedConfig.where ?? '';
     return searchedMultiSources.map(source => ({
       source,
+      disabledReason: multiDisabledReasons.get(source.id),
       config: {
         ...buildMultiSourceSearchConfig(
           source,
           {
             where,
             whereLanguage: 'lucene',
+            filters: multiSourceFilters,
             orderBy: multiSourceDefaultOrderBy(source),
           },
           {
@@ -1701,19 +1764,29 @@ export function DBSearchPage() {
     searchedMultiSources,
     searchedConfig.where,
     multiExtraColumnNames,
+    multiSourceFilters,
+    multiDisabledReasons,
     columnsBySourceId,
     searchedTimeRange,
   ]);
 
   const multiHistogramSpecs = useMemo(() => {
     if (!isMultiSource || isMultiSourceSqlBlocked) return [];
+    if (
+      multiSourceFilters.length > 0 &&
+      columnsBySourceId.size < searchedMultiSources.length
+    ) {
+      return [];
+    }
     const where = searchedConfig.where ?? '';
     return searchedMultiSources.map(source => ({
       source,
+      disabledReason: multiDisabledReasons.get(source.id),
       config: {
         ...buildMultiSourceSearchConfig(source, {
           where,
           whereLanguage: 'lucene',
+          filters: multiSourceFilters,
         }),
         select: ALERT_COUNT_DEFAULT_SELECT,
         orderBy: undefined,
@@ -1731,6 +1804,9 @@ export function DBSearchPage() {
     isMultiSourceSqlBlocked,
     searchedMultiSources,
     searchedConfig.where,
+    multiSourceFilters,
+    multiDisabledReasons,
+    columnsBySourceId,
     searchedTimeRange,
   ]);
   // --- End multi-source search ---------------------------------------------
@@ -2218,18 +2294,26 @@ export function DBSearchPage() {
     ],
   );
 
-  // Multi-source rows span schemas, so single-source affordances
-  // (add-to-search, column toggles) are omitted — the side panel hides them.
-  // Passing no `source` with no toggle callbacks is required: with a null
-  // context source, deriveRowSidePanelContextForSource treats every row as
-  // same-source and would leave stale single-source callbacks enabled.
+  // Multi-source rows span schemas, so the single-source column toggles are
+  // omitted — the side panel hides them. Property-add-to-filter IS wired:
+  // filters resolve per source, and a source that lacks the column is
+  // excluded with a visible reason. Passing no `source` is required: with a
+  // null context source, deriveRowSidePanelContextForSource treats every row
+  // as same-source, which is exactly the cross-source semantics filters now
+  // have.
   const multiRowTableContext = useMemo(
     () => ({
+      onPropertyAddClick: searchFilters.setFilterValue,
       generateSearchUrl,
       isChildModalOpen: isDrawerChildModalOpen,
       setChildModalOpen: setDrawerChildModalOpen,
     }),
-    [generateSearchUrl, isDrawerChildModalOpen, setDrawerChildModalOpen],
+    [
+      searchFilters.setFilterValue,
+      generateSearchUrl,
+      isDrawerChildModalOpen,
+      setDrawerChildModalOpen,
+    ],
   );
 
   const inputSourceTableConnection = useMemo(
@@ -2693,14 +2777,12 @@ export function DBSearchPage() {
             <SearchSubmitButton isFormStateDirty={formState.isDirty} />
           </Flex>
         </Flex>
-        {!isMultiSource && (
-          <ActiveFilterPills
-            searchFilters={searchFilters}
-            chartConfig={filtersChartConfig}
-            dateTimeColumns={dateTimeColumns}
-            mt={6}
-          />
-        )}
+        <ActiveFilterPills
+          searchFilters={searchFilters}
+          chartConfig={filtersChartConfig}
+          dateTimeColumns={effectiveDateTimeColumns}
+          mt={6}
+        />
       </form>
       {searchedConfig != null && searchedSource != null && (
         <SaveSearchModal
@@ -2742,6 +2824,20 @@ export function DBSearchPage() {
                 height: '100%',
               }}
             >
+              {!isFilterSidebarCollapsed &&
+                isMultiSource &&
+                !isMultiSourceSqlBlocked && (
+                  <ErrorBoundary message="Unable to render search filters">
+                    <MultiSourceSearchFilters
+                      specs={multiHistogramSpecs}
+                      dateRange={searchedTimeRange}
+                      isLive={isLive ?? true}
+                      knownColumns={knownColumns}
+                      searchFilters={searchFilters}
+                      onCollapse={() => setIsFilterSidebarCollapsed(true)}
+                    />
+                  </ErrorBoundary>
+                )}
               {!isFilterSidebarCollapsed && !isMultiSource && (
                 <ErrorBoundary message="Unable to render search filters">
                   <DBSearchPageFilters
@@ -2875,25 +2971,26 @@ export function DBSearchPage() {
                           align="center"
                           style={{ width: '100%' }}
                         >
-                          <MultiSourceTotalCountChart
-                            specs={multiHistogramSpecs}
-                            enabled={isReady}
-                            queryKeyPrefix={QUERY_KEY_PREFIX}
-                            enableParallelQueries
-                          />
-                          <Group gap="sm" align="center">
-                            {(searchedConfig.filters?.length ?? 0) > 0 && (
-                              <Text size="xs" c="dimmed">
-                                Sidebar filters aren't applied when searching
-                                multiple sources
-                              </Text>
-                            )}
-                            {shouldShowLiveModeHint && (
-                              <ResumeLiveTailButton
-                                handleResumeLiveTail={handleResumeLiveTail}
+                          <Group gap={4} align="center">
+                            {isFilterSidebarCollapsed && (
+                              <ExpandFiltersButton
+                                onExpand={() =>
+                                  setIsFilterSidebarCollapsed(false)
+                                }
                               />
                             )}
+                            <MultiSourceTotalCountChart
+                              specs={multiHistogramSpecs}
+                              enabled={isReady}
+                              queryKeyPrefix={QUERY_KEY_PREFIX}
+                              enableParallelQueries
+                            />
                           </Group>
+                          {shouldShowLiveModeHint && (
+                            <ResumeLiveTailButton
+                              handleResumeLiveTail={handleResumeLiveTail}
+                            />
+                          )}
                         </Group>
                       </Box>
                       <Box

--- a/packages/app/src/components/DBSearchPageFilters/hooks.ts
+++ b/packages/app/src/components/DBSearchPageFilters/hooks.ts
@@ -254,6 +254,7 @@ export function useFetchFacets({
   filterState,
   showMoreFields,
   disableValues,
+  enabled = true,
 }: {
   chartConfig: BuilderChartConfigWithDateRange;
   sourceId: string | null;
@@ -262,6 +263,8 @@ export function useFetchFacets({
   filterState?: FilterState;
   showMoreFields?: boolean;
   disableValues?: boolean;
+  /** Disable all data fetching (e.g. an unused multi-source hook slot). */
+  enabled?: boolean;
 }) {
   const facetsQuery = useFacets({
     chartConfig,
@@ -270,7 +273,7 @@ export function useFetchFacets({
     dateRange,
     filterState,
     showMoreFields,
-    enabled: true,
+    enabled,
     disableValues,
   });
 

--- a/packages/app/src/components/MultiSourceRowTable.tsx
+++ b/packages/app/src/components/MultiSourceRowTable.tsx
@@ -14,7 +14,7 @@ import {
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import { Flex, Group, Loader, Text, Tooltip } from '@mantine/core';
-import { IconAlertTriangle } from '@tabler/icons-react';
+import { IconAlertTriangle, IconFilterOff } from '@tabler/icons-react';
 
 import api from '@/api';
 import { searchChartConfigDefaults } from '@/defaults';
@@ -41,6 +41,11 @@ import { getMultiSourceColor, SourceBadge } from './MultiSourceBadge';
 export type MultiSourceStreamSpec = {
   source: TSource;
   config: BuilderChartConfigWithDateRange;
+  /**
+   * When set, the source doesn't run at all (e.g. an active filter references
+   * a column its table lacks); shown on the source's status chip.
+   */
+  disabledReason?: string;
 };
 
 // Placeholder config for unused hook slots. The metadata hooks inside
@@ -109,7 +114,11 @@ function useSourceStream(
 
   const { data, fetchNextPage, hasNextPage, isFetching, isError, error } =
     useOffsetPaginatedQuery(mergedConfig ?? configWithDefaults, {
-      enabled: enabled && spec != null && mergedConfig != null,
+      enabled:
+        enabled &&
+        spec != null &&
+        spec.disabledReason == null &&
+        mergedConfig != null,
       isLive,
       queryKeyPrefix,
       enableSmallFirstWindow,
@@ -177,10 +186,23 @@ function StreamStatusChips({ streams }: { streams: SourceStream[] }) {
       {streams.map((stream, i) => {
         if (stream.spec == null) return null;
         const name = stream.spec.source.name;
+        const disabledReason = stream.spec.disabledReason;
         return (
-          <Group key={stream.spec.source.id} gap={4} wrap="nowrap">
+          <Group
+            key={stream.spec.source.id}
+            gap={4}
+            wrap="nowrap"
+            style={disabledReason != null ? { opacity: 0.55 } : undefined}
+          >
             <SourceBadge name={name} color={getMultiSourceColor(i)} />
             {stream.isFetching && <Loader size={10} color="gray" />}
+            {disabledReason != null && (
+              <Tooltip label={disabledReason} multiline maw={420}>
+                <Text component="span" c="dimmed" lh={1}>
+                  <IconFilterOff size={13} />
+                </Text>
+              </Tooltip>
+            )}
             {stream.isError && (
               <Tooltip
                 label={`${name} failed to load and is excluded from these results: ${
@@ -258,7 +280,7 @@ export default function MultiSourceRowTableWithSidebar({
         window: stream.data?.window ?? null,
         lastPageRowCount: stream.data?.lastPageRowCount ?? null,
         hasNextPage: stream.hasNextPage,
-        isActive: !stream.isError,
+        isActive: !stream.isError && stream.spec.disabledReason == null,
         dateRange: stream.spec.config.dateRange,
       })),
     [streams],

--- a/packages/app/src/components/MultiSourceSearchFilters.tsx
+++ b/packages/app/src/components/MultiSourceSearchFilters.tsx
@@ -1,0 +1,315 @@
+import { useMemo } from 'react';
+import { FilterState } from '@hyperdx/common-utils/dist/filters';
+import {
+  BuilderChartConfigWithDateRange,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
+import {
+  ActionIcon,
+  Box,
+  Flex,
+  Group,
+  ScrollArea,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { IconArrowBarToLeft, IconFilterOff } from '@tabler/icons-react';
+
+import {
+  cleanedFacetName,
+  FilterGroup,
+} from '@/components/DBSearchPageFilters';
+import { useFetchFacets } from '@/components/DBSearchPageFilters/hooks';
+import { NestedFilterGroup } from '@/components/DBSearchPageFilters/NestedFilterGroup';
+import {
+  getFilterStateEntry,
+  groupFacetsByBaseName,
+  toQuotedClickHouseKeyExpression,
+} from '@/components/DBSearchPageFilters/utils';
+import { useMultiSourceSlots } from '@/hooks/useMultiSourceSearch';
+import useResizable from '@/hooks/useResizable';
+import { FilterStateHook } from '@/searchFilters';
+
+import resizeStyles from '@styles/ResizablePanel.module.scss';
+import classes from '@styles/SearchPage.module.scss';
+
+export type MultiSourceFilterSpec = {
+  source: TSource;
+  /** Per-source config carrying connection/from/where/filters/dateRange. */
+  config: BuilderChartConfigWithDateRange;
+};
+
+// Placeholder for unused hook slots; never fetched (enabled: false).
+const STUB_CONFIG: BuilderChartConfigWithDateRange = {
+  connection: '',
+  from: { databaseName: '', tableName: '' },
+  timestampValueExpression: '',
+  select: '',
+  where: '',
+  whereLanguage: 'sql',
+  dateRange: [new Date(0), new Date(0)],
+};
+
+type FacetSlotState = {
+  facets: { key: string; value: string[] }[] | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+};
+
+/** Slot hook: the full single-source facet pipeline for one selected source. */
+function useSourceFacetsSlot(
+  spec: MultiSourceFilterSpec | undefined,
+  {
+    dateRange,
+    filterState,
+  }: {
+    dateRange: [Date, Date];
+    filterState: FilterStateHook['filters'];
+  },
+): FacetSlotState {
+  const { data, isLoading, isFetching } = useFetchFacets({
+    chartConfig: spec?.config ?? STUB_CONFIG,
+    sourceId: spec?.source.id ?? null,
+    dateRange,
+    // Value lists show everything in range (not narrowed by the current
+    // query), matching the sidebar's default "show all values" behavior.
+    mode: 'all',
+    filterState,
+    enabled: spec != null,
+  });
+
+  return useMemo(
+    () => ({ facets: data.keyValues, isLoading, isFetching }),
+    [data.keyValues, isLoading, isFetching],
+  );
+}
+
+const NOOP = () => {
+  /* pins and load-more are single-source affordances; no-op in multi mode */
+};
+const VALUE_PINS = { onPinClick: NOOP, isPinned: () => false };
+
+/**
+ * Multi-source variant of the search filters sidebar: one facet pipeline per
+ * selected source, merged by field path with values unioned. Filters apply
+ * per source; a source that lacks a filtered column is excluded from the
+ * search (surfaced as a chip on the results table).
+ *
+ * Single-source-only affordances (pins, shared filters, value counts,
+ * load-more, analysis-mode tabs, denoising) are intentionally absent.
+ */
+export default function MultiSourceSearchFilters({
+  specs,
+  dateRange,
+  isLive,
+  knownColumns,
+  searchFilters,
+  onCollapse,
+}: {
+  specs: MultiSourceFilterSpec[];
+  dateRange: [Date, Date];
+  isLive: boolean;
+  /** Union of the selected sources' top-level column names (for escaping). */
+  knownColumns: Set<string>;
+  searchFilters: FilterStateHook;
+  onCollapse?: () => void;
+}) {
+  const { size, startResize } = useResizable(16, 'left');
+  const {
+    filters: filterState,
+    setFilterValue,
+    clearFilter,
+    clearAllFilters,
+    setFilterRange,
+  } = searchFilters;
+
+  const slots = useMultiSourceSlots(specs, useSourceFacetsSlot, {
+    dateRange,
+    filterState,
+  });
+
+  const isFetching = slots.some(s => s.isFetching);
+  const isLoading = slots.some(s => s.isLoading);
+
+  // Merge facets across sources: union values per field path, in first-seen
+  // order (the first selected source's ordering wins).
+  const mergedFacets = useMemo(() => {
+    const byKey = new Map<string, { values: string[]; seen: Set<string> }>();
+    for (const slot of slots) {
+      for (const facet of slot.facets ?? []) {
+        let entry = byKey.get(facet.key);
+        if (entry == null) {
+          entry = { values: [], seen: new Set() };
+          byKey.set(facet.key, entry);
+        }
+        for (const value of facet.value) {
+          if (!entry.seen.has(value)) {
+            entry.seen.add(value);
+            entry.values.push(value);
+          }
+        }
+      }
+    }
+    return [...byKey.entries()].map(([key, entry]) => ({
+      key,
+      value: entry.values,
+    }));
+  }, [slots]);
+
+  const hasSelections = Object.keys(filterState).length > 0;
+  const firstConfig = specs[0]?.config ?? STUB_CONFIG;
+  const { grouped, nonGrouped } = useMemo(
+    () => groupFacetsByBaseName(mergedFacets),
+    [mergedFacets],
+  );
+
+  return (
+    <Box className={classes.filtersPanel} style={{ width: `${size}%` }}>
+      <div className={resizeStyles.resizeHandle} onMouseDown={startResize} />
+      <ScrollArea
+        h="100%"
+        scrollbarSize={4}
+        scrollbars="y"
+        style={{ display: 'block', width: '100%', overflow: 'hidden' }}
+      >
+        <Stack gap="sm" p="xs">
+          <Flex align="center" justify="space-between">
+            <Text
+              size="xxs"
+              c="dimmed"
+              fw="bold"
+              className={isFetching ? 'effect-pulse' : ''}
+            >
+              Filters {isFetching && '···'}
+            </Text>
+            <Group gap={0} wrap="nowrap">
+              {hasSelections && (
+                <Tooltip label="Clear filters" position="bottom">
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="xs"
+                    onClick={clearAllFilters}
+                    aria-label="Clear filters"
+                  >
+                    <IconFilterOff size={14} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+              {onCollapse && (
+                <Tooltip label="Hide filters" position="bottom">
+                  <ActionIcon
+                    variant="subtle"
+                    size="xs"
+                    onClick={onCollapse}
+                    aria-label="Hide filters"
+                  >
+                    <IconArrowBarToLeft size={14} />
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </Group>
+          </Flex>
+          <Text size="xxs" c="dimmed">
+            Values across all selected sources. A filter on a field a source
+            doesn't have excludes that source from the results.
+          </Text>
+          {grouped.map(group => (
+            <NestedFilterGroup
+              key={group.key}
+              data-testid={`multi-nested-filter-group-${group.key}`}
+              name={group.key}
+              childFilters={group.children.map(child => ({
+                ...child,
+                sqlKey: toQuotedClickHouseKeyExpression(
+                  child.key,
+                  knownColumns,
+                ),
+              }))}
+              selectedValues={group.children.reduce((acc, child) => {
+                acc[child.key] = getFilterStateEntry(
+                  filterState,
+                  child.key,
+                ) ?? {
+                  included: new Set(),
+                  excluded: new Set(),
+                };
+                return acc;
+              }, {} as FilterState)}
+              onChange={(key, value) => setFilterValue(key, value)}
+              onClearClick={key => clearFilter(key)}
+              onOnlyClick={(key, value) => setFilterValue(key, value, 'only')}
+              onExcludeClick={(key, value) =>
+                setFilterValue(key, value, 'exclude')
+              }
+              onPinClick={NOOP}
+              isPinned={() => false}
+              showFilterCounts={false}
+              onLoadMore={NOOP}
+              loadMoreLoading={{}}
+              hasLoadedMore={{}}
+              isDefaultExpanded={group.children.some(child => {
+                const entry = getFilterStateEntry(filterState, child.key);
+                return (
+                  entry != null &&
+                  (entry.included.size > 0 || entry.excluded.size > 0)
+                );
+              })}
+              chartConfig={firstConfig}
+              isLive={isLive}
+            />
+          ))}
+          {nonGrouped.map(facet => {
+            const facetSqlKey = toQuotedClickHouseKeyExpression(
+              facet.key,
+              knownColumns,
+            );
+            const entry = getFilterStateEntry(filterState, facet.key);
+            return (
+              <FilterGroup
+                key={facet.key}
+                data-testid={`multi-filter-group-${facet.key}`}
+                name={cleanedFacetName(facet.key)}
+                distributionKey={facetSqlKey}
+                showFilterCounts={false}
+                options={facet.value.map(value => ({
+                  value,
+                  label: value.toString(),
+                }))}
+                optionsLoading={isLoading}
+                selectedValues={
+                  entry ?? { included: new Set(), excluded: new Set() }
+                }
+                onChange={value => setFilterValue(facet.key, value)}
+                onClearClick={() => clearFilter(facet.key)}
+                onOnlyClick={value => setFilterValue(facet.key, value, 'only')}
+                onExcludeClick={value =>
+                  setFilterValue(facet.key, value, 'exclude')
+                }
+                valuePins={VALUE_PINS}
+                onLoadMore={NOOP}
+                loadMoreLoading={false}
+                hasLoadedMore={false}
+                isDefaultExpanded={
+                  entry != null &&
+                  (entry.included.size > 0 ||
+                    entry.excluded.size > 0 ||
+                    entry.range != null)
+                }
+                chartConfig={firstConfig}
+                isLive={isLive}
+                onRangeChange={range => setFilterRange(facet.key, range)}
+              />
+            );
+          })}
+          {!isLoading && mergedFacets.length === 0 && (
+            <Text size="xxs" c="dimmed">
+              No filterable fields found.
+            </Text>
+          )}
+        </Stack>
+      </ScrollArea>
+    </Box>
+  );
+}

--- a/packages/app/src/components/MultiSourceTimeChart.tsx
+++ b/packages/app/src/components/MultiSourceTimeChart.tsx
@@ -35,6 +35,8 @@ export type MultiSourceChartSpec = {
   source: TSource;
   /** Per-source count() histogram config (canonical WHERE, no groupBy). */
   config: BuilderChartConfigWithDateRange;
+  /** When set, the source doesn't run (mirrors MultiSourceStreamSpec). */
+  disabledReason?: string;
 };
 
 // Placeholder for unused hook slots; never queried (enabled: false).
@@ -92,7 +94,7 @@ function useHistogramSlot(
       placeholderData: keepPreviousData,
       enableQueryChunking: true,
       enableParallelQueries: enableParallelQueries && parallelizeWhenPossible,
-      enabled: enabled && spec != null,
+      enabled: enabled && spec != null && spec.disabledReason == null,
     },
   );
 

--- a/packages/app/src/hooks/__tests__/useMultiSourceSearch.test.ts
+++ b/packages/app/src/hooks/__tests__/useMultiSourceSearch.test.ts
@@ -1,0 +1,87 @@
+import { Filter } from '@hyperdx/common-utils/dist/types';
+
+import {
+  filterRootColumn,
+  resolveExtraColumnsForSource,
+  unresolvedFilterColumns,
+} from '@/hooks/useMultiSourceSearch';
+
+describe('filterRootColumn', () => {
+  it('extracts a plain column reference', () => {
+    const filter: Filter = {
+      type: 'sql_ast',
+      operator: '=',
+      left: 'ServiceName',
+      right: "'cart'",
+    };
+    expect(filterRootColumn(filter)).toBe('ServiceName');
+  });
+
+  it('extracts the root of a map subscript', () => {
+    const filter: Filter = {
+      type: 'sql_ast',
+      operator: '=',
+      left: "LogAttributes['level']",
+      right: "'error'",
+    };
+    expect(filterRootColumn(filter)).toBe('LogAttributes');
+  });
+
+  it('extracts a backticked identifier', () => {
+    const filter: Filter = {
+      type: 'sql_ast',
+      operator: '=',
+      left: '`weird-col`',
+      right: "'x'",
+    };
+    expect(filterRootColumn(filter)).toBe('weird-col');
+  });
+
+  it('returns null for raw sql and lucene filters', () => {
+    expect(
+      filterRootColumn({ type: 'sql', condition: "Foo = 'bar'" }),
+    ).toBeNull();
+    expect(
+      filterRootColumn({ type: 'lucene', condition: 'foo:bar' }),
+    ).toBeNull();
+  });
+});
+
+describe('unresolvedFilterColumns', () => {
+  const filters: Filter[] = [
+    { type: 'sql_ast', operator: '=', left: 'ServiceName', right: "'cart'" },
+    { type: 'sql_ast', operator: '=', left: 'StatusCode', right: "'Unset'" },
+    { type: 'sql', condition: 'anything' },
+  ];
+
+  it('reports columns the source lacks', () => {
+    expect(
+      unresolvedFilterColumns(filters, new Set(['ServiceName', 'Body'])),
+    ).toEqual(['StatusCode']);
+  });
+
+  it('is empty when every attributable column resolves', () => {
+    expect(
+      unresolvedFilterColumns(filters, new Set(['ServiceName', 'StatusCode'])),
+    ).toEqual([]);
+  });
+
+  it('is empty (not excluding) while columns are still unknown', () => {
+    expect(unresolvedFilterColumns(filters, undefined)).toEqual([]);
+  });
+});
+
+describe('resolveExtraColumnsForSource', () => {
+  it('projects the column where present and NULL where missing', () => {
+    expect(
+      resolveExtraColumnsForSource(
+        ['ServiceName', 'StatusCode', 'weird col'],
+        new Set(['ServiceName', 'weird col']),
+      ),
+    ).toEqual([
+      { name: 'ServiceName', expression: 'ServiceName' },
+      { name: 'StatusCode', expression: null },
+      { name: 'weird col', expression: '`weird col`' },
+    ]);
+  });
+});

--- a/packages/app/src/hooks/useMultiSourceSearch.ts
+++ b/packages/app/src/hooks/useMultiSourceSearch.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
-import { ColumnMeta } from '@hyperdx/common-utils/dist/clickhouse';
+import {
+  ColumnMeta,
+  filterColumnMetaByType,
+  JSDataType,
+} from '@hyperdx/common-utils/dist/clickhouse';
 import { MultiSourceExtraColumn } from '@hyperdx/common-utils/dist/core/searchChartConfig';
-import { TSource } from '@hyperdx/common-utils/dist/types';
+import { Filter, TSource } from '@hyperdx/common-utils/dist/types';
 
 import { MAX_SEARCH_SOURCES } from '@/defaults';
 import { useColumns } from '@/hooks/useMetadata';
@@ -69,6 +73,8 @@ function useSourceColumnsSlot(
 export function useMultiSourceColumns(sources: TSource[]): {
   columnsBySourceId: Map<string, Set<string>>;
   unionColumns: MultiSourceColumnOption[];
+  /** Union of Date/DateTime column name → ClickHouse type across sources. */
+  dateTimeColumns: Map<string, string>;
 } {
   const slotData = useMultiSourceSlots(
     sources,
@@ -79,6 +85,7 @@ export function useMultiSourceColumns(sources: TSource[]): {
   return useMemo(() => {
     const columnsBySourceId = new Map<string, Set<string>>();
     const availability = new Map<string, number>();
+    const dateTimeColumns = new Map<string, string>();
 
     for (let i = 0; i < sources.length; i++) {
       const source = sources[i];
@@ -89,6 +96,12 @@ export function useMultiSourceColumns(sources: TSource[]): {
       for (const name of names) {
         availability.set(name, (availability.get(name) ?? 0) + 1);
       }
+      for (const col of filterColumnMetaByType(columns, [JSDataType.Date]) ??
+        []) {
+        if (!dateTimeColumns.has(col.name)) {
+          dateTimeColumns.set(col.name, col.type);
+        }
+      }
     }
 
     const unionColumns = [...availability.entries()]
@@ -98,8 +111,45 @@ export function useMultiSourceColumns(sources: TSource[]): {
           b.availableCount - a.availableCount || a.name.localeCompare(b.name),
       );
 
-    return { columnsBySourceId, unionColumns };
+    return { columnsBySourceId, unionColumns, dateTimeColumns };
   }, [slotData, sources]);
+}
+
+/**
+ * Root column a filter references, for per-source resolvability checks.
+ * sql_ast filters carry the escaped SQL key in `left` (e.g. `ServiceName`,
+ * a backticked identifier, or `LogAttributes['level']` whose root is
+ * `LogAttributes`). Other filter types (raw sql/lucene conditions) can't be
+ * attributed to a single column and return null — callers should apply them
+ * to every source and rely on per-source error isolation.
+ */
+export function filterRootColumn(filter: Filter): string | null {
+  if (filter.type !== 'sql_ast') return null;
+  const left = filter.left.trim();
+  const backticked = left.match(/^`([^`]+)`/);
+  if (backticked) return backticked[1];
+  const plain = left.match(/^[A-Za-z_][A-Za-z0-9_]*/);
+  return plain ? plain[0] : null;
+}
+
+/**
+ * For one source: which of the active filters reference a column its table
+ * doesn't have. A non-empty result means the source can't answer the
+ * filtered search and should be excluded (with a visible reason).
+ */
+export function unresolvedFilterColumns(
+  filters: Filter[],
+  sourceColumns: Set<string> | undefined,
+): string[] {
+  if (sourceColumns == null) return [];
+  const missing = new Set<string>();
+  for (const filter of filters) {
+    const root = filterRootColumn(filter);
+    if (root != null && !sourceColumns.has(root)) {
+      missing.add(root);
+    }
+  }
+  return [...missing];
 }
 
 /** Quote a column name as a ClickHouse identifier when it needs it. */


### PR DESCRIPTION
## Summary

**Stacked on hyperdxio/hyperdx#2862** — review that first; this PR's diff is relative to `tom/multi-source-search`.

Multi-source search shipped without the filters sidebar, because everything about it was single-source: facets come from one table's field list and value queries, and applied filters are SQL predicates naming one table's columns. This PR brings the sidebar back for multi-source searches with cross-source semantics.

Each selected source runs its own facet pipeline (the existing `useFetchFacets`, one hook slot per source), and a new lean `MultiSourceSearchFilters` sidebar merges the results by field path with values unioned, reusing the single-source `FilterGroup`/`NestedFilterGroup` rendering. Checking a value applies the filter to every source that has the field. The key semantic decision: a source whose table lacks a filtered column is **excluded from the search with a visible reason on its status chip** (a quiet filter-off icon plus tooltip), rather than silently returning rows that ignore the filter or erroring the whole search. Filter pills and add-to-filter from the row side panel are re-enabled in multi mode; filter-key escaping and date-column detection now run against the union of the selected sources' schemas.

Single-source-only affordances (pins, shared filters, value counts, load-more, analysis-mode tabs, denoising) are intentionally absent from the multi sidebar for now. Single-source behavior is unchanged.

### Screenshots or video

Verified live against the demo stack: a two-source (logs + traces) search shows merged facet groups (`LogAttributes`, `SpanAttributes`, `SeverityText`, `StatusCode`, ...); filtering `ServiceName = cart` narrows both sources; filtering trace-only `StatusCode = Unset` excludes the log source with the chip reason. Screenshots can be dragged in from the local capture set.

### How to test on Vercel preview

**Preview routes:** /search

**Steps:**

1. Open /search and wait for search result rows to appear.
2. Click the "+" button next to the source selector (data-testid "add-search-source").
3. Click the sources multi-select (data-testid "source-multi-selector") and select "Demo Traces" in the dropdown, then press Escape to close the dropdown.
4. Wait for the Filters panel on the left to list field groups from both sources (for example "LogAttributes", "SpanAttributes", "ServiceName", "StatusCode") — this can take up to 30 seconds.
5. Click the "StatusCode" filter group to expand it, then click its first value checkbox and wait a few seconds for the search to re-run.
6. Verify the results table now shows only "Demo Traces" rows, and the "Demo Logs" status chip above the table is dimmed with a filter icon explaining it is excluded because it doesn't have StatusCode.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
