### PR TITLE
fix(app): use categorical palette on histogram charts

### DIFF
--- a/.changeset/histogram-chart-categorical-color.md
+++ b/.changeset/histogram-chart-categorical-color.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Use the categorical chart palette and shared tooltip on histogram charts (including Request Latency on the Services dashboard) instead of a hardcoded neon green fill and a one-off tooltip.

--- a/packages/app/src/components/DBHistogramChart.tsx
+++ b/packages/app/src/components/DBHistogramChart.tsx
@@ -17,7 +17,7 @@ import { buildMVDateRangeIndicator, INTEGER_NUMBER_FORMAT } from '@/ChartUtils';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import { useSource } from '@/source';
-import { COLORS } from '@/utils';
+import { getColorFromCSSToken } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
 import ChartErrorState, {
@@ -27,7 +27,7 @@ import { ChartTooltipContainer, ChartTooltipItem } from './charts/ChartTooltip';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
 
 /** First categorical series hue (`chart-blue`). Exported for unit tests. */
-export const HISTOGRAM_BAR_COLOR = COLORS[0];
+export const HISTOGRAM_BAR_COLOR = getColorFromCSSToken('chart-blue');
 
 /**
  * Normalize a chart click's `activeIndex` to a real, in-range bar index.

--- a/packages/app/src/components/DBHistogramChart.tsx
+++ b/packages/app/src/components/DBHistogramChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { omit } from 'lodash';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -11,17 +11,23 @@ import {
   YAxis,
 } from 'recharts';
 import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
+import { Text } from '@mantine/core';
 
-import { buildMVDateRangeIndicator } from '@/ChartUtils';
+import { buildMVDateRangeIndicator, INTEGER_NUMBER_FORMAT } from '@/ChartUtils';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import { useSource } from '@/source';
+import { COLORS } from '@/utils';
 
 import ChartContainer from './charts/ChartContainer';
 import ChartErrorState, {
   ChartErrorStateVariant,
 } from './charts/ChartErrorState';
+import { ChartTooltipContainer, ChartTooltipItem } from './charts/ChartTooltip';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
+
+/** First categorical series hue (`chart-blue`). Exported for unit tests. */
+export const HISTOGRAM_BAR_COLOR = COLORS[0];
 
 /**
  * Normalize a chart click's `activeIndex` to a real, in-range bar index.
@@ -129,7 +135,7 @@ function HistogramChart({
           // fresh instance rather than relying on it being reactive after mount.
           key={pinnedIndex ?? 'hover'}
           content={
-            <HDXHistogramChartTooltip generateSearchUrl={generateSearchUrl} />
+            <HistogramChartTooltip generateSearchUrl={generateSearchUrl} />
           }
           // When a bar is pinned, lock the tooltip to that bar: `trigger:
           // 'click'` makes the tooltip ignore hover (which would otherwise let
@@ -140,52 +146,73 @@ function HistogramChart({
             ? { active: true, defaultIndex: pinnedIndex, trigger: 'click' }
             : {})}
         />
-        <Bar dataKey="height" stackId="a" fill="#50FA7B" />
+        <Bar dataKey="height" stackId="a" fill={HISTOGRAM_BAR_COLOR} />
       </BarChart>
     </ResponsiveContainer>
   );
 }
 
-const HDXHistogramChartTooltip = (props: any) => {
-  const { active, payload, generateSearchUrl } = props;
-  if (active && payload && payload.length > 0) {
-    const bucket = props.payload[0].payload;
+export const HistogramChartTooltip = memo(
+  ({
+    active,
+    payload,
+    generateSearchUrl,
+  }: {
+    active?: boolean;
+    payload?: {
+      name?: string;
+      value: number;
+      color?: string;
+      payload: { lower: number; upper: number; height: number };
+    }[];
+    generateSearchUrl?: (lower: string, upper: string) => string;
+  }) => {
+    if (!active || !payload?.length) {
+      return null;
+    }
 
+    const bucket = payload[0].payload;
     const lower = bucket.lower.toFixed(5);
     const upper = bucket.upper.toFixed(5);
 
     return (
-      <div
-        className="bg-muted px-3 py-2 rounded fs-8"
-        style={{ pointerEvents: 'auto' }}
+      <ChartTooltipContainer
+        header={
+          <span>
+            Bucket: {lower} - {upper}
+          </span>
+        }
+        footer={
+          <>
+            {generateSearchUrl && (
+              <Link
+                href={generateSearchUrl(lower, upper)}
+                className="text-muted-hover cursor-pointer"
+                onClick={e => e.stopPropagation()}
+              >
+                View events
+              </Link>
+            )}
+            <Text size="xs" c="dimmed">
+              Click to pin tooltip • Approx value via SPDT algorithm
+            </Text>
+          </>
+        }
       >
-        <div className="mb-2">
-          Bucket: {lower} - {upper}
-        </div>
-        {payload.map((p: any) => (
-          <div key={p.name} style={{ color: p.color }}>
-            Number of Events: {p.value}
-          </div>
+        {payload.map((p, index) => (
+          <ChartTooltipItem
+            key={p.name ?? index}
+            color={p.color ?? HISTOGRAM_BAR_COLOR}
+            name="Number of events"
+            value={p.value}
+            numberFormat={INTEGER_NUMBER_FORMAT}
+            indicator="square"
+          />
         ))}
-        <div className="mt-2">
-          {generateSearchUrl && (
-            <Link
-              href={generateSearchUrl(lower, upper)}
-              className="text-muted-hover cursor-pointer"
-              onClick={e => e.stopPropagation()}
-            >
-              View Events
-            </Link>
-          )}
-        </div>
-        <div className="text-muted fs-9 mt-2">
-          Click to Pin Tooltip • Approx value via SPDT algorithm
-        </div>
-      </div>
+      </ChartTooltipContainer>
     );
-  }
-  return null;
-};
+  },
+);
 
 export default function DBHistogramChart({
   config,

--- a/packages/app/src/components/DBHistogramChart.tsx
+++ b/packages/app/src/components/DBHistogramChart.tsx
@@ -1,5 +1,4 @@
 import { memo, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import { omit } from 'lodash';
 import { useHotkeys } from 'react-hotkeys-hook';
 import {
@@ -48,13 +47,7 @@ export function resolvePinnedBarIndex(
   return Number.isInteger(idx) && idx >= 0 ? idx : undefined;
 }
 
-function HistogramChart({
-  graphResults,
-  generateSearchUrl,
-}: {
-  graphResults: any[];
-  generateSearchUrl?: (lower: string, upper: string) => string;
-}) {
+function HistogramChart({ graphResults }: { graphResults: any[] }) {
   const data = useMemo(() => {
     return (
       graphResults?.map((result: any) => {
@@ -134,9 +127,7 @@ function HistogramChart({
           // Remount when the pinned bar changes so `defaultIndex` re-seeds on a
           // fresh instance rather than relying on it being reactive after mount.
           key={pinnedIndex ?? 'hover'}
-          content={
-            <HistogramChartTooltip generateSearchUrl={generateSearchUrl} />
-          }
+          content={<HistogramChartTooltip />}
           // When a bar is pinned, lock the tooltip to that bar: `trigger:
           // 'click'` makes the tooltip ignore hover (which would otherwise let
           // the tooltip drift to whatever bar the cursor grazes), and
@@ -156,7 +147,6 @@ export const HistogramChartTooltip = memo(
   ({
     active,
     payload,
-    generateSearchUrl,
   }: {
     active?: boolean;
     payload?: {
@@ -165,7 +155,6 @@ export const HistogramChartTooltip = memo(
       color?: string;
       payload: { lower: number; upper: number; height: number };
     }[];
-    generateSearchUrl?: (lower: string, upper: string) => string;
   }) => {
     if (!active || !payload?.length) {
       return null;
@@ -183,20 +172,9 @@ export const HistogramChartTooltip = memo(
           </span>
         }
         footer={
-          <>
-            {generateSearchUrl && (
-              <Link
-                href={generateSearchUrl(lower, upper)}
-                className="text-muted-hover cursor-pointer"
-                onClick={e => e.stopPropagation()}
-              >
-                View events
-              </Link>
-            )}
-            <Text size="xs" c="dimmed">
-              Click to pin tooltip • Approx value via SPDT algorithm
-            </Text>
-          </>
+          <Text size="xs" c="dimmed">
+            Click to pin tooltip • Approx value via SPDT algorithm
+          </Text>
         }
       >
         {payload.map((p, index) => (

--- a/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 
 import DateRangeIndicator from '@/components/charts/DateRangeIndicator';
 import DBHistogramChart, {
+  HISTOGRAM_BAR_COLOR,
+  HistogramChartTooltip,
   resolvePinnedBarIndex,
 } from '@/components/DBHistogramChart';
 import MVOptimizationIndicator from '@/components/MaterializedViews/MVOptimizationIndicator';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import { useSource } from '@/source';
+import { COLORS, getColorFromCSSToken } from '@/utils';
 
 // Mock dependencies
 jest.mock('@/hooks/useChartConfig', () => ({
@@ -152,6 +156,66 @@ describe('DBHistogramChart', () => {
 
     // Verify DateRangeIndicator was not called
     expect(jest.mocked(DateRangeIndicator)).not.toHaveBeenCalled();
+  });
+});
+
+describe('HISTOGRAM_BAR_COLOR', () => {
+  it('uses the first categorical series hue, not a hardcoded neon green', () => {
+    expect(HISTOGRAM_BAR_COLOR).toBe(COLORS[0]);
+    expect(HISTOGRAM_BAR_COLOR).toBe(getColorFromCSSToken('chart-blue'));
+    expect(HISTOGRAM_BAR_COLOR.toLowerCase()).not.toBe('#50fa7b');
+  });
+});
+
+describe('HistogramChartTooltip', () => {
+  const payload = [
+    {
+      name: 'height',
+      value: 1084431.375,
+      color: HISTOGRAM_BAR_COLOR,
+      payload: { lower: 0.01081, upper: 33669.79207, height: 1084431.375 },
+    },
+  ];
+
+  it('renders the shared chart tooltip with a categorical series color', () => {
+    renderWithMantine(<HistogramChartTooltip active payload={payload} />);
+
+    expect(
+      screen.getByText(/Bucket: 0.01081 - 33669.79207/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Number of events')).toHaveStyle({
+      color: HISTOGRAM_BAR_COLOR,
+    });
+    expect(screen.getByText(/1,084,431/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Click to pin tooltip • Approx value via SPDT algorithm/,
+      ),
+    ).toBeInTheDocument();
+    expect(document.querySelector('.bg-muted')).toBeNull();
+  });
+
+  it('renders a view-events link when generateSearchUrl is provided', () => {
+    renderWithMantine(
+      <HistogramChartTooltip
+        active
+        payload={payload}
+        generateSearchUrl={(lower, upper) =>
+          `/search?from=${lower}&to=${upper}`
+        }
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'View events' });
+    expect(link).toHaveAttribute('href', '/search?from=0.01081&to=33669.79207');
+  });
+
+  it('renders nothing when inactive', () => {
+    renderWithMantine(
+      <HistogramChartTooltip active={false} payload={payload} />,
+    );
+
+    expect(screen.queryByText(/Bucket:/)).toBeNull();
   });
 });
 

--- a/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
@@ -11,7 +11,6 @@ import MVOptimizationIndicator from '@/components/MaterializedViews/MVOptimizati
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import { useSource } from '@/source';
-import { getColorFromCSSToken } from '@/utils';
 
 // Mock dependencies
 jest.mock('@/hooks/useChartConfig', () => ({
@@ -161,8 +160,7 @@ describe('DBHistogramChart', () => {
 
 describe('HISTOGRAM_BAR_COLOR', () => {
   it('uses the first categorical series hue, not a hardcoded neon green', () => {
-    expect(HISTOGRAM_BAR_COLOR).toBe(getColorFromCSSToken('chart-blue'));
-    expect(HISTOGRAM_BAR_COLOR.toLowerCase()).not.toBe('#50fa7b');
+    expect(HISTOGRAM_BAR_COLOR.toLowerCase()).toBe('#437eef');
   });
 });
 
@@ -179,6 +177,7 @@ describe('HistogramChartTooltip', () => {
   it('renders the shared chart tooltip with a categorical series color', () => {
     renderWithMantine(<HistogramChartTooltip active payload={payload} />);
 
+    expect(screen.getByTestId('chart-tooltip')).toBeInTheDocument();
     expect(
       screen.getByText(/Bucket: 0.01081 - 33669.79207/),
     ).toBeInTheDocument();
@@ -191,22 +190,29 @@ describe('HistogramChartTooltip', () => {
         /Click to pin tooltip • Approx value via SPDT algorithm/,
       ),
     ).toBeInTheDocument();
-    expect(document.querySelector('.bg-muted')).toBeNull();
   });
 
-  it('renders a view-events link when generateSearchUrl is provided', () => {
+  it('falls back to HISTOGRAM_BAR_COLOR when the payload item has no color', () => {
     renderWithMantine(
       <HistogramChartTooltip
         active
-        payload={payload}
-        generateSearchUrl={(lower, upper) =>
-          `/search?from=${lower}&to=${upper}`
-        }
+        payload={[
+          {
+            name: 'height',
+            value: 1084431.375,
+            payload: {
+              lower: 0.01081,
+              upper: 33669.79207,
+              height: 1084431.375,
+            },
+          },
+        ]}
       />,
     );
 
-    const link = screen.getByRole('link', { name: 'View events' });
-    expect(link).toHaveAttribute('href', '/search?from=0.01081&to=33669.79207');
+    expect(screen.getByText('Number of events')).toHaveStyle({
+      color: HISTOGRAM_BAR_COLOR,
+    });
   });
 
   it('renders nothing when inactive', () => {
@@ -215,6 +221,18 @@ describe('HistogramChartTooltip', () => {
     );
 
     expect(screen.queryByText(/Bucket:/)).toBeNull();
+  });
+
+  it('renders nothing when active with an empty payload', () => {
+    renderWithMantine(<HistogramChartTooltip active payload={[]} />);
+
+    expect(screen.queryByTestId('chart-tooltip')).toBeNull();
+  });
+
+  it('renders nothing when active with an undefined payload', () => {
+    renderWithMantine(<HistogramChartTooltip active />);
+
+    expect(screen.queryByTestId('chart-tooltip')).toBeNull();
   });
 });
 

--- a/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBHistogramChart.test.tsx
@@ -11,7 +11,7 @@ import MVOptimizationIndicator from '@/components/MaterializedViews/MVOptimizati
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 import { useSource } from '@/source';
-import { COLORS, getColorFromCSSToken } from '@/utils';
+import { getColorFromCSSToken } from '@/utils';
 
 // Mock dependencies
 jest.mock('@/hooks/useChartConfig', () => ({
@@ -161,7 +161,6 @@ describe('DBHistogramChart', () => {
 
 describe('HISTOGRAM_BAR_COLOR', () => {
   it('uses the first categorical series hue, not a hardcoded neon green', () => {
-    expect(HISTOGRAM_BAR_COLOR).toBe(COLORS[0]);
     expect(HISTOGRAM_BAR_COLOR).toBe(getColorFromCSSToken('chart-blue'));
     expect(HISTOGRAM_BAR_COLOR.toLowerCase()).not.toBe('#50fa7b');
   });

--- a/packages/app/src/components/charts/ChartTooltip.tsx
+++ b/packages/app/src/components/charts/ChartTooltip.tsx
@@ -233,7 +233,7 @@ export const ChartTooltipContainer = ({
   /** Extra class on the content wrapper (e.g. the hover tooltip's height clamp). */
   contentClassName?: string;
 }) => (
-  <div className={styles.chartTooltip}>
+  <div className={styles.chartTooltip} data-testid="chart-tooltip">
     {header != null && (
       <div className={styles.chartTooltipHeader}>{header}</div>
     )}


### PR DESCRIPTION
## Summary

Histogram charts (including Request Latency on the Services dashboard) now use the categorical palette and the shared chart tooltip instead of a leftover neon green fill and a one-off tooltip.

Bars were hardcoded to `#50FA7B`, which is not in the chart palette. The tooltip also painted "Number of events" in that same color. They now resolve `chart-blue` through `getColorFromCSSToken` and render with `ChartTooltipContainer` / `ChartTooltipItem`, matching line, bar, and pie charts.

The tooltip's unused **View events** link is gone. `generateSearchUrl` was accepted on the inner histogram/tooltip but never passed from `DBHistogramChart`, so the link never appeared in production. The only caller (Services → HTTP Request Latency) has no search-URL builder for a duration bucket. Wiring a working link would be a separate feature (filter events to that latency range); until then the prop was dead code.

<img width="1474" height="1482" alt="image" src="https://github.com/user-attachments/assets/6137015f-dc2c-4b29-a0ee-2a4f32282817" />

## Test plan

- [ ] Open **Services → HTTP**, switch Request Latency to histogram, and confirm bars are chart-blue (`#437eef`), not neon green
- [ ] Hover a bucket: tooltip should match other charts (bordered surface, square swatch, formatted count)
- [ ] Confirm the tooltip does **not** show a View events link
- [ ] Click a bar to pin the tooltip, Esc to unpin
- [ ] `yarn workspace @hyperdx/app jest src/components/__tests__/DBHistogramChart.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor_Grok_4.6](https://img.shields.io/badge/Cursor_Grok_4.6-000000)