### PR TITLE
[HDX-5080] Chart editor UI for metric formulas

### DIFF
--- a/.changeset/formula-tile-alerts.md
+++ b/.changeset/formula-tile-alerts.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+Tile alerts on metric charts with formulas now evaluate the formula value instead of the last raw operand series: the alert task previously dropped `formulas`/`showOperandSeries` when rebuilding the tile's chart config, so an alert on a formula tile compared the threshold against a raw operand (e.g. bytes) rather than the derived value. Grouped ratio tile alerts also now honor `ratioMode` (`share_of_total` previously evaluated as `per_group`).

--- a/.changeset/metric-formula-editor.md
+++ b/.changeset/metric-formula-editor.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': minor
+---
+
+Add metric formula editing to the chart editor. Metric-source charts (time series, table, number) gain an "Add Formula" row: a letter-ref arithmetic expression over the chart's series (`A` = series 1, `B` = series 2, ...) such as `A / (A + B) * 100`, with inline structured validation (malformed expressions, unknown series references), per-formula alias and number format, and a "Show input series" toggle to render only the formula column(s) or the formula alongside its operand series. Series rows now carry their reference letter as a badge. Formulas and the "As Ratio" toggle are mutually exclusive, and formulas persist on dashboard tiles and standalone charts.

--- a/.changeset/number-formula-operands.md
+++ b/.changeset/number-formula-operands.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/common-utils': patch
+---
+
+Number charts on metric formula configs always hide their operand series: `convertToNumberChartConfig` forces `showOperandSeries: false` when formulas are present, so the number tile renders the formula column rather than the first raw operand — regardless of the tile's "Show input series" setting on other display types or when a formula chart is switched to the Number display type.

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -7049,10 +7049,14 @@ describe('checkAlerts', () => {
       metricName: string,
       value: number,
       timestampMs: number,
+      serviceName = 'api',
     ) => ({
       MetricName: metricName,
-      ServiceName: 'api',
-      ResourceAttributes: { host: 'host1' },
+      ServiceName: serviceName,
+      // Include the service in ResourceAttributes so grouped tests get
+      // distinct AttributesHash values per service (see the groupBy test
+      // above); harmless for ungrouped tests.
+      ResourceAttributes: { host: 'host1', 'service.name': serviceName },
       Value: value,
       TimeUnix: new Date(timestampMs),
     });
@@ -7060,10 +7064,18 @@ describe('checkAlerts', () => {
     const setupMetricTileAlert = async ({
       select,
       seriesReturnType,
+      ratioMode,
+      formulas,
+      showOperandSeries,
+      groupBy,
       threshold,
     }: {
       select: Array<Record<string, string>>;
       seriesReturnType?: 'ratio' | 'column';
+      ratioMode?: 'per_group' | 'share_of_total';
+      formulas?: Array<{ expression: string; alias?: string }>;
+      showOperandSeries?: boolean;
+      groupBy?: string;
       threshold: number;
     }) => {
       const { team, webhook, connection, teamWebhooksById, clickhouseClient } =
@@ -7106,10 +7118,13 @@ describe('checkAlerts', () => {
               name: 'Errors vs Requests',
               select,
               ...(seriesReturnType ? { seriesReturnType } : {}),
+              ...(ratioMode ? { ratioMode } : {}),
+              ...(formulas ? { formulas } : {}),
+              ...(showOperandSeries !== undefined ? { showOperandSeries } : {}),
               where: '',
               displayType: 'line',
               source: source.id,
-              groupBy: '',
+              groupBy: groupBy ?? '',
             },
           },
         ],
@@ -7316,6 +7331,253 @@ describe('checkAlerts', () => {
       expect(histories[0].lastValues.length).toBe(0);
 
       expect(slack.postMessageToWebhook).not.toHaveBeenCalled();
+    });
+
+    // ── Metric formula tiles (HDX-5080) ──
+    // A tile with `formulas` derives its displayed series from the operand
+    // series (letter refs: A = select[0], ...). The alert must evaluate the
+    // FORMULA value — never a raw operand — regardless of the tile's
+    // "Show input series" display toggle (getChartConfigFromAlert always
+    // drops the operand columns from the alert query).
+
+    it('TILE alert (metrics, formula) - threshold compares the formula value, not an operand', async () => {
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      // Alert window is [22:05, 22:10)
+      const eventMs = now.getTime() - ms('7m');
+
+      await bulkInsertMetricsGauge([
+        // Both operands are far from the formula result (10 / 200 * 100 = 5),
+        // so a regression back to evaluating either operand fails loudly.
+        gaugePoint('test.requests', 200, eventMs),
+        gaugePoint('test.errors', 10, eventMs),
+      ]);
+
+      const { details, connection, teamWebhooksById, clickhouseClient } =
+        await setupMetricTileAlert({
+          select: [
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.requests',
+            },
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.errors',
+            },
+          ],
+          formulas: [{ expression: 'B / A * 100', alias: 'Error rate' }],
+          // Mirrors the editor default of hiding operands; the alert result
+          // must be identical either way (see the next test).
+          showOperandSeries: false,
+          threshold: 4,
+        });
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+
+      const [history] = await AlertHistory.find({
+        alert: details.alert.id,
+      }).sort({ createdAt: 1 });
+      expect(history.state).toBe('ALERT');
+      expect(history.lastValues.length).toBe(1);
+      // The formula value (5) — not operand A (200) or operand B (10).
+      expect(history.lastValues[0].count).toBe(5);
+
+      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(1);
+      expect(
+        jest.mocked(slack.postMessageToWebhook).mock.calls[0][1].text,
+      ).toContain('5 meets or exceeds 4');
+    });
+
+    it('TILE alert (metrics, formula) - evaluates the formula even when the tile shows its input series', async () => {
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      // Alert window is [22:05, 22:10)
+      const eventMs = now.getTime() - ms('7m');
+
+      await bulkInsertMetricsGauge([
+        gaugePoint('test.requests', 200, eventMs),
+        gaugePoint('test.errors', 10, eventMs),
+      ]);
+
+      const { details, connection, teamWebhooksById, clickhouseClient } =
+        await setupMetricTileAlert({
+          select: [
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.requests',
+            },
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.errors',
+            },
+          ],
+          formulas: [{ expression: 'B / A * 100' }],
+          // showOperandSeries left unset: the dashboard tile renders the raw
+          // operand series alongside the formula, but the alert still
+          // evaluates the formula value only.
+          threshold: 4,
+        });
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+
+      const [history] = await AlertHistory.find({
+        alert: details.alert.id,
+      }).sort({ createdAt: 1 });
+      expect(history.lastValues.length).toBe(1);
+      expect(history.lastValues[0].count).toBe(5);
+
+      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(1);
+      expect(
+        jest.mocked(slack.postMessageToWebhook).mock.calls[0][1].text,
+      ).toContain('5 meets or exceeds 4');
+    });
+
+    it('TILE alert (metrics, formula) - a zero denominator yields NULL and is skipped without NaN history', async () => {
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      // Alert window is [22:05, 22:10)
+      const eventMs = now.getTime() - ms('7m');
+
+      await bulkInsertMetricsGauge([
+        // Numerator present, denominator zero: A / nullif(B, 0) is NULL.
+        gaugePoint('test.errors', 5, eventMs),
+        gaugePoint('test.requests', 0, eventMs),
+      ]);
+
+      const { details, connection, teamWebhooksById, clickhouseClient } =
+        await setupMetricTileAlert({
+          select: [
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.errors',
+            },
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.requests',
+            },
+          ],
+          formulas: [{ expression: 'A / B' }],
+          showOperandSeries: false,
+          threshold: 0.1,
+        });
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('OK');
+
+      const histories = await AlertHistory.find({ alert: details.alert.id });
+      expect(histories.length).toBe(1);
+      expect(histories[0].state).toBe('OK');
+      expect(histories[0].counts).toBe(0);
+      expect(histories[0].lastValues.length).toBe(0);
+
+      expect(slack.postMessageToWebhook).not.toHaveBeenCalled();
+    });
+
+    it('TILE alert (metrics, grouped ratio) - honors ratioMode share_of_total', async () => {
+      const now = new Date('2023-11-16T22:12:00.000Z');
+      // Alert window is [22:05, 22:10)
+      const eventMs = now.getTime() - ms('7m');
+
+      await bulkInsertMetricsGauge([
+        // share_of_total divides each group's numerator by the denominator
+        // total across ALL groups in the bucket:
+        //   service-a: 5 / (10 + 30) = 0.125
+        //   service-b: 3 / (10 + 30) = 0.075
+        // per_group (the default this config must NOT fall back to) would be
+        // 0.5 and 0.1 instead.
+        gaugePoint('test.errors', 5, eventMs, 'service-a'),
+        gaugePoint('test.requests', 10, eventMs, 'service-a'),
+        gaugePoint('test.errors', 3, eventMs, 'service-b'),
+        gaugePoint('test.requests', 30, eventMs, 'service-b'),
+      ]);
+
+      const { details, connection, teamWebhooksById, clickhouseClient } =
+        await setupMetricTileAlert({
+          select: [
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.errors',
+            },
+            {
+              aggFn: 'max',
+              valueExpression: 'Value',
+              metricType: 'gauge',
+              metricName: 'test.requests',
+            },
+          ],
+          seriesReturnType: 'ratio',
+          ratioMode: 'share_of_total',
+          groupBy: 'ServiceName',
+          // Only service-a's share (0.125) crosses; under per_group both
+          // values (0.5, 0.1) would differ and service-a would fire at 0.5.
+          threshold: 0.12,
+        });
+
+      await processAlertAtTime(
+        now,
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      expect((await Alert.findById(details.alert.id))!.state).toBe('ALERT');
+
+      const alertingHistories = await AlertHistory.find({
+        alert: details.alert.id,
+        state: 'ALERT',
+      });
+      expect(alertingHistories.length).toBe(1);
+      expect(alertingHistories[0].group).toContain('service-a');
+      expect(alertingHistories[0].lastValues.length).toBe(1);
+      // The share-of-total value — not service-a's per-group ratio (0.5).
+      expect(alertingHistories[0].lastValues[0].count).toBe(0.125);
+
+      expect(slack.postMessageToWebhook).toHaveBeenCalledTimes(1);
+      // The message value is rounded to the threshold's decimal places
+      // (0.125 -> "0.13"); the exact-value assertion above is the source of
+      // truth for which ratio mode was evaluated.
+      expect(
+        jest.mocked(slack.postMessageToWebhook).mock.calls[0][1].text,
+      ).toContain('meets or exceeds 0.12');
     });
 
     // The auto-resolve logic ensures that if a subsequent bucket within the same tick drops below the threshold,

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -716,6 +716,17 @@ const getChartConfigFromAlert = (
         where: tile.config.where,
         whereLanguage: tile.config.whereLanguage,
         seriesReturnType: tile.config.seriesReturnType,
+        // Grouped ratios can divide per-group or share-of-total; without this
+        // the alert would silently evaluate the default (per-group) mode.
+        ratioMode: tile.config.ratioMode,
+        // Metric formulas (HDX-5080): the alert must evaluate the derived
+        // formula column, not a raw operand series. Operand columns are
+        // always dropped from the alert query — regardless of the tile's
+        // "Show input series" display toggle — so the formula is the value
+        // column parseAlertData picks (the last one wins, consistent with
+        // the multi-series "last series drives the alert" semantics).
+        formulas: tile.config.formulas,
+        ...(tile.config.formulas?.length ? { showOperandSeries: false } : {}),
         variables,
       };
     }

