### PR TITLE
docs(cli): document all CLI features in the README for launch

### DIFF
--- a/.changeset/cli-readme-launch-docs.md
+++ b/.changeset/cli-readme-launch-docs.md
@@ -1,0 +1,8 @@
+---
+'@hyperdx/cli': patch
+---
+
+Rewrite the README with the full feature set and command reference (TUI, chart,
+query, sources/connections/dashboards, auth, team, upload-sourcemaps) ahead of
+launch, so npm and GitHub show everything the CLI can do. Also remove a stale
+reference to the removed `hdx stream` command from `hdx chart --help`.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ include:
 Once HyperDX is running, you can point your OpenTelemetry SDK to the
 OpenTelemetry collector spun up at `http://localhost:4318`.
 
+## HyperDX CLI
+
+Prefer the terminal? [`@hyperdx/cli`](./packages/cli) provides an interactive
+TUI and CLI (`hdx`) for working with your HyperDX data without leaving the
+shell:
+
+```bash
+npm install -g @hyperdx/cli
+hdx auth login
+hdx tui
+```
+
+- 🖥️ Interactive TUI — search, live tail, and trace waterfalls with vim-style
+  keybindings
+- 📊 Render dashboard tiles and ad-hoc charts as ANSI output in the terminal
+- 🤖 Agent-friendly: raw SQL queries, NDJSON output, and Drain log pattern
+  mining for scripts and AI agents
+
+See the [CLI README](./packages/cli#readme) for the full command reference.
+
 ## Contributing
 
 We welcome all contributions! There's many ways to contribute to the project,

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -4,7 +4,8 @@
 
 A terminal CLI for searching, tailing, and inspecting logs and traces from
 HyperDX. It provides both an interactive TUI (built with Ink — React for
-terminals) and a non-interactive streaming mode for piping.
+terminals) and non-interactive commands (`query`, `chart`, `sources`, …) for
+scripting and piping.
 
 The CLI connects to the HyperDX API server and queries ClickHouse directly
 through the API's `/clickhouse-proxy` endpoint, using the same query generation
@@ -13,32 +14,36 @@ logic (`@hyperdx/common-utils`) as the web frontend.
 ## CLI Commands
 
 ```
-hdx tui -s <url>                    # Interactive TUI (main command)
-hdx stream -s <url> --source "Logs" # Non-interactive streaming to stdout
-hdx sources -s <url>                # List available sources
+hdx tui -a <url>                    # Interactive TUI (main command)
+hdx sources -a <url>                # List available sources (with schemas)
 hdx connections                     # List ClickHouse connections (id, name, host)
 hdx dashboards                      # List dashboards with tile summaries
 hdx chart -d <dashboard> [-t tile]  # Render dashboard tiles as ANSI charts
 hdx chart -s <source> [--agg ...]   # Ad-hoc chart over a source (builder mode)
 hdx chart --sql <query> -s <source> # Ad-hoc chart from raw SQL
-hdx auth login -s <url>             # Sign in (interactive or -e/-p flags)
+hdx query --connection-id <id> --sql <query>  # Raw SQL to stdout (NDJSON default)
+hdx query --patterns ...            # Drain log-pattern mining over a query result
+hdx auth login -a <url>             # Sign in (interactive or -e/-p flags)
 hdx auth status                     # Show auth status (reads saved session)
 hdx auth logout                     # Clear saved session
 hdx team list                       # List teams the user belongs to (multi-team)
 hdx team current                    # Show the active team
 hdx team use <name|id>              # Switch the active team (kubectx-style)
+hdx upload-sourcemaps               # Upload JS source maps
 ```
 
