### PR TITLE
test(dashboards): cover release-marker scoping by the tile's own filter

### DIFF
--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -3,9 +3,10 @@
  * Used for creating and configuring dashboard tiles and chart explorer
  */
 import { DisplayType } from '@hyperdx/common-utils/dist/types';
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 
 import { dismissSqlAutocomplete, getSqlEditor } from '../utils/locators';
+import { switchWhereToLucene } from '../utils/lucene-autocomplete';
 
 import { WebhookAlertModalComponent } from './WebhookAlertModalComponent';
 
@@ -98,6 +99,39 @@ export class ChartEditorComponent {
     await this.page.keyboard.type(expression);
     // Dismiss the autocomplete dropdown so it doesn't intercept the next click.
     await dismissSqlAutocomplete(this.page);
+  }
+
+  /**
+   * The tile-editor modal. Series-level lookups have to be scoped to it: the
+   * dashboard behind it renders its own WHERE input with identical markup.
+   * Only meaningful on a dashboard — the chart explorer has no modal.
+   */
+  private get tileEditor() {
+    return this.page
+      .getByRole('dialog')
+      .filter({ has: this.page.getByTestId('chart-name-input') });
+  }
+
+  /**
+   * Set the tile's own filter, which a time chart stores as its series'
+   * `aggCondition` rather than in the config's statement-level `where`.
+   *
+   * Switches to Lucene first for two reasons: the mode is sticky (it is kept in
+   * localStorage, so a previous spec can leave it on SQL), and
+   * `series-where-input` exists only on the Lucene branch of SearchWhereInput —
+   * the SQL branch renders a CodeMirror that carries no test id.
+   */
+  async setSeriesWhere(condition: string) {
+    const editor = this.tileEditor;
+    await switchWhereToLucene(editor.getByTestId('where-language-switch'));
+
+    const input = editor.getByTestId('series-where-input');
+    await expect(input).toBeVisible();
+    await input.fill(condition);
+    // Blur to close the suggestion dropdown, which otherwise overlays the
+    // Run/Save buttons and fails their actionability check. Escape would bubble
+    // to the tile-editor modal and close it.
+    await input.blur();
   }
 
   /**

--- a/packages/app/tests/e2e/features/release-markers.spec.ts
+++ b/packages/app/tests/e2e/features/release-markers.spec.ts
@@ -144,6 +144,35 @@ test.describe('Release markers', { tag: ['@full-stack', '@dashboard'] }, () => {
     await expect(page).not.toHaveURL(/releaseMarkers=true/);
   });
 
+  // The test above filters the *dashboard*; this one filters the *tile*. They
+  // are different fields — a dashboard filter travels as `filters`, while a
+  // time chart's own filter is stored as its series' `aggCondition`, not in the
+  // config's statement-level `where` (the editor clears that). Reading only
+  // `where` left every time chart's markers unscoped, and because the resulting
+  // markers then spanned two services with no matching line, they were all
+  // suppressed: filter to one service, see nothing.
+  test("scopes markers to the tile's own filter", async ({ page }) => {
+    await seedReleases();
+
+    await dashboardPage.createNewDashboard();
+    await dashboardPage.addTileWithSource(
+      'Tile-filtered markers',
+      DEFAULT_LOGS_SOURCE_NAME,
+      `ServiceName:"${RELEASE_SERVICE}"`,
+    );
+    // No dashboard-wide filter this time: the tile's own filter has to be what
+    // narrows the releases query.
+    await dashboardPage.toggleReleaseAnnotations();
+
+    await expect(page).toHaveURL(/releaseMarkers=true/);
+
+    const labels = dashboardPage.getAnnotationLabels();
+    await expect(dashboardPage.getAnnotationMarkers()).toHaveCount(2);
+    await expect(labels.filter({ hasText: OLD_VERSION })).toBeVisible();
+    await expect(labels.filter({ hasText: NEW_VERSION })).toBeVisible();
+    await expect(labels.filter({ hasText: OTHER_VERSION })).toHaveCount(0);
+  });
+
   // Colour alone can't identify a service once the legend overflows its 4-item
   // cap and the matching entry hides behind "+N more". Hover has to name the
   // service outright.

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -589,13 +589,24 @@ export class DashboardPage {
    * Add a tile bound to an explicit source. Unlike addTileWithConfig (which
    * relies on the editor's default source), this selects a known source so the
    * exported tile carries a deterministic source name that auto-maps on import.
+   *
+   * `seriesWhere` sets the tile's own filter, which a time chart stores as its
+   * series' `aggCondition` — a different field from the dashboard-wide filter
+   * that `setGlobalFilter` drives.
    */
-  async addTileWithSource(chartName: string, sourceName: string) {
+  async addTileWithSource(
+    chartName: string,
+    sourceName: string,
+    seriesWhere?: string,
+  ) {
     await this.addTile();
     await expect(this.chartEditor.nameInput).toBeVisible();
     await this.chartEditor.waitForDataToLoad();
     await this.chartEditor.setChartName(chartName);
     await this.chartEditor.selectSource(sourceName);
+    if (seriesWhere != null) {
+      await this.chartEditor.setSeriesWhere(seriesWhere);
+    }
     await this.chartEditor.runQuery(false);
     await this.chartEditor.save();
     await expect(this.getTiles()).toHaveCount(1, { timeout: 10000 });


### PR DESCRIPTION
Test-only. Adds the E2E coverage that should have caught the second bug in #2894, now that #2894 has merged.

## Why

A review comment on #2894 pointed out that the release-marker scope read `chart.config.where`, but timeseries charts don't use it — they keep their filter in each series' `aggCondition`. That was right, and the consequence was worse than a wasted query: the markers came back spanning every service in the source, none matched a line on an ungrouped chart, and `resolveAnnotationSeries` dropped all of them. Filter a tile to one service and you saw *no* markers.

The E2E suite was green through all of it. Its scoping test uses `setGlobalFilter`, a **dashboard** filter, which travels as `filters` and was already applied. Nothing exercised the tile's own filter — the field users actually type into.

The fix landed on #2894 with unit coverage only. This closes the loop at the level that would have prevented the mistake.

## What

One test that filters only the tile, no dashboard filter, and asserts the filtered service's two releases are drawn and the other service's is not.

`ChartEditorComponent.setSeriesWhere` reaches a series' Where. It switches to Lucene explicitly for two reasons: the mode is sticky in localStorage, so a previous spec can leave it on SQL, and `series-where-input` only exists on the Lucene branch — `SearchWhereInput`'s SQL branch renders a CodeMirror that carries no test id. Lookups are scoped to the tile-editor modal, since the dashboard behind it renders the same markup.

`addTileWithSource` grows an optional third argument. Its two other callers (`dashboard-template-import.spec.ts`, `lucene-autocomplete.spec.ts`) pass two, so their behaviour is byte-identical.

## No app-code changes

Three files, all under `packages/app/tests/e2e/`.

An earlier revision of this branch added a `data-testid="series-where"` wrapper, because `SearchWhereInput` forwards a test id only on its Lucene branch. #2902 has since landed `data-testid="series-where-input"`, a `where-language-switch` test id and a `switchWhereToLucene` helper, so the hook is no longer needed and the helper is built on those instead.

## Verification

**Re-proved it's a real regression test, not a tautology.** With `aggConditionScopeFilter` temporarily stubbed to `return undefined` — reproducing the pre-fix behaviour of reading only the statement-level `where` — the new test fails as:

```
Expected: 2
Received: 0
  9 × locator resolved to 0 elements
  at expect(dashboardPage.getAnnotationMarkers()).toHaveCount(2)
     release-markers.spec.ts:170
```

which is exactly the user-visible symptom. Stub reverted; suite green.

- `make dev-e2e FILE=release-markers` — 4/4 passing.
- `make dev-e2e FILE=dashboard-template-import` — 11/11 passing (other `addTileWithSource` caller).
- `make dev-e2e FILE=lucene-autocomplete` — 4/4 passing (owns the test ids and helper this reuses).
- `make ci-lint` — 0 errors, 590 warnings, unchanged.

No changeset: test-only, and #2894 already carries the feature's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