--- a/packages/app/src/__tests__/SessionSidePanel.test.tsx
+++ b/packages/app/src/__tests__/SessionSidePanel.test.tsx
@@ -36,7 +36,7 @@ const mockNuqs: {
 
 jest.mock('nuqs', () => {
   const actual = jest.requireActual('nuqs');
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   const noop = () => {};
   return {
     ...actual,

--- a/packages/app/src/__tests__/source.test.ts
+++ b/packages/app/src/__tests__/source.test.ts
@@ -344,6 +344,33 @@ describe('useSingleSeriesNumberFormat', () => {
       }),
       expected: undefined,
     },
+    // Metric formula configs display the formula column (number charts hide
+    // the operand series), so the format resolves from the formula — not
+    // from an operand that isn't rendered.
+    {
+      name: 'formula config: prefers the formula numberFormat over select[0]',
+      config: makeBuilderConfig({
+        metricTables: METRIC_TABLES,
+        select: [
+          { valueExpression: 'Value', numberFormat: NUMBER_FORMAT },
+          { valueExpression: 'Value' },
+        ],
+        formulas: [{ expression: 'A / B', numberFormat: PERCENT_FORMAT }],
+        showOperandSeries: false,
+      }),
+      expected: PERCENT_FORMAT,
+    },
+    {
+      name: 'formula config: falls back to config.numberFormat when the formula has none',
+      config: makeBuilderConfig({
+        metricTables: METRIC_TABLES,
+        select: [{ valueExpression: 'Value', numberFormat: NUMBER_FORMAT }],
+        formulas: [{ expression: 'A * 100' }],
+        numberFormat: CURRENCY_FORMAT,
+        showOperandSeries: false,
+      }),
+      expected: CURRENCY_FORMAT,
+    },
   ])('$name', ({ config, expected }) => {
     const { result } = renderHook(() => useSingleSeriesNumberFormat(config));
     expect(result.current).toEqual(expected);

--- a/packages/app/src/__tests__/source.test.ts
+++ b/packages/app/src/__tests__/source.test.ts
@@ -10,6 +10,7 @@ import { notifications } from '@mantine/notifications';
 import { renderHook } from '@testing-library/react';
 
 import {
+  getBuilderValueColumnCount,
   getEventBody,
   getSourceValidationNotificationId,
   getTraceDurationNumberFormat,
@@ -229,6 +230,14 @@ describe('useSources validation notifications', () => {
     );
   });
 });
+
+const METRIC_TABLES = {
+  gauge: 'otel_metrics_gauge',
+  sum: 'otel_metrics_sum',
+  histogram: 'otel_metrics_histogram',
+  summary: 'otel_metrics_summary',
+  'exponential histogram': 'otel_metrics_exponential_histogram',
+};
 
 const DURATION_FORMAT: NumberFormat = { output: 'duration', factor: 1e-9 };
 const CURRENCY_FORMAT: NumberFormat = { output: 'currency' };
@@ -520,5 +529,119 @@ describe('useChartNumberFormats', () => {
       useChartNumberFormats(config, [META_A]),
     );
     expect(result.current.formatByColumn.size).toBe(0);
+  });
+
+  // --- metric formula configs (HDX-5080) ---
+  // The composed metric query projects operand series columns (unless
+  // showOperandSeries is false) followed by one column per formula.
+
+  const META_FORMULA = { name: 'A / B', type: 'Float64' } as ColumnMetaType;
+
+  const makeFormulaConfig = (
+    overrides: Partial<ChartConfigWithOptTimestamp> = {},
+  ) =>
+    makeBuilderConfig({
+      metricTables: METRIC_TABLES,
+      select: [
+        { valueExpression: 'Value', numberFormat: NUMBER_FORMAT },
+        { valueExpression: 'Value' },
+      ],
+      formulas: [{ expression: 'A / B', numberFormat: PERCENT_FORMAT }],
+      ...overrides,
+    });
+
+  it('formula config: maps operand columns then formula columns positionally', () => {
+    const config = makeFormulaConfig();
+    const { result } = renderHook(() =>
+      useChartNumberFormats(config, [META_A, META_B, META_FORMULA]),
+    );
+    expect(Array.from(result.current.formatByColumn.entries())).toEqual([
+      ['col_a', NUMBER_FORMAT],
+      ['A / B', PERCENT_FORMAT],
+    ]);
+  });
+
+  it('formula config: maps only formula columns when operand series are hidden', () => {
+    const config = makeFormulaConfig({ showOperandSeries: false });
+    const { result } = renderHook(() =>
+      useChartNumberFormats(config, [META_FORMULA]),
+    );
+    expect(Array.from(result.current.formatByColumn.entries())).toEqual([
+      ['A / B', PERCENT_FORMAT],
+    ]);
+  });
+
+  it('formula config: formula columns fall back to config.numberFormat', () => {
+    const config = makeFormulaConfig({
+      formulas: [{ expression: 'A / B' }],
+      numberFormat: CURRENCY_FORMAT,
+      showOperandSeries: false,
+    });
+    const { result } = renderHook(() =>
+      useChartNumberFormats(config, [META_FORMULA]),
+    );
+    expect(result.current.formatByColumn.get('A / B')).toEqual(CURRENCY_FORMAT);
+  });
+
+  it('formula config: formula supersedes ratio mapping when both are set', () => {
+    const config = makeFormulaConfig({ seriesReturnType: 'ratio' });
+    const { result } = renderHook(() =>
+      useChartNumberFormats(config, [META_A, META_B, META_FORMULA]),
+    );
+    // The ratio branch would map only meta[0]; the formula branch maps
+    // operands + formula columns.
+    expect(result.current.formatByColumn.get('A / B')).toEqual(PERCENT_FORMAT);
+  });
+
+  it('formula config: chartFormat prefers formula format when operands are hidden', () => {
+    const config = makeFormulaConfig({ showOperandSeries: false });
+    const { result } = renderHook(() => useChartNumberFormats(config));
+    expect(result.current.chartFormat).toEqual(PERCENT_FORMAT);
+  });
+
+  it('formula config: chartFormat prefers series format when operands are shown', () => {
+    const config = makeFormulaConfig();
+    const { result } = renderHook(() => useChartNumberFormats(config));
+    expect(result.current.chartFormat).toEqual(NUMBER_FORMAT);
+  });
+});
+
+describe('getBuilderValueColumnCount', () => {
+  it('counts one column per select entry by default', () => {
+    const config = makeBuilderConfig({
+      select: [{ valueExpression: 'count()' }, { valueExpression: 'sum(x)' }],
+    });
+    expect(getBuilderValueColumnCount(config)).toBe(2);
+  });
+
+  it('counts one merged column for ratio configs', () => {
+    const config = makeBuilderConfig({
+      seriesReturnType: 'ratio',
+      select: [{ valueExpression: 'count()' }, { valueExpression: 'sum(x)' }],
+    });
+    expect(getBuilderValueColumnCount(config)).toBe(1);
+  });
+
+  it('counts operand and formula columns for metric formula configs', () => {
+    const config = makeBuilderConfig({
+      metricTables: METRIC_TABLES,
+      select: [{ valueExpression: 'Value' }, { valueExpression: 'Value' }],
+      formulas: [{ expression: 'A / B' }],
+    });
+    expect(getBuilderValueColumnCount(config)).toBe(3);
+  });
+
+  it('counts only formula columns when operand series are hidden', () => {
+    const config = makeBuilderConfig({
+      metricTables: METRIC_TABLES,
+      select: [{ valueExpression: 'Value' }, { valueExpression: 'Value' }],
+      formulas: [{ expression: 'A / B' }, { expression: 'A + B' }],
+      showOperandSeries: false,
+    });
+    expect(getBuilderValueColumnCount(config)).toBe(2);
+  });
+
+  it('returns 0 for raw SQL configs', () => {
+    expect(getBuilderValueColumnCount(makeRawSqlConfig({}))).toBe(0);
   });
 });

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -1742,6 +1742,49 @@ describe('metric formulas (HDX-5080)', () => {
       expect(errors).toHaveLength(0);
     });
 
