### PR TITLE
fix(alerts): don't let failed mentions consume notification slots

### DIFF
--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -551,7 +551,7 @@ describe('per-event notification cap', () => {
       .join(' ');
     const { dispatcher, dispatched } = makeRecordingDispatcher();
 
-    const { results } = await renderAlertTemplate({
+    const { failures } = await renderAlertTemplate({
       alertProvider,
       clickhouseClient: mockClickhouseClient,
       metadata: mockMetadata,
@@ -565,7 +565,7 @@ describe('per-event notification cap', () => {
     });
 
     expect(dispatched).toHaveLength(CAP);
-    expect(results).toHaveLength(0);
+    expect(failures).toHaveLength(0);
   });
 
   it('caps dispatch and records an execution error for each dropped target', async () => {
@@ -576,7 +576,7 @@ describe('per-event notification cap', () => {
       .join(' ');
     const { dispatcher, dispatched } = makeRecordingDispatcher();
 
-    const { results } = await renderAlertTemplate({
+    const { failures } = await renderAlertTemplate({
       alertProvider,
       clickhouseClient: mockClickhouseClient,
       metadata: mockMetadata,
@@ -593,8 +593,48 @@ describe('per-event notification cap', () => {
 
     // The target over the cap is reported, not silently dropped — otherwise the
     // alert looks healthy while a channel was never notified.
-    expect(results).toHaveLength(1);
-    expect(String(results[0].error)).toContain('Notification cap');
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0].error)).toContain('Notification cap');
+  });
+
+  // A pre-dispatch failure (an unparseable mention, a missing webhook, the cap
+  // itself) never reaches the dispatcher, so it must not count against the cap
+  // meant to bound real deliveries. Otherwise enough failed mentions ahead of a
+  // valid webhook silently push it over the cap.
+  it('does not let unresolvable mentions ahead of it push a valid webhook over the cap', async () => {
+    const webhook = makeWebhook(0);
+    const id = webhook._id.toString();
+    const teamWebhooksById = new Map([[id, webhook]]);
+    // CAP unresolvable mentions, then one real webhook target. If failures
+    // counted toward the cap, the webhook would land on the CAP+1'th target
+    // and get turned away.
+    const unresolvableMentions = Array.from(
+      { length: CAP },
+      () => '@here',
+    ).join(' ');
+    const template = `${unresolvableMentions} @webhook-${id}`;
+    const { dispatcher, dispatched } = makeRecordingDispatcher();
+
+    const { failures } = await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: mockClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      template,
+      title: 'Test Alert Title',
+      view: makeSearchView(),
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById,
+      dispatcher,
+    });
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].populatedChannel).toMatchObject({ type: 'webhook' });
+    // Every "@here" is its own failure; none of them is a cap-exceeded error.
+    expect(failures).toHaveLength(CAP);
+    expect(
+      failures.every(f => !String(f.error).includes('Notification cap')),
+    ).toBe(true);
   });
 });
 
@@ -613,7 +653,7 @@ describe('notification targets are resolved once per webhook', () => {
     const id = webhook._id.toString();
     const { dispatcher, dispatched } = makeRecordingDispatcher();
 
-    const { results } = await renderAlertTemplate({
+    const { failures } = await renderAlertTemplate({
       alertProvider,
       clickhouseClient: mockClickhouseClient,
       metadata: mockMetadata,
@@ -634,7 +674,7 @@ describe('notification targets are resolved once per webhook', () => {
     });
 
     expect(dispatched).toHaveLength(1);
-    expect(results).toHaveLength(0);
+    expect(failures).toHaveLength(0);
   });
 
   it('keeps firing configured channels when the message has a plain @mention', async () => {
@@ -642,7 +682,7 @@ describe('notification targets are resolved once per webhook', () => {
     const id = webhook._id.toString();
     const { dispatcher, dispatched } = makeRecordingDispatcher();
 
-    const { results } = await renderAlertTemplate({
+    const { failures } = await renderAlertTemplate({
       alertProvider,
       clickhouseClient: mockClickhouseClient,
       metadata: mockMetadata,
@@ -663,7 +703,7 @@ describe('notification targets are resolved once per webhook', () => {
     });
 
     expect(dispatched).toHaveLength(1);
-    expect(results).toHaveLength(1);
-    expect(String(results[0].error)).toContain('not a webhook channel');
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0].error)).toContain('not a webhook channel');
   });
 });

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -546,7 +546,7 @@ const fireChannelEvent = async ({
     value: totalCount,
   };
 
-  const { results } = await renderAlertTemplate({
+  const { failures } = await renderAlertTemplate({
     alertProvider,
     clickhouseClient,
     metadata,
@@ -561,7 +561,7 @@ const fireChannelEvent = async ({
     teamId,
     teamWebhooksById,
   });
-  return results;
+  return failures;
 };
 
 // Use a delimiter that's unlikely to appear in alert IDs or group names
@@ -1232,7 +1232,7 @@ export const processAlert = async (
         // alert logic requiring large, nested objects. We should look at
         // cleaning this up next. fireChannelEvent guards against null values
         // for these properties.
-        const results = await fireChannelEvent({
+        const failures = await fireChannelEvent({
           alert,
           alertProvider,
           attributes,
@@ -1253,7 +1253,7 @@ export const processAlert = async (
         // Each entry is a target that didn't end up delivered: unresolvable,
         // capped, or (for the inline dispatcher) an actual send rejection —
         // see renderAlertTemplate.
-        for (const failure of results) {
+        for (const failure of failures) {
           logger.error(
             {
               alertId: alert.id,

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -346,7 +346,7 @@ export type NotificationFailure = {
   /** The webhook id/name prefix, or the raw @mention, that failed. */
   target: string;
   /** The channel type the target belongs to, or 'unknown' when it couldn't be determined (e.g. an unparseable @mention). */
-  type: string;
+  type: AlertChannelType | 'unknown';
   error: unknown;
 };
 
@@ -364,7 +364,7 @@ export type RenderedAlert = {
   /** The rendered message body, as delivered to every target. */
   body: string;
   /** One entry per target that did not end up delivered — see NotificationFailure. */
-  results: NotificationFailure[];
+  failures: NotificationFailure[];
 };
 
 // this method will build the body of the alert message and will be used to send the alert to the channel
@@ -452,7 +452,11 @@ export const renderAlertTemplate = async ({
 
   // A target that failed before dispatch still needs to surface as its own
   // result, so the alert reports which channel missed out.
-  const recordPreFailure = (target: string, type: string, error: unknown) => {
+  const recordPreFailure = (
+    target: string,
+    type: AlertChannelType | 'unknown',
+    error: unknown,
+  ) => {
     failures.push({ target, type, error });
   };
 
@@ -519,7 +523,7 @@ export const renderAlertTemplate = async ({
         return;
       }
 
-      if (jobs.length + failures.length >= MAX_NOTIFICATIONS_PER_EVENT) {
+      if (jobs.length >= MAX_NOTIFICATIONS_PER_EVENT) {
         logger.warn(
           { alertId: alert.id, cap: MAX_NOTIFICATIONS_PER_EVENT },
           'Notification cap reached for this alert event; skipping channel',
@@ -721,7 +725,7 @@ ${targetTemplate}`;
       }),
     );
 
-    return { body, results: failures };
+    return { body, failures };
   }
 
   throw new Error(`Unsupported alert source: ${alert.source}`);


### PR DESCRIPTION
Follow-ups from review on #2847, which merged before these were applied.

## The bug (Greptile P1, raised twice on #2847)

The per-event notification cap counted pre-dispatch *failures* toward the limit:

```ts
if (jobs.length + failures.length >= MAX_NOTIFICATIONS_PER_EVENT) {
```

`MAX_NOTIFICATIONS_PER_EVENT` is 20. An ordinary `@here` in an alert message body arrives as an unsupported channel type and becomes a failure — so it burns one of the 20 slots despite delivering nothing. With enough unresolvable mentions ahead of them, **configured webhooks get silently skipped and reported as cap-exceeded**: a missed notification *and* a misleading error explaining it as something else.

The cap exists to bound how many notifications one event sends. A failure sends none, so it shouldn't consume budget. Now counts jobs only.

This is live on `main` as of #2847.

### Test

`renderAlertTemplate.int.test.ts` gains a case putting several unresolvable mentions ahead of a configured webhook and asserting the webhook still gets a job. Verified it fails against the old counting before being fixed — restoring `jobs.length + failures.length` turns it red.

## Reviewer follow-ups from @pulpdrew

- **`NotificationFailure.type`** tightened from `string` to `AlertChannelType | 'unknown'`. `'unknown'` is what the unparseable-mention path already used; the doc comment said so but the type didn't enforce it.
- **`const results = await fireChannelEvent(...)` → `failures`** in `index.ts`. The array only ever holds failures. The `RenderedAlert.failures` half of this rename landed with #2847; the call site didn't.

## On the exhaustiveness question

@pulpdrew asked whether the error-type mapping could be typechecked so the compiler catches an unhandled case. Not cleanly, and not in this PR.

The final branch is a genuine catch-all for a dispatcher rejection, and `NotificationFailure.error` is `unknown` — anything can be thrown. `instanceof` narrowing on `unknown` can't produce a `never` check, so there's no discriminant to exhaust. Doing it properly means introducing a wrapper error type at the dispatch boundary so every failure carries a discriminant, which also touches the parallel failure paths downstream. Worth doing, but as its own change rather than half-applied here.

## Verification

`renderAlertTemplate` 79/79, `checkAlerts` 294/294, api lint 302/302 with 0 errors, `tsc` clean.