### PR TITLE
feat: Support dependent variable value queries

### DIFF
--- a/.changeset/dashboard-filter-variable-dependencies.md
+++ b/.changeset/dashboard-filter-variable-dependencies.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/common-utils': patch
+---
+
+feat: Support dependent variable value queries

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -3178,6 +3178,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           filterValues={filterValues}
           onSetFilterValue={setFilterValue}
           dateRange={searchedTimeRange}
+          variables={showFilterVariableOptions ? variables : undefined}
         />
       )}
       {/* Selection indicator */}
@@ -3354,6 +3355,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           onRemoveFilter={handleRemoveFilter}
           isLoading={isSavingDashboard || isFetchingDashboard}
           showVariableOptions={showFilterVariableOptions}
+          variables={showFilterVariableOptions ? variables : undefined}
         />
       )}
     </>

--- a/packages/app/src/DashboardFilters.tsx
+++ b/packages/app/src/DashboardFilters.tsx
@@ -2,10 +2,14 @@ import { useMemo, useState } from 'react';
 import {
   FilterState,
   getFilterVariableName,
+  getPendingFilterValuesVariables,
   isFilterBroadcastEnabled,
   isFilterVariableEnabled,
 } from '@hyperdx/common-utils/dist/filters';
-import { DashboardFilter } from '@hyperdx/common-utils/dist/types';
+import {
+  ChartVariable,
+  DashboardFilter,
+} from '@hyperdx/common-utils/dist/types';
 import { Group, Stack, Text, Tooltip } from '@mantine/core';
 import { IconAlertTriangle, IconHelp, IconRefresh } from '@tabler/icons-react';
 
@@ -20,7 +24,28 @@ interface DashboardFilterSelectProps {
   values?: string[];
   isLoading?: boolean;
   isError?: boolean;
+  /** Shown instead of the generic message when the query's failure is known. */
+  errorMessage?: string;
+  /**
+   * Variables this filter's dropdown query needs a selection for before it can
+   * match any rows.
+   */
+  pendingVariables?: string[];
 }
