### PR TITLE
[HDX-5089] Allow editing and deleting alerts from the alert details page

### DIFF
--- a/.changeset/edit-alert-from-details-page.md
+++ b/.changeset/edit-alert-from-details-page.md
@@ -1,0 +1,13 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+'@hyperdx/api': patch
+---
+
+Allow editing and deleting alerts directly from the alert details page. An
+"Edit alert" action opens a modal for changing the alert's threshold,
+evaluation interval, schedule, group-by (saved-search alerts), notification
+webhook, and note, and a Delete action (with confirmation) removes the alert
+and returns to the alerts list. Alert API responses now include the
+notification channel's webhook id and the alert's name/message template so
+edits round-trip these fields.

--- a/packages/api/src/routers/api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/alerts.int.test.ts
@@ -130,6 +130,42 @@ describe('alerts router', () => {
     expect(allAlerts.body.data[0].threshold).toBe(10);
   });
 
+  it('returns channel.webhookId, name, and message in GET list and GET single', async () => {
+    const dashboard = await agent
+      .post('/dashboards')
+      .send(MOCK_DASHBOARD)
+      .expect(200);
+    const alert = await agent
+      .post('/alerts')
+      .send({
+        ...makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+        }),
+        name: 'My alert',
+        message: 'My message template',
+      })
+      .expect(200);
+
+    // Edit surfaces (e.g. the alert detail page) prefill from these
+    // responses, so the notification channel and message template fields must
+    // be present — a PUT that omits name/message clears them.
+    const expected = {
+      channel: { type: 'webhook', webhookId: webhook._id.toString() },
+      name: 'My alert',
+      message: 'My message template',
+    };
+
+    const list = await agent.get('/alerts').expect(200);
+    expect(list.body.data[0]).toMatchObject(expected);
+
+    const single = await agent
+      .get(`/alerts/${alert.body.data._id}`)
+      .expect(200);
+    expect(single.body.data).toMatchObject(expected);
+  });
+
   it('returns 404 when updating an alert that does not exist', async () => {
     const dashboard = await agent
       .post('/dashboards')

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -50,7 +50,10 @@ const formatAlertResponse = (
     createdBy: alert.createdBy
       ? pick(alert.createdBy, ['email', 'name'])
       : undefined,
-    channel: pick(alert.channel, ['type']),
+    // webhookId is included so edit surfaces (e.g. the alert detail page) can
+    // prefill the notification channel; webhook ids are already visible to
+    // team members via GET /webhooks.
+    channel: pick(alert.channel, ['type', 'webhookId']),
     ...(alert.dashboard && {
       dashboardId: alert.dashboard._id,
       dashboard: {
@@ -83,6 +86,8 @@ const formatAlertResponse = (
       'thresholdType',
       'state',
       'source',
+      'name',
+      'message',
       'note',
       'createdAt',
       'updatedAt',

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -19,9 +19,9 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { AckAlert } from '@/components/alerts/AckAlert';
 import { AlertDetailChart } from '@/components/alerts/AlertDetailChart';
+import { AlertDetailProperties } from '@/components/alerts/AlertDetailProperties';
 import { AlertEvaluationsTable } from '@/components/alerts/AlertEvaluationsTable';
 import { AlertHistoryCardList } from '@/components/alerts/AlertHistoryCards';
-import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
 import { AlertStateBadge } from '@/components/alerts/AlertStateBadge';
 import { EditAlertModal } from '@/components/alerts/EditAlertModal';
 import ConfirmDeleteMenu from '@/components/ConfirmDeleteMenu';
@@ -75,7 +75,7 @@ const TIMELINE_ITEMS = 60;
 function AlertProperties({ alert }: { alert: AlertsPageItem }) {
   return (
     <Stack gap={2}>
-      <AlertPropertiesSummary alert={alert} showSchedule />
+      <AlertDetailProperties alert={alert} />
       {alert.note && <AlertNote note={alert.note} />}
     </Stack>
   );

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -212,6 +212,7 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
         alert={alert}
         opened={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
+        dateRange={searchedTimeRange}
       />
       <div style={{ overflow: 'auto', flexGrow: 1 }}>
         <Container size="xl" py="md">

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -13,7 +13,9 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { IconExternalLink } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import { IconExternalLink, IconPencil } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { AckAlert } from '@/components/alerts/AckAlert';
 import { AlertDetailChart } from '@/components/alerts/AlertDetailChart';
@@ -21,6 +23,8 @@ import { AlertEvaluationsTable } from '@/components/alerts/AlertEvaluationsTable
 import { AlertHistoryCardList } from '@/components/alerts/AlertHistoryCards';
 import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
 import { AlertStateBadge } from '@/components/alerts/AlertStateBadge';
+import { EditAlertModal } from '@/components/alerts/EditAlertModal';
+import ConfirmDeleteMenu from '@/components/ConfirmDeleteMenu';
 import EmptyState from '@/components/EmptyState';
 import { PageHeader } from '@/components/PageHeader';
 import { TimePicker } from '@/components/TimePicker';
@@ -79,6 +83,35 @@ function AlertProperties({ alert }: { alert: AlertsPageItem }) {
 
 function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
   const alertUrl = getAlertSourceUrl(alert);
+  const brandName = useBrandDisplayName();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const deleteAlert = api.useDeleteAlert();
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
+
+  const onDeleteAlert = React.useCallback(async () => {
+    try {
+      await deleteAlert.mutateAsync(alert._id);
+      notifications.show({
+        color: 'green',
+        message: 'Alert deleted!',
+        autoClose: 5000,
+      });
+      // The alerts list and the source-bound edit surfaces (saved search
+      // modal / dashboard tile editor) all render this alert.
+      queryClient.invalidateQueries({ queryKey: api.getAlertsQueryKey() });
+      queryClient.invalidateQueries({ queryKey: ['saved-search'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
+      router.push('/alerts');
+    } catch (error) {
+      console.error('Failed to delete alert:', error);
+      notifications.show({
+        color: 'red',
+        message: `Something went wrong. Please contact ${brandName} team.`,
+        autoClose: 5000,
+      });
+    }
+  }, [alert._id, brandName, deleteAlert, queryClient, router]);
 
   // Interval-dependent, but fixed for the page lifetime: the body only
   // mounts once the alert has loaded, and useNewTimeQuery reads the initial
@@ -144,6 +177,16 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
         actions={
           <Group gap="sm" wrap="nowrap">
             <AckAlert alert={alert} />
+            <Button
+              data-testid="edit-alert-button"
+              variant="secondary"
+              size="compact-sm"
+              leftSection={<IconPencil size={14} />}
+              onClick={() => setIsEditModalOpen(true)}
+            >
+              Edit alert
+            </Button>
+            <ConfirmDeleteMenu onDelete={onDeleteAlert} />
             {alertUrl && (
               <Button
                 component={Link}
@@ -164,6 +207,11 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
             />
           </Group>
         }
+      />
+      <EditAlertModal
+        alert={alert}
+        opened={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
       />
       <div style={{ overflow: 'auto', flexGrow: 1 }}>
         <Container size="xl" py="md">

--- a/packages/app/src/components/alerts/AlertDetailProperties.tsx
+++ b/packages/app/src/components/alerts/AlertDetailProperties.tsx
@@ -18,8 +18,8 @@ function PropertyRow({
   testId?: string;
 }) {
   return (
-    <Group gap="sm" align="baseline" wrap="nowrap" data-testid={testId}>
-      <Text size="xs" c="dimmed" miw={110} style={{ flexShrink: 0 }}>
+    <Group gap="xs" align="baseline" wrap="nowrap" data-testid={testId}>
+      <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
         {label}
       </Text>
       <Text size="xs" component="div" style={{ minWidth: 0 }}>

--- a/packages/app/src/components/alerts/AlertDetailProperties.tsx
+++ b/packages/app/src/components/alerts/AlertDetailProperties.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { WebhookService } from '@hyperdx/common-utils/dist/types';
+import { Badge, Group, Text } from '@mantine/core';
+
+import api from '@/api';
+import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
+import type { AlertsPageItem } from '@/types';
+import { FormatTime } from '@/useFormatTime';
+import { isAlertSilenceExpired } from '@/utils/alerts';
+
+function PropertyRow({
+  label,
+  children,
+  testId,
+}: {
+  label: string;
+  children: React.ReactNode;
+  testId?: string;
+}) {
+  return (
+    <Group gap="sm" align="baseline" wrap="nowrap" data-testid={testId}>
+      <Text size="xs" c="dimmed" miw={110} style={{ flexShrink: 0 }}>
+        {label}
+      </Text>
+      <Text size="xs" component="div" style={{ minWidth: 0 }}>
+        {children}
+      </Text>
+    </Group>
+  );
+}
+
+/**
+ * Full alert metadata block for the alert detail page: the shared one-line
+ * summary (threshold, schedule, channel, creator) plus every other persisted
+ * property — name, message template, group-by, schedule anchor/offset,
+ * acknowledgement, tags, and created/updated timestamps. Rows render only
+ * when the field is set.
+ */
+export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
+  // Resolve the notification webhook's display name (the alert only stores
+  // its id). Falls back to the generic "Webhook" label while loading or if
+  // the webhook has been deleted.
+  const { data: webhooks } = api.useWebhooks([
+    WebhookService.Slack,
+    WebhookService.Generic,
+    WebhookService.IncidentIO,
+  ]);
+  const webhookName = React.useMemo(() => {
+    if (!alert.channel.webhookId) {
+      return undefined;
+    }
+    return webhooks?.data?.find(
+      (w: { _id: string; name: string }) => w._id === alert.channel.webhookId,
+    )?.name;
+  }, [webhooks, alert.channel.webhookId]);
+
+  const tags = alert.dashboard?.tags ?? alert.savedSearch?.tags ?? [];
+  const hasScheduleAnchor = alert.scheduleStartAt != null;
+  const hasScheduleOffset =
+    alert.scheduleOffsetMinutes != null && alert.scheduleOffsetMinutes > 0;
+
+  return (
+    <div data-testid="alert-detail-properties">
+      <AlertPropertiesSummary
+        alert={alert}
+        showSchedule
+        webhookName={webhookName}
+      />
+      <div className="d-flex flex-column gap-1 mt-2">
+        {alert.name && (
+          <PropertyRow label="Name" testId="alert-property-name">
+            {alert.name}
+          </PropertyRow>
+        )}
+        {alert.message && (
+          <PropertyRow label="Message template" testId="alert-property-message">
+            {alert.message}
+          </PropertyRow>
+        )}
+        {alert.groupBy && (
+          <PropertyRow label="Grouped by" testId="alert-property-group-by">
+            <Text size="xs" ff="monospace" component="span">
+              {alert.groupBy}
+            </Text>
+          </PropertyRow>
+        )}
+        {(hasScheduleAnchor || hasScheduleOffset) && (
+          <PropertyRow label="Schedule" testId="alert-property-schedule">
+            {hasScheduleAnchor ? (
+              <>
+                Windows anchored at{' '}
+                <FormatTime value={alert.scheduleStartAt!} format="withYear" />
+              </>
+            ) : (
+              <>
+                Offset {alert.scheduleOffsetMinutes}m into each evaluation
+                window
+              </>
+            )}
+          </PropertyRow>
+        )}
+        {alert.silenced && (
+          <PropertyRow label="Acknowledged" testId="alert-property-silenced">
+            {alert.silenced.by ? <>by {alert.silenced.by} · </> : null}
+            {isAlertSilenceExpired(alert.silenced) ? (
+              <>
+                expired <FormatTime value={alert.silenced.until} />
+              </>
+            ) : (
+              <>
+                silenced until <FormatTime value={alert.silenced.until} />
+              </>
+            )}
+          </PropertyRow>
+        )}
+        {tags.length > 0 && (
+          <PropertyRow label="Tags" testId="alert-property-tags">
+            <Group gap={4}>
+              {tags.map(tag => (
+                <Badge key={tag} variant="light" color="gray" size="xs">
+                  {tag}
+                </Badge>
+              ))}
+            </Group>
+          </PropertyRow>
+        )}
+        <PropertyRow label="Created" testId="alert-property-created">
+          <Text size="xs" c="dimmed" component="span">
+            <FormatTime value={alert.createdAt} format="withYear" />
+            {alert.updatedAt && alert.updatedAt !== alert.createdAt && (
+              <>
+                {' '}
+                · Updated{' '}
+                <FormatTime value={alert.updatedAt} format="withYear" />
+              </>
+            )}
+          </Text>
+        </PropertyRow>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -65,8 +65,8 @@ export function AlertPropertiesSummary({
       )}
       <span>&middot;</span>
       <Group gap={5}>
-        Notify via {getWebhookChannelIcon(alert.channel.type)}{' '}
-        {webhookName ?? 'Webhook'}
+        Notify via {getWebhookChannelIcon(alert.channel.type)}
+        <span>{webhookName ?? 'Webhook'}</span>
       </Group>
       {alert.createdBy && (
         <>

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -14,6 +14,12 @@ type AlertPropertiesSummaryProps = {
    * keep the shorter line.
    */
   showSchedule?: boolean;
+  /**
+   * Display name of the notification webhook (the alert only stores its id).
+   * The detail page resolves and passes it; the alerts-page rows keep the
+   * generic "Webhook" label.
+   */
+  webhookName?: string;
 };
 
 /**
@@ -24,6 +30,7 @@ type AlertPropertiesSummaryProps = {
 export function AlertPropertiesSummary({
   alert,
   showSchedule = false,
+  webhookName,
 }: AlertPropertiesSummaryProps) {
   const thresholdLabel =
     TILE_ALERT_THRESHOLD_TYPE_OPTIONS[alert.thresholdType] ??
@@ -58,7 +65,8 @@ export function AlertPropertiesSummary({
       )}
       <span>&middot;</span>
       <Group gap={5}>
-        Notify via {getWebhookChannelIcon(alert.channel.type)} Webhook
+        Notify via {getWebhookChannelIcon(alert.channel.type)}{' '}
+        {webhookName ?? 'Webhook'}
       </Group>
       {alert.createdBy && (
         <>

--- a/packages/app/src/components/alerts/EditAlertModal.tsx
+++ b/packages/app/src/components/alerts/EditAlertModal.tsx
@@ -74,7 +74,7 @@ const EditAlertFormSchema = z
  * the fields this form does not edit (name, message) so a save round-trips
  * them instead of clearing them server-side.
  */
-export function alertToFormValues(alert: AlertsPageItem): Alert {
+function alertToFormValues(alert: AlertsPageItem): Alert {
   const base = {
     id: alert._id,
     interval: alert.interval,

--- a/packages/app/src/components/alerts/EditAlertModal.tsx
+++ b/packages/app/src/components/alerts/EditAlertModal.tsx
@@ -15,6 +15,7 @@ import {
   zAlertChannel,
 } from '@hyperdx/common-utils/dist/types';
 import {
+  Accordion,
   Alert as MantineAlert,
   Button,
   Group,
@@ -25,12 +26,13 @@ import {
   Text,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconInfoCircleFilled } from '@tabler/icons-react';
+import { IconChartLine, IconInfoCircleFilled } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import api from '@/api';
 import { AlertNoteField } from '@/components/AlertNoteField';
 import { AlertChannelForm } from '@/components/Alerts';
+import { AlertDetailChart } from '@/components/alerts/AlertDetailChart';
 import { AlertScheduleFields } from '@/components/AlertScheduleFields';
 import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
 import { useSavedSearch } from '@/savedSearch';
@@ -126,10 +128,13 @@ export function EditAlertModal({
   alert,
   opened,
   onClose,
+  dateRange,
 }: {
   alert: AlertsPageItem;
   opened: boolean;
   onClose: () => void;
+  /** Time range for the threshold preview chart (the detail page's picked range). */
+  dateRange: [Date, Date];
 }) {
   const brandName = useBrandDisplayName();
   const queryClient = useQueryClient();
@@ -192,6 +197,30 @@ export function EditAlertModal({
     ? TILE_ALERT_THRESHOLD_TYPE_OPTIONS
     : ALERT_THRESHOLD_TYPE_OPTIONS;
   const intervalLabel = ALERT_INTERVAL_OPTIONS[interval ?? '5m'];
+
+  // Live threshold preview: AlertDetailChart reads everything off the alert
+  // object, so overlay the watched form values onto the persisted alert. The
+  // chart uses the detail page's picked time range (passed via `dateRange`)
+  // so the preview matches the chart behind the modal.
+  const previewAlert = React.useMemo<AlertsPageItem>(
+    () => ({
+      ...alert,
+      interval: interval ?? alert.interval,
+      threshold: threshold ?? alert.threshold,
+      thresholdMax,
+      thresholdType: thresholdType ?? alert.thresholdType,
+      ...(!isTileAlert && { groupBy: groupBy || undefined }),
+    }),
+    [
+      alert,
+      interval,
+      threshold,
+      thresholdMax,
+      thresholdType,
+      groupBy,
+      isTileAlert,
+    ],
+  );
 
   const onSubmit = handleSubmit(async data => {
     // Faithful view of which schedule keys the persisted alert actually has
@@ -257,7 +286,7 @@ export function EditAlertModal({
       opened={opened}
       onClose={onClose}
       title="Edit Alert"
-      size="lg"
+      size="xl"
     >
       <form onSubmit={onSubmit}>
         <Stack gap="xs">
@@ -406,6 +435,16 @@ export function EditAlertModal({
             </MantineAlert>
           )}
         </Stack>
+        <Accordion defaultValue="chart" mt="sm" mx={-16}>
+          <Accordion.Item value="chart">
+            <Accordion.Control icon={<IconChartLine size={16} />}>
+              <Text size="sm">Threshold chart</Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <AlertDetailChart alert={previewAlert} dateRange={dateRange} />
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
         <Group mt="lg" justify="flex-end" gap="xs">
           <Button variant="secondary" onClick={onClose}>
             Cancel

--- a/packages/app/src/components/alerts/EditAlertModal.tsx
+++ b/packages/app/src/components/alerts/EditAlertModal.tsx
@@ -1,0 +1,424 @@
+import * as React from 'react';
+import { Controller, useForm, useWatch } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
+import {
+  type Alert,
+  AlertIntervalSchema,
+  AlertSource,
+  AlertThresholdType,
+  isRangeThresholdType,
+  scheduleStartAtSchema,
+  validateAlertScheduleOffsetMinutes,
+  validateAlertThresholdMax,
+  zAlertChannel,
+} from '@hyperdx/common-utils/dist/types';
+import {
+  Alert as MantineAlert,
+  Button,
+  Group,
+  Modal,
+  NativeSelect,
+  NumberInput,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconInfoCircleFilled } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import api from '@/api';
+import { AlertNoteField } from '@/components/AlertNoteField';
+import { AlertChannelForm } from '@/components/Alerts';
+import { AlertScheduleFields } from '@/components/AlertScheduleFields';
+import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
+import { useSavedSearch } from '@/savedSearch';
+import { useSource } from '@/source';
+import { useBrandDisplayName } from '@/theme/ThemeProvider';
+import type { AlertsPageItem } from '@/types';
+import { optionsToSelectData } from '@/utils';
+import {
+  ALERT_CHANNEL_OPTIONS,
+  ALERT_INTERVAL_OPTIONS,
+  ALERT_THRESHOLD_TYPE_OPTIONS,
+  intervalToMinutes,
+  normalizeNoOpAlertScheduleFields,
+  TILE_ALERT_INTERVAL_OPTIONS,
+  TILE_ALERT_THRESHOLD_TYPE_OPTIONS,
+} from '@/utils/alerts';
+
+// Same validation as the saved-search alert modal: only the fields this form
+// edits are validated; everything else (source discriminator fields, name,
+// message, ...) passes through untouched so a save never drops them.
+const EditAlertFormSchema = z
+  .object({
+    interval: AlertIntervalSchema,
+    threshold: z.number(),
+    thresholdMax: z.number().optional(),
+    scheduleOffsetMinutes: z.number().int().min(0).default(0),
+    scheduleStartAt: scheduleStartAtSchema,
+    thresholdType: z.nativeEnum(AlertThresholdType),
+    channel: zAlertChannel,
+    // nullish() (not optional()): persisted alerts store this as null, which
+    // optional() would reject.
+    numConsecutiveWindows: z.number().int().min(1).nullish(),
+  })
+  .passthrough()
+  .superRefine(validateAlertScheduleOffsetMinutes)
+  .superRefine(validateAlertThresholdMax);
+
+/**
+ * Map the alert detail response onto the update (PUT) payload shape. Carries
+ * the source discriminator fields (savedSearchId / dashboardId + tileId) and
+ * the fields this form does not edit (name, message) so a save round-trips
+ * them instead of clearing them server-side.
+ */
+export function alertToFormValues(alert: AlertsPageItem): Alert {
+  const base = {
+    id: alert._id,
+    interval: alert.interval,
+    threshold: alert.threshold,
+    thresholdMax: alert.thresholdMax,
+    thresholdType: alert.thresholdType,
+    scheduleOffsetMinutes: alert.scheduleOffsetMinutes ?? 0,
+    scheduleStartAt:
+      alert.scheduleStartAt == null
+        ? null
+        : typeof alert.scheduleStartAt === 'string'
+          ? alert.scheduleStartAt
+          : alert.scheduleStartAt.toISOString(),
+    channel: {
+      type: 'webhook' as const,
+      webhookId: alert.channel.webhookId ?? '',
+    },
+    name: alert.name ?? null,
+    message: alert.message ?? null,
+    note: alert.note ?? null,
+    // Persisted null -> undefined for the NumberInput.
+    numConsecutiveWindows: alert.numConsecutiveWindows ?? undefined,
+  };
+
+  if (alert.source === AlertSource.TILE) {
+    return {
+      ...base,
+      source: AlertSource.TILE,
+      dashboardId: alert.dashboardId ?? '',
+      tileId: alert.tileId ?? '',
+    };
+  }
+
+  return {
+    ...base,
+    source: AlertSource.SAVED_SEARCH,
+    savedSearchId: alert.savedSearchId ?? '',
+    groupBy: alert.groupBy,
+  };
+}
+
+/**
+ * Modal for editing an alert's configuration from the alert detail page.
+ * Works for both saved-search and tile alerts; saved-search alerts
+ * additionally expose the group-by expression (tile alerts derive grouping
+ * from the chart config).
+ */
+export function EditAlertModal({
+  alert,
+  opened,
+  onClose,
+}: {
+  alert: AlertsPageItem;
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const brandName = useBrandDisplayName();
+  const queryClient = useQueryClient();
+  const updateAlert = api.useUpdateAlert();
+
+  const isTileAlert = alert.source === AlertSource.TILE;
+
+  // The group-by SQL editor needs the saved search's source table for
+  // autocomplete (same lookup as the detail chart).
+  const { data: savedSearch } = useSavedSearch(
+    { id: alert.savedSearchId ?? '' },
+    { enabled: !isTileAlert && alert.savedSearchId != null },
+  );
+  const { data: source } = useSource({ id: savedSearch?.source });
+
+  const defaultValues = React.useMemo(() => alertToFormValues(alert), [alert]);
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { dirtyFields },
+  } = useForm<Alert>({
+    defaultValues,
+    resolver: zodResolver(EditAlertFormSchema),
+  });
+
+  // Re-sync the form when the modal is (re)opened or the alert refreshes
+  // while closed, without clobbering in-progress edits.
+  React.useEffect(() => {
+    if (!opened) {
+      reset(defaultValues);
+    }
+  }, [opened, defaultValues, reset]);
+
+  const thresholdType = useWatch({ control, name: 'thresholdType' });
+  const threshold = useWatch({ control, name: 'threshold' });
+  const thresholdMax = useWatch({ control, name: 'thresholdMax' });
+  const channelType = useWatch({ control, name: 'channel.type' });
+  const interval = useWatch({ control, name: 'interval' });
+  const groupBy = useWatch({ control, name: 'groupBy' });
+  const scheduleOffsetMinutes = useWatch({
+    control,
+    name: 'scheduleOffsetMinutes',
+  });
+  const numConsecutiveWindows = useWatch({
+    control,
+    name: 'numConsecutiveWindows',
+  });
+
+  const maxScheduleOffsetMinutes = Math.max(
+    intervalToMinutes(interval ?? '5m') - 1,
+    0,
+  );
+  const intervalOptions = isTileAlert
+    ? TILE_ALERT_INTERVAL_OPTIONS
+    : ALERT_INTERVAL_OPTIONS;
+  const thresholdTypeOptions = isTileAlert
+    ? TILE_ALERT_THRESHOLD_TYPE_OPTIONS
+    : ALERT_THRESHOLD_TYPE_OPTIONS;
+  const intervalLabel = ALERT_INTERVAL_OPTIONS[interval ?? '5m'];
+
+  const onSubmit = handleSubmit(async data => {
+    // Faithful view of which schedule keys the persisted alert actually has
+    // (the detail response omits absent keys), so no-op schedule writes are
+    // skipped for pre-migration alerts that never had them.
+    const previousScheduleFields: {
+      scheduleOffsetMinutes?: number;
+      scheduleStartAt?: string | null;
+    } = {
+      ...(alert.scheduleOffsetMinutes !== undefined && {
+        scheduleOffsetMinutes: alert.scheduleOffsetMinutes,
+      }),
+      ...(alert.scheduleStartAt !== undefined && {
+        scheduleStartAt:
+          alert.scheduleStartAt == null
+            ? null
+            : typeof alert.scheduleStartAt === 'string'
+              ? alert.scheduleStartAt
+              : alert.scheduleStartAt.toISOString(),
+      }),
+    };
+    const payload = normalizeNoOpAlertScheduleFields(
+      // `id` is not a registered form field, so carry it from the alert this
+      // modal was opened with.
+      { ...data, id: alert._id },
+      previousScheduleFields,
+      {
+        preserveExplicitScheduleOffsetMinutes:
+          dirtyFields.scheduleOffsetMinutes === true,
+        preserveExplicitScheduleStartAt: dirtyFields.scheduleStartAt === true,
+      },
+    );
+    try {
+      await updateAlert.mutateAsync({ ...payload, id: alert._id });
+      notifications.show({
+        color: 'green',
+        message: 'Alert updated!',
+        autoClose: 5000,
+      });
+      // The detail page, alerts list, and the source-bound edit surfaces
+      // (saved search modal / dashboard tile editor) all render this alert.
+      queryClient.invalidateQueries({
+        queryKey: api.getAlertQueryKey(alert._id),
+      });
+      queryClient.invalidateQueries({ queryKey: api.getAlertsQueryKey() });
+      queryClient.invalidateQueries({ queryKey: ['saved-search'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
+      onClose();
+    } catch (error) {
+      // Keep the modal open so the user's edits aren't lost.
+      console.error('Error updating alert:', error);
+      notifications.show({
+        color: 'red',
+        message: `Something went wrong. Please contact ${brandName} team.`,
+        autoClose: 5000,
+      });
+    }
+  });
+
+  return (
+    <Modal
+      data-testid="edit-alert-modal"
+      opened={opened}
+      onClose={onClose}
+      title="Edit Alert"
+      size="lg"
+    >
+      <form onSubmit={onSubmit}>
+        <Stack gap="xs">
+          <Text size="xxs" opacity={0.5}>
+            Trigger
+          </Text>
+          <Group gap="xs">
+            <Text size="sm" opacity={0.7}>
+              {isTileAlert ? 'Alert when the value' : 'Alert when'}
+            </Text>
+            <Controller
+              control={control}
+              name="thresholdType"
+              render={({ field }) => (
+                <NativeSelect
+                  data={optionsToSelectData(thresholdTypeOptions)}
+                  size="xs"
+                  {...field}
+                  onChange={e => {
+                    field.onChange(e);
+                    if (
+                      isRangeThresholdType(e.currentTarget.value) &&
+                      thresholdMax == null
+                    ) {
+                      setValue('thresholdMax', (threshold ?? 0) + 1);
+                    }
+                  }}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="threshold"
+              render={({ field }) => (
+                <NumberInput size="xs" w={80} {...field} />
+              )}
+            />
+            {isRangeThresholdType(thresholdType as AlertThresholdType) && (
+              <>
+                <Text size="sm" opacity={0.7}>
+                  and
+                </Text>
+                <Controller
+                  control={control}
+                  name="thresholdMax"
+                  render={({ field, fieldState }) => (
+                    <NumberInput
+                      size="xs"
+                      w={80}
+                      {...field}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </>
+            )}
+            <Text size="sm" opacity={0.7}>
+              {isTileAlert ? 'over' : 'lines appear within'}
+            </Text>
+            <Controller
+              control={control}
+              name="interval"
+              render={({ field }) => (
+                <NativeSelect
+                  data={optionsToSelectData(intervalOptions)}
+                  size="xs"
+                  {...field}
+                />
+              )}
+            />
+            <Text size="sm" opacity={0.7}>
+              via
+            </Text>
+            <Controller
+              control={control}
+              name="channel.type"
+              render={({ field }) => (
+                <NativeSelect
+                  data={optionsToSelectData(ALERT_CHANNEL_OPTIONS)}
+                  size="xs"
+                  {...field}
+                />
+              )}
+            />
+          </Group>
+          <AlertScheduleFields
+            control={control}
+            setValue={setValue}
+            scheduleOffsetName="scheduleOffsetMinutes"
+            scheduleStartAtName="scheduleStartAt"
+            scheduleOffsetMinutes={scheduleOffsetMinutes}
+            maxScheduleOffsetMinutes={maxScheduleOffsetMinutes}
+            offsetWindowLabel={`from each ${intervalLabel} window`}
+            numConsecutiveWindowsName="numConsecutiveWindows"
+            numConsecutiveWindows={numConsecutiveWindows ?? undefined}
+          />
+          {!isTileAlert && (
+            <>
+              <Text size="xxs" opacity={0.5} mb={4} mt="xs">
+                grouped by
+              </Text>
+              <SQLInlineEditorControlled
+                tableConnection={tcFromSource(source)}
+                control={control}
+                name="groupBy"
+                placeholder="SQL Columns"
+                disableKeywordAutocomplete
+                size="xs"
+              />
+            </>
+          )}
+          <Text size="xxs" opacity={0.5} mb={4}>
+            Send to
+          </Text>
+          <AlertChannelForm control={control} type={channelType} />
+          <AlertNoteField control={control} name="note" />
+          {!isTileAlert &&
+            groupBy &&
+            (thresholdType === AlertThresholdType.BELOW ||
+              thresholdType === AlertThresholdType.BELOW_OR_EQUAL ||
+              thresholdType === AlertThresholdType.EQUAL ||
+              thresholdType === AlertThresholdType.NOT_EQUAL) && (
+              <MantineAlert
+                icon={<IconInfoCircleFilled size={16} />}
+                color="gray"
+                py="xs"
+              >
+                <Text size="sm" opacity={0.7}>
+                  Warning: Alerts with this threshold type and a &quot;grouped
+                  by&quot; value will not alert for periods with no data for a
+                  group.
+                </Text>
+              </MantineAlert>
+            )}
+          {(thresholdType === AlertThresholdType.EQUAL ||
+            thresholdType === AlertThresholdType.NOT_EQUAL) && (
+            <MantineAlert
+              icon={<IconInfoCircleFilled size={16} />}
+              color="gray"
+              py="xs"
+            >
+              <Text size="sm" opacity={0.7}>
+                Note: Floating-point query results are not rounded during
+                equality comparison.
+              </Text>
+            </MantineAlert>
+          )}
+        </Stack>
+        <Group mt="lg" justify="flex-end" gap="xs">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            type="submit"
+            loading={updateAlert.isPending}
+          >
+            Save Alert
+          </Button>
+        </Group>
+      </form>
+    </Modal>
+  );
+}

--- a/packages/app/src/components/alerts/__tests__/AlertDetailProperties.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertDetailProperties.test.tsx
@@ -1,0 +1,147 @@
+import {
+  AlertSource,
+  AlertThresholdType,
+} from '@hyperdx/common-utils/dist/types';
+import { screen } from '@testing-library/react';
+
+import { AlertDetailProperties } from '@/components/alerts/AlertDetailProperties';
+import type { AlertsPageItem } from '@/types';
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useWebhooks: () => ({
+      data: {
+        data: [
+          { _id: 'webhook-id', name: 'Team Slack' },
+          { _id: 'other-webhook', name: 'Other' },
+        ],
+      },
+    }),
+  },
+}));
+
+// Render raw ISO timestamps so time assertions don't depend on the test
+// runner's timezone or the user's clock-format preference.
+jest.mock('@/useFormatTime', () => ({
+  FormatTime: ({ value }: { value?: number | string | Date }) =>
+    value ? new Date(value).toISOString() : null,
+}));
+
+const baseAlert = {
+  _id: 'alert-1',
+  interval: '5m',
+  threshold: 3,
+  thresholdType: AlertThresholdType.ABOVE,
+  source: AlertSource.SAVED_SEARCH,
+  savedSearchId: 'saved-search-id',
+  channel: { type: 'webhook', webhookId: 'webhook-id' },
+  note: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-02-01T00:00:00.000Z',
+  history: [],
+} as unknown as AlertsPageItem;
+
+describe('AlertDetailProperties', () => {
+  it('renders all persisted metadata fields when set', () => {
+    renderWithMantine(
+      <AlertDetailProperties
+        alert={
+          {
+            ...baseAlert,
+            name: 'CPU alert',
+            message: 'CPU is high on {{group}}',
+            groupBy: 'ServiceName',
+            scheduleOffsetMinutes: 3,
+            silenced: {
+              by: 'user@example.com',
+              at: '2026-03-01T00:00:00.000Z',
+              // Far future so the silence reads as active, not expired.
+              until: '2099-01-01T00:00:00.000Z',
+            },
+            savedSearch: {
+              _id: 'saved-search-id',
+              name: 'My Search',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+              tags: ['prod', 'payments'],
+            },
+          } as AlertsPageItem
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('alert-property-name')).toHaveTextContent(
+      'CPU alert',
+    );
+    expect(screen.getByTestId('alert-property-message')).toHaveTextContent(
+      'CPU is high on {{group}}',
+    );
+    expect(screen.getByTestId('alert-property-group-by')).toHaveTextContent(
+      'ServiceName',
+    );
+    expect(screen.getByTestId('alert-property-schedule')).toHaveTextContent(
+      'Offset 3m into each evaluation window',
+    );
+    expect(screen.getByTestId('alert-property-silenced')).toHaveTextContent(
+      'by user@example.com · silenced until 2099-01-01T00:00:00.000Z',
+    );
+    expect(screen.getByTestId('alert-property-tags')).toHaveTextContent(
+      'prodpayments',
+    );
+    expect(screen.getByTestId('alert-property-created')).toHaveTextContent(
+      '2026-01-01T00:00:00.000Z · Updated 2026-02-01T00:00:00.000Z',
+    );
+    // The summary line resolves the webhook id to its display name.
+    expect(screen.getByText(/Team Slack/)).toBeInTheDocument();
+  });
+
+  it('omits rows for unset fields and marks expired silences', () => {
+    renderWithMantine(
+      <AlertDetailProperties
+        alert={
+          {
+            ...baseAlert,
+            silenced: {
+              by: 'user@example.com',
+              at: '2020-01-01T00:00:00.000Z',
+              until: '2020-01-02T00:00:00.000Z',
+            },
+          } as AlertsPageItem
+        }
+      />,
+    );
+
+    expect(screen.queryByTestId('alert-property-name')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('alert-property-message'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('alert-property-group-by'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('alert-property-schedule'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('alert-property-tags')).not.toBeInTheDocument();
+    expect(screen.getByTestId('alert-property-silenced')).toHaveTextContent(
+      'expired 2020-01-02T00:00:00.000Z',
+    );
+  });
+
+  it('renders a schedule anchor when scheduleStartAt is set', () => {
+    renderWithMantine(
+      <AlertDetailProperties
+        alert={
+          {
+            ...baseAlert,
+            scheduleStartAt: '2026-01-15T09:00:00.000Z',
+          } as AlertsPageItem
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('alert-property-schedule')).toHaveTextContent(
+      'Windows anchored at 2026-01-15T09:00:00.000Z',
+    );
+  });
+});

--- a/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
@@ -50,6 +50,24 @@ jest.mock('@/components/SQLEditor/SQLInlineEditor', () => ({
   __esModule: true,
   SQLInlineEditorControlled: () => <div data-testid="sql-inline-editor" />,
 }));
+// The threshold preview stub surfaces the live values it was rendered with so
+// tests can assert the form -> preview wiring.
+jest.mock('@/components/alerts/AlertDetailChart', () => ({
+  __esModule: true,
+  AlertDetailChart: ({
+    alert,
+    dateRange,
+  }: {
+    alert: { threshold: number };
+    dateRange: [Date, Date];
+  }) => (
+    <div
+      data-testid="alert-detail-chart"
+      data-threshold={alert.threshold}
+      data-date-range={dateRange.map(d => d.toISOString()).join('/')}
+    />
+  ),
+}));
 
 // The persisted alert shape returned by GET /alerts/:id (fields the form
 // doesn't edit — name, message — must round-trip through a save).
@@ -83,13 +101,23 @@ const tileAlert = {
   tileId: 'tile-id',
 } as AlertsPageItem;
 
+const dateRange: [Date, Date] = [
+  new Date('2026-05-01T00:00:00.000Z'),
+  new Date('2026-05-02T00:00:00.000Z'),
+];
+
 const renderModal = (alert: AlertsPageItem) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return renderWithMantine(
     <QueryClientProvider client={queryClient}>
-      <EditAlertModal alert={alert} opened onClose={jest.fn()} />
+      <EditAlertModal
+        alert={alert}
+        opened
+        onClose={jest.fn()}
+        dateRange={dateRange}
+      />
     </QueryClientProvider>,
   );
 };
@@ -162,6 +190,25 @@ describe('EditAlertModal', () => {
 
     expect(updateAlertMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ threshold: 42 }),
+    );
+  });
+
+  it('renders a threshold preview driven by live form values and the page time range', () => {
+    renderModal(savedSearchAlert);
+
+    const chart = screen.getByTestId('alert-detail-chart');
+    expect(chart).toHaveAttribute('data-threshold', '3');
+    expect(chart).toHaveAttribute(
+      'data-date-range',
+      '2026-05-01T00:00:00.000Z/2026-05-02T00:00:00.000Z',
+    );
+
+    // Editing the threshold updates the preview immediately (pre-save).
+    const thresholdInput = screen.getByDisplayValue('3');
+    fireEvent.change(thresholdInput, { target: { value: '42' } });
+    expect(screen.getByTestId('alert-detail-chart')).toHaveAttribute(
+      'data-threshold',
+      '42',
     );
   });
 });

--- a/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
@@ -1,0 +1,167 @@
+import {
+  AlertSource,
+  AlertThresholdType,
+} from '@hyperdx/common-utils/dist/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { EditAlertModal } from '@/components/alerts/EditAlertModal';
+import type { AlertsPageItem } from '@/types';
+
+const updateAlertMutateAsync = jest.fn().mockResolvedValue({ data: {} });
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useUpdateAlert: () => ({
+      mutateAsync: updateAlertMutateAsync,
+      isPending: false,
+    }),
+    getAlertQueryKey: (alertId: string | undefined) => ['alert', alertId],
+    getAlertsQueryKey: () => ['alerts'],
+  },
+}));
+
+jest.mock('@/savedSearch', () => ({
+  __esModule: true,
+  useSavedSearch: () => ({
+    data: { id: 'saved-search-id', source: 'source-id' },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/source', () => ({
+  __esModule: true,
+  useSource: () => ({ data: undefined }),
+}));
+
+jest.mock('@/theme/ThemeProvider', () => ({
+  __esModule: true,
+  useBrandDisplayName: () => 'HyperDX',
+}));
+
+// Heavy / visual child components are stubbed so the form still renders and
+// its submit handler runs.
+jest.mock('@/components/Alerts', () => ({
+  __esModule: true,
+  AlertChannelForm: () => <div data-testid="alert-channel-form" />,
+}));
+jest.mock('@/components/SQLEditor/SQLInlineEditor', () => ({
+  __esModule: true,
+  SQLInlineEditorControlled: () => <div data-testid="sql-inline-editor" />,
+}));
+
+// The persisted alert shape returned by GET /alerts/:id (fields the form
+// doesn't edit — name, message — must round-trip through a save).
+const baseAlert = {
+  _id: '6a5163af632ecadec80ec00e',
+  interval: '5m',
+  threshold: 3,
+  thresholdType: AlertThresholdType.ABOVE,
+  channel: { type: 'webhook', webhookId: 'webhook-id' },
+  name: 'My alert',
+  message: 'My message template',
+  note: null,
+  numConsecutiveWindows: null,
+  scheduleStartAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  history: [],
+} satisfies Partial<AlertsPageItem>;
+
+const savedSearchAlert = {
+  ...baseAlert,
+  source: AlertSource.SAVED_SEARCH,
+  savedSearchId: 'saved-search-id',
+  groupBy: 'ServiceName',
+} as AlertsPageItem;
+
+const tileAlert = {
+  ...baseAlert,
+  source: AlertSource.TILE,
+  dashboardId: 'dashboard-id',
+  tileId: 'tile-id',
+} as AlertsPageItem;
+
+const renderModal = (alert: AlertsPageItem) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderWithMantine(
+    <QueryClientProvider client={queryClient}>
+      <EditAlertModal alert={alert} opened onClose={jest.fn()} />
+    </QueryClientProvider>,
+  );
+};
+
+const submitForm = async () => {
+  const saveButton = await screen.findByText('Save Alert');
+  fireEvent.click(saveButton.closest('button') as HTMLButtonElement);
+  await waitFor(() => {
+    expect(updateAlertMutateAsync).toHaveBeenCalledTimes(1);
+  });
+};
+
+describe('EditAlertModal', () => {
+  beforeEach(() => {
+    updateAlertMutateAsync.mockClear();
+  });
+
+  it('saves a saved-search alert with the source discriminator and preserved fields', async () => {
+    renderModal(savedSearchAlert);
+
+    // Saved-search alerts expose the group-by editor.
+    expect(screen.getByTestId('sql-inline-editor')).toBeInTheDocument();
+
+    await submitForm();
+
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: savedSearchAlert._id,
+        source: AlertSource.SAVED_SEARCH,
+        savedSearchId: 'saved-search-id',
+        groupBy: 'ServiceName',
+        threshold: 3,
+        interval: '5m',
+        channel: { type: 'webhook', webhookId: 'webhook-id' },
+        // Fields the form doesn't edit must be carried through — the PUT
+        // clears any that are omitted.
+        name: 'My alert',
+        message: 'My message template',
+      }),
+    );
+  });
+
+  it('saves a tile alert with dashboardId + tileId and no group-by editor', async () => {
+    renderModal(tileAlert);
+
+    // Tile alerts derive grouping from the chart config.
+    expect(screen.queryByTestId('sql-inline-editor')).not.toBeInTheDocument();
+
+    await submitForm();
+
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: tileAlert._id,
+        source: AlertSource.TILE,
+        dashboardId: 'dashboard-id',
+        tileId: 'tile-id',
+        name: 'My alert',
+        message: 'My message template',
+      }),
+    );
+  });
+
+  it('updates edited threshold values in the PUT payload', async () => {
+    renderModal(savedSearchAlert);
+
+    const thresholdInput = screen.getByDisplayValue('3');
+    fireEvent.change(thresholdInput, { target: { value: '42' } });
+
+    await submitForm();
+
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ threshold: 42 }),
+    );
+  });
+});

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -2250,7 +2250,10 @@ export const AlertsPageItemSchema = z.object({
   threshold: z.number(),
   thresholdMax: z.number().optional(),
   thresholdType: z.nativeEnum(AlertThresholdType),
-  channel: z.object({ type: z.string().optional().nullable() }),
+  channel: z.object({
+    type: z.string().optional().nullable(),
+    webhookId: z.string().optional(),
+  }),
   state: z.nativeEnum(AlertState).optional(),
   source: z.nativeEnum(AlertSource).optional(),
   dashboardId: z.string().optional(),


### PR DESCRIPTION
## Summary

Allows users to **edit an alert's configuration and delete the alert directly from the alert details page** (`/alerts/[alertId]`, behind `NEXT_PUBLIC_ENABLE_ALERT_DETAILS`), instead of having to navigate back to the saved search modal or dashboard tile editor.

**App:**

- New `EditAlertModal` opened from an "Edit alert" header action. Edits threshold type/value(s), evaluation interval, schedule (offset / start anchor / consecutive windows), notification webhook, and note for both saved-search and tile alerts. Saved-search alerts additionally expose the group-by SQL expression (tile alerts derive grouping from the chart config), with autocomplete backed by the saved search's source.
- New "Delete" header action using the existing `ConfirmDeleteMenu` confirmation pattern; on success it redirects back to `/alerts`.
- Saves validate via the same zod schema as the existing saved-search alert modal, invalidate the alert/alerts/saved-search/dashboards queries so the details view reflects changes immediately, and keep the modal open on error (with a notification) so edits aren't lost.

**API / common-utils:**

- `GET /alerts` and `GET /alerts/:id` now include `channel.webhookId` plus the alert's `name`/`message` template. Without these, the edit form couldn't prefill the webhook selector, and a save would silently clear `name`/`message` (the PUT nulls omitted fields). Webhook ids are already visible to team members via `GET /webhooks`, so this is not new exposure.
- `AlertsPageItemSchema.channel` gains an optional `webhookId`.

Edits and deletes go through the existing team-scoped `PUT/DELETE /alerts/:id` endpoints, so existing permission enforcement applies unchanged.

### Screenshots or video

| Before | After |
| :----- | :---- |
|        | Alert details header gains "Edit alert" (opens config modal) and "Delete" (confirm menu) actions |

### How to test on Vercel preview

N/A — non-testable in preview: alerts require cloud mode (LOCAL_MODE has no alert API), and the alert details page is gated behind `NEXT_PUBLIC_ENABLE_ALERT_DETAILS`.

### References

- Linear Issue: [HDX-5089](https://linear.app/clickhouse/issue/HDX-5089/allow-users-to-edit-alert-configs-from-the-alert-details-page)
- Related PRs: N/A

### Testing

- `make ci-lint` — passes (0 errors)
- `make ci-unit` — passes across all packages, including new `EditAlertModal` unit tests (saved-search payload with preserved name/message/webhookId, tile payload with dashboardId+tileId, edited threshold round-trip)
- `make dev-int FILE=alerts.int` — all 288 alert-router integration tests pass, including a new test asserting `channel.webhookId`/`name`/`message` are returned by GET list and GET single

### Screenshots
<img width="1414" height="461" alt="image" src="https://github.com/user-attachments/assets/d66785fd-5187-43e0-8be6-bdfd0e3c643f" />
<img width="1461" height="838" alt="image" src="https://github.com/user-attachments/assets/191f112a-0a50-4a23-b13b-33e8b3178f91" />

