### PR TITLE
feat: Substitute variables in Raw SQL charts

### DIFF
--- a/.changeset/dashboard-variable-substitution.md
+++ b/.changeset/dashboard-variable-substitution.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/common-utils': patch
+---
+
+feat: Substitute dashboard variables in raw SQL tiles

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -47,6 +47,7 @@ import {
   AlertState,
   BuilderChartConfigWithDateRange,
   ChartConfigWithDateRange,
+  ChartVariable,
   DashboardContainer as DashboardContainerSchema,
   DashboardFilter,
   DisplayType,
@@ -60,6 +61,7 @@ import {
   SQLInterval,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
+import { filterReferencedVariables } from '@hyperdx/common-utils/dist/variables';
 import {
   ActionIcon,
   Alert,
@@ -386,6 +388,7 @@ const Tile = forwardRef(
       granularity,
       onTimeRangeSelect,
       filters,
+      variables,
       showAlertAnnotations,
       isLive,
       readOnly,
@@ -414,6 +417,7 @@ const Tile = forwardRef(
       granularity: SQLInterval | undefined;
       onTimeRangeSelect: (start: Date, end: Date) => void;
       filters?: Filter[];
+      variables?: ChartVariable[];
       // When true, draw alert firing/recovery annotations on this tile's chart.
       showAlertAnnotations?: boolean;
       isLive?: boolean;
@@ -530,6 +534,25 @@ const Tile = forwardRef(
       displayTypeRequiresSource(chart.config.displayType) &&
       !chart.config.source;
 
+    // `variables` is a new reference every time the dashboard's filter change. To ensure
+    // `tileVariables` is stable unless the tile's *referenced variables* actually change,
+    // we serialize the referenced subset and use changes in the serialized value to drive
+    // changes to `tileVariables`.
+    const serializedTileVariables = useMemo(
+      () =>
+        !!variables && isRawSqlSavedChartConfig(chart.config)
+          ? JSON.stringify(filterReferencedVariables(chart.config, variables))
+          : undefined,
+      [chart.config, variables],
+    );
+    const tileVariables = useMemo<ChartVariable[] | undefined>(
+      () =>
+        serializedTileVariables
+          ? JSON.parse(serializedTileVariables)
+          : undefined,
+      [serializedTileVariables],
+    );
+
     useEffect(() => {
       if (isPromqlSavedChartConfig(chart.config)) {
         if (source != null) {
@@ -552,6 +575,7 @@ const Tile = forwardRef(
             dateRange,
             granularity,
             filters,
+            variables: tileVariables,
           });
         } else if (source != null) {
           setQueriedConfig({
@@ -570,6 +594,7 @@ const Tile = forwardRef(
             dateRange,
             granularity,
             filters,
+            variables: tileVariables,
           });
         }
 
@@ -614,7 +639,7 @@ const Tile = forwardRef(
           });
         }
       }
-    }, [source, chart, dateRange, granularity, filters]);
+    }, [source, chart, dateRange, granularity, filters, tileVariables]);
 
     const [hovered, setHovered] = useState(false);
 
@@ -1472,6 +1497,7 @@ const EditTileModal = ({
   onSave,
   isSaving,
   dateRange,
+  variables,
 }: {
   dashboardId?: string;
   chart: Tile | undefined;
@@ -1479,6 +1505,7 @@ const EditTileModal = ({
   dateRange: [Date, Date];
   isSaving?: boolean;
   onSave: (chart: Tile) => void;
+  variables?: ChartVariable[];
 }) => {
   const contextZIndex = useZIndex();
   const modalZIndex = contextZIndex + 10;
@@ -1533,6 +1560,7 @@ const EditTileModal = ({
             <EditTimeChartForm
               dashboardId={dashboardId}
               chartConfig={chart.config}
+              variables={variables}
               dateRange={dateRange}
               isSaving={isSaving}
               onSave={config => {
@@ -1783,6 +1811,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setFilterQueries,
     ignoredFilterExpressions,
     getFilterQueriesForSource,
+    variables,
   } = useDashboardFilters(filters);
 
   const { isLoading: isVariablesFlagLoading, isVariablesEnabled } =
@@ -2234,6 +2263,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             },
             ...getFilterQueriesForSource(tileSourceId),
           ]}
+          variables={showFilterVariableOptions ? variables : undefined}
           onTimeRangeSelect={onTimeRangeSelect}
           showAlertAnnotations={showAlertAnnotations}
           isHighlighted={highlightedTileId === chart.id}
@@ -2334,6 +2364,8 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       onTimeRangeSelect,
       showAlertAnnotations,
       getFilterQueriesForSource,
+      showFilterVariableOptions,
+      variables,
       moveTargetContainers,
       handleMoveTileToGroup,
       selectedTileIds,
@@ -3012,6 +3044,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             if (!isSaving) setEditedTile(undefined);
           }}
           dateRange={searchedTimeRange}
+          variables={showFilterVariableOptions ? variables : undefined}
           isSaving={isSaving}
           onSave={newChart => {
             if (dashboard == null) {

--- a/packages/app/src/components/ChartSQLPreview.tsx
+++ b/packages/app/src/components/ChartSQLPreview.tsx
@@ -112,6 +112,7 @@ export default function ChartSQLPreview({
       radius="sm"
       style={{ overflow: 'hidden' }}
       p="xs"
+      data-testid="chart-sql-preview"
     >
       {data ? (
         // Prefer showing the (possibly placeholder) SQL over the loading state

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -12,9 +12,13 @@ import {
   displayTypeSupportsBuilderAlerts,
   displayTypeSupportsRawSqlAlerts,
 } from '@hyperdx/common-utils/dist/core/utils';
-import { isRawSqlSavedChartConfig } from '@hyperdx/common-utils/dist/guards';
+import {
+  isRawSqlChartConfig,
+  isRawSqlSavedChartConfig,
+} from '@hyperdx/common-utils/dist/guards';
 import {
   ChartConfigWithDateRange,
+  ChartVariable,
   DisplayType,
   SavedChartConfig,
   SourceKind,
@@ -88,6 +92,7 @@ import {
   buildChartConfigForExplanations,
   computeDbTimeChartConfig,
   displayTypeToActiveTab,
+  resolvePreviewVariables,
   TABS_WITH_GENERATED_SQL,
   zSavedChartConfig,
 } from './utils';
@@ -95,6 +100,8 @@ import {
 type EditTimeChartFormProps = {
   dashboardId?: string;
   chartConfig: SavedChartConfig;
+  /** Variables and their selected values, from the parent dashboard (if one exists). */
+  variables?: ChartVariable[];
   displayedTimeInputValue?: string;
   dateRange: [Date, Date];
   isSaving?: boolean;
@@ -133,6 +140,7 @@ function applyHeatmapDefaults(
 export default function EditTimeChartForm({
   dashboardId,
   chartConfig,
+  variables,
   displayedTimeInputValue,
   dateRange,
   isSaving,
@@ -364,9 +372,24 @@ export default function EditTimeChartForm({
     [],
   );
 
+  // Attach variables so that variable references can be validated and expanded in the preview
+  const previewConfig = useMemo(() => {
+    if (queriedConfig == null || !isRawSqlChartConfig(queriedConfig)) {
+      return queriedConfig;
+    }
+    return {
+      ...queriedConfig,
+      variables: resolvePreviewVariables({
+        config: queriedConfig,
+        variables,
+        hasAlert: alert != null,
+      }),
+    };
+  }, [queriedConfig, variables, alert]);
+
   const dbTimeChartConfig = useMemo(
-    () => computeDbTimeChartConfig(queriedConfig, alert),
-    [queriedConfig, alert],
+    () => computeDbTimeChartConfig(previewConfig, alert),
+    [previewConfig, alert],
   );
 
   const [saveToDashboardModalOpen, setSaveToDashboardModalOpen] =
@@ -595,7 +618,7 @@ export default function EditTimeChartForm({
   const chartConfigForExplanations = useMemo(
     () =>
       buildChartConfigForExplanations({
-        queriedConfig,
+        queriedConfig: previewConfig,
         queriedSourceId: queriedSource?.id,
         tableSource,
         chartConfig,
@@ -604,7 +627,7 @@ export default function EditTimeChartForm({
         dbTimeChartConfig,
       }),
     [
-      queriedConfig,
+      previewConfig,
       queriedSource?.id,
       tableSource,
       chartConfig,
@@ -903,7 +926,7 @@ export default function EditTimeChartForm({
         />
       </ErrorBoundary>
       <ChartPreviewPanel
-        queriedConfig={queriedConfig}
+        queriedConfig={previewConfig}
         tableSource={tableSource}
         dateRange={dateRange}
         activeTab={activeTab}

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -14,6 +14,7 @@ import {
   ChartAlertBaseSchema,
   ChartConfigWithDateRange,
   ChartConfigWithOptTimestamp,
+  ChartVariable,
   DisplayType,
   Filter,
   SavedChartConfig,
@@ -22,6 +23,7 @@ import {
   TSource,
   validateAlertScheduleOffsetMinutes,
 } from '@hyperdx/common-utils/dist/types';
+import { filterReferencedVariables } from '@hyperdx/common-utils/dist/variables';
 
 import {
   convertToCategoricalChartConfig,
@@ -141,6 +143,28 @@ export function computeDbTimeChartConfig(
       ? extendDateRangeToInterval(queriedConfig.dateRange, alert.interval)
       : queriedConfig.dateRange,
   };
+}
+
+/**
+ * Returns the dashboard variables a chart preview should use.
+ * - Builder and PromQL configs don't yet support variables, so they resolve to an empty set
+ * - Alerts always run with empty variable selections, so they resolve to each referenced variable with an empty `values` array.
+ * - Otherwise, variables are filtered to only those referenced by the chart config.
+ */
+export function resolvePreviewVariables({
+  config,
+  variables,
+  hasAlert,
+}: {
+  config: ChartConfigWithDateRange;
+  variables: ChartVariable[] | undefined;
+  hasAlert: boolean;
+}): ChartVariable[] | undefined {
+  if (!variables) return undefined;
+  const referenced = filterReferencedVariables(config, variables);
+  return hasAlert
+    ? referenced.map(variable => ({ ...variable, values: [] }))
+    : referenced;
 }
 
 export function buildSampleEventsConfig(

--- a/packages/app/src/hooks/__tests__/useDashboardFilters.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardFilters.test.tsx
@@ -338,6 +338,132 @@ describe('useDashboardFilters', () => {
     });
   });
 
+  describe('variables', () => {
+    it('is empty when no filter is variable-enabled', () => {
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+
+      const { result } = renderHook(() => useDashboardFilters(mockFilters));
+
+      expect(result.current.variables).toEqual([]);
+    });
+
+    it('exposes a variable-enabled filter with its expression and selection', () => {
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.variables).toEqual([
+        { name: 'env', expression: 'environment', values: ['production'] },
+      ]);
+    });
+
+    it('derives the name from the filter name when none is set', () => {
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[1], isVariableEnabled: true },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.variables).toEqual([
+        { name: 'Service', expression: 'service.name', values: [] },
+      ]);
+    });
+
+    it('excludes filters that are not variable-enabled', () => {
+      mockState = [
+        { type: 'sql', condition: "environment IN ('production')" },
+        { type: 'sql', condition: "service.name IN ('api')" },
+      ];
+      const filters: DashboardFilter[] = [
+        mockFilters[0],
+        { ...mockFilters[1], isVariableEnabled: true, variableName: 'service' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.variables.map(v => v.name)).toEqual(['service']);
+    });
+
+    it('exposes a broadcast-disabled filter as a variable', () => {
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+      const filters: DashboardFilter[] = [
+        {
+          ...mockFilters[0],
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'env',
+        },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.getFilterQueriesForSource('logs')).toEqual([]);
+      expect(result.current.variables).toEqual([
+        { name: 'env', expression: 'environment', values: ['production'] },
+      ]);
+    });
+
+    it('yields an empty value list when nothing is selected', () => {
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.variables).toEqual([
+        { name: 'env', expression: 'environment', values: [] },
+      ]);
+    });
+
+    it('sorts values so selection order does not change the payload', () => {
+      const { result } = renderHook(() =>
+        useDashboardFilters([
+          { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+        ]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('environment', [
+          'staging',
+          'development',
+          'production',
+        ]);
+      });
+
+      const { result: result2 } = renderHook(() =>
+        useDashboardFilters([
+          { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+        ]),
+      );
+
+      expect(result2.current.variables[0].values).toEqual([
+        'development',
+        'production',
+        'staging',
+      ]);
+    });
+
+    it('keeps the first definition when two share a variable name', () => {
+      mockState = [
+        { type: 'sql', condition: "environment IN ('production')" },
+        { type: 'sql', condition: "service.name IN ('api')" },
+      ];
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[0], isVariableEnabled: true, variableName: 'dupe' },
+        { ...mockFilters[1], isVariableEnabled: true, variableName: 'dupe' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.variables).toEqual([
+        { name: 'dupe', expression: 'environment', values: ['production'] },
+      ]);
+    });
+  });
+
   describe('ignoredFilterExpressions', () => {
     it('is empty when no URL filters are set', () => {
       const { result } = renderHook(() => useDashboardFilters(mockFilters));

--- a/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
+++ b/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
@@ -110,6 +110,7 @@ describe('usePresetDashboardFilters', () => {
       setFilterQueries: jest.fn(),
       ignoredFilterExpressions: [],
       getFilterQueriesForSource: jest.fn().mockReturnValue(mockFilterQueries),
+      variables: [],
     });
   });
 

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -3,9 +3,15 @@ import { useQueryState } from 'nuqs';
 import {
   FilterState,
   filtersToQuery,
+  getFilterVariableName,
   isFilterBroadcastEnabled,
+  isFilterVariableEnabled,
 } from '@hyperdx/common-utils/dist/filters';
-import { DashboardFilter, Filter } from '@hyperdx/common-utils/dist/types';
+import {
+  ChartVariable,
+  DashboardFilter,
+  Filter,
+} from '@hyperdx/common-utils/dist/types';
 
 import { parseQuery } from '@/searchFilters';
 import { parseAsJsonEncoded } from '@/utils/queryParsers';
@@ -59,6 +65,7 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
     queriesForExistingFilters,
     ignoredExpressions,
     filtersByExpression,
+    variables,
   } = useMemo(() => {
     const { filters: parsedFilters } = parseQuery(filterQueries ?? []);
     const valuesForExistingFilters: FilterState = {};
@@ -98,8 +105,29 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
       }
     }
 
+    const variables: ChartVariable[] = [];
+    const takenNames = new Set<string>();
+    for (const definition of filters) {
+      if (!isFilterVariableEnabled(definition)) continue;
+
+      // There shouldn't be any duplicate names, but if there are then the first one wins.
+      const name = getFilterVariableName(definition);
+      if (!name || takenNames.has(name)) continue;
+      takenNames.add(name);
+
+      const selection = valuesForExistingFilters[definition.expression];
+      variables.push({
+        name,
+        expression: definition.expression,
+        values: selection
+          ? Array.from(selection.included).map(String).sort() // Sorted for deterministic react-query keys
+          : [],
+      });
+    }
+
     return {
       valuesForExistingFilters,
+      variables,
       queriesForExistingFilters: filtersToQuery(
         broadcastValues,
         // Wrap keys in `toString()` to support JSON/Dynamic-type columns.
@@ -163,6 +191,8 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
      * apply to no tiles at all.
      */
     getFilterQueriesForSource,
+    /** The dashboard's variable-enabled filters and their currently selected values. */
+    variables,
   };
 };
 

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -247,6 +247,36 @@ export class ChartEditorComponent {
   }
 
   /**
+   * Expand the "Generated SQL" accordion in the preview panel. Safe to call
+   * when it is already open.
+   */
+  async openGeneratedSql() {
+    const control = this.page.getByRole('button', { name: 'Generated SQL' });
+    await control.waitFor({ state: 'visible', timeout: 10000 });
+    if ((await control.getAttribute('aria-expanded')) !== 'true') {
+      await control.click();
+    }
+    await this.generatedSqlContent().waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  /** CodeMirror content of the rendered "Generated SQL" preview. */
+  generatedSqlContent(): Locator {
+    return this.page.getByTestId('chart-sql-preview').locator('.cm-content');
+  }
+
+  /**
+   * The generated SQL as a single whitespace-collapsed line, so assertions
+   * don't depend on how sql-formatter happened to wrap the query.
+   */
+  async getGeneratedSqlText(): Promise<string> {
+    const text = await this.generatedSqlContent().innerText();
+    return text.replace(/\s+/g, ' ').trim();
+  }
+
+  /**
    * Type a SQL query into the CodeMirror SQL editor, replacing any existing
    * contents first. Call switchToSqlMode() first to make the editor visible.
    *

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -1470,6 +1470,159 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
     });
   });
 
+  test.describe('Dashboard Variables in Raw SQL Tiles', () => {
+    // Both `$__filter(<expr>, <name>)` and a bare `$name` reference, so one
+    // query exercises the macro and the plain-reference form together.
+    const VARIABLE_SQL = `SELECT ServiceName, count() AS count FROM default.e2e_otel_logs WHERE Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp <= fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(ServiceName, svc) AND ServiceName IN ($svc) GROUP BY ServiceName LIMIT 200`;
+
+    const VARIABLE_LINE_SQL = `SELECT toStartOfInterval(Timestamp, INTERVAL {intervalSeconds:Int64} SECOND) AS ts, count() AS count FROM default.e2e_otel_logs WHERE Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(ServiceName, svc) GROUP BY ts ORDER BY ts ASC`;
+
+    /** Add a variable-enabled `Service` filter exposed as `$svc`. */
+    const addServiceVariable = async () => {
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.addFilterToDashboard(
+        'Service',
+        DEFAULT_LOGS_SOURCE_NAME,
+        'ServiceName',
+        undefined,
+        undefined,
+        { variableName: 'svc' },
+      );
+      await expect(dashboardPage.getFilterItemByName('Service')).toBeVisible();
+      await dashboardPage.closeFiltersModal();
+    };
+
+    test(
+      'substitutes selected variable values in the tile editor previews',
+      { tag: '@full-stack' },
+      async () => {
+        test.setTimeout(90000);
+        const chartName = `E2E Variable Tile ${Date.now()}`;
+
+        await test.step('Create a dashboard with a variable-enabled filter', async () => {
+          await dashboardPage.createNewDashboard();
+          await addServiceVariable();
+        });
+
+        await test.step('Select a value for the variable', async () => {
+          await dashboardPage.clickFilterOption('Service', 'accounting');
+          await dashboardPage.page.keyboard.press('Escape');
+        });
+
+        await test.step('Add a raw SQL tile that references the variable', async () => {
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          await dashboardPage.chartEditor.setChartType(DisplayType.Table);
+          await dashboardPage.chartEditor.setChartName(chartName);
+          await dashboardPage.chartEditor.switchToSqlMode();
+          await dashboardPage.chartEditor.typeSqlQuery(VARIABLE_SQL);
+          await dashboardPage.chartEditor.runQuery(false);
+        });
+
+        await test.step('Generated SQL expands both reference forms', async () => {
+          await dashboardPage.chartEditor.openGeneratedSql();
+          await expect(async () => {
+            const sql = await dashboardPage.chartEditor.getGeneratedSqlText();
+            // $__filter(ServiceName, svc) -> (ServiceName IN ('accounting'))
+            expect(sql).toContain("(ServiceName IN ('accounting'))");
+            // ServiceName IN ($svc) -> ServiceName IN ('accounting')
+            expect(sql).toMatch(
+              /ServiceName IN \('accounting'\)[\s\S]*ServiceName IN \('accounting'\)/,
+            );
+            expect(sql).not.toContain('$svc');
+          }).toPass({ timeout: 15000 });
+        });
+
+        await test.step('The preview table only shows the selected service', async () => {
+          const preview = dashboardPage.page.getByRole('dialog').first();
+          await expect(
+            preview.getByTitle('accounting', { exact: true }),
+          ).toBeVisible({ timeout: 15000 });
+          await expect(preview.getByTitle('ad', { exact: true })).toHaveCount(
+            0,
+          );
+        });
+
+        await test.step('The saved tile applies the same substitution', async () => {
+          await dashboardPage.saveTile();
+          const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+          await expect(
+            tile.getByTitle('accounting', { exact: true }),
+          ).toBeVisible({ timeout: 15000 });
+          await expect(tile.getByTitle('ad', { exact: true })).toHaveCount(0);
+        });
+
+        await test.step('Changing the selection re-renders the tile', async () => {
+          await dashboardPage.toggleFilterValue('Service', 'accounting');
+          await dashboardPage.toggleFilterValue('Service', 'ad');
+
+          const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+          await expect(tile.getByTitle('ad', { exact: true })).toBeVisible({
+            timeout: 15000,
+          });
+          await expect(
+            tile.getByTitle('accounting', { exact: true }),
+          ).toHaveCount(0);
+        });
+      },
+    );
+
+    test(
+      'previews an alerting tile with every variable value emptied',
+      { tag: '@full-stack' },
+      async () => {
+        test.setTimeout(90000);
+        const chartName = `E2E Variable Alert Tile ${Date.now()}`;
+
+        await test.step('Create a dashboard with a selected variable value', async () => {
+          await dashboardPage.createNewDashboard();
+          await addServiceVariable();
+          await dashboardPage.clickFilterOption('Service', 'accounting');
+          await dashboardPage.page.keyboard.press('Escape');
+        });
+
+        await test.step('Add a raw SQL line tile that references the variable', async () => {
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          await dashboardPage.chartEditor.setChartType(DisplayType.Line);
+          await dashboardPage.chartEditor.setChartName(chartName);
+          await dashboardPage.chartEditor.switchToSqlMode();
+          await dashboardPage.chartEditor.typeSqlQuery(VARIABLE_LINE_SQL);
+          await dashboardPage.chartEditor.runQuery();
+        });
+
+        await test.step('Without an alert the preview uses the selected value', async () => {
+          await dashboardPage.chartEditor.openGeneratedSql();
+          await expect(async () => {
+            const sql = await dashboardPage.chartEditor.getGeneratedSqlText();
+            expect(sql).toContain("ServiceName IN ('accounting')");
+          }).toPass({ timeout: 15000 });
+        });
+
+        await test.step('Adding an alert empties the variable in the preview', async () => {
+          // An alert runs on a schedule with no dashboard filter selection, so
+          // the preview must show what the alert will actually evaluate.
+          await dashboardPage.chartEditor.clickAddAlert();
+          await expect(async () => {
+            const sql = await dashboardPage.chartEditor.getGeneratedSqlText();
+            expect(sql).not.toContain('accounting');
+            expect(sql).toMatch(/1\s*=\s*1/);
+          }).toPass({ timeout: 15000 });
+        });
+
+        await test.step('Removing the alert restores the selected value', async () => {
+          await dashboardPage.chartEditor.clickRemoveAlert();
+          await expect(async () => {
+            const sql = await dashboardPage.chartEditor.getGeneratedSqlText();
+            expect(sql).toContain("ServiceName IN ('accounting')");
+          }).toPass({ timeout: 15000 });
+        });
+      },
+    );
+  });
+
   test(
     'should deselect and hide the Custom aggregation function when switching to a metric source',
     { tag: '@full-stack' },

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -18,7 +18,7 @@ import {
 import type { DashboardFilter, Filter } from '@/types';
 import {
   DASHBOARD_VARIABLE_NAME_MAX_LENGTH,
-  DASHBOARD_VARIABLE_NAME_REGEX,
+  DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED,
 } from '@/types';
 
 describe('filters', () => {
@@ -884,7 +884,9 @@ describe('filters', () => {
       for (const name of names) {
         const derived = deriveVariableName(name);
         expect(derived).not.toBe('');
-        expect(DASHBOARD_VARIABLE_NAME_REGEX.test(derived)).toBe(true);
+        expect(DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED.test(derived)).toBe(
+          true,
+        );
       }
     });
   });

--- a/packages/common-utils/src/__tests__/macros.test.ts
+++ b/packages/common-utils/src/__tests__/macros.test.ts
@@ -296,4 +296,149 @@ describe('replaceMacros', () => {
       }),
     ).toThrow('expects 0-1 argument(s), but got 2');
   });
+
+  it('should keep an unknown macro verbatim', () => {
+    expect(replaceMacros({ sqlTemplate: 'SELECT $__notAMacro(x)' })).toBe(
+      'SELECT $__notAMacro(x)',
+    );
+  });
+
+  it('should parse macro arguments containing quoted parens and commas', () => {
+    const result = replaceMacros({
+      sqlTemplate: "WHERE $__timeFilter(if(c = 'a),b', ts, ts2))",
+    });
+    expect(result).toBe(
+      "WHERE if(c = 'a),b', ts, ts2) >= toDateTime(fromUnixTimestamp64Milli({startDateMilliseconds:Int64})) AND if(c = 'a),b', ts, ts2) <= toDateTime(fromUnixTimestamp64Milli({endDateMilliseconds:Int64}))",
+    );
+  });
+
+  it('should not re-expand macros that appear in the filters SQL', () => {
+    expect(
+      replaceMacros(
+        { sqlTemplate: 'WHERE $__filters' },
+        "(msg IN ('$__fromTime', '$service'))",
+      ),
+    ).toBe("WHERE (msg IN ('$__fromTime', '$service'))");
+  });
+});
+
+describe('replaceMacros with variables', () => {
+  const variables = [
+    { name: 'service', expression: 'ServiceName', values: ['api', 'web'] },
+    { name: 'env', expression: 'Env', values: [] },
+  ];
+
+  describe('without a variables context', () => {
+    it('leaves variable references verbatim', () => {
+      expect(
+        replaceMacros({
+          sqlTemplate: 'WHERE svc = $service AND env = ${env:csv}',
+        }),
+      ).toBe('WHERE svc = $service AND env = ${env:csv}');
+    });
+
+    it('leaves the variable macros verbatim, arguments and all', () => {
+      const sqlTemplate =
+        "WHERE $__filter(ServiceName, service) AND $__conditionalAll(x = 'a)b', env)";
+      expect(replaceMacros({ sqlTemplate })).toBe(sqlTemplate);
+    });
+
+    it('still expands standard macros alongside untouched references', () => {
+      expect(
+        replaceMacros({ sqlTemplate: 'WHERE $__timeFilter(ts) AND $service' }),
+      ).toBe(
+        'WHERE ts >= toDateTime(fromUnixTimestamp64Milli({startDateMilliseconds:Int64})) AND ts <= toDateTime(fromUnixTimestamp64Milli({endDateMilliseconds:Int64})) AND $service',
+      );
+    });
+  });
+
+  describe('with a variables context', () => {
+    it('expands references, variable macros and standard macros in one pass', () => {
+      const result = replaceMacros(
+        {
+          sqlTemplate:
+            'SELECT $__timeInterval(ts) FROM $__sourceTable ' +
+            'WHERE $__timeFilter(ts) AND $__filters AND $__filter(service) ' +
+            'AND svc IN ($service) AND $__conditionalAll(Env != $service, service)',
+          from: { databaseName: 'otel', tableName: 'otel_logs' },
+          variables,
+        },
+        "(toString(Env) IN ('prod'))",
+      );
+
+      expect(result).toBe(
+        'SELECT toStartOfInterval(toDateTime(ts), INTERVAL {intervalSeconds:Int64} second) ' +
+          'FROM `otel`.`otel_logs` ' +
+          'WHERE ts >= toDateTime(fromUnixTimestamp64Milli({startDateMilliseconds:Int64})) ' +
+          'AND ts <= toDateTime(fromUnixTimestamp64Milli({endDateMilliseconds:Int64})) ' +
+          "AND (toString(Env) IN ('prod')) " +
+          "AND (toString(ServiceName) IN ('api', 'web')) " +
+          "AND svc IN ('api', 'web') " +
+          "AND (Env != 'api', 'web')",
+      );
+    });
+
+    it('distinguishes $__filters from $__filter(', () => {
+      expect(
+        replaceMacros(
+          {
+            sqlTemplate: 'WHERE $__filters AND $__filter(ServiceName, service)',
+            variables,
+          },
+          '(1=2)',
+        ),
+      ).toBe("WHERE (1=2) AND (ServiceName IN ('api', 'web'))");
+    });
+
+    it('expands an unselected variable to a no-op predicate', () => {
+      expect(
+        replaceMacros({
+          sqlTemplate: 'WHERE $__filter(env)',
+          variables,
+        }),
+      ).toBe("WHERE (1=1 /** no values selected for variable 'env' */)");
+    });
+
+    it('does not expand references that appear in the filters SQL', () => {
+      expect(
+        replaceMacros(
+          { sqlTemplate: 'WHERE $__filters', variables },
+          "(msg IN ('$service'))",
+        ),
+      ).toBe("WHERE (msg IN ('$service'))");
+    });
+
+    it('does not re-expand a selected value that looks like a macro', () => {
+      expect(
+        replaceMacros({
+          sqlTemplate: 'WHERE msg = $service',
+          variables: [{ name: 'service', values: ['$__fromTime'] }],
+        }),
+      ).toBe("WHERE msg = '$__fromTime'");
+    });
+
+    it('throws when a variable macro names an unknown variable', () => {
+      expect(() =>
+        replaceMacros({
+          sqlTemplate: 'WHERE $__filter(ServiceName, nope)',
+          variables,
+        }),
+      ).toThrow("references unknown variable 'nope'");
+    });
+
+    it('leaves an unknown bare reference verbatim', () => {
+      expect(
+        replaceMacros({ sqlTemplate: "SELECT '$100 $nope'", variables }),
+      ).toBe("SELECT '$100 $nope'");
+    });
+
+    it('treats an empty variables array as a provided context', () => {
+      expect(() =>
+        replaceMacros({
+          sqlTemplate: 'WHERE $__filter(ServiceName, service)',
+          variables: [],
+        }),
+      ).toThrow("references unknown variable 'service'");
+    });
+  });
 });

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -1,0 +1,455 @@
+import type { ChartVariable } from '@/types';
+import {
+  filterReferencedVariables,
+  formatVariableValues,
+  getReferencedVariableNames,
+  substituteVariables,
+} from '@/variables';
+
+const variable = (
+  name: string,
+  values: string[],
+  expression?: string,
+): ChartVariable => ({ name, values, expression });
+
+const SERVICE = variable('service', ['api', 'web'], 'ServiceName');
+const EMPTY_SERVICE = variable('service', [], 'ServiceName');
+
+describe('formatVariableValues', () => {
+  describe('sqlstring', () => {
+    it('renders NULL when nothing is selected', () => {
+      expect(formatVariableValues([], 'sqlstring')).toBe('NULL');
+    });
+
+    it('renders a single quoted value', () => {
+      expect(formatVariableValues(['api'], 'sqlstring')).toBe("'api'");
+    });
+
+    it('renders a comma-separated list', () => {
+      expect(formatVariableValues(['api', 'web'], 'sqlstring')).toBe(
+        "'api', 'web'",
+      );
+    });
+
+    it('escapes quotes and backslashes the same way the broadcast path does', () => {
+      expect(formatVariableValues(["o'brien", 'a\\b'], 'sqlstring')).toBe(
+        "'o''brien', 'a\\\\b'",
+      );
+    });
+  });
+
+  describe('regex', () => {
+    it('matches anything when nothing is selected', () => {
+      expect(formatVariableValues([], 'regex')).toBe('.*');
+    });
+
+    it('leaves a single value unwrapped', () => {
+      expect(formatVariableValues(['api'], 'regex')).toBe('api');
+    });
+
+    it('wraps an alternation of multiple values', () => {
+      expect(formatVariableValues(['api', 'web'], 'regex')).toBe('(api|web)');
+    });
+
+    it('escapes regex metacharacters', () => {
+      expect(formatVariableValues(['a.b+c', 'x(y)'], 'regex')).toBe(
+        '(a\\.b\\+c|x\\(y\\))',
+      );
+    });
+  });
+
+  describe('csv', () => {
+    it('renders empty when nothing is selected', () => {
+      expect(formatVariableValues([], 'csv')).toBe('');
+    });
+
+    it('joins values with commas', () => {
+      expect(formatVariableValues(['api', 'web'], 'csv')).toBe('api,web');
+    });
+  });
+
+  describe('lucene', () => {
+    it('renders a match-all wildcard when nothing is selected', () => {
+      expect(formatVariableValues([], 'lucene')).toBe('*');
+    });
+
+    it('renders a single quoted term', () => {
+      expect(formatVariableValues(['api'], 'lucene')).toBe('("api")');
+    });
+
+    it('ORs multiple terms', () => {
+      expect(formatVariableValues(['api', 'web'], 'lucene')).toBe(
+        '("api" OR "web")',
+      );
+    });
+
+    it('escapes backslashes and double quotes', () => {
+      expect(formatVariableValues(['a"b', 'c\\d'], 'lucene')).toBe(
+        '("a\\"b" OR "c\\\\d")',
+      );
+    });
+  });
+});
+
+describe('substituteVariables', () => {
+  describe('bare references', () => {
+    it('substitutes with the sqlstring format by default', () => {
+      expect(
+        substituteVariables('WHERE ServiceName IN ($service)', [SERVICE]),
+      ).toBe("WHERE ServiceName IN ('api', 'web')");
+    });
+
+    it('substitutes NULL when nothing is selected', () => {
+      expect(
+        substituteVariables('WHERE ServiceName IN ($service)', [EMPTY_SERVICE]),
+      ).toBe('WHERE ServiceName IN (NULL)');
+    });
+
+    it('leaves an unknown name verbatim', () => {
+      expect(substituteVariables("SELECT '$notAVariable'", [SERVICE])).toBe(
+        "SELECT '$notAVariable'",
+      );
+    });
+
+    it('matches names maximally so a longer name is not partially replaced', () => {
+      expect(substituteVariables('$service_name', [SERVICE])).toBe(
+        '$service_name',
+      );
+      expect(
+        substituteVariables('$service_name', [
+          SERVICE,
+          variable('service_name', ['checkout']),
+        ]),
+      ).toBe("'checkout'");
+    });
+
+    it('leaves a lone $ and $-digit sequences alone', () => {
+      expect(substituteVariables('SELECT $, $1, x$', [SERVICE])).toBe(
+        'SELECT $, $1, x$',
+      );
+    });
+
+    it('applies the caller-provided default format', () => {
+      expect(
+        substituteVariables('{service="$service"}', [SERVICE], {
+          defaultFormat: 'regex',
+        }),
+      ).toBe('{service="(api|web)"}');
+    });
+  });
+
+  describe('braced references', () => {
+    it('substitutes ${name} with the default format', () => {
+      expect(substituteVariables('${service}', [SERVICE])).toBe("'api', 'web'");
+    });
+
+    it.each([
+      ['sqlstring', "'api', 'web'"],
+      ['regex', '(api|web)'],
+      ['csv', 'api,web'],
+      ['lucene', '("api" OR "web")'],
+    ])('substitutes ${name:%s}', (format, expected) => {
+      expect(substituteVariables(`\${service:${format}}`, [SERVICE])).toBe(
+        expected,
+      );
+    });
+
+    it('leaves an unknown name verbatim, format and all', () => {
+      expect(substituteVariables('${other:csv}', [SERVICE])).toBe(
+        '${other:csv}',
+      );
+    });
+
+    it('throws on an unknown format for a known name', () => {
+      expect(() => substituteVariables('${service:json}', [SERVICE])).toThrow(
+        "Unknown variable format 'json'",
+      );
+    });
+
+    it('leaves a malformed brace expression as plain text', () => {
+      expect(substituteVariables('${not a name}', [SERVICE])).toBe(
+        '${not a name}',
+      );
+      expect(substituteVariables('${service', [SERVICE])).toBe('${service');
+    });
+  });
+
+  describe('$__filter', () => {
+    it('expands the two-argument form against the given expression', () => {
+      expect(
+        substituteVariables('WHERE $__filter(ServiceName, service)', [SERVICE]),
+      ).toBe("WHERE (ServiceName IN ('api', 'web'))");
+    });
+
+    it('expands the one-argument form using the variable expression', () => {
+      expect(substituteVariables('WHERE $__filter(service)', [SERVICE])).toBe(
+        "WHERE (toString(ServiceName) IN ('api', 'web'))",
+      );
+    });
+
+    it('accepts a $-prefixed name argument', () => {
+      expect(
+        substituteVariables('WHERE $__filter(ServiceName, $service)', [
+          SERVICE,
+        ]),
+      ).toBe("WHERE (ServiceName IN ('api', 'web'))");
+    });
+
+    it('rejects a braced name argument', () => {
+      expect(() =>
+        substituteVariables('WHERE $__filter(ServiceName, ${service})', [
+          SERVICE,
+        ]),
+      ).toThrow("Macro '$__filter' references unknown variable '{service}'");
+    });
+
+    it('expands to a no-op predicate when nothing is selected', () => {
+      expect(
+        substituteVariables('WHERE $__filter(ServiceName, service)', [
+          EMPTY_SERVICE,
+        ]),
+      ).toBe("WHERE (1=1 /** no values selected for variable 'service' */)");
+    });
+
+    it('substitutes references nested in the expression argument', () => {
+      expect(
+        substituteVariables("WHERE $__filter(concat(col, '$env'), service)", [
+          SERVICE,
+          variable('env', ['prod']),
+        ]),
+      ).toBe("WHERE (concat(col, ''prod'') IN ('api', 'web'))");
+    });
+
+    it('throws when the named variable does not exist', () => {
+      expect(() =>
+        substituteVariables('WHERE $__filter(ServiceName, nope)', [SERVICE]),
+      ).toThrow("Macro '$__filter' references unknown variable 'nope'");
+    });
+
+    it('throws on the one-argument form when the variable has no expression', () => {
+      expect(() =>
+        substituteVariables('WHERE $__filter(service)', [
+          variable('service', ['api']),
+        ]),
+      ).toThrow("Macro '$__filter(service)' requires the variable's filter");
+    });
+
+    it('throws on a bad argument count', () => {
+      expect(() =>
+        substituteVariables('$__filter(a, b, c)', [SERVICE]),
+      ).toThrow("Macro 'filter' expects 1-2 argument(s), but got 3");
+    });
+  });
+
+  describe('$__conditionalAll', () => {
+    it('emits the condition when values are selected', () => {
+      expect(
+        substituteVariables(
+          "WHERE $__conditionalAll(ServiceName = 'api', service)",
+          [SERVICE],
+        ),
+      ).toBe("WHERE (ServiceName = 'api')");
+    });
+
+    it('emits a no-op predicate when nothing is selected', () => {
+      expect(
+        substituteVariables(
+          "WHERE $__conditionalAll(ServiceName = 'api', service)",
+          [EMPTY_SERVICE],
+        ),
+      ).toBe("WHERE (1=1 /** no values selected for variable 'service' */)");
+    });
+
+    it('substitutes references inside the condition', () => {
+      expect(
+        substituteVariables(
+          'WHERE $__conditionalAll(ServiceName IN ($service), service)',
+          [SERVICE],
+        ),
+      ).toBe("WHERE (ServiceName IN ('api', 'web'))");
+    });
+
+    it('throws when the named variable does not exist', () => {
+      expect(() =>
+        substituteVariables('$__conditionalAll(x = 1, nope)', [SERVICE]),
+      ).toThrow("Macro '$__conditionalAll' references unknown variable 'nope'");
+    });
+
+    it('throws on a bad argument count', () => {
+      expect(() => substituteVariables('$__conditionalAll(x = 1)', [SERVICE])) //
+        .toThrow("Macro 'conditionalAll' expects 2 argument(s), but got 1");
+    });
+  });
+
+  describe('argument parsing', () => {
+    it('handles a close paren inside a quoted argument', () => {
+      expect(
+        substituteVariables("$__conditionalAll(col = 'a)b', service)", [
+          SERVICE,
+        ]),
+      ).toBe("(col = 'a)b')");
+    });
+
+    it('handles an open paren and a comma inside a quoted argument', () => {
+      expect(
+        substituteVariables("$__conditionalAll(col = 'a,(b', service)", [
+          SERVICE,
+        ]),
+      ).toBe("(col = 'a,(b')");
+    });
+
+    it('handles nested parens in the condition', () => {
+      expect(
+        substituteVariables(
+          '$__conditionalAll(has(splitByChar(:, col), 1), service)',
+          [SERVICE],
+        ),
+      ).toBe('(has(splitByChar(:, col), 1))');
+    });
+
+    it('throws when the argument list is never closed', () => {
+      expect(() =>
+        substituteVariables('$__filter(ServiceName, service', [SERVICE]),
+      ).toThrow('Failed to parse macro arguments');
+    });
+  });
+
+  it('does not re-expand values that themselves look like references', () => {
+    expect(
+      substituteVariables('$a $b', [
+        variable('a', ['$b']),
+        variable('b', ['literal']),
+      ]),
+    ).toBe("'$b' 'literal'");
+  });
+
+  it('leaves non-variable macros untouched', () => {
+    expect(
+      substituteVariables('WHERE $__timeFilter(ts) AND $__filters', [SERVICE]),
+    ).toBe('WHERE $__timeFilter(ts) AND $__filters');
+  });
+
+  it('does not treat $__filters as the $__filter macro', () => {
+    expect(substituteVariables('$__filters', [SERVICE])).toBe('$__filters');
+  });
+});
+
+describe('getReferencedVariableNames', () => {
+  it('returns an empty list for a template with no references', () => {
+    expect(getReferencedVariableNames('SELECT 1 FROM t')).toEqual([]);
+  });
+
+  it('collects bare and braced references in first-encounter order', () => {
+    expect(
+      getReferencedVariableNames('$zulu ${alpha:csv} $zulu ${bravo}'),
+    ).toEqual(['zulu', 'alpha', 'bravo']);
+  });
+
+  it('collects the name argument of both variable macros', () => {
+    expect(
+      getReferencedVariableNames(
+        '$__filter(ServiceName, service) $__filter(env) $__conditionalAll(x = 1, region)',
+      ),
+    ).toEqual(['service', 'env', 'region']);
+  });
+
+  it('collects references nested inside macro expression arguments', () => {
+    expect(
+      getReferencedVariableNames(
+        '$__conditionalAll(ServiceName IN ($service), region)',
+      ),
+    ).toEqual(['region', 'service']);
+  });
+
+  it('accepts $-decorated name arguments', () => {
+    expect(getReferencedVariableNames('$__filter(col, $service)')).toEqual([
+      'service',
+    ]);
+  });
+
+  it('does not collect a braced name argument', () => {
+    expect(getReferencedVariableNames('$__filter(col, ${service})')).toEqual(
+      [],
+    );
+  });
+
+  it('ignores standard macros and their arguments', () => {
+    expect(
+      getReferencedVariableNames(
+        'SELECT $__timeInterval(ts) FROM $__sourceTable(gauge) WHERE $__filters',
+      ),
+    ).toEqual([]);
+  });
+
+  it('does not throw on a malformed macro and still finds later references', () => {
+    expect(getReferencedVariableNames('$__filter(col, service $env')).toEqual([
+      'env',
+    ]);
+  });
+});
+
+describe('filterReferencedVariables', () => {
+  const variables = [
+    SERVICE,
+    variable('env', ['prod']),
+    variable('region', []),
+  ];
+
+  const rawSqlConfig = (sqlTemplate: string) =>
+    ({ configType: 'sql', sqlTemplate, connection: 'local' }) as const;
+
+  it('keeps only the referenced variables, in the input order', () => {
+    expect(
+      filterReferencedVariables(
+        rawSqlConfig(
+          'WHERE $__filter(RegionName, region) AND ServiceName = $service',
+        ),
+        variables,
+      ),
+    ).toEqual([SERVICE, variable('region', [])]);
+  });
+
+  it('returns an empty array when the template references none of them', () => {
+    expect(
+      filterReferencedVariables(
+        rawSqlConfig('SELECT 1 WHERE $__filters'),
+        variables,
+      ),
+    ).toEqual([]);
+  });
+
+  it('ignores references to variables that do not exist', () => {
+    expect(filterReferencedVariables(rawSqlConfig('$nope'), variables)).toEqual(
+      [],
+    );
+  });
+
+  it('returns an empty array for a PromQL config even when its expression mentions a variable', () => {
+    expect(
+      filterReferencedVariables(
+        {
+          configType: 'promql',
+          promqlExpression: 'up{service="$service"}',
+          connection: 'local',
+        },
+        variables,
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns an empty array for a builder config even when its fields mention a variable', () => {
+    expect(
+      filterReferencedVariables(
+        {
+          select: 'count()',
+          from: { databaseName: 'default', tableName: 'logs' },
+          where: 'ServiceName = $service',
+          whereLanguage: 'sql',
+          timestampValueExpression: 'Timestamp',
+          connection: 'local',
+        },
+        variables,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -3,6 +3,8 @@ import {
   filterReferencedVariables,
   formatVariableValues,
   getReferencedVariableNames,
+  getVariableReferences,
+  hasVariableMacro,
   substituteVariables,
 } from '@/variables';
 
@@ -331,6 +333,237 @@ describe('substituteVariables', () => {
 
   it('does not treat $__filters as the $__filter macro', () => {
     expect(substituteVariables('$__filters', [SERVICE])).toBe('$__filters');
+  });
+});
+
+describe('getVariableReferences', () => {
+  it('returns an empty list for a template with no references', () => {
+    expect(getVariableReferences('SELECT 1 FROM t')).toEqual([]);
+  });
+
+  it('reports every occurrence, in source order, with its written form', () => {
+    expect(getVariableReferences('$zulu ${alpha:csv} $zulu')).toEqual([
+      { name: 'zulu', kind: 'bare', inStringLiteral: false, raw: '$zulu' },
+      {
+        name: 'alpha',
+        kind: 'braced',
+        format: 'csv',
+        inStringLiteral: false,
+        raw: '${alpha:csv}',
+      },
+      { name: 'zulu', kind: 'bare', inStringLiteral: false, raw: '$zulu' },
+    ]);
+  });
+
+  it('reports the macro forms under the name they filter by', () => {
+    expect(
+      getVariableReferences(
+        '$__filter(ServiceName, service) $__conditionalAll(x = 1, region)',
+      ),
+    ).toEqual([
+      {
+        name: 'service',
+        kind: 'macro',
+        inStringLiteral: false,
+        raw: '$__filter',
+      },
+      {
+        name: 'region',
+        kind: 'macro',
+        inStringLiteral: false,
+        raw: '$__conditionalAll',
+      },
+    ]);
+  });
+
+  it('drops a macro name argument that is not a valid variable name', () => {
+    expect(getVariableReferences('$__filter(ServiceName, ${service})')).toEqual(
+      [],
+    );
+  });
+
+  it('flags a reference inside a single-quoted string', () => {
+    expect(getVariableReferences("WHERE name = '$service'")).toEqual([
+      { name: 'service', kind: 'bare', inStringLiteral: true, raw: '$service' },
+    ]);
+  });
+
+  it('flags a reference inside a LIKE pattern', () => {
+    expect(getVariableReferences("WHERE name LIKE '%$service%'")).toEqual([
+      { name: 'service', kind: 'bare', inStringLiteral: true, raw: '$service' },
+    ]);
+  });
+
+  it('does not flag a reference after a closed string literal', () => {
+    expect(getVariableReferences("WHERE a = 'x' AND b = $service")).toEqual([
+      {
+        name: 'service',
+        kind: 'bare',
+        inStringLiteral: false,
+        raw: '$service',
+      },
+    ]);
+  });
+
+  describe('comments', () => {
+    const bareRef = (inStringLiteral: boolean) => [
+      { name: 'service', kind: 'bare', inStringLiteral, raw: '$service' },
+    ];
+
+    it.each([
+      ['a hash line comment', "# don't\nWHERE a IN ($service)"],
+      ['a line comment', "-- don't\nWHERE a IN ($service)"],
+      ['a block comment', "/* don't */ WHERE a IN ($service)"],
+      ['a trailing line comment', "WHERE a IN ($service) -- don't"],
+    ])('does not let an apostrophe in %s open a string', (_label, input) => {
+      expect(getVariableReferences(input)).toEqual(bareRef(false));
+    });
+
+    it('still flags a genuinely quoted reference after such a comment', () => {
+      expect(getVariableReferences("-- don't\nWHERE a = '$service'")).toEqual(
+        bareRef(true),
+      );
+    });
+
+    it.each([
+      ['--', "SELECT 'a -- b', $service"],
+      ['#', "SELECT 'a # b', $service"],
+    ])(
+      'does not treat %s inside a string literal as a comment',
+      (_l, input) => {
+        expect(getVariableReferences(input)).toEqual(bareRef(false));
+      },
+    );
+
+    it('treats an unterminated block comment as running to the end', () => {
+      expect(getVariableReferences("SELECT 1 /* don't $service")).toEqual([]);
+    });
+
+    it('leaves a reference inside a comment unsubstituted', () => {
+      expect(substituteVariables('-- see $service\nSELECT 1', [SERVICE])).toBe(
+        '-- see $service\nSELECT 1',
+      );
+      expect(substituteVariables('/* $service */ SELECT 1', [SERVICE])).toBe(
+        '/* $service */ SELECT 1',
+      );
+    });
+
+    it('substitutes normally after a comment ends', () => {
+      expect(
+        substituteVariables('-- see $service\nWHERE a IN ($service)', [
+          SERVICE,
+        ]),
+      ).toBe("-- see $service\nWHERE a IN ('api', 'web')");
+    });
+  });
+
+  it('recovers its quote state when a macro argument list has a stray quote', () => {
+    // The scanner jumps over a balanced argument list, so a stray quote inside
+    // one must not be skipped: findBalancedParens fails, and the text is
+    // rescanned character by character instead.
+    expect(getVariableReferences("$__filter(a', b) $service")).toEqual([
+      { name: 'service', kind: 'bare', inStringLiteral: true, raw: '$service' },
+    ]);
+  });
+
+  it('ignores a quote that is escaped with a backslash', () => {
+    expect(
+      getVariableReferences("WHERE a = 'it\\'s' AND b = $service"),
+    ).toEqual([
+      {
+        name: 'service',
+        kind: 'bare',
+        inStringLiteral: false,
+        raw: '$service',
+      },
+    ]);
+  });
+
+  it('tracks quotes inside a macro expression argument independently', () => {
+    expect(
+      getVariableReferences("$__filter(concat(col, '$env'), service)"),
+    ).toEqual([
+      {
+        name: 'service',
+        kind: 'macro',
+        inStringLiteral: false,
+        raw: '$__filter',
+      },
+      {
+        name: 'env',
+        kind: 'bare',
+        inStringLiteral: true,
+        guardedBy: 'service',
+        raw: '$env',
+      },
+    ]);
+  });
+
+  it('marks a reference in a macro expression as guarded by that macro', () => {
+    expect(
+      getVariableReferences('$__conditionalAll(ServiceName IN ($svc), svc)'),
+    ).toEqual([
+      {
+        name: 'svc',
+        kind: 'macro',
+        inStringLiteral: false,
+        raw: '$__conditionalAll',
+      },
+      {
+        name: 'svc',
+        kind: 'bare',
+        inStringLiteral: false,
+        guardedBy: 'svc',
+        raw: '$svc',
+      },
+    ]);
+  });
+
+  it('leaves a reference outside any macro unguarded', () => {
+    expect(
+      getVariableReferences('WHERE a IN ($svc) AND $__filter(b, other)'),
+    ).toEqual([
+      { name: 'svc', kind: 'bare', inStringLiteral: false, raw: '$svc' },
+      {
+        name: 'other',
+        kind: 'macro',
+        inStringLiteral: false,
+        raw: '$__filter',
+      },
+    ]);
+  });
+
+  it('does not throw on a malformed macro and still finds later references', () => {
+    expect(
+      getVariableReferences('$__filter(ServiceName, service $region'),
+    ).toEqual([
+      { name: 'region', kind: 'bare', inStringLiteral: false, raw: '$region' },
+    ]);
+  });
+});
+
+describe('hasVariableMacro', () => {
+  it('is true for either variable macro', () => {
+    expect(hasVariableMacro('WHERE $__filter(ServiceName, service)')).toBe(
+      true,
+    );
+    expect(hasVariableMacro('WHERE $__conditionalAll(x = 1, region)')).toBe(
+      true,
+    );
+  });
+
+  it('is false for the plural broadcast macro', () => {
+    expect(hasVariableMacro('WHERE $__filters')).toBe(false);
+  });
+
+  it('is false for a bare reference', () => {
+    expect(hasVariableMacro('WHERE ServiceName IN ($service)')).toBe(false);
+  });
+
+  it('does not throw on a malformed macro', () => {
+    expect(hasVariableMacro('WHERE $__filter(ServiceName, service')).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -72,7 +72,14 @@ export function splitAndTrimCSV(input: string): string[] {
     .filter(column => column.length > 0);
 }
 
-function isQuoteEscapedByBackslash(input: string, index: number): boolean {
+/** Escape a value for embedding in a single-quoted ClickHouse string literal. */
+export const escapeSqlString = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "''");
+
+export function isQuoteEscapedByBackslash(
+  input: string,
+  index: number,
+): boolean {
   let backslashes = 0;
   for (let i = index - 1; i >= 0 && input[i] === '\\'; i--) {
     backslashes++;

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -1,10 +1,10 @@
 import * as SQLParser from 'node-sql-parser';
 
-import { replaceJsonExpressions } from '@/core/utils';
+import { escapeSqlString, replaceJsonExpressions } from '@/core/utils';
 import { parse } from '@/queryParser';
 import {
   DASHBOARD_VARIABLE_NAME_MAX_LENGTH,
-  DASHBOARD_VARIABLE_NAME_REGEX,
+  DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED,
   DashboardFilter,
   Filter,
 } from '@/types';
@@ -15,10 +15,6 @@ export type FilterState = {
     excluded: Set<string | boolean>;
     range?: { min: number; max: number }; // For BETWEEN conditions
   };
-};
-
-const escapeString = (s: string) => {
-  return s.replace(/\\/g, '\\\\').replace(/'/g, "''");
 };
 
 // Wrap a quoted string literal in a ClickHouse expression whose result type
@@ -76,8 +72,8 @@ export const filtersToQuery = (
         typeof v !== 'string'
           ? v
           : chType != null
-            ? dateTimeValueExpr(chType, `'${escapeString(v)}'`)
-            : `'${escapeString(v)}'`;
+            ? dateTimeValueExpr(chType, `'${escapeSqlString(v)}'`)
+            : `'${escapeSqlString(v)}'`;
 
       if (values.included.size > 0) {
         conditions.push({
@@ -170,7 +166,7 @@ const getBooleanOrUnquotedString = (value: string): string | boolean => {
   }
 
   // Remove surrounding quotes and reverse the escape sequences produced by
-  // filtersToQuery's escapeString. Order matters: collapse \\ → \ first so
+  // filtersToQuery's escapeSqlString. Order matters: collapse \\ → \ first so
   // that the following '' → ' pass doesn't mistake content for an escape.
   if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
     return trimmed.slice(1, -1).replace(/\\\\/g, '\\').replace(/''/g, "'");
@@ -806,7 +802,7 @@ export function validateVariableName({
   if (trimmed.length > DASHBOARD_VARIABLE_NAME_MAX_LENGTH) {
     return `Variable name must be ${DASHBOARD_VARIABLE_NAME_MAX_LENGTH} characters or fewer`;
   }
-  if (!DASHBOARD_VARIABLE_NAME_REGEX.test(trimmed)) {
+  if (!DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED.test(trimmed)) {
     return 'Variable names must start with a letter and may contain only letters, numbers, and underscores';
   }
   const clash = otherFilters.find(

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -11,10 +11,11 @@ import {
   scanTemplateTokens,
   VARIABLE_MACRO_NAMES,
   VariableContext,
+  VariableMacroName,
 } from './variables';
 
 function expectArgs(
-  macroName: string,
+  macroName: MacroName,
   args: string[],
   minArgs: number,
   maxArgs: number,
@@ -49,7 +50,7 @@ type Macro = {
   replace: (args: string[]) => string;
 };
 
-const MACROS: Macro[] = [
+const MACROS = [
   {
     name: 'fromTime',
     minArgs: 0,
@@ -154,7 +155,18 @@ const MACROS: Macro[] = [
     maxArgs: 0,
     replace: () => intervalS(),
   },
-];
+] as const satisfies readonly Macro[];
+
+/**
+ * Every `$__<name>` a raw SQL template can use: the static macros above, the
+ * two built in `replaceMacros` from the chart's source, and the variable macros
+ * that only exist when a variable context is present.
+ */
+export type MacroName =
+  | (typeof MACROS)[number]['name']
+  | 'filters'
+  | 'sourceTable'
+  | VariableMacroName;
 
 /** Macro metadata for autocomplete suggestions */
 export const MACRO_SUGGESTIONS = [
@@ -234,7 +246,7 @@ function parseMacroArgs(argString: string): { args: string[]; length: number } {
 /**
  * True if the SQL contains at least one occurrence of the `$__<name>` macro.
  */
-export function hasMacro(sql: string, name: string): boolean {
+export function hasMacro(sql: string, name: MacroName): boolean {
   return findMacros(sql, name).length > 0;
 }
 
@@ -257,7 +269,7 @@ export function getSourceTableMacroArgCounts(sqlTemplate: string): number[] {
   return findMacros(sqlTemplate, 'sourceTable').map(match => match.args.length);
 }
 
-function findMacros(input: string, name: string): MacroMatch[] {
+function findMacros(input: string, name: MacroName): MacroMatch[] {
   // eslint-disable-next-line security/detect-non-literal-regexp
   const pattern = new RegExp(`\\$__${name}\\b`, 'g');
   const matches: MacroMatch[] = [];

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -5,6 +5,13 @@ import {
   MetricsDataTypeSchema,
   RawSqlChartConfig,
 } from './types';
+import {
+  expandVariableToken,
+  findBalancedParens,
+  scanTemplateTokens,
+  VARIABLE_MACRO_NAMES,
+  VariableContext,
+} from './variables';
 
 function expectArgs(
   macroName: string,
@@ -212,21 +219,8 @@ function parseMacroArgs(argString: string): { args: string[]; length: number } {
     return { args: [], length: 0 };
   }
 
-  // Find the matching close paren
-  let unmatchedParens = 0;
-  let closeParenIndex = -1;
-  for (let i = 0; i < argString.length; i++) {
-    const c = argString.charAt(i);
-    if (c === '(') {
-      unmatchedParens++;
-    } else if (c === ')') {
-      unmatchedParens--;
-      if (unmatchedParens === 0) {
-        closeParenIndex = i;
-        break;
-      }
-    }
-  }
+  // Quote-aware, so a `)` inside a string literal doesn't end the argument list.
+  const closeParenIndex = findBalancedParens(argString, 0);
 
   if (closeParenIndex < 0) {
     return { args: [], length: -1 };
@@ -285,11 +279,27 @@ function findMacros(input: string, name: string): MacroMatch[] {
 
 const NO_FILTERS = '(1=1 /** no filters applied */)';
 
+/**
+ * Expand every macro and (when a variable context is present) every dashboard
+ * variable reference in a raw SQL template.
+ *
+ * The template is scanned once, left to right, and each token is expanded into
+ * an output buffer — an expansion is never re-scanned, so neither `$__filters`
+ * output nor a selected variable value can trigger further substitution.
+ *
+ * `chartConfig.variables` being undefined means variable references and
+ * the variable macros are left exactly as written; an empty array means the
+ * dashboard has no variables, and references to unknown names still pass
+ * through verbatim while macros naming them error.
+ */
 export function replaceMacros(
-  chartConfig: Pick<RawSqlChartConfig, 'sqlTemplate' | 'from' | 'metricTables'>,
+  chartConfig: Pick<
+    RawSqlChartConfig,
+    'sqlTemplate' | 'from' | 'metricTables' | 'variables'
+  >,
   filtersSQL?: string,
 ): string {
-  const { from, metricTables } = chartConfig;
+  const { from, metricTables, variables } = chartConfig;
 
   const allMacros: Macro[] = [
     ...MACROS,
@@ -352,18 +362,35 @@ export function replaceMacros(
     },
   ];
 
-  const sortedMacros = allMacros.sort(
-    (m1, m2) => m2.name.length - m1.name.length,
-  );
+  const macrosByName = new Map(allMacros.map(macro => [macro.name, macro]));
 
-  let sql = chartConfig.sqlTemplate;
-  for (const macro of sortedMacros) {
-    const matches = findMacros(sql, macro.name);
+  const variableContext: VariableContext | undefined = variables && {
+    variables,
+    defaultFormat: 'sqlstring',
+  };
 
-    for (const match of matches) {
-      sql = sql.replaceAll(match.full, macro.replace(match.args));
-    }
-  }
+  const macroNames = [
+    ...macrosByName.keys(),
+    // Without a variable context the variable macros aren't macros at all —
+    // leaving them unregistered emits them verbatim, arguments and all.
+    ...(variableContext ? VARIABLE_MACRO_NAMES : []),
+  ];
 
-  return sql;
+  return scanTemplateTokens(chartConfig.sqlTemplate, macroNames)
+    .map(token => {
+      if (token.kind === 'text') return token.text;
+
+      if (token.kind === 'macro') {
+        const macro = macrosByName.get(token.name);
+        return macro
+          ? macro.replace(token.args) // Non-variable-referencing macro
+          : expandVariableToken(token, variableContext!); // Variable-referencing macro
+      }
+
+      // Braced and bare variable references ($var, ${var}, or ${var:format})
+      return variableContext
+        ? expandVariableToken(token, variableContext)
+        : token.raw;
+    })
+    .join('');
 }

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1328,6 +1328,17 @@ export const _ChartConfigSchema = SharedChartSettingsSchema.extend({
   groupByColumnsOnLeft: z.boolean().optional(),
 });
 
+/** A dashboard variable as seen by a tile's query. */
+export const ChartVariableSchema = z.object({
+  name: z.string(),
+  /** The filter's target expression; enables the 1-arg `$__filter(name)` form. */
+  expression: z.string().optional(),
+  /** Empty means nothing is selected. */
+  values: z.array(z.string()),
+});
+
+export type ChartVariable = z.infer<typeof ChartVariableSchema>;
+
 // This is a ChartConfig type without the `with` CTE clause included.
 // It needs to be a separate, named schema to avoid use of z.lazy(...),
 // use of which allows for type mistakes to make it past linting.
@@ -1385,6 +1396,7 @@ const RawSqlChartConfigSchema = RawSqlBaseChartConfigSchema.extend({
   bodyExpression: z.string().optional(),
   useTextIndexForImplicitColumn: UseTextIndexSchema.optional(),
   metricTables: MetricTableSchema.optional(),
+  variables: z.array(ChartVariableSchema).optional(),
 });
 
 export type RawSqlChartConfig = z.infer<typeof RawSqlChartConfigSchema>;
@@ -1600,7 +1612,10 @@ export type DashboardContainer = z.infer<typeof DashboardContainerSchema>;
 export const DashboardFilterType = z.enum(['QUERY_EXPRESSION']);
 
 /** Allowed variable names for dashboard filters. Alphanumeric + underscore, must start with a letter. */
-export const DASHBOARD_VARIABLE_NAME_REGEX = /^[a-zA-Z][A-Za-z0-9_]*$/;
+export const DASHBOARD_VARIABLE_NAME_PATTERN = '[a-zA-Z][a-zA-Z0-9_]*';
+export const DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED = new RegExp(
+  `^${DASHBOARD_VARIABLE_NAME_PATTERN}$`,
+);
 export const DASHBOARD_VARIABLE_NAME_MAX_LENGTH = 64;
 
 export const DashboardFilterSchema = z.object({
@@ -1636,7 +1651,7 @@ export const DashboardFilterSchema = z.object({
   variableName: z
     .string()
     .max(DASHBOARD_VARIABLE_NAME_MAX_LENGTH)
-    .regex(DASHBOARD_VARIABLE_NAME_REGEX)
+    .regex(DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED)
     .optional(),
 });
 

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -1,0 +1,462 @@
+import {
+  escapeSqlString,
+  isQuoteEscapedByBackslash,
+  splitAndTrimWithBracket,
+} from './core/utils';
+import {
+  ChartConfigWithOptDateRange,
+  ChartVariable,
+  DASHBOARD_VARIABLE_NAME_PATTERN,
+  DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED,
+  SavedChartConfig,
+} from './types';
+
+/** Rendering formats a reference can request via `${name:format}`. */
+export const VARIABLE_FORMATS = [
+  'sqlstring',
+  'regex',
+  'csv',
+  'lucene',
+] as const;
+
+export type VariableFormat = (typeof VARIABLE_FORMATS)[number];
+
+const isVariableFormat = (format: string): format is VariableFormat =>
+  (VARIABLE_FORMATS as readonly string[]).includes(format);
+
+const escapeRegexValue = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const escapeLuceneValue = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Render a variable's selected values in the requested format. Every format
+ * has an "empty selection" rendering that keeps the surrounding query valid.
+ */
+export function formatVariableValues(
+  values: string[],
+  format: VariableFormat,
+): string {
+  switch (format) {
+    case 'sqlstring':
+      return values.length === 0
+        ? 'NULL'
+        : values.map(value => `'${escapeSqlString(value)}'`).join(', ');
+    case 'regex': {
+      if (values.length === 0) return '.*';
+      const escaped = values.map(escapeRegexValue);
+      return escaped.length === 1 ? escaped[0] : `(${escaped.join('|')})`;
+    }
+    case 'csv':
+      return values.join(',');
+    case 'lucene':
+      return values.length === 0
+        ? '*'
+        : `(${values.map(value => `"${escapeLuceneValue(value)}"`).join(' OR ')})`;
+    default:
+      format satisfies never; // Unreachable
+      throw new Error(`Unknown variable format '${format}'`);
+  }
+}
+
+// -- Template lexer ---------------------------------------------------------
+
+export type TemplateToken =
+  | { kind: 'text'; text: string }
+  | { kind: 'macro'; name: string; args: string[] }
+  | { kind: 'braced'; name: string; format?: string; raw: string }
+  | { kind: 'bare'; name: string; raw: string };
+
+/** Macros whose expansion depends on a variable's selected values. */
+export const VARIABLE_MACRO_NAMES = ['filter', 'conditionalAll'] as const;
+
+export type VariableMacroName = (typeof VARIABLE_MACRO_NAMES)[number];
+
+const isVariableMacroName = (name: string): name is VariableMacroName =>
+  (VARIABLE_MACRO_NAMES as readonly string[]).includes(name);
+
+// Pattern used for recognizing $var references.
+// eslint-disable-next-line security/detect-non-literal-regexp
+const BARE_NAME_REGEX = new RegExp(`^${DASHBOARD_VARIABLE_NAME_PATTERN}`);
+
+// Pattern used for recognizing ${var} and ${var:format} references, and for extracting the name and format.
+// eslint-disable-next-line security/detect-non-literal-regexp
+const BRACED_REFERENCE_REGEX = new RegExp(
+  `^(${DASHBOARD_VARIABLE_NAME_PATTERN})(?::([a-zA-Z][a-zA-Z0-9_]*))?$`,
+);
+
+const isWordChar = (char: string | undefined) =>
+  char !== undefined && /[A-Za-z0-9_]/.test(char);
+
+/**
+ * Index of the `)` closing the `(` at `start`, or -1 when it is unclosed.
+ *
+ * Quote-aware: parens inside single- or double-quoted strings don't count, so
+ * `$__conditionalAll(col = 'a)b', name)` terminates where it should.
+ */
+export function findBalancedParens(input: string, start: number): number {
+  let depth = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let i = start; i < input.length; i++) {
+    const c = input.charAt(i);
+
+    if (c === '"' && !inSingleQuote && !isQuoteEscapedByBackslash(input, i)) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+    if (c === "'" && !inDoubleQuote && !isQuoteEscapedByBackslash(input, i)) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+    if (inSingleQuote || inDoubleQuote) continue;
+
+    if (c === '(') {
+      depth++;
+    } else if (c === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Split a template into text and macro/variable token spans in a single left-to-right pass.
+ *
+ * At each `$` the scanner tries, in order:
+ * 1. a known `$__<name>` macro (longest match, requiring a non-word char after the name so `$__filter` never matches the prefix of `$__filters`),
+ * 2. a `${name}` / `${name:format}` reference, then a
+ * 3. bare `$name` reference (maximal munch). Anything else is plain text, and an unknown `$__x` is emitted verbatim.
+ *
+ * `onMalformed` controls what happens when a macro's argument list has no
+ * closing paren: `throw` (substitution — the query is broken and the user
+ * needs to know) or `skip` (detection — must not crash on malformed saved SQL).
+ */
+export function scanTemplateTokens(
+  input: string,
+  macroNames: readonly string[],
+  { onMalformed = 'throw' }: { onMalformed?: 'throw' | 'skip' } = {},
+): TemplateToken[] {
+  // Longest name first so `$__filters` isn't matched as `$__filter` + `s`, etc.
+  const sortedMacroNames = [...macroNames].sort((a, b) => b.length - a.length);
+
+  const tokens: TemplateToken[] = [];
+  let text = '';
+  const flushText = () => {
+    if (text.length > 0) {
+      tokens.push({ kind: 'text', text });
+      text = '';
+    }
+  };
+
+  let i = 0;
+  while (i < input.length) {
+    if (input.charAt(i) !== '$') {
+      text += input.charAt(i);
+      i++;
+      continue;
+    }
+
+    // Attempt to match a known macro, with or without an argument list
+    if (input.startsWith('$__', i)) {
+      const nameStart = i + 3;
+      const name = sortedMacroNames.find(
+        macroName =>
+          input.startsWith(macroName, nameStart) &&
+          !isWordChar(input.charAt(nameStart + macroName.length) || undefined),
+      );
+
+      // Unknown macro — emit verbatim and keep scanning after the prefix.
+      if (name == null) {
+        text += '$__';
+        i = nameStart;
+        continue;
+      }
+
+      const argsStart = nameStart + name.length;
+      if (input.charAt(argsStart) !== '(') {
+        flushText();
+        tokens.push({ kind: 'macro', name, args: [] });
+        i = argsStart;
+        continue;
+      }
+
+      const closeIndex = findBalancedParens(input, argsStart);
+      if (closeIndex < 0) {
+        if (onMalformed === 'throw') {
+          throw new Error('Failed to parse macro arguments');
+        }
+        text += input.slice(i, argsStart);
+        i = argsStart;
+        continue;
+      }
+
+      flushText();
+      tokens.push({
+        kind: 'macro',
+        name,
+        args: splitAndTrimWithBracket(input.slice(argsStart + 1, closeIndex)),
+      });
+      i = closeIndex + 1;
+      continue;
+    }
+
+    // Attempt to match a braced `${var}` or `${var:format}` reference
+    if (input.charAt(i + 1) === '{') {
+      const closeIndex = input.indexOf('}', i + 2); // no escaping because variable names can't contain `}` or `\`
+      const match =
+        closeIndex > 0
+          ? input.slice(i + 2, closeIndex).match(BRACED_REFERENCE_REGEX)
+          : null;
+      if (match) {
+        flushText();
+        tokens.push({
+          kind: 'braced',
+          name: match[1],
+          format: match[2],
+          raw: input.slice(i, closeIndex + 1),
+        });
+        i = closeIndex + 1;
+        continue;
+      }
+      text += '$';
+      i++;
+      continue;
+    }
+
+    const bareMatch = input.slice(i + 1).match(BARE_NAME_REGEX);
+    if (bareMatch) {
+      flushText();
+      tokens.push({
+        kind: 'bare',
+        name: bareMatch[0],
+        raw: `$${bareMatch[0]}`,
+      });
+      i += 1 + bareMatch[0].length;
+      continue;
+    }
+
+    text += '$';
+    i++;
+  }
+
+  flushText();
+  return tokens;
+}
+
+// -- Variable expansion -----------------------------------------------------
+
+export type VariableContext = {
+  variables: ChartVariable[];
+  /** Format used by references that don't request one. */
+  defaultFormat: VariableFormat;
+};
+
+const sqlNoOp = (name: string) =>
+  `(1=1 /** no values selected for variable '${name}' */)`;
+
+/** Read the variable name out of a macro argument - either `name` or `$name` */
+function parseVariableNameArg(arg: string): string {
+  const trimmed = arg.trim();
+  return trimmed.startsWith('$') ? trimmed.slice(1) : trimmed;
+}
+
+/** Require that a variable with the given name exists in the context. Throws an error if not found. */
+function requireVariable(
+  ctx: VariableContext,
+  macroName: string,
+  variableName: string,
+): ChartVariable {
+  const variable = ctx.variables.find(v => v.name === variableName);
+  if (!variable) {
+    throw new Error(
+      `Macro '$__${macroName}' references unknown variable '${variableName}'. ` +
+        `Available variables: ${
+          ctx.variables.length > 0
+            ? ctx.variables.map(v => v.name).join(', ')
+            : '(none)'
+        }.`,
+    );
+  }
+  return variable;
+}
+
+function expandFilterMacro(args: string[], ctx: VariableContext): string {
+  if (args.length < 1 || args.length > 2) {
+    throw new Error(
+      `Macro 'filter' expects 1-2 argument(s), but got ${args.length}`,
+    );
+  }
+
+  const variableName = parseVariableNameArg(args[args.length - 1]);
+  const variable = requireVariable(ctx, 'filter', variableName);
+
+  // Resolve the filtered expression before the empty-selection shortcut so a
+  // structurally invalid usage reports regardless of what's selected.
+  let expression: string;
+  if (args.length === 2) {
+    expression = substituteWithContext(args[0], ctx);
+  } else {
+    if (!variable.expression) {
+      throw new Error(
+        `Macro '$__filter(${variableName})' requires the variable's filter expression, ` +
+          `which is not available — pass it explicitly, e.g. $__filter(<expression>, ${variableName}).`,
+      );
+    }
+    // Wrap in toString() to match how the broadcast path renders the same
+    // filter, so both forms produce identical SQL for identical selections.
+    expression = `toString(${variable.expression})`;
+  }
+
+  if (variable.values.length === 0) return sqlNoOp(variableName);
+
+  return `(${expression} IN (${formatVariableValues(variable.values, 'sqlstring')}))`;
+}
+
+function expandConditionalAllMacro(
+  args: string[],
+  ctx: VariableContext,
+): string {
+  if (args.length !== 2) {
+    throw new Error(
+      `Macro 'conditionalAll' expects 2 argument(s), but got ${args.length}`,
+    );
+  }
+
+  const variableName = parseVariableNameArg(args[1]);
+  const variable = requireVariable(ctx, 'conditionalAll', variableName);
+
+  if (variable.values.length === 0) return sqlNoOp(variableName);
+
+  return `(${substituteWithContext(args[0], ctx)})`;
+}
+
+/**
+ * Expand one non-text token against a variable context.
+ *
+ * Unknown *reference* names are emitted verbatim (a SQL literal that happens
+ * to look like `$foo` must survive untouched), while a macro naming an unknown
+ * variable is an error — it can't produce meaningful SQL either way.
+ */
+export function expandVariableToken(
+  token: Exclude<TemplateToken, { kind: 'text' }>,
+  ctx: VariableContext,
+): string {
+  if (token.kind === 'macro') {
+    return token.name === 'filter'
+      ? expandFilterMacro(token.args, ctx)
+      : expandConditionalAllMacro(token.args, ctx);
+  }
+
+  const variable = ctx.variables.find(v => v.name === token.name);
+  if (!variable) return token.raw;
+
+  const requestedFormat = token.kind === 'braced' ? token.format : undefined;
+  if (requestedFormat != null && !isVariableFormat(requestedFormat)) {
+    throw new Error(
+      `Unknown variable format '${requestedFormat}' in '${token.raw}'. ` +
+        `Expected one of: ${VARIABLE_FORMATS.join(', ')}.`,
+    );
+  }
+
+  return formatVariableValues(
+    variable.values,
+    requestedFormat ?? ctx.defaultFormat,
+  );
+}
+
+function substituteWithContext(input: string, ctx: VariableContext): string {
+  return scanTemplateTokens(input, VARIABLE_MACRO_NAMES)
+    .map(token =>
+      token.kind === 'text' ? token.text : expandVariableToken(token, ctx),
+    )
+    .join('');
+}
+
+/**
+ * Expand variable references and the variable macros in a template fragment.
+ *
+ * Standard macros (`$__timeFilter` and friends) are *not* known here, so they
+ * pass through as text — raw SQL goes through `replaceMacros`, which scans for
+ * both sets in one pass. This entry point is for the surfaces that only carry
+ * variables (chart-builder where/having, PromQL expressions).
+ */
+export function substituteVariables(
+  input: string,
+  variables: ChartVariable[],
+  { defaultFormat = 'sqlstring' }: { defaultFormat?: VariableFormat } = {},
+): string {
+  return substituteWithContext(input, { variables, defaultFormat });
+}
+
+/**
+ * Returns the names of every variable the template could reference.
+ * Never throws: it runs over saved SQL that may be mid-edit or malformed.
+ */
+export function getReferencedVariableNames(input: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (name: string) => {
+    if (!DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED.test(name) || seen.has(name))
+      return;
+    seen.add(name);
+    names.push(name);
+  };
+
+  const visit = (text: string) => {
+    for (const token of scanTemplateTokens(text, VARIABLE_MACRO_NAMES, {
+      onMalformed: 'skip',
+    })) {
+      if (token.kind === 'text') continue;
+      if (token.kind !== 'macro') {
+        add(token.name);
+        continue;
+      }
+
+      if (!isVariableMacroName(token.name)) continue;
+      switch (token.name) {
+        case 'filter': {
+          // $__filter(name) | $__filter(expression, name)
+          const [first, second] = token.args;
+          if (second != null) {
+            add(parseVariableNameArg(second));
+            visit(first);
+          } else if (first != null) {
+            add(parseVariableNameArg(first));
+          }
+          break;
+        }
+        case 'conditionalAll': {
+          // $__conditionalAll(expression, name)
+          const [expression, name] = token.args;
+          if (name != null) add(parseVariableNameArg(name));
+          if (expression != null) visit(expression);
+          break;
+        }
+        default:
+          token.name satisfies never;
+      }
+    }
+  };
+
+  visit(input);
+  return names;
+}
+
+/** Returns the subset of `variables` that `config` actually references. */
+export function filterReferencedVariables(
+  config: ChartConfigWithOptDateRange | SavedChartConfig,
+  variables: ChartVariable[],
+): ChartVariable[] {
+  // Only Raw SQL configs can reference variables today.
+  if (!('configType' in config) || config.configType !== 'sql') {
+    return [];
+  }
+  const referenced = new Set(getReferencedVariableNames(config.sqlTemplate));
+  return variables.filter(variable => referenced.has(variable.name));
+}

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -82,11 +82,12 @@ export type VariableMacroName = (typeof VARIABLE_MACRO_NAMES)[number];
 const isVariableMacroName = (name: string): name is VariableMacroName =>
   (VARIABLE_MACRO_NAMES as readonly string[]).includes(name);
 
-// Pattern used for recognizing $var references.
+// Pattern used for recognizing $var references. (eslint ignored because DASHBOARD_VARIABLE_NAME_PATTERN is a shared constant, not user input)
 // eslint-disable-next-line security/detect-non-literal-regexp
 const BARE_NAME_REGEX = new RegExp(`^${DASHBOARD_VARIABLE_NAME_PATTERN}`);
 
 // Pattern used for recognizing ${var} and ${var:format} references, and for extracting the name and format.
+// (eslint ignored because DASHBOARD_VARIABLE_NAME_PATTERN is a shared constant, not user input)
 // eslint-disable-next-line security/detect-non-literal-regexp
 const BRACED_REFERENCE_REGEX = new RegExp(
   `^(${DASHBOARD_VARIABLE_NAME_PATTERN})(?::([a-zA-Z][a-zA-Z0-9_]*))?$`,

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -64,9 +64,15 @@ export function formatVariableValues(
 
 export type TemplateToken =
   | { kind: 'text'; text: string }
-  | { kind: 'macro'; name: string; args: string[] }
-  | { kind: 'braced'; name: string; format?: string; raw: string }
-  | { kind: 'bare'; name: string; raw: string };
+  | { kind: 'macro'; name: string; args: string[]; inStringLiteral: boolean }
+  | {
+      kind: 'braced';
+      name: string;
+      format?: string;
+      raw: string;
+      inStringLiteral: boolean;
+    }
+  | { kind: 'bare'; name: string; raw: string; inStringLiteral: boolean };
 
 /** Macros whose expansion depends on a variable's selected values. */
 export const VARIABLE_MACRO_NAMES = ['filter', 'conditionalAll'] as const;
@@ -85,6 +91,30 @@ const BARE_NAME_REGEX = new RegExp(`^${DASHBOARD_VARIABLE_NAME_PATTERN}`);
 const BRACED_REFERENCE_REGEX = new RegExp(
   `^(${DASHBOARD_VARIABLE_NAME_PATTERN})(?::([a-zA-Z][a-zA-Z0-9_]*))?$`,
 );
+
+/**
+ * ClickHouse's line comment introducers, per the `lineCommentTypes` of the
+ * tokenizer this repo already formats and highlights with (`sql-formatter`'s
+ * clickhouse dialect).
+ */
+const LINE_COMMENT_STARTS = ['--', '#'] as const;
+
+/**
+ * Index just past the SQL comment starting at `start`, or `start` when no
+ * comment starts there. Callers must check they are outside a string first,
+ * since `'a -- b'` is a string, not a comment.
+ */
+export function findCommentEnd(input: string, start: number): number {
+  if (LINE_COMMENT_STARTS.some(marker => input.startsWith(marker, start))) {
+    const newline = input.indexOf('\n', start);
+    return newline < 0 ? input.length : newline;
+  }
+  if (input.startsWith('/*', start)) {
+    const close = input.indexOf('*/', start + 2);
+    return close < 0 ? input.length : close + 2;
+  }
+  return start;
+}
 
 const isWordChar = (char: string | undefined) =>
   char !== undefined && /[A-Za-z0-9_]/.test(char);
@@ -153,13 +183,40 @@ export function scanTemplateTokens(
     }
   };
 
+  // Quote state at the current position, so tokens can record whether they sit
+  // inside a string literal.
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
   let i = 0;
   while (i < input.length) {
+    // Consume any comments starting at this position
+    if (!inSingleQuote && !inDoubleQuote) {
+      const commentEnd = findCommentEnd(input, i);
+      if (commentEnd > i) {
+        text += input.slice(i, commentEnd);
+        i = commentEnd;
+        continue;
+      }
+    }
+
     if (input.charAt(i) !== '$') {
-      text += input.charAt(i);
+      const c = input.charAt(i);
+      if (c === '"' && !inSingleQuote && !isQuoteEscapedByBackslash(input, i)) {
+        inDoubleQuote = !inDoubleQuote;
+      } else if (
+        c === "'" &&
+        !inDoubleQuote &&
+        !isQuoteEscapedByBackslash(input, i)
+      ) {
+        inSingleQuote = !inSingleQuote;
+      }
+      text += c;
       i++;
       continue;
     }
+
+    const inStringLiteral = inSingleQuote || inDoubleQuote;
 
     // Attempt to match a known macro, with or without an argument list
     if (input.startsWith('$__', i)) {
@@ -180,7 +237,7 @@ export function scanTemplateTokens(
       const argsStart = nameStart + name.length;
       if (input.charAt(argsStart) !== '(') {
         flushText();
-        tokens.push({ kind: 'macro', name, args: [] });
+        tokens.push({ kind: 'macro', name, args: [], inStringLiteral });
         i = argsStart;
         continue;
       }
@@ -200,6 +257,7 @@ export function scanTemplateTokens(
         kind: 'macro',
         name,
         args: splitAndTrimWithBracket(input.slice(argsStart + 1, closeIndex)),
+        inStringLiteral,
       });
       i = closeIndex + 1;
       continue;
@@ -219,6 +277,7 @@ export function scanTemplateTokens(
           name: match[1],
           format: match[2],
           raw: input.slice(i, closeIndex + 1),
+          inStringLiteral,
         });
         i = closeIndex + 1;
         continue;
@@ -235,6 +294,7 @@ export function scanTemplateTokens(
         kind: 'bare',
         name: bareMatch[0],
         raw: `$${bareMatch[0]}`,
+        inStringLiteral,
       });
       i += 1 + bareMatch[0].length;
       continue;
@@ -268,7 +328,7 @@ function parseVariableNameArg(arg: string): string {
 /** Require that a variable with the given name exists in the context. Throws an error if not found. */
 function requireVariable(
   ctx: VariableContext,
-  macroName: string,
+  macroName: VariableMacroName,
   variableName: string,
 ): ChartVariable {
   const variable = ctx.variables.find(v => v.name === variableName);
@@ -393,28 +453,67 @@ export function substituteVariables(
   return substituteWithContext(input, { variables, defaultFormat });
 }
 
-/**
- * Returns the names of every variable the template could reference.
- * Never throws: it runs over saved SQL that may be mid-edit or malformed.
- */
-export function getReferencedVariableNames(input: string): string[] {
-  const names: string[] = [];
-  const seen = new Set<string>();
+/** One occurrence of a variable reference in a template. */
+export type VariableReference = {
+  name: string;
+  /** `macro` covers `$__filter`/`$__conditionalAll`; the rest are value references. */
+  kind: 'macro' | 'bare' | 'braced';
+  /** The requested format, only ever set for `${name:format}`. */
+  format?: string;
+  /** Whether the reference sits inside a single- or double-quoted string. */
+  inStringLiteral: boolean;
+  /**
+   * The variable whose selection gates whether this reference is emitted at
+   * all, set when the reference sits in a variable macro's expression argument.
+   */
+  guardedBy?: string;
+  /** The reference as written, for use in user-facing messages. */
+  raw: string;
+};
 
-  const add = (name: string) => {
-    if (!DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED.test(name) || seen.has(name))
-      return;
-    seen.add(name);
-    names.push(name);
+/**
+ * Every variable reference in a template, in source order, including repeats.
+ * Never throws: it runs over saved SQL that may be mid-edit or malformed.
+ *
+ * Names that aren't token-safe are dropped — a macro argument like
+ * `$__filter(x, ${svc})` can't name a variable, and expansion reports it.
+ */
+export function getVariableReferences(input: string): VariableReference[] {
+  const references: VariableReference[] = [];
+
+  /** Returns the referenced name, or undefined when the argument isn't one. */
+  const addMacroRef = (
+    macroName: VariableMacroName,
+    arg: string,
+    inStringLiteral: boolean,
+    guardedBy: string | undefined,
+  ): string | undefined => {
+    const name = parseVariableNameArg(arg);
+    if (!DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED.test(name)) return undefined;
+    references.push({
+      name,
+      kind: 'macro',
+      inStringLiteral,
+      guardedBy,
+      raw: `$__${macroName}`,
+    });
+    return name;
   };
 
-  const visit = (text: string) => {
+  const visit = (text: string, guardedBy?: string) => {
     for (const token of scanTemplateTokens(text, VARIABLE_MACRO_NAMES, {
       onMalformed: 'skip',
     })) {
       if (token.kind === 'text') continue;
       if (token.kind !== 'macro') {
-        add(token.name);
+        references.push({
+          name: token.name,
+          kind: token.kind,
+          format: token.kind === 'braced' ? token.format : undefined,
+          inStringLiteral: token.inStringLiteral,
+          guardedBy,
+          raw: token.raw,
+        });
         continue;
       }
 
@@ -424,18 +523,31 @@ export function getReferencedVariableNames(input: string): string[] {
           // $__filter(name) | $__filter(expression, name)
           const [first, second] = token.args;
           if (second != null) {
-            add(parseVariableNameArg(second));
-            visit(first);
+            const name = addMacroRef(
+              'filter',
+              second,
+              token.inStringLiteral,
+              guardedBy,
+            );
+            visit(first, name ?? guardedBy);
           } else if (first != null) {
-            add(parseVariableNameArg(first));
+            addMacroRef('filter', first, token.inStringLiteral, guardedBy);
           }
           break;
         }
         case 'conditionalAll': {
           // $__conditionalAll(expression, name)
           const [expression, name] = token.args;
-          if (name != null) add(parseVariableNameArg(name));
-          if (expression != null) visit(expression);
+          const guard =
+            name != null
+              ? addMacroRef(
+                  'conditionalAll',
+                  name,
+                  token.inStringLiteral,
+                  guardedBy,
+                )
+              : undefined;
+          if (expression != null) visit(expression, guard ?? guardedBy);
           break;
         }
         default:
@@ -445,7 +557,25 @@ export function getReferencedVariableNames(input: string): string[] {
   };
 
   visit(input);
-  return names;
+  return references;
+}
+
+/**
+ * Returns the names of every variable the template could reference.
+ * Never throws: it runs over saved SQL that may be mid-edit or malformed.
+ */
+export function getReferencedVariableNames(input: string): string[] {
+  const names = new Set<string>(
+    getVariableReferences(input).map(ref => ref.name),
+  );
+  return Array.from(names);
+}
+
+/** Whether the template uses `$__filter` or `$__conditionalAll` at all. */
+export function hasVariableMacro(input: string): boolean {
+  return scanTemplateTokens(input, VARIABLE_MACRO_NAMES, {
+    onMalformed: 'skip',
+  }).some(token => token.kind === 'macro');
 }
 
 /** Returns the subset of `variables` that `config` actually references. */

--- a/scripts/ci/__tests__/ratchet.test.mjs
+++ b/scripts/ci/__tests__/ratchet.test.mjs
@@ -64,6 +64,9 @@ test('skips node_modules and build output', () => {
       'src/a.ts': 'const x = y as any;',
       'node_modules/dep/index.ts': 'const a = b as any;',
       'dist/bundle.ts': 'const a = b as any;',
+      // `NEXT_DIST_DIR` renames this, so it is matched by prefix.
+      '.next/dev/types/validator.ts': 'const a = b as any;',
+      '.next-e2e/dev/types/validator.ts': 'const a = b as any;',
     },
   });
   assert.equal(collectCounts(root).app['as-any'], 1);

--- a/scripts/ci/ratchet-baseline.json
+++ b/scripts/ci/ratchet-baseline.json
@@ -17,7 +17,7 @@
   "common-utils": {
     "as-any": 116,
     "ts-ignore": 5,
-    "eslint-disable": 37
+    "eslint-disable": 39
   },
   "hdx-eval": {
     "as-any": 0,

--- a/scripts/ci/ratchet.mjs
+++ b/scripts/ci/ratchet.mjs
@@ -25,11 +25,19 @@ const SKIP_DIRS = new Set([
   'dist',
   'build',
   'coverage',
-  '.next',
   '.nx',
   '.turbo',
+  // .next* is skipped by prefix below
 ]);
 const EXTS = new Set(['.ts', '.tsx']);
+
+/**
+ * `.next` by prefix, not exact name: `NEXT_DIST_DIR` moves the build output
+ * (E2E runs use `.next-e2e`).
+ */
+function isSkippedDir(name) {
+  return SKIP_DIRS.has(name) || name.startsWith('.next');
+}
 
 /**
  * Workspace package directories, keyed by directory name. Derived from the
@@ -73,7 +81,7 @@ function countDir(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
+      if (isSkippedDir(entry.name)) continue;
       const sub = countDir(full);
       for (const name of Object.keys(counts)) counts[name] += sub[name];
     } else if (entry.isFile() && EXTS.has(path.extname(entry.name))) {


### PR DESCRIPTION
## Summary

This PR introduces variable substitution for Raw SQL Charts, on top of the existing macro system. Variable configuration was introduced in #2836.

This is **part 1 of 2** and introduces the core functionality, while #2874 introduces a nicer UX with Autocomplete and variable-related validations in the SQL editor.

Note that the configuration of variables is gated behind `NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true` and  behavior is intended to remain the same when no variables have been configured.

### Supported Variable Formats

<img width="708" height="444" alt="Screenshot 2026-08-12 at 7 52 17 AM" src="https://github.com/user-attachments/assets/53308d57-426d-4cf0-987c-80d7db29174e" />

### Screenshots or video

<details>
<summary>Some Examples</summary>

<img width="991" height="1010" alt="Screenshot 2026-08-12 at 8 30 42 AM" src="https://github.com/user-attachments/assets/b223b750-1b30-43d7-8b44-d885913152f4" />
<img width="614" height="1086" alt="Screenshot 2026-08-12 at 8 33 20 AM" src="https://github.com/user-attachments/assets/d38a10c3-48a6-4fe0-a883-2afce9af3935" />
<img width="732" height="1066" alt="Screenshot 2026-08-12 at 8 33 04 AM" src="https://github.com/user-attachments/assets/b4254fe3-389d-4e54-bccc-93fa4c11358c" />
<img width="967" height="1060" alt="Screenshot 2026-08-12 at 8 32 44 AM" src="https://github.com/user-attachments/assets/64b3a7f0-754e-45c4-8894-b922baf75215" />
<img width="292" height="750" alt="Screenshot 2026-08-12 at 8 31 34 AM" src="https://github.com/user-attachments/assets/57dbdac2-6b8b-4800-9f7d-ca29eeab42d3" />
<img width="369" height="1016" alt="Screenshot 2026-08-12 at 8 31 14 AM" src="https://github.com/user-attachments/assets/a8b81f0b-e873-4d2e-9b94-bb6f3a29204a" />
<img width="445" height="997" alt="Screenshot 2026-08-12 at 8 31 00 AM" src="https://github.com/user-attachments/assets/2747e280-678a-4e08-8f8b-076faf441631" />

</details>

## Future work

Future work includes, but is not limited to:

1. Autocomplete and validation (#2874)
2. Updating the alerts runner to supply a variables context based on the variables configured on the dashboard
3. Extending support to builder charts
4. Supporting dependent variables
5. MCP and external API support
6. Documentation

## How to test locally

1. Clone and restart to ensure `NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true`
7. Create a dashboard
8. Add a filter and enable variable mode
9. Add a SQL tile and test the functionality for each of the formats

## References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5050
- Related PRs:
