### PR TITLE
chore(api): clear remaining small ESLint warnings and enforce their rules

### DIFF
--- a/.changeset/eslint-api-oneoffs.md
+++ b/.changeset/eslint-api-oneoffs.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/api': patch
+---
+
+Clear the remaining small api ESLint warnings and enforce their rules. Merges
+the duplicate Express `declare global` namespace blocks in the auth middleware
+(the `namespace` + empty-interface augmentation pattern is required, so it
+carries a scoped disable with a comment), and scopes `n/no-process-exit` off for
+the process entry points (`src/index.ts`, `src/tasks/index.ts`) where exiting
+with a status code is intended. `@typescript-eslint/no-namespace`,
+`no-empty-object-type`, and `n/no-process-exit` are promoted to `error` and the
+api `--max-warnings` ceiling is lowered. Behavior is unchanged.

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -39,11 +39,11 @@ export default [
       ...securityPlugin.configs['recommended-legacy'].rules,
       '@typescript-eslint/ban-ts-comment': 'error',
       '@typescript-eslint/no-empty-interface': 'off',
-      '@typescript-eslint/no-empty-object-type': 'warn',
+      '@typescript-eslint/no-empty-object-type': 'error',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-unsafe-type-assertion': 'warn',
-      '@typescript-eslint/no-namespace': 'warn',
+      '@typescript-eslint/no-namespace': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -57,7 +57,7 @@ export default [
           tryExtensions: ['.js', '.ts', '.json'],
         },
       ],
-      'n/no-process-exit': 'warn',
+      'n/no-process-exit': 'error',
       'n/no-missing-import': 'off',
       'n/no-unpublished-import': [
         'error',
@@ -112,6 +112,15 @@ export default [
         clearImmediate: 'readonly',
         global: 'readonly',
       },
+    },
+  },
+  {
+    // Process entry points and the CLI task runner: exiting with a status code
+    // on startup failure, task completion, or a last-resort uncaught-exception
+    // handler is the intended behavior here.
+    files: ['src/index.ts', 'src/tasks/index.ts'],
+    rules: {
+      'n/no-process-exit': 'off',
     },
   },
 ];

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -100,7 +100,7 @@
     "dev-task": "DOTENV_CONFIG_PATH=.env.development nodemon --exec 'ts-node' --transpile-only -r tsconfig-paths/register -r dotenv-expand/config -r '@hyperdx/node-opentelemetry/build/src/tracing' ./src/tasks/index.ts",
     "build": "rimraf ./build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && cp -r ./src/opamp/proto ./build/opamp/",
     "build:vercel": "rimraf ./build && tsc -p tsconfig.vercel.json && tsc-alias -p tsconfig.vercel.json && cp -r ./src/opamp/proto ./build/opamp/",
-    "lint": "npx eslint . --ext .ts --max-warnings 311",
+    "lint": "npx eslint . --ext .ts --max-warnings 302",
     "lint:fix": "npx eslint . --ext .ts --fix",
     "ci:lint": "yarn lint && yarn tsc --noEmit && yarn lint:openapi",
     "ci:unit": "jest --ci --coverage",

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -12,10 +12,12 @@ import {
 import logger from '@/utils/logger';
 
 declare global {
+  // Express type augmentation requires `namespace` + interface merging; there is
+  // no non-namespace / non-empty-interface equivalent for extending these types.
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     interface User extends UserDocument {}
-  }
-  namespace Express {
     interface Request {
       _hdx_connection?: Connection;
     }

--- a/scripts/ci/ratchet-baseline.json
+++ b/scripts/ci/ratchet-baseline.json
@@ -1,12 +1,12 @@
 {
   "api": {
-    "as-any": 95,
-    "ts-ignore": 4,
-    "eslint-disable": 29
+    "as-any": 94,
+    "ts-ignore": 0,
+    "eslint-disable": 31
   },
   "app": {
     "as-any": 215,
-    "ts-ignore": 11,
+    "ts-ignore": 0,
     "eslint-disable": 143
   },
   "cli": {
@@ -16,7 +16,7 @@
   },
   "common-utils": {
     "as-any": 116,
-    "ts-ignore": 5,
+    "ts-ignore": 0,
     "eslint-disable": 39
   },
   "hdx-eval": {


### PR DESCRIPTION
## What

Clears the last small batch of api ESLint warnings and promotes their rules to `error`.

| Rule | Count | Resolution |
|---|---|---|
| `@typescript-eslint/no-namespace` | 2 | Merge the duplicate Express `declare global` namespace blocks; scoped disable (pattern is required) |
| `@typescript-eslint/no-empty-object-type` | 1 | Scoped disable on `interface User extends UserDocument {}` (required for Express `User` augmentation) |
| `n/no-process-exit` | 5 | Config override: rule `off` for the two process entry-point files |

## Why

These are all **legitimate patterns the linter flags**, not real issues:

- **Express type augmentation** (`namespace Express { interface User … }`) is the documented way to extend Express's types — interface merging is required, and a type alias / non-empty interface can't do it. I merged the two duplicate `namespace Express` blocks into one for tidiness and disabled the two rules on that single augmentation block with an explanatory comment.
- **`process.exit()`** in `src/index.ts` (startup failure, last-resort `uncaughtException`/`unhandledRejection` handlers) and `src/tasks/index.ts` (CLI task completion/failure) is the intended behavior. Rather than 5 inline disables, the rule is scoped `off` for just those two entry-point files — so it still guards against stray `process.exit()` elsewhere in the api.

Promoting all three to `error` turns these into guardrails: new violations outside the sanctioned spots now fail lint. This is the last of the small mechanical/one-off batches (follows #2903, #2911, #2912).

## Verification

- `yarn lint` (api) — pass (0 errors; 3 rules now enforced as error)
- `tsc --noEmit` (api) — clean (Express augmentation still resolves after the merge)
- `yarn knip` — clean
- api `--max-warnings` lowered **311 → 302**

Behavior is unchanged. Changeset included (`@hyperdx/api` patch).