### PR TITLE
fix(api): drop stale aggregation params from the external dashboards API

### DIFF
--- a/.changeset/stale-agg-params-external-export.md
+++ b/.changeset/stale-agg-params-external-export.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+Stop the external dashboards API returning aggregation parameters the aggregation cannot carry: a `level` left over from a quantile agg, or a `valueExpression` left over on a count. Both are ignored when rendering, but the input schema rejects them, so a GET body could not be PUT back and importing a dashboard into Terraform failed with "Level can only be used with quantile aggregation function".

--- a/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
@@ -14,6 +14,7 @@ import {
   convertToExternalDashboard,
   convertToInternalTileConfig,
 } from '@/routers/external-api/v2/utils/dashboards';
+import { externalDashboardSelectItemSchema } from '@/utils/zod';
 
 function makeMarkdownTile(
   markdown?: string,
@@ -445,4 +446,113 @@ describe('convertToExternalDashboard orphan-ref heal', () => {
       });
     },
   );
+});
+
+describe('convertToExternalDashboard stale aggregation params', () => {
+  // Switching a tile's aggregation in the editor leaves the previous agg's
+  // parameter behind in the stored config. It is inert for rendering, but the
+  // external input schema rejects it, so emitting it on read produced a GET
+  // body that could not be PUT back — and broke `terraform plan` on an
+  // imported dashboard.
+  function makeDoc(select: Record<string, unknown>[]): DashboardDocument {
+    return {
+      _id: new mongoose.Types.ObjectId(),
+      name: 'Test',
+      tiles: [
+        {
+          id: 't1',
+          x: 0,
+          y: 0,
+          w: 12,
+          h: 4,
+          config: {
+            displayType: DisplayType.Line,
+            source: new mongoose.Types.ObjectId().toString(),
+            where: '',
+            select,
+            name: 'Tile',
+          },
+        },
+      ],
+      tags: [],
+      filters: [],
+      savedQuery: null,
+      savedQueryLanguage: null,
+      savedFilterValues: [],
+    } as unknown as DashboardDocument;
+  }
+
+  function firstSelect(doc: DashboardDocument) {
+    const config = convertToExternalDashboard(doc).tiles[0].config;
+    if (config == null || !('select' in config) || config.select == null) {
+      throw new Error('expected a select on the converted tile');
+    }
+    return config.select[0];
+  }
+
+  it('drops level left over from a quantile agg on a count', () => {
+    const select = firstSelect(
+      makeDoc([{ aggFn: 'count', level: 0.9, aggCondition: '' }]),
+    );
+    expect(select).not.toHaveProperty('level');
+  });
+
+  it('keeps level on a quantile agg', () => {
+    const select = firstSelect(
+      makeDoc([
+        {
+          aggFn: 'quantile',
+          level: 0.95,
+          valueExpression: 'Duration',
+          aggCondition: '',
+        },
+      ]),
+    );
+    expect(select).toMatchObject({ aggFn: 'quantile', level: 0.95 });
+  });
+
+  it('drops valueExpression left over from a value agg on a count', () => {
+    const select = firstSelect(
+      makeDoc([
+        { aggFn: 'count', valueExpression: 'Duration', aggCondition: '' },
+      ]),
+    );
+    expect(select).not.toHaveProperty('valueExpression');
+  });
+
+  it('keeps valueExpression on a non-count agg', () => {
+    const select = firstSelect(
+      makeDoc([
+        { aggFn: 'avg', valueExpression: 'Duration', aggCondition: '' },
+      ]),
+    );
+    expect(select).toMatchObject({
+      aggFn: 'avg',
+      valueExpression: 'Duration',
+    });
+  });
+
+  it('emits a select the input schema accepts', () => {
+    // The point of the heal: what GET returns must survive a PUT. Both stale
+    // fields at once, on a tile that also carries a real alias.
+    const select = firstSelect(
+      makeDoc([
+        {
+          aggFn: 'count',
+          level: 0.99,
+          valueExpression: 'Duration',
+          alias: 'errors',
+          aggCondition: "ServiceName = 'api'",
+        },
+      ]),
+    );
+    expect(externalDashboardSelectItemSchema.safeParse(select).success).toBe(
+      true,
+    );
+    expect(select).toMatchObject({
+      aggFn: 'count',
+      alias: 'errors',
+      where: "ServiceName = 'api'",
+    });
+  });
 });

--- a/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
+++ b/packages/api/src/routers/external-api/v2/utils/__tests__/dashboards.test.ts
@@ -283,49 +283,51 @@ describe('collectTileContainerRefIssues', () => {
   });
 });
 
-describe('convertToExternalDashboard orphan-ref heal', () => {
-  // `tiles` is `Mixed` in Mongoose, so the model layer can't enforce
-  // ref consistency. These tests cover the read-path heal: a doc that
-  // somehow ends up with a tile pointing at a missing container or
-  // tab must round-trip on read as if the ref were absent. Without
-  // this, the next PUT body schema rejects the round-tripped tile
-  // and the dashboard becomes uneditable from the external API.
-  function makeDoc(
-    overrides: Partial<DashboardDocument> = {},
-  ): DashboardDocument {
-    return {
-      _id: new mongoose.Types.ObjectId(),
-      name: 'Test',
-      tiles: [],
-      tags: [],
-      filters: [],
-      savedQuery: null,
-      savedQueryLanguage: null,
-      savedFilterValues: [],
-      ...overrides,
-    } as unknown as DashboardDocument;
-  }
+// `tiles` is `Mixed` in Mongoose, so the model layer enforces nothing and a
+// stored doc can hold shapes the TS types do not describe — an orphan container
+// ref, a select entry carrying a field its aggregation cannot use. Overrides are
+// loosely typed so a fixture can model that; the read-path heal is what these
+// tests are about.
+function makeDoc(overrides: Record<string, unknown> = {}): DashboardDocument {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    name: 'Test',
+    tiles: [],
+    tags: [],
+    filters: [],
+    savedQuery: null,
+    savedQueryLanguage: null,
+    savedFilterValues: [],
+    ...overrides,
+  } as unknown as DashboardDocument;
+}
 
-  function makeTile(
-    overrides: Partial<DashboardDocument['tiles'][number]> = {},
-  ): DashboardDocument['tiles'][number] {
-    return {
-      id: 't1',
-      x: 0,
-      y: 0,
-      w: 1,
-      h: 1,
-      config: {
-        displayType: DisplayType.Markdown,
-        markdown: '',
-        source: '',
-        where: '',
-        select: [],
-        name: '',
-      },
-      ...overrides,
-    };
-  }
+function makeTile(
+  overrides: Record<string, unknown> = {},
+): DashboardDocument['tiles'][number] {
+  return {
+    id: 't1',
+    x: 0,
+    y: 0,
+    w: 1,
+    h: 1,
+    config: {
+      displayType: DisplayType.Markdown,
+      markdown: '',
+      source: '',
+      where: '',
+      select: [],
+      name: '',
+    },
+    ...overrides,
+  } as DashboardDocument['tiles'][number];
+}
+
+describe('convertToExternalDashboard orphan-ref heal', () => {
+  // A tile pointing at a missing container or tab must round-trip on read as if
+  // the ref were absent. Without this, the next PUT body schema rejects the
+  // round-tripped tile and the dashboard becomes uneditable from the external
+  // API.
 
   it('drops containerId on read when no container matches', () => {
     const doc = makeDoc({
@@ -454,17 +456,10 @@ describe('convertToExternalDashboard stale aggregation params', () => {
   // external input schema rejects it, so emitting it on read produced a GET
   // body that could not be PUT back — and broke `terraform plan` on an
   // imported dashboard.
-  function makeDoc(select: Record<string, unknown>[]): DashboardDocument {
-    return {
-      _id: new mongoose.Types.ObjectId(),
-      name: 'Test',
+  function firstSelect(select: Record<string, unknown>[]) {
+    const doc = makeDoc({
       tiles: [
-        {
-          id: 't1',
-          x: 0,
-          y: 0,
-          w: 12,
-          h: 4,
+        makeTile({
           config: {
             displayType: DisplayType.Line,
             source: new mongoose.Types.ObjectId().toString(),
@@ -472,17 +467,9 @@ describe('convertToExternalDashboard stale aggregation params', () => {
             select,
             name: 'Tile',
           },
-        },
+        }),
       ],
-      tags: [],
-      filters: [],
-      savedQuery: null,
-      savedQueryLanguage: null,
-      savedFilterValues: [],
-    } as unknown as DashboardDocument;
-  }
-
-  function firstSelect(doc: DashboardDocument) {
+    });
     const config = convertToExternalDashboard(doc).tiles[0].config;
     if (config == null || !('select' in config) || config.select == null) {
       throw new Error('expected a select on the converted tile');
@@ -491,61 +478,59 @@ describe('convertToExternalDashboard stale aggregation params', () => {
   }
 
   it('drops level left over from a quantile agg on a count', () => {
-    const select = firstSelect(
-      makeDoc([{ aggFn: 'count', level: 0.9, aggCondition: '' }]),
-    );
+    const select = firstSelect([
+      { aggFn: 'count', level: 0.9, aggCondition: '' },
+    ]);
     expect(select).not.toHaveProperty('level');
   });
 
   it('keeps level on a quantile agg', () => {
-    const select = firstSelect(
-      makeDoc([
-        {
-          aggFn: 'quantile',
-          level: 0.95,
-          valueExpression: 'Duration',
-          aggCondition: '',
-        },
-      ]),
-    );
+    const select = firstSelect([
+      {
+        aggFn: 'quantile',
+        level: 0.95,
+        valueExpression: 'Duration',
+        aggCondition: '',
+      },
+    ]);
     expect(select).toMatchObject({ aggFn: 'quantile', level: 0.95 });
   });
 
   it('drops valueExpression left over from a value agg on a count', () => {
-    const select = firstSelect(
-      makeDoc([
-        { aggFn: 'count', valueExpression: 'Duration', aggCondition: '' },
-      ]),
-    );
+    const select = firstSelect([
+      { aggFn: 'count', valueExpression: 'Duration', aggCondition: '' },
+    ]);
     expect(select).not.toHaveProperty('valueExpression');
   });
 
+  it('keeps an empty valueExpression on a count', () => {
+    // What the editor writes for every count tile. The input schema accepts it,
+    // so healing it would change the response shape for no reason.
+    const select = firstSelect([
+      { aggFn: 'count', valueExpression: '', aggCondition: '' },
+    ]);
+    expect(select).toMatchObject({ aggFn: 'count', valueExpression: '' });
+  });
+
   it('keeps valueExpression on a non-count agg', () => {
-    const select = firstSelect(
-      makeDoc([
-        { aggFn: 'avg', valueExpression: 'Duration', aggCondition: '' },
-      ]),
-    );
-    expect(select).toMatchObject({
-      aggFn: 'avg',
-      valueExpression: 'Duration',
-    });
+    const select = firstSelect([
+      { aggFn: 'avg', valueExpression: 'Duration', aggCondition: '' },
+    ]);
+    expect(select).toMatchObject({ aggFn: 'avg', valueExpression: 'Duration' });
   });
 
   it('emits a select the input schema accepts', () => {
     // The point of the heal: what GET returns must survive a PUT. Both stale
     // fields at once, on a tile that also carries a real alias.
-    const select = firstSelect(
-      makeDoc([
-        {
-          aggFn: 'count',
-          level: 0.99,
-          valueExpression: 'Duration',
-          alias: 'errors',
-          aggCondition: "ServiceName = 'api'",
-        },
-      ]),
-    );
+    const select = firstSelect([
+      {
+        aggFn: 'count',
+        level: 0.99,
+        valueExpression: 'Duration',
+        alias: 'errors',
+        aggCondition: "ServiceName = 'api'",
+      },
+    ]);
     expect(externalDashboardSelectItemSchema.safeParse(select).success).toBe(
       true,
     );

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -146,11 +146,16 @@ const convertToExternalSelectItem = (
   // both, so the GET body could not be PUT back and an imported dashboard
   // failed `terraform plan` with "Level can only be used with quantile
   // aggregation function". Same read-path heal as the container refs below.
+  //
+  // Scoped to exactly what that schema rejects: an *empty* valueExpression on a
+  // count is what the editor writes for every count tile and validates fine, so
+  // it stays. Only a leftover value is dropped.
   const level =
     aggFn === 'quantile' && parsedLevel?.success ? parsedLevel.data : undefined;
+  const staleValueExpression = aggFn === 'count' && !!item.valueExpression;
   return {
     ...pick(item, ['alias', 'metricType', 'metricName', 'numberFormat']),
-    ...(aggFn === 'count' ? {} : pick(item, ['valueExpression'])),
+    ...(staleValueExpression ? {} : pick(item, ['valueExpression'])),
     aggFn,
     where: item.aggCondition ?? '',
     whereLanguage: item.aggConditionLanguage ?? 'lucene',

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -138,15 +138,19 @@ const convertToExternalSelectItem = (
     'level' in item
       ? externalQuantileLevelSchema.safeParse(item.level)
       : undefined;
-  const level = parsedLevel?.success ? parsedLevel.data : undefined;
+  // Drop aggregation parameters the emitted aggFn cannot carry. Changing a
+  // tile's aggregation in the editor leaves the previous agg's field behind in
+  // the stored config, where it is inert: renderChartConfig reads `level` only
+  // for a quantile or histogram agg, and ignores `valueExpression` for a count.
+  // On the way out it is not inert — externalDashboardSelectItemSchema rejects
+  // both, so the GET body could not be PUT back and an imported dashboard
+  // failed `terraform plan` with "Level can only be used with quantile
+  // aggregation function". Same read-path heal as the container refs below.
+  const level =
+    aggFn === 'quantile' && parsedLevel?.success ? parsedLevel.data : undefined;
   return {
-    ...pick(item, [
-      'valueExpression',
-      'alias',
-      'metricType',
-      'metricName',
-      'numberFormat',
-    ]),
+    ...pick(item, ['alias', 'metricType', 'metricName', 'numberFormat']),
+    ...(aggFn === 'count' ? {} : pick(item, ['valueExpression'])),
     aggFn,
     where: item.aggCondition ?? '',
     whereLanguage: item.aggConditionLanguage ?? 'lucene',

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -194,7 +194,7 @@ const externalOnClickSchema = z.discriminatedUnion('type', [
   externalOnClickExternalSchema,
 ]);
 
-const externalDashboardSelectItemSchema = z
+export const externalDashboardSelectItemSchema = z
   .object({
     // For logs, traces, and metrics
     valueExpression: z.string().max(10000).optional(),


### PR DESCRIPTION
Closes HDX-5114.

Importing a dashboard through the Terraform provider fails on `terraform plan` with `tiles.8.config.select.0: Level can only be used with quantile aggregation function`, while the same dashboard renders fine in the UI. The external API is emitting aggregation parameters that its own input schema rejects, so the body a GET returns cannot be PUT back.

## What changed

`convertToExternalSelectItem` now drops the parameters the emitted `aggFn` cannot carry — `level` unless the agg is `quantile`, and a non-empty `valueExpression` when the agg is `count`. This is the same read-path self-heal the container and tab refs already get a few lines below, for the same reason: what GET returns has to survive a PUT.

## Background

Changing a tile's aggregation in the editor leaves the previous agg's parameter behind in the stored config. `renderChartConfig` reads `level` only for a quantile or histogram agg and ignores `valueExpression` for a count, so the leftovers never affect the chart and nobody notices them. `externalDashboardSelectItemSchema` is stricter than the internal `RootValueExpressionSchema` the editor writes through, which is where the two representations diverge.

The reported failure was a tile named "p90" whose agg had been switched to a `countIf`, still carrying the quantile's `level`.

## Key decisions

**Healed on read rather than on write.** Fixing the editor so it stops persisting the leftover would only help dashboards saved after the change; every existing dashboard would still fail to import. Healing on read fixes them all at once, and because `convertToInternalSelectItem` defaults a missing `valueExpression` to `''`, a GET → PUT round trip now also clears the stale field from the stored document.

**Matched the validator rather than relaxing it.** The rules are right — a `level` on a count is meaningless. Loosening the input schema to accept what the export emits would keep the dead data alive in both directions.

Scoped to exactly what the input schema rejects. An *empty* `valueExpression` on a count is what the editor writes for every count tile and validates fine, so it stays — dropping it too would have changed the response shape for every count select, which the integration tests caught.

## Impact

External API consumers stop seeing these fields. Nothing else reads them, and a Terraform import of an affected dashboard now plans clean. The provider carries a client-side workaround (`dropInvalidSelectFields`) for older server versions, which this makes redundant going forward.

<details>
<summary>Implementation detail</summary>

`AggregateFunctionSchema` has no `histogram` or `*If(State|Merge)` members, so those aggs already degrade to `aggFn: 'none'` on export and gating `level` on `quantile` does not cost a histogram tile anything it was keeping.

Five tests in `dashboards.test.ts` cover both directions — the two stale cases dropped, the two legitimate cases (`level` on a quantile, `valueExpression` on an `avg`) kept, and a combined case asserted to parse against `externalDashboardSelectItemSchema`, which is now exported for that check. Reverting the fix fails the three heal tests and leaves the two "keeps" tests green.

Not handled: an empty `valueExpression` on a non-count agg, which the schema requires to be present rather than absent. That tile is already broken and needs a real value, not a heal.

`yarn ci:unit` in `packages/api` passes 714 tests across 38 suites, `tsc --noEmit` clean, `yarn lint:fix` clean.

</details>
