### PR TITLE
fix(mcp): populate StatusMessage on failed tool calls

### DIFF
--- a/.changeset/mcp-tool-error-status-message.md
+++ b/.changeset/mcp-tool-error-status-message.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+fix: populate the span StatusMessage on failed MCP tool calls so the error text is visible in the trace

--- a/packages/api/src/mcp/__tests__/tracing.test.ts
+++ b/packages/api/src/mcp/__tests__/tracing.test.ts
@@ -233,9 +233,60 @@ describe('withToolTracing', () => {
     const traced = withToolTracing('my_tool', context, handler);
     await traced({});
 
-    expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 2 }); // SpanStatusCode.ERROR
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: 2, // SpanStatusCode.ERROR
+      message: 'something went wrong',
+    });
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('mcp.tool.error', true);
     expect(mockSpan.end).toHaveBeenCalled();
+  });
+
+  it('should join all text blocks into the ERROR status message', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      isError: true,
+      content: [
+        { type: 'text', text: 'Query failed' },
+        { type: 'text', text: 'timeout after 10000ms' },
+      ],
+    });
+
+    const traced = withToolTracing('my_tool', context, handler);
+    await traced({});
+
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: 'Query failed\ntimeout after 10000ms',
+    });
+  });
+
+  it('should truncate a long ERROR status message', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      isError: true,
+      content: [{ type: 'text', text: 'x'.repeat(600) }],
+    });
+
+    const traced = withToolTracing('my_tool', context, handler);
+    await traced({});
+
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: `${'x'.repeat(512)}...`,
+    });
+  });
+
+  it('should omit the status message when the error has no text', async () => {
+    const handler = jest.fn().mockResolvedValue({
+      isError: true,
+      content: [{ type: 'text', text: '   ' }],
+    });
+
+    const traced = withToolTracing('my_tool', context, handler);
+    await traced({});
+
+    expect(mockSpan.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: undefined,
+    });
   });
 
   it('should set ERROR status and re-throw on handler exception', async () => {

--- a/packages/api/src/mcp/utils/tracing.ts
+++ b/packages/api/src/mcp/utils/tracing.ts
@@ -21,6 +21,31 @@ const toolErrorCounter = getCounter('hyperdx.mcp.tool.errors', {
     'Count of MCP tool invocations that returned an error or threw an exception.',
 });
 
+/** Keeps a runaway error body from becoming the whole span status message. */
+const MAX_STATUS_MESSAGE_LENGTH = 512;
+
+/**
+ * Flatten a tool result's text blocks into a span status message. Tool errors
+ * carry their explanation in `content`, so without this the span shows
+ * StatusCode=Error with an empty StatusMessage.
+ */
+function toStatusMessage(
+  content: { text?: string }[] | undefined,
+): string | undefined {
+  // Defensive on both counts: tracing must never turn a tool error into a
+  // crash, and handlers reach this through a cast in the SDK's callback type.
+  const text = (content ?? [])
+    .map(block => block?.text ?? '')
+    .join('\n')
+    .trim();
+  if (!text) {
+    return undefined;
+  }
+  return text.length > MAX_STATUS_MESSAGE_LENGTH
+    ? `${text.slice(0, MAX_STATUS_MESSAGE_LENGTH)}...`
+    : text;
+}
+
 /**
  * Wraps an MCP tool handler with tracing, metrics, and structured logging.
  * Creates a span for each tool invocation and logs start/end with duration.
@@ -71,7 +96,12 @@ export function withToolTracing<TArgs>(
             const errorCategory: McpErrorCategory =
               getErrorCategory(result as McpErrorResult) ?? 'server';
 
-            span.setStatus({ code: SpanStatusCode.ERROR });
+            const errorMessage = toStatusMessage(result.content);
+
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: errorMessage,
+            });
             span.setAttribute('mcp.tool.error', true);
             span.setAttribute('mcp.tool.error_category', errorCategory);
             toolErrorCounter.add(1, {
@@ -79,7 +109,7 @@ export function withToolTracing<TArgs>(
               error_category: errorCategory,
             });
             logger.warn(
-              { ...logContext, durationMs, errorCategory },
+              { ...logContext, durationMs, errorCategory, errorMessage },
               `MCP tool error: ${toolName}`,
             );
           } else {


### PR DESCRIPTION
When an MCP tool returns an error result, the span was marked `StatusCode=Error` with an empty `StatusMessage`, so a trace showed that a tool failed but not why. The explanation was already sitting in the tool result's text content blocks — nothing read it.

## What changed

- Failed tool calls now set the span status message from the result's text content blocks, joined with newlines and capped at 512 characters.
- The same text is included in the `MCP tool error` warn log as `errorMessage`.

The thrown-exception path already got its status message from `withSpan`, so only the non-throwing `isError` path needed fixing.

## Impact

Error text from tool results now lands in trace data and logs. That text is written by our own tool handlers, but some of it wraps ClickHouse or Mongo error messages, which can include fragments of the query being run.

<details>
<summary>Implementation detail</summary>

`toStatusMessage` in `packages/api/src/mcp/utils/tracing.ts` flattens the content blocks. It tolerates missing `content` and blocks without `text`: handlers reach the tracing wrapper through a cast in the SDK's callback type, and instrumentation should never be what turns a tool error into a crash. An error with no usable text leaves the status message unset rather than setting an empty string.

Covered in `packages/api/src/mcp/__tests__/tracing.test.ts`: single block, multiple blocks joined, truncation past 512 characters, and whitespace-only content.

</details>