-The `-s, --server <url>` flag is required for commands that talk to the API. If
-omitted, the CLI falls back to the server URL saved in the session file from a
-previous `hdx auth login`.
+The `-a, --app-url <url>` flag points commands at a HyperDX app URL. If omitted,
+the CLI falls back to the app URL saved in the session file from a previous
+`hdx auth login`. (Note: `hdx chart` uses `-s` for `--source`.)
 
 ## Architecture
 
 ```
 src/
 ├── cli.tsx              # Entry point — Commander CLI with commands:
-│                        #   tui, stream, sources, auth (login/logout/status)
+│                        #   tui, sources, connections, dashboards, chart,
+│                        #   query, auth (login/logout/status), team,
+│                        #   upload-sourcemaps
 │                        #   Also contains the standalone LoginPrompt component
 ├── App.tsx              # App shell — state machine:
 │                        #   loading → login → pick-source → EventViewer
@@ -133,53 +138,51 @@ Port of the web frontend's `DBRowOverviewPanel`. Three sections:
 
 ### DashboardPage + Tile charting (`components/DashboardPage.tsx`, `components/Tile/`)
 
-Dashboard tiles are queried and rendered with the **same SQL pipeline as the
-web dashboard**:
+Dashboard tiles are queried and rendered with the **same SQL pipeline as the web
+dashboard**:
 
 1. `shared/tileConfig.ts` resolves a tile's `SavedChartConfig` against its
    source (port of the web Tile's `queriedConfig` effect in
    `DBDashboardPage.tsx`) and applies the per-displayType config transform
    (`convertToTimeChartConfig` / `convertToNumberChartConfig` /
    `convertToTableChartConfig` / `convertToCategoricalChartConfig`).
-2. `shared/tileQuery.ts` executes it via
-   `clickhouseClient.queryChartConfig()` from common-utils — internally
-   `setChartSelectsAlias → splitChartConfigs → renderChartConfig`, identical
-   to the web's `useQueriedChartConfig` core (minus chunking / MV
-   optimization / PromQL).
+2. `shared/tileQuery.ts` executes it via `clickhouseClient.queryChartConfig()`
+   from common-utils — internally
+   `setChartSelectsAlias → splitChartConfigs → renderChartConfig`, identical to
+   the web's `useQueriedChartConfig` core (minus chunking / MV optimization /
+   PromQL).
 3. `shared/chartData.ts` shapes the response (ports of
    `formatResponseForTimeChart`, `formatResponseForCategoricalChart`, etc.).
-4. `termchart/` renders pure ANSI strings, consumed by both the Ink
-   `TileChart` component and the non-interactive `hdx chart` command. It is
-   a self-contained module (only dependency: chalk) — number formatting is
-   injected via callbacks, and it must never import from the rest of the
-   CLI.
+4. `termchart/` renders pure ANSI strings, consumed by both the Ink `TileChart`
+   component and the non-interactive `hdx chart` command. It is a self-contained
+   module (only dependency: chalk) — number formatting is injected via
+   callbacks, and it must never import from the rest of the CLI.
 
-Supported display types: line, stacked_bar, number, table, bar, pie,
-markdown. Heatmap / search / event patterns / PromQL show a placeholder.
-The web's previous-period comparison overlay is not rendered; tiles with
-`compareToPreviousPeriod` set show a dim callout instead.
-Time-series charts stretch to the full terminal width via peak-preserving
-resampling (`resampleSeries`): bucket values are placed exactly at their
-nearest column (upscale) or each column keeps its bucket range's
-max-magnitude value (downscale) — plain linear interpolation would sample
-*between* buckets and attenuate narrow spikes. Stacked bars map columns to
-buckets nearest-neighbor (upscale) or by max-total bucket (downscale).
-Auto granularity is capped at 80 buckets like the web (`maxTimeBuckets`).
-Y-axes use "nice" tick domains (`niceTicks`, steps of 1/2/2.5/5×10ⁿ,
-zero-pinned, max rounded up) with sparse tick-row labels — mirroring the
-web's recharts `domain={[0, 'auto']}` axis rather than labeling every row
-with raw range fractions.
+Supported display types: line, stacked*bar, number, table, bar, pie, markdown.
+Heatmap / search / event patterns / PromQL show a placeholder. The web's
+previous-period comparison overlay is not rendered; tiles with
+`compareToPreviousPeriod` set show a dim callout instead. Time-series charts
+stretch to the full terminal width via peak-preserving resampling
+(`resampleSeries`): bucket values are placed exactly at their nearest column
+(upscale) or each column keeps its bucket range's max-magnitude value
+(downscale) — plain linear interpolation would sample \_between* buckets and
+attenuate narrow spikes. Stacked bars map columns to buckets nearest-neighbor
+(upscale) or by max-total bucket (downscale). Auto granularity is capped at 80
+buckets like the web (`maxTimeBuckets`). Y-axes use "nice" tick domains
+(`niceTicks`, steps of 1/2/2.5/5×10ⁿ, zero-pinned, max rounded up) with sparse
+tick-row labels — mirroring the web's recharts `domain={[0, 'auto']}` axis
+rather than labeling every row with raw range fractions.
 
-The `hdx chart` command (designed for agent-driven troubleshooting) reuses
-this same pipeline in three modes: dashboard tiles (`-d`), ad-hoc builder
-charts (`-s <source>` + `--agg/--value/--where/--group-by/--series`, built
-by `shared/adhocChart.ts`), and ad-hoc raw SQL (`--sql` with
-`$__timeFilter` / `$__timeInterval` macros). ANSI colors are stripped
-automatically when stdout is not a TTY (`--color auto|always|never`), and
-`--json` emits raw rows + column metadata.
+The `hdx chart` command (designed for agent-driven troubleshooting) reuses this
+same pipeline in three modes: dashboard tiles (`-d`), ad-hoc builder charts
+(`-s <source>` + `--agg/--value/--where/--group-by/--series`, built by
+`shared/adhocChart.ts`), and ad-hoc raw SQL (`--sql` with `$__timeFilter` /
+`$__timeInterval` macros). ANSI colors are stripped automatically when stdout is
+not a TTY (`--color auto|always|never`), and `--json` emits raw rows + column
+metadata.
 
-Do NOT change resolution/shaping rules without checking the web components
-first (see the alignment table below).
+Do NOT change resolution/shaping rules without checking the web components first
+(see the alignment table below).
 
 ### ColumnValues (`components/ColumnValues.tsx`)
 
@@ -196,17 +199,17 @@ This package mirrors several web frontend components. **Always check the
 corresponding web component before making changes** to ensure behavior stays
 consistent:
 
-| CLI Component          | Web Component                     | Notes                              |
-| ---------------------- | --------------------------------- | ---------------------------------- |
-| `TraceWaterfall`       | `DBTraceWaterfallChart`           | Tree builder is a direct port      |
-| `RowOverview`          | `DBRowOverviewPanel`              | Same sections and field list       |
-| Trace tab logic        | `DBTracePanel`                    | Source resolution (trace/log)      |
-| Detail panel           | `DBRowSidePanel`                  | Tab structure, highlight hint      |
-| Event query            | `DBTraceWaterfallChart`           | `getConfig()` → `buildTrace*Sql`   |
-| `shared/tileConfig`    | `DBDashboardPage` + `ChartUtils`  | Tile config resolution/transforms  |
-| `shared/tileRender`    | `DBDashboardPage`                 | `renderChartContent` dispatch      |
-| `shared/chartData`     | `ChartUtils`                      | Response shaping ports             |
-| `shared/formatNumber`  | `utils.ts` + `source.ts`          | formatNumber + format resolution   |
+| CLI Component         | Web Component                    | Notes                             |
+| --------------------- | -------------------------------- | --------------------------------- |
+| `TraceWaterfall`      | `DBTraceWaterfallChart`          | Tree builder is a direct port     |
+| `RowOverview`         | `DBRowOverviewPanel`             | Same sections and field list      |
+| Trace tab logic       | `DBTracePanel`                   | Source resolution (trace/log)     |
+| Detail panel          | `DBRowSidePanel`                 | Tab structure, highlight hint     |
+| Event query           | `DBTraceWaterfallChart`          | `getConfig()` → `buildTrace*Sql`  |
+| `shared/tileConfig`   | `DBDashboardPage` + `ChartUtils` | Tile config resolution/transforms |
+| `shared/tileRender`   | `DBDashboardPage`                | `renderChartContent` dispatch     |
+| `shared/chartData`    | `ChartUtils`                     | Response shaping ports            |
+| `shared/formatNumber` | `utils.ts` + `source.ts`         | formatNumber + format resolution  |
 
 Key expression mappings from the web frontend's `getConfig()`:
 
@@ -253,7 +256,7 @@ screen).
 ```bash
 # Run in dev mode (tsx, no compile step)
 cd packages/cli
-yarn dev tui -s http://localhost:8000
+yarn dev tui -a http://localhost:8080
 
 # Type check
 npx tsc --noEmit

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Before using the TUI, authenticate with your HyperDX instance:
 
 ```bash
 # Interactive login (opens email/password prompts)
-yarn dev auth login -s http://localhost:8000
+yarn dev auth login -a http://localhost:8080
 
 # Non-interactive login (for scripting/CI)
-yarn dev auth login -s http://localhost:8000 -e user@example.com -p password
+yarn dev auth login -a http://localhost:8080 -e user@example.com -p password
 
 # Verify auth status
 yarn dev auth status
@@ -34,8 +34,8 @@ yarn dev auth status
 # Session is saved to ~/.config/hyperdx/cli/session.json
 ```
 
-Once authenticated, the `-s` flag is optional — the CLI reads the server URL
-from the saved session.
+Once authenticated, the `-a` flag is optional — the CLI reads the app URL from
+the saved session.
 
 ### Running in Dev Mode
 
@@ -45,8 +45,8 @@ from the saved session.
 # Interactive TUI
 yarn dev tui
 
-# With explicit server URL
-yarn dev tui -s http://localhost:8000
+# With explicit app URL
+yarn dev tui -a http://localhost:8080
 
 # Skip source picker
 yarn dev tui --source "Logs"
@@ -54,12 +54,11 @@ yarn dev tui --source "Logs"
 # Start with a search query + follow mode
 yarn dev tui -q "level:error" -f
 
-# Non-interactive streaming
-yarn dev stream --source "Logs"
+# Raw SQL query (NDJSON to stdout)
+yarn dev query --connection-id <id> --sql "SELECT 1"
 
 # List available sources
 yarn dev sources
-
 ```
 
 ## Building & Compiling
@@ -87,7 +86,9 @@ The compiled binary is a single file at `dist/hdx` (or `dist/hdx-<platform>`).
 ```
 src/
 ├── cli.tsx                # Entry point — Commander CLI commands
-│                          # (tui, stream, sources, auth login/logout/status)
+│                          # (tui, sources, connections, dashboards, chart,
+│                          # query, auth login/logout/status, team,
+│                          # upload-sourcemaps)
 │                          # Also contains LoginPrompt component
 ├── App.tsx                # Ink app shell — state machine:
 │                          # loading → login → pick-source → EventViewer
@@ -164,13 +165,13 @@ User switches to Trace tab
 - Injects session cookies + `x-hyperdx-connection-id` header
 - Forces `content-type: text/plain` to prevent Express body parser issues
 
-### Server URL Resolution
+### App URL Resolution
 
-The `-s` flag is optional on most commands. Resolution order:
+The `-a, --app-url` flag is optional on most commands. Resolution order:
 
-1. Explicit `-s <url>` flag
-2. Saved session's `apiUrl` from `~/.config/hyperdx/cli/session.json`
-3. Error: "No server specified"
+1. Explicit `-a <url>` flag
+2. Saved session's `appUrl` from `~/.config/hyperdx/cli/session.json`
+3. Prompt for login (interactive) or error
 
 ## Key Patterns
 
@@ -263,7 +264,7 @@ When updating these files, check the original source in `packages/app` first.
 ### Adding a New CLI Command
 
 1. Add the command in `cli.tsx` using Commander
-2. Use `resolveServer(opts.server)` for server URL resolution
+2. Use `resolveServer(opts.appUrl)` (or `ensureSession`) for app URL resolution
 3. Use `withVerbose()` if the command needs `--verbose` support
 4. Update `README.md` and `AGENTS.md` with the new command
 
