### PR TITLE
feat(iac): team-scoped Terraform import ids

### DIFF
--- a/.changeset/iac-team-scoped-import-ids.md
+++ b/.changeset/iac-team-scoped-import-ids.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/common-utils': minor
+'@hyperdx/app': minor
+---
+
+Terraform export now emits team-scoped import ids (`<team_id>/<resource_id>`),
+so resources can be imported from a ClickStack deployment that backs more than
+one team. Each imported resource gains a `team` attribute, which the provider
+marks as forcing replacement — the generated file now says to keep it. The
+provider floor moves to `>= 3.25.0`, which drops server-only dashboard ids when
+importing, so the generated dashboard config no longer churns tile ids (and the
+tile alerts attached to them) on apply.

--- a/packages/app/src/components/Iac/ResourceTerraformPopover.tsx
+++ b/packages/app/src/components/Iac/ResourceTerraformPopover.tsx
@@ -8,6 +8,7 @@ import {
 import { ActionIcon, Popover, Tooltip } from '@mantine/core';
 import { IconBrandTerraform } from '@tabler/icons-react';
 
+import api from '@/api';
 import { BASE_PATH, IS_IAC_EXPORT_ENABLED } from '@/config';
 
 import {
@@ -33,7 +34,7 @@ import {
  * Everything here is derived synchronously from the ref — no fetch.
  *
  * Feature and local-mode gating lives here rather than at each call site, so
- * the four surfaces that render this cannot drift on when it appears. Callers
+ * the surfaces that render this cannot drift on when it appears. Callers
  * still own per-resource eligibility: the provider models only saved-search
  * alerts, so an alert call site must not render this for a tile alert.
  */
@@ -47,6 +48,11 @@ export default function ResourceTerraformPopover({
   // inline in JSX, so depending on the object itself would re-run this on
   // every render.
   const { type, id, name } = resource;
+  // Import ids are team-scoped. Read here rather than taken as a prop so the
+  // call sites don't each have to know that. `me` is fetched once for the app
+  // shell, so this is a cache read; it is only null in local mode, where
+  // IS_IAC_EXPORT_ENABLED is false and this component never renders.
+  const teamId = api.useMe().data?.team.id;
 
   const snippets = useMemo<TerraformSnippet[]>(() => {
     // Nothing is built until the popover is opened, which can only happen
@@ -57,7 +63,7 @@ export default function ResourceTerraformPopover({
     // The dropdown is unmounted while closed, so there is nothing to show
     // anyway. (`McpServerSection` dodges the same hazard by returning early
     // before it touches `window`.)
-    if (!opened) return [];
+    if (!opened || !teamId) return [];
     return [
       {
         // An `import {}` block, not the CLI `terraform import` one-liner: the
@@ -68,7 +74,7 @@ export default function ResourceTerraformPopover({
         // bulk export writes, so both surfaces produce the same artefact.
         label: 'Import block',
         hint: 'Add to your Terraform project, then run `terraform plan -generate-config-out=generated.tf` and review before applying. The address is derived from this resource’s id, so it survives a rename in HyperDX.',
-        snippet: buildImportBlock({ type, id, name }),
+        snippet: buildImportBlock({ type, id, name }, teamId),
       },
       {
         // Terraform permits one `required_providers` and one default provider
@@ -82,7 +88,7 @@ export default function ResourceTerraformPopover({
         ),
       },
     ];
-  }, [opened, type, id, name]);
+  }, [opened, type, id, name, teamId]);
 
   // After the hooks, so the early return cannot change hook order.
   if (!IS_IAC_EXPORT_ENABLED) return null;

--- a/packages/app/src/components/Iac/TerraformHelperPanel.stories.tsx
+++ b/packages/app/src/components/Iac/TerraformHelperPanel.stories.tsx
@@ -32,7 +32,10 @@ const ref = {
 export const Default: Story = {
   args: {
     snippets: [
-      { label: 'Import block', snippet: buildImportBlock(ref) },
+      {
+        label: 'Import block',
+        snippet: buildImportBlock(ref, '7a1c0de5b2f34c9d8e0a1b2c'),
+      },
       {
         label: 'Provider setup',
         collapsible: true,

--- a/packages/app/src/components/Iac/__tests__/ResourceTerraformPopover.test.tsx
+++ b/packages/app/src/components/Iac/__tests__/ResourceTerraformPopover.test.tsx
@@ -5,6 +5,21 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import ResourceTerraformPopover from '@/components/Iac/ResourceTerraformPopover';
 
+const TEAM_ID = '7a1c0de5b2f34c9d8e0a1b2c';
+
+// Same getter trick as the config mock below: `mock` prefix so the hoisted
+// factory may close over it, and one test blanks it to stand in for a `me`
+// that has not resolved yet.
+let mockMeTeamId: string | undefined = TEAM_ID;
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useMe: () => ({
+      data: mockMeTeamId ? { team: { id: mockMeTeamId } } : undefined,
+    }),
+  },
+}));
+
 // A getter, not a literal: the component reads the binding at render time, so
 // this lets one test flip the gate without re-requiring React.
 let iacExportEnabled = true;
@@ -44,6 +59,7 @@ describe('ResourceTerraformPopover', () => {
   beforeEach(() => {
     iacExportEnabled = true;
     basePath = '';
+    mockMeTeamId = TEAM_ID;
   });
 
   // The dropdown mounts through Mantine's `<Transition>`, which renders on a
@@ -56,6 +72,28 @@ describe('ResourceTerraformPopover', () => {
         /to = clickhouse_clickstack_dashboard\.dashboard_655b1b7d9143aa1b1b73f4f4/,
       ),
     ).toBeInTheDocument();
+  });
+
+  // The address stays id-only, but the import id is team-scoped: on ClickHouse
+  // Cloud one service can back several teams.
+  it('scopes the import id to the team', async () => {
+    openPopover();
+
+    expect(
+      await screen.findByText(new RegExp(`id = "${TEAM_ID}/${DASHBOARD.id}"`)),
+    ).toBeInTheDocument();
+  });
+
+  it('shows no snippets until the team is known', async () => {
+    mockMeTeamId = undefined;
+
+    openPopover();
+
+    // Await the panel before asserting absence. The dropdown mounts a tick
+    // later, so a synchronous queryByText passes whether or not the guard
+    // works — the panel testid is the anchor that makes this test able to fail.
+    await screen.findByTestId('terraform-helper-panel');
+    expect(screen.queryByText(/^# Usage import \{/)).not.toBeInTheDocument();
   });
 
   // The CLI `terraform import` one-liner refuses to run unless the address is
@@ -92,8 +130,8 @@ describe('ResourceTerraformPopover', () => {
     ).not.toBeInTheDocument();
   });
 
-  // Gating lives in this component rather than at each of the four call
-  // sites, so this one assertion covers all of them — including local mode,
+  // Gating lives in this component rather than at each call site, so this
+  // one assertion covers all of them — including local mode,
   // which has no API server for the provider to talk to.
   it('renders nothing when the export is disabled', () => {
     iacExportEnabled = false;

--- a/packages/app/src/components/TeamSettings/IacMigrationSection.tsx
+++ b/packages/app/src/components/TeamSettings/IacMigrationSection.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mantine/core';
 import { IconDownload } from '@tabler/icons-react';
 
+import api from '@/api';
 import { useIacImportManifest } from '@/components/Iac/useIacImportManifest';
 import { BASE_PATH } from '@/config';
 import { downloadTextFile } from '@/utils/downloadFile';
@@ -89,6 +90,9 @@ export default function IacMigrationSection({
     isRefetching,
     refetch,
   } = useIacImportManifest({ enabled: active });
+  // Prefixes every import id — see buildImportBlock. Same team the manifest is
+  // scoped to; both come from the session.
+  const teamId = api.useMe().data?.team.id;
   const [selected, setSelected] = useState<IacResourceType[]>([
     'dashboard',
     'alert',
@@ -186,12 +190,13 @@ export default function IacMigrationSection({
       // a truthiness check would write exactly the stale file this refetch
       // exists to avoid. The failure surfaces through the isError banner below.
       const result = await refetch();
-      if (!result.isSuccess || !result.data) return;
+      if (!result.isSuccess || !result.data || !teamId) return;
       const freshSelection = collectImportableResources(result.data, selected);
 
       downloadTextFile(
         buildImportFile({
           endpoint: providerEndpoint(window.location.origin, BASE_PATH),
+          teamId,
           resources: freshSelection.resources,
           connectionLocals: freshSelection.connectionLocals,
           // From the refetched payload, not the banner's cached one: a listing
@@ -299,6 +304,7 @@ export default function IacMigrationSection({
           disabled={
             isLoading ||
             isError ||
+            !teamId ||
             (resources.length === 0 && connectionLocals.length === 0)
           }
           data-testid="iac-download-button"

--- a/packages/app/src/components/TeamSettings/__tests__/IacMigrationSection.test.tsx
+++ b/packages/app/src/components/TeamSettings/__tests__/IacMigrationSection.test.tsx
@@ -18,6 +18,19 @@ jest.mock('@/components/Iac/useIacImportManifest', () => ({
   useIacImportManifest: (...args: unknown[]) => useIacImportManifest(...args),
 }));
 
+// `mock` prefix so the hoisted jest.mock factory below may close over them.
+const mockTeamId = '7a1c0de5b2f34c9d8e0a1b2c';
+// Blanked by one test to stand in for a `me` that has not resolved yet.
+let mockMeTeamId: string | undefined = mockTeamId;
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useMe: () => ({
+      data: mockMeTeamId ? { team: { id: mockMeTeamId } } : undefined,
+    }),
+  },
+}));
+
 const MANIFEST = {
   dashboards: [
     { id: '1'.repeat(24), name: 'D1' },
@@ -77,6 +90,7 @@ describe('resource type registry', () => {
 describe('IacMigrationSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMeTeamId = mockTeamId;
     refetch.mockResolvedValue({ data: MANIFEST, isSuccess: true });
     useIacImportManifest.mockReturnValue({
       data: MANIFEST,
@@ -118,8 +132,27 @@ describe('IacMigrationSection', () => {
     expect(content).toContain(
       `to = clickhouse_clickstack_saved_search.saved_search_${'4'.repeat(24)}`,
     );
+    // Team-scoped import ids — a ClickHouse Cloud service can back several
+    // teams, so the resource id alone does not say which one to read.
+    expect(content).toContain(`id = "${mockTeamId}/${'1'.repeat(24)}"`);
     expect(content).not.toContain('5'.repeat(24)); // tile alert excluded
     expect(content).not.toContain('6'.repeat(24)); // connections not selected by default
+  });
+
+  // Every import id is prefixed with the team, so a file built before `me`
+  // resolves would carry "undefined/<id>" on every block. The guard is the
+  // disabled button; this pins that it also cannot be driven past.
+  it('writes nothing while the team is unknown', async () => {
+    mockMeTeamId = undefined;
+    renderSection();
+
+    const button = screen.getByTestId('iac-download-button');
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(refetch).not.toHaveBeenCalled());
+    expect(downloadTextFile).not.toHaveBeenCalled();
   });
 
   // The manifest is cached for 60s. Building the file from that cache writes

--- a/packages/common-utils/src/__tests__/iac.test.ts
+++ b/packages/common-utils/src/__tests__/iac.test.ts
@@ -17,6 +17,8 @@ import {
 import { DisplayType, SourceKind } from '@/types';
 
 const ID = '655b1b7d9143aa1b1b73f4f4';
+// Import ids are team-scoped: `<team_id>/<resource_id>`.
+const TEAM_ID = '7a1c0de5b2f34c9d8e0a1b2c';
 
 function emptyManifest(
   overrides: Partial<IacImportManifest> = {},
@@ -279,17 +281,22 @@ describe('buildImportBlock', () => {
   // The block form, not the CLI `terraform import` one-liner: the CLI form
   // refuses to run unless the address is already declared in configuration,
   // and this feature generates none.
-  it('emits an import block with the plain-id form (never <teamId>/<id>)', () => {
+  // `<team_id>/<resource_id>`: on ClickHouse Cloud one service backs several
+  // teams, so a bare resource id is ambiguous. Accepted since provider 3.22.0.
+  it('emits an import block with the team-scoped id form', () => {
     expect(
-      buildImportBlock({ type: 'dashboard', id: ID, name: 'HyperDX Usage' }),
+      buildImportBlock(
+        { type: 'dashboard', id: ID, name: 'HyperDX Usage' },
+        TEAM_ID,
+      ),
     ).toBe(
-      `# HyperDX Usage\nimport {\n  to = clickhouse_clickstack_dashboard.dashboard_${ID}\n  id = "${ID}"\n}`,
+      `# HyperDX Usage\nimport {\n  to = clickhouse_clickstack_dashboard.dashboard_${ID}\n  id = "${TEAM_ID}/${ID}"\n}`,
     );
   });
 
   it('omits the comment line when the resource has no name', () => {
-    expect(buildImportBlock({ type: 'alert', id: ID })).toBe(
-      `import {\n  to = clickhouse_clickstack_alert.alert_${ID}\n  id = "${ID}"\n}`,
+    expect(buildImportBlock({ type: 'alert', id: ID }, TEAM_ID)).toBe(
+      `import {\n  to = clickhouse_clickstack_alert.alert_${ID}\n  id = "${TEAM_ID}/${ID}"\n}`,
     );
   });
 
@@ -298,7 +305,7 @@ describe('buildImportBlock', () => {
   it.each(Object.keys(TERRAFORM_RESOURCE_TYPES) as IacResourceType[])(
     'maps %s to its provider resource name',
     type => {
-      expect(buildImportBlock({ type, id: ID })).toContain(
+      expect(buildImportBlock({ type, id: ID }, TEAM_ID)).toContain(
         `to = ${TERRAFORM_RESOURCE_TYPES[type]}.${type}_${ID}`,
       );
     },
@@ -327,19 +334,22 @@ describe('name sanitisation', () => {
     '`id`',
     'tab\tseparated',
   ])('keeps a hostile name on one comment line: %s', hostile => {
-    const block = buildImportBlock({ type: 'alert', id: ID, name: hostile });
+    const block = buildImportBlock(
+      { type: 'alert', id: ID, name: hostile },
+      TEAM_ID,
+    );
     const [comment, ...rest] = block.split('\n');
 
     expect(comment.startsWith('# ')).toBe(true);
     // Everything after the comment is the untouched import block.
     expect(rest.join('\n')).toBe(
-      `import {\n  to = clickhouse_clickstack_alert.alert_${ID}\n  id = "${ID}"\n}`,
+      `import {\n  to = clickhouse_clickstack_alert.alert_${ID}\n  id = "${TEAM_ID}/${ID}"\n}`,
     );
   });
 
   it('drops a name that is only whitespace', () => {
     expect(
-      buildImportBlock({ type: 'alert', id: ID, name: ' \n\t ' }),
+      buildImportBlock({ type: 'alert', id: ID, name: ' \n\t ' }, TEAM_ID),
     ).not.toContain('#');
   });
 });
@@ -356,15 +366,25 @@ describe('resource id validation', () => {
     'ZZZb1b7d9143aa1b1b73f4f4',
     '',
   ])('refuses to emit an import block for id %p', badId => {
-    expect(() => buildImportBlock({ type: 'alert', id: badId })).toThrow(
-      /non-ObjectId id/,
-    );
+    expect(() =>
+      buildImportBlock({ type: 'alert', id: badId }, TEAM_ID),
+    ).toThrow(/non-ObjectId resource id/);
+  });
+
+  // The team id is now the other half of the same sink.
+  it('refuses to emit an import block for a bad team id', () => {
+    expect(
+      () =>
+        buildImportBlock({ type: 'alert', id: ID }, 'a"; provider "null" {} #'),
+      // Labelled, so the thrown error says which half of the id was wrong.
+    ).toThrow(/non-ObjectId team id/);
   });
 
   it('refuses to emit a connection local for a bad id', () => {
     expect(() =>
       buildImportFile({
         endpoint: 'https://hyperdx.example.com/api',
+        teamId: TEAM_ID,
         resources: [],
         connectionLocals: [{ id: 'not-an-objectid', name: 'Sneaky' }],
       }),
@@ -373,7 +393,7 @@ describe('resource id validation', () => {
 
   it('accepts ObjectId hex in either case', () => {
     expect(() =>
-      buildImportBlock({ type: 'alert', id: ID.toUpperCase() }),
+      buildImportBlock({ type: 'alert', id: ID.toUpperCase() }, TEAM_ID),
     ).not.toThrow();
   });
 });
@@ -383,13 +403,14 @@ describe('buildImportFile', () => {
     const otherId = 'a55b1b7d9143aa1b1b73f4f4';
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [
         { type: 'dashboard', id: ID, name: 'Usage' },
         { type: 'saved_search', id: otherId, name: 'Errors' },
       ],
     });
     expect(file).toContain('source  = "ClickHouse/clickhouse"');
-    expect(file).toContain('version = ">= 3.22.0"');
+    expect(file).toContain('version = ">= 3.25.0"');
     // `import {}` and -generate-config-out both need Terraform 1.5+; without
     // the constraint an older CLI fails with a syntax error instead.
     expect(file).toContain('required_version = ">= 1.5.0"');
@@ -403,7 +424,7 @@ describe('buildImportFile', () => {
     expect(file).toContain(
       `to = clickhouse_clickstack_dashboard.dashboard_${ID}`,
     );
-    expect(file).toContain(`id = "${ID}"`);
+    expect(file).toContain(`id = "${TEAM_ID}/${ID}"`);
     expect(file).toContain(
       `to = clickhouse_clickstack_saved_search.saved_search_${otherId}`,
     );
@@ -417,6 +438,7 @@ describe('buildImportFile', () => {
   it('emits a unique address per resource when names and id suffixes collide', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [
         { type: 'alert', id: `${'a'.repeat(19)}11111`, name: 'Alert' },
         { type: 'alert', id: `${'b'.repeat(19)}11111`, name: 'Alert' },
@@ -433,6 +455,7 @@ describe('buildImportFile', () => {
   it('warns that re-exporting is not additive', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [{ type: 'dashboard', id: ID, name: 'Usage' }],
     });
 
@@ -445,6 +468,7 @@ describe('buildImportFile', () => {
   it('marks the file partial when a listing was capped', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [{ type: 'dashboard', id: ID, name: 'Usage' }],
       truncatedTypes: ['dashboards', 'alerts'],
     });
@@ -457,15 +481,31 @@ describe('buildImportFile', () => {
   it('omits the partial-export marker when nothing was capped', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [{ type: 'dashboard', id: ID, name: 'Usage' }],
     });
 
     expect(file).not.toContain('PARTIAL EXPORT');
   });
 
+  // The team prefix has two consequences a user only discovers at apply time:
+  // the `team` attribute it writes forces replacement if dropped, and a
+  // provider configured against the Cloud API rejects team scoping outright.
+  it('warns about the team attribute and the Cloud-configured provider', () => {
+    const file = buildImportFile({
+      endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
+      resources: [{ type: 'dashboard', id: ID, name: 'Usage' }],
+    });
+
+    expect(file).toContain('RequiresReplace');
+    expect(file).toContain('clickstack_service_id');
+  });
+
   it('explains that addresses survive a rename, and warns about whole-body writes', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [{ type: 'dashboard', id: ID, name: 'Usage' }],
     });
     expect(file).toContain('survive a rename');
@@ -476,11 +516,14 @@ describe('buildImportFile', () => {
   it('emits connections of unknown provenance as a locals block', () => {
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources: [],
       connectionLocals: [{ id: ID, name: 'Local ClickHouse' }],
     });
     expect(file).toContain('locals {');
     expect(file).toContain('# Local ClickHouse');
+    // Bare id, not the team-scoped import form: a local is a value other
+    // resources reference, not an address Terraform imports through.
     expect(file).toContain(`connection_${ID}_id = "${ID}"`);
     expect(file).not.toContain('clickhouse_clickstack_connection');
   });
@@ -498,6 +541,7 @@ describe('buildImportFile', () => {
     );
     const file = buildImportFile({
       endpoint: 'https://hyperdx.example.com/api',
+      teamId: TEAM_ID,
       resources,
       connectionLocals,
     });

--- a/packages/common-utils/src/iac.ts
+++ b/packages/common-utils/src/iac.ts
@@ -26,8 +26,13 @@ export {
 // the same artefact a human gets from the UI.
 
 const TERRAFORM_PROVIDER_SOURCE = 'ClickHouse/clickhouse';
-// First provider version shipping the ClickStack (HyperDX) resources.
-const TERRAFORM_PROVIDER_VERSION_CONSTRAINT = '>= 3.22.0';
+// The floor is about dashboards, not about the id form: below it, importing a
+// dashboard carries server-only ids into the config `-generate-config-out`
+// writes, and applying that config is what churns tile ids and takes the tile
+// alerts with them (provider #654, released in 3.24.1; 3.25.0 is the version
+// we pin). The `<team_id>/<resource_id>` id we emit has been accepted since
+// 3.22.0 and does not need this floor.
+const TERRAFORM_PROVIDER_VERSION_CONSTRAINT = '>= 3.25.0';
 // `import {}` blocks and `-generate-config-out` both landed in Terraform 1.5.
 // Without this, an older CLI fails with a syntax error instead of saying so.
 const TERRAFORM_VERSION_CONSTRAINT = '>= 1.5.0';
@@ -111,18 +116,26 @@ export const IAC_RESOURCE_ID_RE = /^[0-9a-fA-F]{24}$/;
  * ObjectId hex means the caller is wrong about what it is holding, and a
  * silently rewritten id would import the wrong resource.
  */
-function assertResourceId(id: string): string {
+function assertResourceId(id: string, label = 'id'): string {
   if (!IAC_RESOURCE_ID_RE.test(id)) {
-    throw new Error(`Refusing to emit Terraform for a non-ObjectId id: ${id}`);
+    throw new Error(
+      `Refusing to emit Terraform for a non-ObjectId ${label}: ${id}`,
+    );
   }
   return id;
 }
 
-export function buildImportBlock(ref: IacResourceRef): string {
+/**
+ * Import ids are `<team_id>/<resource_id>`. On ClickHouse Cloud one ClickStack
+ * service can back several teams, so a bare resource id does not say which
+ * team's resource to read. The team stays out of the Terraform address (see
+ * terraformResourceLabel) — it belongs to the lookup, not the identity.
+ */
+export function buildImportBlock(ref: IacResourceRef, teamId: string): string {
   const name = commentSafeName(ref.name);
   return `${name ? `# ${name}\n` : ''}import {
   to = ${TERRAFORM_RESOURCE_TYPES[ref.type]}.${terraformResourceLabel(ref)}
-  id = "${assertResourceId(ref.id)}"
+  id = "${assertResourceId(teamId, 'team id')}/${assertResourceId(ref.id, 'resource id')}"
 }`;
 }
 
@@ -190,12 +203,15 @@ ${lines.join('\n')}
 
 export function buildImportFile({
   endpoint,
+  teamId,
   resources,
   connectionLocals = [],
   truncatedTypes = [],
   skipNotices = [],
 }: {
   endpoint: string;
+  /** Prefixes every import id — see buildImportBlock. */
+  teamId: string;
   resources: IacResourceRef[];
   connectionLocals?: IacConnectionRef[];
   /**
@@ -216,7 +232,7 @@ export function buildImportFile({
     ...(connectionLocals.length
       ? [buildConnectionLocalsBlock(connectionLocals)]
       : []),
-    ...resources.map(buildImportBlock),
+    ...resources.map(r => buildImportBlock(r, teamId)),
   ];
   const partialWarning = truncatedTypes.length
     ? `#
@@ -255,6 +271,19 @@ ${partialWarning}${skipped}#
 # * Resource addresses below are derived from each resource's id, so they
 #   survive a rename in HyperDX. The name in the comment above each block is
 #   a label for humans only.
+# * Import ids are "<team_id>/<resource_id>", so each imported resource gets a
+#   "team" attribute. Keep it in generated.tf: the provider marks that
+#   attribute RequiresReplace, so removing or changing it plans a destroy and
+#   recreate rather than an update.
+# * Team-scoped ids need the provider configured with clickstack_endpoint, as
+#   the block below does. A provider configured against the Cloud API instead
+#   (clickstack_service_id) rejects any team-scoped call — on that path a
+#   service is a single ClickStack, so drop the "<team_id>/" prefix.
+# * The provider version constraint below is a floor, not decoration. If you
+#   delete the "terraform" block per step 1, check your own declaration
+#   requires >= 3.25.0 — older providers write server-only ids into the config
+#   generated for a dashboard, and applying that churns its tile ids and
+#   deletes the tile alerts attached to them.
 # * Re-exporting later does NOT produce an additive file. It re-emits every
 #   resource, including the ones already in state, so two of these files in one
 #   module means duplicate "to" addresses — which Terraform rejects for the


### PR DESCRIPTION
Terraform export now emits `id = "<team_id>/<resource_id>"` in each `import {}` block instead of a bare resource id, so an export can be imported against a ClickStack deployment that backs more than one team. The provider floor moves to `>= 3.25.0` at the same time, for a separate reason described below.

### What changed

- Import blocks carry a team-scoped id. The team comes from the session (`/me`), and both halves go through the existing ObjectId assertion before reaching generated HCL.
- Terraform addresses are unchanged — still `<type>_<resource_id>`, so a rename in HyperDX is still a non-event and existing addresses do not move.
- Connection `locals` still emit a bare id. They are values other resources reference, not addresses Terraform imports through.
- The generated file warns about two things that only surface at apply time: the `team` attribute an import writes is `RequiresReplace`, and a provider configured against the Cloud API rejects team-scoped calls.

### Key decisions

**The version bump is not what makes the id form work.** `<team>/<id>` has been parsed since 3.22.0 — `alert_resource.go` splits on `/` and sets the `team` attribute at that tag, and `client.go` is byte-identical between 3.22.0 and 3.25.0. The floor moves for the dashboard fix in provider #654: below it, importing a dashboard writes server-only ids into the config `-generate-config-out` produces, and applying that churns tile ids and deletes the tile alerts attached to them. Worth stating plainly because the first version of this change justified the bump with the id form, which is wrong.

**Team id read from `api.useMe()` in each surface**, rather than threaded through `IacResourceRef` or added to the `/iac/import-manifest` response. It matches how a dozen other components get team context, and there is no team switching within a session. Putting it on the ref would copy the same scalar onto every resource.

### Background

The provider only enters "cloud mode" when configured with `clickstack_service_id`; that path rejects any team-scoped call, because on Cloud a service is a single ClickStack. What we generate uses `clickstack_endpoint` plus an API key, which takes the self-hosted branch, so team scoping works. Anyone who merges these blocks into a project that configures the provider the other way needs to drop the prefix — hence the warning in the file.

### Impact

Existing state is untouched: addresses do not change, and this only affects ids in newly generated files. A user on a provider below 3.25.0 gets a `terraform init` failure from the constraint rather than a confusing apply-time result. Each newly imported resource gains a `team` attribute in state that must stay in the config.

<details>
<summary>Implementation detail</summary>

`buildImportBlock(ref, teamId)` takes the team as a second argument and `buildImportFile` as an option, so the two call sites supply it and `IacResourceRef` keeps meaning "resource identity". `assertResourceId` gained a label so a rejection says which half was malformed.

Tests: the previous suite asserted the plain-id form (`never <teamId>/<id>`), which was the deliberate earlier decision — those are rewritten. Added coverage for a hostile team id, for the two new warnings in the generated file, and for the bulk export refusing to build while the team is unknown. One new test was checked by inverting its mock: `shows no snippets until the team is known` originally passed with the team present, because it asserted before the Mantine dropdown mounts, and now anchors on the panel first.

`make ci-unit` passes. `make ci-lint` is clean; its `ts-ignore` ratchet failure reproduces on a clean `main` and is unrelated.

</details>
