### PR TITLE
[HDX-5037] Deliver alert notifications on a cross-tick queue with delivery-failure feedback

### DIFF
--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -43,6 +43,7 @@ import {
   parseAlertData,
   processAlert,
 } from '@/tasks/checkAlerts';
+import { InProcessNotificationDispatcher } from '@/tasks/checkAlerts/notificationQueue';
 import {
   AlertDetails,
   AlertProvider,
@@ -2114,6 +2115,7 @@ describe('checkAlerts', () => {
       connection: IConnection,
       alertProvider: AlertProvider,
       teamWebhooksById: Map<string, IWebhook>,
+      notificationDispatcher?: InProcessNotificationDispatcher,
     ) => {
       const [previousMap, recentHistoryMap] = await Promise.all([
         getPreviousAlertHistories([details.alert.id], now),
@@ -2130,6 +2132,7 @@ describe('checkAlerts', () => {
         connection.id,
         alertProvider,
         teamWebhooksById,
+        notificationDispatcher,
       );
     };
 
@@ -3859,6 +3862,253 @@ describe('checkAlerts', () => {
           AlertErrorType.WEBHOOK_ERROR,
         );
         expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it('with a notification dispatcher, a hung webhook endpoint does not block the evaluation', async () => {
+        // A webhook endpoint that hangs until the test releases it. Without
+        // the dispatcher, processAlert would await this forever (this test
+        // would time out); with it, evaluation returns immediately.
+        let releaseFetch!: (response: unknown) => void;
+        const fetchGate = new Promise(resolve => {
+          releaseFetch = resolve;
+        });
+        const fetchMock = jest.fn().mockImplementation(() => fetchGate);
+        global.fetch = jest.mocked(fetchMock);
+
+        const {
+          team,
+          webhook,
+          connection,
+          source,
+          teamWebhooksById,
+          clickhouseClient,
+          dashboard,
+        } = await setupTileAlertForErrors({
+          webhookSettings: {
+            service: WebhookService.Generic,
+            url: 'https://webhook.site/hang',
+            name: 'Generic Webhook',
+            description: 'generic webhook',
+            body: JSON.stringify({ text: '{{title}}' }),
+          },
+        });
+
+        const now = new Date('2023-11-16T22:12:00.000Z');
+        const eventMs = now.getTime() - ms('5m');
+        await bulkInsertLogs([
+          {
+            ServiceName: 'api',
+            Timestamp: new Date(eventMs),
+            SeverityText: 'error',
+            Body: 'oh no',
+          },
+          {
+            ServiceName: 'api',
+            Timestamp: new Date(eventMs),
+            SeverityText: 'error',
+            Body: 'oh no',
+          },
+        ]);
+
+        const tile = dashboard.tiles?.find((t: any) => t.id === 'tile-err');
+        const details = await createAlertDetails(
+          team,
+          source,
+          {
+            source: AlertSource.TILE,
+            channel: {
+              type: 'webhook',
+              webhookId: webhook._id.toString(),
+            },
+            interval: '5m',
+            thresholdType: AlertThresholdType.ABOVE,
+            threshold: 1,
+            dashboardId: dashboard.id,
+            tileId: 'tile-err',
+          },
+          {
+            taskType: AlertTaskType.TILE,
+            tile: tile!,
+            dashboard,
+          },
+        );
+
+        const dispatcher = new InProcessNotificationDispatcher();
+        await processAlertAtTime(
+          now,
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+          dispatcher,
+        );
+
+        // Evaluation completed and persisted state while the delivery is
+        // still hanging on the background queue.
+        expect(dispatcher.pending).toBe(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const updated = await Alert.findById(details.alert.id);
+        expect(updated!.state).toBe(AlertState.ALERT);
+        expect(
+          await AlertHistory.countDocuments({ alert: details.alert.id }),
+        ).toBe(1);
+
+        // Release the endpoint; the queued delivery drains.
+        releaseFetch({
+          ok: true,
+          status: 200,
+          text: jest.fn().mockResolvedValue(''),
+        });
+        await dispatcher.shutdown(5_000);
+        expect(dispatcher.pending).toBe(0);
+      });
+
+      it('surfaces queued webhook delivery failures in executionErrors on the next evaluation', async () => {
+        // A generic webhook endpoint that fails every attempt, then recovers.
+        let endpointHealthy = false;
+        const fetchMock = jest.fn().mockImplementation(async () =>
+          endpointHealthy
+            ? { ok: true, status: 200, text: async () => '' }
+            : {
+                ok: false,
+                status: 500,
+                text: async () => 'webhook exploded',
+              },
+        );
+        global.fetch = jest.mocked(fetchMock);
+
+        const {
+          team,
+          webhook,
+          connection,
+          source,
+          teamWebhooksById,
+          clickhouseClient,
+          dashboard,
+        } = await setupTileAlertForErrors({
+          webhookSettings: {
+            service: WebhookService.Generic,
+            url: 'https://webhook.site/fail',
+            name: 'Generic Webhook',
+            description: 'generic webhook',
+            body: JSON.stringify({ text: '{{title}}' }),
+          },
+        });
+
+        // Three consecutive breaching 5m windows so every tick fires.
+        const tickOne = new Date('2023-11-16T22:12:00.000Z');
+        const tickTwo = new Date('2023-11-16T22:17:00.000Z');
+        const tickThree = new Date('2023-11-16T22:22:00.000Z');
+        await bulkInsertLogs(
+          [tickOne, tickTwo, tickThree].flatMap(tick => {
+            const eventMs = tick.getTime() - ms('5m');
+            return [
+              {
+                ServiceName: 'api',
+                Timestamp: new Date(eventMs),
+                SeverityText: 'error',
+                Body: 'oh no',
+              },
+              {
+                ServiceName: 'api',
+                Timestamp: new Date(eventMs),
+                SeverityText: 'error',
+                Body: 'oh no',
+              },
+            ];
+          }),
+        );
+
+        const tile = dashboard.tiles?.find((t: any) => t.id === 'tile-err');
+        const details = await createAlertDetails(
+          team,
+          source,
+          {
+            source: AlertSource.TILE,
+            channel: {
+              type: 'webhook',
+              webhookId: webhook._id.toString(),
+            },
+            interval: '5m',
+            thresholdType: AlertThresholdType.ABOVE,
+            threshold: 1,
+            dashboardId: dashboard.id,
+            tileId: 'tile-err',
+          },
+          {
+            taskType: AlertTaskType.TILE,
+            tile: tile!,
+            dashboard,
+          },
+        );
+
+        const dispatcher = new InProcessNotificationDispatcher();
+
+        // Tick 1: fires, delivery fails in the background AFTER the
+        // evaluation already persisted — executionErrors stays empty.
+        await processAlertAtTime(
+          tickOne,
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+          dispatcher,
+        );
+        await dispatcher.shutdown(15_000);
+        let updated = await Alert.findById(details.alert.id);
+        expect(updated!.state).toBe(AlertState.ALERT);
+        expect(updated!.executionErrors ?? []).toHaveLength(0);
+
+        // Tick 2 (endpoint recovered): drains tick 1's buffered failure into
+        // executionErrors, so the failure surfaces one tick late.
+        endpointHealthy = true;
+        await processAlertAtTime(
+          tickTwo,
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+          dispatcher,
+        );
+        await dispatcher.shutdown(15_000);
+        updated = await Alert.findById(details.alert.id);
+        expect(updated!.executionErrors).toHaveLength(1);
+        expect(updated!.executionErrors![0].type).toBe(
+          AlertErrorType.WEBHOOK_ERROR,
+        );
+        expect(updated!.executionErrors![0].message).toBe(
+          'Failed to send webhook notification. Check the webhook configuration and destination.',
+        );
+        // The drained failure is also visible in the evaluation history as an
+        // ERROR row for tick 2's window.
+        const errorHistories = await AlertHistory.find({
+          alert: details.alert.id,
+          state: AlertState.ERROR,
+        });
+        expect(errorHistories).toHaveLength(1);
+        expect(errorHistories[0].errors).toHaveLength(1);
+        expect(errorHistories[0].errors![0].type).toBe(
+          AlertErrorType.WEBHOOK_ERROR,
+        );
+
+        // Tick 3: tick 2's delivery succeeded, nothing left to drain — the
+        // stale webhook error clears from executionErrors.
+        await processAlertAtTime(
+          tickThree,
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+          dispatcher,
+        );
+        await dispatcher.shutdown(15_000);
+        updated = await Alert.findById(details.alert.id);
+        expect(updated!.state).toBe(AlertState.ALERT);
+        expect(updated!.executionErrors ?? []).toHaveLength(0);
       });
 
       it('sets state to OK and records a WEBHOOK_ERROR when a resolving webhook send fails', async () => {

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlertsTask.test.ts
@@ -8,6 +8,7 @@ import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
 import * as checkAlerts from '@/tasks/checkAlerts';
 import CheckAlertTask from '@/tasks/checkAlerts';
+import { InProcessNotificationDispatcher } from '@/tasks/checkAlerts/notificationQueue';
 import {
   AlertDetails,
   AlertProvider,
@@ -167,6 +168,7 @@ describe('CheckAlertTask', () => {
         'conn-123',
         mockAlertProvider,
         teamWebhooksById,
+        expect.any(InProcessNotificationDispatcher),
       );
 
       mockProcessAlert.mockRestore();
@@ -308,6 +310,7 @@ describe('CheckAlertTask', () => {
         'conn-123',
         mockAlertProvider,
         team1WebhooksById,
+        expect.any(InProcessNotificationDispatcher),
       );
 
       // Second call should use team2's webhooks
@@ -319,6 +322,7 @@ describe('CheckAlertTask', () => {
         'conn-456',
         mockAlertProvider,
         team2WebhooksById,
+        expect.any(InProcessNotificationDispatcher),
       );
 
       // Verify getWebhooks was called for each team
@@ -427,6 +431,7 @@ describe('CheckAlertTask', () => {
           'conn-healthy',
           mockAlertProvider,
           expect.any(Map),
+          expect.any(InProcessNotificationDispatcher),
         );
       });
 

--- a/packages/api/src/tasks/checkAlerts/__tests__/notificationQueue.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/notificationQueue.test.ts
@@ -1,0 +1,331 @@
+import { AlertErrorType } from '@hyperdx/common-utils/dist/types';
+
+import { AlertState } from '@/models/alert';
+import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
+import { InProcessNotificationDispatcher } from '@/tasks/checkAlerts/notificationQueue';
+import { NotificationJob } from '@/tasks/checkAlerts/notifications';
+import { tasksTracer } from '@/tasks/tracer';
+
+const makeJob = (eventId: string, title = 'Alert fired'): NotificationJob =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  ({
+    v: 1,
+    eventId,
+    alertId: 'alert-1',
+    channel: { type: 'webhook', webhookId: 'webhook-1' },
+    message: {
+      hdxLink: 'https://app.example.com/search/1',
+      title,
+      body: 'body',
+      state: AlertState.ALERT,
+      startTime: 1700000000000,
+      endTime: 1700000060000,
+      eventId,
+    },
+    populatedChannel: { type: 'webhook', channel: {} },
+  }) as unknown as NotificationJob;
+
+/** A controllable delivery: each call returns a promise the test resolves. */
+const makeControlledDeliver = () => {
+  const settled: Array<() => void> = [];
+  const failed: Array<(err: Error) => void> = [];
+  const calls: NotificationJob[] = [];
+  const deliver = jest.fn((job: NotificationJob) => {
+    calls.push(job);
+    return new Promise<void>((resolve, reject) => {
+      settled.push(resolve);
+      failed.push(reject);
+    });
+  });
+  return { deliver, settled, failed, calls };
+};
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+describe('InProcessNotificationDispatcher', () => {
+  it('dispatch resolves before delivery completes', async () => {
+    const { deliver, settled } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('a'));
+    await tick();
+
+    // Delivery started but has not settled — dispatch didn't wait for it.
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.pending).toBe(1);
+
+    settled[0]();
+    await tick();
+    expect(dispatcher.pending).toBe(0);
+  });
+
+  it('serializes deliveries sharing an eventId (RESOLVED never overtakes ALERT)', async () => {
+    const { deliver, settled, calls } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('same', 'ALERT'));
+    await dispatcher.dispatch(makeJob('same', 'RESOLVED'));
+    await tick();
+
+    // Second delivery must not start while the first is in flight.
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(calls[0].message.title).toBe('ALERT');
+
+    settled[0]();
+    await tick();
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(calls[1].message.title).toBe('RESOLVED');
+  });
+
+  it('delivers different eventIds concurrently', async () => {
+    const { deliver } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('a'));
+    await dispatcher.dispatch(makeJob('b'));
+    await tick();
+
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failed delivery does not break the eventId chain or reject anything', async () => {
+    const { deliver, settled, failed } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('same'));
+    await dispatcher.dispatch(makeJob('same'));
+    await tick();
+
+    failed[0](new Error('endpoint down'));
+    await tick();
+
+    // The failure was swallowed and the next chained delivery started.
+    expect(deliver).toHaveBeenCalledTimes(2);
+    settled[1]();
+    await dispatcher.shutdown(1_000);
+    expect(dispatcher.pending).toBe(0);
+  });
+
+  it('drops new jobs beyond maxPending', async () => {
+    const { deliver } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver, {
+      maxPending: 2,
+    });
+
+    await dispatcher.dispatch(makeJob('a'));
+    await dispatcher.dispatch(makeJob('b'));
+    await dispatcher.dispatch(makeJob('c'));
+    await tick();
+
+    expect(dispatcher.pending).toBe(2);
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(deliver).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'c' }),
+    );
+  });
+
+  it('shutdown waits for pending deliveries', async () => {
+    const { deliver, settled } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('a'));
+    await tick();
+
+    const shutdown = dispatcher.shutdown(5_000);
+    settled[0]();
+    await shutdown;
+
+    expect(dispatcher.pending).toBe(0);
+  });
+
+  it('shutdown gives up at the deadline when a delivery never settles', async () => {
+    const { deliver } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(makeJob('stuck'));
+    await tick();
+
+    const startedAt = performance.now();
+    await dispatcher.shutdown(100);
+
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+    expect(dispatcher.pending).toBe(1);
+  });
+
+  describe('when delivery machinery itself throws (not the endpoint)', () => {
+    // The task runner's unhandledRejection handler exits the process, so no
+    // queue-side throw may ever escape as an unhandled rejection.
+    let unhandledRejections: unknown[];
+    let onUnhandledRejection: (reason: unknown) => void;
+
+    beforeEach(() => {
+      unhandledRejections = [];
+      onUnhandledRejection = reason => unhandledRejections.push(reason);
+      process.on('unhandledRejection', onUnhandledRejection);
+    });
+
+    afterEach(() => {
+      process.off('unhandledRejection', onUnhandledRejection);
+    });
+
+    // Attribute building reads populatedChannel before delivery starts;
+    // stripping it makes the pre-delivery span setup throw.
+    const makeMalformedJob = (eventId: string): NotificationJob => {
+      const job = makeJob(eventId);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      delete (job as any).populatedChannel;
+      return job;
+    };
+
+    it('never escalates to an unhandled rejection', async () => {
+      const { deliver } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      await dispatcher.dispatch(makeMalformedJob('boom'));
+      await dispatcher.shutdown(1_000);
+      // Give any stray rejection a macrotask to surface.
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(unhandledRejections).toEqual([]);
+      expect(dispatcher.pending).toBe(0);
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    it('does not poison the same-eventId chain', async () => {
+      const { deliver, settled } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      await dispatcher.dispatch(makeMalformedJob('same'));
+      await dispatcher.dispatch(makeJob('same', 'AFTER'));
+      await tick();
+
+      // The broken link was swallowed and the follow-up still delivers.
+      expect(deliver).toHaveBeenCalledTimes(1);
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({ title: 'AFTER' }),
+        }),
+      );
+
+      settled[0]();
+      await dispatcher.shutdown(1_000);
+      expect(dispatcher.pending).toBe(0);
+      expect(unhandledRejections).toEqual([]);
+    });
+  });
+
+  it('delivers jobs dispatched from inside an active span (origin link capture)', async () => {
+    const { deliver, settled } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+    await tasksTracer.startActiveSpan('processAlert', async span => {
+      await dispatcher.dispatch(makeJob('a'));
+      span.end();
+    });
+    await tick();
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    settled[0]();
+    await dispatcher.shutdown(1_000);
+    expect(dispatcher.pending).toBe(0);
+  });
+
+  it('respects the delivery concurrency limit', async () => {
+    const { deliver } = makeControlledDeliver();
+    const dispatcher = new InProcessNotificationDispatcher(deliver, {
+      concurrency: 2,
+    });
+
+    for (const id of ['a', 'b', 'c', 'd']) {
+      await dispatcher.dispatch(makeJob(id));
+    }
+    await tick();
+
+    // Only `concurrency` deliveries are in flight at once.
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  describe('delivery-failure feedback (drainDeliveryFailures)', () => {
+    it('buffers a WEBHOOK_ERROR per failed delivery and drains once', async () => {
+      const { deliver, failed } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      await dispatcher.dispatch(makeJob('a'));
+      await tick();
+      failed[0](new Error('endpoint down'));
+      await dispatcher.shutdown(1_000);
+
+      const drained = dispatcher.drainDeliveryFailures('alert-1');
+      expect(drained).toHaveLength(1);
+      expect(drained[0].type).toBe(AlertErrorType.WEBHOOK_ERROR);
+
+      // Draining clears the buffer.
+      expect(dispatcher.drainDeliveryFailures('alert-1')).toEqual([]);
+    });
+
+    it('preserves the redirect-specific message for WebhookRedirectError', async () => {
+      const { deliver, failed } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      await dispatcher.dispatch(makeJob('a'));
+      await tick();
+      failed[0](new WebhookRedirectError(302));
+      await dispatcher.shutdown(1_000);
+
+      const drained = dispatcher.drainDeliveryFailures('alert-1');
+      expect(drained).toHaveLength(1);
+      expect(drained[0].message).toMatch(/redirect/i);
+    });
+
+    it('does not buffer successful deliveries', async () => {
+      const { deliver, settled } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      await dispatcher.dispatch(makeJob('a'));
+      await tick();
+      settled[0]();
+      await dispatcher.shutdown(1_000);
+
+      expect(dispatcher.drainDeliveryFailures('alert-1')).toEqual([]);
+    });
+
+    it('keeps failures per alert and only the most recent per alert (bounded)', async () => {
+      const { deliver, failed } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      // 7 failures for alert-1 (distinct eventIds so they run unchained),
+      // 1 for alert-2.
+      for (let i = 0; i < 7; i++) {
+        await dispatcher.dispatch(makeJob(`a-${i}`));
+      }
+      const otherAlertJob = {
+        ...makeJob('b-0'),
+        alertId: 'alert-2',
+      } as NotificationJob;
+      await dispatcher.dispatch(otherAlertJob);
+      await tick();
+      failed.forEach(reject => reject(new Error('endpoint down')));
+      await dispatcher.shutdown(1_000);
+
+      // Capped at the 5 most recent for alert-1; alert-2 is tracked apart.
+      expect(dispatcher.drainDeliveryFailures('alert-1')).toHaveLength(5);
+      expect(dispatcher.drainDeliveryFailures('alert-2')).toHaveLength(1);
+    });
+
+    it('ignores failures for jobs without an alertId (preview paths)', async () => {
+      const { deliver, failed } = makeControlledDeliver();
+      const dispatcher = new InProcessNotificationDispatcher(deliver);
+
+      const previewJob = {
+        ...makeJob('a'),
+        alertId: undefined,
+      } as NotificationJob;
+      await dispatcher.dispatch(previewJob);
+      await tick();
+      failed[0](new Error('endpoint down'));
+      await dispatcher.shutdown(1_000);
+
+      expect(dispatcher.drainDeliveryFailures('alert-1')).toEqual([]);
+    });
+  });
+});

--- a/packages/api/src/tasks/checkAlerts/__tests__/notifications.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/notifications.test.ts
@@ -1,0 +1,84 @@
+import { AlertState } from '@/models/alert';
+import {
+  InlineNotificationDispatcher,
+  NotificationJob,
+  NotificationJobCore,
+  zNotificationJobCore,
+} from '@/tasks/checkAlerts/notifications';
+
+const jobCore: NotificationJobCore = {
+  v: 1,
+  eventId: 'event-abc',
+  alertId: 'alert-1',
+  teamId: 'team-1',
+  group: 'ServiceName:api',
+  channel: {
+    type: 'webhook',
+    webhookId: 'webhook-1',
+  },
+  message: {
+    hdxLink: 'https://app.example.com/search/1',
+    title: 'Alert fired',
+    body: 'value over threshold',
+    state: AlertState.ALERT,
+    startTime: 1700000000000,
+    endTime: 1700000060000,
+    eventId: 'event-abc',
+  },
+};
+
+describe('NotificationJob contract', () => {
+  it('survives a JSON round trip — the future wire contract', () => {
+    const roundTripped = zNotificationJobCore.parse(
+      JSON.parse(JSON.stringify(jobCore)),
+    );
+    expect(roundTripped).toEqual(jobCore);
+  });
+
+  it('rejects unknown channel types', () => {
+    expect(() =>
+      zNotificationJobCore.parse({
+        ...jobCore,
+        channel: { type: 'carrier-pigeon' },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('InlineNotificationDispatcher', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const job = {
+    ...jobCore,
+    populatedChannel: { type: 'webhook', channel: {} },
+  } as unknown as NotificationJob;
+
+  it('delivers synchronously and resolves on success', async () => {
+    const deliver = jest.fn().mockResolvedValue(undefined);
+    const dispatcher = new InlineNotificationDispatcher(deliver);
+
+    await dispatcher.dispatch(job);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(job);
+  });
+
+  it('propagates delivery errors to the caller (pre-seam parity)', async () => {
+    const deliver = jest.fn().mockRejectedValue(new Error('endpoint down'));
+    const dispatcher = new InlineNotificationDispatcher(deliver);
+
+    await expect(dispatcher.dispatch(job)).rejects.toThrow('endpoint down');
+  });
+
+  it('shutdown is a no-op', async () => {
+    const dispatcher = new InlineNotificationDispatcher(jest.fn());
+    await expect(dispatcher.shutdown(1_000)).resolves.toBeUndefined();
+  });
+
+  it('buffers no delivery failures — errors propagate inline instead', async () => {
+    const deliver = jest.fn().mockRejectedValue(new Error('endpoint down'));
+    const dispatcher = new InlineNotificationDispatcher(deliver);
+
+    await expect(dispatcher.dispatch(job)).rejects.toThrow('endpoint down');
+    expect(dispatcher.drainDeliveryFailures('alert-1')).toEqual([]);
+  });
+});

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -7,6 +7,12 @@ import mongoose from 'mongoose';
 
 import { makeTile } from '@/fixtures';
 import { AlertSource } from '@/models/alert';
+import { IWebhook } from '@/models/webhook';
+import {
+  NotificationDispatcher,
+  NotificationJob,
+  zNotificationJobCore,
+} from '@/tasks/checkAlerts/notifications';
 import { loadProvider } from '@/tasks/checkAlerts/providers';
 import {
   AlertMessageTemplateDefaultView,
@@ -316,6 +322,106 @@ describe('renderAlertTemplate', () => {
         );
         expect(result).toMatchSnapshot();
       });
+    });
+  });
+
+  describe('notification dispatcher seam', () => {
+    const webhookId = '64a000000000000000000001';
+    const makeGenericWebhook = (): IWebhook =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      ({
+        _id: {
+          toString: () => webhookId,
+        },
+        team: { toString: () => 'team-123' },
+        service: 'generic',
+        url: 'https://example.com/hook',
+        name: 'Test Webhook',
+      }) as unknown as IWebhook;
+
+    const makeNotifyingView = () => {
+      const view = makeSearchView();
+      view.alert.id = 'alert-123';
+      // Route the alert to a webhook channel so the default external action
+      // dispatches a notification during render.
+      view.alert.channel = { type: 'webhook', webhookId };
+      return view;
+    };
+
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('routes notifications through the provided dispatcher instead of delivering inline', async () => {
+      const fetchMock = jest.fn();
+      global.fetch = jest.mocked(fetchMock);
+      const dispatched: NotificationJob[] = [];
+      const dispatcher: NotificationDispatcher = {
+        dispatch: async job => {
+          dispatched.push(job);
+        },
+        shutdown: async () => {},
+        drainDeliveryFailures: () => [],
+      };
+
+      await renderAlertTemplate({
+        alertProvider,
+        clickhouseClient: mockClickhouseClient,
+        dispatcher,
+        metadata: mockMetadata,
+        state: AlertState.ALERT,
+        template: null,
+        title: 'Test Alert Title',
+        view: makeNotifyingView(),
+        teamWebhooksById: new Map([[webhookId, makeGenericWebhook()]]),
+      });
+
+      expect(dispatched).toHaveLength(1);
+      const job = dispatched[0];
+      expect(job).toMatchObject({
+        v: 1,
+        alertId: 'alert-123',
+        teamId: 'team-123',
+        channel: { type: 'webhook', webhookId },
+        message: {
+          title: 'Test Alert Title',
+          state: AlertState.ALERT,
+        },
+      });
+      expect(job.eventId).toEqual(job.message.eventId);
+      // The transport-local channel carries the resolved webhook doc.
+      expect(job.populatedChannel).toMatchObject({ type: 'webhook' });
+      // The serializable core is a valid wire message.
+      const { populatedChannel: _populatedChannel, ...core } = job;
+      expect(() =>
+        zNotificationJobCore.parse(JSON.parse(JSON.stringify(core))),
+      ).not.toThrow();
+      // Delivery was deferred to the dispatcher — nothing sent inline.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('delivers inline when no dispatcher is provided', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(''),
+      });
+      global.fetch = jest.mocked(fetchMock);
+
+      await renderAlertTemplate({
+        alertProvider,
+        clickhouseClient: mockClickhouseClient,
+        metadata: mockMetadata,
+        state: AlertState.ALERT,
+        template: null,
+        title: 'Test Alert Title',
+        view: makeNotifyingView(),
+        teamWebhooksById: new Map([[webhookId, makeGenericWebhook()]]),
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://example.com/hook');
     });
   });
 

--- a/packages/api/src/tasks/checkAlerts/errors.ts
+++ b/packages/api/src/tasks/checkAlerts/errors.ts
@@ -1,4 +1,7 @@
 import { ClickHouseError } from '@clickhouse/client-common';
+import { AlertErrorType } from '@hyperdx/common-utils/dist/types';
+
+import { IAlertError } from '@/models/alert';
 
 export const WEBHOOK_REDIRECT_ERROR_MESSAGE =
   'Webhook destination responded with a redirect. Redirects are not supported.';
@@ -12,6 +15,48 @@ export class WebhookRedirectError extends Error {
     this.status = status;
   }
 }
+
+// For security, we do not surface raw error messages for webhook or unknown
+// failures — they may leak URLs, response bodies, or other sensitive detail
+// from upstream systems. QUERY_ERROR and INVALID_ALERT messages are authored
+// by us (ClickHouse errors or our own validation) and are safe to display.
+const HARDCODED_ALERT_ERROR_MESSAGES: Partial<Record<AlertErrorType, string>> =
+  {
+    [AlertErrorType.WEBHOOK_ERROR]:
+      'Failed to send webhook notification. Check the webhook configuration and destination.',
+    [AlertErrorType.UNKNOWN]:
+      'An unknown error occurred while processing the alert.',
+  };
+
+export const makeAlertError = (
+  type: AlertErrorType,
+  message: string,
+): IAlertError => ({
+  timestamp: new Date(),
+  type,
+  message: (HARDCODED_ALERT_ERROR_MESSAGES[type] ?? message).slice(0, 10000),
+});
+
+export const getErrorMessage = (e: unknown): string => {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return String(e);
+};
+
+// Most webhook errors show a hardcoded message to avoid leaking sensitive request details in the UI.
+// Redirect errors are a known class of errors which we want to surface to the user, so it has a specific message.
+export const makeWebhookAlertError = (error: unknown): IAlertError => {
+  if (error instanceof WebhookRedirectError) {
+    return {
+      timestamp: new Date(),
+      type: AlertErrorType.WEBHOOK_ERROR,
+      message: WEBHOOK_REDIRECT_ERROR_MESSAGE,
+    };
+  }
+
+  return makeAlertError(AlertErrorType.WEBHOOK_ERROR, getErrorMessage(error));
+};
 
 // @clickhouse/client (Node) rejects with these exact messages when the
 // configured request_timeout elapses or the request is aborted. See

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -41,6 +41,7 @@ import {
   pickSampleWeightExpressionProps,
   SourceKind,
 } from '@hyperdx/common-utils/dist/types';
+import { trace } from '@opentelemetry/api';
 import * as fns from 'date-fns';
 import { isString, pick } from 'lodash';
 import { ObjectId } from 'mongoose';
@@ -60,11 +61,14 @@ import { ISavedSearch } from '@/models/savedSearch';
 import { ISource } from '@/models/source';
 import { IWebhook } from '@/models/webhook';
 import {
+  getErrorMessage,
   isClientTimeoutOrAbortError,
   isQueryTimeoutError,
-  WEBHOOK_REDIRECT_ERROR_MESSAGE,
-  WebhookRedirectError,
+  makeAlertError,
+  makeWebhookAlertError,
 } from '@/tasks/checkAlerts/errors';
+import { getNotificationDispatcher } from '@/tasks/checkAlerts/notificationQueue';
+import { NotificationDispatcher } from '@/tasks/checkAlerts/notifications';
 import {
   AlertDetails,
   AlertProvider,
@@ -192,34 +196,6 @@ class InvalidAlertError extends Error {
   }
 }
 
-// For security, we do not surface raw error messages for webhook or unknown
-// failures — they may leak URLs, response bodies, or other sensitive detail
-// from upstream systems. QUERY_ERROR and INVALID_ALERT messages are authored
-// by us (ClickHouse errors or our own validation) and are safe to display.
-const HARDCODED_ALERT_ERROR_MESSAGES: Partial<Record<AlertErrorType, string>> =
-  {
-    [AlertErrorType.WEBHOOK_ERROR]:
-      'Failed to send webhook notification. Check the webhook configuration and destination.',
-    [AlertErrorType.UNKNOWN]:
-      'An unknown error occurred while processing the alert.',
-  };
-
-const makeAlertError = (
-  type: AlertErrorType,
-  message: string,
-): IAlertError => ({
-  timestamp: new Date(),
-  type,
-  message: (HARDCODED_ALERT_ERROR_MESSAGES[type] ?? message).slice(0, 10000),
-});
-
-const getErrorMessage = (e: unknown): string => {
-  if (e instanceof Error) {
-    return e.message;
-  }
-  return String(e);
-};
-
 const QUERY_TIMEOUT_RETRY_NOTE =
   'The evaluation is retried on every check, but the alert will not fire until the query completes in time.';
 
@@ -241,20 +217,6 @@ const makeQueryAlertError = (
     ? `Alert query did not complete within the ${Math.round(requestTimeoutMs / 1000)}s evaluation timeout. ${QUERY_TIMEOUT_RETRY_NOTE}`
     : `Alert query timed out before completing: ${getErrorMessage(e)}. ${QUERY_TIMEOUT_RETRY_NOTE}`;
   return makeAlertError(AlertErrorType.QUERY_TIMEOUT, message);
-};
-
-// Most webhook errors show a hardcoded message to avoid leaking sensitive request details in the UI.
-// Redirect errors are a known class of errors which we want to surface to the user, so it has a specific message.
-const makeWebhookAlertError = (error: unknown): IAlertError => {
-  if (error instanceof WebhookRedirectError) {
-    return {
-      timestamp: new Date(),
-      type: AlertErrorType.WEBHOOK_ERROR,
-      message: WEBHOOK_REDIRECT_ERROR_MESSAGE,
-    };
-  }
-
-  return makeAlertError(AlertErrorType.WEBHOOK_ERROR, getErrorMessage(error));
 };
 
 export const doesExceedThreshold = (
@@ -406,6 +368,7 @@ const fireChannelEvent = async ({
   attributes,
   clickhouseClient,
   dashboard,
+  dispatcher,
   endTime,
   group,
   isGroupedAlert,
@@ -423,6 +386,7 @@ const fireChannelEvent = async ({
   attributes: Record<string, string>; // TODO: support other types than string
   clickhouseClient: ClickhouseClient;
   dashboard?: IDashboard | null;
+  dispatcher?: NotificationDispatcher;
   endTime: Date;
   group?: string;
   isGroupedAlert: boolean;
@@ -479,6 +443,7 @@ const fireChannelEvent = async ({
   await renderAlertTemplate({
     alertProvider,
     clickhouseClient,
+    dispatcher,
     metadata,
     state,
     title: buildAlertMessageTemplateTitle({
@@ -813,6 +778,7 @@ export const processAlert = async (
   connectionId: string,
   alertProvider: AlertProvider,
   teamWebhooksById: Map<string, IWebhook>,
+  notificationDispatcher?: NotificationDispatcher,
 ) => {
   const { alert, previousMap, recentHistoryMap } = details;
   const source = 'source' in details ? details.source : undefined;
@@ -936,6 +902,16 @@ export const processAlert = async (
       return;
     }
 
+    // This evaluation is going to run (all skip gates passed) and every exit
+    // from here on persists executionErrors, so pick up webhook failures the
+    // background delivery queue buffered since the last evaluation. Queued
+    // deliveries fail after their originating evaluation already persisted
+    // state, so this is where they join the alert's executionErrors — one
+    // tick late, clearing once deliveries succeed again.
+    executionErrors.push(
+      ...(notificationDispatcher?.drainDeliveryFailures(alert.id) ?? []),
+    );
+
     const metadata = getMetadata(clickhouseClient);
 
     // For saved search alerts, the WHERE clause may reference aliased columns
@@ -1048,9 +1024,12 @@ export const processAlert = async (
       // Record the error on the alert and as an ERROR history row for this
       // window. ERROR rows are excluded from the due-ness gate and date-range
       // computation, so the failed window is still retried/backfilled.
+      // executionErrors carries any drained webhook delivery failures from
+      // earlier evaluations — recordAlertErrors replaces the alert's errors,
+      // so they must ride along or they would be silently dropped.
       await alertProvider.recordAlertErrors(
         alert.id,
-        [alertError],
+        [...executionErrors, alertError],
         nowInMinsRoundDown,
         evaluationAnalytics,
       );
@@ -1145,6 +1124,7 @@ export const processAlert = async (
           attributes,
           clickhouseClient,
           dashboard: (details as any).dashboard,
+          dispatcher: notificationDispatcher,
           startTime,
           endTime: fns.addMinutes(startTime, windowSizeInMins),
           group,
@@ -1514,9 +1494,11 @@ export const processAlert = async (
         ? AlertErrorType.INVALID_ALERT
         : AlertErrorType.UNKNOWN;
     try {
+      // Include any already-collected errors (e.g. drained webhook delivery
+      // failures) — recordAlertErrors replaces the alert's executionErrors.
       await alertProvider.recordAlertErrors(
         alert.id,
-        [makeAlertError(type, message)],
+        [...executionErrors, makeAlertError(type, message)],
         evaluationWindowStart,
         Object.keys(evaluationAnalytics).length > 0
           ? evaluationAnalytics
@@ -1786,6 +1768,9 @@ export default class CheckAlertTask implements HdxTask {
               conn.id,
               this.provider,
               teamWebhooksById,
+              // Cross-tick singleton: deliveries continue after this tick
+              // ends and are drained only at process exit.
+              getNotificationDispatcher(),
             ),
           );
         }
@@ -1877,11 +1862,21 @@ export default class CheckAlertTask implements HdxTask {
     // functions to execute. if not, execute will terminate without
     // executing all checks
     await this.task_queue.onIdle();
+    // Heartbeat reading: the notification queue outlives the tick, so record
+    // its backlog on the tick span (once a minute) where it stays sliceable.
+    const notificationQueueDepth = getNotificationDispatcher().pending;
+    trace
+      .getActiveSpan()
+      ?.setAttribute(
+        'hyperdx.alerts.notification_queue.depth',
+        notificationQueueDepth,
+      );
     logger.info(
       {
         args: this.args,
         taskCount,
         failedBatchCount,
+        notificationQueueDepth,
       },
       'finished processing all tasks on task_queue',
     );

--- a/packages/api/src/tasks/checkAlerts/notificationQueue.ts
+++ b/packages/api/src/tasks/checkAlerts/notificationQueue.ts
@@ -1,0 +1,346 @@
+import PQueue from '@esm2cjs/p-queue';
+import opentelemetry, {
+  Attributes,
+  ROOT_CONTEXT,
+  SpanContext,
+  SpanKind,
+  SpanStatusCode,
+} from '@opentelemetry/api';
+
+import { IAlertError } from '@/models/alert';
+import { makeWebhookAlertError } from '@/tasks/checkAlerts/errors';
+import {
+  NotificationDeliverFn,
+  NotificationDispatcher,
+  NotificationJob,
+} from '@/tasks/checkAlerts/notifications';
+import { deliverNotification } from '@/tasks/checkAlerts/template';
+import { tasksTracer } from '@/tasks/tracer';
+import {
+  getCounter,
+  recordOperationOutcome,
+  setBusinessContext,
+} from '@/utils/instrumentation';
+import logger from '@/utils/logger';
+
+// External endpoints are slow and untrusted; a small worker pool bounds the
+// concurrent egress without ever blocking evaluation.
+const DEFAULT_DELIVERY_CONCURRENCY = 20;
+
+// Backpressure bound: beyond this many undelivered notifications, new ones
+// are dropped (logged + counted) rather than growing memory without limit.
+const DEFAULT_MAX_PENDING = 5_000;
+
+// Delivery-failure buffer bounds. Failures are buffered per alert until the
+// next evaluation drains them into the alert's executionErrors; a channel
+// that fails on every group of a grouped alert would otherwise accumulate
+// without limit between ticks.
+const MAX_BUFFERED_FAILURES_PER_ALERT = 5;
+const MAX_ALERTS_WITH_BUFFERED_FAILURES = 10_000;
+
+const droppedNotificationsCounter = getCounter(
+  'hyperdx.alerts.notifications_dropped',
+  {
+    description:
+      'Count of alert notifications dropped by the in-process delivery queue, labeled by reason (overflow, shutdown).',
+  },
+);
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * A dispatched job plus the context needed to trace its delivery back to the
+ * evaluation that produced it. Queue-internal; never part of the job contract.
+ */
+type QueuedNotification = {
+  job: NotificationJob;
+  enqueuedAt: number;
+  /** Span context of the evaluation active at dispatch time, if any. */
+  originSpanContext?: SpanContext;
+};
+
+/**
+ * Cross-tick, in-process notification delivery queue.
+ *
+ * Evaluations dispatch fully rendered NotificationJobs and continue
+ * immediately; deliveries drain in the background on a bounded worker pool,
+ * so a slow or hung endpoint never occupies an alert-evaluation slot or
+ * extends the tick. Jobs sharing an eventId (same alert+channel+group)
+ * deliver strictly in dispatch order, so a RESOLVED notification can never
+ * overtake its still-pending ALERT.
+ *
+ * Accepted semantics vs inline delivery: alert state persists before the
+ * webhook lands, so a crash loses queued notifications instead of duplicating
+ * them, and a delivery failure reaches the alert's executionErrors one tick
+ * late — it is buffered here and drained by the next evaluation via
+ * drainDeliveryFailures() (in addition to surfacing immediately in logs and
+ * the `alerts.notification_delivery` SLI).
+ */
+export class InProcessNotificationDispatcher implements NotificationDispatcher {
+  private readonly queue: PQueue;
+  /** Per-eventId chain tails enforcing FIFO delivery within a channel. */
+  private readonly chains = new Map<string, Promise<unknown>>();
+  /** Jobs accepted but not yet settled (queued, chained, or in flight). */
+  private pendingCount = 0;
+  private readonly maxPending: number;
+  /**
+   * Delivery failures awaiting pickup by the alert's next evaluation,
+   * keyed by alertId. Bounded per alert and in tracked-alert count.
+   */
+  private readonly deliveryFailures = new Map<string, IAlertError[]>();
+
+  constructor(
+    private readonly deliver: NotificationDeliverFn = deliverNotification,
+    opts?: { concurrency?: number; maxPending?: number },
+  ) {
+    this.queue = new PQueue({
+      concurrency: opts?.concurrency ?? DEFAULT_DELIVERY_CONCURRENCY,
+    });
+    this.maxPending = opts?.maxPending ?? DEFAULT_MAX_PENDING;
+  }
+
+  /** Accept a job for background delivery. Resolves after enqueue. */
+  async dispatch(job: NotificationJob): Promise<void> {
+    if (this.pendingCount >= this.maxPending) {
+      droppedNotificationsCounter.add(1, { reason: 'overflow' });
+      logger.error(
+        {
+          alertId: job.alertId,
+          eventId: job.eventId,
+          pendingCount: this.pendingCount,
+        },
+        'Notification delivery queue overflow; dropping notification',
+      );
+      return;
+    }
+
+    const queued: QueuedNotification = {
+      job,
+      enqueuedAt: performance.now(),
+      originSpanContext: opentelemetry.trace.getActiveSpan()?.spanContext(),
+    };
+
+    this.pendingCount++;
+    const previousTail = this.chains.get(job.eventId) ?? Promise.resolve();
+    // Only enqueue once the previous delivery for this eventId has settled.
+    // deliverJob is structured to never reject, and the trailing catch makes
+    // the stored link rejection-proof regardless: a broken link must neither
+    // skip successors nor escalate to the process-killing
+    // unhandledRejection handler in tasks/index.ts.
+    const tail = previousTail
+      .then(() => this.queue.add(() => this.deliverJob(queued)))
+      .catch(() => {});
+    this.chains.set(job.eventId, tail);
+    void tail
+      .finally(() => {
+        this.pendingCount--;
+        if (this.chains.get(job.eventId) === tail) {
+          this.chains.delete(job.eventId);
+        }
+      })
+      .catch(() => {});
+  }
+
+  /** Undelivered notifications (queued, chained, or in flight). */
+  get pending(): number {
+    return this.pendingCount;
+  }
+
+  /**
+   * Return and clear the delivery failures buffered for this alert. Called by
+   * the alert's next evaluation, which merges them into its executionErrors
+   * so asynchronous webhook failures still surface on the alert.
+   */
+  drainDeliveryFailures(alertId: string): IAlertError[] {
+    const errors = this.deliveryFailures.get(alertId);
+    if (errors == null) {
+      return [];
+    }
+    this.deliveryFailures.delete(alertId);
+    return errors;
+  }
+
+  /**
+   * Wait for pending deliveries to settle, giving up (and dropping whatever
+   * remains) after deadlineMs. Call before process exit; the cron path never
+   * calls this — the dispatcher outlives individual ticks by design.
+   */
+  async shutdown(deadlineMs: number): Promise<void> {
+    const deadline = Date.now() + deadlineMs;
+    while (this.pendingCount > 0 && Date.now() < deadline) {
+      await sleep(25);
+    }
+    if (this.pendingCount > 0) {
+      droppedNotificationsCounter.add(this.pendingCount, {
+        reason: 'shutdown',
+      });
+      logger.error(
+        { pendingCount: this.pendingCount, deadlineMs },
+        'Notification queue shutdown deadline reached; dropping pending deliveries',
+      );
+    }
+  }
+
+  /**
+   * Buffer a delivery failure for the next evaluation of its alert. Bounded:
+   * per-alert only the most recent failures are kept, and past the
+   * tracked-alert cap new alerts' failures stay log/metric-only rather than
+   * growing memory without limit.
+   */
+  private recordDeliveryFailure(job: NotificationJob, err: unknown): void {
+    const alertId = job.alertId;
+    // Preview/template paths dispatch without a saved alert; there is no
+    // executionErrors document to feed back into.
+    if (alertId == null) {
+      return;
+    }
+    const existing = this.deliveryFailures.get(alertId);
+    if (
+      existing == null &&
+      this.deliveryFailures.size >= MAX_ALERTS_WITH_BUFFERED_FAILURES
+    ) {
+      logger.warn(
+        { alertId, trackedAlerts: this.deliveryFailures.size },
+        'Delivery-failure buffer is full; failure will not surface in executionErrors',
+      );
+      return;
+    }
+    const errors = existing ?? [];
+    errors.push(makeWebhookAlertError(err));
+    if (errors.length > MAX_BUFFERED_FAILURES_PER_ALERT) {
+      errors.splice(0, errors.length - MAX_BUFFERED_FAILURES_PER_ALERT);
+    }
+    this.deliveryFailures.set(alertId, errors);
+  }
+
+  /**
+   * Deliver one notification, never rejecting: a rejection here would surface
+   * as an unhandledRejection (which the task runner escalates to
+   * process.exit(1), dropping the whole queue) and would poison the
+   * same-eventId chain. Delivery failures are handled with full semantics in
+   * deliverJobInner; this catch is the last resort for anything unexpected
+   * (malformed jobs, instrumentation errors).
+   */
+  private async deliverJob(queued: QueuedNotification): Promise<void> {
+    try {
+      await this.deliverJobInner(queued);
+    } catch (err) {
+      logger.error(
+        {
+          error: err,
+          alertId: queued.job?.alertId,
+          eventId: queued.job?.eventId,
+        },
+        'Unexpected error delivering alert notification',
+      );
+    }
+  }
+
+  /**
+   * Deliver one notification inside its own root span. Delivery happens after
+   * (and outside) the evaluation that produced it, so parenting under either
+   * the origin evaluation span (already ended) or whatever tick happens to be
+   * ambient at flush time would misattribute it — instead the span is a new
+   * root carrying a link back to the origin evaluation.
+   */
+  private async deliverJobInner(queued: QueuedNotification): Promise<void> {
+    const { job, enqueuedAt, originSpanContext } = queued;
+    const startedAt = performance.now();
+
+    // Wide event for the delivery: everything needed to slice failures and
+    // backlog after the fact, without pre-declaring dimensions.
+    const attributes: Attributes = {
+      'hyperdx.alerts.notification.event_id': job.eventId,
+      'hyperdx.alerts.notification.channel': job.channel.type,
+      'hyperdx.alerts.notification.state': job.message.state,
+      'hyperdx.alerts.notification.queue_wait_ms': Math.round(
+        startedAt - enqueuedAt,
+      ),
+      'hyperdx.alerts.notification_queue.depth': this.pendingCount,
+    };
+    if (job.alertId != null) {
+      attributes['hyperdx.alerts.alert.id'] = job.alertId;
+    }
+    if (job.group != null) {
+      attributes['hyperdx.alerts.notification.group'] = job.group;
+    }
+    if (job.populatedChannel.type === 'webhook') {
+      attributes['hyperdx.alerts.notification.webhook.service'] =
+        job.populatedChannel.channel.service;
+    }
+    if (originSpanContext != null) {
+      attributes['hyperdx.alerts.origin_trace_id'] = originSpanContext.traceId;
+    }
+
+    await tasksTracer.startActiveSpan(
+      'deliverNotification',
+      {
+        kind: SpanKind.INTERNAL,
+        links: originSpanContext ? [{ context: originSpanContext }] : [],
+        attributes,
+      },
+      ROOT_CONTEXT,
+      async span => {
+        try {
+          setBusinessContext({ teamId: job.teamId });
+          await this.deliver(job);
+          span.setStatus({ code: SpanStatusCode.OK });
+          recordOperationOutcome({
+            operation: 'alerts.notification_delivery',
+            outcome: 'success',
+            durationMs: performance.now() - startedAt,
+          });
+        } catch (err) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err instanceof Error ? err.message : String(err),
+          });
+          span.recordException(
+            err instanceof Error ? err : new Error(String(err)),
+          );
+          recordOperationOutcome({
+            operation: 'alerts.notification_delivery',
+            outcome: 'error',
+            durationMs: performance.now() - startedAt,
+          });
+          logger.error(
+            {
+              error: err,
+              alertId: job.alertId,
+              eventId: job.eventId,
+              channelType: job.channel.type,
+            },
+            'Failed to deliver alert notification',
+          );
+          this.recordDeliveryFailure(job, err);
+        } finally {
+          span.end();
+        }
+      },
+    );
+  }
+}
+
+// Process-lifetime singleton: CheckAlertTask instances are created per cron
+// tick, but deliveries must be able to outlive the tick that produced them.
+let singleton: InProcessNotificationDispatcher | undefined;
+
+/** The shared cross-tick notification dispatcher for the alert task. */
+export const getNotificationDispatcher =
+  (): InProcessNotificationDispatcher => {
+    singleton ??= new InProcessNotificationDispatcher();
+    return singleton;
+  };
+
+/**
+ * Drain the singleton (if it was ever created) before process exit. Used by
+ * the one-shot task runner path, where exiting immediately after execute()
+ * would abandon queued deliveries.
+ */
+export const shutdownNotificationDispatcher = async (
+  deadlineMs: number,
+): Promise<void> => {
+  if (singleton) {
+    await singleton.shutdown(deadlineMs);
+  }
+};

--- a/packages/api/src/tasks/checkAlerts/notifications.ts
+++ b/packages/api/src/tasks/checkAlerts/notifications.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+
+import { AlertState, IAlertError } from '@/models/alert';
+import { PopulatedAlertChannel } from '@/tasks/checkAlerts/providers';
+
+/**
+ * Alert notification dispatch seam.
+ *
+ * Evaluation produces fully rendered NotificationJobs; a NotificationDispatcher
+ * owns delivery. Today's implementations are in-process, but the job's
+ * serializable core is designed as the wire contract for a future standalone
+ * notification service: `eventId` is the idempotency key, and the channel is
+ * referenced by id — never by live document.
+ */
+
+/** Fully rendered notification content, ready for delivery to any channel. */
+const zNotificationMessage = z.object({
+  hdxLink: z.string(),
+  title: z.string(),
+  body: z.string(),
+  state: z.nativeEnum(AlertState),
+  startTime: z.number(),
+  endTime: z.number(),
+  eventId: z.string(),
+});
+export type NotificationMessage = z.infer<typeof zNotificationMessage>;
+
+/**
+ * The serializable core of a notification job — the future notification
+ * service's wire contract. Must never carry live mongoose documents, secrets
+ * beyond the channel reference, or ClickHouse client state.
+ */
+export const zNotificationJobCore = z.object({
+  v: z.literal(1),
+  /**
+   * Idempotency key: stable hash of (alert, channel, group) — see the eventId
+   * computation in renderAlertTemplate.
+   */
+  eventId: z.string(),
+  // Optional because template preview paths render without a saved alert; the
+  // task path always sets it.
+  alertId: z.string().optional(),
+  teamId: z.string().optional(),
+  group: z.string().optional(),
+  channel: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('webhook'),
+      webhookId: z.string(),
+    }),
+  ]),
+  message: zNotificationMessage,
+});
+export type NotificationJobCore = z.infer<typeof zNotificationJobCore>;
+
+/**
+ * A dispatchable notification. `populatedChannel` is transport-local: the
+ * in-process dispatchers deliver with the already-resolved channel (webhook
+ * doc including secrets); a future out-of-process transport serializes only
+ * the core and re-resolves the channel from its own store.
+ */
+export type NotificationJob = NotificationJobCore & {
+  populatedChannel: PopulatedAlertChannel;
+};
+
+/** Delivers one job to its channel. Rejections signal delivery failure. */
+export type NotificationDeliverFn = (job: NotificationJob) => Promise<void>;
+
+/**
+ * Transport seam for notification delivery, mirroring the AlertProvider
+ * pattern: evaluation code only ever calls dispatch().
+ *
+ * dispatch() contract: the inline implementation resolves after delivery
+ * (errors propagate to the caller); queueing implementations resolve after
+ * enqueue and instead buffer delivery failures for the next evaluation to
+ * drain via drainDeliveryFailures().
+ */
+export interface NotificationDispatcher {
+  dispatch(job: NotificationJob): Promise<void>;
+  /** Flush anything pending, giving up after deadlineMs. */
+  shutdown(deadlineMs: number): Promise<void>;
+  /**
+   * Return and clear the delivery failures buffered for the given alert since
+   * its last drain. Evaluations merge these into the alert's executionErrors
+   * so asynchronous delivery failures still surface on the alert (one tick
+   * late). Inline delivery propagates errors to the caller directly, so the
+   * inline implementation always returns an empty array.
+   */
+  drainDeliveryFailures(alertId: string): IAlertError[];
+}
+
+/**
+ * Default dispatcher: delivers synchronously so errors flow into the calling
+ * evaluation's executionErrors — the original inline behavior.
+ */
+export class InlineNotificationDispatcher implements NotificationDispatcher {
+  constructor(private readonly deliver: NotificationDeliverFn) {}
+
+  async dispatch(job: NotificationJob): Promise<void> {
+    await this.deliver(job);
+  }
+
+  async shutdown(_deadlineMs: number): Promise<void> {
+    // Nothing buffered.
+  }
+
+  drainDeliveryFailures(_alertId: string): IAlertError[] {
+    // Inline delivery rejects dispatch() itself; nothing is buffered.
+    return [];
+  }
+}

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -32,6 +32,12 @@ import {
 } from '@/tasks/checkAlerts';
 import { WebhookRedirectError } from '@/tasks/checkAlerts/errors';
 import {
+  InlineNotificationDispatcher,
+  NotificationDispatcher,
+  NotificationJob,
+  NotificationMessage,
+} from '@/tasks/checkAlerts/notifications';
+import {
   AlertProvider,
   PopulatedAlertChannel,
 } from '@/tasks/checkAlerts/providers';
@@ -173,15 +179,7 @@ export type AlertMessageTemplateDefaultView = {
   value: number;
 };
 
-interface Message {
-  hdxLink: string;
-  title: string;
-  body: string;
-  state: AlertState;
-  startTime: number;
-  endTime: number;
-  eventId: string;
-}
+type Message = NotificationMessage;
 
 export const isAlertResolved = (state?: AlertState): boolean => {
   return state === AlertState.OK;
@@ -214,13 +212,12 @@ export const formatValueToMatchThreshold = (
   }).format(value);
 };
 
-const notifyChannel = async ({
-  channel,
-  message,
-}: {
-  channel: PopulatedAlertChannel;
-  message: Message;
-}) => {
+/**
+ * Deliver one rendered notification to its channel. Used by every
+ * NotificationDispatcher implementation; rejections signal delivery failure.
+ */
+export const deliverNotification = async (job: NotificationJob) => {
+  const { populatedChannel: channel, message } = job;
   switch (channel.type) {
     case 'webhook': {
       const webhook = channel.channel;
@@ -238,6 +235,45 @@ const notifyChannel = async ({
     default:
       throw new Error(`Unsupported channel type: ${channel.type}`);
   }
+};
+
+// Default dispatcher: deliver inline so errors propagate into the calling
+// evaluation's executionErrors — exactly the pre-seam behavior.
+const inlineNotificationDispatcher = new InlineNotificationDispatcher(
+  deliverNotification,
+);
+
+/**
+ * Build the NotificationJob for a rendered notification and hand it to the
+ * dispatcher (inline delivery when none is provided).
+ */
+const notifyChannel = async ({
+  alertId,
+  channel,
+  dispatcher,
+  group,
+  message,
+}: {
+  alertId?: string;
+  channel: PopulatedAlertChannel;
+  dispatcher?: NotificationDispatcher;
+  group?: string;
+  message: Message;
+}) => {
+  const job: NotificationJob = {
+    v: 1,
+    eventId: message.eventId,
+    alertId,
+    teamId: channel.channel.team?.toString(),
+    group,
+    channel: {
+      type: 'webhook',
+      webhookId: channel.channel._id.toString(),
+    },
+    message,
+    populatedChannel: channel,
+  };
+  await (dispatcher ?? inlineNotificationDispatcher).dispatch(job);
 };
 
 export const handleSendSlackWebhook = async (
@@ -552,6 +588,7 @@ const getPopulatedChannel = (
 export const renderAlertTemplate = async ({
   alertProvider,
   clickhouseClient,
+  dispatcher,
   metadata,
   state,
   template,
@@ -561,6 +598,8 @@ export const renderAlertTemplate = async ({
 }: {
   alertProvider: AlertProvider;
   clickhouseClient: ClickhouseClient;
+  /** Notification transport; omitted = inline delivery. */
+  dispatcher?: NotificationDispatcher;
   metadata: Metadata;
   state: AlertState;
   template?: string | null;
@@ -654,7 +693,10 @@ export const renderAlertTemplate = async ({
         });
 
         await notifyChannel({
+          alertId: alert.id,
           channel,
+          dispatcher,
+          group: view.group,
           message: {
             hdxLink: buildAlertMessageTemplateHdxLink(alertProvider, view),
             title,

--- a/packages/api/src/tasks/index.ts
+++ b/packages/api/src/tasks/index.ts
@@ -4,6 +4,7 @@ import { serializeError } from 'serialize-error';
 
 import { RUN_SCHEDULED_TASKS_EXTERNALLY } from '@/config';
 import CheckAlertTask from '@/tasks/checkAlerts';
+import { shutdownNotificationDispatcher } from '@/tasks/checkAlerts/notificationQueue';
 import {
   taskExecutionDurationGauge,
   taskExecutionFailureCounter,
@@ -82,7 +83,11 @@ if (!RUN_SCHEDULED_TASKS_EXTERNALLY) {
 } else {
   logger.warn('In-app cron job is disabled');
   instrumentedMain(argv)
-    .then(() => {
+    .then(async () => {
+      // One-shot mode exits right after execute(); give the cross-tick
+      // notification queue a bounded window to flush queued deliveries
+      // before the process dies. No-op if never instantiated.
+      await shutdownNotificationDispatcher(60_000);
       process.exit(0);
     })
     .catch(err => {


### PR DESCRIPTION
## Why

Notification deliveries are awaited inline inside `processAlert`, so each webhook send occupies an alert-evaluation slot for its full duration — including up to 3 retry attempts with backoff against slow or dead endpoints. On large tenants this extends the check-alerts tick and pushes it into skipped cron fires.

Linear: [HDX-5037](https://linear.app/hyperdx/issue/HDX-5037)

## What

### Cross-tick background delivery queue

Evaluations now dispatch fully rendered `NotificationJob`s to an `InProcessNotificationDispatcher` and continue immediately:

- **`NotificationJob`** (`notifications.ts`): versioned, fully serializable core (zod) designed as a future notification service's wire contract — `eventId` (the existing alert+channel+group `objectHash`) is the idempotency key, channels are referenced by id. The resolved webhook doc rides along as a transport-local sidecar for in-process delivery.
- **`NotificationDispatcher`** interface (`dispatch` / `shutdown` / `drainDeliveryFailures`), mirroring the `AlertProvider` pattern. `InlineNotificationDispatcher` is the default, so direct `processAlert` / `renderAlertTemplate` calls without a dispatcher keep today's inline delivery and error semantics.
- **`InProcessNotificationDispatcher`** (`notificationQueue.ts`): bounded worker pool (concurrency 20); per-`eventId` FIFO chaining guarantees a RESOLVED notification never overtakes its still-pending ALERT for the same alert+channel+group; bounded depth (5k) with overflow drops counted on `hyperdx.alerts.notifications_dropped`; each delivery runs in its own root span linked back to the originating evaluation, with health on the `alerts.notification_delivery` operation SLI.
- **Process-lifetime singleton**: `CheckAlertTask` instances are per cron tick, but deliveries outlive the tick that produced them. The one-shot runner path (`RUN_SCHEDULED_TASKS_EXTERNALLY`) drains with a 60s deadline before exiting.

### Delivery-failure feedback into `executionErrors`

Because alert state now persists *before* the webhook lands, a naive queue would silently drop delivery errors from the alert's `executionErrors` — the alert details page would show a permanently failing webhook as perfectly healthy. (We observed exactly this on a deployment running a queued-delivery variant: an alert firing every minute against a dead webhook endpoint, with per-minute `Failed to deliver alert notification` logs, yet `executionErrors: []` forever.)

This PR builds the feedback loop in from the start:

- The dispatcher buffers each delivery failure per alert (`WEBHOOK_ERROR`, bounded: 5 most-recent per alert, 10k tracked alerts).
- The alert's **next evaluation** drains them via `drainDeliveryFailures()` and merges them into its `executionErrors`, so the failure surfaces on the alert one tick late and clears once deliveries succeed again. The existing provider logic also upserts them as an ERROR row in the evaluation history — no UI changes needed.
- The error-path `recordAlertErrors` calls include drained errors so a failing query tick doesn't wipe them.

### Accepted semantics vs inline delivery

- Alert state persists before delivery lands, so a crash loses queued notifications instead of duplicating them.
- Webhook failure visibility lags by one evaluation tick.
- `evaluationAnalytics.webhookDurationMs` now measures dispatch (enqueue) time, not delivery time; delivery latency lives on the `alerts.notification_delivery` SLI and the `deliverNotification` span.

Also moves `makeAlertError` / `makeWebhookAlertError` / `getErrorMessage` from `checkAlerts/index.ts` into `checkAlerts/errors.ts` so the queue can build `IAlertError`s without an import cycle.

## Testing

- `notifications.test.ts` / `notificationQueue.test.ts` (new, unit): job wire-contract round trip; dispatch-before-delivery; per-eventId FIFO; overflow drops; shutdown drain/deadline; no unhandled rejections from broken jobs; failure buffering, per-alert caps, redirect-specific messages, preview-path (no alertId) exclusion.
- `checkAlerts.int.test.ts` (integration):
  - a hung webhook endpoint no longer blocks the evaluation — state and history persist while delivery is still pending;
  - a failing webhook surfaces as `WEBHOOK_ERROR` in `executionErrors` **and** an ERROR history row on the next evaluation, then clears after the endpoint recovers.
- `renderAlertTemplate.int.test.ts` (integration): notifications route through a provided dispatcher (nothing sent inline; serializable core validates against the zod contract); inline delivery is preserved when no dispatcher is passed.
- Full api unit suite (727 passed), `checkAlerts.int` (166 passed), `renderAlertTemplate` (76 passed), `tsc --noEmit` clean, eslint at the 302-warning budget.