### PR TITLE
fix(ci): build workspace deps before running unit tests

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -26,6 +26,16 @@
       "dependsOn": ["^ci:build"],
       "inputs": ["default", "^production", { "runtime": "node --version" }]
     },
+    // Unit tests import the compiled `dist` of workspace dependencies (e.g.
+    // `@hyperdx/common-utils/dist/types`), so they need the same `^ci:build`
+    // that `ci:lint` has. Without it, `nx run-many -t ci:unit` can run jest
+    // against a stale or absent dist — which fails intermittently, because the
+    // nx cache usually leaves a usable dist behind and occasionally does not.
+    "ci:unit": {
+      "cache": true,
+      "dependsOn": ["^ci:build"],
+      "inputs": ["default", "^production", { "runtime": "node --version" }]
+    },
     "dev:build": {
       "cache": true
     },


### PR DESCRIPTION
## The bug

`nx.json` declares `dependsOn: ["^ci:build"]` for `ci:build` and `ci:lint`, but **`ci:unit` has no `targetDefaults` entry at all**. So `nx run-many -t ci:unit` runs jest without building workspace dependencies first.

`packages/{api,app,cli}` all have a `ci:unit` target and all import `@hyperdx/common-utils`, so all three can run their tests against a stale or absent `common-utils/dist`.

## Why it looks flaky rather than broken

Lint and unit are separate CI jobs. The unit job only sees a current `dist` if the nx cache happens to restore one. When it doesn't, tests fail against stale compiled output — so the same commit passes or fails depending on cache state.

The cache isn't the bug; it's what hides the bug most of the time.

## What it looks like when it bites

Failures land in suites that have nothing to do with the change under test, which makes it read as an unrelated regression on `main`. On #2848 it surfaced as 40 failures across `searchFilters` and `useDashboardFilterValues`. Both suites pass on the same commit once `common-utils` is built — nothing was actually broken.

## Verification

Deleted `packages/common-utils/dist`, then ran the app's unit target through nx with this change:

```
NX  Running target ci:unit for project @hyperdx/app and 1 task it depends on:
> nx run @hyperdx/common-utils:"ci:build"
Test Suites: 181 passed, 181 total
Tests:       3081 passed, 3081 total
```

Without the change, the same clean-`dist` starting point produces 40 failures across those two suites.

The `inputs` mirror `ci:lint`'s, so unit results stay cached on the same terms as lint.