+
+/**
+ * Explain a dropdown query that may list nothing until one of the variables it
+ * depends on is selected. Only the bare SQL reference form gets here — the
+ * macros and Lucene both have an empty state that lists every value.
+ */
+export const getPendingVariablesTooltip = (
+  pendingVariables: string[],
+): string => {
+  const names = pendingVariables.map(name => `$${name}`).join(', ');
+  return `Filter depends on ${names}, which ${
+    pendingVariables.length === 1 ? 'has' : 'have'
+  } no selected value.`;
+};
 
 /**
  * Describe what a filter does with the value you pick: broadcast it as a
@@ -66,6 +91,8 @@ const DashboardFilterSelect = ({
   values,
   isLoading,
   isError,
+  errorMessage,
+  pendingVariables,
 }: DashboardFilterSelectProps) => {
   const valuesOrEmptyMemo = useMemo(() => values ?? [], [values]);
   const effect = getFilterEffect(filter);
@@ -91,10 +118,29 @@ const DashboardFilterSelect = ({
             />
           )}
         </Tooltip>
+        {!!pendingVariables?.length && (
+          <Tooltip
+            label={getPendingVariablesTooltip(pendingVariables)}
+            withinPortal
+            multiline
+            maw={400}
+          >
+            <IconAlertTriangle
+              size={12}
+              color="var(--color-text-warning)"
+              data-testid={`dashboard-filter-pending-variable-${filter.name}`}
+            />
+          </Tooltip>
+        )}
         {isError && (
           <Tooltip
-            label="Filter values query failed. The filter's query may be invalid."
+            label={
+              errorMessage ??
+              "Filter values query failed. The filter's query may be invalid."
+            }
             withinPortal
+            multiline
+            maw={400}
           >
             <IconAlertTriangle
               size={12}
@@ -126,6 +172,8 @@ interface DashboardFilterProps {
   filterValues: FilterState;
   onSetFilterValue: (expression: string, values: string[]) => void;
   dateRange: [Date, Date];
+  /** The dashboard's variables and their current selections, if any */
+  variables?: ChartVariable[];
 }
 
 const DashboardFilters = ({
@@ -133,6 +181,7 @@ const DashboardFilters = ({
   dateRange,
   filterValues,
   onSetFilterValue,
+  variables,
 }: DashboardFilterProps) => {
   // "Link" mode (opt-in, off by default): each dropdown's values are narrowed by
   // the others' selections. Off by default because contingent value lookups
@@ -143,10 +192,12 @@ const DashboardFilters = ({
   const {
     data: filterValuesById,
     erroredFilterIds,
+    filterErrorMessages,
     isFetching,
   } = useDashboardFilterValues({
     filters,
     dateRange,
+    variables,
     // Only narrow by sibling selections when linked.
     filterValues: linked ? filterValues : {},
   });
@@ -171,6 +222,11 @@ const DashboardFilters = ({
             filter={filter}
             isLoading={isLoadingValues}
             isError={erroredFilterIds?.has(filter.id) ?? false}
+            errorMessage={filterErrorMessages?.get(filter.id)}
+            pendingVariables={getPendingFilterValuesVariables(
+              filter,
+              variables,
+            )}
             onChange={values => onSetFilterValue(filter.expression, values)}
             values={queriedFilterValues?.values}
             value={selectedValues}

--- a/packages/app/src/DashboardFilters.tsx
+++ b/packages/app/src/DashboardFilters.tsx
@@ -172,7 +172,11 @@ interface DashboardFilterProps {
   filterValues: FilterState;
   onSetFilterValue: (expression: string, values: string[]) => void;
   dateRange: [Date, Date];
-  /** The dashboard's variables and their current selections, if any */
+  /**
+   * The dashboard's variables and their current selections. Defined only when
+   * filters on this dashboard can be exposed as variables at all, so it doubles
+   * as the gate for variable-specific copy.
+   */
   variables?: ChartVariable[];
 }
 
@@ -242,6 +246,7 @@ const DashboardFilters = ({
           <FilterLinkToggle
             linked={linked}
             onChange={setLinked}
+            showVariableNote={variables !== undefined}
             data-testid="dashboard-filters-link-toggle"
           />
         </Stack>

--- a/packages/app/src/DashboardFiltersModal.tsx
+++ b/packages/app/src/DashboardFiltersModal.tsx
@@ -17,6 +17,7 @@ import {
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import {
+  Alert,
   Box,
   Button,
   Center,
@@ -34,6 +35,7 @@ import {
   UnstyledButton,
 } from '@mantine/core';
 import {
+  IconAlertTriangle,
   IconFilter,
   IconInfoCircle,
   IconPencil,
@@ -160,11 +162,30 @@ const DashboardFilterEditForm = ({
     [filters, filter.id],
   );
 
-  const [formFilterName, formIsBroadCastEnabled, formIsVariableEnabled] =
-    useWatch({
-      control,
-      name: ['name', 'isBroadcastEnabled', 'isVariableEnabled'],
-    });
+  const [
+    formFilterName,
+    formIsBroadCastEnabled,
+    formIsVariableEnabled,
+    formAppliesToSourceIds,
+  ] = useWatch({
+    control,
+    name: [
+      'name',
+      'isBroadcastEnabled',
+      'isVariableEnabled',
+      'appliesToSourceIds',
+    ],
+  });
+
+  // Both modes on with an unrestricted broadcast is almost always a mistake:
+  // broadcast already reaches every tile, so the variable adds nothing and the
+  // tiles that reference it get filtered twice over. Scoping the broadcast is
+  // what makes the pair meaningful, so nudge toward "Applies to sources".
+  const showUnscopedBroadcastWarning =
+    showVariableOptions &&
+    formIsBroadCastEnabled !== false &&
+    formIsVariableEnabled === true &&
+    !formAppliesToSourceIds?.some(id => !!id?.length);
 
   const derivedVariableName = deriveVariableName(formFilterName ?? '');
 
@@ -385,7 +406,7 @@ const DashboardFilterEditForm = ({
                   name="isBroadcastEnabled"
                   size="xs"
                   label="Broadcast filter condition"
-                  description="Apply the selected value as a filter condition on each tile."
+                  description="Automatically apply the selected value to every query builder tile, and to every Raw SQL tile that uses the $__filters macro. Optionally, narrow to tiles that use specific sources."
                   data-testid="filter-broadcast-checkbox"
                 />
               </>
@@ -399,7 +420,7 @@ const DashboardFilterEditForm = ({
                 <Box ml={showVariableOptions ? 'xl' : undefined}>
                   <CustomInputWrapper
                     label="Applies to sources"
-                    tooltipText="Leave empty to apply to all tiles. Selecting one or more sources restricts the filter to only tiles using those sources."
+                    tooltipText="Which tiles the broadcast reaches. Leave empty to broadcast to all tiles. Selecting one or more sources restricts the broadcast to tiles using those sources."
                   >
                     <SourceMultiSelectControlled
                       control={control}
@@ -425,7 +446,7 @@ const DashboardFilterEditForm = ({
                   name="isVariableEnabled"
                   size="xs"
                   label="Available as variable"
-                  description="Expose the selected value a $variable."
+                  description="Expose the selected value as a $variable. Selections only affect tiles that reference the variable explicitly, typically via the $__filter or $__conditionalAll macros."
                   data-testid="filter-variable-enabled-checkbox"
                   rules={{ validate: validateFilterModes }}
                 />
@@ -446,6 +467,19 @@ const DashboardFilterEditForm = ({
                       />
                     </CustomInputWrapper>
                   </Box>
+                )}
+                {showUnscopedBroadcastWarning && (
+                  <Alert
+                    variant="warning"
+                    icon={<IconAlertTriangle size={16} />}
+                    data-testid="filter-unscoped-broadcast-warning"
+                  >
+                    Broadcast already applies this filter to every tile,
+                    including the ones that reference the variable. Set “Applies
+                    to sources” to limit which tiles the broadcast reaches, or
+                    turn off broadcast so only tiles that reference the variable
+                    are filtered.
+                  </Alert>
                 )}
               </>
             )}
@@ -700,10 +734,7 @@ const DashboardFiltersModal = ({
       where: '',
       whereLanguage: getStoredLanguage() ?? 'sql',
       isBroadcastEnabled: true,
-      // New filters are variable-enabled wherever the controls are available, so
-      // the checkbox is controlled from the first render. Callers that hide the
-      // controls get false, since their UI offers no way to turn it back off.
-      isVariableEnabled: showVariableOptions,
+      isVariableEnabled: false,
     });
   };
 

--- a/packages/app/src/DashboardFiltersModal.tsx
+++ b/packages/app/src/DashboardFiltersModal.tsx
@@ -10,6 +10,7 @@ import {
   validateVariableName,
 } from '@hyperdx/common-utils/dist/filters';
 import {
+  ChartVariable,
   DashboardFilter,
   MetricsDataType,
   SourceKind,
@@ -46,6 +47,7 @@ import SearchWhereInput, {
   getStoredLanguage,
 } from '@/components/SearchInput/SearchWhereInput';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
+import { SqlVariablesProvider } from '@/components/SQLEditor/variableCompletions';
 
 import { SourceMultiSelectControlled } from './components/SourceMultiSelect';
 import SourceSchemaPreview, {
@@ -359,7 +361,7 @@ const DashboardFilterEditForm = ({
 
             <CustomInputWrapper
               label="Dropdown values filter"
-              tooltipText="Optional condition used to filter the rows from which available filter values are queried"
+              tooltipText="Optional condition used to filter the rows from which available filter values are queried. May reference the dashboard's other variables."
             >
               <SearchWhereInput
                 tableConnection={tableConnection}
@@ -371,6 +373,7 @@ const DashboardFilterEditForm = ({
                 allowMultiline={true}
                 sqlPlaceholder="Filter for dropdown values"
                 lucenePlaceholder="Filter for dropdown values"
+                enableVariables={showVariableOptions}
               />
             </CustomInputWrapper>
 
@@ -652,6 +655,8 @@ interface DashboardFiltersEditModalProps {
   source?: TSource;
   /** Whether to offer the broadcast / variable controls. */
   showVariableOptions: boolean;
+  /** The dashboard's variables, if any */
+  variables?: ChartVariable[];
   onClose: () => void;
   onSaveFilter: (filter: DashboardFilter) => void;
   onRemoveFilter: (id: string) => void;
@@ -665,6 +670,7 @@ const DashboardFiltersModal = ({
   isLoading,
   source,
   showVariableOptions,
+  variables,
   onClose,
   onSaveFilter,
   onRemoveFilter,
@@ -719,16 +725,18 @@ const DashboardFiltersModal = ({
     return <EmptyState onCreateFilter={handleAddNewFilter} onClose={onClose} />;
   } else if (selectedFilter) {
     return (
-      <DashboardFilterEditForm
-        filter={selectedFilter}
-        onSave={handleSaveFilter}
-        onCancel={() => setSelectedFilter(undefined)}
-        onClose={onClose}
-        isNew={selectedFilter.id === NEW_FILTER_ID}
-        source={source}
-        filters={filters}
-        showVariableOptions={showVariableOptions}
-      />
+      <SqlVariablesProvider variables={variables}>
+        <DashboardFilterEditForm
+          filter={selectedFilter}
+          onSave={handleSaveFilter}
+          onCancel={() => setSelectedFilter(undefined)}
+          onClose={onClose}
+          isNew={selectedFilter.id === NEW_FILTER_ID}
+          source={source}
+          filters={filters}
+          showVariableOptions={showVariableOptions}
+        />
+      </SqlVariablesProvider>
     );
   } else {
     return (

--- a/packages/app/src/__tests__/DashboardFilters.test.ts
+++ b/packages/app/src/__tests__/DashboardFilters.test.ts
@@ -1,16 +1,19 @@
 import { DashboardFilter } from '@hyperdx/common-utils/dist/types';
 
-import { getFilterEffect } from '@/DashboardFilters';
+import {
+  getFilterEffect,
+  getPendingVariablesTooltip,
+} from '@/DashboardFilters';
+
+const baseFilter: DashboardFilter = {
+  id: 'filter1',
+  type: 'QUERY_EXPRESSION',
+  name: 'Service Name',
+  expression: 'ServiceName',
+  source: 'logs',
+};
 
 describe('getFilterEffect', () => {
-  const baseFilter: DashboardFilter = {
-    id: 'filter1',
-    type: 'QUERY_EXPRESSION',
-    name: 'Service Name',
-    expression: 'ServiceName',
-    source: 'logs',
-  };
-
   it('describes both effects when broadcast and variable are on', () => {
     expect(
       getFilterEffect({
@@ -95,5 +98,19 @@ describe('getFilterEffect', () => {
         variableName: 'svc',
       }).tooltip,
     ).toEqual('Available as variable ($svc)');
+  });
+});
+
+describe('getPendingVariablesTooltip', () => {
+  it('names the variable that has no selected value', () => {
+    expect(getPendingVariablesTooltip(['svc'])).toBe(
+      'Filter depends on $svc, which has no selected value.',
+    );
+  });
+
+  it('agrees with more than one pending variable', () => {
+    expect(getPendingVariablesTooltip(['svc', 'env'])).toContain(
+      '$svc, $env, which have no selected value',
+    );
   });
 });

--- a/packages/app/src/components/FilterLinkToggle.tsx
+++ b/packages/app/src/components/FilterLinkToggle.tsx
@@ -5,8 +5,18 @@ import { IconArrowsLeftRight } from '@tabler/icons-react';
 type FilterLinkToggleProps = {
   linked: boolean;
   onChange: (linked: boolean) => void;
+  /**
+   * Whether filters on this page can declare variables. When they can, the
+   * tooltip adds a note that linking is separate from variable references
+   * written into a filter's own "Dropdown values filter".
+   */
+  showVariableNote?: boolean;
   'data-testid'?: string;
 };
+
+/** Appended when a filter's dropdown values can be written against a variable. */
+const VARIABLE_NOTE =
+  ' This does not affect variable references ($__filter, $__conditionalAll, $variable) in filter definitions — those always apply, linked or not.';
 
 /**
  * Opt-in toggle that "links" a set of filter dropdowns so each one's selectable
@@ -17,19 +27,17 @@ type FilterLinkToggleProps = {
 export function FilterLinkToggle({
   linked,
   onChange,
+  showVariableNote = false,
   'data-testid': dataTestId = 'filter-link-toggle',
 }: FilterLinkToggleProps) {
+  const label =
+    (linked
+      ? 'Filters are linked: each dropdown only shows values that match the other selections. Click to unlink.'
+      : 'Link filters: narrow each dropdown to values that match the other selections (filter-aware). May be slower on large datasets.') +
+    (showVariableNote ? VARIABLE_NOTE : '');
+
   return (
-    <Tooltip
-      withinPortal
-      multiline
-      w={250}
-      label={
-        linked
-          ? 'Filters are linked: each dropdown only shows values that match the other selections. Click to unlink.'
-          : 'Link filters: narrow each dropdown to values that match the other selections (filter-aware). May be slower on large datasets.'
-      }
-    >
+    <Tooltip withinPortal multiline w={400} label={label}>
       <ActionIcon
         variant="subtle"
         // Active state: a high-contrast inverted "pill" via theme tokens (never

--- a/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
@@ -1356,5 +1356,253 @@ describe('useDashboardFilterValues', () => {
       });
       expect(call?.keyConditions).toEqual([undefined, envProductionConstraint]);
     });
+
+    it('expands variable references in the where clause without dropping the conditions', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [
+              envAndStatus[0],
+              {
+                ...envAndStatus[1],
+                where: '$__filter(service_name, svc)',
+                whereLanguage: 'sql',
+              },
+            ],
+            dateRange: mockDateRange,
+            filterValues: {
+              environment: {
+                included: new Set<string>(['production']),
+                excluded: new Set<string>(),
+              },
+            },
+            variables: [
+              { name: 'svc', expression: 'service_name', values: ['api'] },
+            ],
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      // The two filters no longer share a where clause, so `status` runs its own
+      // faceted scan — still constrained by the environment selection.
+      const call = callForKeys(['status']);
+      expect(call?.chartConfig?.where).toBe("(service_name IN ('api'))");
+      expect(call?.keyConditions).toEqual([envProductionConstraint]);
+    });
+  });
+
+  describe('variable references in the dropdown values filter', () => {
+    const svcVariable = (values: string[]) => [
+      { name: 'svc', expression: 'service_name', values },
+    ];
+
+    /** A `status` filter whose dropdown query is `where`. */
+    const statusFilter = (
+      where: string,
+      whereLanguage: 'lucene' | 'sql' = 'sql',
+    ): DashboardFilter => ({
+      id: 'status',
+      type: 'QUERY_EXPRESSION',
+      name: 'Status',
+      expression: 'status',
+      source: 'logs-source',
+      where,
+      whereLanguage,
+    });
+
+    /** The where clause the most recent lookup for `keys` actually ran. */
+    const lastWhereFor = (keys: string[]) =>
+      mockMetadata.getKeyValues.mock.calls
+        .filter(([arg]) => JSON.stringify(arg.keys) === JSON.stringify(keys))
+        .at(-1)?.[0].chartConfig.where;
+
+    beforeEach(() => {
+      jest.spyOn(sourceModule, 'useSources').mockReturnValue({
+        data: mockSources,
+        isLoading: false,
+      } as unknown as ReturnType<typeof sourceModule.useSources>);
+      jest
+        .mocked(optimizeGetKeyValuesCalls)
+        .mockImplementation(async ({ keys, chartConfig }) => [
+          { keys, chartConfig },
+        ]);
+    });
+
+    it('expands a macro against the selected values', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [statusFilter('$__filter(service_name, svc)')],
+            dateRange: mockDateRange,
+            variables: svcVariable(['api']),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      const expanded = "(service_name IN ('api'))";
+      // Both the MV optimizer and the values query see the expansion, so a
+      // rollup can be ruled out by the columns the clause actually reads.
+      expect(optimizeGetKeyValuesCalls).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chartConfig: expect.objectContaining({ where: expanded }),
+        }),
+      );
+      expect(lastWhereFor(['status'])).toBe(expanded);
+    });
+
+    it('still queries when the variable it depends on has no selection', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [statusFilter('$__filter(service_name, svc)')],
+            dateRange: mockDateRange,
+            variables: svcVariable([]),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      // The whole point: an unselected dependency expands to a no-op rather
+      // than holding the lookup back.
+      expect(mockMetadata.getKeyValues).toHaveBeenCalledTimes(1);
+      expect(lastWhereFor(['status'])).toContain('1=1');
+      expect(result.current.data?.get('status')?.values).toEqual([
+        '200',
+        '404',
+        '500',
+      ]);
+      expect(result.current.erroredFilterIds.has('status')).toBe(false);
+    });
+
+    it('expands a lucene clause in the lucene format', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [statusFilter('service_name:$svc', 'lucene')],
+            dateRange: mockDateRange,
+            variables: svcVariable(['api']),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      expect(lastWhereFor(['status'])).toBe('service_name:("api")');
+    });
+
+    it('refetches when a referenced variable changes', async () => {
+      const { result, rerender } = renderHook(
+        ({ values }: { values: string[] }) =>
+          useDashboardFilterValues({
+            filters: [statusFilter('$__filter(service_name, svc)')],
+            dateRange: mockDateRange,
+            variables: svcVariable(values),
+          }),
+        { wrapper, initialProps: { values: ['api'] } },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+      expect(lastWhereFor(['status'])).toBe("(service_name IN ('api'))");
+
+      rerender({ values: ['worker'] });
+
+      await waitFor(() =>
+        expect(lastWhereFor(['status'])).toBe("(service_name IN ('worker'))"),
+      );
+    });
+
+    it('does not refetch when an unreferenced variable changes', async () => {
+      const { result, rerender } = renderHook(
+        ({ values }: { values: string[] }) =>
+          useDashboardFilterValues({
+            filters: [statusFilter("service_name = 'api'")],
+            dateRange: mockDateRange,
+            variables: [
+              { name: 'other', expression: 'other', values },
+              ...svcVariable(['api']),
+            ],
+          }),
+        { wrapper, initialProps: { values: ['a'] } },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+      expect(mockMetadata.getKeyValues).toHaveBeenCalledTimes(1);
+
+      rerender({ values: ['b'] });
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      // The resolved clause is unchanged, so the query key is too.
+      expect(mockMetadata.getKeyValues).toHaveBeenCalledTimes(1);
+    });
+
+    it('groups filters whose different clauses expand to the same SQL', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [
+              // Written out exactly as the macro below expands.
+              statusFilter("(service_name IN ('api'))"),
+              {
+                ...statusFilter('$__filter(service_name, svc)'),
+                id: 'log_level',
+                name: 'Log Level',
+                expression: 'log_level',
+              },
+            ],
+            dateRange: mockDateRange,
+            variables: svcVariable(['api']),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      expect(mockMetadata.getKeyValues).toHaveBeenCalledTimes(1);
+      expect(mockMetadata.getKeyValues).toHaveBeenCalledWith(
+        expect.objectContaining({ keys: ['status', 'log_level'] }),
+      );
+    });
+
+    it('reports a macro naming an undeclared variable, and still runs the query', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [statusFilter('$__filter(service_name, nope)')],
+            dateRange: mockDateRange,
+            variables: svcVariable(['api']),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      // Left as written — ClickHouse will reject it, but the control reports why.
+      expect(lastWhereFor(['status'])).toBe('$__filter(service_name, nope)');
+      expect(result.current.erroredFilterIds.has('status')).toBe(true);
+      expect(result.current.filterErrorMessages.get('status')).toMatch(
+        /unknown variable 'nope'/,
+      );
+    });
+
+    it('leaves the clause as written when no variables are in scope', async () => {
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters: [statusFilter('service_name IN ($svc)')],
+            dateRange: mockDateRange,
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      expect(lastWhereFor(['status'])).toBe('service_name IN ($svc)');
+      expect(result.current.erroredFilterIds.has('status')).toBe(false);
+    });
   });
 });

--- a/packages/app/src/hooks/useDashboardFilterValues.tsx
+++ b/packages/app/src/hooks/useDashboardFilterValues.tsx
@@ -7,10 +7,13 @@ import {
 } from '@hyperdx/common-utils/dist/core/materializedViews';
 import {
   FilterState,
+  ResolvedFilterValuesQuery,
+  resolveFilterValuesWhere,
   serializeFilterState,
 } from '@hyperdx/common-utils/dist/filters';
 import {
   BuilderChartConfigWithDateRange,
+  ChartVariable,
   DashboardFilter,
   isLogSource,
   isTraceSource,
@@ -34,13 +37,29 @@ type FilterSourceKey = {
   whereLanguage: 'sql' | 'lucene';
 };
 
-const filterToKey = (filter: DashboardFilter): string =>
+const filterToKey = (
+  filter: DashboardFilter,
+  resolved: ResolvedFilterValuesQuery,
+): string =>
   JSON.stringify({
     sourceId: filter.source,
     metricType: filter.sourceMetricType,
+    // The RESOLVED clause, so two filters whose dropdown queries expand to the
+    // same SQL share one lookup, and a filter whose expansion changes with a
+    // variable's selection gets a distinct query key rather than a stale one.
+    where: resolved.where,
+    whereLanguage: resolved.whereLanguage,
+  } satisfies FilterSourceKey);
+
+/** The resolved dropdown query for `filter`, falling back to the clause as written. */
+const resolvedFor = (
+  resolvedByFilterId: Map<string, ResolvedFilterValuesQuery>,
+  filter: DashboardFilter,
+): ResolvedFilterValuesQuery =>
+  resolvedByFilterId.get(filter.id) ?? {
     where: filter.where ?? '',
     whereLanguage: filter.whereLanguage ?? 'sql',
-  } satisfies FilterSourceKey);
+  };
 
 type EnrichedCall = GetKeyValueCall<BuilderChartConfigWithDateRange> & {
   /** filterIds[i] = array of filter IDs whose values come from keys[i] */
@@ -53,14 +72,27 @@ function useOptimizedKeyValuesCalls({
   filters,
   dateRange,
   filterValues,
+  variables,
 }: {
   filters: DashboardFilter[];
   dateRange: [Date, Date];
   filterValues: FilterState;
+  variables?: ChartVariable[];
 }) {
   const clickhouseClient = useClickhouseClient();
   const metadata = useMetadataWithSettings();
   const { data: sources, isLoading: isLoadingSources } = useSources();
+
+  // A filter's dropdown query may reference the dashboard's variables. Expand
+  // them here, before the chart config is built, so that react-query and metadata
+  // caches key on the resolved clause rather than the raw one.
+  const resolvedByFilterId = useMemo(() => {
+    const byId = new Map<string, ResolvedFilterValuesQuery>();
+    for (const filter of filters) {
+      byId.set(filter.id, resolveFilterValuesWhere(filter, variables));
+    }
+    return byId;
+  }, [filters, variables]);
 
   // Faceted filtering: each filter's selectable values are narrowed by the
   // CURRENT selections of its sibling filters. For every filter, collect the
@@ -112,7 +144,7 @@ function useOptimizedKeyValuesCalls({
   const filtersByGroupKey = useMemo(() => {
     const byGroupKey = new Map<string, DashboardFilter[]>();
     for (const filter of filters) {
-      const key = filterToKey(filter);
+      const key = filterToKey(filter, resolvedFor(resolvedByFilterId, filter));
       const existing = byGroupKey.get(key);
       if (existing) {
         existing.push(filter);
@@ -121,7 +153,7 @@ function useOptimizedKeyValuesCalls({
       }
     }
     return byGroupKey;
-  }, [filters]);
+  }, [filters, resolvedByFilterId]);
 
   const results: UseQueryResult<EnrichedCall[]>[] = useQueries({
     queries: Array.from(filtersByGroupKey.values())
@@ -132,8 +164,10 @@ function useOptimizedKeyValuesCalls({
         const representative = filtersInGroup[0];
         const sourceId = representative.source;
         const metricType = representative.sourceMetricType;
-        const where = representative.where ?? '';
-        const whereLanguage = representative.whereLanguage ?? 'sql';
+        const { where, whereLanguage } = resolvedFor(
+          resolvedByFilterId,
+          representative,
+        );
         const source = sources!.find(s => s.id === sourceId)!;
         const keyExpressions = filtersInGroup.map(f => f.expression);
         const keyConditions = filtersInGroup.map(f =>
@@ -234,8 +268,18 @@ function useOptimizedKeyValuesCalls({
       }),
   });
 
+  // Errors during variable/macro resolution (eg. unclosed parentheses), by filter ID.
+  const resolutionErrors = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const [filterId, resolved] of resolvedByFilterId) {
+      if (resolved.error) byId.set(filterId, resolved.error);
+    }
+    return byId;
+  }, [resolvedByFilterId]);
+
   return {
     data: results.map(r => r.data ?? []).flat(),
+    resolveErrors: resolutionErrors,
     isFetching: isLoadingSources || results.some(r => r.isFetching),
     isLoading: isLoadingSources || results.every(r => r.isLoading),
   };
@@ -245,20 +289,25 @@ export function useDashboardFilterValues({
   filters,
   dateRange,
   filterValues = {},
+  variables,
 }: {
   filters: DashboardFilter[];
   dateRange: [Date, Date];
   filterValues?: FilterState;
+  /** The dashboard's variables and their current selections, if any */
+  variables?: ChartVariable[];
 }) {
   const metadata = useMetadataWithSettings();
   const {
     data: calls,
+    resolveErrors,
     isFetching: isFetchingOptimizedCalls,
     isLoading: isLoadingOptimizedCalls,
   } = useOptimizedKeyValuesCalls({
     filters,
     dateRange,
     filterValues,
+    variables,
   });
 
   const { data: sources, isLoading: isSourcesLoading } = useSources();
@@ -348,15 +397,20 @@ export function useDashboardFilterValues({
         }
       });
     });
+    for (const filterId of resolveErrors.keys()) {
+      errored.add(filterId);
+    }
     return { data: map, erroredFilterIds: errored };
-  }, [results, calls]);
+  }, [results, calls, resolveErrors]);
 
   return {
     data: flattenedData,
-    /** Filter IDs whose key-values query failed. */
+    /** Filter IDs whose key-values query failed, or never resolved. */
     erroredFilterIds,
+    /** Error messages, when known, for filters in erroredFilterIds */
+    filterErrorMessages: resolveErrors,
     isLoading: isLoadingOptimizedCalls || results.every(r => r.isLoading),
     isFetching: isFetchingOptimizedCalls || results.some(r => r.isFetching),
-    isError: results.some(r => r.isError),
+    isError: results.some(r => r.isError) || resolveErrors.size > 0,
   };
 }

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * A dashboard filter's "Dropdown values filter" may reference the dashboard's
+ * other variables, so one filter's option list can be narrowed by another's
+ * selection.
+ *
+ * Every test here is `@full-stack`: the option lists come from real ClickHouse
+ * queries, and the dashboard-variables flag is only set on the full-stack
+ * webServer (see playwright.config.ts).
+ *
+ * The seed data makes the narrowing checkable: default logs are generated with
+ * `SERVICES[i % 10]` and `SEVERITIES[i % 4]`, so each service carries exactly
+ * two of the four severities — `accounting` (index 5) has only warn and debug,
+ * `api-server` (index 0) only info and error.
+ */
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { expect, test } from '../utils/base-test';
+import { DEFAULT_LOGS_SOURCE_NAME } from '../utils/constants';
+
+/** Severities `accounting` logs carry, and the two it does not. */
+const ACCOUNTING_SEVERITIES = ['warn', 'debug'];
+const OTHER_SEVERITIES = ['info', 'error'];
+const ALL_SEVERITIES = [...ACCOUNTING_SEVERITIES, ...OTHER_SEVERITIES];
+
+test.describe(
+  "Dashboard variables in a filter's dropdown values query",
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    let dashboardPage: DashboardPage;
+
+    test.beforeEach(async ({ page }) => {
+      dashboardPage = new DashboardPage(page);
+      await dashboardPage.goto();
+    });
+
+    /**
+     * A dashboard with a `Service` filter exposed as `$svc` and a `Severity`
+     * filter whose dropdown query is `where`.
+     */
+    const createDependentFilters = async (where: {
+      value: string;
+      language?: 'sql' | 'lucene';
+    }) => {
+      await dashboardPage.createNewDashboard();
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.addFilterToDashboard(
+        'Service',
+        DEFAULT_LOGS_SOURCE_NAME,
+        'ServiceName',
+        undefined,
+        undefined,
+        { variableName: 'svc' },
+      );
+      await expect(dashboardPage.getFilterItemByName('Service')).toBeVisible();
+      await dashboardPage.addFilterToDashboard(
+        'Severity',
+        DEFAULT_LOGS_SOURCE_NAME,
+        'SeverityText',
+        undefined,
+        undefined,
+        { variableName: 'sev' },
+        where,
+      );
+      await expect(dashboardPage.getFilterItemByName('Severity')).toBeVisible();
+      await dashboardPage.closeFiltersModal();
+    };
+
+    /**
+     * Assert the Severity dropdown offers `visible` and none of `absent`.
+     *
+     * Asserted as a pair, and retried together: the values query reuses the
+     * previous result as placeholder data while it refetches, so a snapshot of
+     * only one of the two can pass against a stale list.
+     */
+    const expectSeverityOptions = async (
+      visible: string[],
+      absent: string[] = [],
+    ) => {
+      await expect(async () => {
+        // Close first: a retry after a failed attempt would otherwise click an
+        // already-open select, toggling it shut.
+        await dashboardPage.page.keyboard.press('Escape');
+        await dashboardPage.openFilterDropdown('Severity');
+        for (const value of visible) {
+          await expect(dashboardPage.getFilterOption(value)).toBeVisible({
+            timeout: 1000,
+          });
+        }
+        for (const value of absent) {
+          await expect(dashboardPage.getFilterOption(value)).toHaveCount(0);
+        }
+      }).toPass({ timeout: 30000 });
+      await dashboardPage.page.keyboard.press('Escape');
+    };
+
+    test('a $__filter macro narrows the dropdown to the selected service', async () => {
+      test.setTimeout(120000);
+
+      await test.step('Create a Severity filter that depends on $svc', async () => {
+        await createDependentFilters({
+          value: '$__filter(ServiceName, svc)',
+          language: 'sql',
+        });
+      });
+
+      await test.step('With nothing selected, every severity is still offered', async () => {
+        // The macro expands to a no-op rather than holding the lookup back —
+        // this fails loudly if the query is ever gated on the dependency.
+        await expectSeverityOptions(ALL_SEVERITIES);
+        await expect(
+          dashboardPage.getFilterPendingVariableWarning('Severity'),
+        ).toBeHidden();
+        await expect(dashboardPage.getFilterErrorIcon('Severity')).toBeHidden();
+      });
+
+      await test.step('Selecting a service narrows the severities to its own', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expectSeverityOptions(ACCOUNTING_SEVERITIES, OTHER_SEVERITIES);
+      });
+
+      await test.step('Changing the service swaps the severities', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await dashboardPage.toggleFilterValue('Service', 'api-server');
+        await expectSeverityOptions(OTHER_SEVERITIES, ACCOUNTING_SEVERITIES);
+      });
+
+      await test.step('Clearing the service restores every severity', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'api-server');
+        await expectSeverityOptions(ALL_SEVERITIES);
+      });
+    });
+
+    test('a Lucene dropdown query lists every value until its variable is selected', async () => {
+      test.setTimeout(120000);
+
+      await test.step('Create a Lucene Severity filter that depends on $svc', async () => {
+        await createDependentFilters({
+          value: 'ServiceName:$svc',
+          language: 'lucene',
+        });
+      });
+
+      await test.step('With nothing selected, every severity is still offered', async () => {
+        // Lucene has no macro form, but an empty selection renders as `("")`,
+        // whose empty term the query parser turns into `(1=1)`.
+        await expectSeverityOptions(ALL_SEVERITIES);
+        // So there is nothing to warn about, unlike the bare SQL form below.
+        await expect(
+          dashboardPage.getFilterPendingVariableWarning('Severity'),
+        ).toBeHidden();
+      });
+
+      await test.step('Selecting a service narrows the severities to its own', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expectSeverityOptions(ACCOUNTING_SEVERITIES, OTHER_SEVERITIES);
+      });
+    });
+
+    test('a bare SQL reference warns while its variable has no value', async () => {
+      test.setTimeout(120000);
+
+      await test.step('Create a Severity filter using the bare reference form', async () => {
+        await createDependentFilters({
+          value: 'ServiceName IN ($svc)',
+          language: 'sql',
+        });
+      });
+
+      await test.step('With nothing selected the dropdown is empty, and says why', async () => {
+        // `$svc` renders as NULL, so the clause matches no rows. The query
+        // still runs — the filter reports the missing selection instead.
+        const warning =
+          dashboardPage.getFilterPendingVariableWarning('Severity');
+        await expect(warning).toBeVisible();
+        await warning.hover();
+        await expect(
+          dashboardPage.page.getByText(
+            'Filter depends on $svc, which has no selected value.',
+            { exact: false },
+          ),
+        ).toBeVisible();
+
+        await dashboardPage.openFilterDropdown('Severity');
+        await expect(dashboardPage.getFilterEmptyDropdownState()).toBeVisible({
+          timeout: 20000,
+        });
+        await dashboardPage.page.keyboard.press('Escape');
+      });
+
+      await test.step('Selecting a service clears the warning and lists its severities', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expect(
+          dashboardPage.getFilterPendingVariableWarning('Severity'),
+        ).toBeHidden();
+        await expectSeverityOptions(ACCOUNTING_SEVERITIES, OTHER_SEVERITIES);
+      });
+    });
+
+    test('the dropdown values filter completes and validates variable references', async () => {
+      test.setTimeout(120000);
+
+      await test.step('Create a dashboard with a variable-enabled filter', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+      });
+
+      const filterForm = dashboardPage.getFilterForm();
+
+      await test.step('Open the add-filter form on the logs source', async () => {
+        await dashboardPage.openAddFilterForm();
+        await expect(filterForm).toBeVisible();
+        await dashboardPage.selectFilterSource(DEFAULT_LOGS_SOURCE_NAME);
+      });
+
+      await test.step('The dropdown values filter offers the variable', async () => {
+        // Typed, not inserted: the completion popup only opens on input events.
+        await dashboardPage.fillFilterDropdownValuesWhere({
+          value: '$s',
+          language: 'sql',
+        });
+        await dashboardPage.getFilterWhereSqlEditor().click();
+        await dashboardPage.page.keyboard.press('End');
+        await dashboardPage.page.keyboard.type('v');
+
+        await expect(
+          dashboardPage.page
+            .locator('.cm-tooltip-autocomplete > ul > li')
+            .filter({
+              has: dashboardPage.page.getByText('$svc', { exact: true }),
+            })
+            .first(),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('A macro in a Lucene clause is flagged', async () => {
+        await dashboardPage.fillFilterDropdownValuesWhere({
+          value: '$__filter(ServiceName, svc)',
+          language: 'lucene',
+        });
+        const indicator = dashboardPage.getFilterWhereVariableWarning();
+        await expect(indicator).toBeVisible({ timeout: 15000 });
+        await expect(indicator).toHaveAttribute(
+          'aria-label',
+          /no meaning in a Lucene expression/,
+        );
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -669,12 +669,10 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
         const label = dashboardPage.getFilterLabel('SpanName');
         await expect(label).toBeVisible();
         await label.hover();
-        // New filters are variable-enabled by default while the feature is on,
-        // so both effects are described.
+        // New filters are broadcast-only by default, so only the broadcast
+        // effect is described.
         await expect(
-          dashboardPage.page.getByText(
-            'Filters 1 source, available as variable ($SpanName)',
-          ),
+          dashboardPage.page.getByText('Filters 1 source'),
         ).toBeVisible();
       });
 
@@ -725,9 +723,7 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       const label = dashboardPage.getFilterLabel('Service');
       await label.hover();
       await expect(
-        dashboardPage.page.getByText(
-          'Filters all sources, available as variable ($Service)',
-        ),
+        dashboardPage.page.getByText('Filters all sources'),
       ).toBeVisible();
     },
   );
@@ -745,18 +741,53 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       });
     });
 
-    await test.step('Variable name is derived from the filter name', async () => {
+    await test.step('New filters default to broadcast only', async () => {
       await dashboardPage.openEditFiltersModal();
       await dashboardPage.addFiltersButton.click();
 
-      // Enabled by default for new filters while the feature is on.
       await expect(dashboardPage.broadcastFilterCheckbox).toBeChecked();
-      await expect(dashboardPage.variableEnabledCheckbox).toBeChecked();
+      await expect(dashboardPage.variableEnabledCheckbox).not.toBeChecked();
+      // The variable name only appears once the mode is turned on.
+      await expect(dashboardPage.variableNameInput).toBeHidden();
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeHidden();
+    });
+
+    await test.step('Variable name is derived from the filter name', async () => {
+      await dashboardPage.variableEnabledCheckbox.check();
 
       await dashboardPage.page
         .getByTestId('filter-name-input')
         .fill('Service Name');
       await expect(dashboardPage.variableNameInput).toHaveValue('Service_Name');
+    });
+
+    await test.step('Both modes with an unscoped broadcast warns', async () => {
+      // Broadcast reaches every tile, so the variable is redundant until the
+      // broadcast is scoped or turned off.
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeVisible();
+
+      await dashboardPage.appliesToSourceSelector.click();
+      await dashboardPage.page
+        .getByRole('option', { name: DEFAULT_LOGS_SOURCE_NAME, exact: true })
+        .click();
+      await dashboardPage.page.keyboard.press('Escape');
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeHidden();
+
+      // Clearing the scope brings it back — re-picking a selected source in the
+      // multi-select toggles it back off.
+      await dashboardPage.appliesToSourceSelector.click();
+      await dashboardPage.page
+        .getByRole('option', { name: DEFAULT_LOGS_SOURCE_NAME, exact: true })
+        .click();
+      await dashboardPage.page.keyboard.press('Escape');
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeVisible();
+
+      // ...and so does turning broadcast off entirely, since then only the
+      // tiles that reference the variable are affected.
+      await dashboardPage.broadcastFilterCheckbox.uncheck();
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeHidden();
+      await dashboardPage.broadcastFilterCheckbox.check();
+      await expect(dashboardPage.unscopedBroadcastWarning).toBeVisible();
     });
 
     await test.step('Editing the variable name stops the auto-derivation', async () => {
@@ -828,6 +859,7 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       const editor = getSqlEditor(dashboardPage.page, 'expression');
       await editor.click();
       await dashboardPage.page.keyboard.type('ServiceName');
+      await dashboardPage.variableEnabledCheckbox.check();
       await dashboardPage.variableNameInput.fill('svc');
       await dashboardPage.page.getByTestId('save-filter-button').click();
 
@@ -874,11 +906,12 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
         await editor.click();
         await dashboardPage.page.keyboard.type('ServiceName');
 
-        // Both modes are on by default, so nothing is wrong yet.
+        // Broadcast-only by default, so nothing is wrong yet.
         await expect(dashboardPage.page.getByText(modeError)).toHaveCount(0);
       });
 
-      await test.step('Turning off only one mode is fine', async () => {
+      await test.step('Either mode on its own is fine', async () => {
+        await dashboardPage.variableEnabledCheckbox.check();
         await dashboardPage.broadcastFilterCheckbox.uncheck();
         await expect(dashboardPage.page.getByText(modeError)).toHaveCount(0);
 
@@ -963,13 +996,15 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
         await dashboardPage.openEditFiltersModal();
         await expect(dashboardPage.emptyFiltersList).toBeVisible();
 
+        // Variable-only: a filter has to do one of the two, so turning off
+        // broadcast means turning on the variable.
         await dashboardPage.addFilterToDashboard(
           'Service',
           DEFAULT_LOGS_SOURCE_NAME,
           'ServiceName',
           undefined,
           undefined,
-          { isBroadcastEnabled: false },
+          { isBroadcastEnabled: false, isVariableEnabled: true },
         );
 
         await expect(
@@ -985,8 +1020,7 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
       });
 
       await test.step('Filter label tooltip drops the broadcast half', async () => {
-        // Broadcast off, variable still on (the default for a new filter while
-        // the feature is enabled), so only the variable effect is described.
+        // Broadcast off, variable on, so only the variable effect is described.
         const label = dashboardPage.getFilterLabel('Service');
         await expect(label).toBeVisible();
         await label.hover();

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -7,7 +7,14 @@ import { expect, Locator, Page } from '@playwright/test';
 
 import { ChartEditorComponent } from '../components/ChartEditorComponent';
 import { TimePickerComponent } from '../components/TimePickerComponent';
-import { getSqlEditor } from '../utils/locators';
+import { dismissSqlAutocomplete, getSqlEditor } from '../utils/locators';
+import { switchWhereLanguage } from '../utils/lucene-autocomplete';
+
+/** The "Dropdown values filter" on a dashboard filter, and its language. */
+export type FilterWhereOptions = {
+  value: string;
+  language?: 'sql' | 'lucene';
+};
 
 /**
  * Config format tile config, as accepted by the external dashboard API.
@@ -856,6 +863,7 @@ export class DashboardPage {
       isVariableEnabled?: boolean;
       variableName?: string;
     },
+    whereOptions?: FilterWhereOptions,
   ) {
     const filterNameInput = this.page.getByTestId('filter-name-input');
     await filterNameInput.fill(name);
@@ -870,6 +878,10 @@ export class DashboardPage {
       await this.page
         .getByRole('radio', { name: metricType, exact: true })
         .click();
+    }
+
+    if (whereOptions) {
+      await this.fillFilterDropdownValuesWhere(whereOptions);
     }
 
     // Applied before the applies-to selector below, because unchecking broadcast
@@ -910,6 +922,7 @@ export class DashboardPage {
       isVariableEnabled?: boolean;
       variableName?: string;
     },
+    whereOptions?: FilterWhereOptions,
   ) {
     await this.addFiltersButton.click();
 
@@ -920,7 +933,75 @@ export class DashboardPage {
       metricType,
       appliesToSourceNames,
       variableOptions,
+      whereOptions,
     );
+  }
+
+  /** The filter edit form's dialog, scoped so page-level locators stay unambiguous. */
+  getFilterForm(): Locator {
+    return this.page
+      .getByRole('dialog')
+      .filter({ has: this.page.getByTestId('filter-name-input') });
+  }
+
+  /**
+   * The "Dropdown values filter" input's root, reached from its language switch.
+   *
+   * Located this way because the input itself carries no test id, and matching
+   * it by placeholder only works while it is empty.
+   */
+  getFilterWhereRoot(): Locator {
+    return this.getFilterForm()
+      .getByTestId('where-language-switch')
+      .locator('xpath=..');
+  }
+
+  /** The CodeMirror editor behind the SQL form of the dropdown values filter. */
+  getFilterWhereSqlEditor(): Locator {
+    return this.getFilterWhereRoot().locator('div.cm-editor');
+  }
+
+  /** What the dropdown values filter flags about the variables it references. */
+  getFilterWhereVariableWarning(): Locator {
+    return this.getFilterWhereRoot().getByTestId('variable-validation');
+  }
+
+  /**
+   * Fill the "Dropdown values filter" (the filter's `where`) in the open filter
+   * edit form, replacing whatever is there.
+   *
+   * The language is always set explicitly: the form seeds it from the
+   * `hdx-search-where-language` localStorage key, which other specs write, so
+   * "it defaults to SQL" is not safe to assume.
+   */
+  async fillFilterDropdownValuesWhere({
+    value,
+    language = 'sql',
+  }: FilterWhereOptions) {
+    await switchWhereLanguage(
+      this.getFilterForm().getByTestId('where-language-switch'),
+      language === 'sql' ? 'SQL' : 'Lucene',
+    );
+
+    if (language === 'lucene') {
+      const input = this.getFilterWhereRoot().getByRole('textbox');
+      await input.click();
+      await input.fill(value);
+      // Blur so the Lucene suggestion dropdown can't cover the save button.
+      await this.page.getByTestId('filter-name-input').click();
+      return;
+    }
+
+    const editor = this.getFilterWhereSqlEditor();
+    await editor.click();
+    await this.page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+    );
+    await this.page.keyboard.press('Backspace');
+    // insertText, not type: CodeMirror's bracket auto-closing would corrupt a
+    // clause containing `(`, as every macro reference does.
+    await this.page.keyboard.insertText(value);
+    await dismissSqlAutocomplete(this.page);
   }
 
   getFilterLabel(name: string) {
@@ -1000,6 +1081,37 @@ export class DashboardPage {
    */
   getFilterEmptyDropdownState(): Locator {
     return this.page.getByText('Nothing found...').first();
+  }
+
+  /**
+   * Open a dashboard filter's dropdown, leaving it open so the caller can
+   * assert on the options it offers.
+   */
+  async openFilterDropdown(filterName: string) {
+    const select = this.getFilterSelectByName(filterName);
+    await select.waitFor({ state: 'visible', timeout: 15000 });
+    await select.scrollIntoViewIfNeeded();
+    await select.click();
+  }
+
+  /**
+   * Locator for one option in a dashboard filter's (open) dropdown. The
+   * dropdown is portaled out of the select, so this is located at page level.
+   */
+  getFilterOption(value: string): Locator {
+    return this.page.getByRole('option', { name: value, exact: true });
+  }
+
+  /** The warning shown when a filter's dropdown query awaits a variable's value. */
+  getFilterPendingVariableWarning(filterName: string): Locator {
+    return this.page.getByTestId(
+      `dashboard-filter-pending-variable-${filterName}`,
+    );
+  }
+
+  /** The error shown when a filter's dropdown values query failed. */
+  getFilterErrorIcon(filterName: string): Locator {
+    return this.page.getByTestId(`dashboard-filter-error-${filterName}`);
   }
 
   /**

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -889,11 +889,18 @@ export class DashboardPage {
     if (variableOptions?.isBroadcastEnabled === false) {
       await this.broadcastFilterCheckbox.uncheck();
     }
+    // New filters default to broadcast-only, so the variable box is opt-in here:
+    // asking for a variable name, or for the mode outright, checks it.
     if (variableOptions?.isVariableEnabled === false) {
       await this.variableEnabledCheckbox.uncheck();
-    } else if (variableOptions?.variableName !== undefined) {
+    } else if (
+      variableOptions?.isVariableEnabled === true ||
+      variableOptions?.variableName !== undefined
+    ) {
       await this.variableEnabledCheckbox.check();
-      await this.variableNameInput.fill(variableOptions.variableName);
+      if (variableOptions.variableName !== undefined) {
+        await this.variableNameInput.fill(variableOptions.variableName);
+      }
     }
 
     if (appliesToSourceNames && appliesToSourceNames.length > 0) {
@@ -1036,6 +1043,14 @@ export class DashboardPage {
     await this.page.getByTestId(`edit-filter-button-${filterName}`).click();
     await this.broadcastFilterCheckbox.setChecked(enabled);
     await this.page.getByTestId('save-filter-button').click();
+  }
+
+  /**
+   * The warning shown in the filter edit form when a filter both broadcasts and
+   * is a variable, with no "Applies to sources" scope to limit the broadcast.
+   */
+  get unscopedBroadcastWarning() {
+    return this.page.getByTestId('filter-unscoped-broadcast-warning');
   }
 
   /** The warning icon shown when a filter neither broadcasts nor is a variable. */

--- a/packages/app/tests/e2e/utils/lucene-autocomplete.ts
+++ b/packages/app/tests/e2e/utils/lucene-autocomplete.ts
@@ -14,19 +14,27 @@ import { expect, Locator } from '@playwright/test';
 const SUGGESTION_TIMEOUT = 15_000;
 
 /**
- * Switch a WHERE input to Lucene via its language select.
+ * Switch a WHERE input's query language via its language select.
  *
  * Takes the input's own `where-language-switch` rather than looking it up on
  * the page, because a page commonly renders several: the trace waterfall has
  * one per filter, and the dashboard's tile editor overlays the dashboard's own.
  */
-export async function switchWhereToLucene(languageSwitch: Locator) {
+export async function switchWhereLanguage(
+  languageSwitch: Locator,
+  language: 'SQL' | 'Lucene',
+) {
   await languageSwitch.getByLabel('Query language').click();
   // The Select's dropdown is portalled out of the switch, so go via the page.
   await languageSwitch
     .page()
-    .getByRole('option', { name: 'Lucene', exact: true })
+    .getByRole('option', { name: language, exact: true })
     .click();
+}
+
+/** Switch a WHERE input to Lucene. */
+export async function switchWhereToLucene(languageSwitch: Locator) {
+  await switchWhereLanguage(languageSwitch, 'Lucene');
 }
 
 /**

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -5,18 +5,20 @@ import {
   filtersToQuery,
   getDashboardVariableDeclarations,
   getFilterVariableName,
+  getPendingFilterValuesVariables,
   hasFilterEffect,
   isFilterBroadcastEnabled,
   isFilterVariableEnabled,
   isRenderablePinnedFilter,
   parseQuery,
+  resolveFilterValuesWhere,
   serializeFilterState,
   validateDashboardFilterQueries,
   validateSavedFilterValues,
   validateSavedQuery,
   validateVariableName,
 } from '@/filters';
-import type { DashboardFilter, Filter } from '@/types';
+import type { ChartVariable, DashboardFilter, Filter } from '@/types';
 import {
   DASHBOARD_VARIABLE_NAME_MAX_LENGTH,
   DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED,
@@ -733,6 +735,324 @@ describe('filters', () => {
           where: 'Bad:((("',
         },
       ]);
+    });
+
+    describe('variable references', () => {
+      /** A variable-enabled `Service` filter, exposed as `$svc`. */
+      const svcVariableFilter = filter({
+        id: 'svc',
+        name: 'Service',
+        isVariableEnabled: true,
+        variableName: 'svc',
+      });
+
+      it.each([
+        ['a macro on an explicit expression', '$__filter(ServiceName, svc)'],
+        ['a macro on the variable expression', '$__filter(svc)'],
+        ['a conditionalAll macro', "$__conditionalAll(ServiceName = 'x', svc)"],
+        ['a braced reference', 'ServiceName IN (${svc})'],
+        ['a bare reference', 'ServiceName IN ($svc)'],
+      ])('accepts a sql where clause using %s', (_label, where) => {
+        expect(
+          validateDashboardFilterQueries([
+            svcVariableFilter,
+            filter({
+              id: 'sev',
+              name: 'Severity',
+              where,
+              whereLanguage: 'sql',
+            }),
+          ]),
+        ).toEqual([]);
+      });
+
+      it('accepts a lucene where clause referencing a variable', () => {
+        expect(
+          validateDashboardFilterQueries([
+            svcVariableFilter,
+            filter({
+              id: 'sev',
+              name: 'Severity',
+              where: 'ServiceName:$svc',
+              whereLanguage: 'lucene',
+            }),
+          ]),
+        ).toEqual([]);
+      });
+
+      it('flags a macro naming a variable the dashboard does not declare', () => {
+        const issues = validateDashboardFilterQueries([
+          svcVariableFilter,
+          filter({
+            id: 'sev',
+            name: 'Severity',
+            where: '$__filter(ServiceName, nope)',
+            whereLanguage: 'sql',
+          }),
+        ]);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toMatchObject({
+          filterId: 'sev',
+          filterName: 'Severity',
+          language: 'sql',
+          // The raw template is reported, not its expansion.
+          where: '$__filter(ServiceName, nope)',
+        });
+        expect(issues[0].detail).toMatch(/unknown variable 'nope'/);
+      });
+
+      it('flags a macro when no filter is variable-enabled', () => {
+        const issues = validateDashboardFilterQueries([
+          filter({
+            id: 'sev',
+            name: 'Severity',
+            where: '$__filter(ServiceName, svc)',
+            whereLanguage: 'sql',
+          }),
+        ]);
+        expect(issues).toHaveLength(1);
+        expect(issues[0].detail).toMatch(/unknown variable 'svc'/);
+      });
+
+      it('still flags a clause that is malformed after expansion', () => {
+        const issues = validateDashboardFilterQueries([
+          svcVariableFilter,
+          filter({
+            id: 'sev',
+            name: 'Severity',
+            where: 'ServiceName IN (${svc}',
+            whereLanguage: 'sql',
+          }),
+        ]);
+        expect(issues).toEqual([
+          {
+            filterId: 'sev',
+            filterName: 'Severity',
+            language: 'sql',
+            where: 'ServiceName IN (${svc}',
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('resolveFilterValuesWhere', () => {
+    const svc = (values: string[]): ChartVariable => ({
+      name: 'svc',
+      expression: 'ServiceName',
+      values,
+    });
+
+    it('returns the template as written when there is no variable context', () => {
+      expect(
+        resolveFilterValuesWhere(
+          { where: 'ServiceName IN ($svc)', whereLanguage: 'sql' },
+          undefined,
+        ),
+      ).toEqual({ where: 'ServiceName IN ($svc)', whereLanguage: 'sql' });
+    });
+
+    it('defaults the language to sql', () => {
+      expect(resolveFilterValuesWhere({ where: '' }, [svc([])])).toEqual({
+        where: '',
+        whereLanguage: 'sql',
+      });
+    });
+
+    it('expands a macro against the selected values', () => {
+      expect(
+        resolveFilterValuesWhere(
+          { where: '$__filter(ServiceName, svc)', whereLanguage: 'sql' },
+          [svc(['accounting'])],
+        ),
+      ).toEqual({
+        where: "(ServiceName IN ('accounting'))",
+        whereLanguage: 'sql',
+      });
+    });
+
+    it('expands a macro to a no-op when nothing is selected', () => {
+      const { where } = resolveFilterValuesWhere(
+        { where: '$__filter(ServiceName, svc)', whereLanguage: 'sql' },
+        [svc([])],
+      );
+      expect(where).toContain('1=1');
+    });
+
+    it('expands the one-argument macro form using the declared expression', () => {
+      expect(
+        resolveFilterValuesWhere({ where: '$__filter(svc)' }, [
+          svc(['accounting']),
+        ]).where,
+      ).toBe("(toString(ServiceName) IN ('accounting'))");
+    });
+
+    it('expands a bare sql reference, including its empty state', () => {
+      expect(
+        resolveFilterValuesWhere({ where: 'ServiceName IN ($svc)' }, [
+          svc(['accounting', 'ad']),
+        ]).where,
+      ).toBe("ServiceName IN ('accounting', 'ad')");
+      expect(
+        resolveFilterValuesWhere({ where: 'ServiceName IN ($svc)' }, [svc([])])
+          .where,
+      ).toBe('ServiceName IN (NULL)');
+    });
+
+    it('expands a lucene reference in the lucene format', () => {
+      expect(
+        resolveFilterValuesWhere(
+          { where: 'ServiceName:$svc', whereLanguage: 'lucene' },
+          [svc(['accounting'])],
+        ).where,
+      ).toBe('ServiceName:("accounting")');
+      expect(
+        resolveFilterValuesWhere(
+          { where: 'ServiceName:$svc', whereLanguage: 'lucene' },
+          [svc([])],
+        ).where,
+      ).toBe('ServiceName:("")');
+    });
+
+    it('leaves a macro as written in a lucene clause', () => {
+      expect(
+        resolveFilterValuesWhere(
+          { where: '$__filter(ServiceName, svc)', whereLanguage: 'lucene' },
+          [svc(['accounting'])],
+        ).where,
+      ).toBe('$__filter(ServiceName, svc)');
+    });
+
+    it("narrows by a filter's own variable when it references itself", () => {
+      // Honored literally: a self-referencing dropdown query collapses to the
+      // filter's own selection, which is what the author asked for.
+      expect(
+        resolveFilterValuesWhere(
+          { where: '$__filter(ServiceName, svc)', whereLanguage: 'sql' },
+          [svc(['accounting'])],
+        ).where,
+      ).toBe("(ServiceName IN ('accounting'))");
+    });
+
+    it('reports a macro naming an unknown variable without throwing', () => {
+      const resolved = resolveFilterValuesWhere(
+        { where: '$__filter(ServiceName, nope)', whereLanguage: 'sql' },
+        [svc(['accounting'])],
+      );
+      expect(resolved.where).toBe('$__filter(ServiceName, nope)');
+      expect(resolved.error).toMatch(/unknown variable 'nope'/);
+    });
+
+    it('reports an unrecognized format without throwing', () => {
+      const resolved = resolveFilterValuesWhere(
+        { where: 'ServiceName IN (${svc:bogus})', whereLanguage: 'sql' },
+        [svc(['accounting'])],
+      );
+      expect(resolved.where).toBe('ServiceName IN (${svc:bogus})');
+      expect(resolved.error).toMatch(/Unknown variable format 'bogus'/);
+    });
+
+    it('leaves an undeclared bare reference alone', () => {
+      const resolved = resolveFilterValuesWhere(
+        { where: "Body = '$notAVariable'", whereLanguage: 'sql' },
+        [svc(['accounting'])],
+      );
+      expect(resolved.where).toBe("Body = '$notAVariable'");
+      expect(resolved.error).toBeUndefined();
+    });
+  });
+
+  describe('getPendingFilterValuesVariables', () => {
+    const svc = (values: string[]): ChartVariable => ({
+      name: 'svc',
+      expression: 'ServiceName',
+      values,
+    });
+
+    it('reports a bare sql reference to an unselected variable', () => {
+      expect(
+        getPendingFilterValuesVariables({ where: 'ServiceName IN ($svc)' }, [
+          svc([]),
+        ]),
+      ).toEqual(['svc']);
+    });
+
+    it('reports a braced reference once, however often it appears', () => {
+      expect(
+        getPendingFilterValuesVariables(
+          { where: 'ServiceName IN (${svc}) OR Other IN ($svc)' },
+          [svc([])],
+        ),
+      ).toEqual(['svc']);
+    });
+
+    it('reports a csv reference, which renders as nothing when empty', () => {
+      expect(
+        getPendingFilterValuesVariables(
+          { where: 'ServiceName IN (${svc:csv})' },
+          [svc([])],
+        ),
+      ).toEqual(['svc']);
+    });
+
+    it('reports nothing once the variable has a selection', () => {
+      expect(
+        getPendingFilterValuesVariables({ where: 'ServiceName IN ($svc)' }, [
+          svc(['accounting']),
+        ]),
+      ).toEqual([]);
+    });
+
+    it.each([
+      ['a macro', '$__filter(ServiceName, svc)', 'sql'],
+      [
+        'a conditionalAll macro',
+        "$__conditionalAll(ServiceName = 'x', svc)",
+        'sql',
+      ],
+      [
+        'a reference guarded by its own macro',
+        '$__filter(ServiceName IN ($svc), svc)',
+        'sql',
+      ],
+      [
+        'a regex-formatted reference',
+        'match(ServiceName, ${svc:regex})',
+        'sql',
+      ],
+    ] as const)('reports nothing for %s', (_label, where, whereLanguage) => {
+      expect(
+        getPendingFilterValuesVariables({ where, whereLanguage }, [svc([])]),
+      ).toEqual([]);
+    });
+
+    it('reports nothing for a lucene clause, whose empty term is a no-op', () => {
+      expect(
+        getPendingFilterValuesVariables(
+          { where: 'ServiceName:$svc', whereLanguage: 'lucene' },
+          [svc([])],
+        ),
+      ).toEqual([]);
+    });
+
+    it('ignores references that name no declared variable', () => {
+      expect(
+        getPendingFilterValuesVariables({ where: 'ServiceName IN ($nope)' }, [
+          svc([]),
+        ]),
+      ).toEqual([]);
+    });
+
+    it('reports nothing without a variable context or a where clause', () => {
+      expect(
+        getPendingFilterValuesVariables(
+          { where: 'ServiceName IN ($svc)' },
+          undefined,
+        ),
+      ).toEqual([]);
+      expect(
+        getPendingFilterValuesVariables({ where: '  ' }, [svc([])]),
+      ).toEqual([]);
     });
   });
 

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -9,6 +9,7 @@ import {
   hasVariableMacro,
   substituteChartConfigVariables,
   substituteVariables,
+  substituteVariablesForLanguage,
   validateVariableReferencesInTemplate,
 } from '@/variables';
 
@@ -351,6 +352,55 @@ describe('substituteVariables', () => {
 
   it('does not treat $__filters as the $__filter macro', () => {
     expect(substituteVariables('$__filters', [SERVICE])).toBe('$__filters');
+  });
+});
+
+describe('substituteVariablesForLanguage', () => {
+  it('expands references as SQL strings and macros as predicates for sql', () => {
+    expect(
+      substituteVariablesForLanguage(
+        'ServiceName IN ($service) AND $__filter(ServiceName, service)',
+        [SERVICE],
+        'sql',
+      ),
+    ).toBe("ServiceName IN ('api', 'web') AND (ServiceName IN ('api', 'web'))");
+  });
+
+  it('expands references in the lucene format for lucene', () => {
+    expect(
+      substituteVariablesForLanguage(
+        'ServiceName:$service',
+        [SERVICE],
+        'lucene',
+      ),
+    ).toBe('ServiceName:("api" OR "web")');
+  });
+
+  it('leaves macros as written in a lucene expression', () => {
+    expect(
+      substituteVariablesForLanguage(
+        '$__filter(ServiceName, service)',
+        [SERVICE],
+        'lucene',
+      ),
+    ).toBe('$__filter(ServiceName, service)');
+  });
+
+  it('renders an empty selection in each language', () => {
+    expect(
+      substituteVariablesForLanguage(
+        'ServiceName IN ($service)',
+        [EMPTY_SERVICE],
+        'sql',
+      ),
+    ).toBe('ServiceName IN (NULL)');
+    expect(
+      substituteVariablesForLanguage(
+        'ServiceName:$service',
+        [EMPTY_SERVICE],
+        'lucene',
+      ),
+    ).toBe('ServiceName:("")');
   });
 });
 

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -9,6 +9,10 @@ import {
   DashboardFilter,
   Filter,
 } from '@/types';
+import {
+  getVariableReferences,
+  substituteVariablesForLanguage,
+} from '@/variables';
 
 export type FilterState = {
   [key: string]: {
@@ -687,6 +691,8 @@ export type DashboardFilterQueryIssue = {
   language: 'lucene' | 'sql';
   /** The raw `where` clause that failed to parse */
   where: string;
+  /** Why it failed, when the clause itself parses but its variables don't resolve. */
+  detail?: string;
 };
 
 /**
@@ -698,6 +704,8 @@ export type DashboardFilterQueryIssue = {
  * after opening the dashboard. Returns one issue per filter whose `where`
  * fails to parse as its declared language.
  *
+ * Variable references are expanded before the parse validation.
+ *
  * Note: this only checks that the `where` clause *parses*. It cannot catch a
  * `where`/`expression` that references a non-existent column — that only fails
  * when the query runs against ClickHouse.
@@ -706,12 +714,27 @@ export function validateDashboardFilterQueries(
   filters: DashboardFilter[],
 ): DashboardFilterQueryIssue[] {
   const issues: DashboardFilterQueryIssue[] = [];
+
+  // Variables are expanded with an empty selection.
+  const variables: ChartVariable[] = getDashboardVariableDeclarations(
+    filters,
+  ).map(declaration => ({ ...declaration, values: [] }));
+
   for (const filter of filters) {
     const where = filter.where ?? '';
     if (!where.trim()) continue;
     const language = filter.whereLanguage ?? 'sql';
     if (language !== 'lucene' && language !== 'sql') continue;
-    if (!isValidFilterCondition(where, language)) {
+    const resolved = resolveFilterValuesWhere(filter, variables);
+    if (resolved.error) {
+      issues.push({
+        filterId: filter.id,
+        filterName: filter.name,
+        language,
+        where,
+        detail: resolved.error,
+      });
+    } else if (!isValidFilterCondition(resolved.where, language)) {
       issues.push({
         filterId: filter.id,
         filterName: filter.name,
@@ -804,6 +827,82 @@ export function getDashboardVariableDeclarations(
   }
 
   return declarations;
+}
+
+export type ResolvedFilterValuesQuery = {
+  /** The clause the values lookup actually runs. */
+  where: string;
+  whereLanguage: 'lucene' | 'sql';
+  /** Set when expansion failed; `where` is then the template as written. */
+  error?: string;
+};
+
+/**
+ * Expand the dashboard variables a filter's dropdown-values query references.
+ *
+ * Never throws. Failures (unknown variables, etc) leave the clause as written, so
+ * downstream lookup still runs and reports an `error`.
+ */
+export function resolveFilterValuesWhere(
+  filter: { where?: string; whereLanguage?: 'lucene' | 'sql' },
+  variables: ChartVariable[] | undefined,
+): ResolvedFilterValuesQuery {
+  const where = filter.where ?? '';
+  const whereLanguage = filter.whereLanguage ?? 'sql';
+  if (variables == null || !where.trim()) {
+    return { where, whereLanguage };
+  }
+
+  try {
+    return {
+      where: substituteVariablesForLanguage(where, variables, whereLanguage),
+      whereLanguage,
+    };
+  } catch (e) {
+    return {
+      where,
+      whereLanguage,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * Variables whose selection a filter's dropdown-values query needs before it can
+ * match anything.
+ *
+ * Only bare and braced SQL references qualify. `$__filter` /
+ * `$__conditionalAll` expand to `(1=1)`, the `regex` format to `.*`, and a
+ * Lucene reference to `("")` (rendered as `(1=1)`), so all of those list every
+ * value while their variable is empty. A `sqlstring` reference renders as
+ * `NULL` and a `csv` one as nothing at all, which match no rows.
+ */
+export function getPendingFilterValuesVariables(
+  filter: { where?: string; whereLanguage?: 'lucene' | 'sql' },
+  variables: ChartVariable[] | undefined,
+): string[] {
+  const where = filter.where ?? '';
+  const whereLanguage = filter.whereLanguage ?? 'sql';
+  if (variables == null || !where.trim() || whereLanguage !== 'sql') return [];
+
+  const emptyVariableNames = new Set(
+    variables.filter(v => v.values.length === 0).map(v => v.name),
+  );
+  if (emptyVariableNames.size === 0) return [];
+
+  const pending = getVariableReferences(where)
+    .filter(
+      reference =>
+        reference.kind !== 'macro' &&
+        // A reference inside the macro that guards it is only emitted once the
+        // variable has values, so it needs no empty-state rendering of its own.
+        reference.guardedBy !== reference.name &&
+        (reference.format ?? 'sqlstring') !== 'regex' &&
+        emptyVariableNames.has(reference.name),
+    )
+    .map(reference => reference.name);
+
+  return Array.from(new Set(pending));
 }
 
 /**

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -479,6 +479,22 @@ export function substituteVariables(
   });
 }
 
+/**
+ * Expand a template for the language its renderer will parse it as.
+ * A Lucene expression renders values in the `lucene` format and gets no macros.
+ */
+export function substituteVariablesForLanguage(
+  input: string,
+  variables: ChartVariable[],
+  language: SearchConditionLanguage,
+): string {
+  const isLucene = language === 'lucene';
+  return substituteVariables(input, variables, {
+    defaultFormat: isLucene ? 'lucene' : 'sqlstring',
+    disableMacros: isLucene,
+  });
+}
+
 // -- Chart builder configs --------------------------------------------------
 
 /**
@@ -584,13 +600,8 @@ export function substituteChartConfigVariables<
 
   const substituted = mapBuilderVariableTemplates(
     config,
-    (template, language) => {
-      const isLucene = language === 'lucene';
-      return substituteVariables(template, variables, {
-        defaultFormat: isLucene ? 'lucene' : 'sqlstring',
-        disableMacros: isLucene,
-      });
-    },
+    (template, language) =>
+      substituteVariablesForLanguage(template, variables, language),
   );
 
   return { ...substituted, variables: undefined };


### PR DESCRIPTION
## Summary

This PR extends dashboard variable support by allowing filters (variable) definitions to reference other variables in their where clause. This allows for drop-downs to be scoped by selections in other drop-downs.

Options will still be queried even when the query references a variable which is not yet selected. The user can use the `$__filters` or `$__conditionalAll` macros to ensure values populate even when no value is selected for the dependent filter. If the user uses a bare `<expression> IN ($var)`, no values will be populated until values are selected for `$var` and the user will see a tooltip warning describing why this is happening.

Auto-complete for variables and variable macros is enabled in the WHERE input in the filters modal.

Circular dependencies are possible, and cause no significant harm because variables are replaced by _selections_ and selections are stable until the user changes them - they are not pruned by the available values returned by the query.

Note that creation of variables is gated behind NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES (enabled by default in development locally).

### Screenshots or video

https://github.com/user-attachments/assets/aeb601ce-4c14-4603-ab71-8c67bd569d52

### How to test locally

- Create a dashboard
- Add a couple filters, enable variable mode, and reference variables in the WHERE clause of another filter.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5053
- Related PRs:
