### PR TITLE
feat: Persist and read variable-keyed filter state

### DIFF
--- a/.changeset/dashboard-filter-value-format.md
+++ b/.changeset/dashboard-filter-value-format.md
@@ -4,4 +4,4 @@
 '@hyperdx/app': patch
 ---
 
-feat: Accept variable-keyed dashboard filter values
+feat: Persist variable-keyed dashboard filter value state

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -76,6 +76,7 @@ import {
   Flex,
   Group,
   Indicator,
+  List,
   Menu,
   Modal,
   Paper,
@@ -179,9 +180,7 @@ import SearchWhereInput, {
   getStoredLanguage,
 } from './components/SearchInput/SearchWhereInput';
 import { Tags } from './components/Tags';
-import useDashboardFilters, {
-  filterQueriesParser,
-} from './hooks/useDashboardFilters';
+import useDashboardFilters from './hooks/useDashboardFilters';
 import { useDashboardRefresh } from './hooks/useDashboardRefresh';
 import { useIsVariablesEnabled } from './hooks/useIsVariablesEnabled';
 import useTileSelection from './hooks/useTileSelection';
@@ -1830,9 +1829,6 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     'whereLanguage',
     whereLanguageParser,
   );
-  // Get raw filter queries from URL (not processed by hook)
-  const [rawFilterQueries] = useQueryState('filters', filterQueriesParser);
-
   // Toggle for overlaying alert firing/recovery markers on tile charts.
   // Ephemeral view state (URL param), not persisted on the dashboard.
   const [showAlertAnnotations, setShowAlertAnnotations] = useQueryState(
@@ -1852,10 +1848,12 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
 
   const filters = dashboard?.filters ?? [];
   const {
-    filterValues,
+    selectionByFilterId,
     setFilterValue,
-    setFilterQueries,
+    setFilterValueEntries,
+    filterValueEntries,
     ignoredFilterExpressions,
+    ignoredVariableNames,
     getFilterQueriesForSource,
     variables,
   } = useDashboardFilters(filters);
@@ -1888,7 +1886,9 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
   useEffect(() => {
     if (!dashboardReady || lastLoadedIdForBannerRef.current === dashboard?.id)
       return;
-    setShouldShowIgnoredFiltersBanner(ignoredFilterExpressions.length > 0);
+    setShouldShowIgnoredFiltersBanner(
+      ignoredFilterExpressions.length > 0 || ignoredVariableNames.length > 0,
+    );
     lastLoadedIdForBannerRef.current = dashboard?.id;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboard?.id, dashboardReady]);
@@ -2016,9 +2016,9 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     // dashboard without defaults, clear selected filters.
     if (!hasFiltersInUrl) {
       if (dashboard.savedFilterValues) {
-        setFilterQueries(dashboard.savedFilterValues);
+        setFilterValueEntries(dashboard.savedFilterValues);
       } else if (isSwitchingDashboards) {
-        setFilterQueries(null);
+        setFilterValueEntries(null);
       }
     }
 
@@ -2035,7 +2035,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     setValue,
     setWhere,
     setWhereLanguage,
-    setFilterQueries,
+    setFilterValueEntries,
   ]);
 
   // Sync changes to the URL params into the form
@@ -2061,8 +2061,8 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     const currentWhereLanguage = currentWhere
       ? formValues.whereLanguage || 'lucene'
       : null;
-    const currentFilterValues = rawFilterQueries?.length
-      ? rawFilterQueries
+    const currentFilterValues = filterValueEntries?.length
+      ? filterValueEntries
       : [];
 
     setDashboard(
@@ -2086,7 +2086,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     isLocalDashboard,
     setDashboard,
     getValues,
-    rawFilterQueries,
+    filterValueEntries,
     onSubmit,
   ]);
   const handleRemoveSavedQuery = useCallback(() => {
@@ -3153,10 +3153,11 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       )}
       {!isKioskMode &&
         shouldShowIgnoredFiltersBanner &&
-        ignoredFilterExpressions.length > 0 && (
+        (ignoredFilterExpressions.length > 0 ||
+          ignoredVariableNames.length > 0) && (
           <Alert
-            mt="sm"
-            color="yellow"
+            mb="sm"
+            variant="warning"
             icon={<IconAlertTriangle size={16} />}
             title="Some filters could not be applied"
             data-testid="ignored-url-filters-banner"
@@ -3164,18 +3165,32 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
             closeButtonLabel="Dismiss"
             onClose={() => setShouldShowIgnoredFiltersBanner(false)}
           >
-            No dashboard filter(s) found for{' '}
-            {ignoredFilterExpressions.length === 1
-              ? 'expression'
-              : 'expressions'}{' '}
-            in the URL: {ignoredFilterExpressions.join(', ')}. Add a filter with
-            a matching expression to apply these filters.
+            <List type="unordered" size="sm" mb="xs">
+              {ignoredFilterExpressions.length > 0 && (
+                <List.Item>
+                  No dashboard filter(s) found for{' '}
+                  {ignoredFilterExpressions.length === 1
+                    ? 'expression'
+                    : 'expressions'}{' '}
+                  in the URL: {ignoredFilterExpressions.join(', ')}. Add a
+                  filter with a matching expression to apply these filters.
+                </List.Item>
+              )}
+              {ignoredVariableNames.length > 0 && (
+                <List.Item>
+                  No dashboard variable(s) found for{' '}
+                  {ignoredVariableNames.map(name => `$${name}`).join(', ')} in
+                  the URL. Add a variable-enabled filter with a matching
+                  variable name to apply these values.
+                </List.Item>
+              )}
+            </List>
           </Alert>
         )}
       {!isKioskMode && (
         <DashboardFilters
           filters={filters}
-          filterValues={filterValues}
+          selectionByFilterId={selectionByFilterId}
           onSetFilterValue={setFilterValue}
           dateRange={searchedTimeRange}
           variables={showFilterVariableOptions ? variables : undefined}

--- a/packages/app/src/DashboardFilters.tsx
+++ b/packages/app/src/DashboardFilters.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
+import { FilterSelection } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
-  FilterState,
   getFilterVariableName,
   getPendingFilterValuesVariables,
   isFilterBroadcastEnabled,
@@ -167,10 +167,13 @@ const DashboardFilterSelect = ({
   );
 };
 
+/** Stable identity for the unlinked case, so the memo below doesn't re-run. */
+const EMPTY_SELECTIONS: ReadonlyMap<string, FilterSelection> = new Map();
+
 interface DashboardFilterProps {
   filters: DashboardFilter[];
-  filterValues: FilterState;
-  onSetFilterValue: (expression: string, values: string[]) => void;
+  selectionByFilterId: ReadonlyMap<string, FilterSelection>;
+  onSetFilterValue: (filterId: string, values: string[]) => void;
   dateRange: [Date, Date];
   /**
    * The dashboard's variables and their current selections. Defined only when
@@ -183,7 +186,7 @@ interface DashboardFilterProps {
 const DashboardFilters = ({
   filters,
   dateRange,
-  filterValues,
+  selectionByFilterId,
   onSetFilterValue,
   variables,
 }: DashboardFilterProps) => {
@@ -203,14 +206,14 @@ const DashboardFilters = ({
     dateRange,
     variables,
     // Only narrow by sibling selections when linked.
-    filterValues: linked ? filterValues : {},
+    selectionByFilterId: linked ? selectionByFilterId : EMPTY_SELECTIONS,
   });
 
   return (
     <Group align="start">
       {Object.values(filters).map(filter => {
         const queriedFilterValues = filterValuesById?.get(filter.id);
-        const included = filterValues[filter.expression]?.included;
+        const included = selectionByFilterId.get(filter.id)?.included;
         const selectedValues = included
           ? Array.from(included).map(v => v.toString())
           : [];
@@ -231,7 +234,7 @@ const DashboardFilters = ({
               filter,
               variables,
             )}
-            onChange={values => onSetFilterValue(filter.expression, values)}
+            onChange={values => onSetFilterValue(filter.id, values)}
             values={queriedFilterValues?.values}
             value={selectedValues}
           />

--- a/packages/app/src/ServicesDashboardPage/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage/ServicesDashboardPage.tsx
@@ -236,7 +236,7 @@ function ServicesDashboardPage() {
   const [showFiltersModal, setShowFiltersModal] = useState(false);
   const {
     filters,
-    filterValues,
+    selectionByFilterId,
     setFilterValue,
     filterQueries: additionalFilters,
     handleSaveFilter,
@@ -409,7 +409,7 @@ function ServicesDashboardPage() {
       </form>
       <DashboardFilters
         filters={filters}
-        filterValues={filterValues}
+        selectionByFilterId={selectionByFilterId}
         onSetFilterValue={setFilterValue}
         dateRange={searchedTimeRange}
       />

--- a/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
@@ -5,7 +5,7 @@ import {
   optimizeGetKeyValuesCalls,
 } from '@hyperdx/common-utils/dist/core/materializedViews';
 import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
-import { FilterState } from '@hyperdx/common-utils/dist/filters';
+import { FilterSelection } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   DashboardFilter,
   MetricsDataType,
@@ -1119,18 +1119,25 @@ describe('useDashboardFilterValues', () => {
       },
     };
 
+    /** The same selection as the hook receives it: keyed by filter ID. */
+    const envProductionSelection: ReadonlyMap<string, FilterSelection> =
+      new Map([
+        [
+          'filter1',
+          {
+            included: new Set<string | boolean>(['production']),
+            excluded: new Set<string | boolean>(),
+          },
+        ],
+      ]);
+
     it('resolves every key in one faceted scan, constraining each by the others (exclude-self)', async () => {
       const { result } = renderHook(
         () =>
           useDashboardFilterValues({
             filters: envAndStatus,
             dateRange: mockDateRange,
-            filterValues: {
-              environment: {
-                included: new Set<string>(['production']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: envProductionSelection,
           }),
         { wrapper },
       );
@@ -1153,7 +1160,7 @@ describe('useDashboardFilterValues', () => {
           useDashboardFilterValues({
             filters: envAndStatus,
             dateRange: mockDateRange,
-            filterValues: {},
+            selectionByFilterId: new Map(),
           }),
         { wrapper },
       );
@@ -1184,12 +1191,7 @@ describe('useDashboardFilterValues', () => {
           useDashboardFilterValues({
             filters,
             dateRange: mockDateRange,
-            filterValues: {
-              environment: {
-                included: new Set<string>(['production']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: envProductionSelection,
           }),
         { wrapper },
       );
@@ -1201,6 +1203,60 @@ describe('useDashboardFilterValues', () => {
       expect(
         callForKeys(['environment', 'status', 'log_level'])?.keyConditions,
       ).toEqual([undefined, envProductionConstraint, envProductionConstraint]);
+    });
+
+    it('intersects two siblings that share an expression but hold different selections', async () => {
+      // Both definitions constrain the same column independently, so a third
+      // dropdown's lookup is narrowed by both — not by whichever was written
+      // into the constraint state last.
+      const filters: DashboardFilter[] = [
+        { ...envAndStatus[0], id: 'env-a' },
+        { ...envAndStatus[0], id: 'env-b' },
+        envAndStatus[1],
+      ];
+
+      const { result } = renderHook(
+        () =>
+          useDashboardFilterValues({
+            filters,
+            dateRange: mockDateRange,
+            selectionByFilterId: new Map([
+              [
+                'env-a',
+                {
+                  included: new Set<string | boolean>([
+                    'production',
+                    'staging',
+                  ]),
+                  excluded: new Set<string | boolean>(),
+                },
+              ],
+              [
+                'env-b',
+                {
+                  included: new Set<string | boolean>(['staging', 'dev']),
+                  excluded: new Set<string | boolean>(),
+                },
+              ],
+            ]),
+          }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      const call = callForKeys(['environment', 'environment', 'status']);
+      // Neither `environment` key is constrained by its own column...
+      expect(call?.keyConditions?.[0]).toBeUndefined();
+      expect(call?.keyConditions?.[1]).toBeUndefined();
+      // ...and `status` sees the intersection of the two.
+      expect(call?.keyConditions?.[2]).toEqual({
+        environment: {
+          included: new Set(['staging']),
+          excluded: new Set(),
+          range: undefined,
+        },
+      });
     });
 
     it('does not apply a selection from one source to filters on another source', async () => {
@@ -1220,12 +1276,7 @@ describe('useDashboardFilterValues', () => {
           useDashboardFilterValues({
             filters,
             dateRange: mockDateRange,
-            filterValues: {
-              environment: {
-                included: new Set<string>(['production']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: envProductionSelection,
           }),
         { wrapper },
       );
@@ -1268,12 +1319,15 @@ describe('useDashboardFilterValues', () => {
           useDashboardFilterValues({
             filters,
             dateRange: mockDateRange,
-            filterValues: {
-              MetricName: {
-                included: new Set<string>(['CPU_Usage']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: new Map([
+              [
+                'gauge-filter',
+                {
+                  included: new Set<string | boolean>(['CPU_Usage']),
+                  excluded: new Set<string | boolean>(),
+                },
+              ],
+            ]),
           }),
         { wrapper },
       );
@@ -1286,15 +1340,20 @@ describe('useDashboardFilterValues', () => {
 
     it('refetches with updated conditions when a selection changes', async () => {
       const { result, rerender } = renderHook(
-        ({ filterValues }) =>
+        ({ selectionByFilterId }) =>
           useDashboardFilterValues({
             filters: envAndStatus,
             dateRange: mockDateRange,
-            filterValues,
+            selectionByFilterId,
           }),
         {
           wrapper,
-          initialProps: { filterValues: {} as FilterState },
+          initialProps: {
+            selectionByFilterId: new Map() as ReadonlyMap<
+              string,
+              FilterSelection
+            >,
+          },
         },
       );
 
@@ -1303,14 +1362,7 @@ describe('useDashboardFilterValues', () => {
         callForKeys(['environment', 'status'])?.keyConditions,
       ).toBeUndefined();
 
-      rerender({
-        filterValues: {
-          environment: {
-            included: new Set<string>(['production']),
-            excluded: new Set<string>(),
-          },
-        },
-      });
+      rerender({ selectionByFilterId: envProductionSelection });
 
       await waitFor(() => expect(result.current.isFetching).toBe(false));
 
@@ -1335,12 +1387,7 @@ describe('useDashboardFilterValues', () => {
           useDashboardFilterValues({
             filters: envAndStatus,
             dateRange: mockDateRange,
-            filterValues: {
-              environment: {
-                included: new Set<string>(['production']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: envProductionSelection,
           }),
         { wrapper },
       );
@@ -1370,12 +1417,7 @@ describe('useDashboardFilterValues', () => {
               },
             ],
             dateRange: mockDateRange,
-            filterValues: {
-              environment: {
-                included: new Set<string>(['production']),
-                excluded: new Set<string>(),
-              },
-            },
+            selectionByFilterId: envProductionSelection,
             variables: [
               { name: 'svc', expression: 'service_name', values: ['api'] },
             ],

--- a/packages/app/src/hooks/__tests__/useDashboardFilters.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardFilters.test.tsx
@@ -1,12 +1,23 @@
-import { DashboardFilter, Filter } from '@hyperdx/common-utils/dist/types';
+import {
+  DashboardFilter,
+  DashboardFilterValue,
+  Filter,
+} from '@hyperdx/common-utils/dist/types';
 import { act, renderHook } from '@testing-library/react';
 
 import useDashboardFilters from '@/hooks/useDashboardFilters';
 
 // Mock nuqs useQueryState with a simple useState-like implementation
-let mockState: Filter[] | null = null;
+let mockState: DashboardFilterValue[] | null = null;
 const mockSetState = jest.fn(
-  (updater: Filter[] | null | ((prev: Filter[] | null) => Filter[] | null)) => {
+  (
+    updater:
+      | DashboardFilterValue[]
+      | null
+      | ((
+          prev: DashboardFilterValue[] | null,
+        ) => DashboardFilterValue[] | null),
+  ) => {
     if (typeof updater === 'function') {
       mockState = updater(mockState);
     } else {
@@ -45,6 +56,14 @@ describe('useDashboardFilters', () => {
     },
   ];
 
+  const selectionFor = (
+    result: { current: ReturnType<typeof useDashboardFilters> },
+    filterId: string,
+  ) => result.current.selectionByFilterId.get(filterId);
+
+  const conditionsFor = (queries: Filter[]) =>
+    queries.map(q => ('condition' in q ? q.condition : ''));
+
   beforeEach(() => {
     mockState = null;
     mockSetState.mockClear();
@@ -53,15 +72,15 @@ describe('useDashboardFilters', () => {
   it('should initialize with empty filter values', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
-    expect(result.current.filterValues).toEqual({});
-    expect(result.current.filterQueries).toEqual([]);
+    expect(result.current.selectionByFilterId.size).toBe(0);
+    expect(result.current.broadcastedFilters).toEqual([]);
   });
 
   it('should set a single filter value', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production']);
+      result.current.setFilterValue('filter1', ['production']);
     });
 
     // Re-render to pick up the new mockState
@@ -69,7 +88,7 @@ describe('useDashboardFilters', () => {
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment.included).toEqual(
+    expect(selectionFor(result2, 'filter1')?.included).toEqual(
       new Set(['production']),
     );
   });
@@ -78,14 +97,14 @@ describe('useDashboardFilters', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production', 'staging']);
+      result.current.setFilterValue('filter1', ['production', 'staging']);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment.included).toEqual(
+    expect(selectionFor(result2, 'filter1')?.included).toEqual(
       new Set(['production', 'staging']),
     );
   });
@@ -94,86 +113,83 @@ describe('useDashboardFilters', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production', 'staging']);
+      result.current.setFilterValue('filter1', ['production', 'staging']);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterQueries).toHaveLength(1);
-    const query = result2.current.filterQueries[0];
-    const condition = 'condition' in query ? query.condition : '';
-    expect(condition).toEqual(
+    expect(conditionsFor(result2.current.broadcastedFilters)).toEqual([
       "toString(environment) IN ('production', 'staging')",
-    );
+    ]);
   });
 
   it('should clear filter when set to empty array', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production']);
+      result.current.setFilterValue('filter1', ['production']);
     });
     act(() => {
-      result.current.setFilterValue('environment', []);
+      result.current.setFilterValue('filter1', []);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment).toBeUndefined();
-    expect(result2.current.filterQueries).toEqual([]);
+    expect(selectionFor(result2, 'filter1')).toBeUndefined();
+    expect(result2.current.broadcastedFilters).toEqual([]);
   });
 
   it('should support multi-select on multiple expressions simultaneously', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production', 'staging']);
+      result.current.setFilterValue('filter1', ['production', 'staging']);
     });
     act(() => {
-      result.current.setFilterValue('service.name', ['api', 'web']);
+      result.current.setFilterValue('filter2', ['api', 'web']);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment.included).toEqual(
+    expect(selectionFor(result2, 'filter1')?.included).toEqual(
       new Set(['production', 'staging']),
     );
-    expect(result2.current.filterValues['service.name'].included).toEqual(
+    expect(selectionFor(result2, 'filter2')?.included).toEqual(
       new Set(['api', 'web']),
     );
-    expect(result2.current.filterQueries).toHaveLength(2);
+    expect(result2.current.broadcastedFilters).toHaveLength(2);
   });
 
   it('should replace previous multi-select values when updated', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production', 'staging']);
+      result.current.setFilterValue('filter1', ['production', 'staging']);
     });
     act(() => {
-      result.current.setFilterValue('environment', ['development']);
+      result.current.setFilterValue('filter1', ['development']);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment.included).toEqual(
+    expect(selectionFor(result2, 'filter1')?.included).toEqual(
       new Set(['development']),
     );
   });
 
-  it('should ignore filter values for non-existent filter expressions', () => {
+  it('should ignore a write targeting a filter the dashboard does not declare', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production']);
+      result.current.setFilterValue('filter1', ['production']);
     });
     act(() => {
       result.current.setFilterValue('nonexistent', ['value']);
@@ -183,36 +199,35 @@ describe('useDashboardFilters', () => {
       useDashboardFilters(mockFilters),
     );
 
-    expect(Object.keys(result2.current.filterValues)).toEqual(['environment']);
+    expect(Array.from(result2.current.selectionByFilterId.keys())).toEqual([
+      'filter1',
+    ]);
   });
 
   it('should clear one filter without affecting others', () => {
     const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
     act(() => {
-      result.current.setFilterValue('environment', ['production', 'staging']);
+      result.current.setFilterValue('filter1', ['production', 'staging']);
     });
     act(() => {
-      result.current.setFilterValue('service.name', ['api']);
+      result.current.setFilterValue('filter2', ['api']);
     });
     act(() => {
-      result.current.setFilterValue('environment', []);
+      result.current.setFilterValue('filter1', []);
     });
 
     const { result: result2 } = renderHook(() =>
       useDashboardFilters(mockFilters),
     );
 
-    expect(result2.current.filterValues.environment).toBeUndefined();
-    expect(result2.current.filterValues['service.name'].included).toEqual(
+    expect(selectionFor(result2, 'filter1')).toBeUndefined();
+    expect(selectionFor(result2, 'filter2')?.included).toEqual(
       new Set(['api']),
     );
   });
 
   describe('getFilterQueriesForSource', () => {
-    const conditionsFor = (queries: Filter[]) =>
-      queries.map(q => ('condition' in q ? q.condition : ''));
-
     it('applies an unscoped filter to every tile', () => {
       mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
 
@@ -250,7 +265,7 @@ describe('useDashboardFilters', () => {
       expect(result.current.getFilterQueriesForSource('traces')).toEqual([]);
       expect(result.current.getFilterQueriesForSource(undefined)).toEqual([]);
       // The value still exists for the filter bar and for variable use.
-      expect(result.current.filterValues.environment.included).toEqual(
+      expect(selectionFor(result, 'filter1')?.included).toEqual(
         new Set(['production']),
       );
     });
@@ -310,6 +325,25 @@ describe('useDashboardFilters', () => {
       );
       expect(result.current.getFilterQueriesForSource('logs')).toEqual([]);
     });
+
+    it('applies a variable-enabled filter reading a variable-keyed entry', () => {
+      mockState = [{ type: 'variable', name: 'env', values: ['production'] }];
+      const filters: DashboardFilter[] = [
+        {
+          ...mockFilters[0],
+          isVariableEnabled: true,
+          variableName: 'env',
+          appliesToSourceIds: ['logs'],
+        },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(
+        conditionsFor(result.current.getFilterQueriesForSource('logs')),
+      ).toEqual(["toString(environment) IN ('production')"]);
+      expect(result.current.getFilterQueriesForSource('traces')).toEqual([]);
+    });
   });
 
   describe('filterQueries', () => {
@@ -325,15 +359,13 @@ describe('useDashboardFilters', () => {
 
       const { result } = renderHook(() => useDashboardFilters(filters));
 
-      expect(result.current.filterQueries).toHaveLength(1);
-      const query = result.current.filterQueries[0];
-      expect('condition' in query ? query.condition : '').toEqual(
+      expect(conditionsFor(result.current.broadcastedFilters)).toEqual([
         "toString(service.name) IN ('api')",
-      );
+      ]);
       // Preset dashboards never persist the field, so they keep broadcasting.
-      expect(Object.keys(result.current.filterValues)).toEqual([
-        'environment',
-        'service.name',
+      expect(Array.from(result.current.selectionByFilterId.keys())).toEqual([
+        'filter1',
+        'filter2',
       ]);
     });
   });
@@ -419,14 +451,13 @@ describe('useDashboardFilters', () => {
     });
 
     it('sorts values so selection order does not change the payload', () => {
-      const { result } = renderHook(() =>
-        useDashboardFilters([
-          { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
-        ]),
-      );
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+      ];
+      const { result } = renderHook(() => useDashboardFilters(filters));
 
       act(() => {
-        result.current.setFilterValue('environment', [
+        result.current.setFilterValue('filter1', [
           'staging',
           'development',
           'production',
@@ -434,9 +465,7 @@ describe('useDashboardFilters', () => {
       });
 
       const { result: result2 } = renderHook(() =>
-        useDashboardFilters([
-          { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
-        ]),
+        useDashboardFilters(filters),
       );
 
       expect(result2.current.variables[0].values).toEqual([
@@ -492,7 +521,7 @@ describe('useDashboardFilters', () => {
 
       expect(result.current.ignoredFilterExpressions).toEqual(['team']);
       // sanity: declared expression still wins through normal path
-      expect(result.current.filterValues.environment.included).toEqual(
+      expect(selectionFor(result, 'filter1')?.included).toEqual(
         new Set(['production']),
       );
     });
@@ -512,7 +541,9 @@ describe('useDashboardFilters', () => {
         'region',
         'owner',
       ]);
-      expect(Object.keys(result.current.filterValues)).toEqual(['environment']);
+      expect(Array.from(result.current.selectionByFilterId.keys())).toEqual([
+        'filter1',
+      ]);
     });
 
     it('does not flag declared expressions with no URL values as ignored', () => {
@@ -523,8 +554,389 @@ describe('useDashboardFilters', () => {
 
       const { result } = renderHook(() => useDashboardFilters(mockFilters));
 
-      expect(result.current.filterValues).toEqual({});
+      expect(result.current.selectionByFilterId.size).toBe(0);
       expect(result.current.ignoredFilterExpressions).toEqual([]);
+    });
+
+    it('does not flag an expression owned only by variable-enabled filters', () => {
+      // A legacy expression-keyed entry aimed at a variable-enabled filter is a
+      // valid back-compat entry that just applied — not an ignored one.
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+      const filters: DashboardFilter[] = [
+        { ...mockFilters[0], isVariableEnabled: true, variableName: 'env' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(result.current.ignoredFilterExpressions).toEqual([]);
+      expect(result.current.ignoredVariableNames).toEqual([]);
+      expect(selectionFor(result, 'filter1')?.included).toEqual(
+        new Set(['production']),
+      );
+    });
+  });
+
+  describe('ignoredVariableNames', () => {
+    const envVariableFilter: DashboardFilter = {
+      ...mockFilters[0],
+      isVariableEnabled: true,
+      variableName: 'env',
+    };
+
+    it('is empty when every variable entry names a declared variable', () => {
+      mockState = [{ type: 'variable', name: 'env', values: ['production'] }];
+
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      expect(result.current.ignoredVariableNames).toEqual([]);
+    });
+
+    it('lists a variable entry naming no declared variable-enabled filter', () => {
+      mockState = [
+        { type: 'variable', name: 'nope', values: ['x'] },
+        { type: 'variable', name: 'env', values: ['production'] },
+      ];
+
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      expect(result.current.ignoredVariableNames).toEqual(['nope']);
+      expect(result.current.ignoredFilterExpressions).toEqual([]);
+      expect(selectionFor(result, 'filter1')?.included).toEqual(
+        new Set(['production']),
+      );
+    });
+
+    it('treats a name matching a filter with variables turned off as orphaned', () => {
+      mockState = [{ type: 'variable', name: 'Environment', values: ['x'] }];
+
+      const { result } = renderHook(() => useDashboardFilters(mockFilters));
+
+      expect(result.current.ignoredVariableNames).toEqual(['Environment']);
+    });
+
+    it('keeps an orphaned variable entry across a write to another filter', () => {
+      mockState = [
+        { type: 'variable', name: 'nope', values: ['x'] },
+        { type: 'variable', name: 'env', values: ['production'] },
+      ];
+
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('filter1', ['staging']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'variable', name: 'env', values: ['staging'] },
+        { type: 'variable', name: 'nope', values: ['x'] },
+      ]);
+    });
+  });
+
+  describe('entry format', () => {
+    const envVariableFilter: DashboardFilter = {
+      ...mockFilters[0],
+      isVariableEnabled: true,
+      variableName: 'env',
+    };
+
+    it('writes a variable-keyed entry for a variable-enabled filter', () => {
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('filter1', ['production']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'variable', name: 'env', values: ['production'] },
+      ]);
+    });
+
+    it('writes an expression-keyed entry for a filter that is not variable-enabled', () => {
+      const { result } = renderHook(() => useDashboardFilters(mockFilters));
+
+      act(() => {
+        result.current.setFilterValue('filter1', ['production']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "environment IN ('production')" },
+      ]);
+    });
+
+    it('writes an expression-keyed entry for preset-shaped filters', () => {
+      // Preset dashboard filters carry no variable fields at all.
+      const { result } = renderHook(() =>
+        useDashboardFilters([mockFilters[1]]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('filter2', ['api']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "service.name IN ('api')" },
+      ]);
+    });
+
+    it('reads a legacy entry for a variable-enabled filter and migrates it on the next write', () => {
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+      const filters = [envVariableFilter, mockFilters[1]];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+      expect(selectionFor(result, 'filter1')?.included).toEqual(
+        new Set(['production']),
+      );
+
+      // Touching a *different* filter still migrates the whole array.
+      act(() => {
+        result.current.setFilterValue('filter2', ['api']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "service.name IN ('api')" },
+        { type: 'variable', name: 'env', values: ['production'] },
+      ]);
+    });
+
+    it('clears a variable-keyed selection without resurrecting the legacy entry', () => {
+      mockState = [{ type: 'sql', condition: "environment IN ('production')" }];
+
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('filter1', []);
+      });
+
+      expect(mockState).toEqual([]);
+    });
+
+    it('does not migrate a legacy exclusion, and does not lose it', () => {
+      // `NOT IN` has no representation in the variable-keyed format.
+      mockState = [
+        { type: 'sql', condition: "environment NOT IN ('production')" },
+      ];
+      const filters = [envVariableFilter, mockFilters[1]];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      act(() => {
+        result.current.setFilterValue('filter2', ['api']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "environment NOT IN ('production')" },
+        { type: 'sql', condition: "service.name IN ('api')" },
+      ]);
+    });
+
+    it('does not migrate a legacy range, and does not lose it', () => {
+      mockState = [{ type: 'sql', condition: 'environment BETWEEN 1 AND 2' }];
+      const filters = [envVariableFilter, mockFilters[1]];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      act(() => {
+        result.current.setFilterValue('filter2', ['api']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: 'environment BETWEEN 1 AND 2' },
+        { type: 'sql', condition: "service.name IN ('api')" },
+      ]);
+    });
+
+    it('carries an entry no scheme can represent through a write', () => {
+      mockState = [
+        { type: 'lucene', condition: 'level:error' },
+        { type: 'sql', condition: "environment IN ('production')" },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(mockFilters));
+
+      act(() => {
+        result.current.setFilterValue('filter2', ['api']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "environment IN ('production')" },
+        { type: 'sql', condition: "service.name IN ('api')" },
+        { type: 'lucene', condition: 'level:error' },
+      ]);
+    });
+
+    it('does not grow the param when a filter expression cannot round-trip', () => {
+      // `parseQuery` rejects a clause whose key carries a top-level comparison
+      // operator, so `Duration > 1000000 IN ('v')` reads back as nothing. The
+      // selection can't persist for such a filter (true before this format too),
+      // but each write must still replace the dead entry rather than append to
+      // it — carrying it as passthrough grew the URL by one entry per click.
+      const filters: DashboardFilter[] = [
+        {
+          id: 'filter1',
+          type: 'QUERY_EXPRESSION',
+          name: 'Slow',
+          expression: 'Duration > 1000000',
+          source: 'logs',
+        },
+      ];
+
+      for (const value of ['v0', 'v1', 'v2', 'v3']) {
+        const { result } = renderHook(() => useDashboardFilters(filters));
+        act(() => {
+          result.current.setFilterValue('filter1', [value]);
+        });
+      }
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "Duration > 1000000 IN ('v3')" },
+      ]);
+    });
+
+    it('keeps a literal "true" quoted, which the legacy format cannot', () => {
+      const { result } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      act(() => {
+        result.current.setFilterValue('filter1', ['true']);
+      });
+
+      const { result: result2 } = renderHook(() =>
+        useDashboardFilters([envVariableFilter]),
+      );
+
+      expect(mockState).toEqual([
+        { type: 'variable', name: 'env', values: ['true'] },
+      ]);
+      expect(conditionsFor(result2.current.broadcastedFilters)).toEqual([
+        "toString(environment) IN ('true')",
+      ]);
+    });
+
+    it('coerces an unquoted legacy `true` to a boolean, which the variable format avoids', () => {
+      // Documents the known lossiness of expression keying: an unquoted `true`
+      // in the URL parses back as a JS boolean and re-renders unquoted, which
+      // is a type error against a String column.
+      mockState = [{ type: 'sql', condition: 'environment IN (true)' }];
+
+      const { result } = renderHook(() => useDashboardFilters(mockFilters));
+
+      expect(conditionsFor(result.current.broadcastedFilters)).toEqual([
+        'toString(environment) IN (true)',
+      ]);
+    });
+  });
+
+  describe('two filters sharing one expression', () => {
+    const sharedExpressionFilters: DashboardFilter[] = [
+      {
+        id: 'shared-variable',
+        type: 'QUERY_EXPRESSION',
+        name: 'Service A',
+        expression: 'ServiceName',
+        source: 'logs',
+        isVariableEnabled: true,
+        variableName: 'svcA',
+      },
+      {
+        id: 'shared-plain',
+        type: 'QUERY_EXPRESSION',
+        name: 'Service B',
+        expression: 'ServiceName',
+        source: 'logs',
+      },
+    ];
+
+    it('holds independent selections and emits one predicate per definition', () => {
+      mockState = [
+        { type: 'variable', name: 'svcA', values: ['accounting'] },
+        { type: 'sql', condition: "ServiceName IN ('frontend')" },
+      ];
+
+      const { result } = renderHook(() =>
+        useDashboardFilters(sharedExpressionFilters),
+      );
+
+      expect(selectionFor(result, 'shared-variable')?.included).toEqual(
+        new Set(['accounting']),
+      );
+      expect(selectionFor(result, 'shared-plain')?.included).toEqual(
+        new Set(['frontend']),
+      );
+      // Two independent constraints on one column AND together.
+      expect(conditionsFor(result.current.broadcastedFilters)).toEqual([
+        "toString(ServiceName) IN ('accounting')",
+        "toString(ServiceName) IN ('frontend')",
+      ]);
+    });
+
+    it('de-duplicates identical predicates from two definitions', () => {
+      mockState = [{ type: 'sql', condition: "ServiceName IN ('frontend')" }];
+      const filters: DashboardFilter[] = [
+        { ...sharedExpressionFilters[1], id: 'a' },
+        { ...sharedExpressionFilters[1], id: 'b' },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      expect(conditionsFor(result.current.broadcastedFilters)).toEqual([
+        "toString(ServiceName) IN ('frontend')",
+      ]);
+    });
+
+    it('writes one variable entry and one sql entry, and keeps them independent', () => {
+      const { result } = renderHook(() =>
+        useDashboardFilters(sharedExpressionFilters),
+      );
+
+      act(() => {
+        result.current.setFilterValue('shared-variable', ['accounting']);
+      });
+      act(() => {
+        result.current.setFilterValue('shared-plain', ['frontend']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'sql', condition: "ServiceName IN ('frontend')" },
+        { type: 'variable', name: 'svcA', values: ['accounting'] },
+      ]);
+    });
+
+    it('lets the override win when two definitions share a variable name', () => {
+      mockState = [{ type: 'variable', name: 'dupe', values: ['old'] }];
+      const filters: DashboardFilter[] = [
+        {
+          ...sharedExpressionFilters[0],
+          id: 'first',
+          variableName: 'dupe',
+        },
+        {
+          ...sharedExpressionFilters[0],
+          id: 'second',
+          variableName: 'dupe',
+        },
+      ];
+
+      const { result } = renderHook(() => useDashboardFilters(filters));
+
+      act(() => {
+        result.current.setFilterValue('second', ['new']);
+      });
+
+      expect(mockState).toEqual([
+        { type: 'variable', name: 'dupe', values: ['new'] },
+      ]);
     });
   });
 });

--- a/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
+++ b/packages/app/src/hooks/__tests__/usePresetDashboardFilters.test.tsx
@@ -1,4 +1,4 @@
-import { FilterState } from '@hyperdx/common-utils/dist/filters';
+import { FilterSelection } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   DashboardFilter,
   Filter,
@@ -51,12 +51,17 @@ describe('usePresetDashboardFilters', () => {
     },
   ];
 
-  const mockFilterValues: FilterState = {
-    environment: {
-      included: new Set(['production']),
-      excluded: new Set(),
-    },
-  };
+  const mockSelectionByFilterId: ReadonlyMap<string, FilterSelection> = new Map(
+    [
+      [
+        'filter-1',
+        {
+          included: new Set<string | boolean>(['production']),
+          excluded: new Set<string | boolean>(),
+        },
+      ],
+    ],
+  );
 
   const mockFilterQueries: Filter[] = [
     {
@@ -104,11 +109,13 @@ describe('usePresetDashboardFilters', () => {
 
     // Mock useDashboardFilters
     jest.mocked(useDashboardFilters).mockReturnValue({
-      filterValues: mockFilterValues,
+      selectionByFilterId: mockSelectionByFilterId,
       setFilterValue: mockSetFilterValue,
-      filterQueries: mockFilterQueries,
-      setFilterQueries: jest.fn(),
+      broadcastedFilters: mockFilterQueries,
+      setFilterValueEntries: jest.fn(),
+      filterValueEntries: null,
       ignoredFilterExpressions: [],
+      ignoredVariableNames: [],
       getFilterQueriesForSource: jest.fn().mockReturnValue(mockFilterQueries),
       variables: [],
     });
@@ -228,7 +235,7 @@ describe('usePresetDashboardFilters', () => {
       }),
     );
 
-    expect(result.current.filterValues).toEqual(mockFilterValues);
+    expect(result.current.selectionByFilterId).toEqual(mockSelectionByFilterId);
     expect(result.current.filterQueries).toEqual(mockFilterQueries);
     expect(result.current.setFilterValue).toBe(mockSetFilterValue);
   });

--- a/packages/app/src/hooks/useDashboardFilterValues.tsx
+++ b/packages/app/src/hooks/useDashboardFilterValues.tsx
@@ -5,6 +5,7 @@ import {
   optimizeFacetedKeyValuesConfig,
   optimizeGetKeyValuesCalls,
 } from '@hyperdx/common-utils/dist/core/materializedViews';
+import { FilterSelection } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   FilterState,
   ResolvedFilterValuesQuery,
@@ -29,6 +30,9 @@ import { useSources } from '@/source';
 import { getMetricTableName, mapKeyBy } from '@/utils';
 
 import { useMetadataWithSettings } from './useMetadata';
+
+/** Stable identity for the default, so memos keyed on it don't re-run. */
+const EMPTY_SELECTIONS: ReadonlyMap<string, FilterSelection> = new Map();
 
 type FilterSourceKey = {
   sourceId: string;
@@ -61,6 +65,33 @@ const resolvedFor = (
     whereLanguage: filter.whereLanguage ?? 'sql',
   };
 
+/**
+ * AND two constraints on the same column together. Reached when two filter
+ * definitions share an expression but hold independent selections: both narrow
+ * a third dropdown's lookup, so the intersection of their inclusions applies,
+ * not whichever one happened to be written last.
+ */
+const intersectSelections = (
+  a: FilterSelection,
+  b: FilterSelection,
+): FilterSelection => ({
+  // An empty `included` is "no inclusion constraint", not "match nothing".
+  included:
+    a.included.size === 0
+      ? b.included
+      : b.included.size === 0
+        ? a.included
+        : new Set([...a.included].filter(v => b.included.has(v))),
+  excluded: new Set([...a.excluded, ...b.excluded]),
+  range:
+    a.range && b.range
+      ? {
+          min: Math.max(a.range.min, b.range.min),
+          max: Math.min(a.range.max, b.range.max),
+        }
+      : (a.range ?? b.range),
+});
+
 type EnrichedCall = GetKeyValueCall<BuilderChartConfigWithDateRange> & {
   /** filterIds[i] = array of filter IDs whose values come from keys[i] */
   filterIds: string[][];
@@ -71,12 +102,12 @@ type EnrichedCall = GetKeyValueCall<BuilderChartConfigWithDateRange> & {
 function useOptimizedKeyValuesCalls({
   filters,
   dateRange,
-  filterValues,
+  selectionByFilterId,
   variables,
 }: {
   filters: DashboardFilter[];
   dateRange: [Date, Date];
-  filterValues: FilterState;
+  selectionByFilterId: ReadonlyMap<string, FilterSelection>;
   variables?: ChartVariable[];
 }) {
   const clickhouseClient = useClickhouseClient();
@@ -121,21 +152,24 @@ function useOptimizedKeyValuesCalls({
         ) {
           continue;
         }
-        const selection = filterValues[sibling.expression];
+        const selection = selectionByFilterId.get(sibling.id);
         if (
           selection &&
           (selection.included.size > 0 ||
             selection.excluded.size > 0 ||
             selection.range != null)
         ) {
-          prunedState[sibling.expression] = selection;
+          const existing = prunedState[sibling.expression];
+          prunedState[sibling.expression] = existing
+            ? intersectSelections(existing, selection)
+            : selection;
           hasSelection = true;
         }
       }
       byId.set(filter.id, hasSelection ? prunedState : undefined);
     }
     return byId;
-  }, [filters, filterValues]);
+  }, [filters, selectionByFilterId]);
 
   // Group filters by (source, metricType, where, whereLanguage). Every filter in
   // a group is resolved together: an unconstrained group goes through the MV
@@ -288,12 +322,13 @@ function useOptimizedKeyValuesCalls({
 export function useDashboardFilterValues({
   filters,
   dateRange,
-  filterValues = {},
+  selectionByFilterId = EMPTY_SELECTIONS,
   variables,
 }: {
   filters: DashboardFilter[];
   dateRange: [Date, Date];
-  filterValues?: FilterState;
+  /** Each filter's current selection, keyed by `filter.id`. */
+  selectionByFilterId?: ReadonlyMap<string, FilterSelection>;
   /** The dashboard's variables and their current selections, if any */
   variables?: ChartVariable[];
 }) {
@@ -306,7 +341,7 @@ export function useDashboardFilterValues({
   } = useOptimizedKeyValuesCalls({
     filters,
     dateRange,
-    filterValues,
+    selectionByFilterId,
     variables,
   });
 

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -1,31 +1,26 @@
 import { useCallback, useMemo } from 'react';
 import { useQueryState } from 'nuqs';
 import {
+  FilterSelection,
+  filterSelectionKey,
+  parseDashboardFilterValues,
+  ParsedDashboardFilterValues,
+  resolveFilterSelection,
+  serializeDashboardFilterValues,
+} from '@hyperdx/common-utils/dist/dashboardFilterValues';
+import {
   FilterState,
   filtersToQuery,
-  getDashboardVariableDeclarations,
+  getDashboardVariableFilters,
   isFilterBroadcastEnabled,
 } from '@hyperdx/common-utils/dist/filters';
 import {
   ChartVariable,
   DashboardFilter,
-  DashboardFilterValue,
   Filter,
 } from '@hyperdx/common-utils/dist/types';
 
-import { parseQuery } from '@/searchFilters';
-import { parseAsJsonEncoded } from '@/utils/queryParsers';
-
-export const filterQueriesParser = parseAsJsonEncoded<DashboardFilterValue[]>();
-
-/**
- * Narrow the persisted entries to the ones the expression-keyed reader
- * understands. Variable-keyed entries are not read or written here yet.
- */
-const expressionKeyedEntries = (
-  entries: DashboardFilterValue[] | null | undefined,
-): Filter[] =>
-  (entries ?? []).filter((entry): entry is Filter => entry.type !== 'variable');
+import { dashboardFilterValuesParser } from '@/utils/queryParsers';
 
 /**
  * Whether a filter definition broadcasts its selected value onto a tile
@@ -41,155 +36,241 @@ const definitionAppliesToSource = (
   return !!sourceId && appliesTo.includes(sourceId);
 };
 
+const hasSelection = (selection: FilterSelection): boolean =>
+  selection.included.size > 0 ||
+  selection.excluded.size > 0 ||
+  selection.range != null;
+
+/**
+ * The variable-keyed format carries a plain list of selected values, so it can
+ * only represent an inclusion. An (unsupported) `NOT IN` / `BETWEEN` entry stays
+ * expression-keyed.
+ */
+const isRepresentableAsVariable = (selection: FilterSelection): boolean =>
+  selection.excluded.size === 0 && selection.range == null;
+
+/**
+ * Rebuild the whole state array from the selections every declared filter
+ * currently resolves to. Anything that belongs to no declared filter is
+ * carried over untouched.
+ */
+const rebuildEntries = (
+  filters: DashboardFilter[],
+  parsed: ParsedDashboardFilterValues,
+) => {
+  const byExpression: FilterState = {};
+  const byVariable = new Map<string, string[]>();
+  const declaredExpressions = new Set<string>();
+  const declaredVariableNames = new Set<string>();
+
+  for (const filter of filters) {
+    declaredExpressions.add(filter.expression);
+    const key = filterSelectionKey(filter);
+    if (key.kind !== 'variable') continue;
+    declaredVariableNames.add(key.name);
+    if (byVariable.has(key.name)) continue; // First definition of a name wins.
+
+    const selection = resolveFilterSelection(filter, parsed);
+    if (!selection) continue;
+    if (!isRepresentableAsVariable(selection)) {
+      byExpression[filter.expression] = selection;
+    } else if (selection.included.size > 0) {
+      byVariable.set(key.name, Array.from(selection.included).map(String));
+    }
+  }
+
+  // Filters that aren't variable-enabled stay expression-keyed. Written after
+  // the loop above so that when a plain and a variable-enabled filter share an
+  // expression, the surviving entry carries the plain filter's selection.
+  for (const filter of filters) {
+    if (filterSelectionKey(filter).kind === 'variable') continue;
+    const selection = resolveFilterSelection(filter, parsed);
+    if (selection && hasSelection(selection)) {
+      byExpression[filter.expression] = selection;
+    }
+  }
+
+  // Pass through any entries that don't correspond to a declared filter.
+  for (const [name, values] of parsed.byVariable) {
+    if (!declaredVariableNames.has(name)) byVariable.set(name, values);
+  }
+  for (const [expression, selection] of Object.entries(parsed.byExpression)) {
+    if (!declaredExpressions.has(expression)) {
+      byExpression[expression] = selection;
+    }
+  }
+
+  return serializeDashboardFilterValues({
+    byExpression,
+    byVariable,
+    passthrough: parsed.passthrough,
+  });
+};
+
 const useDashboardFilters = (filters: DashboardFilter[]) => {
-  const [filterQueries, setFilterQueries] = useQueryState(
+  const [filterValueEntries, setFilterValueEntries] = useQueryState(
     'filters',
-    filterQueriesParser,
+    dashboardFilterValuesParser,
   );
 
   const setFilterValue = useCallback(
-    (expression: string, values: string[]) => {
-      setFilterQueries(prev => {
-        const { filters: filterValues } = parseQuery(
-          expressionKeyedEntries(prev),
-        );
-        if (values.length === 0) {
-          delete filterValues[expression];
+    (filterId: string, values: string[]) => {
+      setFilterValueEntries(prev => {
+        const target = filters.find(f => f.id === filterId);
+        if (!target) return prev;
+
+        const parsed = parseDashboardFilterValues(prev ?? []);
+
+        // Apply the change to the parsed state rather than to the rebuilt
+        // output, so the filter it targets resolves to the new values even when
+        // a sibling shares its variable name or expression.
+        const key = filterSelectionKey(target);
+        if (key.kind === 'variable') {
+          // Set even when empty to avoid falling back to a legacy expression-keyed value
+          parsed.byVariable.set(key.name, values);
+        } else if (values.length === 0) {
+          delete parsed.byExpression[key.expression];
         } else {
-          filterValues[expression] = {
+          parsed.byExpression[key.expression] = {
             included: new Set(values),
             excluded: new Set(),
           };
         }
 
-        return filtersToQuery(
-          filterValues,
-          { stringifyKeys: false }, // Don't wrap keys with toString(), to preserve exact key names in URL query parameters
-        );
+        return rebuildEntries(filters, parsed);
       });
     },
-    [setFilterQueries],
+    [setFilterValueEntries, filters],
   );
 
   const {
-    valuesForExistingFilters,
-    queriesForExistingFilters,
+    selectionByFilterId,
     ignoredExpressions,
-    filtersByExpression,
+    ignoredVariableNames,
     variables,
-  } = useMemo(() => {
-    const { filters: parsedFilters } = parseQuery(
-      expressionKeyedEntries(filterQueries),
-    );
-    const valuesForExistingFilters: FilterState = {};
+  } = useMemo<{
+    selectionByFilterId: ReadonlyMap<string, FilterSelection>;
+    ignoredExpressions: string[];
+    ignoredVariableNames: string[];
+    variables: ChartVariable[];
+  }>(() => {
+    const parsed = parseDashboardFilterValues(filterValueEntries ?? []);
+
+    // Keyed by filter ID: two definitions may share one expression
+    const selectionByFilterId = new Map<string, FilterSelection>();
+    for (const filter of filters) {
+      const selection = resolveFilterSelection(filter, parsed);
+      if (selection) selectionByFilterId.set(filter.id, selection);
+    }
+
+    // Find state that doesn't correspond to any declared filter, so the caller can surface a warning.
     const knownExpressions = new Set(filters.map(f => f.expression));
-    const ignored: string[] = [];
+    const ignoredExpressions = Object.keys(parsed.byExpression).filter(
+      expression => !knownExpressions.has(expression),
+    );
 
-    for (const { expression } of filters) {
-      if (expression in parsedFilters) {
-        valuesForExistingFilters[expression] = parsedFilters[expression];
-      }
-    }
-    for (const key of Object.keys(parsedFilters)) {
-      if (!knownExpressions.has(key)) {
-        ignored.push(key);
-      }
-    }
+    const variableFilters = getDashboardVariableFilters(filters);
+    const declaredVariableNames = new Set(variableFilters.map(v => v.name));
+    const ignoredVariableNames = Array.from(parsed.byVariable.keys()).filter(
+      name => !declaredVariableNames.has(name),
+    );
 
-    // Multiple filter definitions may share the same expression but each
-    // declare a different `appliesToSourceIds` scope.
-    const filtersByExpression = new Map<string, DashboardFilter[]>();
-    for (const f of filters) {
-      const existing = filtersByExpression.get(f.expression);
-      if (existing) {
-        existing.push(f);
-      } else {
-        filtersByExpression.set(f.expression, [f]);
-      }
-    }
-
-    const broadcastValues: FilterState = {};
-    for (const [expression, state] of Object.entries(
-      valuesForExistingFilters,
-    )) {
-      const definitions = filtersByExpression.get(expression) ?? [];
-      if (definitions.some(isFilterBroadcastEnabled)) {
-        broadcastValues[expression] = state;
-      }
-    }
-
-    const variables: ChartVariable[] = getDashboardVariableDeclarations(
-      filters,
-    ).map(definition => {
-      const selection = definition.expression
-        ? valuesForExistingFilters[definition.expression]
-        : undefined;
-      return {
-        ...definition,
-        values: selection
-          ? Array.from(selection.included).map(String).sort() // Sorted for deterministic react-query keys
-          : [],
-      };
-    });
+    const variables: ChartVariable[] = variableFilters.map(
+      ({ filter, name }) => {
+        const selection = selectionByFilterId.get(filter.id);
+        return {
+          name,
+          expression: filter.expression,
+          // Sorted for deterministic react-query keys. Built explicitly rather
+          // than by spreading the definition, so no extra key leaks into them.
+          values: selection
+            ? Array.from(selection.included).map(String).sort()
+            : [],
+        };
+      },
+    );
 
     return {
-      valuesForExistingFilters,
+      selectionByFilterId,
       variables,
-      queriesForExistingFilters: filtersToQuery(
-        broadcastValues,
+      ignoredExpressions,
+      ignoredVariableNames,
+    };
+  }, [filterValueEntries, filters]);
+
+  /** Returns the set of rendered filter conditions corresponding to filters matching the given predicate */
+  const getFiltersQueriesFor = useCallback(
+    (predicate: (filter: DashboardFilter) => boolean): Filter[] => {
+      const seen = new Set<string>();
+      const queries: Filter[] = [];
+      for (const filter of filters) {
+        if (!predicate(filter)) continue;
+        const selection = selectionByFilterId.get(filter.id);
+        if (!selection) continue;
         // Wrap keys in `toString()` to support JSON/Dynamic-type columns.
         // All keys can be stringified, since filter select values are stringified as well.
-        { stringifyKeys: true },
-      ),
-      ignoredExpressions: ignored,
-      filtersByExpression,
-    };
-  }, [filterQueries, filters]);
-
-  // Return only the filter queries that should be applied to a tile whose
-  // source is `sourceId`. When multiple filter definitions share the same
-  // expression, their scopes are unioned: the filter value applies if ANY
-  // sibling broadcasts to `sourceId`. A filter with no `appliesToSourceIds`
-  // (or an empty array) is treated as "applies to all"; a filter with
-  // broadcasting disabled applies to nothing. If `sourceId` is undefined
-  // (e.g. a RawSQL tile with no resolvable source), scoped filters are
-  // skipped and only unscoped filters are returned.
-  const getFilterQueriesForSource = useCallback(
-    (sourceId: string | undefined): Filter[] => {
-      const scoped: FilterState = {};
-      for (const [expression, state] of Object.entries(
-        valuesForExistingFilters,
-      )) {
-        const definitions = filtersByExpression.get(expression) ?? [];
-        const applies = definitions.some(def =>
-          definitionAppliesToSource(def, sourceId),
+        const emitted = filtersToQuery(
+          { [filter.expression]: selection },
+          { stringifyKeys: true },
         );
-        if (applies) {
-          scoped[expression] = state;
+        for (const query of emitted) {
+          // Two definitions resolving to the same selection would otherwise
+          // emit an identical condition twice, churning react-query keys.
+          const dedupeKey = JSON.stringify(query);
+          if (!seen.has(dedupeKey)) {
+            seen.add(dedupeKey);
+            queries.push(query);
+          }
         }
       }
-      // Wrap keys in `toString()` to support JSON/Dynamic-type columns,
-      // consistent with the transformation applied in `queriesForExistingFilters` above.
-      return filtersToQuery(scoped, { stringifyKeys: true });
+      return queries;
     },
-    [valuesForExistingFilters, filtersByExpression],
+    [filters, selectionByFilterId],
+  );
+
+  const broadcastedFilters = useMemo(
+    () => getFiltersQueriesFor(isFilterBroadcastEnabled),
+    [getFiltersQueriesFor],
+  );
+
+  /**
+   * Returns the set of rendered filter conditions which should be
+   * broadcast to tiles with the given sourceId
+   **/
+  const getFilterQueriesForSource = useCallback(
+    (sourceId: string | undefined): Filter[] =>
+      getFiltersQueriesFor(definition =>
+        definitionAppliesToSource(definition, sourceId),
+      ),
+    [getFiltersQueriesFor],
   );
 
   return {
-    filterValues: valuesForExistingFilters,
+    /** Each declared filter's current selection, keyed by `filter.id`. */
+    selectionByFilterId,
     /**
      * Queries for the broadcasting filters, unscoped by source. Callers with a
      * per-tile source should prefer `getFilterQueriesForSource`.
      */
-    filterQueries: queriesForExistingFilters,
+    broadcastedFilters,
+    /** Set the selected values for a filter, by its ID */
     setFilterValue,
-    setFilterQueries,
+    /** Set the raw filter value state */
+    setFilterValueEntries,
+    /** The raw persisted entries, as they appear in the URL param. */
+    filterValueEntries,
     /**
      * Expressions parsed from the URL `filters=` param that don't correspond
      * to any of this dashboard's declared filters — i.e., values that would
      * be silently dropped. Callers can surface a warning.
      */
     ignoredFilterExpressions: ignoredExpressions,
+    /**
+     * Variable names from the URL `filters=` param that name no declared
+     * variable-enabled filter — orphaned by a rename, a deletion, or a filter
+     * whose variable was turned off.
+     */
+    ignoredVariableNames,
     /**
      * Returns the subset of filter queries that should apply to a tile whose
      * source is `sourceId`. Filters with no `appliesToSourceIds` apply to all

--- a/packages/app/src/hooks/usePresetDashboardFilters.tsx
+++ b/packages/app/src/hooks/usePresetDashboardFilters.tsx
@@ -28,9 +28,11 @@ export default function usePresetDashboardFilters({
     enabled,
   );
 
-  const { filterValues, setFilterValue, filterQueries } = useDashboardFilters(
-    data ?? [],
-  );
+  const {
+    selectionByFilterId,
+    setFilterValue,
+    broadcastedFilters: filterQueries,
+  } = useDashboardFilters(data ?? []);
 
   const onSuccess = useCallback(() => {
     refetch();
@@ -91,7 +93,7 @@ export default function usePresetDashboardFilters({
 
   return {
     filters: data ?? [],
-    filterValues,
+    selectionByFilterId,
     setFilterValue,
     filterQueries,
     handleSaveFilter,

--- a/packages/app/src/utils/__tests__/queryParsers.test.ts
+++ b/packages/app/src/utils/__tests__/queryParsers.test.ts
@@ -1,4 +1,8 @@
-import { parseAsJsonEncoded, parseAsStringEncoded } from '@/utils/queryParsers';
+import {
+  dashboardFilterValuesParser,
+  parseAsJsonEncoded,
+  parseAsStringEncoded,
+} from '@/utils/queryParsers';
 
 // Helper: extract the parse/serialize functions from the parser object
 const stringParser = parseAsStringEncoded;
@@ -140,7 +144,7 @@ describe('parseAsJsonEncoded', () => {
     });
 
     it('returns null when the validator returns null instead of throwing', () => {
-      const nullingParser = parseAsJsonEncoded<number[]>(() => null as never);
+      const nullingParser = parseAsJsonEncoded<number[]>(() => null);
       expect(nullingParser.parse(encodeURIComponent('[1,2,3]'))).toBeNull();
     });
 
@@ -150,5 +154,74 @@ describe('parseAsJsonEncoded', () => {
       expect(parser.parse('not-json')).toBeNull();
       expect(validate).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('dashboardFilterValuesParser', () => {
+  // Encoded the same way `serialize` does, but built here so the malformed
+  // shapes below don't have to be cast through the parser's value type.
+  const parse = (value: unknown) =>
+    dashboardFilterValuesParser.parse(
+      encodeURIComponent(JSON.stringify(value)),
+    );
+
+  const sqlEntry = { type: 'sql', condition: "ServiceName IN ('accounting')" };
+  const variableEntry = {
+    type: 'variable',
+    name: 'svc',
+    values: ['accounting'],
+  };
+
+  it('parses an array of legacy expression-keyed entries', () => {
+    expect(parse([sqlEntry])).toEqual([sqlEntry]);
+  });
+
+  it('parses an array of variable-keyed entries', () => {
+    expect(parse([variableEntry])).toEqual([variableEntry]);
+  });
+
+  it('parses a mixed array, preserving order', () => {
+    expect(parse([sqlEntry, variableEntry])).toEqual([sqlEntry, variableEntry]);
+  });
+
+  it('parses an empty array', () => {
+    expect(parse([])).toEqual([]);
+  });
+
+  it.each([
+    ['a bare number', 5],
+    ['an object', {}],
+    ['a bare string', 'x'],
+    ['a null literal', null],
+  ])('returns null for %s', (_label, input) => {
+    expect(parse(input)).toBeNull();
+  });
+
+  it('drops a single invalid entry and keeps the rest', () => {
+    // A variable entry with no `name` can't address anything; the sql entry
+    // beside it should still apply.
+    expect(parse([{ type: 'variable', values: ['a'] }, sqlEntry])).toEqual([
+      sqlEntry,
+    ]);
+  });
+
+  it('reads raw JSON written by an older client', () => {
+    expect(
+      dashboardFilterValuesParser.parse(JSON.stringify([sqlEntry])),
+    ).toEqual([sqlEntry]);
+  });
+
+  it('reads a percent-encoded param', () => {
+    expect(
+      dashboardFilterValuesParser.parse(
+        encodeURIComponent(JSON.stringify([variableEntry])),
+      ),
+    ).toEqual([variableEntry]);
+  });
+
+  it('strips unknown keys from an entry', () => {
+    expect(parse([{ ...variableEntry, somethingNew: true }])).toEqual([
+      variableEntry,
+    ]);
   });
 });

--- a/packages/app/src/utils/queryParsers.ts
+++ b/packages/app/src/utils/queryParsers.ts
@@ -1,4 +1,8 @@
 import { createParser } from 'nuqs';
+import {
+  DashboardFilterValue,
+  DashboardFilterValueSchema,
+} from '@hyperdx/common-utils/dist/types';
 import { SortingState } from '@tanstack/react-table';
 
 /**
@@ -48,7 +52,9 @@ export const parseAsStringEncoded = createParser<string>({
  * the safe default rather than a value that throws downstream during render.
  * Zod schemas satisfy this signature via `schema.parse`.
  */
-export function parseAsJsonEncoded<T>(validate?: (value: unknown) => T) {
+export function parseAsJsonEncoded<T>(
+  validate?: (value: unknown) => T | null | undefined,
+) {
   const finalize = (parsed: unknown): T | null => {
     if (!validate) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -82,6 +88,24 @@ export function parseAsJsonEncoded<T>(validate?: (value: unknown) => T) {
     serialize: value => encodeURIComponent(JSON.stringify(value)),
   });
 }
+
+/**
+ * The dashboard `filters=` param: an array of filter-value entries, each either
+ * expression-keyed (`{type:'sql'}`) or variable-keyed (`{type:'variable'}`).
+ *
+ * Lenient by design — an unrecognized entry is dropped and the rest of the
+ * array survives.
+ */
+export const dashboardFilterValuesParser = parseAsJsonEncoded<
+  DashboardFilterValue[]
+>(value =>
+  Array.isArray(value)
+    ? value.flatMap(entry => {
+        const parsed = DashboardFilterValueSchema.safeParse(entry);
+        return parsed.success ? [parsed.data] : [];
+      })
+    : null,
+);
 
 export const parseAsSortingStateString = createParser<SortingState[number]>({
   parse: value => {

--- a/packages/app/tests/e2e/features/dashboard-filter-value-format.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-value-format.spec.ts
@@ -1,0 +1,384 @@
+/**
+ * Dashboard filter selections are persisted in the `filters=` URL param (and in
+ * `savedFilterValues`) in one of two shapes:
+ *
+ *   legacy, keyed by SQL expression: { type: 'sql', condition: "E IN ('a')" }
+ *   variable-keyed:                  { type: 'variable', name: 'svc', values: ['a'] }
+ *
+ * A variable-enabled filter reads both and writes the variable-keyed form. These
+ * tests pin the round trip through the real URL and the real ClickHouse query:
+ * back-compat on read, migration on write, independence of two filters that
+ * share an expression, and verbatim escaping.
+ *
+ * Every test is `@full-stack`: the variables flag is only set on the full-stack
+ * webServer (see playwright.config.ts).
+ */
+import type { Page } from '@playwright/test';
+
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { expect, test } from '../utils/base-test';
+import { DEFAULT_LOGS_SOURCE_NAME } from '../utils/constants';
+
+type FilterEntry =
+  | { type: 'sql'; condition: string }
+  | { type: 'variable'; name: string; values: string[] };
+
+/** The `filters=` param, decoded. `null` when the param is absent. */
+const filtersParam = (page: Page): FilterEntry[] | null => {
+  const raw = new URL(page.url()).searchParams.get('filters');
+  if (raw === null) return null;
+  return JSON.parse(decodeURIComponent(raw));
+};
+
+/** Wait for the param to settle on `expected` — nuqs writes it asynchronously. */
+const expectFiltersParam = async (page: Page, expected: FilterEntry[]) => {
+  await expect(async () => {
+    expect(filtersParam(page)).toEqual(expected);
+  }).toPass({ timeout: 10000 });
+};
+
+/** Navigate to a dashboard with a hand-written `filters=` param. */
+const gotoWithFilters = async (
+  page: Page,
+  dashboardId: string,
+  entries: FilterEntry[],
+) => {
+  await page.goto(
+    `/dashboards/${dashboardId}?filters=${encodeURIComponent(
+      JSON.stringify(entries),
+    )}`,
+  );
+};
+
+/** Assert exactly `values` are selected in `filterName`'s multi-select. */
+const expectSelected = async (
+  dashboardPage: DashboardPage,
+  filterName: string,
+  values: string[],
+) => {
+  for (const value of values) {
+    await expect(dashboardPage.getFilterPill(filterName, value)).toBeVisible({
+      timeout: 20000,
+    });
+  }
+};
+
+test.describe(
+  'Dashboard filter value format',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    let dashboardPage: DashboardPage;
+
+    test.beforeEach(async ({ page }) => {
+      dashboardPage = new DashboardPage(page);
+      await dashboardPage.goto();
+      await dashboardPage.createNewDashboard();
+      await dashboardPage.timePicker.selectRelativeTime('Last 1 hour');
+    });
+
+    test('reads a legacy sql entry for a variable-enabled filter and migrates it on the next write', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+      let dashboardId = '';
+
+      await test.step('Create a dashboard with a variable-enabled Service filter', async () => {
+        await dashboardPage.addNumberTile(
+          'Count tile',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        dashboardId = dashboardPage.getCurrentDashboardId();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('An old-format link still applies, with no banner', async () => {
+        await gotoWithFilters(page, dashboardId, [
+          { type: 'sql', condition: "ServiceName IN ('accounting')" },
+        ]);
+        await dashboardPage.waitForLoaded();
+
+        await expectSelected(dashboardPage, 'Service', ['accounting']);
+        await expect(dashboardPage.ignoredUrlFiltersBanner).toBeHidden();
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+      });
+
+      await test.step('Adding a second value rewrites the param in the variable format', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'frontend');
+
+        await expectFiltersParam(page, [
+          { type: 'variable', name: 'svc', values: ['accounting', 'frontend'] },
+        ]);
+      });
+
+      await test.step('Both values survive a reload', async () => {
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+
+        await expectSelected(dashboardPage, 'Service', [
+          'accounting',
+          'frontend',
+        ]);
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+      });
+    });
+
+    test('keeps two filters on one expression independent', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      await test.step('Declare a variable-enabled and a plain filter on ServiceName', async () => {
+        await dashboardPage.addNumberTile(
+          'Count tile',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service A',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svcA' },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service A'),
+        ).toBeVisible();
+        await dashboardPage.addFilterToDashboard(
+          'Service B',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { isVariableEnabled: false },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service B'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('Each dropdown holds only its own selection', async () => {
+        await dashboardPage.toggleFilterValue('Service A', 'accounting');
+        await dashboardPage.toggleFilterValue('Service B', 'frontend');
+
+        await expectSelected(dashboardPage, 'Service A', ['accounting']);
+        await expectSelected(dashboardPage, 'Service B', ['frontend']);
+        // Neither dropdown picked up the other's value.
+        await expect(
+          dashboardPage.getFilterPill('Service A', 'frontend'),
+        ).toHaveCount(0);
+        await expect(
+          dashboardPage.getFilterPill('Service B', 'accounting'),
+        ).toHaveCount(0);
+      });
+
+      await test.step('The URL carries one variable entry and one sql entry', async () => {
+        await expectFiltersParam(page, [
+          { type: 'sql', condition: "ServiceName IN ('frontend')" },
+          { type: 'variable', name: 'svcA', values: ['accounting'] },
+        ]);
+      });
+
+      await test.step('Both survive a reload independently', async () => {
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+
+        await expectSelected(dashboardPage, 'Service A', ['accounting']);
+        await expectSelected(dashboardPage, 'Service B', ['frontend']);
+        await expect(
+          dashboardPage.getFilterPill('Service A', 'frontend'),
+        ).toHaveCount(0);
+      });
+    });
+
+    test('warns about an orphaned variable name and preserves it', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+      let dashboardId = '';
+
+      await test.step('Create a dashboard with a variable-enabled Service filter', async () => {
+        await dashboardPage.addNumberTile(
+          'Count tile',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        dashboardId = dashboardPage.getCurrentDashboardId();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('An entry naming no declared variable raises the banner', async () => {
+        await gotoWithFilters(page, dashboardId, [
+          { type: 'variable', name: 'nope', values: ['x'] },
+          { type: 'variable', name: 'svc', values: ['accounting'] },
+        ]);
+        await dashboardPage.waitForLoaded();
+
+        await expect(dashboardPage.ignoredUrlFiltersBanner).toBeVisible({
+          timeout: 20000,
+        });
+        await expect(dashboardPage.ignoredUrlFiltersBanner).toContainText(
+          '$nope',
+        );
+        await expect(dashboardPage.ignoredUrlFiltersBanner).not.toContainText(
+          '$svc',
+        );
+        // The declared variable still applied.
+        await expectSelected(dashboardPage, 'Service', ['accounting']);
+      });
+
+      await test.step('The orphan survives a write to another filter', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'frontend');
+
+        await expectFiltersParam(page, [
+          { type: 'variable', name: 'svc', values: ['accounting', 'frontend'] },
+          { type: 'variable', name: 'nope', values: ['x'] },
+        ]);
+      });
+    });
+
+    test('carries values verbatim through the variable-keyed format', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+      let dashboardId = '';
+      // None of these match seeded data — the point is that they survive the
+      // round trip unmangled and produce a valid query, not that they match.
+      const awkwardValues = ["a'b\\c,d)e", 'true', 'toString(x)'];
+
+      await test.step('Create a variable-enabled Service filter and a plain Severity filter', async () => {
+        await dashboardPage.addNumberTile(
+          'Count tile',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        dashboardId = dashboardPage.getCurrentDashboardId();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+        await dashboardPage.addFilterToDashboard(
+          'Severity',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'SeverityText',
+          undefined,
+          undefined,
+          { isVariableEnabled: false },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Severity'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('The values render verbatim as chips and the tile still queries', async () => {
+        await gotoWithFilters(page, dashboardId, [
+          { type: 'variable', name: 'svc', values: awkwardValues },
+        ]);
+        await dashboardPage.waitForLoaded();
+
+        await expectSelected(dashboardPage, 'Service', awkwardValues);
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+      });
+
+      await test.step('They are byte-identical after touching another filter', async () => {
+        await dashboardPage.toggleFilterValue('Severity', 'error');
+
+        await expectFiltersParam(page, [
+          { type: 'sql', condition: "SeverityText IN ('error')" },
+          { type: 'variable', name: 'svc', values: awkwardValues },
+        ]);
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+      });
+    });
+
+    test('restores a variable-keyed selection from the dashboard default', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+      let dashboardId = '';
+
+      await test.step('Create a variable-enabled Service filter and select a value', async () => {
+        await dashboardPage.addNumberTile(
+          'Count tile',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        dashboardId = dashboardPage.getCurrentDashboardId();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        // The list must show the filter before the next add: the modal
+        // writes the dashboard optimistically, so a racing add drops one.
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expectFiltersParam(page, [
+          { type: 'variable', name: 'svc', values: ['accounting'] },
+        ]);
+      });
+
+      await test.step('Save it as the dashboard default', async () => {
+        await dashboardPage.saveQueryAndFiltersAsDefault();
+      });
+
+      await test.step('Opening the dashboard with no params restores it', async () => {
+        await dashboardPage.gotoDashboard(dashboardId);
+        await dashboardPage.waitForLoaded();
+
+        await expectSelected(dashboardPage, 'Service', ['accounting']);
+        await expect(dashboardPage.ignoredUrlFiltersBanner).toBeHidden();
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/features/dashboard-table-linking.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-table-linking.spec.ts
@@ -670,6 +670,94 @@ test.describe(
       });
     });
 
+    test('Dashboard mode: a variable-enabled target filter still receives an expression-keyed link', async ({
+      page,
+    }) => {
+      // `renderOnClickDashboard` has no view of the target's variable config, so
+      // links stay in the expression-keyed format. The target must still apply
+      // them — this is the back-compat read path through the real cross-page
+      // navigation.
+      const ts = Date.now();
+      const targetDashboardName = `E2E Variable Filter Target ${ts}`;
+      let targetDashboardId = '';
+
+      await test.step('Create the target dashboard with a variable-enabled ServiceName filter', async () => {
+        // beforeEach already created a dashboard; repurpose it as the target.
+        await dashboardPage.editDashboardName(targetDashboardName);
+        await dashboardPage.addTile();
+        await dashboardPage.chartEditor.createBasicChart(
+          `Variable Filter Target Tile ${ts}`,
+        );
+        targetDashboardId = dashboardPage.getCurrentDashboardId();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service Filter',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('Create source dashboard with a Dashboard-mode filter template', async () => {
+        await dashboardPage.goto();
+        await dashboardPage.createNewDashboard();
+        await addTableTile(`E2E Variable Dashboard Filter ${ts}`);
+        await dashboardPage.chartEditor.openRowClickDrawer();
+        await dashboardPage.chartEditor.setRowClickMode('Dashboard');
+        await dashboardPage.chartEditor.selectRowClickTarget(
+          targetDashboardName,
+        );
+        await expect(
+          dashboardPage.chartEditor.onClickFilterExpressionInput(0),
+        ).toHaveValue('ServiceName');
+        await dashboardPage.chartEditor
+          .onClickFilterTemplateInput(0)
+          .fill('{{ServiceName}}');
+        await dashboardPage.chartEditor.applyRowClickDrawer();
+        await dashboardPage.saveTile();
+      });
+
+      await test.step('Set dashboard time range to Last 6 hours', async () => {
+        await dashboardPage.timePicker.selectRelativeTime('Last 6 hours');
+      });
+
+      await dashboardPage.waitForTableTileRows(0);
+      const serviceName = await dashboardPage.getFirstTableRowValue(0, 1);
+      expect(serviceName.length).toBeGreaterThan(0);
+
+      await test.step('Click first table row', async () => {
+        await dashboardPage.clickFirstTableRow(0);
+      });
+
+      await test.step('Verify the link is still expression-keyed', async () => {
+        await expect(page).toHaveURL(
+          new RegExp(`/dashboards/${targetDashboardId}`),
+          { timeout: 10000 },
+        );
+        const url = new URL(page.url());
+        const filtersRaw = url.searchParams.get('filters');
+        expect(filtersRaw).not.toBeNull();
+        const filters = JSON.parse(decodeURIComponent(filtersRaw!));
+        expect(filters).toEqual([
+          {
+            type: 'sql',
+            condition: `ServiceName IN ('${serviceName}')`,
+          },
+        ]);
+      });
+
+      await test.step('Verify the target applied it, with no banner', async () => {
+        await expect(
+          dashboardPage.getFilterPill('Service Filter', serviceName),
+        ).toBeVisible({ timeout: 20000 });
+        await expect(dashboardPage.ignoredUrlFiltersBanner).toBeHidden();
+        await expect(dashboardPage.getLinkErrorNotification()).toBeHidden();
+      });
+    });
+
     test('Dashboard mode: ignored-filter warning banner is dismissable', async ({
       page,
     }) => {

--- a/packages/app/tests/e2e/features/filter-key-edge-cases.spec.ts
+++ b/packages/app/tests/e2e/features/filter-key-edge-cases.spec.ts
@@ -507,3 +507,72 @@ for (const scenario of SCENARIOS) {
     },
   );
 }
+
+// A variable-enabled filter persists its selection under the variable's NAME,
+// so the filter's expression never reaches the URL. That takes the whole
+// key-mangling class above — brackets, quotes, dots, hyphens — off the
+// persistence path entirely, while the executed query is unchanged.
+test.describe(
+  'Filter key edge cases — variable-keyed persistence',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    test('a Map-key filter persists under its variable name, not its expression', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+      const dashboardPage = new DashboardPage(page);
+      const SOURCE = INTERESTING_FILTER_KEYS_SOURCE_NAME;
+      const EXPRESSION = "ResourceAttributes['key.subKey.subSubKey']";
+
+      await test.step('create a count Number tile with a variable-enabled Map-key filter', async () => {
+        await dashboardPage.goto();
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.timePicker.selectRelativeTime('Last 1 hour');
+        await dashboardPage.addNumberTile('Count tile', SOURCE);
+        await expect(dashboardPage.getNumberTileValue()).toHaveText('3', {
+          timeout: QUERY_TIMEOUT,
+        });
+
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addCustomFilter('MapKeyVar', SOURCE, EXPRESSION, {
+          variableName: 'mapkey',
+        });
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('selecting a value filters the tile and writes a variable entry', async () => {
+        await dashboardPage.toggleFilterValue(
+          'MapKeyVar',
+          ROW1.resourceAttrValue,
+        );
+        await expect(dashboardPage.getNumberTileValue()).toHaveText('1', {
+          timeout: QUERY_TIMEOUT,
+        });
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+
+        await expect(async () => {
+          const raw = new URL(page.url()).searchParams.get('filters');
+          expect(raw).not.toBeNull();
+          expect(JSON.parse(decodeURIComponent(raw!))).toEqual([
+            {
+              type: 'variable',
+              name: 'mapkey',
+              values: [ROW1.resourceAttrValue],
+            },
+          ]);
+          // No bracket- or quote-bearing key anywhere in the param.
+          expect(raw).not.toContain('ResourceAttributes');
+        }).toPass({ timeout: 10000 });
+      });
+
+      await test.step('the selection survives a reload', async () => {
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+        await expect(dashboardPage.getNumberTileValue()).toHaveText('1', {
+          timeout: QUERY_TIMEOUT,
+        });
+        await expect(dashboardPage.getTileError()).toHaveCount(0);
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -1199,7 +1199,12 @@ export class DashboardPage {
    * or backticks. Assumes the Edit Filters modal is already open; leaves it open
    * (on the filters list) so multiple filters can be added in sequence.
    */
-  async addCustomFilter(name: string, sourceName: string, expression: string) {
+  async addCustomFilter(
+    name: string,
+    sourceName: string,
+    expression: string,
+    variableOptions?: { variableName: string },
+  ) {
     await this.addFiltersButton.click();
     const nameInput = this.page.getByTestId('filter-name-input');
     await nameInput.waitFor({ state: 'visible', timeout: 10000 });
@@ -1219,6 +1224,10 @@ export class DashboardPage {
     // closes — left open it overlaps the save button and makes the click flake
     // on "element is not stable".
     await nameInput.click();
+    if (variableOptions) {
+      await this.variableEnabledCheckbox.check();
+      await this.variableNameInput.fill(variableOptions.variableName);
+    }
     const saveButton = this.page.getByTestId('save-filter-button');
     await expect(saveButton).toBeEnabled();
     await saveButton.click();


### PR DESCRIPTION
## Summary

Part 2/2 in enabling variable-name-based dashboard filter state. This part updates the dashboard filter hooks to read and write state in the new variable-keyed format.

### Why

Historically, dashboard filter selection state has been persisted (in the URL, dashboard documents, and exports) as keyed by the filter's expression, in the same format used by search-page filters. This has two problems:

1. Filters that share an expression (eg. ServiceName from two different sources) must necessarily share a selection state despite being two dropdowns in the UI.
2. Future "static custom values" filters will have no expression (since they're not queried) and thus would have no way to key their state

### What

This change will persist dashboard filter selection state (that is, what values are selected in the filter's drop-down) based on the variableName of the filter, when it has one.

- Existing expression-keyed filter state will be migrated on write. Existing URLs and saved filter states continue working.
- Filters that are not variable-enabled continue being written in expression-keyed format
- Variable-keyed state takes precedence over expression-keyed state, when both may apply to a single filter.

### Screenshots or video

Updated banner showing URL state that doesn't correspond to the declared filters

<img width="1577" height="234" alt="Screenshot 2026-08-21 at 12 59 06 PM" src="https://github.com/user-attachments/assets/c8c77050-cf95-4956-b0ba-6c7d64d6820d" />

### How to test

- Create a dashboard and add some filters. Make some of them variable enabled and some of them not
- Select values for the filters
- Try saving the default filter values, importing/exporting the dashboard, sharing the link, etc

Use a [URL Decoder](https://meyerweb.com/eric/tools/dencoder/) if you want to inspect the URL

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: HDX-5052
- Related PRs:
