### PR TITLE
fix(theme): lighten HyperDX Code backgrounds

### DIFF
--- a/.changeset/hyperdx-code-bg.md
+++ b/.changeset/hyperdx-code-bg.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Lighten HyperDX Code backgrounds so inline code and code blocks contrast more clearly against the page in both color schemes.

--- a/packages/app/src/theme/themes/hyperdx/_tokens.scss
+++ b/packages/app/src/theme/themes/hyperdx/_tokens.scss
@@ -120,7 +120,7 @@
   --color-slider-dot-active: var(--mantine-color-green-8);
 
   /* Code / Misc UI */
-  --color-bg-code: var(--mantine-color-dark-8);
+  --color-bg-code: var(--mantine-color-dark-7);
   --color-border-code: var(--mantine-color-dark-6);
   --color-bg-kbd: var(--mantine-color-dark-9);
 
@@ -260,7 +260,7 @@
   --color-slider-dot-active: var(--mantine-color-gray-1);
 
   /* Code / Misc UI - inverted */
-  --color-bg-code: var(--mantine-color-dark-1);
+  --color-bg-code: var(--mantine-color-gray-1);
   --color-border-code: var(--mantine-color-dark-3);
   --color-bg-kbd: var(--mantine-color-dark-0);
 


### PR DESCRIPTION
## Summary
- Lightens HyperDX `--color-bg-code` so Mantine inline code and code blocks contrast more clearly against the page.
- Dark mode: `dark-8` → `dark-7`. Light mode: `dark-1` → `gray-1`.

## Test plan
- [ ] In HyperDX dark mode, check inline `<Code>` (e.g. Sessions empty state, source field hints) and `<Code block>` (e.g. error collapse, copy snippets) against the page background.
- [ ] Repeat in HyperDX light mode; code surfaces should be light gray, not a mid/dark gray.
- [ ] Confirm ClickStack is unchanged (its `--color-bg-code` tokens were not touched).
- [ ] Optional: `yarn app:storybook` and scan any stories that render `Code`.
