### PR TITLE
Fix dashboard filter selection state breaking on complex expressions

### DIFF
--- a/.changeset/fix-filter-parser-paren-depth.md
+++ b/.changeset/fix-filter-parser-paren-depth.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/common-utils': patch
+---
+
+Fix dashboard filter selection state breaking on complex expressions. The
+filter parser (shared with the search page) now tracks parenthesis depth in
+addition to quote depth, so selections stored for expression-based filters such
+as `if(SeverityText = 'error' OR SeverityText = 'fatal', 'Errors', 'Non-errors')`
+or `if(SeverityText IN ('error', 'fatal'), 'Errors', 'Non-errors')` are parsed
+correctly instead of being dropped or split on operators/keywords nested inside
+the expression.

--- a/packages/app/src/__tests__/searchFilters.test.ts
+++ b/packages/app/src/__tests__/searchFilters.test.ts
@@ -472,6 +472,147 @@ describe('searchFilters', () => {
         },
       });
     });
+
+    // Dashboard filters can be defined by an arbitrary expression, not just a
+    // bare column. The parser must treat the whole expression as the key and
+    // ignore operators/keywords nested inside its parentheses.
+    describe('complex expression keys', () => {
+      const ifExpr = `if(SeverityText = 'error' or SeverityText = 'fatal', 'Errors', 'Non-errors')`;
+      const ifWithInExpr = `if(SeverityText IN ('error', 'fatal'), 'Errors', 'Non-errors')`;
+
+      it('keeps the whole expression as the key when it contains OR and = inside parens', () => {
+        const result = parseQuery([
+          { type: 'sql', condition: `${ifExpr} IN ('Errors')` },
+        ]);
+        expect(result.filters).toEqual({
+          [ifExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('splits on the outer IN, not the IN nested inside the expression', () => {
+        const result = parseQuery([
+          { type: 'sql', condition: `${ifWithInExpr} IN ('Errors')` },
+        ]);
+        expect(result.filters).toEqual({
+          [ifWithInExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('parses multiple selected values on an expression key', () => {
+        const result = parseQuery([
+          {
+            type: 'sql',
+            condition: `${ifExpr} IN ('Errors', 'Non-errors')`,
+          },
+        ]);
+        expect(result.filters).toEqual({
+          [ifExpr]: {
+            included: new Set(['Errors', 'Non-errors']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('parses NOT IN on an expression key without splitting on nested IN', () => {
+        const result = parseQuery([
+          { type: 'sql', condition: `${ifWithInExpr} NOT IN ('Errors')` },
+        ]);
+        expect(result.filters).toEqual({
+          [ifWithInExpr]: {
+            included: new Set(),
+            excluded: new Set(['Errors']),
+          },
+        });
+      });
+
+      it('parses included and excluded selections on the same expression key', () => {
+        const result = parseQuery([
+          { type: 'sql', condition: `${ifExpr} IN ('Errors')` },
+          { type: 'sql', condition: `${ifExpr} NOT IN ('Non-errors')` },
+        ]);
+        expect(result.filters).toEqual({
+          [ifExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(['Non-errors']),
+          },
+        });
+      });
+
+      it('extracts an expression clause from an AND-joined compound condition', () => {
+        const result = parseQuery([
+          {
+            type: 'sql',
+            condition: `ServiceName IN ('api') AND ${ifExpr} IN ('Errors')`,
+          },
+        ]);
+        expect(result.filters).toEqual({
+          ServiceName: {
+            included: new Set(['api']),
+            excluded: new Set(),
+          },
+          [ifExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('does not split on AND nested inside an expression key', () => {
+        const betweenExpr = `if(Duration BETWEEN 1 AND 2, 'fast', 'slow')`;
+        const result = parseQuery([
+          { type: 'sql', condition: `${betweenExpr} IN ('fast')` },
+        ]);
+        expect(result.filters).toEqual({
+          [betweenExpr]: {
+            included: new Set(['fast']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('does not treat a BETWEEN nested inside an expression key as a range', () => {
+        const betweenExpr = `if(Duration BETWEEN 1 AND 2, 'fast', 'slow')`;
+        const result = parseQuery([
+          { type: 'sql', condition: `${betweenExpr} NOT IN ('slow')` },
+        ]);
+        expect(result.filters).toEqual({
+          [betweenExpr]: {
+            included: new Set(),
+            excluded: new Set(['slow']),
+          },
+        });
+      });
+
+      it('handles a nested function expression key', () => {
+        const key = `toString(multiIf(Status >= 500, 'error', Status >= 400, 'warn', 'ok'))`;
+        const result = parseQuery([
+          { type: 'sql', condition: `${key} IN ('error', 'warn')` },
+        ]);
+        expect(result.filters).toEqual({
+          [key]: {
+            included: new Set(['error', 'warn']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('round-trips an expression key through filtersToQuery', () => {
+        const originalFilters = {
+          [ifExpr]: {
+            included: new Set<string | boolean>(['Errors']),
+            excluded: new Set<string | boolean>(['Non-errors']),
+          },
+        };
+        const query = filtersToQuery(originalFilters);
+        expect(parseQuery(query).filters).toEqual(originalFilters);
+      });
+    });
   });
 
   describe('areFiltersEqual', () => {

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -1163,6 +1163,181 @@ describe('filters', () => {
     });
   });
 
+  // Dashboard filters can be defined by an arbitrary expression, not just a
+  // bare column. The parser must treat the whole expression as the key and
+  // ignore operators/keywords nested inside its parentheses, rather than
+  // dropping the clause or splitting on a nested operator. These cases exercise
+  // the parenthesis-depth awareness of parseQuery (and, transitively,
+  // countTopLevelAnd via isRenderablePinnedFilter).
+  describe('complex expression keys (nested parentheses)', () => {
+    const ifOrExpr = `if(SeverityText = 'error' or SeverityText = 'fatal', 'Errors', 'Non-errors')`;
+    const ifInExpr = `if(SeverityText IN ('error', 'fatal'), 'Errors', 'Non-errors')`;
+    const ifBetweenExpr = `if(Duration BETWEEN 1 AND 2, 'fast', 'slow')`;
+
+    describe('parseQuery', () => {
+      it('keeps the whole expression as the key when it nests OR and = inside parens', () => {
+        expect(
+          parseQuery([{ type: 'sql', condition: `${ifOrExpr} IN ('Errors')` }])
+            .filters,
+        ).toEqual({
+          [ifOrExpr]: { included: new Set(['Errors']), excluded: new Set() },
+        });
+      });
+
+      it('splits on the outer IN, not the IN nested inside the expression', () => {
+        expect(
+          parseQuery([{ type: 'sql', condition: `${ifInExpr} IN ('Errors')` }])
+            .filters,
+        ).toEqual({
+          [ifInExpr]: { included: new Set(['Errors']), excluded: new Set() },
+        });
+      });
+
+      it('parses multiple selected values on an expression key', () => {
+        expect(
+          parseQuery([
+            {
+              type: 'sql',
+              condition: `${ifOrExpr} IN ('Errors', 'Non-errors')`,
+            },
+          ]).filters,
+        ).toEqual({
+          [ifOrExpr]: {
+            included: new Set(['Errors', 'Non-errors']),
+            excluded: new Set(),
+          },
+        });
+      });
+
+      it('parses NOT IN on an expression key without splitting on nested IN', () => {
+        expect(
+          parseQuery([
+            { type: 'sql', condition: `${ifInExpr} NOT IN ('Errors')` },
+          ]).filters,
+        ).toEqual({
+          [ifInExpr]: { included: new Set(), excluded: new Set(['Errors']) },
+        });
+      });
+
+      it('merges included and excluded selections on the same expression key', () => {
+        expect(
+          parseQuery([
+            { type: 'sql', condition: `${ifOrExpr} IN ('Errors')` },
+            { type: 'sql', condition: `${ifOrExpr} NOT IN ('Non-errors')` },
+          ]).filters,
+        ).toEqual({
+          [ifOrExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(['Non-errors']),
+          },
+        });
+      });
+
+      it('extracts an expression clause from an AND-joined compound condition', () => {
+        expect(
+          parseQuery([
+            {
+              type: 'sql',
+              condition: `ServiceName IN ('api') AND ${ifOrExpr} IN ('Errors')`,
+            },
+          ]).filters,
+        ).toEqual({
+          ServiceName: { included: new Set(['api']), excluded: new Set() },
+          [ifOrExpr]: { included: new Set(['Errors']), excluded: new Set() },
+        });
+      });
+
+      it('does not split on AND nested inside an expression key', () => {
+        expect(
+          parseQuery([
+            { type: 'sql', condition: `${ifBetweenExpr} IN ('fast')` },
+          ]).filters,
+        ).toEqual({
+          [ifBetweenExpr]: { included: new Set(['fast']), excluded: new Set() },
+        });
+      });
+
+      it('does not treat a BETWEEN nested inside an expression key as a range', () => {
+        // toEqual asserts the exact shape: an unexpected `range` key would fail
+        // this, so it doubles as the "no range was extracted" check.
+        expect(
+          parseQuery([
+            { type: 'sql', condition: `${ifBetweenExpr} NOT IN ('slow')` },
+          ]).filters,
+        ).toEqual({
+          [ifBetweenExpr]: { included: new Set(), excluded: new Set(['slow']) },
+        });
+      });
+
+      it('handles a nested function expression key', () => {
+        const key = `toString(multiIf(Status >= 500, 'error', Status >= 400, 'warn', 'ok'))`;
+        expect(
+          parseQuery([
+            { type: 'sql', condition: `${key} IN ('error', 'warn')` },
+          ]).filters,
+        ).toEqual({
+          [key]: { included: new Set(['error', 'warn']), excluded: new Set() },
+        });
+      });
+
+      it('round-trips an expression key through filtersToQuery', () => {
+        const originalFilters: FilterState = {
+          [ifOrExpr]: {
+            included: new Set(['Errors']),
+            excluded: new Set(['Non-errors']),
+          },
+        };
+        expect(parseQuery(filtersToQuery(originalFilters)).filters).toEqual(
+          originalFilters,
+        );
+      });
+    });
+
+    describe('isRenderablePinnedFilter', () => {
+      const sql = (condition: string): Filter => ({ type: 'sql', condition });
+
+      // A nested IN carries no bare AND/OR/NOT keyword, so an expression key
+      // built only from it round-trips to a single renderable facet. Before the
+      // parser tracked parenthesis depth this same input parsed to the garbage
+      // key `if(SeverityText` — accepted for the wrong reason; now it is
+      // accepted with the correct, whole-expression key.
+      it('accepts an expression key whose only nested keyword is IN', () => {
+        expect(isRenderablePinnedFilter(sql(`${ifInExpr} IN ('Errors')`))).toBe(
+          true,
+        );
+      });
+
+      it('accepts a nested-function expression key', () => {
+        const key = `toString(multiIf(Status >= 500, 'error', 'ok'))`;
+        expect(isRenderablePinnedFilter(sql(`${key} IN ('error')`))).toBe(true);
+      });
+
+      // A key that nests OR/AND (including the AND of a nested BETWEEN) still
+      // carries that keyword as bare text, so it is rejected: the sidebar can't
+      // render it as a plain column facet even though the value list parses.
+      it('rejects an expression key that nests OR', () => {
+        expect(isRenderablePinnedFilter(sql(`${ifOrExpr} IN ('Errors')`))).toBe(
+          false,
+        );
+      });
+
+      it('rejects an expression key that nests a BETWEEN ... AND', () => {
+        expect(
+          isRenderablePinnedFilter(sql(`${ifBetweenExpr} IN ('fast')`)),
+        ).toBe(false);
+      });
+
+      // countTopLevelAnd counts a BETWEEN's own bounds AND (exactly one
+      // top-level conjunct) while the parentheses of the function key are
+      // tracked without disturbing that count, so the filter stays renderable.
+      it('accepts a numeric BETWEEN on a parenthesized (function) key', () => {
+        expect(
+          isRenderablePinnedFilter(sql('length(Body) BETWEEN 1 AND 5')),
+        ).toBe(true);
+      });
+    });
+  });
+
   describe('deriveVariableName', () => {
     it.each([
       ['Total Requests', 'Total_Requests'],

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -249,14 +249,22 @@ function splitValuesOnComma(valuesStr: string): (string | boolean)[] {
   return values;
 }
 
-// Check whether a SQL fragment contains a keyword or operator outside of
-// single-quoted strings.  Accepts either single characters (=, <, >) or
-// multi-character keywords (' OR ', ' BETWEEN ') to search for.
+// Check whether a SQL fragment contains a keyword or operator at the *top
+// level* — outside single-quoted strings and outside any parentheses.  Accepts
+// either single characters (=, <, >) or multi-character keywords (' OR ',
+// ' BETWEEN ') to search for.
+//
+// Parenthesis-depth awareness is what lets a complex expression key survive
+// parsing: in `if(SeverityText = 'error' OR SeverityText = 'fatal', ...) IN
+// ('Errors')` the `=` and ` OR ` live inside the `if(...)` sub-expression, so
+// they must not be mistaken for top-level operators that would disqualify the
+// clause. Parentheses inside quoted strings don't affect depth.
 function containsOutsideQuotes(
   text: string,
   targets: (string | { char: string })[],
 ): boolean {
   let inString = false;
+  let depth = 0;
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
     if (isQuoteBoundary(text, i)) {
@@ -271,6 +279,16 @@ function containsOutsideQuotes(
       continue;
     }
     if (inString) continue;
+
+    if (char === '(') {
+      depth++;
+      continue;
+    }
+    if (char === ')') {
+      if (depth > 0) depth--;
+      continue;
+    }
+    if (depth > 0) continue;
 
     for (const target of targets) {
       if (typeof target === 'object') {
@@ -293,15 +311,24 @@ function containsOperatorOutsideQuotes(part: string): boolean {
   ]);
 }
 
-// Split a string on the first occurrence of `delimiter` that is outside
-// single-quoted strings.  Returns [before, after] or null if not found.
+// Split a string on the first occurrence of `delimiter` that is at the top
+// level — outside single-quoted strings and outside any parentheses.  Returns
+// [before, after] or null if not found.
+//
+// Depth awareness makes the split land on the separator between the key
+// expression and its value list rather than on an operator nested inside the
+// key: `if(SeverityText IN ('error','fatal'), ...) IN ('Errors')` must split on
+// the outer ` IN `, keeping the whole `if(...)` as the key, not on the ` IN `
+// inside the `if(...)`.
 function splitOnFirstOutsideQuotes(
   text: string,
   delimiter: string,
 ): [string, string] | null {
   let inString = false;
+  let depth = 0;
   const upper = delimiter.toUpperCase();
   for (let i = 0; i < text.length; i++) {
+    const char = text.charAt(i);
     if (isQuoteBoundary(text, i)) {
       if (inString) {
         const esc = handleQuoteEscape(text, i);
@@ -314,6 +341,15 @@ function splitOnFirstOutsideQuotes(
       continue;
     }
     if (inString) continue;
+    if (char === '(') {
+      depth++;
+      continue;
+    }
+    if (char === ')') {
+      if (depth > 0) depth--;
+      continue;
+    }
+    if (depth > 0) continue;
     if (text.slice(i, i + upper.length).toUpperCase() === upper) {
       return [text.slice(0, i), text.slice(i + upper.length)];
     }
@@ -334,10 +370,15 @@ function extractInClauses(condition: string): Array<{
     isExclude: boolean;
   }> = [];
 
-  // Split on ' AND ' while respecting quoted strings (including SQL-escaped quotes)
+  // Split on ' AND ' while respecting quoted strings (including SQL-escaped
+  // quotes) and parenthesis depth. Only a *top-level* ` AND ` joins two
+  // separate predicates; an ` AND ` nested inside parentheses belongs to a key
+  // sub-expression (e.g. `if(x BETWEEN 1 AND 2, ...) IN (...)`) and must not
+  // split the clause.
   const parts: string[] = [];
   let currentPart = '';
   let inString = false;
+  let depth = 0;
 
   for (let i = 0; i < condition.length; i++) {
     const char = condition[i];
@@ -356,13 +397,22 @@ function extractInClauses(condition: string): Array<{
       continue;
     }
 
-    if (!inString && condition.slice(i, i + 5).toUpperCase() === ' AND ') {
-      if (currentPart.trim()) {
-        parts.push(currentPart.trim());
+    if (!inString) {
+      if (char === '(') {
+        depth++;
+      } else if (char === ')') {
+        if (depth > 0) depth--;
+      } else if (
+        depth === 0 &&
+        condition.slice(i, i + 5).toUpperCase() === ' AND '
+      ) {
+        if (currentPart.trim()) {
+          parts.push(currentPart.trim());
+        }
+        currentPart = '';
+        i += 4; // Skip past ' AND '
+        continue;
       }
-      currentPart = '';
-      i += 4; // Skip past ' AND '
-      continue;
     }
 
     currentPart += char;
@@ -375,7 +425,10 @@ function extractInClauses(condition: string): Array<{
   // Process each part to extract IN/NOT IN clauses
   for (const part of parts) {
     // Skip parts that contain OR (not supported) or comparison operators,
-    // but only when those operators appear outside of quoted strings.
+    // but only when those operators appear at the top level — outside quoted
+    // strings and outside any parentheses. Operators nested inside a key
+    // expression's parentheses (e.g. `if(a = 'x' OR b = 'y', ...)`) are part of
+    // that expression and must not disqualify the clause.
     if (containsOperatorOutsideQuotes(part)) {
       continue;
     }
@@ -496,12 +549,16 @@ export const parseQuery = (
   return { filters: Object.fromEntries(state) };
 };
 
-// Count top-level ` AND ` separators (outside quoted strings). Used to detect
-// conjuncts the pinned-filter parser silently drops.
+// Count top-level ` AND ` separators (outside quoted strings and outside any
+// parentheses). Used to detect conjuncts the pinned-filter parser silently
+// drops. An ` AND ` nested inside parentheses belongs to a key sub-expression
+// and is not a top-level conjunct.
 function countTopLevelAnd(condition: string): number {
   let count = 0;
   let inString = false;
+  let depth = 0;
   for (let i = 0; i < condition.length; i++) {
+    const char = condition.charAt(i);
     if (isQuoteBoundary(condition, i)) {
       if (inString) {
         const esc = handleQuoteEscape(condition, i);
@@ -514,6 +571,15 @@ function countTopLevelAnd(condition: string): number {
       continue;
     }
     if (inString) continue;
+    if (char === '(') {
+      depth++;
+      continue;
+    }
+    if (char === ')') {
+      if (depth > 0) depth--;
+      continue;
+    }
+    if (depth > 0) continue;
     if (condition.slice(i, i + 5).toUpperCase() === ' AND ') {
       count++;
       i += 4;


### PR DESCRIPTION
## Why

Dashboard filters are defined by an expression — usually a bare column (e.g. `ServiceName`), but sometimes a more complex expression used to transform the queried options. The selection state is serialized to/from URL state by `parseQuery`, the filter parser shared with the search page.

That parser tracked single-quote **string** depth but not **parenthesis** depth, so it mis-parsed valid selection state whenever the filter expression contained operators or keywords nested inside parentheses. Examples:

1. `if(SeverityText = 'error' or SeverityText = 'fatal', 'Errors', 'Non-errors')` — the selection was **dropped** because the parser saw the `=`/`OR` inside `if(...)` and treated the whole clause as an unsupported.
2. `if(SeverityText IN ('error','fatal'), 'Errors', 'Non-errors')` — the selection was **mis-split** on the first `IN` (the one *inside* the `if(...)`)

## What

Made the parser's scanning helpers in `packages/common-utils/src/filters.ts` parenthesis-depth aware. Operators (`=`, `<`, `>`, ` OR `), the ` AND ` conjunct splitter, the ` IN `/` NOT IN ` split point, and ` BETWEEN ` detection are now only recognized at the **top level** (depth 0, outside quotes). Anything nested inside parentheses is treated as part of a key sub-expression.

Note: wrapping the *entire* condition including the `IN` and value list in parens (e.g. `(col IN ('x'))`) is not something `filtersToQuery` ever emits, and was not parsed correctly prior to these changes, so we're not breaking anything here.

## Testing

- Create a dashboard filter with a complex expression
- Ensure that the dropdown values populate, can be selected, and properly broadcast to the dashboard's tiles

## References

Linear Issue: Closes HDX-5129

