### PR TITLE
fix(common-utils): map NULL-literal SELECT aliases

### DIFF
--- a/.changeset/null-literal-select-alias.md
+++ b/.changeset/null-literal-select-alias.md
@@ -1,0 +1,9 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+Fix `NULL AS "alias"` projections being dropped from the SELECT alias map. A
+column projected as a NULL literal was omitted, so anything resolving a value
+back to its source expression (for example building a WHERE clause that
+identifies a specific row) treated the alias as a real table column and
+produced SQL referencing a column that does not exist.

--- a/packages/common-utils/src/__tests__/clickhouse.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouse.test.ts
@@ -185,6 +185,22 @@ describe('chSqlToAliasMap - alias unit test', () => {
     expect(res).toEqual(aliasMap);
   });
 
+  it('NULL literal alias (multi-source padding column)', () => {
+    const chSqlInput: ChSql = {
+      sql: 'SELECT Timestamp as "__hdx_timestamp", NULL as "__hdx_duration_ms" FROM {HYPERDX_PARAM_1544803905:Identifier}.{HYPERDX_PARAM_129845054:Identifier} ORDER BY Timestamp DESC LIMIT {HYPERDX_PARAM_49586:Int32}',
+      params: {
+        HYPERDX_PARAM_1544803905: 'default',
+        HYPERDX_PARAM_129845054: 'otel_logs',
+        HYPERDX_PARAM_49586: 200,
+      },
+    };
+    const res = chSqlToAliasMap(chSqlInput);
+    expect(res).toEqual({
+      __hdx_timestamp: 'Timestamp',
+      __hdx_duration_ms: 'NULL',
+    });
+  });
+
   it('Normal alias, with brackets', () => {
     const chSqlInput: ChSql = {
       sql: "SELECT Timestamp as ts,ResourceAttributes['service.name'] as serviceTest,Body,TimestampTime,ServiceName,TimestampTime FROM {HYPERDX_PARAM_1544803905:Identifier}.{HYPERDX_PARAM_129845054:Identifier} WHERE (TimestampTime >= fromUnixTimestamp64Milli({HYPERDX_PARAM_1456399765:Int64}) AND TimestampTime <= fromUnixTimestamp64Milli({HYPERDX_PARAM_1719057412:Int64})) ORDER BY TimestampTime DESC LIMIT {HYPERDX_PARAM_49586:Int32} OFFSET {HYPERDX_PARAM_48:Int32}",

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -1003,6 +1003,10 @@ function selectColumnsToAliasMap(
                 `${column.expr.column.expr.value}['${column.expr.array_index[0].index.value}']`
               : // normal alias
                 column.expr.column.expr.value;
+        } else if (column.expr.type === 'null') {
+          // NULL literal projection (multi-source search pads columns a source
+          // lacks with `NULL AS "alias"`); the parser emits it without a loc.
+          aliasMap[column.as] = 'NULL';
         } else if (column.expr.loc != null) {
           aliasMap[column.as] = parsedSql.slice(
             column.expr.loc.start.offset,


### PR DESCRIPTION
A column projected as `NULL AS "alias"` was dropped from the SELECT alias map, because a NULL literal parses without a source location and fell through every branch. Callers that resolve a result column back to its source expression then treated the alias as a real table column — the row-identity WHERE builder emitted a predicate against a column that doesn't exist instead of `isNull(NULL)`.

Found while building multi-source search, where a source that lacks a field projects it as NULL, but the bug is independent of that work and this fixes it on its own.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5-D97757?logo=claude&logoColor=white)