### PR TITLE
feat: Autocomplete and validations for SQL Dashboard Variables

### DIFF
--- a/.changeset/dashboard-variable-editor-validation.md
+++ b/.changeset/dashboard-variable-editor-validation.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/common-utils': patch
+---
+
+feat: Improve SQL Editor validations and autocomplete for variables

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -43,6 +43,7 @@ import {
   dashboardHasUnexportableTiles,
   isImportableDashboard,
 } from '@hyperdx/common-utils/dist/iac';
+import { isMissingFiltersMacro } from '@hyperdx/common-utils/dist/macros';
 import {
   AlertState,
   BuilderChartConfigWithDateRange,
@@ -698,20 +699,21 @@ const Tile = forwardRef(
         return null;
 
       const isMissingSourceForFiltering = !queriedConfig.source;
-      const isMissingFiltersMacro =
-        !queriedConfig.sqlTemplate.includes('$__filters');
+      const missingFiltersMacro = isMissingFiltersMacro(
+        queriedConfig.sqlTemplate,
+      );
       const isMetricsSourceWithLuceneFilter =
         source?.kind === SourceKind.Metric && doLuceneFiltersExist;
 
       if (
         !isMissingSourceForFiltering &&
-        !isMissingFiltersMacro &&
+        !missingFiltersMacro &&
         !isMetricsSourceWithLuceneFilter
       )
         return null;
 
-      const message = isMissingFiltersMacro
-        ? 'Filters are not applied because the SQL does not include the required $__filters macro'
+      const message = missingFiltersMacro
+        ? 'Filters may not be applied correctly because the SQL does not include the recommended $__filters macro'
         : isMetricsSourceWithLuceneFilter
           ? 'Lucene filters are not applied because they are not supported for metrics sources.'
           : 'Filters are not applied because no Source is set for this chart';

--- a/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
@@ -9,9 +9,10 @@ import {
   validateRawSqlChartConfig,
   validateRawSqlForAlert,
 } from '@hyperdx/common-utils/dist/core/utils';
-import { MACRO_SUGGESTIONS } from '@hyperdx/common-utils/dist/macros';
-import { QUERY_PARAMS_BY_DISPLAY_TYPE } from '@hyperdx/common-utils/dist/rawSqlParams';
-import { RawSqlChartConfig } from '@hyperdx/common-utils/dist/types';
+import {
+  ChartVariable,
+  RawSqlChartConfig,
+} from '@hyperdx/common-utils/dist/types';
 import {
   DisplayType,
   isLogSource,
@@ -49,6 +50,7 @@ import { DEFAULT_TILE_ALERT } from '@/utils/alerts';
 import { SQL_PLACEHOLDERS } from './constants';
 import { RawSqlChartInstructions } from './RawSqlChartInstructions';
 import { ChartEditorFormState } from './types';
+import { buildRawSqlCompletions } from './utils';
 
 import resizeStyles from '@/../styles/ResizablePanel.module.scss';
 
@@ -117,6 +119,7 @@ export default function RawSqlChartEditor({
   isDashboardForm,
   alert,
   dashboardId,
+  variables,
 }: {
   control: Control<ChartEditorFormState>;
   setValue: UseFormSetValue<ChartEditorFormState>;
@@ -125,6 +128,7 @@ export default function RawSqlChartEditor({
   isDashboardForm: boolean;
   alert: ChartEditorFormState['alert'];
   dashboardId?: string;
+  variables?: ChartVariable[];
 }) {
   const { size, startResize } = useResizable(20, 'bottom');
 
@@ -148,8 +152,9 @@ export default function RawSqlChartEditor({
             ? sourceObject.metricTables
             : undefined,
         displayType,
+        variables,
       }) satisfies RawSqlChartConfig,
-    [sqlTemplate, connection, sourceObject, displayType],
+    [sqlTemplate, connection, sourceObject, displayType, variables],
   );
 
   const [debouncedRawSqlConfig] = useDebouncedValue(rawSqlConfig, 300);
@@ -196,28 +201,10 @@ export default function RawSqlChartEditor({
 
   const placeholderSQl = SQL_PLACEHOLDERS[displayType ?? DisplayType.Table];
 
-  const additionalCompletions: SQLCompletion[] = useMemo(() => {
-    const effectiveDisplayType = displayType ?? DisplayType.Table;
-    const params = QUERY_PARAMS_BY_DISPLAY_TYPE[effectiveDisplayType];
-
-    const paramCompletions: SQLCompletion[] = params.map(({ name, type }) => ({
-      label: `{${name}:${type}}`,
-      apply: `{${name}:${type}`, // Omit the closing } because the editor will have added it when the user types {
-      detail: 'param',
-      type: 'variable',
-    }));
-
-    const macroCompletions: SQLCompletion[] = MACRO_SUGGESTIONS.map(
-      ({ name, minArgs }) => ({
-        label: `$__${name}`,
-        apply: minArgs > 0 ? `$__${name}(` : `$__${name}`,
-        detail: 'macro',
-        type: 'function',
-      }),
-    );
-
-    return [...paramCompletions, ...macroCompletions];
-  }, [displayType]);
+  const additionalCompletions: SQLCompletion[] = useMemo(
+    () => buildRawSqlCompletions({ displayType, variables }),
+    [displayType, variables],
+  );
 
   const [isSourceSchemaPreviewOpen, setIsSourceSchemaPreviewOpen] =
     useState(false);
@@ -332,7 +319,10 @@ export default function RawSqlChartEditor({
           </Group>
         </Group>
       </Group>
-      <RawSqlChartInstructions displayType={displayType ?? DisplayType.Table} />
+      <RawSqlChartInstructions
+        displayType={displayType ?? DisplayType.Table}
+        variables={variables}
+      />
       <Box style={{ position: 'relative' }}>
         <SQLEditorControlled
           control={control}
@@ -347,7 +337,11 @@ export default function RawSqlChartEditor({
         <div className={resizeStyles.resizeYHandle} onMouseDown={startResize} />
       </Box>
       {(chartErrors.length > 0 || chartWarnings.length > 0) && (
-        <Alert variant={sqlValidationAlertVariant} py="xs">
+        <Alert
+          variant={sqlValidationAlertVariant}
+          py="xs"
+          data-testid="raw-sql-validation"
+        >
           <List size="xs" spacing={2}>
             {chartErrors.map(message => (
               <List.Item key={message}>Error: {message}</List.Item>

--- a/packages/app/src/components/ChartEditor/RawSqlChartInstructions.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartInstructions.tsx
@@ -1,16 +1,12 @@
 import { atom, useAtom } from 'jotai';
-import {
-  QUERY_PARAM_EXAMPLES,
-  QUERY_PARAMS_BY_DISPLAY_TYPE,
-} from '@hyperdx/common-utils/dist/rawSqlParams';
-import { DisplayType } from '@hyperdx/common-utils/dist/types';
+import { QUERY_PARAM_EXAMPLES } from '@hyperdx/common-utils/dist/rawSqlParams';
+import { ChartVariable, DisplayType } from '@hyperdx/common-utils/dist/types';
 import {
   ActionIcon,
   Anchor,
   Code,
   Collapse,
   Group,
-  List,
   Paper,
   Stack,
   Text,
@@ -25,46 +21,19 @@ import {
 } from '@tabler/icons-react';
 
 import { DISPLAY_TYPE_INSTRUCTIONS } from './constants';
+import { RawSqlVariableInstructions } from './RawSqlVariableInstructions';
 
 const helpOpenedAtom = atom(true);
 
-function ParamSnippet({
-  value,
-  description,
-}: {
-  value: string;
-  description: string;
-}) {
-  const clipboard = useClipboard({ timeout: 1500 });
-
-  return (
-    <Group gap={4} display="inline-flex">
-      <Code fz="xs">{value}</Code>
-      <Tooltip label={clipboard.copied ? 'Copied!' : 'Copy'} withArrow>
-        <ActionIcon
-          variant="subtle"
-          size="xs"
-          color={clipboard.copied ? 'green' : 'gray'}
-          onClick={() => clipboard.copy(value)}
-        >
-          {clipboard.copied ? <IconCheck size={10} /> : <IconCopy size={10} />}
-        </ActionIcon>
-      </Tooltip>
-      <Text span size="xs">
-        &mdash; {description}
-      </Text>
-    </Group>
-  );
-}
-
 export function RawSqlChartInstructions({
   displayType,
+  variables,
 }: {
   displayType: DisplayType;
+  variables?: ChartVariable[];
 }) {
   const [helpOpened, setHelpOpened] = useAtom(helpOpenedAtom);
   const toggleHelp = () => setHelpOpened(v => !v);
-  const availableParams = QUERY_PARAMS_BY_DISPLAY_TYPE[displayType];
   const exampleClipboard = useClipboard({ timeout: 1500 });
 
   return (
@@ -96,41 +65,22 @@ export function RawSqlChartInstructions({
             {DISPLAY_TYPE_INSTRUCTIONS[displayType]}
 
             <Text size="xs" fw="bold">
-              The following parameters and macros can be used in this chart:
+              Query parameters and macros
             </Text>
-            <List size="xs" withPadding spacing={3}>
-              {availableParams.map(({ name, type, description }) => (
-                <List.Item key={name}>
-                  <ParamSnippet
-                    value={`{${name}:${type}}`}
-                    description={description}
-                  />
-                </List.Item>
-              ))}
-              <List.Item>
-                <ParamSnippet
-                  value={`$__sourceTable([metricType])`}
-                  description="Resolves to selected source table (Source must be selected)"
-                />
-              </List.Item>
-              <List.Item>
-                <ParamSnippet
-                  value={`$__filters`}
-                  description="Applies the selected dashboard filter conditions to the chart (Source must be selected)"
-                />
-              </List.Item>
-              <List.Item>
-                <Text size="xs">
-                  Other available macros are described in the{' '}
-                  <Anchor
-                    href="https://clickhouse.com/docs/use-cases/observability/clickstack/dashboards/sql-visualizations"
-                    target="_blank"
-                  >
-                    ClickStack documentation.
-                  </Anchor>
-                </Text>
-              </List.Item>
-            </List>
+            <Text size="xs">
+              This chart may use query parameters or macros to reference
+              dashboard context. Use editor autocomplete to see available
+              options, or see the{' '}
+              <Anchor
+                href="https://clickhouse.com/docs/use-cases/observability/clickstack/dashboards/sql-visualizations"
+                target="_blank"
+              >
+                ClickStack documentation
+              </Anchor>{' '}
+              for an exhaustive list.
+            </Text>
+
+            <RawSqlVariableInstructions variables={variables} />
 
             <Text size="xs" fw="bold">
               Example:

--- a/packages/app/src/components/ChartEditor/RawSqlChartInstructions.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartInstructions.tsx
@@ -1,4 +1,3 @@
-import { atom, useAtom } from 'jotai';
 import { QUERY_PARAM_EXAMPLES } from '@hyperdx/common-utils/dist/rawSqlParams';
 import { ChartVariable, DisplayType } from '@hyperdx/common-utils/dist/types';
 import {
@@ -20,10 +19,12 @@ import {
   IconCopy,
 } from '@tabler/icons-react';
 
+import { useLocalStorage } from '@/utils';
+
 import { DISPLAY_TYPE_INSTRUCTIONS } from './constants';
 import { RawSqlVariableInstructions } from './RawSqlVariableInstructions';
 
-const helpOpenedAtom = atom(true);
+const HELP_OPENED_KEY = 'hdx-raw-sql-chart-instructions-opened';
 
 export function RawSqlChartInstructions({
   displayType,
@@ -32,7 +33,10 @@ export function RawSqlChartInstructions({
   displayType: DisplayType;
   variables?: ChartVariable[];
 }) {
-  const [helpOpened, setHelpOpened] = useAtom(helpOpenedAtom);
+  const [helpOpened, setHelpOpened] = useLocalStorage<boolean>(
+    HELP_OPENED_KEY,
+    true,
+  );
   const toggleHelp = () => setHelpOpened(v => !v);
   const exampleClipboard = useClipboard({ timeout: 1500 });
 

--- a/packages/app/src/components/ChartEditor/RawSqlVariableInstructions.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlVariableInstructions.tsx
@@ -1,0 +1,34 @@
+import { ChartVariable } from '@hyperdx/common-utils/dist/types';
+import { Box, Text } from '@mantine/core';
+
+/**
+ * Documents the dashboard variables a tile can reference, and how.
+ * Renders nothing when variables is undefined or empty.
+ */
+export function RawSqlVariableInstructions({
+  variables,
+}: {
+  variables: ChartVariable[] | undefined;
+}) {
+  if (!variables?.length) {
+    return null;
+  }
+
+  return (
+    <Box mb="xs">
+      <Text size="xs" fw="bold">
+        Dashboard variables
+      </Text>
+      <Text size="xs">
+        This chart may reference the following variables from the dashboard:{' '}
+        {variables.map(variable => `$${variable.name}`).join(', ')}.
+      </Text>
+
+      <Text size="xs">
+        Prefer using the $__filter and $__conditionalAll macros when referencing
+        variables, to ensure that the query remains valid when a variable has no
+        selection.
+      </Text>
+    </Box>
+  );
+}

--- a/packages/app/src/components/ChartEditor/__tests__/buildRawSqlCompletions.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/buildRawSqlCompletions.test.ts
@@ -1,0 +1,202 @@
+import { ChartVariable, DisplayType } from '@hyperdx/common-utils/dist/types';
+
+import { buildRawSqlCompletions } from '@/components/ChartEditor/utils';
+
+const SERVICE: ChartVariable = {
+  name: 'service',
+  values: ['api', 'web'],
+  expression: 'ServiceName',
+};
+
+const labels = (variables: ChartVariable[] | undefined) =>
+  buildRawSqlCompletions({ displayType: DisplayType.Table, variables }).map(
+    completion => completion.label,
+  );
+
+const find = (variables: ChartVariable[] | undefined, label: string) =>
+  buildRawSqlCompletions({ displayType: DisplayType.Table, variables }).find(
+    completion => completion.label === label,
+  );
+
+/** The rendered help for a completion, whether it is a string or a Node. */
+const infoOf = (variables: ChartVariable[] | undefined, label: string) => {
+  const { info } = find(variables, label) ?? {};
+  if (typeof info !== 'function') return info;
+  const rendered = info();
+  return rendered instanceof HTMLElement ? rendered : undefined;
+};
+
+const infoText = (variables: ChartVariable[] | undefined, label: string) => {
+  const info = infoOf(variables, label);
+  return typeof info === 'string' ? info : (info?.textContent ?? '');
+};
+
+describe('buildRawSqlCompletions', () => {
+  it('offers the query params for the display type', () => {
+    expect(labels(undefined)).toEqual(
+      expect.arrayContaining([
+        '{startDateMilliseconds:Int64}',
+        '{endDateMilliseconds:Int64}',
+      ]),
+    );
+  });
+
+  it('offers only the params the display type supports', () => {
+    const timeSeries = buildRawSqlCompletions({
+      displayType: DisplayType.Line,
+      variables: undefined,
+    }).map(c => c.label);
+    expect(timeSeries).toContain('{intervalSeconds:Int64}');
+    expect(labels(undefined)).not.toContain('{intervalSeconds:Int64}');
+  });
+
+  it('always offers the standard macros', () => {
+    expect(labels(undefined)).toEqual(
+      expect.arrayContaining(['$__timeFilter', '$__sourceTable', '$__filters']),
+    );
+  });
+
+  it('opens an argument list only for macros that take arguments', () => {
+    expect(find(undefined, '$__timeFilter')?.apply).toBe('$__timeFilter(');
+    expect(find(undefined, '$__interval_s')?.apply).toBe('$__interval_s');
+  });
+
+  it('inserts a param with its own closing brace', () => {
+    // The completion source's replace range covers the `}` the editor
+    // auto-inserts after `{`, so omitting it here truncates the param.
+    expect(find(undefined, '{startDateMilliseconds:Int64}')?.apply).toBe(
+      '{startDateMilliseconds:Int64}',
+    );
+  });
+
+  describe('with no variables', () => {
+    it.each([
+      ['off a dashboard', undefined],
+      ['on a dashboard that defines none', [] as ChartVariable[]],
+    ])('withholds the variable macros %s', (_label, variables) => {
+      expect(labels(variables)).not.toContain('$__filter');
+      expect(labels(variables)).not.toContain('$__conditionalAll');
+    });
+  });
+
+  describe('with variables', () => {
+    it('offers the variable macros', () => {
+      expect(labels([SERVICE])).toEqual(
+        expect.arrayContaining(['$__filter', '$__conditionalAll']),
+      );
+    });
+
+    it('inserts the one-argument filter as written', () => {
+      // Not rewritten to `$__filter(ServiceName, service)`: the one-argument
+      // form is valid on its own, and the bare `$__filter` completion is
+      // already there for anyone who wants to pass an expression.
+      expect(find([SERVICE], '$__filter(service)')?.apply).toBe(
+        '$__filter(service)',
+      );
+    });
+
+    it('withholds the one-argument filter when the variable has no expression', () => {
+      // Nothing for `$__filter(env)` to filter on, so it would throw at render.
+      const staticVariable: ChartVariable = { name: 'env', values: ['prod'] };
+      expect(labels([staticVariable])).not.toContain('$__filter(env)');
+      expect(labels([staticVariable])).toContain('$env');
+    });
+
+    it('offers the bare reference and warns about it in the hover text', () => {
+      expect(find([SERVICE], '$service')?.apply).toBe('$service');
+      expect(infoText([SERVICE], '$service')).toContain(
+        '$__filter(<expression>, service)',
+      );
+    });
+
+    it('offers the braced forms, which are the only match once ${ is typed', () => {
+      // `${` cannot fuzzy-match `$service`, so without these the popup is
+      // empty the moment a user types the Grafana-style opening brace.
+      expect(find([SERVICE], '${service}')?.apply).toBe('${service}');
+      expect(find([SERVICE], '${service:csv}')?.apply).toBe('${service:csv}');
+    });
+
+    it('offers every supported format', () => {
+      expect(labels([SERVICE])).toEqual(
+        expect.arrayContaining([
+          '${service:sqlstring}',
+          '${service:csv}',
+          '${service:regex}',
+          '${service:lucene}',
+        ]),
+      );
+    });
+
+    const footnoteOf = (
+      variables: ChartVariable[],
+      label: string,
+    ): string | undefined => {
+      const info = infoOf(variables, label);
+      // A plain string means the completion has no second line at all.
+      if (typeof info !== 'object') return undefined;
+      return (
+        info.querySelector('.cm-completionInfo-footnote')?.textContent ??
+        undefined
+      );
+    };
+
+    it.each([
+      [
+        '$__filter(service)',
+        "Expands to: (toString(ServiceName) IN ('api', 'web'))",
+      ],
+      ['$service', "Expands to: 'api', 'web'"],
+      ['${service}', "Expands to: 'api', 'web'"],
+      ['${service:sqlstring}', "Expands to: 'api', 'web'"],
+      ['${service:csv}', 'Expands to: api,web'],
+      ['${service:regex}', 'Expands to: (api|web)'],
+      ['${service:lucene}', 'Expands to: ("api" OR "web")'],
+    ])('shows what %s expands to', (label, expected) => {
+      expect(footnoteOf([SERVICE], label)).toBe(expected);
+    });
+
+    it('puts the expansion on its own line, not appended to the prose', () => {
+      // A string `info` renders as one text node, so the expansion has to be a
+      // separate element to reliably sit on its own line.
+      const info = infoOf([SERVICE], '$service');
+      if (typeof info !== 'object') throw new Error('expected rendered markup');
+      const footnote = info.querySelector('.cm-completionInfo-footnote');
+      expect(info.firstChild).not.toBe(footnote);
+      expect(info.firstChild?.textContent).not.toContain('Expands to:');
+    });
+
+    it.each([
+      ['$__filter(service)', 'Expands to: (1=1'],
+      ['$service', 'Expands to: NULL'],
+      ['${service:csv}', 'Expands to: (empty string)'],
+      ['${service:regex}', 'Expands to: .*'],
+    ])('shows the empty-selection expansion of %s', (label, expected) => {
+      const unselected: ChartVariable = {
+        name: 'service',
+        values: [],
+        expression: 'ServiceName',
+      };
+      expect(footnoteOf([unselected], label)).toContain(expected);
+    });
+
+    it('offers the same set of completions for every variable', () => {
+      const second: ChartVariable = {
+        name: 'env',
+        values: [],
+        expression: 'Env',
+      };
+      expect(labels([SERVICE, second])).toEqual(
+        expect.arrayContaining([
+          '$__filter(service)',
+          '$service',
+          '${service}',
+          '${service:csv}',
+          '$__filter(env)',
+          '$env',
+          '${env}',
+          '${env:csv}',
+        ]),
+      );
+    });
+  });
+});

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -7,8 +7,15 @@ import {
   isRawSqlSavedChartConfig,
 } from '@hyperdx/common-utils/dist/guards';
 import {
+  MACRO_SUGGESTIONS,
+  MacroSuggestion,
+  VARIABLE_MACRO_SUGGESTIONS,
+} from '@hyperdx/common-utils/dist/macros';
+import { QUERY_PARAMS_BY_DISPLAY_TYPE } from '@hyperdx/common-utils/dist/rawSqlParams';
+import {
   BuilderSavedChartConfig,
   ChartConfigWithDateRange,
+  ChartVariable,
   DisplayType,
   getSampleWeightExpression,
   isLogSource,
@@ -23,10 +30,176 @@ import {
   SourceKind,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
+import {
+  substituteVariables,
+  VARIABLE_FORMATS,
+  VariableFormat,
+} from '@hyperdx/common-utils/dist/variables';
 
 import { getStoredLanguage } from '@/components/SearchInput';
+import { type SQLCompletion } from '@/components/SQLEditor/utils';
 
 import { ChartEditorFormState } from './types';
+
+/** What each `${name:format}` renders, for the completion's help text. */
+const VARIABLE_FORMAT_DESCRIPTIONS: Record<VariableFormat, string> = {
+  sqlstring: "Quoted and comma-separated, escaped for SQL. e.g. 'a', 'b', 'c'",
+  csv: 'Comma-separated and unquoted. Not SQL-escaped. e.g. a,b,c',
+  regex: 'A regex alternation. Regex escaped. e.g. (a|b|c)',
+  lucene: 'An OR of quoted terms, for Lucene inputs. e.g. ("a" OR "b" OR "c")',
+};
+
+/** What `snippet` expands to against the variable's current selection. */
+function describeVariableExpansion(
+  snippet: string,
+  variable: ChartVariable,
+): string | undefined {
+  let expansion: string;
+  try {
+    expansion = substituteVariables(snippet, [variable]);
+  } catch {
+    return undefined;
+  }
+  return `Expands to: ${expansion === '' ? '(empty string)' : expansion}`;
+}
+
+/**
+ * Completion help built as markup rather than a string, so `footnote` sits on
+ * its own line.
+ *
+ * CodeMirror turns a string `info` into a single text node, where a `\n` is
+ * subject to the inherited `white-space` and generally collapses to a space.
+ * A `Node` is rendered as given, so the break is structural.
+ */
+function completionInfo(description: string, footnote: string) {
+  return () => {
+    const dom = document.createElement('div');
+
+    const main = document.createElement('div');
+    main.textContent = description;
+    dom.appendChild(main);
+
+    const sub = document.createElement('div');
+    sub.className = 'cm-completionInfo-footnote';
+    sub.textContent = footnote;
+    dom.appendChild(sub);
+
+    return dom;
+  };
+}
+
+const toMacroCompletion = ({
+  name,
+  minArgs,
+  description,
+}: MacroSuggestion): SQLCompletion => ({
+  label: `$__${name}`,
+  apply: minArgs > 0 ? `$__${name}(` : `$__${name}`,
+  detail: 'macro',
+  info: description,
+  type: 'function',
+});
+
+/**
+ * Autocomplete entries offered on top of columns/keywords in the raw SQL
+ * editor: query params, macros, and variables (when available).
+ */
+export function buildRawSqlCompletions({
+  displayType,
+  variables,
+}: {
+  displayType: DisplayType | undefined;
+  variables: ChartVariable[] | undefined;
+}): SQLCompletion[] {
+  const effectiveDisplayType = displayType ?? DisplayType.Table;
+  const params = QUERY_PARAMS_BY_DISPLAY_TYPE[effectiveDisplayType];
+
+  const paramCompletions: SQLCompletion[] = params.map(
+    ({ name, type, description }) => ({
+      label: `{${name}:${type}}`,
+      apply: `{${name}:${type}}`,
+      detail: 'param',
+      info: description,
+      type: 'variable',
+    }),
+  );
+
+  const macroCompletions = MACRO_SUGGESTIONS.map(toMacroCompletion);
+
+  if (!variables?.length) {
+    return [...paramCompletions, ...macroCompletions];
+  }
+
+  const variableMacroCompletions =
+    VARIABLE_MACRO_SUGGESTIONS.map(toMacroCompletion);
+
+  const variableCompletions = variables.flatMap((variable): SQLCompletion[] => {
+    const { name } = variable;
+
+    /** A static description and an expansion preview given the current variable selections */
+    const help = (snippet: string | undefined, description: string) => {
+      const expansion =
+        snippet == null
+          ? undefined
+          : describeVariableExpansion(snippet, variable);
+      return expansion ? completionInfo(description, expansion) : description;
+    };
+
+    return [
+      ...(variable.expression
+        ? [
+            {
+              label: `$__filter(${name})`,
+              apply: `$__filter(${name})`,
+              detail: 'variable filter',
+              info: help(
+                `$__filter(${name})`,
+                `Filters by the ${name} variable using its defined expression. Matches every row when no values are selected for the variable.`,
+              ),
+              type: 'function',
+            },
+          ]
+        : []),
+      {
+        label: `$${name}`,
+        apply: `$${name}`,
+        detail: 'variable',
+        info: help(
+          `$${name}`,
+          `The selected values of ${name}, in the default sqlstring format. Has no valid empty state — prefer $__filter(<expression>, ${name}).`,
+        ),
+        type: 'variable',
+      },
+      {
+        label: `\${${name}}`,
+        apply: `\${${name}}`,
+        detail: 'variable',
+        info: help(
+          `\${${name}}`,
+          `The same as $${name}, but delimited — use it when the reference runs into following word characters, as in \${${name}}_total.`,
+        ),
+        type: 'variable',
+      },
+      ...VARIABLE_FORMATS.map((format): SQLCompletion => {
+        const reference = `\${${name}:${format}}`;
+        return {
+          label: reference,
+          apply: reference,
+          detail: 'variable',
+          info: help(reference, VARIABLE_FORMAT_DESCRIPTIONS[format]),
+          type: 'variable',
+        };
+      }),
+    ];
+  });
+
+  return [
+    ...paramCompletions,
+    ...macroCompletions,
+    ...variableMacroCompletions,
+    ...variableCompletions,
+  ];
+}
 
 function normalizeChartConfig<
   C extends Pick<

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -873,6 +873,7 @@ export default function EditTimeChartForm({
             isDashboardForm={isDashboardForm}
             alert={alert}
             dashboardId={dashboardId}
+            variables={variables}
           />
         ) : (
           <ChartEditorControls

--- a/packages/app/src/components/SQLEditor/utils.ts
+++ b/packages/app/src/components/SQLEditor/utils.ts
@@ -17,6 +17,7 @@ export type SQLCompletion = {
   label: string;
   apply?: string;
   detail?: string;
+  info?: string | (() => Node);
   type?: string;
 };
 
@@ -159,6 +160,20 @@ export const createCodeMirrorStyleTheme = (maxEditorHeight?: string) =>
       borderRadius: '4px',
       padding: '8px',
       color: 'var(--color-text)',
+      // Override the `nowrap` from the autocomplete list, so that the info
+      // text (longer, only one shown at a time) wraps instead of overflowing.
+      whiteSpace: 'normal',
+      overflowWrap: 'break-word',
+      width: 'max-content',
+      maxWidth: '320px',
+      maxHeight: '300px',
+      overflowY: 'auto',
+    },
+    // Trailing detail on a completion's help — the variable's current
+    // selection — set apart from the prose above it.
+    '& .cm-tooltip-autocomplete .cm-completionInfo-footnote': {
+      marginTop: '6px',
+      color: 'var(--color-text-muted)',
     },
     '& .cm-completionIcon': {
       width: '16px',

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -277,6 +277,111 @@ export class ChartEditorComponent {
   }
 
   /**
+   * The raw SQL validation banner. Absent from the DOM entirely when the
+   * template raises neither an error nor a warning.
+   */
+  sqlValidationBanner(): Locator {
+    return this.page.getByTestId('raw-sql-validation');
+  }
+
+  /**
+   * The validation banner's messages as one whitespace-collapsed string.
+   * Validation is debounced by 300ms, so assert with `toPass`.
+   */
+  async getSqlValidationText(): Promise<string> {
+    const banner = this.sqlValidationBanner();
+    if ((await banner.count()) === 0) return '';
+    return (await banner.innerText()).replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * Type `prefix` into the SQL editor to open the autocomplete popup, and
+   * report the info panel of the highlighted suggestion.
+   *
+   * Dismisses the popup and clears the editor before returning: the tooltip
+   * sits over the editor and would intercept the next caller's click.
+   *
+   * `overflowX` is how far the content extends past the panel's own box, so a
+   * caller can assert the help text stays inside its background.
+   */
+  async readSqlCompletionInfo(
+    prefix: string,
+  ): Promise<{ text: string; overflowX: number }> {
+    await this.replaceSqlQuery(prefix);
+
+    const info = this.page.locator('.cm-completionInfo');
+    await info.waitFor({ state: 'visible', timeout: 10000 });
+
+    const text = await info.innerText();
+    const overflowX = await info.evaluate(
+      el => el.scrollWidth - el.clientWidth,
+    );
+
+    await this.dismissSqlCompletion();
+
+    return { text, overflowX };
+  }
+
+  /**
+   * Close the autocomplete popup by emptying the editor, leaving it clean for
+   * the next interaction.
+   *
+   * The popup sits over the editor and intercepts clicks, so anything that
+   * opens one has to close it. Emptying the document is the way to do that:
+   * Escape also closes it, but it bubbles to the tile modal and pops the
+   * discard-changes dialog.
+   */
+  async dismissSqlCompletion() {
+    await this.page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+    );
+    await this.page.keyboard.press('Backspace');
+    await this.page
+      .locator('.cm-tooltip-autocomplete')
+      .waitFor({ state: 'hidden', timeout: 10000 });
+  }
+
+  /** Labels currently offered by the SQL autocomplete popup. */
+  sqlCompletionOptions(): Locator {
+    return this.page.locator(
+      '.cm-tooltip-autocomplete > ul > li .cm-completionLabel',
+    );
+  }
+
+  /**
+   * Type `prefix` into the SQL editor, accept the suggestion labelled `label`,
+   * and return the resulting document text.
+   *
+   * Verifies that what a completion inserts is actually well-formed — the
+   * replace range extends over trailing identifier characters, so a bracket
+   * auto-inserted by the editor is inside it and `apply` has to supply its own.
+   */
+  async acceptSqlCompletion(prefix: string, label: string): Promise<string> {
+    await this.replaceSqlQuery(prefix);
+
+    const option = this.page
+      .locator('.cm-tooltip-autocomplete > ul > li')
+      .filter({ has: this.page.getByText(label, { exact: true }) })
+      .first();
+    await option.waitFor({ state: 'visible', timeout: 10000 });
+    await option.click();
+
+    const text = await this.getSqlEditorText();
+    // Accepting can immediately re-open the popup on the inserted text, which
+    // would intercept the next caller's click.
+    await this.dismissSqlCompletion();
+    return text;
+  }
+
+  /** The "SQL Chart Instructions" panel, which documents params and macros. */
+  sqlInstructions(): Locator {
+    return this.page
+      .locator('div')
+      .filter({ hasText: /^SQL Chart Instructions/ })
+      .first();
+  }
+
+  /**
    * Type a SQL query into the CodeMirror SQL editor, replacing any existing
    * contents first. Call switchToSqlMode() first to make the editor visible.
    *

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -1621,6 +1621,209 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
         });
       },
     );
+
+    test(
+      'autocompletes every variable reference form',
+      { tag: '@full-stack' },
+      async () => {
+        test.setTimeout(90000);
+
+        await test.step('Open a raw SQL tile on a dashboard with a variable', async () => {
+          await dashboardPage.createNewDashboard();
+          await addServiceVariable();
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          await dashboardPage.chartEditor.setChartType(DisplayType.Table);
+          await dashboardPage.chartEditor.switchToSqlMode();
+        });
+
+        await test.step('The variable macros are offered, with wrapped help text', async () => {
+          const { text, overflowX } =
+            await dashboardPage.chartEditor.readSqlCompletionInfo('$__filter');
+          expect(text).toContain('Expands to 1=1 when nothing is selected');
+          // The suggestion list sets white-space: nowrap, which the info panel
+          // inherits and which ran this prose straight out of its background.
+          expect(overflowX).toBeLessThanOrEqual(1);
+        });
+
+        await test.step("The reference's expansion renders on its own line", async () => {
+          await dashboardPage.chartEditor.replaceSqlQuery('$svc');
+          const info = dashboardPage.page.locator('.cm-completionInfo');
+          await info.waitFor({ state: 'visible', timeout: 10000 });
+
+          // Nothing is selected on this dashboard, so the bare form shows the
+          // empty state it expands to.
+          const footnote = info.locator('.cm-completionInfo-footnote');
+          await expect(footnote).toHaveText('Expands to: NULL');
+
+          // Below the prose rather than run onto the end of it. A `\n` in a
+          // string `info` collapses to a space, which is why this is markup.
+          const gap = await info.evaluate(el => {
+            const sub = el.querySelector('.cm-completionInfo-footnote');
+            const main = sub?.previousElementSibling;
+            if (!sub || !main) return null;
+            return (
+              sub.getBoundingClientRect().top -
+              main.getBoundingClientRect().bottom
+            );
+          });
+          expect(gap).toBeGreaterThanOrEqual(0);
+
+          await dashboardPage.chartEditor.dismissSqlCompletion();
+        });
+
+        await test.step('Typing ${ offers the braced form and every format', async () => {
+          // `${` cannot fuzzy-match `$svc`, so without dedicated braced
+          // entries the popup is empty the moment the brace is typed.
+          await dashboardPage.chartEditor.replaceSqlQuery('${');
+          const options = dashboardPage.chartEditor.sqlCompletionOptions();
+          await expect(options).toHaveCount(5);
+          // Compared as a set: ranking between equally-good matches is
+          // CodeMirror's business, not something worth pinning here.
+          expect((await options.allTextContents()).sort()).toEqual(
+            [
+              '${svc}',
+              '${svc:sqlstring}',
+              '${svc:regex}',
+              '${svc:csv}',
+              '${svc:lucene}',
+            ].sort(),
+          );
+          await dashboardPage.chartEditor.dismissSqlCompletion();
+        });
+
+        await test.step('Accepting a completion inserts well-formed text', async () => {
+          // The replace range covers trailing identifier characters, which
+          // includes the `}` the editor auto-inserts after `${` or `{` — so
+          // `apply` has to carry its own closing brace rather than rely on it.
+          for (const [prefix, label, expected] of [
+            ['${', '${svc}', '${svc}'],
+            ['${', '${svc:csv}', '${svc:csv}'],
+            ['$sv', '$svc', '$svc'],
+            // The one-argument form goes in as written, rather than being
+            // silently rewritten to `$__filter(ServiceName, svc)`.
+            ['$__f', '$__filter(svc)', '$__filter(svc)'],
+            [
+              '{start',
+              '{startDateMilliseconds:Int64}',
+              '{startDateMilliseconds:Int64}',
+            ],
+          ]) {
+            expect(
+              await dashboardPage.chartEditor.acceptSqlCompletion(
+                prefix,
+                label,
+              ),
+            ).toBe(expected);
+          }
+        });
+      },
+    );
+
+    test(
+      'documents the dashboard variables and flags questionable references',
+      { tag: '@full-stack' },
+      async () => {
+        test.setTimeout(90000);
+
+        await test.step('Create a dashboard with a variable-enabled filter', async () => {
+          await dashboardPage.createNewDashboard();
+          await addServiceVariable();
+        });
+
+        await test.step('Open a raw SQL tile editor', async () => {
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          await dashboardPage.chartEditor.setChartType(DisplayType.Table);
+          await dashboardPage.chartEditor.switchToSqlMode();
+        });
+
+        await test.step('The instructions panel documents the variable', async () => {
+          const instructions = dashboardPage.chartEditor.sqlInstructions();
+          await expect(instructions).toContainText('Dashboard variables');
+          await expect(instructions).toContainText(
+            'This chart may reference the following variables from the dashboard: $svc.',
+          );
+          await expect(instructions).toContainText(
+            '$__filter and $__conditionalAll',
+          );
+        });
+
+        /**
+         * Put `sql` in the editor and assert what the validation banner says
+         * about it. Both the typing and the (debounced) validation are
+         * retried: CodeMirror occasionally drops a keystroke burst, which
+         * otherwise strands the assertion on the previous step's SQL.
+         */
+        const expectValidationFor = async (
+          sql: string,
+          assertBanner: (banner: string) => void,
+        ) => {
+          const normalize = (text: string) => text.replace(/\s+/g, ' ').trim();
+          await expect(async () => {
+            const editor = await dashboardPage.chartEditor.getSqlEditorText();
+            if (normalize(editor) !== normalize(sql)) {
+              await dashboardPage.chartEditor.replaceSqlQuery(sql);
+            }
+            assertBanner(
+              await dashboardPage.chartEditor.getSqlValidationText(),
+            );
+          }).toPass({ timeout: 20000 });
+        };
+
+        await test.step('An empty editor raises nothing at all', async () => {
+          await expectValidationFor('', banner => expect(banner).toBe(''));
+        });
+
+        await test.step('An unknown variable in a macro is an error', async () => {
+          await expectValidationFor(
+            `SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, nope) AND $__timeFilter(Timestamp)`,
+            banner =>
+              expect(banner).toContain(
+                "Error: Macro '$__filter' references unknown variable 'nope'",
+              ),
+          );
+        });
+
+        await test.step('A bare reference is a warning, not an error', async () => {
+          await expectValidationFor(
+            `SELECT count() FROM $__sourceTable WHERE ServiceName IN ($svc) AND $__timeFilter(Timestamp)`,
+            banner => {
+              expect(banner).toContain(
+                'Warning: $svc has no valid empty-selection value',
+              );
+              expect(banner).not.toContain('Error:');
+            },
+          );
+        });
+
+        await test.step('A quoted reference is an error, because it always breaks', async () => {
+          await expectValidationFor(
+            `SELECT count() FROM $__sourceTable WHERE ServiceName = '$svc' AND $__timeFilter(Timestamp)`,
+            banner =>
+              expect(banner).toContain('Error: $svc is wrapped in quotes'),
+          );
+        });
+
+        await test.step('A reference guarded by $__conditionalAll raises nothing', async () => {
+          // The condition is dropped entirely while `svc` is unselected, so
+          // the nested $svc never renders as NULL.
+          await expectValidationFor(
+            `SELECT count() FROM $__sourceTable WHERE $__conditionalAll(ServiceName NOT IN ($svc), svc) AND $__timeFilter(Timestamp)`,
+            banner => expect(banner).toBe(''),
+          );
+        });
+
+        await test.step('A correct $__filter usage raises nothing', async () => {
+          await expectValidationFor(
+            `SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, svc) AND $__timeFilter(Timestamp)`,
+            banner => expect(banner).toBe(''),
+          );
+        });
+      },
+    );
   });
 
   test(

--- a/packages/common-utils/src/__tests__/macros.test.ts
+++ b/packages/common-utils/src/__tests__/macros.test.ts
@@ -2,6 +2,7 @@ import { MalformedMacroArgsError } from '@/macroErrors';
 import {
   getSourceDependentMacrosUsed,
   hasMacro,
+  isMissingFiltersMacro,
   replaceMacros,
 } from '@/macros';
 import type { MetricTable } from '@/types';
@@ -29,6 +30,33 @@ describe('hasMacro', () => {
 
   it('detects macros that take arguments', () => {
     expect(hasMacro('WHERE $__timeFilter(ts)', 'timeFilter')).toBe(true);
+  });
+});
+
+describe('isMissingFiltersMacro', () => {
+  it('is true when nothing consumes the dashboard filters', () => {
+    expect(isMissingFiltersMacro('SELECT * WHERE $__timeFilter(ts)')).toBe(
+      true,
+    );
+  });
+
+  it('is false when $__filters is used', () => {
+    expect(isMissingFiltersMacro('SELECT * WHERE $__filters')).toBe(false);
+  });
+
+  it('is false when a variable macro applies filtering instead', () => {
+    expect(
+      isMissingFiltersMacro('SELECT * WHERE $__filter(ServiceName, service)'),
+    ).toBe(false);
+    expect(
+      isMissingFiltersMacro(
+        'SELECT * WHERE $__conditionalAll(ServiceName IN ${service}, service)',
+      ),
+    ).toBe(false);
+  });
+
+  it('reads a half-typed macro as applied rather than throwing', () => {
+    expect(isMissingFiltersMacro('SELECT * WHERE $__filters(')).toBe(false);
   });
 });
 

--- a/packages/common-utils/src/__tests__/macros.test.ts
+++ b/packages/common-utils/src/__tests__/macros.test.ts
@@ -1,3 +1,4 @@
+import { MalformedMacroArgsError } from '@/macroErrors';
 import {
   getSourceDependentMacrosUsed,
   hasMacro,
@@ -172,7 +173,7 @@ describe('replaceMacros', () => {
 
   it('should throw on missing close bracket', () => {
     expect(() => replaceMacros({ sqlTemplate: '$__timeFilter(col' })).toThrow(
-      'Failed to parse macro arguments',
+      MalformedMacroArgsError,
     );
   });
 

--- a/packages/common-utils/src/__tests__/validateRawSqlChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/validateRawSqlChartConfig.test.ts
@@ -1,4 +1,7 @@
-import { validateRawSqlChartConfig } from '@/core/utils';
+import {
+  validateRawSqlChartConfig,
+  validateRawSqlForAlert,
+} from '@/core/utils';
 import { DisplayType, RawSqlChartConfig } from '@/types';
 
 function config(overrides: Partial<RawSqlChartConfig>): RawSqlChartConfig {
@@ -208,6 +211,29 @@ describe('validateRawSqlChartConfig', () => {
     ).not.toThrow();
   });
 
+  it('stays silent on the console while a macro is half-typed', () => {
+    // The editor revalidates on every keystroke, so an unterminated argument
+    // list is the expected path, not a bug. Logging it would put a stack trace
+    // in the console on each debounce tick.
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      for (const sqlTemplate of [
+        'SELECT * FROM $__sourceTable(',
+        'SELECT * WHERE $__filters(',
+        'SELECT $__sourceTable( FROM logs',
+      ]) {
+        validateRawSqlChartConfig(config({ sqlTemplate }), {
+          isDashboardTile: true,
+        });
+      }
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('reports the missing-interval error for a metric $__sourceTable(type) macro when metricTables is provided', () => {
     const { errors } = validateRawSqlChartConfig(
       config({
@@ -335,5 +361,249 @@ describe('validateRawSqlChartConfig', () => {
       configType: 'metric',
     } as unknown as RawSqlChartConfig);
     expect(result).toEqual({ errors: [], warnings: [] });
+  });
+
+  describe('an empty SQL template', () => {
+    it.each([
+      ['empty', ''],
+      ['whitespace only', '  \n  '],
+    ])('reports nothing when the editor is %s', (_label, sqlTemplate) => {
+      expect(
+        validateRawSqlChartConfig(
+          config({ sqlTemplate, displayType: DisplayType.Line }),
+          { isDashboardTile: true },
+        ),
+      ).toEqual({ errors: [], warnings: [] });
+    });
+
+    it('is still rejected for an alert', () => {
+      // The quiet-while-empty rule above is for the editor banner only.
+      // `validateRawSqlForAlert` also backs `validateAlertInput` on the API,
+      // where an empty template must not be allowed to save an alert on a
+      // tile that can never produce a series.
+      const { errors } = validateRawSqlForAlert(
+        config({ sqlTemplate: '', displayType: DisplayType.Line }),
+      );
+      expect(errors).toContain(
+        'SQL used for alerts must include an interval parameter or macro.',
+      );
+    });
+  });
+
+  describe('macro expansion failures', () => {
+    it('surfaces an unresolvable metric type, which no other check covers', () => {
+      const { errors } = validateRawSqlChartConfig(
+        config({
+          sqlTemplate:
+            'SELECT count() FROM $__sourceTable(bogus) WHERE $__timeFilter(ts)',
+          metricTables: {
+            gauge: 'otel_metrics_gauge',
+            histogram: 'otel_metrics_histogram',
+            sum: 'otel_metrics_sum',
+            summary: 'otel_metrics_summary',
+            'exponential histogram': 'otel_metrics_exponential_histogram',
+          },
+        }),
+      );
+      expect(errors).toContain(
+        "Macro '$__sourceTable(metricType)' invalid argument 'bogus'. Expected a valid metrics data type (gauge, histogram, sum, summary, exponential histogram).",
+      );
+    });
+
+    it('stays silent on an unterminated argument list, which is what half-typed SQL looks like', () => {
+      const { errors } = validateRawSqlChartConfig(
+        config({
+          sqlTemplate:
+            'SELECT count() FROM $__sourceTable WHERE $__timeFilter(',
+        }),
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('does not repeat a $__sourceTable failure the source checks already describe', () => {
+      const { errors } = validateRawSqlChartConfig(
+        config({
+          sqlTemplate:
+            'SELECT count() FROM $__sourceTable(gauge) WHERE $__timeFilter(ts)',
+          metricTables: undefined,
+        }),
+      );
+      expect(errors).toEqual([
+        'SQL uses $__sourceTable(<metricType>) but the selected source is not a metrics source — use a bare $__sourceTable instead.',
+      ]);
+    });
+  });
+
+  describe('variable references', () => {
+    const withVariables = (sqlTemplate: string) =>
+      config({
+        sqlTemplate,
+        variables: [
+          { name: 'service', values: ['api'], expression: 'ServiceName' },
+          { name: 'env', values: [], expression: 'Env' },
+        ],
+      });
+
+    it('errors on a macro naming a variable the dashboard does not have', () => {
+      const { errors } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, nope)',
+        ),
+      );
+      expect(errors).toContain(
+        "Macro '$__filter' references unknown variable 'nope'. Available variables: service, env.",
+      );
+    });
+
+    it('warns on a bare reference the dashboard does not have', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE ServiceName IN ($nope)',
+        ),
+      );
+      expect(warnings).toContain(
+        'SQL references unknown variable $nope. Available variables: service, env.',
+      );
+    });
+
+    it('errors on a resolved reference wrapped in quotes, which always produces invalid SQL', () => {
+      const { errors } = validateRawSqlChartConfig(
+        withVariables(
+          "SELECT count() FROM $__sourceTable WHERE ServiceName = '$service'",
+        ),
+      );
+      expect(errors).toContain(
+        '$service is wrapped in quotes, but the default sqlstring format already quotes each value. Did you mean to use $__filter(<expression>, service) or ${service:csv} instead?',
+      );
+    });
+
+    it('warns that a bare reference has no valid empty state', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE ServiceName IN ($service)',
+        ),
+      );
+      expect(warnings).toContain(
+        '$service has no valid empty-selection value — it renders as NULL before anything is selected. Prefer $__filter(<expression>, service) or $__conditionalAll(<condition>, service) so the query stays valid when no values are selected.',
+      );
+    });
+
+    it('leaves an explicitly formatted reference alone', () => {
+      // A non-default format is a deliberate choice, and the empty-selection
+      // warning below is specific to how sqlstring renders.
+      const { errors, warnings } = validateRawSqlChartConfig(
+        withVariables(
+          "SELECT count() FROM $__sourceTable WHERE ServiceName IN ('${service:csv}') AND $__timeFilter(ts)",
+        ),
+      );
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('does not call a reference unguarded when the enclosing macro guards that same variable', () => {
+      const { errors, warnings } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE $__conditionalAll(ServiceName NOT IN ($service), service) AND $__timeFilter(ts)',
+        ),
+      );
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('still warns when the enclosing macro guards a different variable', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE $__conditionalAll(Env IN ($env), service) AND $__timeFilter(ts)',
+        ),
+      );
+      expect(warnings).toContain(
+        '$env has no valid empty-selection value — it renders as NULL before anything is selected. Prefer $__filter(<expression>, env) or $__conditionalAll(<condition>, env) so the query stays valid when no values are selected.',
+      );
+    });
+
+    it('leaves a correct $__filter usage alone', () => {
+      const { errors, warnings } = validateRawSqlChartConfig(
+        withVariables(
+          'SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, service) AND $__timeFilter(ts)',
+        ),
+      );
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('reports each unknown name once however many times it is written', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        withVariables('SELECT $nope FROM $__sourceTable WHERE x = $nope'),
+      );
+      expect(warnings.filter(w => w.includes('unknown variable'))).toHaveLength(
+        1,
+      );
+    });
+
+    it('says "(none)" when the dashboard exposes no variables at all', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        config({
+          sqlTemplate: 'SELECT count() FROM $__sourceTable WHERE x = $nope',
+          variables: [],
+        }),
+      );
+      expect(warnings).toContain(
+        'SQL references unknown variable $nope. Available variables: (none).',
+      );
+    });
+
+    describe('with no variable context (chart explorer, or the feature disabled)', () => {
+      it('errors on the macro forms, which are always invalid SQL there', () => {
+        const { errors } = validateRawSqlChartConfig(
+          config({
+            sqlTemplate:
+              'SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, service)',
+          }),
+        );
+        expect(errors).toContain(
+          'SQL uses $__filter, but no variables are available here.',
+        );
+      });
+
+      it('warns on a bare reference, which may well be a literal', () => {
+        const { warnings } = validateRawSqlChartConfig(
+          config({
+            sqlTemplate:
+              'SELECT count() FROM $__sourceTable WHERE x IN ($service)',
+          }),
+        );
+        expect(warnings).toContain(
+          'SQL references $service, but no variables are available here.',
+        );
+      });
+    });
+  });
+
+  describe('the $__filters recommendation', () => {
+    it('is made for a dashboard tile that filters nothing', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        config({ sqlTemplate: 'SELECT count() FROM $__sourceTable' }),
+        { isDashboardTile: true },
+      );
+      expect(warnings).toContain(
+        'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+      );
+    });
+
+    it('is withheld from a tile that already filters per-variable', () => {
+      const { warnings } = validateRawSqlChartConfig(
+        config({
+          sqlTemplate:
+            'SELECT count() FROM $__sourceTable WHERE $__filter(ServiceName, service)',
+          variables: [
+            { name: 'service', values: ['api'], expression: 'ServiceName' },
+          ],
+        }),
+        { isDashboardTile: true },
+      );
+      expect(warnings).not.toContain(
+        'SQL should include the $__filters macro so dashboard filters apply to this tile.',
+      );
+    });
   });
 });

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -1,3 +1,4 @@
+import { MalformedMacroArgsError } from '@/macroErrors';
 import type { ChartVariable } from '@/types';
 import {
   filterReferencedVariables,
@@ -312,7 +313,7 @@ describe('substituteVariables', () => {
     it('throws when the argument list is never closed', () => {
       expect(() =>
         substituteVariables('$__filter(ServiceName, service', [SERVICE]),
-      ).toThrow('Failed to parse macro arguments');
+      ).toThrow(MalformedMacroArgsError);
     });
   });
 

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -7,10 +7,12 @@ import { z } from 'zod';
 export { default as objectHash } from 'object-hash';
 
 import { isBuilderSavedChartConfig, isRawSqlSavedChartConfig } from '@/guards';
+import { MacroExpansionError, MalformedMacroArgsError } from '@/macroErrors';
 import {
   getSourceDependentMacrosUsed,
   getSourceTableMacroArgCounts,
   hasMacro,
+  MacroName,
   replaceMacros,
 } from '@/macros';
 import { QUERY_PARAMS, RawSqlQueryParam } from '@/rawSqlParams';
@@ -33,6 +35,13 @@ import {
   TileTemplateSchema,
   TSource,
 } from '@/types';
+import {
+  getVariableReferences,
+  hasVariableMacro,
+  VARIABLE_FORMATS,
+  VariableFormat,
+  VariableReference,
+} from '@/variables';
 
 import { SkipIndexMetadata, TableMetadata } from './metadata';
 
@@ -1385,43 +1394,37 @@ export function displayTypeSupportsPromQLAlerts(
   return displayType ? false : false;
 }
 
+/** Expand the chart's macros, returning failures instead of throwing. */
+function resolveRawSqlMacros(
+  chartConfig: RawSqlChartConfig,
+): { sql: string; error?: undefined } | { sql?: undefined; error: Error } {
+  try {
+    return { sql: replaceMacros(chartConfig) };
+  } catch (e) {
+    return { error: e instanceof Error ? e : new Error(String(e)) };
+  }
+}
+
 /**
- * Resolves the chart's macros and reports which raw-SQL time-range/interval
- * query params are present in the resolved SQL. Shared by
- * `validateRawSqlForAlert` and `validateRawSqlChartConfig`, which each build
- * their own error/warning messages from this on top.
- *
- * Returns `null` if the config isn't raw SQL or macro resolution fails
- * (`replaceMacros` throws frequently while a user is still typing).
+ * Reports which time-range/interval query params are present in the given SQL.
  */
-function getRawSqlTimeRangeStatus(chartConfig: RawSqlChartConfig): {
+function getRawSqlTimeRangeStatus(
+  chartConfig: RawSqlChartConfig,
+  sql: string,
+): {
   isTimeSeries: boolean;
   hasInterval: boolean;
   hasTimeFilter: boolean;
-} | null {
-  try {
-    if (!isRawSqlSavedChartConfig(chartConfig)) {
-      return null;
-    }
-
-    const sql = replaceMacros(chartConfig);
-
-    return {
-      isTimeSeries: isTimeSeriesDisplayType(chartConfig.displayType),
-      hasInterval:
-        sql.includes(
-          QUERY_PARAMS[RawSqlQueryParam.intervalMilliseconds].name,
-        ) || sql.includes(QUERY_PARAMS[RawSqlQueryParam.intervalSeconds].name),
-      hasTimeFilter:
-        sql.includes(
-          QUERY_PARAMS[RawSqlQueryParam.startDateMilliseconds].name,
-        ) &&
-        sql.includes(QUERY_PARAMS[RawSqlQueryParam.endDateMilliseconds].name),
-    };
-  } catch {
-    // replaceMacros will often fail as users type in the SQL template
-    return null;
-  }
+} {
+  return {
+    isTimeSeries: isTimeSeriesDisplayType(chartConfig.displayType),
+    hasInterval:
+      sql.includes(QUERY_PARAMS[RawSqlQueryParam.intervalMilliseconds].name) ||
+      sql.includes(QUERY_PARAMS[RawSqlQueryParam.intervalSeconds].name),
+    hasTimeFilter:
+      sql.includes(QUERY_PARAMS[RawSqlQueryParam.startDateMilliseconds].name) &&
+      sql.includes(QUERY_PARAMS[RawSqlQueryParam.endDateMilliseconds].name),
+  };
 }
 
 export function validateRawSqlForAlert(chartConfig: RawSqlChartConfig): {
@@ -1441,8 +1444,9 @@ export function validateRawSqlForAlert(chartConfig: RawSqlChartConfig): {
     );
   }
 
-  const status = getRawSqlTimeRangeStatus(chartConfig);
-  if (status) {
+  const { sql } = resolveRawSqlMacros(chartConfig);
+  if (sql != null) {
+    const status = getRawSqlTimeRangeStatus(chartConfig, sql);
     // Interval params are only required for time-series display types (Line, StackedBar).
     // Number charts don't use interval bucketing.
     if (status.isTimeSeries && !status.hasInterval) {
@@ -1456,6 +1460,105 @@ export function validateRawSqlForAlert(chartConfig: RawSqlChartConfig): {
         `SQL used for alerts should include start and end date parameters or macros.`,
       );
     }
+  }
+
+  return { errors, warnings };
+}
+
+/** `$a, $b` — deduplicated, in source order, for use in a message. */
+function formatReferenceList(references: VariableReference[]): string {
+  return [...new Set(references.map(reference => reference.raw))].join(', ');
+}
+
+const isKnownFormat = (format: string): format is VariableFormat =>
+  (VARIABLE_FORMATS as readonly string[]).includes(format);
+
+/**
+ * Checks on the dashboard variables a raw SQL template references.
+ *
+ * `chartConfig.variables` is tri-state and each state means something
+ * different here: `undefined` is "no variable context" (the chart explorer, or
+ * a dashboard with the feature flag off) where nothing is substituted at all;
+ * `[]` is a dashboard whose filters expose no variables.
+ *
+ * Only *value* references (`$name`, `${name}`, `${name:format}`) are inspected.
+ * The macro forms either expand correctly or throw, and those messages reach
+ * the user through `resolveRawSqlMacros` — except when there is no context at
+ * all, in which case they silently pass through and are reported here.
+ */
+function validateVariableReferences(chartConfig: RawSqlChartConfig): {
+  errors: string[];
+  warnings: string[];
+} {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const references = getVariableReferences(chartConfig.sqlTemplate);
+  if (references.length === 0) return { errors, warnings };
+
+  const macroReferences = references.filter(r => r.kind === 'macro');
+  const valueReferences = references.filter(r => r.kind !== 'macro');
+  const { variables } = chartConfig;
+
+  // Variables are not available on chart explorer (and maybe other contexts)
+  if (variables == null) {
+    // Macros are always an error, we assume no query will intentionally include them without variable context.
+    if (macroReferences.length > 0) {
+      errors.push(
+        `SQL uses ${formatReferenceList(macroReferences)}, but no variables are available here.`,
+      );
+    }
+
+    // $var and ${var} references only trigger a warning since they may be a literal the user means to keep.
+    if (valueReferences.length > 0) {
+      warnings.push(
+        `SQL references ${formatReferenceList(valueReferences)}, but no variables are available here.`,
+      );
+    }
+    return { errors, warnings };
+  }
+
+  const knownVariableNames = new Set(variables.map(variable => variable.name));
+  const available =
+    variables.length > 0
+      ? variables.map(variable => variable.name).join(', ')
+      : '(none)';
+
+  const unknown = valueReferences.filter(r => !knownVariableNames.has(r.name));
+  if (unknown.length > 0) {
+    warnings.push(
+      `SQL references unknown variable ${formatReferenceList(unknown)}. Available variables: ${available}.`,
+    );
+  }
+
+  // An unrecognized format throws during expansion, so it is already reported.
+  const resolved = valueReferences.filter(
+    r =>
+      knownVariableNames.has(r.name) &&
+      (r.format == null || isKnownFormat(r.format)),
+  );
+
+  const quoted = resolved.filter(
+    r => (r.format ?? 'sqlstring') === 'sqlstring' && r.inStringLiteral,
+  );
+  if (quoted.length > 0) {
+    const [{ name }] = quoted;
+    errors.push(
+      `${formatReferenceList(quoted)} is wrapped in quotes, but the default sqlstring format already quotes each value. Did you mean to use $__filter(<expression>, ${name}) or \${${name}:csv} instead?`,
+    );
+  }
+
+  const unguarded = resolved.filter(
+    r =>
+      (r.format ?? 'sqlstring') === 'sqlstring' &&
+      !r.inStringLiteral &&
+      r.guardedBy !== r.name,
+  );
+  if (unguarded.length > 0) {
+    const [{ name }] = unguarded;
+    warnings.push(
+      `${formatReferenceList(unguarded)} has no valid empty-selection value — it renders as NULL before anything is selected. Prefer $__filter(<expression>, ${name}) or $__conditionalAll(<condition>, ${name}) so the query stays valid when no values are selected.`,
+    );
   }
 
   return { errors, warnings };
@@ -1476,9 +1579,23 @@ export function validateRawSqlChartConfig(
     return { errors, warnings };
   }
 
+  // An empty editor has nothing wrong with it yet.
+  if (!chartConfig.sqlTemplate.trim()) {
+    return { errors, warnings };
+  }
+
+  // Track macros this function has already described with an error, to avoid repetition.
+  const reportedMacros = new Set<MacroName>();
+  const pushError = (message: string, macro?: MacroName) => {
+    errors.push(message);
+    if (macro != null) reportedMacros.add(macro);
+  };
+
   try {
-    const status = getRawSqlTimeRangeStatus(chartConfig);
-    if (status) {
+    const resolved = resolveRawSqlMacros(chartConfig);
+
+    if (resolved.sql != null) {
+      const status = getRawSqlTimeRangeStatus(chartConfig, resolved.sql);
       if (status.isTimeSeries && !status.hasInterval) {
         errors.push(
           'SQL must include an interval parameter or macro (e.g. $__interval_s) for this display type.',
@@ -1492,13 +1609,20 @@ export function validateRawSqlChartConfig(
       }
     }
 
+    const variableIssues = validateVariableReferences(chartConfig);
+    errors.push(...variableIssues.errors);
+    warnings.push(...variableIssues.warnings);
+
     if (isDashboardTile) {
       if (!hasMacro(chartConfig.sqlTemplate, 'sourceTable')) {
         warnings.push(
           'SQL should include the $__sourceTable macro so this tile queries its configured source.',
         );
       }
-      if (!hasMacro(chartConfig.sqlTemplate, 'filters')) {
+      if (
+        !hasMacro(chartConfig.sqlTemplate, 'filters') &&
+        !hasVariableMacro(chartConfig.sqlTemplate)
+      ) {
         warnings.push(
           'SQL should include the $__filters macro so dashboard filters apply to this tile.',
         );
@@ -1513,6 +1637,7 @@ export function validateRawSqlChartConfig(
         errors.push(
           `SQL uses ${usedMacros.map(m => `$__${m}`).join(' and ')} but no source is selected — select a source so ${usedMacros.length > 1 ? 'these macros' : 'this macro'} can resolve correctly.`,
         );
+        usedMacros.forEach(macro => reportedMacros.add(macro));
       }
     } else {
       // A metric type argument is required for a metrics source and
@@ -1521,21 +1646,48 @@ export function validateRawSqlChartConfig(
       const isMetricsSource = !!chartConfig.metricTables;
 
       if (argCounts.some(count => count > 0) && !isMetricsSource) {
-        errors.push(
+        pushError(
           'SQL uses $__sourceTable(<metricType>) but the selected source is not a metrics source — use a bare $__sourceTable instead.',
+          'sourceTable',
         );
       }
 
       if (argCounts.some(count => count === 0) && isMetricsSource) {
-        errors.push(
+        pushError(
           'SQL uses a bare $__sourceTable but the selected source is a metrics source — specify a metric type, e.g. $__sourceTable(gauge).',
+          'sourceTable',
         );
       }
     }
-  } catch {
+
+    // Report anything else macro expansion refused to do
+    const { error } = resolved;
+    if (error != null) {
+      // An unterminated argument list is what a half-typed macro looks like, so it stays silent.
+      const isStillTyping = error instanceof MalformedMacroArgsError;
+      const isAlreadyReported =
+        error instanceof MacroExpansionError && reportedMacros.has(error.macro);
+
+      // Everything else — an unknown variable, a bad argument count, an
+      // unrecognized `${v:format}`, an unconfigured metric type — is invisible
+      // to the user until the query fails, so it is reported verbatim.
+      if (!isStillTyping && !isAlreadyReported) {
+        errors.push(error.message);
+      }
+    }
+  } catch (e) {
     // hasMacro/getSourceDependentMacrosUsed throw on malformed macro args
     // (e.g. an unmatched paren) while the user is still typing; fall back to
     // whatever errors/warnings were already accumulated rather than crash.
+    // That is the expected path here — the editor revalidates on every
+    // keystroke, so logging it would put a stack trace in the console on each
+    // debounce tick and drown out the case below.
+    if (e instanceof MalformedMacroArgsError) {
+      return { errors, warnings };
+    }
+
+    // Anything else is a bug in the checks above, so surface it for investigation:
+    console.error('Unexpected error validating raw SQL chart config', e);
   }
 
   return { errors, warnings };

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -12,6 +12,7 @@ import {
   getSourceDependentMacrosUsed,
   getSourceTableMacroArgCounts,
   hasMacro,
+  isMissingFiltersMacro,
   MacroName,
   replaceMacros,
 } from '@/macros';
@@ -37,7 +38,6 @@ import {
 } from '@/types';
 import {
   getVariableReferences,
-  hasVariableMacro,
   VARIABLE_FORMATS,
   VariableFormat,
   VariableReference,
@@ -1619,10 +1619,7 @@ export function validateRawSqlChartConfig(
           'SQL should include the $__sourceTable macro so this tile queries its configured source.',
         );
       }
-      if (
-        !hasMacro(chartConfig.sqlTemplate, 'filters') &&
-        !hasVariableMacro(chartConfig.sqlTemplate)
-      ) {
+      if (isMissingFiltersMacro(chartConfig.sqlTemplate)) {
         warnings.push(
           'SQL should include the $__filters macro so dashboard filters apply to this tile.',
         );

--- a/packages/common-utils/src/macroErrors.ts
+++ b/packages/common-utils/src/macroErrors.ts
@@ -1,0 +1,20 @@
+import type { MacroName } from './macros';
+
+/** Thrown for an unterminated macro argument list, e.g. `$__timeFilter(col`. */
+export class MalformedMacroArgsError extends Error {
+  constructor() {
+    super('Failed to parse macro arguments');
+    this.name = 'MalformedMacroArgsError';
+  }
+}
+
+/** Thrown when a macro cannot expand, tagged with the macro it came. */
+export class MacroExpansionError extends Error {
+  constructor(
+    public readonly macro: MacroName,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MacroExpansionError';
+  }
+}

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -9,6 +9,7 @@ import {
 import {
   expandVariableToken,
   findBalancedParens,
+  hasVariableMacro,
   scanTemplateTokens,
   VARIABLE_MACRO_NAMES,
   VariableContext,
@@ -317,6 +318,23 @@ function parseMacroArgs(argString: string): { args: string[]; length: number } {
  */
 export function hasMacro(sql: string, name: MacroName): boolean {
   return findMacros(sql, name).length > 0;
+}
+
+/**
+ * Whether a dashboard tile's SQL leaves dashboard filters unapplied: neither
+ * `$__filters` nor a variable macro (`$__filter`/`$__conditionalAll`) appears,
+ * so nothing in the template consumes the dashboard's filter state.
+ */
+export function isMissingFiltersMacro(sqlTemplate: string): boolean {
+  try {
+    return !hasMacro(sqlTemplate, 'filters') && !hasVariableMacro(sqlTemplate);
+  } catch (e) {
+    if (e instanceof MalformedMacroArgsError) {
+      return false;
+    }
+    console.log('unexpected error in isMissingFiltersMacro', e);
+    return false;
+  }
 }
 
 /**

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -1,4 +1,5 @@
 import { splitAndTrimWithBracket } from './core/utils';
+import { MacroExpansionError, MalformedMacroArgsError } from './macroErrors';
 import { RawSqlQueryParam, renderQueryParam } from './rawSqlParams';
 import {
   MetricsDataType,
@@ -23,7 +24,8 @@ function expectArgs(
   if (args.length < minArgs || args.length > maxArgs) {
     const expected =
       minArgs === maxArgs ? `${minArgs}` : `${minArgs}-${maxArgs}`;
-    throw new Error(
+    throw new MacroExpansionError(
+      macroName,
       `Macro '${macroName}' expects ${expected} argument(s), but got ${args.length}`,
     );
   }
@@ -47,6 +49,8 @@ type Macro = {
   name: string;
   minArgs: number;
   maxArgs: number;
+  /** One-line summary of what the macro expands to, shown in autocomplete. */
+  description: string;
   replace: (args: string[]) => string;
 };
 
@@ -55,30 +59,38 @@ const MACROS = [
     name: 'fromTime',
     minArgs: 0,
     maxArgs: 0,
+    description: 'Start of the selected time range, as a DateTime.',
     replace: () => timeToDateTime(startMs()),
   },
   {
     name: 'toTime',
     minArgs: 0,
     maxArgs: 0,
+    description: 'End of the selected time range, as a DateTime.',
     replace: () => timeToDateTime(endMs()),
   },
   {
     name: 'fromTime_ms',
     minArgs: 0,
     maxArgs: 0,
+    description:
+      'Start of the selected time range, as a millisecond-precision DateTime64.',
     replace: () => timeToDateTime64(startMs()),
   },
   {
     name: 'toTime_ms',
     minArgs: 0,
     maxArgs: 0,
+    description:
+      'End of the selected time range, as a millisecond-precision DateTime64.',
     replace: () => timeToDateTime64(endMs()),
   },
   {
     name: 'timeFilter',
     minArgs: 1,
     maxArgs: 1,
+    description:
+      'Filters the given DateTime column to the selected time range (inclusive of both ends).',
     replace: (args: string[]) => {
       expectArgs('timeFilter', args, 1, 1);
       const [col] = args;
@@ -89,6 +101,8 @@ const MACROS = [
     name: 'timeFilter_ms',
     minArgs: 1,
     maxArgs: 1,
+    description:
+      'Filters the given millisecond-precision DateTime64 column to the selected time range.',
     replace: (args: string[]) => {
       expectArgs('timeFilter_ms', args, 1, 1);
       const [col] = args;
@@ -99,6 +113,7 @@ const MACROS = [
     name: 'dateFilter',
     minArgs: 1,
     maxArgs: 1,
+    description: 'Filters the given Date column to the selected time range.',
     replace: (args: string[]) => {
       expectArgs('dateFilter', args, 1, 1);
       const [col] = args;
@@ -109,6 +124,8 @@ const MACROS = [
     name: 'dateTimeFilter',
     minArgs: 2,
     maxArgs: 2,
+    description:
+      'Filters the given Date and DateTime columns to the selected time range, for tables partitioned on a date.',
     replace: (args: string[]) => {
       expectArgs('dateTimeFilter', args, 2, 2);
       const [dateCol, timeCol] = args;
@@ -121,6 +138,7 @@ const MACROS = [
     name: 'dt',
     minArgs: 2,
     maxArgs: 2,
+    description: 'Short alias for $__dateTimeFilter(dateCol, timeCol).',
     replace: (args: string[]) => {
       expectArgs('dt', args, 2, 2);
       const [dateCol, timeCol] = args;
@@ -133,6 +151,8 @@ const MACROS = [
     name: 'timeInterval',
     minArgs: 1,
     maxArgs: 1,
+    description:
+      'Buckets the provided DateTime column to the chart granularity, for the time axis of a time-series chart.',
     replace: (args: string[]) => {
       expectArgs('timeInterval', args, 1, 1);
       const [col] = args;
@@ -143,6 +163,8 @@ const MACROS = [
     name: 'timeInterval_ms',
     minArgs: 1,
     maxArgs: 1,
+    description:
+      'Buckets the provided millisecond-precision column to the chart granularity.',
     replace: (args: string[]) => {
       expectArgs('timeInterval_ms', args, 1, 1);
       const [col] = args;
@@ -153,6 +175,7 @@ const MACROS = [
     name: 'interval_s',
     minArgs: 0,
     maxArgs: 0,
+    description: 'The chart granularity, in seconds.',
     replace: () => intervalS(),
   },
 ] as const satisfies readonly Macro[];
@@ -168,16 +191,62 @@ export type MacroName =
   | 'sourceTable'
   | VariableMacroName;
 
+const FILTERS_MACRO_DESCRIPTION =
+  'Applies all broadcasted dashboard filters to this tile, as a single predicate. Expands to 1=1 when none apply. Requires a source selection for the tile.';
+const SOURCE_TABLE_MACRO_DESCRIPTION =
+  "The selected source's table, fully qualified. Requires a source selection for the tile.";
+
+export type MacroSuggestion = {
+  name: string;
+  minArgs: number;
+  maxArgs: number;
+  description: string;
+};
+
 /** Macro metadata for autocomplete suggestions */
-export const MACRO_SUGGESTIONS = [
-  ...MACROS.map(({ name, minArgs, maxArgs }) => ({ name, minArgs, maxArgs })),
-  { name: 'filters', minArgs: 0, maxArgs: 0 },
-  { name: 'sourceTable', minArgs: 0, maxArgs: 1 },
+export const MACRO_SUGGESTIONS: MacroSuggestion[] = [
+  ...MACROS.map(({ name, minArgs, maxArgs, description }) => ({
+    name,
+    minArgs,
+    maxArgs,
+    description,
+  })),
+  {
+    name: 'filters',
+    minArgs: 0,
+    maxArgs: 0,
+    description: FILTERS_MACRO_DESCRIPTION,
+  },
+  {
+    name: 'sourceTable',
+    minArgs: 0,
+    maxArgs: 1,
+    description: SOURCE_TABLE_MACRO_DESCRIPTION,
+  },
   ...Object.values(MetricsDataType).map(type => ({
     name: `sourceTable(${type})`,
     minArgs: 0,
     maxArgs: 0,
+    description: `The selected metrics source's ${type} table, fully qualified.`,
   })),
+];
+
+/** Macros that only resolve when the chart is rendered with a variable context */
+export const VARIABLE_MACRO_SUGGESTIONS: MacroSuggestion[] = [
+  {
+    name: 'filter',
+    minArgs: 1,
+    maxArgs: 2,
+    description:
+      "$__filter(<expression>, <variable>) — matches the expression against the variable's selected values. Expands to 1=1 when nothing is selected, so the query stays valid. The recommended way to use a variable in SQL.",
+  },
+  {
+    name: 'conditionalAll',
+    minArgs: 2,
+    maxArgs: 2,
+    description:
+      '$__conditionalAll(<condition>, <variable>) — applies the condition only while the variable has a selection, and expands to 1=1 otherwise. Use it for operators IN cannot express, such as NOT IN or LIKE.',
+  },
 ];
 
 /**
@@ -280,7 +349,7 @@ function findMacros(input: string, name: MacroName): MacroMatch[] {
     const { args, length } = parseMacroArgs(input.slice(end));
 
     if (length < 0) {
-      throw new Error('Failed to parse macro arguments');
+      throw new MalformedMacroArgsError();
     }
 
     matches.push({ full: input.slice(start, end + length), args });
@@ -319,28 +388,33 @@ export function replaceMacros(
       name: 'filters',
       minArgs: 0,
       maxArgs: 0,
+      description: FILTERS_MACRO_DESCRIPTION,
       replace: () => filtersSQL || NO_FILTERS,
     },
     {
       name: 'sourceTable',
       minArgs: 0,
       maxArgs: 1,
+      description: SOURCE_TABLE_MACRO_DESCRIPTION,
       replace: (args: string[]) => {
         expectArgs('sourceTable', args, 0, 1);
         if (!from) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             "Macro '$__sourceTable' requires a source to be selected",
           );
         }
 
         if (args.length === 0 && metricTables) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             "Macro '$__sourceTable(metricType)' requires a metricType when a metrics source is selected",
           );
         }
 
         if (args.length === 0 && !from.tableName) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             "Macro '$__sourceTable' requires a source with a table to be selected when no arguments are provided",
           );
         }
@@ -350,14 +424,16 @@ export function replaceMacros(
         }
 
         if (!metricTables) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             "Macro '$__sourceTable(metricType)' with a metric type argument requires a metrics source to be selected",
           );
         }
 
         const metricsTypeParseResult = MetricsDataTypeSchema.safeParse(args[0]);
         if (!metricsTypeParseResult.success) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             `Macro '$__sourceTable(metricType)' invalid argument '${args[0]}'. Expected a valid metrics data type (${Object.values(MetricsDataType).join(', ')}).`,
           );
         }
@@ -365,7 +441,8 @@ export function replaceMacros(
         const metricType = metricsTypeParseResult.data;
         const table = metricTables[metricType];
         if (!table) {
-          throw new Error(
+          throw new MacroExpansionError(
+            'sourceTable',
             `Macro '$__sourceTable(metricType)': No table configured for metric type '${metricType}'.`,
           );
         }

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -3,6 +3,7 @@ import {
   isQuoteEscapedByBackslash,
   splitAndTrimWithBracket,
 } from './core/utils';
+import { MacroExpansionError, MalformedMacroArgsError } from './macroErrors';
 import {
   ChartConfigWithOptDateRange,
   ChartVariable,
@@ -246,7 +247,7 @@ export function scanTemplateTokens(
       const closeIndex = findBalancedParens(input, argsStart);
       if (closeIndex < 0) {
         if (onMalformed === 'throw') {
-          throw new Error('Failed to parse macro arguments');
+          throw new MalformedMacroArgsError();
         }
         text += input.slice(i, argsStart);
         i = argsStart;
@@ -334,7 +335,8 @@ function requireVariable(
 ): ChartVariable {
   const variable = ctx.variables.find(v => v.name === variableName);
   if (!variable) {
-    throw new Error(
+    throw new MacroExpansionError(
+      macroName,
       `Macro '$__${macroName}' references unknown variable '${variableName}'. ` +
         `Available variables: ${
           ctx.variables.length > 0
@@ -348,7 +350,8 @@ function requireVariable(
 
 function expandFilterMacro(args: string[], ctx: VariableContext): string {
   if (args.length < 1 || args.length > 2) {
-    throw new Error(
+    throw new MacroExpansionError(
+      'filter',
       `Macro 'filter' expects 1-2 argument(s), but got ${args.length}`,
     );
   }
@@ -363,7 +366,8 @@ function expandFilterMacro(args: string[], ctx: VariableContext): string {
     expression = substituteWithContext(args[0], ctx);
   } else {
     if (!variable.expression) {
-      throw new Error(
+      throw new MacroExpansionError(
+        'filter',
         `Macro '$__filter(${variableName})' requires the variable's filter expression, ` +
           `which is not available — pass it explicitly, e.g. $__filter(<expression>, ${variableName}).`,
       );
@@ -383,7 +387,8 @@ function expandConditionalAllMacro(
   ctx: VariableContext,
 ): string {
   if (args.length !== 2) {
-    throw new Error(
+    throw new MacroExpansionError(
+      'conditionalAll',
       `Macro 'conditionalAll' expects 2 argument(s), but got ${args.length}`,
     );
   }


### PR DESCRIPTION
## Summary

This PR builds on the variable substitution for Raw SQL Charts added in #2873, adding autocomplete and validations to improve the user experience.

Note that the configuration of variables is gated behind `NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true` and  behavior is intended to remain the same when no variables have been configured.

### Supported Variable Formats

<img width="708" height="444" alt="Screenshot 2026-08-12 at 7 52 17 AM" src="https://github.com/user-attachments/assets/53308d57-426d-4cf0-987c-80d7db29174e" />

### Autocomplete

Codemirror autocomplete has been updated to

1. Include variables and variable-related macros
2. Show a description of the completion, which in the case of variables also includes what the variable will expand to

<img width="816" height="181" alt="Screenshot 2026-08-12 at 8 42 50 AM" src="https://github.com/user-attachments/assets/54bcbc15-f4cc-4550-b596-51e694bc08fc" />
<img width="779" height="195" alt="Screenshot 2026-08-12 at 8 43 14 AM" src="https://github.com/user-attachments/assets/917617af-a955-4af1-87f8-f72499e0996c" />

Since the autocomplete now includes the full description of each macro and query parameter, I have removed the individual macro and query parameter descriptions from the Raw SQL Chart Instructions, which was growing very large, particularly if we were to add the variable related macro.

<img width="1156" height="473" alt="Screenshot 2026-08-12 at 8 42 34 AM" src="https://github.com/user-attachments/assets/c117c4fc-809f-4d64-b50a-faa621a126a9" />

### Validations

Validations have been reworked and now cover the following variables scenarios:

- References to variables that don't exist
- References to variables without using $__filter or $__conditionalAll (which have a safe empty state)

Further, an empty SQL input is now treated as temporarily valid, to avoid flashing error states when the user first navigates to the SQL Editor.

## Future work

Future work includes, but is not limited to:

1. Updating the alerts runner to supply a variables context based on the variables configured on the dashboard
4. Extending support to builder charts
5. Supporting dependent variables
6. MCP and external API support
7. Documentation

## How to test locally

1. Clone and restart to ensure `NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true`
8. Create a dashboard
9. Add a filter and enable variable mode
10. Add a SQL tile and test the autocomplete and validation functionality

## References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5051
- Related PRs:
