### PR TITLE
feat: Add dashboard variables to external API

### DIFF
--- a/.changeset/external-api-dashboard-filter-variables.md
+++ b/.changeset/external-api-dashboard-filter-variables.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+'@hyperdx/common-utils': patch
+---
+
+feat: Add dashboard variable properties to external dashboards API

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -2908,7 +2908,7 @@
       },
       "FilterInput": {
         "type": "object",
-        "description": "Dashboard filter key that can be added to a dashboard",
+        "description": "A drop-down filter on a dashboard. Every filter can either broadcast its\nselected value(s) to every tile (isBroadcastEnabled), expose its selected\nvalue as a variable (isVariableEnabled) or both. Typically a filter should\ndo just one of these things.\n",
         "required": [
           "type",
           "name",
@@ -2933,7 +2933,7 @@
           "expression": {
             "type": "string",
             "minLength": 1,
-            "description": "Key expression used when applying this dashboard filter key",
+            "description": "SQL expression used when querying values for this filter, and when applying this dashboard filter to tiles.",
             "example": "environment"
           },
           "sourceId": {
@@ -2973,10 +2973,29 @@
             "items": {
               "type": "string"
             },
-            "description": "Optional list of source IDs this filter applies to. Omit or provide\nan empty array to apply the filter to ALL tiles regardless of source.\nA non-empty array restricts the filter to only tiles whose source ID\nis in the list; tiles using other sources are not affected by the\nselected filter value(s).\n",
+            "description": "Optional list of source IDs this filter applies to. Omit or provide\nan empty array to apply the filter to ALL tiles regardless of source.\nA non-empty array restricts the filter to only tiles whose source ID\nis in the list; tiles using other sources are not affected by the\nselected filter value(s). Scopes the broadcast condition only, so a\nnon-empty array is rejected when isBroadcastEnabled is false, and is\nomitted from responses for such a filter.\n",
             "example": [
               "65f5e4a3b9e77c001a111111"
             ]
+          },
+          "isBroadcastEnabled": {
+            "type": "boolean",
+            "description": "Whether the selected value is applied as a filter condition on every\nbuilder tile this filter applies to (see appliesToSourceIds), and every\nraw sql tile using the $__filters macro. Omitting the field means enabled.\n",
+            "default": true,
+            "example": false
+          },
+          "isVariableEnabled": {
+            "type": "boolean",
+            "description": "Whether the selected value is exposed to tile queries as a dashboard\nvariable named by variableName. Tiles may reference it as `$variableName`\nor using the (preferred) `$__filter(<variableName>)` and\n`$__conditionalAll(<condition>, <variableName>)` macros.\n",
+            "default": false,
+            "example": true
+          },
+          "variableName": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$",
+            "description": "Token tiles reference this filter's selected value by, as\n`$variableName`. Must start with a letter and may contain only\nletters, numbers, and underscores. Defaults to the display name with\nwhitespace replaced by underscores and remaining illegal characters\nremoved, so a variable-enabled filter whose name derives nothing\nusable must send this field explicitly. Variable names must be unique\nacross a dashboard's variable-enabled filters. Names the variable\nonly, so the field is rejected when isVariableEnabled is not true, and\nis omitted from responses for such a filter.\n",
+            "example": "environment"
           }
         }
       },
@@ -3036,7 +3055,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys added to the dashboard and applied to all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts\nits selected value as a condition, acts as a variable which\ncan be referenced in tile queries, or both.\n",
             "items": {
               "$ref": "#/components/schemas/Filter"
             }
@@ -3106,7 +3125,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys to add to the dashboard and apply across all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts\nits selected value as a condition, acts as a variable which\ncan be referenced in tile queries, or both.\n",
             "items": {
               "$ref": "#/components/schemas/FilterInput"
             }
@@ -3177,7 +3196,7 @@
           },
           "filters": {
             "type": "array",
-            "description": "Dashboard filter keys on the dashboard, applied across all tiles",
+            "description": "Dropdown filters added to the dashboard. Each one broadcasts\nits selected value as a condition, acts as a variable which\ncan be referenced in tile queries, or both.\n",
             "items": {
               "$ref": "#/components/schemas/Filter"
             }

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -3649,6 +3649,95 @@ describe('External API v2 Dashboards - new format', () => {
       expect(getResponse.body.data.filters).toEqual(response.body.data.filters);
     });
 
+    // The create body schema takes filters without ids, so the variable
+    // settings ride a different schema than the update case.
+    it('should round-trip the filter variable settings', async () => {
+      const payload = createMockDashboardWithIds(traceSource._id.toString(), {
+        filters: [
+          // Broadcast only, stated explicitly rather than left to the
+          // missing-means-enabled default.
+          {
+            type: 'QUERY_EXPRESSION' as const,
+            name: 'Environment',
+            expression: 'environment',
+            sourceId: traceSource._id.toString(),
+            isBroadcastEnabled: true,
+            isVariableEnabled: false,
+          },
+          // Variable only: collects a value for `$service` without filtering
+          // any tile directly.
+          {
+            type: 'QUERY_EXPRESSION' as const,
+            name: 'Service Name',
+            expression: 'ServiceName',
+            sourceId: traceSource._id.toString(),
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'service',
+          },
+          // Both modes, with the variable name left to derive from the display
+          // name (`Region_Name`).
+          {
+            type: 'QUERY_EXPRESSION' as const,
+            name: 'Region Name',
+            expression: 'region',
+            sourceId: traceSource._id.toString(),
+            isVariableEnabled: true,
+          },
+        ],
+      });
+
+      const response = await authRequest('post', BASE_URL)
+        .send(payload)
+        .expect(200);
+
+      expect(response.body.data.filters).toMatchObject([
+        {
+          name: 'Environment',
+          isBroadcastEnabled: true,
+          isVariableEnabled: false,
+        },
+        {
+          name: 'Service Name',
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'service',
+        },
+        { name: 'Region Name', isVariableEnabled: true },
+      ]);
+      // Neither omitted field is materialized on read: an absent
+      // isBroadcastEnabled has to keep reading as enabled, and an absent
+      // variableName keeps deriving the token from the display name.
+      expect(response.body.data.filters[2]).not.toHaveProperty(
+        'isBroadcastEnabled',
+      );
+      expect(response.body.data.filters[2]).not.toHaveProperty('variableName');
+
+      const getResponse = await authRequest(
+        'get',
+        `${BASE_URL}/${response.body.data.id}`,
+      ).expect(200);
+      expect(getResponse.body.data.filters).toEqual(response.body.data.filters);
+
+      const stored = await Dashboard.findById(response.body.data.id).lean();
+      expect(stored?.filters).toMatchObject([
+        {
+          source: traceSource._id.toString(),
+          isBroadcastEnabled: true,
+          isVariableEnabled: false,
+        },
+        {
+          source: traceSource._id.toString(),
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'service',
+        },
+        { source: traceSource._id.toString(), isVariableEnabled: true },
+      ]);
+      expect(stored?.filters?.[2]).not.toHaveProperty('isBroadcastEnabled');
+      expect(stored?.filters?.[2]).not.toHaveProperty('variableName');
+    });
+
     it('should return 400 when filter source ID does not exist', async () => {
       const nonExistentSourceId = new ObjectId().toString();
       const dashboardPayload = {
@@ -3987,236 +4076,131 @@ describe('External API v2 Dashboards - new format', () => {
       });
     });
 
-    it('should reject a filter variableName that is not a bare token', async () => {
-      const dashboard = await createTestDashboard({});
+    it('should clear the filter variable settings when an update omits them', async () => {
+      const filterId = new ObjectId().toString();
+      const storedFilter = {
+        id: filterId,
+        type: 'QUERY_EXPRESSION' as const,
+        name: 'Service Name',
+        expression: 'ServiceName',
+        source: traceSource._id.toString(),
+        isBroadcastEnabled: false,
+        isVariableEnabled: true,
+        variableName: 'service',
+      };
+      const dashboard = await createTestDashboard({ filters: [storedFilter] });
       const payload = createMockDashboardWithIds(
         traceSource._id.toString(),
         {},
       );
 
-      await authRequest('put', `${BASE_URL}/${dashboard._id}`)
+      const response = await authRequest('put', `${BASE_URL}/${dashboard._id}`)
         .send({
           ...payload,
           filters: [
             {
-              id: new ObjectId().toString(),
-              type: 'QUERY_EXPRESSION' as const,
-              name: 'Service Name',
-              expression: 'ServiceName',
+              ...omit(
+                storedFilter,
+                'source',
+                'isBroadcastEnabled',
+                'isVariableEnabled',
+                'variableName',
+              ),
               sourceId: traceSource._id.toString(),
-              variableName: 'has space',
             },
           ],
         })
-        .expect(400);
+        .expect(200);
+
+      // Filters are replaced wholesale, so dropping the fields turns the
+      // variable back off instead of leaving the stored settings behind.
+      expect(response.body.data.filters[0]).toMatchObject({ id: filterId });
+      expect(response.body.data.filters[0]).not.toHaveProperty(
+        'isBroadcastEnabled',
+      );
+      expect(response.body.data.filters[0]).not.toHaveProperty(
+        'isVariableEnabled',
+      );
+      expect(response.body.data.filters[0]).not.toHaveProperty('variableName');
+
+      const stored = await Dashboard.findById(dashboard._id).lean();
+      expect(stored?.filters?.[0]).not.toHaveProperty('isVariableEnabled');
+      expect(stored?.filters?.[0]).not.toHaveProperty('variableName');
     });
 
-    describe('filter variable name uniqueness', () => {
-      const externalFilter = (overrides = {}) => ({
-        id: new ObjectId().toString(),
-        type: 'QUERY_EXPRESSION' as const,
-        name: 'Service Name',
-        expression: 'ServiceName',
-        sourceId: traceSource._id.toString(),
-        isVariableEnabled: true,
-        variableName: 'service',
-        ...overrides,
-      });
-
-      const expectPutFilters = async (
-        filters: unknown[],
-        expectedStatus: number,
-      ) => {
-        const dashboard = await createTestDashboard({});
-        const payload = createMockDashboardWithIds(
-          traceSource._id.toString(),
-          {},
-        );
-        await authRequest('put', `${BASE_URL}/${dashboard._id}`)
-          .send({ ...payload, filters })
-          .expect(expectedStatus);
-      };
-
-      it('rejects two variable-enabled filters sharing a variable name', async () => {
-        await expectPutFilters([externalFilter(), externalFilter()], 400);
-      });
-
-      it('rejects a clash against a name derived from the filter name', async () => {
-        await expectPutFilters(
-          [
-            externalFilter({ name: 'Service Name', variableName: undefined }),
-            externalFilter({ variableName: 'Service_Name' }),
-          ],
-          400,
-        );
-      });
-
-      it('accepts distinct variable names', async () => {
-        await expectPutFilters(
-          [
-            externalFilter({ variableName: 'service' }),
-            externalFilter({ variableName: 'environment' }),
-          ],
-          200,
-        );
-      });
-
-      // A caller that never enabled the feature must not be blocked by this rule.
-      it('accepts duplicate names when the filters are not variable-enabled', async () => {
-        await expectPutFilters(
-          [
-            externalFilter({ isVariableEnabled: false }),
-            externalFilter({ isVariableEnabled: undefined }),
-          ],
-          200,
-        );
-      });
-
-      it('accepts identically named filters that carry no variable fields', async () => {
-        const legacyFilter = {
-          isVariableEnabled: undefined,
-          variableName: undefined,
-        };
-        await expectPutFilters(
-          [externalFilter(legacyFilter), externalFilter(legacyFilter)],
-          200,
-        );
-      });
-
-      it('rejects a duplicate on create', async () => {
-        const payload = createMockDashboardWithIds(
-          traceSource._id.toString(),
-          {},
-        );
-        await authRequest('post', BASE_URL)
-          .send({
-            ...payload,
-            filters: [
-              omit(externalFilter(), 'id'),
-              omit(externalFilter(), 'id'),
-            ],
-          })
-          .expect(400);
-      });
-
-      // `variableName` is optional in the schema, so without this check a caller
-      // could enable variables on a filter whose name yields no derivable token and
-      // persist a variable no tile could reference.
-      it('rejects a variable-enabled filter with no usable variable name', async () => {
-        await expectPutFilters(
-          [externalFilter({ name: '环境', variableName: undefined })],
-          400,
-        );
-      });
-
-      it('accepts an unusable filter name when an explicit variable name is sent', async () => {
-        await expectPutFilters(
-          [externalFilter({ name: '环境', variableName: 'env' })],
-          200,
-        );
-      });
-
-      it('accepts an unusable filter name when the filter is not variable-enabled', async () => {
-        await expectPutFilters(
-          [
-            externalFilter({
-              name: '环境',
-              variableName: undefined,
-              isVariableEnabled: false,
-            }),
-          ],
-          200,
-        );
-      });
-    });
-
-    describe('filter requires at least one mode', () => {
-      const modeFilter = (overrides = {}) => ({
-        id: new ObjectId().toString(),
-        type: 'QUERY_EXPRESSION' as const,
-        name: 'Service Name',
-        expression: 'ServiceName',
-        sourceId: traceSource._id.toString(),
-        ...overrides,
-      });
-
-      const putFilters = async (filters: unknown[]) => {
-        const dashboard = await createTestDashboard({});
-        const payload = createMockDashboardWithIds(
-          traceSource._id.toString(),
-          {},
-        );
-        return authRequest('put', `${BASE_URL}/${dashboard._id}`).send({
-          ...payload,
-          filters,
-        });
-      };
-
-      it('rejects a filter with both modes off', async () => {
-        const response = await putFilters([
-          modeFilter({ isBroadcastEnabled: false, isVariableEnabled: false }),
-        ]);
-
-        expect(response.status).toBe(400);
-        // Quote-free slice of the message: the body nests a serialized error,
-        // so the quotes around the filter name come back re-escaped.
-        expect(JSON.stringify(response.body)).toContain(
-          'must broadcast its value, be available as a variable, or both',
-        );
-      });
-
-      it('treats an omitted variable flag as off', async () => {
-        const response = await putFilters([
-          modeFilter({ isBroadcastEnabled: false }),
-        ]);
-
-        expect(response.status).toBe(400);
-      });
-
-      it('rejects it on create too', async () => {
-        const payload = createMockDashboardWithIds(
-          traceSource._id.toString(),
-          {},
-        );
-        await authRequest('post', BASE_URL)
-          .send({
-            ...payload,
-            filters: [
-              omit(
-                modeFilter({
-                  isBroadcastEnabled: false,
-                  isVariableEnabled: false,
-                }),
-                'id',
-              ),
-            ],
-          })
-          .expect(400);
-      });
-
-      it('accepts broadcast-only and variable-only filters', async () => {
-        const response = await putFilters([
-          modeFilter({ isBroadcastEnabled: true, isVariableEnabled: false }),
-          modeFilter({
+    // The app's filter form leaves a chosen `appliesToSourceIds` on a filter
+    // whose broadcast it switches off, so stored filters can hold the
+    // combination the write schema now rejects. Reads drop the ignored fields
+    // so such a dashboard still survives a GET -> PUT.
+    it('omits the ignored fields on read so a stored filter round-trips', async () => {
+      const variableOnlyId = new ObjectId().toString();
+      const broadcastOnlyId = new ObjectId().toString();
+      const dashboard = await createTestDashboard({
+        filters: [
+          {
+            id: variableOnlyId,
+            type: 'QUERY_EXPRESSION' as const,
+            name: 'Service Name',
+            expression: 'ServiceName',
+            source: traceSource._id.toString(),
             isBroadcastEnabled: false,
             isVariableEnabled: true,
             variableName: 'service',
-          }),
-        ]);
-
-        expect(response.status).toBe(200);
+            // Left behind by the form when broadcast was switched off.
+            appliesToSourceIds: [traceSource._id.toString()],
+          },
+          {
+            id: broadcastOnlyId,
+            type: 'QUERY_EXPRESSION' as const,
+            name: 'Environment',
+            expression: 'environment',
+            source: traceSource._id.toString(),
+            isBroadcastEnabled: true,
+            isVariableEnabled: false,
+            // Left behind by the form when the variable was switched off.
+            variableName: 'environment',
+          },
+        ],
       });
 
-      // Backwards compatibility: a missing `isBroadcastEnabled` reads as
-      // enabled, so a caller that never sends the field cannot be rejected.
-      it('accepts a filter that carries neither flag', async () => {
-        const response = await putFilters([modeFilter()]);
+      const getResponse = await authRequest(
+        'get',
+        `${BASE_URL}/${dashboard._id}`,
+      ).expect(200);
 
-        expect(response.status).toBe(200);
-        expect(response.body.data.filters[0]).not.toHaveProperty(
-          'isBroadcastEnabled',
-        );
+      const [variableOnly, broadcastOnly] = getResponse.body.data.filters;
+      expect(variableOnly).toMatchObject({
+        id: variableOnlyId,
+        isBroadcastEnabled: false,
+        variableName: 'service',
       });
+      expect(variableOnly).not.toHaveProperty('appliesToSourceIds');
+      expect(broadcastOnly).toMatchObject({
+        id: broadcastOnlyId,
+        isBroadcastEnabled: true,
+      });
+      expect(broadcastOnly).not.toHaveProperty('variableName');
+
+      // The healed body is exactly what a caller would send back.
+      const putResponse = await authRequest(
+        'put',
+        `${BASE_URL}/${dashboard._id}`,
+      )
+        .send({
+          name: getResponse.body.data.name,
+          tiles: getResponse.body.data.tiles,
+          filters: getResponse.body.data.filters,
+        })
+        .expect(200);
+      expect(putResponse.body.data.filters).toEqual(
+        getResponse.body.data.filters,
+      );
+
+      // The re-PUT persists the healed filters, dropping the fields the
+      // stored document carried in the mode that ignored them.
+      const stored = await Dashboard.findById(dashboard._id).lean();
+      expect(stored?.filters?.[0]).not.toHaveProperty('appliesToSourceIds');
+      expect(stored?.filters?.[1]).not.toHaveProperty('variableName');
     });
 
     it('should clear existing dashboard filters when provided an empty filters array', async () => {
@@ -5316,6 +5300,257 @@ describe('External API v2 Dashboards - new format', () => {
           tags: [],
         })
         .expect(200);
+    });
+  });
+
+  // The create and update body schemas share these filter validations but take
+  // different filter shapes (only an update filter may carry an `id`), so every
+  // rule runs against both request paths.
+  describe.each(['post', 'put'] as const)('filter validation (%s)', method => {
+    const filterInput = (overrides = {}) => ({
+      id: new ObjectId().toString(),
+      type: 'QUERY_EXPRESSION' as const,
+      name: 'Service Name',
+      expression: 'ServiceName',
+      sourceId: traceSource._id.toString(),
+      ...overrides,
+    });
+
+    const sendFilters = async (filters: Record<string, unknown>[]) => {
+      const payload = createMockDashboardWithIds(
+        traceSource._id.toString(),
+        {},
+      );
+      if (method === 'post') {
+        // A create body may not choose filter ids, so the shared fixtures shed
+        // theirs on this path.
+        return authRequest('post', BASE_URL).send({
+          ...payload,
+          filters: filters.map(filter => omit(filter, 'id')),
+        });
+      }
+      const dashboard = await createTestDashboard({});
+      return authRequest('put', `${BASE_URL}/${dashboard._id}`).send({
+        ...payload,
+        filters,
+      });
+    };
+
+    const expectFilters = async (
+      filters: Record<string, unknown>[],
+      expectedStatus: number,
+    ) => {
+      const response = await sendFilters(filters);
+      expect(response.status).toBe(expectedStatus);
+    };
+
+    it('rejects a variableName that is not a bare token', async () => {
+      await expectFilters(
+        [filterInput({ isVariableEnabled: true, variableName: 'has space' })],
+        400,
+      );
+    });
+
+    describe('filter variable name uniqueness', () => {
+      const variableFilter = (overrides = {}) =>
+        filterInput({
+          isVariableEnabled: true,
+          variableName: 'service',
+          ...overrides,
+        });
+
+      it('rejects two variable-enabled filters sharing a variable name', async () => {
+        await expectFilters([variableFilter(), variableFilter()], 400);
+      });
+
+      it('rejects a clash against a name derived from the filter name', async () => {
+        await expectFilters(
+          [
+            variableFilter({ name: 'Service Name', variableName: undefined }),
+            variableFilter({ variableName: 'Service_Name' }),
+          ],
+          400,
+        );
+      });
+
+      it('accepts distinct variable names', async () => {
+        await expectFilters(
+          [
+            variableFilter({ variableName: 'service' }),
+            variableFilter({ variableName: 'environment' }),
+          ],
+          200,
+        );
+      });
+
+      // A caller that never enabled the feature must not be blocked by this
+      // rule. `variableName` goes with the flag: a filter that is not
+      // variable-enabled may not carry one (see the field-gating tests below).
+      it('accepts duplicate names when the filters are not variable-enabled', async () => {
+        await expectFilters(
+          [
+            variableFilter({
+              isVariableEnabled: false,
+              variableName: undefined,
+            }),
+            variableFilter({
+              isVariableEnabled: undefined,
+              variableName: undefined,
+            }),
+          ],
+          200,
+        );
+      });
+
+      it('accepts identically named filters that carry no variable fields', async () => {
+        const legacyFilter = {
+          isVariableEnabled: undefined,
+          variableName: undefined,
+        };
+        await expectFilters(
+          [variableFilter(legacyFilter), variableFilter(legacyFilter)],
+          200,
+        );
+      });
+
+      // `variableName` is optional in the schema, so without this check a caller
+      // could enable variables on a filter whose name yields no derivable token and
+      // persist a variable no tile could reference.
+      it('rejects a variable-enabled filter with no usable variable name', async () => {
+        await expectFilters(
+          [variableFilter({ name: '环境', variableName: undefined })],
+          400,
+        );
+      });
+
+      it('accepts an unusable filter name when an explicit variable name is sent', async () => {
+        await expectFilters(
+          [variableFilter({ name: '环境', variableName: 'env' })],
+          200,
+        );
+      });
+
+      it('accepts an unusable filter name when the filter is not variable-enabled', async () => {
+        await expectFilters(
+          [
+            variableFilter({
+              name: '环境',
+              variableName: undefined,
+              isVariableEnabled: false,
+            }),
+          ],
+          200,
+        );
+      });
+    });
+
+    describe('filter requires at least one mode', () => {
+      it('rejects a filter with both modes off', async () => {
+        const response = await sendFilters([
+          filterInput({ isBroadcastEnabled: false, isVariableEnabled: false }),
+        ]);
+
+        expect(response.status).toBe(400);
+        // Quote-free slice of the message: the body nests a serialized error,
+        // so the quotes around the filter name come back re-escaped.
+        expect(JSON.stringify(response.body)).toContain(
+          'must broadcast its value, be available as a variable, or both',
+        );
+      });
+
+      it('treats an omitted variable flag as off', async () => {
+        const response = await sendFilters([
+          filterInput({ isBroadcastEnabled: false }),
+        ]);
+
+        expect(response.status).toBe(400);
+      });
+
+      it('accepts broadcast-only and variable-only filters', async () => {
+        const response = await sendFilters([
+          filterInput({ isBroadcastEnabled: true, isVariableEnabled: false }),
+          filterInput({
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'service',
+          }),
+        ]);
+
+        expect(response.status).toBe(200);
+      });
+
+      // Backwards compatibility: a missing `isBroadcastEnabled` reads as
+      // enabled, so a caller that never sends the field cannot be rejected.
+      it('accepts a filter that carries neither flag', async () => {
+        const response = await sendFilters([filterInput()]);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.filters[0]).not.toHaveProperty(
+          'isBroadcastEnabled',
+        );
+      });
+    });
+
+    describe('filter fields are gated on the mode that uses them', () => {
+      it('rejects a variableName on a filter that is not variable-enabled', async () => {
+        const response = await sendFilters([
+          filterInput({ isVariableEnabled: false, variableName: 'service' }),
+        ]);
+
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          'sets variableName but is not available as a variable',
+        );
+      });
+
+      it('rejects a variableName when the variable flag is omitted', async () => {
+        const response = await sendFilters([
+          filterInput({ variableName: 'service' }),
+        ]);
+
+        expect(response.status).toBe(400);
+      });
+
+      it('rejects appliesToSourceIds on a filter that does not broadcast', async () => {
+        const response = await sendFilters([
+          filterInput({
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'service',
+            appliesToSourceIds: [traceSource._id.toString()],
+          }),
+        ]);
+
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          'sets appliesToSourceIds but does not broadcast its value',
+        );
+      });
+
+      // An empty array is what "applies to all tiles" looks like, so it
+      // restricts nothing and cannot contradict a disabled broadcast.
+      it('accepts an empty appliesToSourceIds on a non-broadcasting filter', async () => {
+        const response = await sendFilters([
+          filterInput({
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'service',
+            appliesToSourceIds: [],
+          }),
+        ]);
+
+        expect(response.status).toBe(200);
+      });
+
+      it('accepts appliesToSourceIds when the broadcast flag is omitted', async () => {
+        const response = await sendFilters([
+          filterInput({
+            appliesToSourceIds: [traceSource._id.toString()],
+          }),
+        ]);
+
+        expect(response.status).toBe(200);
+      });
     });
   });
 

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1629,7 +1629,11 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *
  *     FilterInput:
  *       type: object
- *       description: Dashboard filter key that can be added to a dashboard
+ *       description: |
+ *         A drop-down filter on a dashboard. Every filter can either broadcast its
+ *         selected value(s) to every tile (isBroadcastEnabled), expose its selected
+ *         value as a variable (isVariableEnabled) or both. Typically a filter should
+ *         do just one of these things.
  *       required:
  *         - type
  *         - name
@@ -1649,7 +1653,7 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *         expression:
  *           type: string
  *           minLength: 1
- *           description: Key expression used when applying this dashboard filter key
+ *           description: SQL expression used when querying values for this filter, and when applying this dashboard filter to tiles.
  *           example: "environment"
  *         sourceId:
  *           type: string
@@ -1679,8 +1683,42 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *             an empty array to apply the filter to ALL tiles regardless of source.
  *             A non-empty array restricts the filter to only tiles whose source ID
  *             is in the list; tiles using other sources are not affected by the
- *             selected filter value(s).
+ *             selected filter value(s). Scopes the broadcast condition only, so a
+ *             non-empty array is rejected when isBroadcastEnabled is false, and is
+ *             omitted from responses for such a filter.
  *           example: ["65f5e4a3b9e77c001a111111"]
+ *         isBroadcastEnabled:
+ *           type: boolean
+ *           description: |
+ *             Whether the selected value is applied as a filter condition on every
+ *             builder tile this filter applies to (see appliesToSourceIds), and every
+ *             raw sql tile using the $__filters macro. Omitting the field means enabled.
+ *           default: true
+ *           example: false
+ *         isVariableEnabled:
+ *           type: boolean
+ *           description: |
+ *             Whether the selected value is exposed to tile queries as a dashboard
+ *             variable named by variableName. Tiles may reference it as `$variableName`
+ *             or using the (preferred) `$__filter(<variableName>)` and
+ *             `$__conditionalAll(<condition>, <variableName>)` macros.
+ *           default: false
+ *           example: true
+ *         variableName:
+ *           type: string
+ *           maxLength: 64
+ *           pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+ *           description: |
+ *             Token tiles reference this filter's selected value by, as
+ *             `$variableName`. Must start with a letter and may contain only
+ *             letters, numbers, and underscores. Defaults to the display name with
+ *             whitespace replaced by underscores and remaining illegal characters
+ *             removed, so a variable-enabled filter whose name derives nothing
+ *             usable must send this field explicitly. Variable names must be unique
+ *             across a dashboard's variable-enabled filters. Names the variable
+ *             only, so the field is rejected when isVariableEnabled is not true, and
+ *             is omitted from responses for such a filter.
+ *           example: "environment"
  *
  *     Filter:
  *       allOf:
@@ -1721,7 +1759,10 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           example: ["production", "monitoring"]
  *         filters:
  *           type: array
- *           description: Dashboard filter keys added to the dashboard and applied to all tiles
+ *           description: |
+ *             Dropdown filters added to the dashboard. Each one broadcasts
+ *             its selected value as a condition, acts as a variable which
+ *             can be referenced in tile queries, or both.
  *           items:
  *             $ref: '#/components/schemas/Filter'
  *         savedQuery:
@@ -1774,7 +1815,10 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           example: ["development"]
  *         filters:
  *           type: array
- *           description: Dashboard filter keys to add to the dashboard and apply across all tiles
+ *           description: |
+ *             Dropdown filters added to the dashboard. Each one broadcasts
+ *             its selected value as a condition, acts as a variable which
+ *             can be referenced in tile queries, or both.
  *           items:
  *             $ref: '#/components/schemas/FilterInput'
  *         savedQuery:
@@ -1827,7 +1871,10 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *           example: ["production", "updated"]
  *         filters:
  *           type: array
- *           description: Dashboard filter keys on the dashboard, applied across all tiles
+ *           description: |
+ *             Dropdown filters added to the dashboard. Each one broadcasts
+ *             its selected value as a condition, acts as a variable which
+ *             can be referenced in tile queries, or both.
  *           items:
  *             $ref: '#/components/schemas/Filter'
  *         savedQuery:

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -4,6 +4,7 @@ import {
 } from '@hyperdx/common-utils/dist/core/utils';
 import {
   validateDashboardContainersStructure,
+  validateDashboardFilterFieldGating,
   validateDashboardFilterModes,
   validateDashboardFilterVariableNames,
   validateDashboardTileContainerRefs,
@@ -1419,6 +1420,7 @@ function buildDashboardBodySchema(filterSchema: z.ZodTypeAny): z.ZodEffects<
       // with pre-`isBroadcastEnabled` payloads.
       validateDashboardFilterVariableNames(data.filters ?? [], ctx);
       validateDashboardFilterModes(data.filters ?? [], ctx);
+      validateDashboardFilterFieldGating(data.filters ?? [], ctx);
     });
 }
 

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -1,4 +1,8 @@
 import {
+  isFilterBroadcastEnabled,
+  isFilterVariableEnabled,
+} from '@hyperdx/common-utils/dist/filters';
+import {
   AlertErrorType,
   AlertThresholdType,
   BuilderSavedChartConfig,
@@ -211,8 +215,15 @@ export function translateExternalChartToTileConfig(
 export function translateFilterToExternalFilter(
   filter: DashboardFilter,
 ): ExternalDashboardFilterWithId {
+  // Ignore variableName and appliesToSourceIds if the filter is not in a mode that uses them
+  const ignoredKeys = [
+    ...(isFilterVariableEnabled(filter) ? [] : (['variableName'] as const)),
+    ...(isFilterBroadcastEnabled(filter)
+      ? []
+      : (['appliesToSourceIds'] as const)),
+  ];
   return {
-    ...omit(filter, 'source'),
+    ...omit(filter, 'source', ...ignoredKeys),
     sourceId: filter.source.toString(),
   };
 }

--- a/packages/common-utils/src/__tests__/dashboardValidation.test.ts
+++ b/packages/common-utils/src/__tests__/dashboardValidation.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import {
+  validateDashboardFilterFieldGating,
   validateDashboardFilterModes,
   validateDashboardFilterVariableNames,
 } from '@/dashboardValidation';
@@ -275,5 +276,146 @@ describe('validateDashboardFilterModes', () => {
       0,
       'isBroadcastEnabled',
     ]);
+  });
+});
+
+type GatingFilter = ModeFilter & {
+  variableName?: string;
+  appliesToSourceIds?: string[];
+};
+
+const collectGatingIssues = (
+  filters: GatingFilter[],
+  paths?: { filtersPath?: (string | number)[] },
+) => {
+  const schema = z
+    .object({})
+    .superRefine((_, ctx) =>
+      validateDashboardFilterFieldGating(filters, ctx, paths),
+    );
+  const result = schema.safeParse({});
+  return result.success ? [] : result.error.issues;
+};
+
+describe('validateDashboardFilterFieldGating', () => {
+  it('accepts an empty filter list', () => {
+    expect(collectGatingIssues([])).toEqual([]);
+  });
+
+  it('accepts a filter that carries neither field', () => {
+    expect(collectGatingIssues([{ name: 'Service' }])).toEqual([]);
+  });
+
+  it('accepts each field in the mode that uses it', () => {
+    expect(
+      collectGatingIssues([
+        {
+          name: 'Variable',
+          isVariableEnabled: true,
+          variableName: 'service',
+        },
+        {
+          name: 'Broadcast',
+          isBroadcastEnabled: true,
+          appliesToSourceIds: ['source-1'],
+        },
+        {
+          name: 'Both',
+          isVariableEnabled: true,
+          variableName: 'environment',
+          appliesToSourceIds: ['source-1'],
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('rejects a variableName on a filter that is not variable-enabled', () => {
+    const issues = collectGatingIssues([
+      { name: 'Service', variableName: 'service' },
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toEqual(['filters', 0, 'variableName']);
+    expect(issues[0].message).toBe(
+      'Filter "Service" sets variableName but is not available as a variable; set isVariableEnabled to true or drop variableName',
+    );
+  });
+
+  it('rejects a variableName when the variable is explicitly disabled', () => {
+    expect(
+      collectGatingIssues([
+        { name: 'Service', isVariableEnabled: false, variableName: 'service' },
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it('rejects appliesToSourceIds on a filter that does not broadcast', () => {
+    const issues = collectGatingIssues([
+      {
+        name: 'Service',
+        isBroadcastEnabled: false,
+        isVariableEnabled: true,
+        appliesToSourceIds: ['source-1'],
+      },
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toEqual(['filters', 0, 'appliesToSourceIds']);
+    expect(issues[0].message).toBe(
+      'Filter "Service" sets appliesToSourceIds but does not broadcast its value; set isBroadcastEnabled to true or drop appliesToSourceIds',
+    );
+  });
+
+  // An empty array is what "applies to all tiles" looks like, so it restricts
+  // nothing and cannot contradict a disabled broadcast.
+  it('accepts an empty appliesToSourceIds on a non-broadcasting filter', () => {
+    expect(
+      collectGatingIssues([
+        {
+          name: 'Service',
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          appliesToSourceIds: [],
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  // Missing means broadcasting, so a filter that predates the flag keeps its
+  // scope.
+  it('accepts appliesToSourceIds when the broadcast flag is omitted', () => {
+    expect(
+      collectGatingIssues([
+        { name: 'Service', appliesToSourceIds: ['source-1'] },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('reports both fields on one filter, and every offending filter', () => {
+    const issues = collectGatingIssues([
+      { name: 'Fine', isVariableEnabled: true, variableName: 'service' },
+      {
+        name: 'Both wrong',
+        isBroadcastEnabled: false,
+        variableName: 'environment',
+        appliesToSourceIds: ['source-1'],
+      },
+      { name: 'Stray name', variableName: 'region' },
+    ]);
+
+    expect(issues.map(i => i.path)).toEqual([
+      ['filters', 1, 'variableName'],
+      ['filters', 1, 'appliesToSourceIds'],
+      ['filters', 2, 'variableName'],
+    ]);
+  });
+
+  it('honors a custom filters path', () => {
+    const issues = collectGatingIssues(
+      [{ name: 'Service', variableName: 'service' }],
+      { filtersPath: ['body', 'filters'] },
+    );
+
+    expect(issues[0].path).toEqual(['body', 'filters', 0, 'variableName']);
   });
 });

--- a/packages/common-utils/src/dashboardValidation.ts
+++ b/packages/common-utils/src/dashboardValidation.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   getFilterVariableName,
   hasFilterEffect,
+  isFilterBroadcastEnabled,
   isFilterVariableEnabled,
 } from './filters';
 import { DashboardContainerSchema } from './types';
@@ -24,6 +25,10 @@ type FilterForModeValidation = {
   name: string;
   isBroadcastEnabled?: boolean;
   isVariableEnabled?: boolean;
+};
+type FilterForGatingValidation = FilterForModeValidation & {
+  variableName?: string;
+  appliesToSourceIds?: string[];
 };
 
 /**
@@ -222,5 +227,45 @@ export function validateDashboardFilterModes<T extends FilterForModeValidation>(
       message: `Filter "${filter.name}" must broadcast its value, be available as a variable, or both`,
       path: [...filtersPath, filterIdx, 'isBroadcastEnabled'],
     });
+  });
+}
+
+/**
+ * Validate that the `variableName` and `appliesToSourceIds` fields are only set
+ * on filters with the appropriate modes enabled.
+ *
+ * Issues raised:
+ * - `variableName` on a filter that is not variable-enabled (path `<filtersPath>[i].variableName`).
+ * - A non-empty `appliesToSourceIds` on a filter that does not broadcast (path `<filtersPath>[i].appliesToSourceIds`).
+ */
+export function validateDashboardFilterFieldGating<
+  T extends FilterForGatingValidation,
+>(
+  filters: T[],
+  ctx: z.RefinementCtx,
+  paths?: { filtersPath?: (string | number)[] },
+): void {
+  const filtersPath = paths?.filtersPath ?? ['filters'];
+
+  filters.forEach((filter, filterIdx) => {
+    if (filter.variableName !== undefined && !isFilterVariableEnabled(filter)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Filter "${filter.name}" sets variableName but is not available as a variable; set isVariableEnabled to true or drop variableName`,
+        path: [...filtersPath, filterIdx, 'variableName'],
+      });
+    }
+
+    if (
+      filter.appliesToSourceIds !== undefined &&
+      filter.appliesToSourceIds.length > 0 &&
+      !isFilterBroadcastEnabled(filter)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Filter "${filter.name}" sets appliesToSourceIds but does not broadcast its value; set isBroadcastEnabled to true or drop appliesToSourceIds`,
+        path: [...filtersPath, filterIdx, 'appliesToSourceIds'],
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

This PR updates the external API to allow reading and writing dashboards with variable-enabled filters configured.

MCP support will be implemented in the following PR.

### Screenshots or video

### How to test locally

Send requests to PUT/POST dashboards external API endpoints and ensure that variables can be configured, and that the validations and projections work as expected.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5061
- Related PRs:
