### PR TITLE
chore(api): remove dead alert-silence-token endpoint and code

### DIFF
--- a/.changeset/remove-alert-silence-token.md
+++ b/.changeset/remove-alert-silence-token.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+Remove the non-functional `GET /ext/silence-alert/:token` endpoint and its dead code path.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,7 +46,6 @@
     "http-graceful-shutdown": "^3.1.13",
     "http-proxy-middleware": "^4.0.0",
     "ip-address": "^10.3.1",
-    "jsonwebtoken": "^9.0.0",
     "lodash": "^4.18.1",
     "minimist": "^1.2.7",
     "mongodb": "^6.15.0",

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -3,9 +3,7 @@ import {
   validateRawSqlForAlert,
 } from '@hyperdx/common-utils/dist/core/utils';
 import { isRawSqlSavedChartConfig } from '@hyperdx/common-utils/dist/guards';
-import { sign, verify } from 'jsonwebtoken';
 import { groupBy } from 'lodash';
-import ms from 'ms';
 import { z } from 'zod';
 
 import type { ObjectId } from '@/models';
@@ -15,7 +13,6 @@ import { ISavedSearch, SavedSearch } from '@/models/savedSearch';
 import { IUser } from '@/models/user';
 import Webhook from '@/models/webhook';
 import { Api400Error } from '@/utils/errors';
-import logger from '@/utils/logger';
 import { alertSchema, objectIdSchema } from '@/utils/zod';
 
 export type AlertInput = Omit<
@@ -332,74 +329,4 @@ export const deleteAlert = async (id: string, teamId: ObjectId) => {
     _id: id,
     team: teamId,
   });
-};
-
-/**
- * Generates the signed JWT consumed by {@link silenceAlertByToken} and the
- * `GET /ext/silence-alert/:token` route. The verify-half is live; this
- * generate-half is not yet wired into the alert-notification path (no caller
- * builds silence links yet), so it is intentionally kept as public API.
- *
- * @public
- */
-export const generateAlertSilenceToken = async (
-  alertId: ObjectId | string,
-  teamId: ObjectId | string,
-) => {
-  const secret = process.env.EXPRESS_SESSION_SECRET;
-
-  if (!secret) {
-    logger.error(
-      'EXPRESS_SESSION_SECRET is not set for signing token, skipping alert silence JWT generation',
-    );
-    return '';
-  }
-
-  const alert = await getAlertById(alertId, teamId);
-  if (alert == null) {
-    throw new Error('Alert not found');
-  }
-
-  const token = sign(
-    { alertId: alert._id.toString(), teamId: teamId.toString() },
-    secret,
-    { expiresIn: '1h' },
-  );
-
-  // Slack does not accept ids longer than 255 characters
-  if (token.length > 255) {
-    logger.error(
-      'Alert silence JWT length is greater than 255 characters, this may cause issues with some clients.',
-    );
-  }
-
-  return token;
-};
-
-export const silenceAlertByToken = async (token: string) => {
-  const secret = process.env.EXPRESS_SESSION_SECRET;
-
-  if (!secret) {
-    throw new Error('EXPRESS_SESSION_SECRET is not set for verifying token');
-  }
-
-  const decoded = verify(token, secret, {
-    algorithms: ['HS256'],
-  }) as { alertId: string; teamId: string };
-
-  if (!decoded?.alertId || !decoded?.teamId) {
-    throw new Error('Invalid token');
-  }
-
-  const alert = await getAlertById(decoded.alertId, decoded.teamId);
-  if (alert == null) {
-    throw new Error('Alert not found');
-  }
-
-  alert.silenced = {
-    at: new Date(),
-    until: new Date(Date.now() + ms('30m')),
-  };
-
-  return alert.save();
 };

--- a/packages/api/src/routers/api/root.ts
+++ b/packages/api/src/routers/api/root.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 import { validateRequest } from 'zod-express-middleware';
 
 import * as config from '@/config';
-import { silenceAlertByToken } from '@/controllers/alerts';
 import { createTeam, isTeamExisting } from '@/controllers/team';
 import { handleAuthError, redirectToDashboard } from '@/middleware/auth';
 import TeamInvite from '@/models/teamInvite';