@@ -279,7 +280,7 @@ When updating these files, check the original source in `packages/app` first.
 
 ### "Not logged in" error
 
-Run `yarn dev auth login -s <url>` to authenticate. The session may have expired
+Run `yarn dev auth login -a <url>` to authenticate. The session may have expired
 or the server URL may have changed.
 
 ### HTML response instead of JSON

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,12 +1,223 @@
 # @hyperdx/cli
 
-Command line interface for HyperDX.
+[![npm version](https://img.shields.io/npm/v/@hyperdx/cli.svg)](https://www.npmjs.com/package/@hyperdx/cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-## Uploading Source Maps
+Terminal UI and CLI for [HyperDX](https://github.com/hyperdxio/hyperdx) —
+search, tail, chart, and query your logs, traces, and metrics without leaving
+the terminal.
 
-Upload JavaScript source maps to HyperDX for stack trace de-obfuscation.
+The CLI talks to your HyperDX instance (Cloud or self-hosted) and runs the exact
+same query pipeline as the web app, so results always match what you see in the
+browser.
 
-In your build pipeline, run the CLI tool:
+## Install
+
+```bash
+npm install -g @hyperdx/cli    # installs the `hdx` binary
+# or run without installing:
+npx @hyperdx/cli --help
+```
+
+Requires Node.js >= 22.16.
+
+## Quickstart
+
+```bash
+# Sign in (interactive — prompts for app URL and credentials)
+hdx auth login
+
+# Launch the interactive TUI
+hdx tui
+
+# Chart error volume by service for the past 3 hours
+hdx chart -s Logs --where 'SeverityText:error' --group-by ServiceName --since 3h
+
+# Run raw SQL against ClickHouse
+hdx query --connection-id "$CONN" --sql "SELECT count() FROM default.otel_logs"
+```
+
+## Features
+
+- **Interactive TUI** — search and live-tail events, inspect rows, and walk
+  trace waterfalls with vim-style keybindings
+- **Trace waterfall** — full span tree with correlated logs, span-level detail,
+  and open-in-browser deep links
+- **Terminal charts** — render saved dashboard tiles or ad-hoc charts (line,
+  stacked bar, number, table, bar, pie) as ANSI output
+- **Raw SQL** — query ClickHouse directly through the HyperDX proxy, in any
+  ClickHouse output format
+- **Log pattern mining** — cluster query results into Drain log patterns to
+  summarize large result sets
+- **Alerts & dashboards** — browse alerts (with trigger history) and dashboards
+  from the TUI
+- **Multi-team support** — kubectx-style team switching for users in multiple
+  teams
+- **Agent-friendly** — `--json` output on discovery commands, NDJSON streaming,
+  documented exit codes, and colors stripped automatically when piping
+
+## Commands
+
+```
+hdx tui                             # Interactive TUI (search + live tail)
+hdx chart -d <dashboard> [-t tile]  # Render dashboard tiles as ANSI charts
+hdx chart -s <source> [--agg ...]   # Ad-hoc chart over a source
+hdx chart --sql <query> -s <source> # Ad-hoc chart from raw SQL
+hdx query --connection-id <id> --sql <query>  # Raw SQL to stdout
+hdx sources                         # List data sources with table schemas
+hdx connections                     # List ClickHouse connections
+hdx dashboards                      # List dashboards with tile summaries
+hdx auth login|status|logout        # Manage authentication
+hdx team list|current|use <team>    # Switch between teams
+hdx upload-sourcemaps               # Upload JS source maps
+```
+
+Every command accepts `-a, --app-url <url>` to point at a HyperDX instance.
+After `hdx auth login`, the URL is saved and the flag becomes optional. Run
+`hdx <command> --help` for full flag documentation.
+
+### `hdx tui` — Interactive TUI
+
+The main event viewer: a searchable, live-tailing table of logs or traces with a
+detail panel, trace waterfall, pattern mining, alerts, and dashboards.
+
+```bash
+hdx tui                          # Pick a source interactively
+hdx tui --source "Logs"          # Skip the source picker
+hdx tui -q "level:error" -f      # Start with a search query, in follow mode
+```
+
+| Key           | Action                                     |
+| ------------- | ------------------------------------------ |
+| `j` / `↓`     | Move selection down                        |
+| `k` / `↑`     | Move selection up                          |
+| `l` / `Enter` | Expand row detail                          |
+| `h` / `Esc`   | Close detail / blur search                 |
+| `G` / `g`     | Jump to newest / oldest                    |
+| `Ctrl+D/U`    | Page down / up                             |
+| `/`           | Search (global in table, filter in detail) |
+| `Tab`         | Cycle sources/searches or detail tabs      |
+| `Shift+Tab`   | Cycle backwards                            |
+| `t`           | Edit time range in `$EDITOR`               |
+| `s`           | Edit SELECT clause in `$EDITOR`            |
+| `Shift+P`     | Show event patterns                        |
+| `Shift+D`     | Show generated SQL                         |
+| `f`           | Toggle follow mode (live tail)             |
+| `o`           | Open trace in browser                      |
+| `w`           | Toggle line wrap                           |
+| `Shift+A`     | Open alerts page                           |
+| `d`           | Open dashboards page                       |
+| `?`           | Toggle help                                |
+| `q`           | Quit                                       |
+
+The row detail panel has three tabs — **Overview** (structured OTel attributes),
+**Column Values** (every column of the row), and **Trace** (span waterfall with
+correlated logs, navigable with `j`/`k`).
+
+### `hdx chart` — Terminal charts
+
+Render charts as terminal output. Designed for troubleshooting from the CLI
+(including by AI agents): visualize a metric, spot the spike, then narrow down
+with `--where` or `hdx query`. All modes run through the same
+`renderChartConfig` pipeline as the web dashboards.
+
+Three modes:
+
+```bash
+# 1. Dashboard tiles — render saved tiles from a dashboard
+hdx chart -d "Service Health"                       # All tiles, past 1h
+hdx chart -d "Service Health" -t "P95 Latency" --since 24h
+
+# 2. Ad-hoc builder — chart an aggregation over a source
+hdx chart -s Logs --where 'SeverityText:error' --group-by ServiceName --since 3h
+hdx chart -s Traces --agg quantile --level 0.95 --value Duration \
+    --where 'ServiceName:api' --since 6h
+hdx chart -s Logs --display bar --where 'SeverityText:error' --group-by ServiceName
+hdx chart -s Metrics --metric-type sum --metric-name otelcol_exporter_sent_spans
+
+# 3. Raw SQL — chart arbitrary queries with time macros
+hdx chart -s Logs --sql "SELECT \$__timeInterval(TimestampTime) AS ts, count()
+    FROM default.otel_logs WHERE \$__timeFilter(TimestampTime) GROUP BY ts ORDER BY ts"
+```
+
+- **Display types** (`--display`): `line` (default), `stacked_bar`, `number`,
+  `table`, `bar`, `pie`
+- **Time ranges**: `--since 15m|1h|7d`, or `--from`/`--to` with ISO 8601
+  (`2026-07-01T00:00:00Z`), dates (`2026-07-01`), or relative values (`now-24h`)
+- **SQL macros**: `$__timeFilter(col)` expands to the selected range,
+  `$__timeInterval(col)` buckets by the chart granularity
+- **Output**: ANSI colors are stripped automatically when piping (override with
+  `--color always|never`); `--json` emits raw rows + column metadata
+
+### `hdx query` — Raw SQL
+
+Execute raw ClickHouse SQL through the HyperDX proxy. Output defaults to
+`JSONEachRow` (NDJSON — one JSON object per line), so results pipe cleanly into
+`jq` and friends. Any ClickHouse output format is accepted via `--format`
+(`JSON`, `TabSeparated`, `CSV`, ...).
+
+```bash
+CONN=$(hdx connections --json | jq -r '.[0].id')
+hdx query --connection-id "$CONN" --sql "SELECT count() FROM default.otel_logs"
+hdx query --connection-id "$CONN" --sql "SELECT * FROM default.otel_traces LIMIT 5"
+```
+
+**Pattern mining** (`--patterns`): cluster the result into templated log
+patterns using the [Drain](https://github.com/logpai/Drain3) algorithm and emit
+one JSON object per pattern, sorted by count — useful for summarizing thousands
+of rows into a handful of templates:
+
+```bash
+hdx query --connection-id "$CONN" --patterns \
+    --sql "SELECT Body FROM default.otel_logs LIMIT 10000" --body-column Body
+# {"pattern":"connection <*> closed","count":4823,"sample":"connection 10.0.3.7 closed"}
+```
+
+Exit codes: `0` on success (empty stdout means zero rows), `1` on failure.
+
+### `hdx sources` / `hdx connections` / `hdx dashboards` — Discovery
+
+List the data sources, ClickHouse connections, and dashboards available to your
+team. All three support `--json` for structured output.
+
+```bash
+hdx sources               # Sources with ClickHouse CREATE TABLE schemas
+hdx sources --json        # Includes column expression mappings per source
+hdx connections --json    # Connection IDs for `hdx query` / `hdx chart --sql`
+hdx dashboards            # Dashboards + tile names for `hdx chart -d`
+```
+
+### `hdx auth` — Authentication
+
+```bash
+hdx auth login                                    # Interactive prompts
+hdx auth login -a https://your-hyperdx.example \
+    -e user@example.com -p "$PASSWORD"            # Non-interactive (CI)
+hdx auth status                                   # Who am I + active team
+hdx auth logout
+```
+
+The session is saved to `~/.config/hyperdx/cli/session.json` (mode `0600`) and
+reused by all commands until it expires.
+
+### `hdx team` — Team switching
+
+For users that belong to multiple teams (HyperDX Cloud / EE), switch the team
+that all commands are scoped to — kubectx-style:
+
+```bash
+hdx team list             # All teams, active one marked
+hdx team current          # Print the active team
+hdx team use "My Team"    # Switch by name or ID
+```
+
+The choice persists across CLI invocations. On single-team deployments these
+commands are effectively no-ops.
+
+### `hdx upload-sourcemaps` — Source maps
+
+Upload JavaScript source maps to HyperDX for stack trace de-obfuscation. Run it
+in your build pipeline:
 
 ```bash
 npx @hyperdx/cli upload-sourcemaps \
@@ -16,25 +227,41 @@ npx @hyperdx/cli upload-sourcemaps \
   --releaseId "$RELEASE_ID"
 ```
 
-You can also add this as an npm script:
-
-```json
-{
-  "scripts": {
-    "upload-sourcemaps": "npx @hyperdx/cli upload-sourcemaps --path=\".next\""
-  }
-}
-```
-
-### Options
-
-| Flag                      | Description                                            | Default |
-| ------------------------- | ------------------------------------------------------ | ------- |
-| `-k, --serviceKey <key>`  | HyperDX service account API key                        |         |
-| `-p, --path <dir>`        | Directory containing sourcemaps                        | `.`     |
-| `-u, --apiUrl <url>`      | HyperDX API URL (required for self-hosted deployments) |         |
-| `-rid, --releaseId <id>`  | Release ID to associate with the sourcemaps            |         |
-| `-bp, --basePath <path>`  | Base path for the uploaded sourcemaps                  |         |
+| Flag                     | Description                                            | Default |
+| ------------------------ | ------------------------------------------------------ | ------- |
+| `-k, --serviceKey <key>` | HyperDX service account API key                        |         |
+| `-p, --path <dir>`       | Directory containing sourcemaps                        | `.`     |
+| `-u, --apiUrl <url>`     | HyperDX API URL (required for self-hosted deployments) |         |
+| `-rid, --releaseId <id>` | Release ID to associate with the sourcemaps            |         |
+| `-bp, --basePath <path>` | Base path for the uploaded sourcemaps                  |         |
+| `--apiVersion <version>` | API version: `v1` (HyperDX V1 Cloud) or `v2` (latest)  | `v1`    |
 
 Optionally, set the `HYPERDX_SERVICE_KEY` environment variable to avoid passing
 the `--serviceKey` flag.
+
+## For AI agents & scripting
+
+The CLI is built to be driven by scripts and AI agents:
+
+- `hdx sources --json`, `hdx connections --json`, `hdx dashboards --json`, and
+  `hdx team list --json` emit structured output for discovery
+- `hdx query` streams NDJSON by default and documents its exit-code contract
+  (`0` success, `1` failure — with "unknown connection" distinguished from "bad
+  SQL" on stderr)
+- `hdx query --patterns` compresses large result sets into a few templated
+  patterns
+- `hdx chart --json` returns the queried rows + column metadata instead of a
+  rendered chart; ANSI colors are stripped automatically when stdout is not a
+  TTY
+- Non-interactive login: `hdx auth login -a <url> -e <email> -p <password>`
+
+## Links
+
+- [HyperDX repository](https://github.com/hyperdxio/hyperdx)
+- [ClickStack documentation](https://clickhouse.com/docs/use-cases/observability/clickstack/overview)
+- [Report an issue](https://github.com/hyperdxio/hyperdx/issues)
+- [Contributing](https://github.com/hyperdxio/hyperdx/tree/main/packages/cli/CONTRIBUTING.md)
+
+## License
+
+[MIT](https://github.com/hyperdxio/hyperdx/blob/main/LICENSE)

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -1161,7 +1161,7 @@ program
 About:
   Renders charts as terminal output. Designed for troubleshooting from
   the CLI (including by AI agents): visualize a metric, spot the spike,
-  then narrow down with --where, 'hdx query', or 'hdx stream'.
+  then narrow down with --where or 'hdx query'.
 
   All modes query through the exact same renderChartConfig pipeline the
   web dashboards use, so SQL and results match the web UI.


### PR DESCRIPTION
## Why

We're preparing to launch `@hyperdx/cli`. The package README — what people see on [npm](https://www.npmjs.com/package/@hyperdx/cli) and the GitHub package page — only documented `upload-sourcemaps`, badly underselling everything the CLI can do (interactive TUI, terminal charts, raw SQL, pattern mining, team switching, ...).

## What changed

### `packages/cli/README.md` (rewrite, 40 → ~280 lines)

- Header with badges, one-line pitch, install & quickstart
- Features-at-a-glance list
- Full command reference with real examples for every command:
  - `hdx tui` — incl. accurate keybindings table taken from the in-app HelpScreen (Ctrl+D/U, Shift+P patterns, Shift+D SQL view, etc.)
  - `hdx chart` — all three modes (dashboard tiles / ad-hoc builder / raw SQL with `$__timeFilter` / `$__timeInterval` macros), display types, time ranges
  - `hdx query` — NDJSON output, `--format`, `--patterns` Drain log-pattern mining, exit-code contract
  - `hdx sources` / `connections` / `dashboards`, `hdx auth`, `hdx team`, `hdx upload-sourcemaps` (kept existing content, added the missing `--apiVersion` flag)
- "For AI agents & scripting" section (`--json` everywhere, NDJSON piping, non-interactive login)

### Root `README.md`

- New "HyperDX CLI" section with install one-liner, highlights, and a link to `packages/cli`

### Doc-drift fixes found during research

- `src/cli.tsx` — `chart --help` referenced the removed `hdx stream` command; now points to `hdx query`
- `packages/cli/AGENTS.md` / `CONTRIBUTING.md` — dropped `hdx stream`, fixed the pre-0.3.0 `-s/--server` flag to `-a/--app-url`, added the missing `query` command, corrected session field name (`apiUrl` → `appUrl`)

Note: prettier reflowed a few untouched prose paragraphs in `AGENTS.md`, so that diff is slightly larger than the content change.

## Verification

- `yarn tsc --noEmit` in `packages/cli` passes
- `yarn lint` clean (7 pre-existing warnings, under the max-9 budget)
- Smoke-tested `hdx --help` and `hdx chart --help` — command list matches the README, stale `stream` mention gone
- Changeset included (patch — the README ships in the npm tarball)