### PR TITLE
fix(app): sort builder tables by output identifiers

### DIFF
--- a/.changeset/fix-table-output-identifiers.md
+++ b/.changeset/fix-table-output-identifiers.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/app': patch
+---
+
+Fix table sorting for builder charts with generated metric and formula output
+column names.

--- a/packages/app/src/__tests__/utils.test.ts
+++ b/packages/app/src/__tests__/utils.test.ts
@@ -1142,6 +1142,11 @@ describe('sortingStateToOrderByString', () => {
     const sortingState: SortingState = [{ id: 'user_count', desc: false }];
     expect(sortingStateToOrderByString(sortingState)).toBe('user_count ASC');
   });
+
+  it('preserves quoted column names with spaces', () => {
+    const sortingState: SortingState = [{ id: '"error rate"', desc: true }];
+    expect(sortingStateToOrderByString(sortingState)).toBe('"error rate" DESC');
+  });
 });
 
 describe('orderByStringToSortingState', () => {
@@ -1161,6 +1166,12 @@ describe('orderByStringToSortingState', () => {
   it('converts "column DESC" to sorting state with desc: true', () => {
     const result = orderByStringToSortingState('timestamp DESC');
     expect(result).toEqual([{ id: 'timestamp', desc: true }]);
+  });
+
+  it('converts quoted column names with spaces', () => {
+    expect(orderByStringToSortingState('"error rate" DESC')).toEqual([
+      { id: '"error rate"', desc: true },
+    ]);
   });
 
   it('handles case insensitive direction keywords', () => {
@@ -1205,6 +1216,13 @@ describe('orderByStringToSortingState', () => {
 
   it('round-trips correctly with sortingStateToOrderByString', () => {
     const originalSort: SortingState = [{ id: 'service_name', desc: true }];
+    const orderByString = sortingStateToOrderByString(originalSort);
+    const roundTripSort = orderByStringToSortingState(orderByString);
+    expect(roundTripSort).toEqual(originalSort);
+  });
+
+  it('round-trips quoted column names with spaces', () => {
+    const originalSort: SortingState = [{ id: '"error rate"', desc: true }];
     const orderByString = sortingStateToOrderByString(originalSort);
     const roundTripSort = orderByStringToSortingState(orderByString);
     expect(roundTripSort).toEqual(originalSort);

--- a/packages/app/src/components/DBTableChart.tsx
+++ b/packages/app/src/components/DBTableChart.tsx
@@ -35,6 +35,9 @@ import ChartErrorState, {
 import { getClientSideSortingFn } from './DBTable/sorting';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
 
+const quoteClickHouseOutputIdentifier = (name: string) =>
+  `"${name.replaceAll('"', '""')}"`;
+
 export default function DBTableChart({
   config,
   getRowSearchLink,
@@ -112,26 +115,6 @@ export default function DBTableChart({
       queryKeyPrefix,
     });
   const { observerRef: fetchMoreRef } = useIntersectionObserver(fetchNextPage);
-
-  // Returns an array of aliases, so we can check if something is using an alias
-  const aliasMap = useMemo(() => {
-    if (isRawSqlChartConfig(config) || isPromqlChartConfig(config)) {
-      return [];
-    }
-
-    // If the config.select is a string, we can't infer this.
-    // One day, we could potentially run this through chSqlToAliasMap but AST parsing
-    //  doesn't work for most DBTableChart queries.
-    if (typeof config.select === 'string') {
-      return [];
-    }
-    return config.select.reduce((acc, select) => {
-      if (select.alias) {
-        acc.push(select.alias);
-      }
-      return acc;
-    }, [] as string[]);
-  }, [config]);
 
   const { formatByColumn } = useChartNumberFormats(queriedConfig, data?.meta);
 
@@ -213,8 +196,11 @@ export default function DBTableChart({
     return orderedKeys
       .filter(key => !hiddenColumns?.includes(key))
       .map(key => ({
-        // If it's an alias, wrap in quotes to support a variety of formats (ex "Time (ms)", "Req/s", etc)
-        id: aliasMap.includes(key) ? `"${key}"` : key,
+        // Builder sorting runs against the final result, so every returned key
+        // must be treated as an output identifier rather than an expression.
+        id: isBuilderChartConfig(queriedConfig)
+          ? quoteClickHouseOutputIdentifier(key)
+          : key,
         dataKey: key,
         displayName: key,
         numberFormat: groupByKeys.includes(key)
@@ -230,7 +216,6 @@ export default function DBTableChart({
     data,
     queriedConfig,
     hiddenColumns,
-    aliasMap,
     formatByColumn,
     colorByColumn,
     rulesByColumn,

--- a/packages/app/src/components/DBTableChart.tsx
+++ b/packages/app/src/components/DBTableChart.tsx
@@ -36,7 +36,7 @@ import { getClientSideSortingFn } from './DBTable/sorting';
 import MVOptimizationIndicator from './MaterializedViews/MVOptimizationIndicator';
 
 const quoteClickHouseOutputIdentifier = (name: string) =>
-  `"${name.replaceAll('"', '""')}"`;
+  `"${name.replaceAll('\\', '\\\\').replaceAll('"', '""')}"`;
 
 export default function DBTableChart({
   config,

--- a/packages/app/src/components/__tests__/DBTableChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBTableChart.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { isBuilderChartConfig } from '@hyperdx/common-utils/dist/guards';
+import { act } from '@testing-library/react';
 
 import DateRangeIndicator from '@/components/charts/DateRangeIndicator';
 import DBTableChart from '@/components/DBTableChart';
@@ -344,6 +346,120 @@ describe('DBTableChart', () => {
         'ServiceName',
         'SpanName',
       ]);
+    });
+  });
+
+  describe('builder output column identifiers', () => {
+    const builderConfig = {
+      ...baseTestConfig,
+      select: [{ aggFn: 'avg' as const, valueExpression: 'metric.total' }],
+      formulas: [{ expression: 'A * 2', alias: 'error rate' }],
+      groupBy: 'ServiceName',
+    };
+
+    beforeEach(() => {
+      jest.mocked(useOffsetPaginatedQuery).mockReturnValue({
+        data: {
+          data: [
+            {
+              'avg(metric.total)': 42,
+              'error rate': 84,
+              ServiceName: 'web',
+            },
+          ],
+          meta: [],
+          chSql: { sql: '', params: {} },
+          window: {
+            startTime: new Date(),
+            endTime: new Date(),
+            windowIndex: 0,
+            direction: 'DESC' as const,
+          },
+        },
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('quotes generated aggregate, formula, and group-by output names', () => {
+      renderWithMantine(<DBTableChart config={builderConfig} />);
+
+      const columns = jest.mocked(Table).mock.calls.at(-1)![0].columns;
+
+      expect(
+        columns.map(column => ({ id: column.id, dataKey: column.dataKey })),
+      ).toEqual([
+        { id: '"avg(metric.total)"', dataKey: 'avg(metric.total)' },
+        { id: '"error rate"', dataKey: 'error rate' },
+        { id: '"ServiceName"', dataKey: 'ServiceName' },
+      ]);
+    });
+
+    it('uses the quoted output name when building server-side sorting', () => {
+      renderWithMantine(<DBTableChart config={builderConfig} />);
+
+      const tableProps = jest.mocked(Table).mock.calls.at(-1)![0];
+
+      act(() => {
+        tableProps.onSortingChange?.([
+          { id: '"avg(metric.total)"', desc: true },
+        ]);
+      });
+
+      const queriedConfig = jest
+        .mocked(useOffsetPaginatedQuery)
+        .mock.calls.at(-1)![0];
+
+      if (!isBuilderChartConfig(queriedConfig)) {
+        throw new Error('Expected a builder chart config');
+      }
+
+      expect(queriedConfig.orderBy).toEqual([
+        {
+          valueExpression: '"avg(metric.total)"',
+          ordering: 'DESC',
+        },
+      ]);
+    });
+
+    it('escapes double quotes in output names', () => {
+      const config = {
+        ...builderConfig,
+        formulas: [{ expression: 'A * 2', alias: 'bad"name' }],
+      };
+
+      jest.mocked(useOffsetPaginatedQuery).mockReturnValue({
+        data: {
+          data: [{ 'avg(metric.total)': 42, 'bad"name': 84 }],
+          meta: [],
+          chSql: { sql: '', params: {} },
+          window: {
+            startTime: new Date(),
+            endTime: new Date(),
+            windowIndex: 0,
+            direction: 'DESC' as const,
+          },
+        },
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+      } as any);
+
+      renderWithMantine(<DBTableChart config={config} />);
+
+      const columns = jest.mocked(Table).mock.calls.at(-1)![0].columns;
+      const formulaColumn = columns.find(
+        column => column.dataKey === 'bad"name',
+      );
+
+      expect(formulaColumn?.id).toBe('"bad""name"');
     });
   });
 

--- a/packages/app/src/components/__tests__/DBTableChart.test.tsx
+++ b/packages/app/src/components/__tests__/DBTableChart.test.tsx
@@ -56,6 +56,32 @@ jest.mock('../MaterializedViews/MVOptimizationIndicator', () =>
 jest.mock('../charts/DateRangeIndicator', () => jest.fn(() => null));
 
 describe('DBTableChart', () => {
+  type TableQueryResult = ReturnType<typeof useOffsetPaginatedQuery>;
+  type TableQueryData = NonNullable<TableQueryResult['data']>;
+
+  const createTableQueryResult = (
+    rows: TableQueryData['data'],
+    meta: TableQueryData['meta'] = [],
+  ): TableQueryResult => ({
+    data: {
+      data: rows,
+      meta,
+      chSql: { sql: '', params: {} },
+      window: {
+        startTime: new Date(),
+        endTime: new Date(),
+        windowIndex: 0,
+        direction: 'DESC',
+      },
+    },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+  });
+
   const baseTestConfig = {
     dateRange: [new Date(), new Date()] as [Date, Date],
     from: { databaseName: 'test', tableName: 'test' },
@@ -340,11 +366,37 @@ describe('DBTableChart', () => {
       renderWithMantine(<DBTableChart config={rawSqlConfig} />);
 
       const columns = jest.mocked(Table).mock.calls.at(-1)![0].columns;
+      expect(columns.map(c => c.id)).toEqual([
+        'Count',
+        'AvgDuration',
+        'ServiceName',
+        'SpanName',
+      ]);
       expect(columns.map(c => c.dataKey)).toEqual([
         'Count',
         'AvgDuration',
         'ServiceName',
         'SpanName',
+      ]);
+    });
+
+    it('keeps PromQL output identifiers unchanged', () => {
+      const promqlConfig = {
+        configType: 'promql' as const,
+        dateRange: [new Date(), new Date()] as [Date, Date],
+        connection: 'test-connection',
+        promqlExpression: 'up',
+      };
+
+      jest
+        .mocked(useOffsetPaginatedQuery)
+        .mockReturnValue(createTableQueryResult([{ 'error rate': 1 }]));
+
+      renderWithMantine(<DBTableChart config={promqlConfig} />);
+
+      const columns = jest.mocked(Table).mock.calls.at(-1)![0].columns;
+      expect(columns.map(c => ({ id: c.id, dataKey: c.dataKey }))).toEqual([
+        { id: 'error rate', dataKey: 'error rate' },
       ]);
     });
   });
@@ -358,31 +410,15 @@ describe('DBTableChart', () => {
     };
 
     beforeEach(() => {
-      jest.mocked(useOffsetPaginatedQuery).mockReturnValue({
-        data: {
-          data: [
-            {
-              'avg(metric.total)': 42,
-              'error rate': 84,
-              ServiceName: 'web',
-            },
-          ],
-          meta: [],
-          chSql: { sql: '', params: {} },
-          window: {
-            startTime: new Date(),
-            endTime: new Date(),
-            windowIndex: 0,
-            direction: 'DESC' as const,
+      jest.mocked(useOffsetPaginatedQuery).mockReturnValue(
+        createTableQueryResult([
+          {
+            'avg(metric.total)': 42,
+            'error rate': 84,
+            ServiceName: 'web',
           },
-        },
-        fetchNextPage: jest.fn(),
-        hasNextPage: false,
-        isLoading: false,
-        isFetching: false,
-        isError: false,
-        error: null,
-      } as any);
+        ]),
+      );
     });
 
     it('quotes generated aggregate, formula, and group-by output names', () => {
@@ -432,25 +468,11 @@ describe('DBTableChart', () => {
         formulas: [{ expression: 'A * 2', alias: 'bad"name' }],
       };
 
-      jest.mocked(useOffsetPaginatedQuery).mockReturnValue({
-        data: {
-          data: [{ 'avg(metric.total)': 42, 'bad"name': 84 }],
-          meta: [],
-          chSql: { sql: '', params: {} },
-          window: {
-            startTime: new Date(),
-            endTime: new Date(),
-            windowIndex: 0,
-            direction: 'DESC' as const,
-          },
-        },
-        fetchNextPage: jest.fn(),
-        hasNextPage: false,
-        isLoading: false,
-        isFetching: false,
-        isError: false,
-        error: null,
-      } as any);
+      jest
+        .mocked(useOffsetPaginatedQuery)
+        .mockReturnValue(
+          createTableQueryResult([{ 'avg(metric.total)': 42, 'bad"name': 84 }]),
+        );
 
       renderWithMantine(<DBTableChart config={config} />);
 
@@ -460,6 +482,31 @@ describe('DBTableChart', () => {
       );
 
       expect(formulaColumn?.id).toBe('"bad""name"');
+    });
+
+    it('escapes backslashes in output names', () => {
+      const outputName = 'bad\\name';
+      const config = {
+        ...builderConfig,
+        formulas: [{ expression: 'A * 2', alias: outputName }],
+      };
+
+      jest
+        .mocked(useOffsetPaginatedQuery)
+        .mockReturnValue(
+          createTableQueryResult([
+            { 'avg(metric.total)': 42, [outputName]: 84 },
+          ]),
+        );
+
+      renderWithMantine(<DBTableChart config={config} />);
+
+      const columns = jest.mocked(Table).mock.calls.at(-1)![0].columns;
+      const formulaColumn = columns.find(
+        column => column.dataKey === outputName,
+      );
+
+      expect(formulaColumn?.id).toBe('"bad\\\\name"');
     });
   });
 

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -1326,17 +1326,24 @@ export const orderByStringToSortingState = (
     return undefined;
   }
 
-  const orderByParts = orderBy.split(' ');
-  const endsWithDirection = orderBy.toLowerCase().match(/ (asc|desc)$/i);
+  const match = orderBy.trim().match(/^(.+)\s+(ASC|DESC)$/i);
+  if (!match) {
+    return undefined;
+  }
 
-  if (orderByParts.length !== 2 || !endsWithDirection) {
+  const column = match[1].trim();
+  const direction = match[2];
+  const isQuotedIdentifier =
+    /^"(?:[^"]|"")*"$/.test(column) || /^`(?:[^`]|``)*`$/.test(column);
+
+  if (!isQuotedIdentifier && /\s/.test(column)) {
     return undefined;
   }
 
   return [
     {
-      id: orderByParts[0].trim(),
-      desc: orderByParts[1].trim().toUpperCase() === 'DESC',
+      id: column,
+      desc: direction.toUpperCase() === 'DESC',
     },
   ];
 };


### PR DESCRIPTION
## What changed

Builder table sorting now uses the returned column name as a quoted ClickHouse identifier.

This fixes sorting for:

- generated metric columns like `avg(metric.total)`
- formula output columns
- group-by columns with special characters

Also:

- **keeps quoted sort state** after a table remount or reload
- **escapes quotes and backslashes** in output names
- keeps raw SQL and PromQL table sorting unchanged

## Why

The composed metric query sorts in the outer result scope. The table was sending generated names as expressions, so ClickHouse could not resolve them.

The sort state parser also split on every space, so a quoted name like `"error rate" DESC` was lost after reload.

## Tests

- `yarn workspace @hyperdx/app jest --runInBand src/__tests__/utils.test.ts src/components/__tests__/DBTableChart.test.tsx`
- `yarn workspace @hyperdx/app tsc --noEmit`
- `yarn lint:fix`