@@ -176,40 +175,6 @@ router.post('/team/setup/:token', async (req, res, next) => {
   } catch (e) {
     next(e);
   }
-});
-
-router.get('/ext/silence-alert/:token', async (req, res) => {
-  let isError = false;
-
-  try {
-    const token = req.params.token;
-    await silenceAlertByToken(token);
-  } catch (e) {
-    isError = true;
-    logger.error({ err: e }, 'Failed to silence alert');
-  }
-
-  // TODO: Create a template for utility pages
-  return res.send(`
-  <html>
-    <head>
-      <title>HyperDX</title>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.min.css" />
-    </head>
-    <body>
-      <header>
-        <img src="https://www.hyperdx.io/Icon32.png" />
-      </header>
-      <main>
-        ${
-          isError
-            ? '<p><strong>Link is invalid or expired.</strong> Please try again.</p>'
-            : '<p><strong>Alert silenced.</strong> You can close this window now.</p>'
-        }
-        <a href="${config.FRONTEND_URL}">Back to HyperDX</a>
-      </main>
-    </body>
-  </html>`);
 });
 
 export default router;

--- a/packages/api/src/utils/__tests__/logger.test.ts
+++ b/packages/api/src/utils/__tests__/logger.test.ts
@@ -55,7 +55,7 @@ describe('logger redaction', () => {
 
   it('censors a redirect Location header', () => {
     const out = logAndCapture({
-      res: { headers: { location: '/ext/silence-alert/secret-token' } },
+      res: { headers: { location: '/team/setup/secret-token' } },
     });
 
     expect(out).not.toContain('secret-token');
@@ -72,16 +72,15 @@ describe('logger redaction', () => {
 
 /**
  * `redact` addresses object paths, so a token living inside a URL string is
- * out of its reach. These two routes take a standalone bearer credential as a
+ * out of its reach. This route takes a standalone bearer credential as a
  * path segment.
  */
 describe('scrubUrlTokens', () => {
   it.each([
-    ['/ext/silence-alert/abc123', '/ext/silence-alert/[REDACTED]'],
     ['/team/setup/tok-xyz', '/team/setup/[REDACTED]'],
-    ['/api/ext/silence-alert/abc123', '/api/ext/silence-alert/[REDACTED]'],
+    ['/api/team/setup/tok-xyz', '/api/team/setup/[REDACTED]'],
     // Query strings and fragments must not be swallowed into the token.
-    ['/ext/silence-alert/abc123?x=1', '/ext/silence-alert/[REDACTED]?x=1'],
+    ['/team/setup/tok-xyz?x=1', '/team/setup/[REDACTED]?x=1'],
   ])('scrubs %s', (input, expected) => {
     expect(scrubUrlTokens(input)).toBe(expected);
   });
@@ -114,7 +113,7 @@ describe('scrubbedRequestSerializer', () => {
 
     const req = new IncomingMessage(socket);
     req.method = 'GET';
-    req.url = '/api/ext/silence-alert/super-secret-token?ack=1';
+    req.url = '/api/team/setup/super-secret-token?ack=1';
     req.headers = { authorization: 'Bearer x' };
     return req;
   };
@@ -124,7 +123,7 @@ describe('scrubbedRequestSerializer', () => {
       pino.stdSerializers.req(rawRequest()),
     );
 
-    expect(out.url).toBe('/api/ext/silence-alert/[REDACTED]?ack=1');
+    expect(out.url).toBe('/api/team/setup/[REDACTED]?ack=1');
     expect(out.remoteAddress).toBe('203.0.113.7');
     expect(out.remotePort).toBe(51234);
     expect(out.method).toBe('GET');
@@ -175,7 +174,7 @@ describe('production log line', () => {
     Object.defineProperty(socket, 'remoteAddress', { value: '203.0.113.7' });
     const req = new IncomingMessage(socket);
     req.method = 'GET';
-    req.url = '/api/ext/silence-alert/super-secret-token';
+    req.url = '/api/team/setup/super-secret-token';
     req.headers = {
       authorization: 'Bearer super-secret-key',
       cookie: 'connect.sid=secret-session',

--- a/packages/api/src/utils/logger.ts
+++ b/packages/api/src/utils/logger.ts
@@ -67,10 +67,10 @@ export const REDACTED_PATHS = [
 ];
 
 // `redact` addresses object paths, so it cannot reach a credential embedded in
-// a URL string. These two routes each take a standalone bearer token as a path
-// segment, which pino-http emits via `req.url` and which the custom message
-// builders interpolate into `msg`.
-const TOKEN_PATH_RE = /\/(ext\/silence-alert|team\/setup)\/[^/?#]+/g;
+// a URL string. This route takes a standalone bearer token as a path segment,
+// which pino-http emits via `req.url` and which the custom message builders
+// interpolate into `msg`.
+const TOKEN_PATH_RE = /\/(team\/setup)\/[^/?#]+/g;
 
 export const scrubUrlTokens = (url: string): string =>
   url.replace(TOKEN_PATH_RE, '/$1/[REDACTED]');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,7 +4656,6 @@ __metadata:
     http-proxy-middleware: "npm:^4.0.0"
     ip-address: "npm:^10.3.1"
     jest: "npm:^30.2.0"
-    jsonwebtoken: "npm:^9.0.0"
     lodash: "npm:^4.18.1"
     migrate-mongo: "npm:^11.0.0"
     minimist: "npm:^1.2.7"
@@ -13072,13 +13071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "buffer-equal-constant-time@npm:1.0.1"
-  checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -15285,15 +15277,6 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
-  languageName: node
-  linkType: hard
-
-"ecdsa-sig-formatter@npm:1.0.11":
-  version: 1.0.11
-  resolution: "ecdsa-sig-formatter@npm:1.0.11"
-  dependencies:
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
   languageName: node
   linkType: hard
 
@@ -20699,18 +20682,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "jsonwebtoken@npm:9.0.0"
-  dependencies:
-    jws: "npm:^3.2.2"
-    lodash: "npm:^4.17.21"
-    ms: "npm:^2.1.1"
-    semver: "npm:^7.3.8"
-  checksum: 10c0/60c30d90d8a69b8e7148306e0c299ac120dbde9c032add48d26df928fe349e952cf4b09f12d7942257681a936e3374e4d49280ab20f8a4578688c7f08d87f9bc
-  languageName: node
-  linkType: hard
-
 "jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.5":
   version: 3.3.5
   resolution: "jsx-ast-utils@npm:3.3.5"
@@ -20720,27 +20691,6 @@ __metadata:
     object.assign: "npm:^4.1.4"
     object.values: "npm:^1.1.6"
   checksum: 10c0/a32679e9cb55469cb6d8bbc863f7d631b2c98b7fc7bf172629261751a6e7bc8da6ae374ddb74d5fbd8b06cf0eb4572287b259813d92b36e384024ed35e4c13e1
-  languageName: node
-  linkType: hard
-
-"jwa@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "jwa@npm:1.4.2"
-  dependencies:
-    buffer-equal-constant-time: "npm:^1.0.1"
-    ecdsa-sig-formatter: "npm:1.0.11"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/210a544a42ca22203e8fc538835205155ba3af6a027753109f9258bdead33086bac3c25295af48ac1981f87f9c5f941bc8f70303670f54ea7dcaafb53993d92c
-  languageName: node
-  linkType: hard
-
-"jws@npm:^3.2.2":
-  version: 3.2.3
-  resolution: "jws@npm:3.2.3"
-  dependencies:
-    jwa: "npm:^1.4.2"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/9fdf9d6783b1892ef413ef373cd351eacc847ba01deec6fbfea96830e93241863ccbee66f3b749fc2310c59b6db2209d3f4b52931c0c259b52b17de20715917f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Building on #2903, this removes the alert-silence-token code path, which was never reachable in production. `generateAlertSilenceToken` — the half that mints the signed silence link — had no caller, so no valid token could ever be produced. That made its verify counterpart (`silenceAlertByToken`) and the public `GET /ext/silence-alert/:token` route it backed unreachable dead code.

All three are removed, along with the now-orphaned `jsonwebtoken` dependency (this was its only consumer) and the unused `ms`/`logger` imports in the alerts controller. The logger token-redaction tests, which happened to use the deleted route as their example path, now exercise the still-live `/team/setup/:token` route instead.

The user-facing alert silence controls (`POST`/`DELETE /alerts/:id/silenced`) are untouched.