+    it('rejects multiple formulas on a Number chart', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          displayType: DisplayType.Number,
+          formulas: [{ expression: 'A + B' }, { expression: 'A / B' }],
+          showOperandSeries: false,
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({
+          path: 'formulas',
+          message: 'Number charts support a single formula',
+        }),
+      ]);
+    });
+
+    it('allows a single formula on a Number chart and multiple elsewhere', () => {
+      const setError = jest.fn();
+      expect(
+        validateChartForm(
+          makeMetricForm({
+            displayType: DisplayType.Number,
+            formulas: [{ expression: 'A + B' }],
+            showOperandSeries: false,
+          }),
+          metricSource,
+          setError,
+        ),
+      ).toHaveLength(0);
+      expect(
+        validateChartForm(
+          makeMetricForm({
+            formulas: [{ expression: 'A + B' }, { expression: 'A / B' }],
+          }),
+          metricSource,
+          setError,
+        ),
+      ).toHaveLength(0);
+    });
+
     it('lifts the Number chart series cap when formulas are present', () => {
       const setError = jest.fn();
       const errors = validateChartForm(
@@ -1795,6 +1838,31 @@ describe('metric formulas (HDX-5080)', () => {
       );
       expect(saved.formulas).toEqual([{ expression: 'A / B', alias: 'Ratio' }]);
       expect(saved.showOperandSeries).toBe(false);
+    });
+
+    it('always persists hidden operand series for Number charts with a formula', () => {
+      // A Number chart displays the first value column, so the formula must
+      // be the only projection — even when the tile showed its operand
+      // series on another display type before the switch.
+      const saved = savedBuilderConfig(
+        makeMetricForm({
+          displayType: DisplayType.Number,
+          formulas: [{ expression: 'A / B' }],
+          // Unset (operands shown) — e.g. a Line chart switched to Number.
+        }),
+        metricSource,
+      );
+      expect(saved.showOperandSeries).toBe(false);
+    });
+
+    it('keeps the tile showOperandSeries choice on non-Number display types', () => {
+      const saved = savedBuilderConfig(
+        makeMetricForm({
+          formulas: [{ expression: 'A / B' }],
+        }),
+        metricSource,
+      );
+      expect(saved.showOperandSeries).toBeUndefined();
     });
 
     it('strips formulas for non-metric sources', () => {

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -1619,3 +1619,233 @@ describe('heatmap round-trip', () => {
     );
   });
 });
+
+describe('metric formulas (HDX-5080)', () => {
+  const metricSeriesItem = {
+    aggFn: 'avg' as const,
+    valueExpression: 'Value',
+    aggCondition: '',
+    aggConditionLanguage: 'lucene' as const,
+    metricType: MetricsDataType.Gauge,
+    metricName: 'cpu.usage',
+  };
+
+  const makeMetricForm = (
+    overrides: Partial<ChartEditorFormState>,
+  ): ChartEditorFormState => ({
+    displayType: DisplayType.Line,
+    source: 'source-metric',
+    where: '',
+    series: [
+      metricSeriesItem,
+      { ...metricSeriesItem, metricName: 'cpu.limit' },
+    ],
+    ...overrides,
+  });
+
+  describe('validateChartForm', () => {
+    it('accepts a valid formula referencing existing series', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          formulas: [{ expression: 'A / (A + B) * 100' }],
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toHaveLength(0);
+      expect(setError).not.toHaveBeenCalled();
+    });
+
+    it('reports a malformed formula expression at its field path', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({ formulas: [{ expression: 'A +' }] }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({ path: 'formulas.0.expression' }),
+      ]);
+      expect(setError).toHaveBeenCalledWith(
+        'formulas.0.expression',
+        expect.objectContaining({ type: 'manual' }),
+      );
+    });
+
+    it('reports an unknown series reference', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({ formulas: [{ expression: 'A + C' }] }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({
+          path: 'formulas.0.expression',
+          message: expect.stringContaining('Unknown series "C"'),
+        }),
+      ]);
+    });
+
+    it('reports an empty formula expression', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({ formulas: [{ expression: '' }] }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({ path: 'formulas.0.expression' }),
+      ]);
+    });
+
+    it('validates each formula independently', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          formulas: [{ expression: 'A + B' }, { expression: 'A *' }],
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({ path: 'formulas.1.expression' }),
+      ]);
+    });
+
+    it('skips formula validation for non-metric sources (formulas are stripped on save)', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          source: 'source-log',
+          series: [seriesItem],
+          formulas: [{ expression: 'A +' }],
+        }),
+        logSource,
+        setError,
+      );
+      expect(errors).toHaveLength(0);
+    });
+
+    it('skips formula validation for non-formula display types (formulas are stripped on save)', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          displayType: DisplayType.Pie,
+          series: [metricSeriesItem],
+          formulas: [{ expression: 'A +' }],
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toHaveLength(0);
+    });
+
+    it('lifts the Number chart series cap when formulas are present', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          displayType: DisplayType.Number,
+          series: [metricSeriesItem, metricSeriesItem, metricSeriesItem],
+          formulas: [{ expression: 'A / (A + B + C) * 100' }],
+          showOperandSeries: false,
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toHaveLength(0);
+    });
+
+    it('keeps the Number chart series cap without formulas', () => {
+      const setError = jest.fn();
+      const errors = validateChartForm(
+        makeMetricForm({
+          displayType: DisplayType.Number,
+          series: [metricSeriesItem, metricSeriesItem, metricSeriesItem],
+        }),
+        metricSource,
+        setError,
+      );
+      expect(errors).toEqual([expect.objectContaining({ path: 'series' })]);
+    });
+  });
+
+  describe('normalization (convertFormStateToSavedChartConfig)', () => {
+    // Narrow the SavedChartConfig union without an unsafe assertion — every
+    // form here is a builder config, so anything else is a test failure.
+    const savedBuilderConfig = (
+      form: ChartEditorFormState,
+      source: TSource,
+    ): BuilderSavedChartConfig => {
+      const saved = convertFormStateToSavedChartConfig(form, source);
+      if (!saved || 'configType' in saved) {
+        throw new Error('expected a builder saved chart config');
+      }
+      return saved;
+    };
+
+    it('retains formulas and showOperandSeries for a metric time series chart', () => {
+      const saved = savedBuilderConfig(
+        makeMetricForm({
+          formulas: [{ expression: 'A / B', alias: 'Ratio' }],
+          showOperandSeries: false,
+        }),
+        metricSource,
+      );
+      expect(saved.formulas).toEqual([{ expression: 'A / B', alias: 'Ratio' }]);
+      expect(saved.showOperandSeries).toBe(false);
+    });
+
+    it('strips formulas for non-metric sources', () => {
+      const saved = savedBuilderConfig(
+        makeMetricForm({
+          source: 'source-log',
+          series: [seriesItem],
+          formulas: [{ expression: 'A * 100' }],
+          showOperandSeries: false,
+        }),
+        logSource,
+      );
+      expect(saved.formulas).toBeUndefined();
+      expect(saved.showOperandSeries).toBeUndefined();
+    });
+
+    it('strips formulas for display types the composed metric query does not render', () => {
+      const saved = savedBuilderConfig(
+        makeMetricForm({
+          displayType: DisplayType.Pie,
+          series: [metricSeriesItem],
+          formulas: [{ expression: 'A * 100' }],
+        }),
+        metricSource,
+      );
+      expect(saved.formulas).toBeUndefined();
+      expect(saved.showOperandSeries).toBeUndefined();
+    });
+
+    it('round-trips formulas through saved config and form state', () => {
+      const saved = convertFormStateToSavedChartConfig(
+        makeMetricForm({
+          formulas: [
+            {
+              expression: 'A / (A + B) * 100',
+              alias: 'Error rate',
+              numberFormat: { output: 'percent' },
+            },
+          ],
+        }),
+        metricSource,
+      );
+      expect(saved).toBeDefined();
+      const restored = convertSavedChartConfigToFormState(saved!);
+      expect(restored.formulas).toEqual([
+        {
+          expression: 'A / (A + B) * 100',
+          alias: 'Error rate',
+          numberFormat: { output: 'percent' },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -100,7 +100,15 @@ function normalizeChartConfig<
         : config.select,
     metricTables: isMetricSource ? config.metricTables : undefined,
     formulas: keepFormulas ? config.formulas : undefined,
-    showOperandSeries: keepFormulas ? config.showOperandSeries : undefined,
+    // Number charts display the first value column, so the operand series
+    // are always hidden there (persisted explicitly so the saved tile config
+    // is self-describing; convertToNumberChartConfig enforces the same at
+    // render time). Other display types keep the tile's own toggle value.
+    showOperandSeries: keepFormulas
+      ? config.displayType === DisplayType.Number
+        ? false
+        : config.showOperandSeries
+      : undefined,
     // Order By and Having can only be set by the user for table charts
     having:
       config.displayType === DisplayType.Table ? config.having : undefined,
@@ -488,6 +496,17 @@ export const validateChartForm = (
         });
       }
     });
+
+    // A number chart displays a single value — its one formula. Multiple
+    // formulas can only get here by switching an existing multi-formula
+    // chart to the Number display type (the editor hides "Add Formula" once
+    // a Number tile has one); block rather than silently dropping one.
+    if (form.displayType === DisplayType.Number && form.formulas.length > 1) {
+      errors.push({
+        path: `formulas`,
+        message: 'Number charts support a single formula',
+      });
+    }
   }
 
   // Validate raw SQL alert has required time filters and interval parameters

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -1,5 +1,6 @@
 import { omit, pick } from 'lodash';
 import { Path, UseFormSetError } from 'react-hook-form';
+import { validateFormula } from '@hyperdx/common-utils/dist/core/formula';
 import { validateRawSqlForAlert } from '@hyperdx/common-utils/dist/core/utils';
 import {
   isBuilderSavedChartConfig,
@@ -70,10 +71,26 @@ export function buildRawSqlCompletions({
 function normalizeChartConfig<
   C extends Pick<
     BuilderSavedChartConfig,
-    'select' | 'having' | 'orderBy' | 'displayType' | 'metricTables' | 'onClick'
+    | 'select'
+    | 'having'
+    | 'orderBy'
+    | 'displayType'
+    | 'metricTables'
+    | 'onClick'
+    | 'formulas'
+    | 'showOperandSeries'
   >,
 >(config: C, source: TSource): C {
   const isMetricSource = source.kind === SourceKind.Metric;
+  // Formulas (HDX-5080) only render on metric sources, and only through the
+  // composed multi-series metric query shapes (time series / table / number).
+  // Strip them elsewhere so a source or display-type switch can't persist a
+  // config the renderer would reject. The form state keeps them, so switching
+  // back restores the formula rows.
+  const keepFormulas =
+    isMetricSource &&
+    (config.formulas?.length ?? 0) > 0 &&
+    isFormulaDisplayType(config.displayType);
   return {
     ...config,
     // Strip out metric-specific fields for non-metric sources
@@ -82,6 +99,8 @@ function normalizeChartConfig<
         ? config.select.map(s => omit(s, ['metricName', 'metricType']))
         : config.select,
     metricTables: isMetricSource ? config.metricTables : undefined,
+    formulas: keepFormulas ? config.formulas : undefined,
+    showOperandSeries: keepFormulas ? config.showOperandSeries : undefined,
     // Order By and Having can only be set by the user for table charts
     having:
       config.displayType === DisplayType.Table ? config.having : undefined,
@@ -144,6 +163,23 @@ const isCustomOrderByDisplayType = (
   displayType === DisplayType.Table ||
   displayType === DisplayType.Bar ||
   displayType === DisplayType.Pie;
+
+/**
+ * Display types that can carry metric formulas (HDX-5080) — the shapes the
+ * composed multi-series metric query renders. Mirrors the "Add Formula"
+ * gating in ChartEditorControls.
+ */
+export const isFormulaDisplayType = (
+  displayType: DisplayType | undefined,
+): displayType is
+  | DisplayType.Line
+  | DisplayType.StackedBar
+  | DisplayType.Table
+  | DisplayType.Number =>
+  displayType === DisplayType.Line ||
+  displayType === DisplayType.StackedBar ||
+  displayType === DisplayType.Table ||
+  displayType === DisplayType.Number;
 
 export function convertFormStateToSavedChartConfig(
   form: ChartEditorFormState,
@@ -430,6 +466,30 @@ export const validateChartForm = (
     });
   }
 
+  // Validate metric formulas (HDX-5080) with the structured validator the
+  // query renderer uses, so a bad expression is caught here rather than at
+  // render time. Only applies where formulas survive normalization (metric
+  // source + formula-capable display type).
+  if (
+    !isRawSqlChart &&
+    source?.kind === SourceKind.Metric &&
+    isFormulaDisplayType(form.displayType) &&
+    Array.isArray(form.formulas)
+  ) {
+    const seriesCount = Array.isArray(form.series) ? form.series.length : 0;
+    form.formulas.forEach((formula, index) => {
+      const result = validateFormula(formula.expression ?? '', {
+        seriesCount,
+      });
+      if (!result.ok) {
+        errors.push({
+          path: `formulas.${index}.expression`,
+          message: result.errors.map(e => e.message).join('; '),
+        });
+      }
+    });
+  }
+
   // Validate raw SQL alert has required time filters and interval parameters
   if (isRawSqlChart && form.alert) {
     const config = {
@@ -482,11 +542,13 @@ export const validateChartForm = (
 
   // Number charts allow a second series only for ratio mode (numerator /
   // denominator, which can be shown as a percentage via the number format);
-  // otherwise they show a single value.
+  // otherwise they show a single value. With formulas the extra series are
+  // operands (e.g. A / (A + B + C)), so the cap doesn't apply.
   if (
     !isRawSqlChart &&
     Array.isArray(form.series) &&
     form.displayType === DisplayType.Number &&
+    !(form.formulas?.length && source?.kind === SourceKind.Metric) &&
     form.series.length > (form.seriesReturnType === 'ratio' ? 2 : 1)
   ) {
     errors.push({

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -125,18 +125,16 @@ export function ChartEditorControls({
     tableSource?.kind === SourceKind.Metric &&
     isFormulaDisplayType(displayType);
   // Formulas and the ratio toggle are mutually exclusive (formulas supersede
-  // ratio in the renderer, so the editor never lets both be set).
-  const canAddFormula = sourceSupportsFormulas && seriesReturnType !== 'ratio';
+  // ratio in the renderer, so the editor never lets both be set). Number
+  // tiles display a single value, so they take exactly one formula.
+  const canAddFormula =
+    sourceSupportsFormulas &&
+    seriesReturnType !== 'ratio' &&
+    !(displayType === DisplayType.Number && hasFormulas);
 
   const handleAddFormula = useCallback(() => {
-    // On a Number tile the chart displays the first value column, so hide
-    // the operand series by default — the formula is what the user wants to
-    // see. (The "Show input series" toggle can bring them back.)
-    if (displayType === DisplayType.Number && formulaFields.length === 0) {
-      setValue('showOperandSeries', false);
-    }
     appendFormula({ expression: '', alias: '' });
-  }, [appendFormula, displayType, formulaFields.length, setValue]);
+  }, [appendFormula]);
 
   const handleRemoveFormula = useCallback(
     (index: number) => {
@@ -408,23 +406,28 @@ export function ChartEditorControls({
                 </Button>
               )}
               {/* Only the formula column(s) vs formula + raw operand series
-                  (renderer: showOperandSeries, default shown). */}
-              {sourceSupportsFormulas && hasFormulas && (
-                <Switch
-                  label="Show input series"
-                  size="sm"
-                  color="gray"
-                  variant="subtle"
-                  onClick={() => {
-                    setValue(
-                      'showOperandSeries',
-                      showOperandSeries === false ? undefined : false,
-                    );
-                    onSubmit();
-                  }}
-                  checked={showOperandSeries !== false}
-                />
-              )}
+                  (renderer: showOperandSeries, default shown). Not offered on
+                  Number tiles: they display the first value column, so the
+                  operand series are always hidden there (hardcoded in
+                  normalizeChartConfig / convertToNumberChartConfig). */}
+              {sourceSupportsFormulas &&
+                hasFormulas &&
+                displayType !== DisplayType.Number && (
+                  <Switch
+                    label="Show input series"
+                    size="sm"
+                    color="gray"
+                    variant="subtle"
+                    onClick={() => {
+                      setValue(
+                        'showOperandSeries',
+                        showOperandSeries === false ? undefined : false,
+                      );
+                      onSubmit();
+                    }}
+                    checked={showOperandSeries !== false}
+                  />
+                )}
               {/* Ratio merges exactly two series via divide(); only
                   Line/StackedBar/Table/Number can reach two series, so gating
                   on the count alone covers them all (Number included).

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   Control,
   FieldArrayWithId,
   FieldErrors,
+  useFieldArray,
   UseFormClearErrors,
   UseFormSetValue,
   useWatch,
@@ -19,12 +20,17 @@ import {
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import { Box, Button, Divider, Flex, Group, Switch, Text } from '@mantine/core';
-import { IconBell, IconCirclePlus } from '@tabler/icons-react';
+import {
+  IconBell,
+  IconCirclePlus,
+  IconMathFunction,
+} from '@tabler/icons-react';
 
 import {
   ChartEditorFormState,
   SavedChartConfigWithSelectArray,
 } from '@/components/ChartEditor/types';
+import { isFormulaDisplayType } from '@/components/ChartEditor/utils';
 import MVOptimizationIndicator from '@/components/MaterializedViews/MVOptimizationIndicator';
 import SearchWhereInput from '@/components/SearchInput/SearchWhereInput';
 import SourceSchemaPreview, {
@@ -37,6 +43,7 @@ import { getEventBody, isSingleExpression } from '@/source';
 import { DEFAULT_TILE_ALERT } from '@/utils/alerts';
 
 import { OnClickFormButton } from './OnClickForm/OnClickFormButton';
+import { ChartFormulaEditor } from './ChartFormulaEditor';
 import { ChartSeriesEditor } from './ChartSeriesEditor';
 import { HeatmapSeriesEditor } from './HeatmapSeriesEditor';
 import { TileAlertEditor } from './TileAlertEditor';
@@ -103,13 +110,57 @@ export function ChartEditorControls({
   openDisplaySettings,
   openHeatmapSettings,
 }: ChartEditorControlsProps) {
+  // Metric formulas (HDX-5080): derived series computed from the chart's
+  // series via letter-ref arithmetic expressions. Metric sources only, and
+  // only on display types the composed multi-series metric query renders
+  // (time series / table / number).
+  const {
+    fields: formulaFields,
+    append: appendFormula,
+    remove: removeFormula,
+  } = useFieldArray({ control, name: 'formulas' });
+  const hasFormulas = formulaFields.length > 0;
+  const showOperandSeries = useWatch({ control, name: 'showOperandSeries' });
+  const sourceSupportsFormulas =
+    tableSource?.kind === SourceKind.Metric &&
+    isFormulaDisplayType(displayType);
+  // Formulas and the ratio toggle are mutually exclusive (formulas supersede
+  // ratio in the renderer, so the editor never lets both be set).
+  const canAddFormula = sourceSupportsFormulas && seriesReturnType !== 'ratio';
+
+  const handleAddFormula = useCallback(() => {
+    // On a Number tile the chart displays the first value column, so hide
+    // the operand series by default — the formula is what the user wants to
+    // see. (The "Show input series" toggle can bring them back.)
+    if (displayType === DisplayType.Number && formulaFields.length === 0) {
+      setValue('showOperandSeries', false);
+    }
+    appendFormula({ expression: '', alias: '' });
+  }, [appendFormula, displayType, formulaFields.length, setValue]);
+
+  const handleRemoveFormula = useCallback(
+    (index: number) => {
+      removeFormula(index);
+      if (formulaFields.length <= 1) {
+        // Removing the last formula: clear the keys entirely so saved
+        // configs don't carry an empty formulas array or a dangling
+        // showOperandSeries flag.
+        setValue('formulas', undefined);
+        setValue('showOperandSeries', undefined);
+      }
+      onSubmit(true);
+    },
+    [removeFormula, formulaFields.length, setValue, onSubmit],
+  );
+
   const canAddSeries =
     displayType !== DisplayType.Pie &&
     displayType !== DisplayType.Bar &&
     displayType !== DisplayType.Heatmap &&
     // Number tiles support up to two series (numerator + denominator for
-    // ratio mode); Line/Table types remain unbounded.
-    !(displayType === DisplayType.Number && fields.length >= 2);
+    // ratio mode); Line/Table types remain unbounded. With formulas the
+    // series are operands (e.g. A / (A + B + C)), so the cap is lifted.
+    !(displayType === DisplayType.Number && fields.length >= 2 && !hasFormulas);
   const [isSourceSchemaPreviewOpen, setIsSourceSchemaPreviewOpen] =
     useState(false);
 
@@ -251,6 +302,18 @@ export function ChartEditorControls({
               clearErrors={clearErrors}
             />
           ))}
+          {sourceSupportsFormulas &&
+            formulaFields.map((field, index) => (
+              <ChartFormulaEditor
+                key={field.id}
+                control={control}
+                index={index}
+                namePrefix={`formulas.${index}.`}
+                onRemoveFormula={handleRemoveFormula}
+                onSubmit={onSubmit}
+                setValue={setValue}
+              />
+            ))}
           {fields.length > 1 && displayType !== DisplayType.Number && (
             <>
               <Divider mt="md" mb="sm" />
@@ -332,10 +395,42 @@ export function ChartEditorControls({
                   Add Series
                 </Button>
               )}
+              {canAddFormula && (
+                <Button
+                  variant="subtle"
+                  size="sm"
+                  color="gray"
+                  onClick={handleAddFormula}
+                  data-testid="add-formula-button"
+                >
+                  <IconMathFunction size={14} className="me-2" />
+                  Add Formula
+                </Button>
+              )}
+              {/* Only the formula column(s) vs formula + raw operand series
+                  (renderer: showOperandSeries, default shown). */}
+              {sourceSupportsFormulas && hasFormulas && (
+                <Switch
+                  label="Show input series"
+                  size="sm"
+                  color="gray"
+                  variant="subtle"
+                  onClick={() => {
+                    setValue(
+                      'showOperandSeries',
+                      showOperandSeries === false ? undefined : false,
+                    );
+                    onSubmit();
+                  }}
+                  checked={showOperandSeries !== false}
+                />
+              )}
               {/* Ratio merges exactly two series via divide(); only
                   Line/StackedBar/Table/Number can reach two series, so gating
-                  on the count alone covers them all (Number included). */}
-              {fields.length === 2 && (
+                  on the count alone covers them all (Number included).
+                  Formulas supersede ratio in the renderer, so the toggle is
+                  hidden while any formula exists (mutually exclusive). */}
+              {fields.length === 2 && !hasFormulas && (
                 <Switch
                   label="As Ratio"
                   size="sm"

--- a/packages/app/src/components/DBEditTimeChartForm/ChartFormulaEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartFormulaEditor.tsx
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+import {
+  Control,
+  Controller,
+  UseFormSetValue,
+  useWatch,
+} from 'react-hook-form';
+import { validateFormula } from '@hyperdx/common-utils/dist/core/formula';
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Divider,
+  Group,
+  Text,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconTrash } from '@tabler/icons-react';
+
+import { ChartEditorFormState } from '@/components/ChartEditor/types';
+import { TextInputControlled } from '@/components/InputControlled';
+import { FORMAT_ICONS } from '@/components/NumberFormat';
+import SeriesNumberFormatDrawer from '@/components/SeriesNumberFormatDrawer';
+
+type ChartFormulaEditorProps = {
+  control: Control<ChartEditorFormState>;
+  index: number;
+  namePrefix: `formulas.${number}.`;
+  onRemoveFormula: (index: number) => void;
+  onSubmit: () => void;
+  setValue: UseFormSetValue<ChartEditorFormState>;
+};
+
+/**
+ * Editor row for one metric formula (HDX-5080): a derived series computed
+ * from the chart's `select` entries via a letter-ref arithmetic expression
+ * (`A` = series 1, `B` = series 2, ...). See `core/formula.ts` in
+ * common-utils for the grammar; expressions are validated inline with the
+ * same structured validator the query renderer uses, so errors surface here
+ * before they can reach ClickHouse.
+ */
+export function ChartFormulaEditor({
+  control,
+  index,
+  namePrefix,
+  onRemoveFormula,
+  onSubmit,
+  setValue,
+}: ChartFormulaEditorProps) {
+  const series = useWatch({ control, name: 'series' });
+  const seriesCount = Array.isArray(series) ? series.length : 0;
+
+  const expression = useWatch({
+    control,
+    name: `${namePrefix}expression`,
+  });
+
+  // Live structured validation (unknown refs, malformed expressions, ...).
+  // An empty expression is not flagged red while the user is still composing
+  // the row — the save-time validation in validateChartForm catches it.
+  const validationError = useMemo(() => {
+    if (!expression || expression.trim() === '') {
+      return undefined;
+    }
+    const result = validateFormula(expression, { seriesCount });
+    if (result.ok) {
+      return undefined;
+    }
+    return result.errors.map(e => e.message).join('; ');
+  }, [expression, seriesCount]);
+
+  const numberFormat = useWatch({
+    control,
+    name: `${namePrefix}numberFormat`,
+  });
+
+  const [
+    isNumberFormatOpen,
+    { open: openNumberFormat, close: closeNumberFormat },
+  ] = useDisclosure(false);
+
+  return (
+    <>
+      <Divider
+        label={
+          <Group gap="xs">
+            <Badge size="sm" radius="sm" variant="light" color="teal">
+              Formula
+            </Badge>
+            <Text size="xxs">Alias</Text>
+            <div style={{ width: 150 }}>
+              <TextInputControlled
+                name={`${namePrefix}alias`}
+                control={control}
+                placeholder="Formula alias"
+                onChange={() => onSubmit()}
+                size="xs"
+                data-testid="formula-alias-input"
+              />
+            </div>
+            <Button
+              variant="subtle"
+              color="gray"
+              size="xs"
+              onClick={() => onRemoveFormula(index)}
+              data-testid="formula-remove-button"
+            >
+              <IconTrash size={14} className="me-2" />
+              Remove Formula
+            </Button>
+            <Tooltip label="Edit formula display format">
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="xs"
+                onClick={openNumberFormat}
+                aria-label="Edit formula display format"
+              >
+                {FORMAT_ICONS[numberFormat?.output ?? 'number']}
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+        }
+        labelPosition="right"
+        mb={8}
+        mt="sm"
+      />
+      <Controller
+        control={control}
+        name={`${namePrefix}expression`}
+        render={({ field, fieldState: { error } }) => (
+          <TextInput
+            {...field}
+            value={field.value ?? ''}
+            size="sm"
+            placeholder="A / (A + B) * 100"
+            error={validationError ?? error?.message}
+            description={
+              validationError == null && !error
+                ? 'Arithmetic over series letters (A = series 1, B = series 2, ...)'
+                : undefined
+            }
+            inputWrapperOrder={['label', 'input', 'description', 'error']}
+            styles={{
+              input: { fontFamily: 'var(--mantine-font-family-monospace)' },
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                onSubmit();
+              }
+            }}
+            onBlur={() => {
+              field.onBlur();
+              onSubmit();
+            }}
+            data-testid="formula-expression-input"
+          />
+        )}
+      />
+      <SeriesNumberFormatDrawer
+        opened={isNumberFormatOpen}
+        numberFormat={numberFormat}
+        onChange={format => {
+          setValue(`${namePrefix}numberFormat`, format.numberFormat);
+          onSubmit();
+        }}
+        onClose={closeNumberFormat}
+      />
+    </>
+  );
+}

--- a/packages/app/src/components/DBEditTimeChartForm/ChartSeriesEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartSeriesEditor.tsx
@@ -6,6 +6,7 @@ import {
   UseFormSetValue,
   useWatch,
 } from 'react-hook-form';
+import { indexToSeriesRef } from '@hyperdx/common-utils/dist/core/formula';
 import {
   DateRange,
   isChartPaletteToken,
@@ -15,6 +16,7 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import {
   ActionIcon,
+  Badge,
   Button,
   Divider,
   Flex,
@@ -254,6 +256,23 @@ export function ChartSeriesEditor({
       <Divider
         label={
           <Group gap="xs">
+            {/* Formula series reference (HDX-5080): formulas address series
+                positionally by letter (`A` = series 1, ...), so surface the
+                letter on each row. Metric sources only — formulas are only
+                supported there. */}
+            {tableSource?.kind === SourceKind.Metric && (
+              <Tooltip label="Reference this series in a formula by this letter">
+                <Badge
+                  size="sm"
+                  radius="sm"
+                  variant="light"
+                  color="gray"
+                  data-testid="series-ref-badge"
+                >
+                  {indexToSeriesRef(index) ?? index + 1}
+                </Badge>
+              </Tooltip>
+            )}
             <Text size="xxs">Alias</Text>
 
             <div style={{ width: 150 }}>

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
@@ -881,6 +881,32 @@ describe('DBEditTimeChartForm - Metric formulas', () => {
     expect(onSave.mock.calls[0][0].showOperandSeries).toBe(false);
   });
 
+  it('Number tiles take a single formula and always hide input series', async () => {
+    const onSave = jest.fn();
+    renderComponent({
+      chartConfig: {
+        ...twoSeriesConfig,
+        displayType: DisplayType.Number,
+        // A formula defined before switching the display type to Number,
+        // with the operand series still shown.
+        formulas: [{ expression: 'A / (A + B) * 100' }],
+      },
+      onSave,
+    });
+
+    // One formula is the cap on Number tiles, and the operand series are
+    // hidden unconditionally, so neither control is offered.
+    expect(screen.queryByTestId('add-formula-button')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Show input series'),
+    ).not.toBeInTheDocument();
+
+    // Saving hardcodes hidden operand series onto the config.
+    await userEvent.click(screen.getByTestId('chart-save-button'));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0].showOperandSeries).toBe(false);
+  });
+
   it('does not show formula controls for non-metric sources', () => {
     mockUseSourceData({
       id: 'log-source',

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
@@ -678,3 +678,235 @@ describe('DBEditTimeChartForm - Column color', () => {
     expect(screen.getByTestId('series-color-apply')).toBeInTheDocument();
   });
 });
+
+describe('DBEditTimeChartForm - Metric formulas', () => {
+  const mockUseSourceData = (data: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const mocked = { data } as ReturnType<typeof useSource>;
+    jest.mocked(useSource).mockReturnValue(mocked);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Earlier describes override the useSource mock with mockReturnValue
+    // (which survives clearAllMocks), so pin the metric source back.
+    mockUseSourceData({
+      id: 'metric-source',
+      kind: SourceKind.Metric,
+      name: 'Test Metric Source',
+      from: { databaseName: 'default', tableName: '' },
+      connection: 'default',
+      timestampValueExpression: 'Timestamp',
+      metricTables: {
+        gauge: 'metrics.gauge',
+        sum: 'metrics.sum',
+        histogram: 'metrics.histogram',
+      },
+    });
+  });
+
+  const gaugeSeries = {
+    aggFn: 'avg' as const,
+    aggCondition: '',
+    aggConditionLanguage: 'lucene' as const,
+    valueExpression: 'Value',
+    metricType: MetricsDataType.Gauge,
+    metricName: 'test.metric.gauge',
+  };
+
+  const twoSeriesConfig: SavedChartConfig = {
+    ...defaultChartConfig,
+    select: [gaugeSeries, { ...gaugeSeries, metricName: 'test.metric.sum' }],
+  };
+
+  it('shows the Add Formula button and series letter badges for metric sources', () => {
+    renderComponent({ chartConfig: twoSeriesConfig });
+
+    expect(screen.getByTestId('add-formula-button')).toBeInTheDocument();
+    const badges = screen.getAllByTestId('series-ref-badge');
+    expect(badges.map(b => b.textContent)).toEqual(['A', 'B']);
+  });
+
+  it('adds a formula row with an expression input when Add Formula is clicked', async () => {
+    renderComponent({ chartConfig: twoSeriesConfig });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+
+    expect(screen.getByTestId('formula-expression-input')).toBeInTheDocument();
+    expect(screen.getByTestId('formula-alias-input')).toBeInTheDocument();
+  });
+
+  it('shows an inline validation error for a malformed expression', async () => {
+    renderComponent({ chartConfig: twoSeriesConfig });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+    await userEvent.type(screen.getByTestId('formula-expression-input'), 'A +');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Unexpected end of expression/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows an inline validation error for an unknown series reference', async () => {
+    renderComponent({ chartConfig: twoSeriesConfig });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+    await userEvent.type(screen.getByTestId('formula-expression-input'), 'C');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unknown series "C"/)).toBeInTheDocument();
+    });
+  });
+
+  it('clears the inline error once the expression becomes valid', async () => {
+    renderComponent({ chartConfig: twoSeriesConfig });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+    const input = screen.getByTestId('formula-expression-input');
+    await userEvent.type(input, 'C');
+    await waitFor(() => {
+      expect(screen.getByText(/Unknown series "C"/)).toBeInTheDocument();
+    });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'A / (A + B) * 100');
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Unknown series/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('saves formulas on the chart config', async () => {
+    const onSave = jest.fn();
+    renderComponent({ chartConfig: twoSeriesConfig, onSave });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+    await userEvent.type(
+      screen.getByTestId('formula-expression-input'),
+      'A / (A + B) * 100',
+    );
+    await userEvent.type(
+      screen.getByTestId('formula-alias-input'),
+      'Share of gauge',
+    );
+    await userEvent.click(screen.getByTestId('chart-save-button'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.formulas).toEqual([
+      { expression: 'A / (A + B) * 100', alias: 'Share of gauge' },
+    ]);
+  });
+
+  it('blocks save when the formula expression is invalid', async () => {
+    const onSave = jest.fn();
+    renderComponent({ chartConfig: twoSeriesConfig, onSave });
+
+    await userEvent.click(screen.getByTestId('add-formula-button'));
+    await userEvent.type(screen.getByTestId('formula-expression-input'), 'Z');
+    await userEvent.click(screen.getByTestId('chart-save-button'));
+
+    // Save is rejected by validateChartForm; onSave never fires.
+    await waitFor(() => {
+      expect(screen.getAllByText(/Unknown series "Z"/).length).toBeGreaterThan(
+        0,
+      );
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('removes the formula row and clears formulas from the saved config', async () => {
+    const onSave = jest.fn();
+    renderComponent({
+      chartConfig: {
+        ...twoSeriesConfig,
+        formulas: [{ expression: 'A + B' }],
+        showOperandSeries: false,
+      },
+      onSave,
+    });
+
+    expect(screen.getByTestId('formula-expression-input')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('formula-remove-button'));
+    expect(
+      screen.queryByTestId('formula-expression-input'),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('chart-save-button'));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.formulas).toBeUndefined();
+    expect(saved.showOperandSeries).toBeUndefined();
+  });
+
+  it('hides the As Ratio toggle while a formula exists', () => {
+    renderComponent({
+      chartConfig: {
+        ...twoSeriesConfig,
+        formulas: [{ expression: 'A + B' }],
+      },
+    });
+
+    expect(screen.queryByLabelText('As Ratio')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Show input series')).toBeInTheDocument();
+  });
+
+  it('hides the Add Formula button while ratio mode is enabled', () => {
+    renderComponent({
+      chartConfig: { ...twoSeriesConfig, seriesReturnType: 'ratio' },
+    });
+
+    expect(screen.getByLabelText('As Ratio')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-formula-button')).not.toBeInTheDocument();
+  });
+
+  it('toggles showOperandSeries via the Show input series switch', async () => {
+    const onSave = jest.fn();
+    renderComponent({
+      chartConfig: {
+        ...twoSeriesConfig,
+        formulas: [{ expression: 'A + B' }],
+      },
+      onSave,
+    });
+
+    const toggle = screen.getByLabelText('Show input series');
+    expect(toggle).toBeChecked();
+    await userEvent.click(toggle);
+
+    await userEvent.click(screen.getByTestId('chart-save-button'));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0].showOperandSeries).toBe(false);
+  });
+
+  it('does not show formula controls for non-metric sources', () => {
+    mockUseSourceData({
+      id: 'log-source',
+      kind: SourceKind.Log,
+      name: 'Logs',
+      from: { databaseName: 'default', tableName: 'otel_logs' },
+      connection: 'default',
+      timestampValueExpression: 'Timestamp',
+    });
+
+    renderComponent({
+      chartConfig: {
+        ...defaultChartConfig,
+        source: 'log-source',
+        select: [
+          {
+            aggFn: 'count',
+            aggCondition: '',
+            aggConditionLanguage: 'lucene' as const,
+            valueExpression: '',
+          },
+        ],
+      },
+    });
+
+    expect(screen.queryByTestId('add-formula-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('series-ref-badge')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/DBTableChart.tsx
+++ b/packages/app/src/components/DBTableChart.tsx
@@ -21,7 +21,11 @@ import { Table, TableVariant } from '@/HDXMultiSeriesTableChart';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import useOffsetPaginatedQuery from '@/hooks/useOffsetPaginatedQuery';
 import { useOnClickLinkBuilder } from '@/hooks/useOnClickLinkBuilder';
-import { useChartNumberFormats, useSource } from '@/source';
+import {
+  getBuilderValueColumnCount,
+  useChartNumberFormats,
+  useSource,
+} from '@/source';
 import { useIntersectionObserver } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
@@ -137,7 +141,11 @@ export default function DBTableChart({
   // identically and the columns memo consumes them the same way. Color targets
   // aggregation (series) columns only; group-by columns are not select items
   // and never appear here. Ratio configs merge two series into one column, so
-  // per-column color is skipped (matching the numberFormat treatment).
+  // per-column color is skipped (matching the numberFormat treatment). Metric
+  // formula configs with hidden operand series project no per-series columns
+  // at all (only formula columns, which carry no color config), so they're
+  // skipped too; with operands shown the positional mapping below still holds
+  // (formula columns come after the operands and simply get no color).
   const { colorByColumn, rulesByColumn } = useMemo(() => {
     const colorByColumn = new Map<string, ChartPaletteToken>();
     const rulesByColumn = new Map<string, ColorCondition[]>();
@@ -146,7 +154,9 @@ export default function DBTableChart({
       !meta ||
       !isBuilderChartConfig(queriedConfig) ||
       !Array.isArray(queriedConfig.select) ||
-      isRatioChartConfig(queriedConfig.select, queriedConfig)
+      isRatioChartConfig(queriedConfig.select, queriedConfig) ||
+      (queriedConfig.formulas?.length &&
+        queriedConfig.showOperandSeries === false)
     ) {
       return { colorByColumn, rulesByColumn };
     }
@@ -181,8 +191,9 @@ export default function DBTableChart({
       isBuilderChartConfig(queriedConfig) &&
       Array.isArray(queriedConfig.select)
     ) {
-      const isRatio = isRatioChartConfig(queriedConfig.select, queriedConfig);
-      const seriesCount = isRatio ? 1 : queriedConfig.select.length;
+      // Value columns come first (formula-aware: operands + formula columns,
+      // or one merged ratio column); everything after is a group-by column.
+      const seriesCount = getBuilderValueColumnCount(queriedConfig);
       const groupByCount = allKeys.length - seriesCount;
       groupByKeys = groupByCount > 0 ? allKeys.slice(-groupByCount) : [];
     }

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -734,8 +734,20 @@ function DBTimeChartComponent({
           }
         | undefined;
 
+      // Metric formula configs with hidden operand series project only the
+      // formula column(s), so value columns no longer map positionally onto
+      // `select` — skip the value-range filter rather than misattributing a
+      // formula value to an operand's expression. (With operands shown, the
+      // operand columns still map by index and formula columns fall past the
+      // `< config.select.length` bound below.)
+      const operandsHidden =
+        isBuilderChartConfig(config) &&
+        (config.formulas?.length ?? 0) > 0 &&
+        config.showOperandSeries === false;
+
       if (
         seriesValue &&
+        !operandsHidden &&
         Array.isArray(config.select) &&
         config.select.length > 0
       ) {

--- a/packages/app/src/components/__tests__/DBTableChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBTableChart.test.tsx
@@ -32,6 +32,10 @@ jest.mock('@/source', () => ({
   useChartNumberFormats: jest
     .fn()
     .mockReturnValue({ formatByColumn: new Map(), chartFormat: undefined }),
+  // Pure helper (no hooks/network) — use the real implementation so the
+  // group-by column inference under test matches production behavior.
+  getBuilderValueColumnCount:
+    jest.requireActual('@/source').getBuilderValueColumnCount,
 }));
 
 jest.mock('@/HDXMultiSeriesTableChart', () => ({

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -15,7 +15,10 @@ import { splitAndTrimWithBracket } from '@hyperdx/common-utils/dist/core/utils';
 import { isBuilderChartConfig } from '@hyperdx/common-utils/dist/guards';
 import {
   BuilderSavedChartConfig,
+  ChartConfig,
+  ChartConfigWithOptDateRange,
   ChartConfigWithOptTimestamp,
+  MetricFormula,
   MetricsDataType,
   NumberFormat,
   SourceKind,
@@ -595,6 +598,54 @@ interface ResolvedNumberFormats {
 }
 
 /**
+ * The formula projection settings of a builder metric config, or undefined
+ * when formulas don't apply (non-builder configs, non-metric sources, or no
+ * formulas configured).
+ */
+function getFormulaConfig(
+  config: ChartConfig | ChartConfigWithOptDateRange,
+): { formulas: MetricFormula[]; operandsHidden: boolean } | undefined {
+  if (
+    !isBuilderChartConfig(config) ||
+    config.metricTables == null ||
+    !config.formulas?.length
+  ) {
+    return undefined;
+  }
+  return {
+    formulas: config.formulas,
+    operandsHidden: config.showOperandSeries === false,
+  };
+}
+
+/**
+ * How many value (series) columns a builder chart config's query result
+ * carries, ahead of any group-by passthrough columns.
+ *
+ * Mirrors the projection built by the query renderer
+ * (renderMultiSeriesMetricChartConfig / ratio merging in common-utils):
+ *  - metric formula configs project the operand series columns (unless
+ *    `showOperandSeries` is false) followed by one column per formula;
+ *  - ratio configs merge their two series into a single column;
+ *  - everything else projects one column per select entry.
+ */
+export function getBuilderValueColumnCount(
+  config: ChartConfig | ChartConfigWithOptDateRange,
+): number {
+  if (!isBuilderChartConfig(config) || !Array.isArray(config.select)) {
+    return 0;
+  }
+  const formulaConfig = getFormulaConfig(config);
+  if (formulaConfig) {
+    const operandCount = formulaConfig.operandsHidden
+      ? 0
+      : config.select.length;
+    return operandCount + formulaConfig.formulas.length;
+  }
+  return isRatioChartConfig(config.select, config) ? 1 : config.select.length;
+}
+
+/**
  * Returns the number formats to use when formatting chart series values.
  *
  * The chart-wide number format is determined with the following priorities:
@@ -618,15 +669,26 @@ export function useChartNumberFormats(
   const { data: source } = useSource({ id: config.source });
 
   return useMemo(() => {
+    const formulaConfig = getFormulaConfig(config);
+
     // The chart-wide number format does not depend on meta, so that it can be
     // resolved without querying. Further, it prioritizes the config's numberFormat
     // over series-specific formats, so that the user can specify the y-axis format
-    // for charts with multiple series-specific formats.
+    // for charts with multiple series-specific formats. When only formula
+    // columns render (operands hidden), formula formats take priority over
+    // formats of series that aren't in the result at all.
+    const firstFormulaFormat = formulaConfig?.formulas.find(
+      f => f.numberFormat,
+    )?.numberFormat;
+    const firstSeriesFormat =
+      isBuilderChartConfig(config) && Array.isArray(config.select)
+        ? getFirstSeriesNumberFormat(config.select, source)
+        : undefined;
     const chartFormat =
       config.numberFormat ??
-      (isBuilderChartConfig(config) && Array.isArray(config.select)
-        ? getFirstSeriesNumberFormat(config.select, source)
-        : undefined);
+      (formulaConfig?.operandsHidden
+        ? (firstFormulaFormat ?? firstSeriesFormat)
+        : (firstSeriesFormat ?? firstFormulaFormat));
 
     // meta must be provided to map result column names (from meta) to number formats
     if (!meta) {
@@ -636,6 +698,35 @@ export function useChartNumberFormats(
     // For Raw-SQL or string-based select configs, series-specific formats are not available
     if (!isBuilderChartConfig(config) || !Array.isArray(config.select)) {
       return { formatByColumn: new Map(), chartFormat };
+    }
+
+    // Metric formula configs project the operand series columns (unless
+    // hidden) followed by one column per formula, ahead of any group-by
+    // passthrough columns (see renderMultiSeriesMetricChartConfig). Map
+    // formats positionally in that order. Formulas supersede ratio, so this
+    // takes priority over the ratio branch below.
+    if (formulaConfig) {
+      const orderedFormats: (NumberFormat | undefined)[] = [
+        ...(formulaConfig.operandsHidden
+          ? []
+          : config.select.map(
+              series =>
+                series.numberFormat ??
+                config.numberFormat ??
+                getTraceDurationNumberFormat(source, series),
+            )),
+        ...formulaConfig.formulas.map(
+          formula => formula.numberFormat ?? config.numberFormat,
+        ),
+      ];
+      const formatByColumn = new Map<string, NumberFormat>();
+      orderedFormats.forEach((format, i) => {
+        const key = meta[i]?.name;
+        if (key != null && format) {
+          formatByColumn.set(key, format);
+        }
+      });
+      return { formatByColumn, chartFormat };
     }
 
     // Ratio-based configs have exactly two series, which

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -570,6 +570,15 @@ export function useSingleSeriesNumberFormat(
   const { data: source } = useSource({ id: config.source });
 
   return useMemo(() => {
+    // Metric formula configs display the formula — number charts always
+    // hide the operand series (see convertToNumberChartConfig), so the
+    // first (only) value column is formulas[0], not select[0]. Resolve the
+    // format from the formula, not from an operand that isn't rendered.
+    const formulaConfig = getFormulaConfig(config);
+    if (formulaConfig) {
+      return formulaConfig.formulas[0]?.numberFormat ?? config.numberFormat;
+    }
+
     if (
       isBuilderChartConfig(config) &&
       Array.isArray(config.select) &&

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -936,6 +936,73 @@ export class ChartEditorComponent {
   }
 
   /**
+   * Select a metric by name on the series at zero-based `index`. Like
+   * selectMetric, but disambiguates between the metric selectors of a
+   * multi-series metric chart.
+   */
+  async selectMetricForSeries(
+    index: number,
+    metricName: string,
+    metricValue?: string,
+  ) {
+    const selector = this.page.getByTestId('metric-name-selector').nth(index);
+    await selector.waitFor({ state: 'visible', timeout: 5000 });
+    await selector.click();
+    await selector.fill(metricName);
+    if (metricValue) {
+      // Every series' select keeps its (hidden) option list mounted, so
+      // scope to the visible one — the dropdown just opened for this series.
+      const targetMetricOption = this.page
+        .locator(`[data-combobox-option="true"][value="${metricValue}"]`)
+        .filter({ visible: true });
+      await targetMetricOption.waitFor({ state: 'visible', timeout: 5000 });
+      await targetMetricOption.click({ timeout: 5000 });
+    } else {
+      await this.page.keyboard.press('Enter');
+    }
+  }
+
+  /**
+   * Click the "Add Formula" button (metric sources only) to append a formula
+   * row, and fill its expression (and optional alias). Targets the last
+   * formula row so multiple formulas can be added in sequence.
+   */
+  async addFormula(expression: string, alias?: string) {
+    await this.page.getByTestId('add-formula-button').click();
+    const expressionInput = this.page
+      .getByTestId('formula-expression-input')
+      .last();
+    await expressionInput.fill(expression);
+    if (alias !== undefined) {
+      await this.page.getByTestId('formula-alias-input').last().fill(alias);
+    }
+    await expressionInput.blur();
+  }
+
+  /**
+   * Read the inline validation error of the formula row at zero-based
+   * `index`, or null when the expression is valid.
+   */
+  async getFormulaError(index: number): Promise<string | null> {
+    const input = this.page.getByTestId('formula-expression-input').nth(index);
+    // Mantine renders the error node as a sibling within the input wrapper.
+    const wrapper = input.locator('..').locator('..');
+    const error = wrapper.locator('.mantine-InputWrapper-error');
+    if ((await error.count()) === 0) {
+      return null;
+    }
+    return error.textContent();
+  }
+
+  /**
+   * Toggle the "Show input series" switch (visible while a metric formula
+   * exists) between formula-only and formula + operand series output.
+   */
+  async toggleShowInputSeries() {
+    await this.page.getByRole('switch', { name: 'Show input series' }).click();
+  }
+
+  /**
    * Toggle the "As Ratio" switch. Only visible when the chart has exactly
    * two series.
    */

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -2797,6 +2797,137 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
     },
   );
 
+  test.describe(
+    'Metric formulas (HDX-5080)',
+    { tag: ['@full-stack', '@dashboard'] },
+    () => {
+      test.beforeEach(async () => {
+        await dashboardPage.createNewDashboard();
+      });
+
+      test('creates a metric tile with two series and a formula, saves, reloads, and renders it', async ({
+        page,
+      }) => {
+        test.setTimeout(60000);
+        const ts = Date.now();
+        const chartName = `E2E Metric Formula ${ts}`;
+
+        await test.step('Configure a metric Table chart with two gauge series', async () => {
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          // Table display keeps the assertions robust: the formula surfaces
+          // as a named column header rather than a chart legend entry.
+          await dashboardPage.chartEditor.setChartType(DisplayType.Table);
+          await dashboardPage.chartEditor.selectSource(
+            DEFAULT_METRICS_SOURCE_NAME,
+          );
+          await dashboardPage.chartEditor.setChartName(chartName);
+
+          await dashboardPage.chartEditor.selectMetricForSeries(
+            0,
+            'container.cpu.utilization',
+            'container.cpu.utilization:::::::gauge',
+          );
+          await dashboardPage.chartEditor.setSeriesAlias(0, 'ContainerCpu');
+
+          await dashboardPage.chartEditor.addSeries();
+          await dashboardPage.chartEditor.selectMetricForSeries(
+            1,
+            'k8s.pod.cpu.utilization',
+            'k8s.pod.cpu.utilization:::::::gauge',
+          );
+          await dashboardPage.chartEditor.setSeriesAlias(1, 'PodCpu');
+        });
+
+        await test.step('Series rows expose their formula reference letters', async () => {
+          const badges = page.getByTestId('series-ref-badge');
+          await expect(badges).toHaveCount(2);
+          await expect(badges.nth(0)).toHaveText('A');
+          await expect(badges.nth(1)).toHaveText('B');
+        });
+
+        await test.step('An invalid formula surfaces an inline validation error', async () => {
+          await dashboardPage.chartEditor.addFormula('A / C');
+          expect(await dashboardPage.chartEditor.getFormulaError(0)).toContain(
+            'Unknown series "C"',
+          );
+        });
+
+        await test.step('Fix the formula and run the query', async () => {
+          await page
+            .getByTestId('formula-expression-input')
+            .fill('A / (A + B) * 100');
+          await page.getByTestId('formula-alias-input').fill('CpuShare');
+          expect(await dashboardPage.chartEditor.getFormulaError(0)).toBeNull();
+          await dashboardPage.chartEditor.runQuery(false);
+
+          const headers =
+            await dashboardPage.chartEditor.getPreviewTableHeaders();
+          expect(headers).toContain('ContainerCpu');
+          expect(headers).toContain('PodCpu');
+          expect(headers).toContain('CpuShare');
+        });
+
+        await test.step('Hide the operand series so only the formula column renders', async () => {
+          await dashboardPage.chartEditor.toggleShowInputSeries();
+
+          await expect
+            .poll(
+              async () => dashboardPage.chartEditor.getPreviewTableHeaders(),
+              { timeout: 15000 },
+            )
+            .toEqual(['CpuShare']);
+        });
+
+        await test.step('Save the tile and verify the formula column renders on the dashboard', async () => {
+          await dashboardPage.saveTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeHidden({
+            timeout: 5000,
+          });
+
+          const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+          await expect(tile.locator('table')).toBeVisible({ timeout: 15000 });
+          const tileHeaders = await dashboardPage.getTileTableHeaders(0);
+          expect(tileHeaders).toEqual(['CpuShare']);
+        });
+
+        await test.step('Reload the page and verify the saved formula tile still renders', async () => {
+          await page.reload();
+
+          const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+          await expect(tile.locator('table')).toBeVisible({ timeout: 15000 });
+          const tileHeaders = await dashboardPage.getTileTableHeaders(0);
+          expect(tileHeaders).toEqual(['CpuShare']);
+
+          // The formula value is a percentage share, so the column must hold
+          // a finite number — a NaN/empty cell would mean the composed
+          // formula projection failed.
+          const cells = await dashboardPage.getTileTableCellTexts(0, 0);
+          expect(cells.length).toBeGreaterThan(0);
+          expect(Number.parseFloat(cells[0])).not.toBeNaN();
+        });
+
+        await test.step('Reopen the tile editor and verify the formula round-tripped', async () => {
+          await dashboardPage.editTile(0);
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+
+          await expect(
+            dashboardPage.page.getByTestId('formula-expression-input'),
+          ).toHaveValue('A / (A + B) * 100');
+          await expect(
+            dashboardPage.page.getByTestId('formula-alias-input'),
+          ).toHaveValue('CpuShare');
+          await expect(
+            dashboardPage.page.getByRole('switch', {
+              name: 'Show input series',
+            }),
+          ).not.toBeChecked();
+        });
+      });
+    },
+  );
+
   test(
     'should isolate the fullscreen tile time picker from the dashboard time range',
     { tag: ['@full-stack', '@dashboard'] },

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   convertToCategoricalChartConfig,
   convertToDashboardDocument,
   convertToDashboardTemplate,
+  convertToNumberChartConfig,
   extractSettingsClauseFromEnd,
   findJsonExpressions,
   formatDate,
@@ -508,6 +509,59 @@ describe('utils', () => {
       expect(config.select[0]).not.toHaveProperty('alias');
       expect(config.orderBy).toBeUndefined();
       expect(config.limit).toBeUndefined();
+    });
+  });
+
+  describe('convertToNumberChartConfig', () => {
+    const dateRange: [Date, Date] = [
+      new Date('2025-11-26T00:00:00Z'),
+      new Date('2025-11-27T00:00:00Z'),
+    ];
+
+    it('drops granularity and groupBy', () => {
+      const config = {
+        select: [{ aggFn: 'count', valueExpression: '' }],
+        granularity: '5 minute',
+        groupBy: 'ServiceName',
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      const converted = convertToNumberChartConfig(config);
+
+      expect(converted.granularity).toBeUndefined();
+      expect(converted.groupBy).toBeUndefined();
+    });
+
+    it('leaves showOperandSeries untouched without formulas', () => {
+      const config = {
+        select: [{ aggFn: 'count', valueExpression: '' }],
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      expect(convertToNumberChartConfig(config).showOperandSeries).toBe(
+        undefined,
+      );
+    });
+
+    it('always hides operand series for formula configs (HDX-5080)', () => {
+      // A number chart displays the first value column of the result, so the
+      // formula column must be the only projection — even when the stored
+      // config shows operand series on other display types.
+      const config = {
+        select: [
+          { aggFn: 'max', valueExpression: 'Value' },
+          { aggFn: 'max', valueExpression: 'Value' },
+        ],
+        formulas: [{ expression: 'A / B * 100' }],
+        granularity: '5 minute',
+        dateRange,
+      } as BuilderChartConfigWithDateRange;
+
+      expect(convertToNumberChartConfig(config).showOperandSeries).toBe(false);
+      expect(
+        convertToNumberChartConfig({ ...config, showOperandSeries: true })
+          .showOperandSeries,
+      ).toBe(false);
     });
   });
 

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -877,11 +877,21 @@ export function convertToCategoricalChartConfig(
 /**
  * Number charts collapse to a single aggregate value, so drop the time bucket
  * (granularity) and any group-by.
+ *
+ * Metric formula configs (HDX-5080) additionally always hide their operand
+ * series: the number chart displays the first value column of the result, so
+ * the formula column must be the only one projected — never a raw operand.
+ * Enforced here (the choke point every number render passes through) so it
+ * holds for stale saved configs and display-type switches alike, regardless
+ * of the tile's "Show input series" setting on other display types.
  */
 export function convertToNumberChartConfig(
   config: BuilderChartConfigWithOptTimestamp,
 ): BuilderChartConfigWithOptTimestamp {
-  return omit(config, ['granularity', 'groupBy']);
+  const converted = omit(config, ['granularity', 'groupBy']);
+  return config.formulas?.length
+    ? { ...converted, showOperandSeries: false }
+    : converted;
 }
 
 /**


### PR DESCRIPTION
## Summary

Exposes metric formulas (HDX-5078's `formulas` config, rendered by HDX-5079) in the chart editor for metric sources, so a derived series like `A / (A + B + C) * 100` can be built, validated, saved, and reloaded from the UI.

Rebased onto main now that #2908 (HDX-5079 rendering) has merged.

### Editor

- **Formula rows** (`ChartFormulaEditor`) on metric-source builder charts (time series / table / number): "Add Formula" appends a row with a monospace letter-ref expression input, an alias, a per-formula number format (reuses the per-series format drawer), and "Remove Formula".
- **Inline validation** with the structured validator from HDX-5078 (`validateFormula`): malformed expressions, unknown series refs, constant-only expressions, etc. surface live under the input; `validateChartForm` blocks save/run with the same messages so an invalid expression can never reach ClickHouse.
- **Letter badges** (`A`, `B`, `C`, ...) on metric series rows so formula refs are discoverable.
- **"Show input series" toggle** drives `showOperandSeries` (formula + raw operand series vs formula column(s) only). Adding a formula on a Number tile defaults operands to hidden, since Number tiles render the first value column.
- **Mutual exclusion with ratio**: the "As Ratio" switch is hidden while a formula exists, and "Add Formula" is hidden while ratio mode is on (formulas supersede ratio in the renderer).
- The Number-tile series cap (1, or 2 for ratio) is lifted when formulas exist, so operand-only series like `A / (A + B + C)` can be built.
- `normalizeChartConfig` strips `formulas`/`showOperandSeries` on save for non-metric sources and for display types the composed metric query does not render (pie/bar/heatmap/search/patterns), mirroring the existing `metricName`/`having` stripping. The form state keeps them, so switching back restores the rows.

### Rendering consumers (positional value-column contract)

The composed metric query projects operand columns (unless hidden) then formula columns, ahead of group-by passthrough columns. Updated the consumers that map columns positionally:

- `useChartNumberFormats`: operand columns → `select[i].numberFormat`, formula columns → `formulas[j].numberFormat`, both falling back to the chart-wide format; chart-wide axis format prefers formula formats when operands are hidden.
- New `getBuilderValueColumnCount` helper (formula/ratio-aware) used by `DBTableChart` for group-by column inference; per-column color mapping skips hidden-operand formula configs.
- `DBTimeChart` drill-down skips the value-range filter when operands are hidden (formula columns don't map onto `select` expressions).
- Legend/tooltip naming needs no changes — formula columns arrive as named result columns (`alias || expression`).

Persistence needs no API changes: tiles validate against `SavedChartConfigSchema`, which already carries `formulas`/`showOperandSeries`, and `builderToRawSql` already rejects formula configs with a clear message on the Builder → SQL switch.

### Alerts on formula tiles (`packages/api`)

Contrary to #2908's "alerts work with no changes" claim, the alert task does **not** run the tile config as-is — `getChartConfigFromAlert` rebuilds it from an explicit field list that dropped `formulas`/`showOperandSeries`. An alert on a formula tile therefore queried only the raw operand series and compared the threshold against the **last operand's value** (e.g. `740442112.0 meets or exceeds 0.1` for a byte-valued operand), regardless of the tile's "Show input series" toggle. Fixed here:

- `formulas` is passed through, and operand columns are always dropped from the alert query (`showOperandSeries: false`) so the formula is the value column `parseAlertData` picks — the alert evaluates exactly what the tile displays.
- Drive-by with the same omission shape: `ratioMode` is now passed through, so grouped `share_of_total` ratio tile alerts no longer silently evaluate as `per_group`.
- New integration tests (`make dev-int FILE=checkAlerts`, 168 passing): formula value drives the alert (fixture chosen so the formula result differs from both operands), toggle-independence, NULL formula (zero denominator) skipped without NaN history, and `share_of_total` honored (asserting the exact share value a `per_group` fallback couldn't produce).

### Testing

- `make ci-lint`, `make ci-unit` pass.
- New unit tests:
  - `DBEditTimeChartForm.test.tsx`: Add/Remove Formula, inline validation (malformed / unknown ref / clears when fixed), save round-trip, save blocked on invalid expression, ratio mutual exclusion, `showOperandSeries` toggle, non-metric sources show no formula controls.
  - `ChartEditor/utils.test.ts`: `validateChartForm` formula rules (including the Number-tile cap lift) and normalization stripping/round-trip.
  - `source.test.ts`: `useChartNumberFormats` formula-column mapping (operands shown/hidden, ratio precedence, chart-format fallbacks) and `getBuilderValueColumnCount`.
- New dashboard E2E (`make dev-e2e FILE=dashboard GREP="Metric formulas"`, passing): creates a metric table tile with two gauge series + `A / (A + B) * 100`, asserts the inline error for an invalid ref, hides operands, saves, reloads the page, verifies the formula column renders with a finite value, and reopens the editor to verify the round-trip.

### How to test on Vercel preview

1. Open a dashboard → Add tile → select a metrics source.
2. Add two series (note the `A`/`B` badges), click **Add Formula**, enter `A / (A + B) * 100`.
3. Try `A / C` to see the inline error; toggle **Show input series**; save, reload, and confirm the tile renders the formula series.

### References

- Linear Issue: [HDX-5080](https://linear.app/clickhouse/issue/HDX-5080/chart-editor-ui-for-metric-formulas)
- Related PRs: #2908 (HDX-5079 formula rendering, base branch), #2872 (HDX-5078 schema + parser)

### Screenshots
<img width="1676" height="725" alt="image" src="https://github.com/user-attachments/assets/f16478f7-ac82-496d-90f2-056cc1260c70" />


