### PR TITLE
refactor: Split DashboardFiltersModal  into smaller components

### DIFF
--- a/.changeset/refactor-dashboard-filters-modal.md
+++ b/.changeset/refactor-dashboard-filters-modal.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+refactor: Split `DashboardFiltersModal` into smaller components

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -166,6 +166,7 @@ import ChartContainer, {
   CollapsedToolbarProvider,
   DASHBOARD_TILE_PADDING_INLINE,
 } from './components/charts/ChartContainer';
+import DashboardFiltersModal from './components/DashboardFiltersModal';
 import { DBBarChart } from './components/DBBarChart';
 import DBHeatmapChart, {
   toHeatmapChartConfig,
@@ -193,7 +194,6 @@ import {
 import { useConnections } from './connection';
 import { useDashboard } from './dashboard';
 import DashboardFilters from './DashboardFilters';
-import DashboardFiltersModal from './DashboardFiltersModal';
 import { EditablePageName } from './EditablePageName';
 import {
   GranularityPicker,

--- a/packages/app/src/ServicesDashboardPage/ServicesDashboardPage.tsx
+++ b/packages/app/src/ServicesDashboardPage/ServicesDashboardPage.tsx
@@ -38,6 +38,7 @@ import {
   IconRefresh,
 } from '@tabler/icons-react';
 
+import DashboardFiltersModal from '@/components/DashboardFiltersModal';
 import OnboardingModal from '@/components/OnboardingModal';
 import SearchWhereInput, {
   getStoredLanguage,
@@ -49,7 +50,6 @@ import { SourceSelectControlled } from '@/components/SourceSelect';
 import { TimePicker } from '@/components/TimePicker';
 import { IS_LOCAL_MODE } from '@/config';
 import DashboardFilters from '@/DashboardFilters';
-import DashboardFiltersModal from '@/DashboardFiltersModal';
 import { useQueriedChartConfig } from '@/hooks/useChartConfig';
 import { useDashboardRefresh } from '@/hooks/useDashboardRefresh';
 import usePresetDashboardFilters from '@/hooks/usePresetDashboardFilters';

--- a/packages/app/src/ServicesDashboardPage/__tests__/ServicesDashboardPage.test.tsx
+++ b/packages/app/src/ServicesDashboardPage/__tests__/ServicesDashboardPage.test.tsx
@@ -78,7 +78,7 @@ jest.mock('@/DashboardFilters', () => ({
   __esModule: true,
   default: () => null,
 }));
-jest.mock('@/DashboardFiltersModal', () => ({
+jest.mock('@/components/DashboardFiltersModal', () => ({
   __esModule: true,
   default: () => null,
 }));

--- a/packages/app/src/components/DashboardFiltersModal/CustomInputWrapper.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/CustomInputWrapper.tsx
@@ -1,0 +1,39 @@
+import { FieldError } from 'react-hook-form';
+import { Input, Tooltip } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+
+interface CustomInputWrapperProps {
+  children: React.ReactNode;
+  label: string;
+  tooltipText?: string;
+  error?: FieldError;
+}
+
+export const CustomInputWrapper = ({
+  children,
+  label,
+  tooltipText,
+  error,
+}: CustomInputWrapperProps) => {
+  const errorMessage =
+    error &&
+    (error.message ||
+      (error?.type === 'required' ? 'This field is required' : 'Error'));
+
+  return (
+    <div>
+      <Input.Label>{label}</Input.Label>
+      {tooltipText && (
+        <Tooltip label={tooltipText}>
+          <IconInfoCircle size={14} className="ms-2" />
+        </Tooltip>
+      )}
+      {errorMessage && (
+        <Input.Error color="red" size="sm">
+          {errorMessage}
+        </Input.Error>
+      )}
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+};

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
@@ -56,6 +56,13 @@ interface DashboardFilterEditFormProps {
   onCancel: () => void;
 }
 
+/**
+ * The modal body scrolls, so an autocomplete popup rendered inside it is
+ * clipped at the modal's edge. Portal it to the document body instead.
+ */
+const TOOLTIP_PORTAL_TARGET =
+  typeof document !== 'undefined' ? document.body : null;
+
 /** Normalize a stored filter into form values. */
 const toFormValues = (filter: DashboardFilter): DashboardFilter => ({
   ...filter,
@@ -199,9 +206,6 @@ export const DashboardFilterEditForm = ({
     source?.kind === SourceKind.Metric ? source.metricTables?.[type] : false,
   );
 
-  const [modalContentRef, setModalContentRef] = useState<HTMLElement | null>(
-    null,
-  );
   const [isSourceSchemaPreviewOpen, setIsSourceSchemaPreviewOpen] =
     useState(false);
 
@@ -212,237 +216,236 @@ export const DashboardFilterEditForm = ({
       onClose={onClose}
       size={MODAL_SIZE}
     >
-      <div ref={setModalContentRef}>
-        <form
-          onSubmit={handleSubmit(values => {
-            const trimmedWhere = values.where?.trim() ?? '';
-            const appliesTo = values.appliesToSourceIds?.filter(
-              id => !!id?.length,
-            );
-            const isVariableEnabled = values.isVariableEnabled === true;
-            const isBroadcastEnabled = values.isBroadcastEnabled !== false;
-            const trimmedVariableName = values.variableName?.trim() ?? '';
-            onSave({
-              ...values,
-              where: trimmedWhere || undefined,
-              whereLanguage: trimmedWhere
-                ? (values.whereLanguage ?? 'sql')
-                : undefined,
-              appliesToSourceIds: appliesTo?.length ? appliesTo : undefined,
-              isBroadcastEnabled,
-              isVariableEnabled,
-              // Dropped when the variable is disabled, so the set of variable
-              // names is exactly the set of enabled filters.
-              variableName: isVariableEnabled
-                ? trimmedVariableName ||
-                  deriveVariableName(values.name) ||
-                  undefined
-                : undefined,
-            });
-          })}
-        >
-          <Stack>
+      <form
+        onSubmit={handleSubmit(values => {
+          const trimmedWhere = values.where?.trim() ?? '';
+          const appliesTo = values.appliesToSourceIds?.filter(
+            id => !!id?.length,
+          );
+          const isVariableEnabled = values.isVariableEnabled === true;
+          const isBroadcastEnabled = values.isBroadcastEnabled !== false;
+          const trimmedVariableName = values.variableName?.trim() ?? '';
+          onSave({
+            ...values,
+            where: trimmedWhere || undefined,
+            whereLanguage: trimmedWhere
+              ? (values.whereLanguage ?? 'sql')
+              : undefined,
+            appliesToSourceIds: appliesTo?.length ? appliesTo : undefined,
+            isBroadcastEnabled,
+            isVariableEnabled,
+            // Dropped when the variable is disabled, so the set of variable
+            // names is exactly the set of enabled filters.
+            variableName: isVariableEnabled
+              ? trimmedVariableName ||
+                deriveVariableName(values.name) ||
+                undefined
+              : undefined,
+          });
+        })}
+      >
+        <Stack>
+          <CustomInputWrapper
+            label="Display name"
+            error={formState.errors.name}
+          >
+            <TextInput
+              placeholder="Name"
+              data-testid="filter-name-input"
+              {...register('name', { required: true, minLength: 1 })}
+            />
+          </CustomInputWrapper>
+          <CustomInputWrapper
+            label="Data source"
+            tooltipText="The data source that the filter values are queried from"
+            error={formState.errors.source}
+          >
+            <SourceSelectControlled
+              control={control}
+              name="source"
+              data-testid="source-selector"
+              rules={{ required: true }}
+              comboboxProps={{ withinPortal: true }}
+              onSchemaPreview={() => setIsSourceSchemaPreviewOpen(true)}
+              isSchemaPreviewEnabled={isSourceSchemaPreviewEnabled(source)}
+              disabled={!!presetSource}
+              allowedSourceKinds={[
+                SourceKind.Log,
+                SourceKind.Trace,
+                SourceKind.Session,
+                SourceKind.Metric,
+              ]}
+            />
+            <SourceSchemaPreview
+              source={source}
+              controlled
+              open={isSourceSchemaPreviewOpen}
+              onClose={() => setIsSourceSchemaPreviewOpen(false)}
+            />
+          </CustomInputWrapper>
+          {sourceIsMetric && (
             <CustomInputWrapper
-              label="Display name"
-              error={formState.errors.name}
+              label="Metric type"
+              tooltipText="The metric table that the filter values are queried from"
+              error={formState.errors.sourceMetricType}
             >
-              <TextInput
-                placeholder="Name"
-                data-testid="filter-name-input"
-                {...register('name', { required: true, minLength: 1 })}
-              />
-            </CustomInputWrapper>
-            <CustomInputWrapper
-              label="Data source"
-              tooltipText="The data source that the filter values are queried from"
-              error={formState.errors.source}
-            >
-              <SourceSelectControlled
+              <Controller
                 control={control}
-                name="source"
-                data-testid="source-selector"
+                name="sourceMetricType"
                 rules={{ required: true }}
-                comboboxProps={{ withinPortal: true }}
-                onSchemaPreview={() => setIsSourceSchemaPreviewOpen(true)}
-                isSchemaPreviewEnabled={isSourceSchemaPreviewEnabled(source)}
-                disabled={!!presetSource}
-                allowedSourceKinds={[
-                  SourceKind.Log,
-                  SourceKind.Trace,
-                  SourceKind.Session,
-                  SourceKind.Metric,
-                ]}
-              />
-              <SourceSchemaPreview
-                source={source}
-                controlled
-                open={isSourceSchemaPreviewOpen}
-                onClose={() => setIsSourceSchemaPreviewOpen(false)}
+                render={({ field: { onChange, value } }) => (
+                  <Radio.Group
+                    value={value}
+                    onChange={v => onChange(v)}
+                    withAsterisk
+                  >
+                    <Group>
+                      {metricTypes.map(type => (
+                        <Radio key={type} value={type} label={type} />
+                      ))}
+                    </Group>
+                  </Radio.Group>
+                )}
               />
             </CustomInputWrapper>
-            {sourceIsMetric && (
-              <CustomInputWrapper
-                label="Metric type"
-                tooltipText="The metric table that the filter values are queried from"
-                error={formState.errors.sourceMetricType}
-              >
-                <Controller
-                  control={control}
-                  name="sourceMetricType"
-                  rules={{ required: true }}
-                  render={({ field: { onChange, value } }) => (
-                    <Radio.Group
-                      value={value}
-                      onChange={v => onChange(v)}
-                      withAsterisk
-                    >
-                      <Group>
-                        {metricTypes.map(type => (
-                          <Radio key={type} value={type} label={type} />
-                        ))}
-                      </Group>
-                    </Radio.Group>
-                  )}
-                />
-              </CustomInputWrapper>
-            )}
+          )}
 
-            <CustomInputWrapper
-              label="Filter expression"
-              tooltipText="The SQL column or expression to filter on"
-              error={formState.errors.expression}
-            >
-              <SQLInlineEditorControlled
-                tableConnection={tableConnection}
+          <CustomInputWrapper
+            label="Filter expression"
+            tooltipText="The SQL column or expression to filter on"
+            error={formState.errors.expression}
+          >
+            <SQLInlineEditorControlled
+              tableConnection={tableConnection}
+              control={control}
+              name="expression"
+              placeholder="SQL column or expression"
+              language="sql"
+              enableHotkey
+              rules={{ required: true }}
+              parentRef={TOOLTIP_PORTAL_TARGET}
+            />
+          </CustomInputWrapper>
+
+          <CustomInputWrapper
+            label="Dropdown values filter"
+            tooltipText="Optional condition used to filter the rows from which available filter values are queried. May reference the dashboard's other variables."
+          >
+            <SearchWhereInput
+              tableConnection={tableConnection}
+              sourceId={sourceId}
+              control={control}
+              name="where"
+              languageName="whereLanguage"
+              showLabel={false}
+              allowMultiline={true}
+              sqlPlaceholder="Filter for dropdown values"
+              lucenePlaceholder="Filter for dropdown values"
+              enableVariables={showVariableOptions}
+              parentRef={TOOLTIP_PORTAL_TARGET}
+            />
+          </CustomInputWrapper>
+
+          {showVariableOptions && (
+            <>
+              <Divider />
+              <CheckBoxControlled
                 control={control}
-                name="expression"
-                placeholder="SQL column or expression"
-                language="sql"
-                enableHotkey
-                rules={{ required: true }}
-                parentRef={modalContentRef}
+                name="isBroadcastEnabled"
+                size="xs"
+                label="Broadcast filter condition"
+                description="Automatically apply the selected value to every query builder tile, and to every Raw SQL tile that uses the $__filters macro. Optionally, narrow to tiles that use specific sources."
+                data-testid="filter-broadcast-checkbox"
               />
-            </CustomInputWrapper>
-
-            <CustomInputWrapper
-              label="Dropdown values filter"
-              tooltipText="Optional condition used to filter the rows from which available filter values are queried. May reference the dashboard's other variables."
-            >
-              <SearchWhereInput
-                tableConnection={tableConnection}
-                sourceId={sourceId}
-                control={control}
-                name="where"
-                languageName="whereLanguage"
-                showLabel={false}
-                allowMultiline={true}
-                sqlPlaceholder="Filter for dropdown values"
-                lucenePlaceholder="Filter for dropdown values"
-                enableVariables={showVariableOptions}
-              />
-            </CustomInputWrapper>
-
-            {showVariableOptions && (
-              <>
-                <Divider />
-                <CheckBoxControlled
-                  control={control}
-                  name="isBroadcastEnabled"
-                  size="xs"
-                  label="Broadcast filter condition"
-                  description="Automatically apply the selected value to every query builder tile, and to every Raw SQL tile that uses the $__filters macro. Optionally, narrow to tiles that use specific sources."
-                  data-testid="filter-broadcast-checkbox"
-                />
-              </>
+            </>
+          )}
+          {/**
+           * Not available for filters on preset dashboards, always shown when showVariableOptions is disabled,
+           * and shown only when the broadcast condition is enabled if showVariableOptions is enabled.
+           **/}
+          {!presetSource &&
+            (!showVariableOptions || formIsBroadCastEnabled) && (
+              <Box ml={showVariableOptions ? 'xl' : undefined}>
+                <CustomInputWrapper
+                  label="Applies to sources"
+                  tooltipText="Which tiles the broadcast reaches. Leave empty to broadcast to all tiles. Selecting one or more sources restricts the broadcast to tiles using those sources."
+                >
+                  <SourceMultiSelectControlled
+                    control={control}
+                    name="appliesToSourceIds"
+                    data-testid="applies-to-source-selector"
+                    comboboxProps={{ withinPortal: true }}
+                    placeholder="All sources"
+                    allowedSourceKinds={[
+                      SourceKind.Log,
+                      SourceKind.Trace,
+                      SourceKind.Session,
+                      SourceKind.Metric,
+                    ]}
+                  />
+                </CustomInputWrapper>
+              </Box>
             )}
-            {/**
-             * Not available for filters on preset dashboards, always shown when showVariableOptions is disabled,
-             * and shown only when the broadcast condition is enabled if showVariableOptions is enabled.
-             **/}
-            {!presetSource &&
-              (!showVariableOptions || formIsBroadCastEnabled) && (
+          {showVariableOptions && (
+            <>
+              <Divider />
+              <CheckBoxControlled
+                control={control}
+                name="isVariableEnabled"
+                size="xs"
+                label="Available as variable"
+                description="Expose the selected value as a $variable. Selections only affect tiles that reference the variable explicitly, typically via the $__filter or $__conditionalAll macros."
+                data-testid="filter-variable-enabled-checkbox"
+                rules={{ validate: validateFilterModes }}
+              />
+              {formIsVariableEnabled && (
                 <Box ml={showVariableOptions ? 'xl' : undefined}>
                   <CustomInputWrapper
-                    label="Applies to sources"
-                    tooltipText="Which tiles the broadcast reaches. Leave empty to broadcast to all tiles. Selecting one or more sources restricts the broadcast to tiles using those sources."
+                    label="Variable name"
+                    tooltipText="The name by which the variable is referenced"
+                    error={formState.errors.variableName}
                   >
-                    <SourceMultiSelectControlled
-                      control={control}
-                      name="appliesToSourceIds"
-                      data-testid="applies-to-source-selector"
-                      comboboxProps={{ withinPortal: true }}
-                      placeholder="All sources"
-                      allowedSourceKinds={[
-                        SourceKind.Log,
-                        SourceKind.Trace,
-                        SourceKind.Session,
-                        SourceKind.Metric,
-                      ]}
+                    <TextInput
+                      placeholder={derivedVariableName || 'variable_name'}
+                      data-testid="filter-variable-name-input"
+                      {...register('variableName', {
+                        onChange: () => setHasEditedVariableName(true),
+                        validate: validateVariableNameField,
+                      })}
                     />
                   </CustomInputWrapper>
                 </Box>
               )}
-            {showVariableOptions && (
-              <>
-                <Divider />
-                <CheckBoxControlled
-                  control={control}
-                  name="isVariableEnabled"
-                  size="xs"
-                  label="Available as variable"
-                  description="Expose the selected value as a $variable. Selections only affect tiles that reference the variable explicitly, typically via the $__filter or $__conditionalAll macros."
-                  data-testid="filter-variable-enabled-checkbox"
-                  rules={{ validate: validateFilterModes }}
-                />
-                {formIsVariableEnabled && (
-                  <Box ml={showVariableOptions ? 'xl' : undefined}>
-                    <CustomInputWrapper
-                      label="Variable name"
-                      tooltipText="The name by which the variable is referenced"
-                      error={formState.errors.variableName}
-                    >
-                      <TextInput
-                        placeholder={derivedVariableName || 'variable_name'}
-                        data-testid="filter-variable-name-input"
-                        {...register('variableName', {
-                          onChange: () => setHasEditedVariableName(true),
-                          validate: validateVariableNameField,
-                        })}
-                      />
-                    </CustomInputWrapper>
-                  </Box>
-                )}
-                {showUnscopedBroadcastWarning && (
-                  <Alert
-                    variant="warning"
-                    icon={<IconAlertTriangle size={16} />}
-                    data-testid="filter-unscoped-broadcast-warning"
-                  >
-                    Broadcast already applies this filter to every tile,
-                    including the ones that reference the variable. Set “Applies
-                    to sources” to limit which tiles the broadcast reaches, or
-                    turn off broadcast so only tiles that reference the variable
-                    are filtered.
-                  </Alert>
-                )}
-              </>
-            )}
+              {showUnscopedBroadcastWarning && (
+                <Alert
+                  variant="warning"
+                  icon={<IconAlertTriangle size={16} />}
+                  data-testid="filter-unscoped-broadcast-warning"
+                >
+                  Broadcast already applies this filter to every tile, including
+                  the ones that reference the variable. Set “Applies to sources”
+                  to limit which tiles the broadcast reaches, or turn off
+                  broadcast so only tiles that reference the variable are
+                  filtered.
+                </Alert>
+              )}
+            </>
+          )}
 
-            <Group justify="space-between" my="xs">
-              <Button variant="secondary" onClick={onCancel}>
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                data-testid="save-filter-button"
-              >
-                Save filter
-              </Button>
-            </Group>
-          </Stack>
-        </form>
-      </div>
+          <Group justify="space-between" my="xs">
+            <Button variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              data-testid="save-filter-button"
+            >
+              Save filter
+            </Button>
+          </Group>
+        </Stack>
+      </form>
     </Modal>
   );
 };

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Controller, FieldError, useForm, useWatch } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { TableConnection } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   deriveVariableName,
-  getFilterVariableName,
   hasFilterEffect,
   isFilterBroadcastEnabled,
   isFilterVariableEnabled,
   validateVariableName,
 } from '@hyperdx/common-utils/dist/filters';
 import {
-  ChartVariable,
   DashboardFilter,
   MetricsDataType,
   SourceKind,
@@ -20,84 +18,30 @@ import {
   Alert,
   Box,
   Button,
-  Center,
   Divider,
   Group,
-  Input,
   Modal,
-  Paper,
   Radio,
   Stack,
-  Text,
   TextInput,
-  Title,
-  Tooltip,
-  UnstyledButton,
 } from '@mantine/core';
-import {
-  IconAlertTriangle,
-  IconFilter,
-  IconInfoCircle,
-  IconPencil,
-  IconRefresh,
-  IconSearch,
-  IconTrash,
-} from '@tabler/icons-react';
+import { IconAlertTriangle } from '@tabler/icons-react';
 
 import { CheckBoxControlled } from '@/components/InputControlled';
 import SearchWhereInput, {
   getStoredLanguage,
 } from '@/components/SearchInput/SearchWhereInput';
-import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
-import { SqlVariablesProvider } from '@/components/SQLEditor/variableCompletions';
-
-import { SourceMultiSelectControlled } from './components/SourceMultiSelect';
+import { SourceMultiSelectControlled } from '@/components/SourceMultiSelect';
 import SourceSchemaPreview, {
   isSourceSchemaPreviewEnabled,
-} from './components/SourceSchemaPreview';
-import { SourceSelectControlled } from './components/SourceSelect';
-import { useSource, useSources } from './source';
-import { getMetricTableName } from './utils';
+} from '@/components/SourceSchemaPreview';
+import { SourceSelectControlled } from '@/components/SourceSelect';
+import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEditor';
+import { useSource } from '@/source';
+import { getMetricTableName } from '@/utils';
 
-import styles from '@styles/DashboardFiltersModal.module.scss';
-
-const MODAL_SIZE = 'lg';
-
-interface CustomInputWrapperProps {
-  children: React.ReactNode;
-  label: string;
-  tooltipText?: string;
-  error?: FieldError;
-}
-
-const CustomInputWrapper = ({
-  children,
-  label,
-  tooltipText,
-  error,
-}: CustomInputWrapperProps) => {
-  const errorMessage =
-    error &&
-    (error.message ||
-      (error?.type === 'required' ? 'This field is required' : 'Error'));
-
-  return (
-    <div>
-      <Input.Label>{label}</Input.Label>
-      {tooltipText && (
-        <Tooltip label={tooltipText}>
-          <IconInfoCircle size={14} className="ms-2" />
-        </Tooltip>
-      )}
-      {errorMessage && (
-        <Input.Error color="red" size="sm">
-          {errorMessage}
-        </Input.Error>
-      )}
-      <div className="mt-1">{children}</div>
-    </div>
-  );
-};
+import { MODAL_SIZE } from './constants';
+import { CustomInputWrapper } from './CustomInputWrapper';
 
 interface DashboardFilterEditFormProps {
   filter: DashboardFilter;
@@ -123,7 +67,7 @@ const toFormValues = (filter: DashboardFilter): DashboardFilter => ({
   variableName: filter.variableName ?? '',
 });
 
-const DashboardFilterEditForm = ({
+export const DashboardFilterEditForm = ({
   filter,
   isNew,
   source: presetSource,
@@ -502,287 +446,3 @@ const DashboardFilterEditForm = ({
     </Modal>
   );
 };
-
-interface EmptyStateProps {
-  onCreateFilter: () => void;
-  onClose: () => void;
-}
-
-const EmptyState = ({ onCreateFilter, onClose }: EmptyStateProps) => {
-  return (
-    <Modal opened onClose={onClose} size={MODAL_SIZE}>
-      <Stack
-        align="center"
-        justify="center"
-        pt="lg"
-        pb="xl"
-        data-testid="dashboard-filters-empty-state"
-      >
-        <IconFilter />
-        <Title order={4}>No filters yet.</Title>
-        <Text size="sm" ta="center" px="xl">
-          Add filters to let users quickly narrow data on key columns. Saved
-          filters will stay with this dashboard.
-        </Text>
-        <Button
-          variant="primary"
-          onClick={onCreateFilter}
-          data-testid="add-filter-button"
-        >
-          Add new filter
-        </Button>
-      </Stack>
-    </Modal>
-  );
-};
-
-interface DashboardFiltersListProps {
-  filters: DashboardFilter[];
-  isLoading?: boolean;
-  hideAppliesTo?: boolean;
-  /** Whether the broadcast / variable controls are available. */
-  showVariableOptions: boolean;
-  onEdit: (filter: DashboardFilter) => void;
-  onRemove: (id: string) => void;
-  onClose: () => void;
-  onAddNew: () => void;
-}
-
-const DashboardFiltersList = ({
-  filters,
-  isLoading,
-  hideAppliesTo,
-  showVariableOptions,
-  onEdit,
-  onRemove,
-  onClose,
-  onAddNew,
-}: DashboardFiltersListProps) => {
-  const { data: sources } = useSources();
-
-  return (
-    <Modal
-      opened
-      onClose={onClose}
-      title={showVariableOptions ? 'Filters and Variables' : 'Filters'}
-      size={MODAL_SIZE}
-      className={styles.modal}
-    >
-      <Stack
-        className={styles.filtersContainer}
-        gap="xs"
-        data-testid="dashboard-filters-list"
-      >
-        {filters.map(filter => {
-          const queriedSourceName = sources?.find(
-            s => s.id === filter.source,
-          )?.name;
-          const appliedSourceNames = filter.appliesToSourceIds?.length
-            ? filter.appliesToSourceIds
-                .map(id => sources?.find(s => s.id === id)?.name)
-                .filter((name): name is string => !!name)
-            : undefined;
-          const appliedDisplay = appliedSourceNames
-            ? appliedSourceNames.join(', ')
-            : 'All sources';
-          const variableName =
-            showVariableOptions && isFilterVariableEnabled(filter)
-              ? getFilterVariableName(filter)
-              : undefined;
-          return (
-            <Paper
-              key={filter.id}
-              withBorder
-              className={styles.filterPaper}
-              p="xs"
-              variant="muted"
-              data-testid={`dashboard-filter-item-${filter.name}`}
-            >
-              <Group justify="space-between" className={styles.filterHeader}>
-                <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
-                  <Text size="xs" truncate="end">
-                    {filter.name}
-                    {!!variableName && ` ($${variableName})`}
-                  </Text>
-                </Group>
-                <Group>
-                  <UnstyledButton
-                    onClick={() => onEdit(filter)}
-                    className={styles.filterActionButton}
-                    data-testid={`edit-filter-button-${filter.name}`}
-                  >
-                    <IconPencil size={16} />
-                  </UnstyledButton>
-                  <UnstyledButton
-                    onClick={() => onRemove(filter.id)}
-                    className={`${styles.filterActionButton} ${styles.deleteButton}`}
-                    data-testid={`delete-filter-button-${filter.name}`}
-                  >
-                    <IconTrash size={16} />
-                  </UnstyledButton>
-                </Group>
-              </Group>
-              <Group gap="xs" wrap="nowrap">
-                <Tooltip
-                  label="Source the dropdown values are queried from"
-                  withinPortal
-                >
-                  <IconSearch size={14} />
-                </Tooltip>
-                <Text size="xs" truncate="end">
-                  {queriedSourceName}
-                </Text>
-              </Group>
-              {!hideAppliesTo && isFilterBroadcastEnabled(filter) && (
-                <Group
-                  gap="xs"
-                  wrap="nowrap"
-                  data-testid={`dashboard-filter-applies-to-${filter.name}`}
-                >
-                  <Tooltip
-                    label={'Sources this filter applies to'}
-                    withinPortal
-                    multiline
-                    maw={400}
-                  >
-                    <IconFilter size={14} style={{ flexShrink: 0 }} />
-                  </Tooltip>
-                  <Text size="xs" truncate="end">
-                    {appliedDisplay}
-                  </Text>
-                </Group>
-              )}
-            </Paper>
-          );
-        })}
-        {isLoading && (
-          <Center>
-            <IconRefresh className="spin-animate" />
-          </Center>
-        )}
-      </Stack>
-
-      <Group justify="space-between" my="sm">
-        <Button
-          variant="secondary"
-          onClick={onClose}
-          data-testid="close-filters-button"
-        >
-          Close
-        </Button>
-        <Button
-          variant="primary"
-          onClick={onAddNew}
-          data-testid="add-filter-button"
-        >
-          Add new filter
-        </Button>
-      </Group>
-    </Modal>
-  );
-};
-
-interface DashboardFiltersEditModalProps {
-  opened: boolean;
-  filters: DashboardFilter[];
-  isLoading?: boolean;
-  source?: TSource;
-  /** Whether to offer the broadcast / variable controls. */
-  showVariableOptions: boolean;
-  /** The dashboard's variables, if any */
-  variables?: ChartVariable[];
-  onClose: () => void;
-  onSaveFilter: (filter: DashboardFilter) => void;
-  onRemoveFilter: (id: string) => void;
-}
-
-const NEW_FILTER_ID = 'new';
-
-const DashboardFiltersModal = ({
-  opened,
-  filters,
-  isLoading,
-  source,
-  showVariableOptions,
-  variables,
-  onClose,
-  onSaveFilter,
-  onRemoveFilter,
-}: DashboardFiltersEditModalProps) => {
-  const [selectedFilter, setSelectedFilter] = useState<DashboardFilter>();
-
-  useEffect(() => {
-    if (opened) {
-      setSelectedFilter(undefined);
-    }
-  }, [opened]);
-
-  const handleRemoveFilter = (id: string) => {
-    if (id === selectedFilter?.id) {
-      setSelectedFilter(filters.find(f => f.id !== id));
-    }
-    onRemoveFilter(id);
-  };
-
-  const handleAddNewFilter = () => {
-    setSelectedFilter({
-      id: NEW_FILTER_ID,
-      type: 'QUERY_EXPRESSION',
-      name: '',
-      expression: '',
-      source: source?.id ?? '',
-      where: '',
-      whereLanguage: getStoredLanguage() ?? 'sql',
-      isBroadcastEnabled: true,
-      isVariableEnabled: false,
-    });
-  };
-
-  const handleSaveFilter = (filter: DashboardFilter) => {
-    setSelectedFilter(undefined);
-    if (filter.id === NEW_FILTER_ID) {
-      const filterWithRealId = { ...filter, id: crypto.randomUUID() };
-      onSaveFilter(filterWithRealId);
-    } else {
-      onSaveFilter(filter);
-    }
-  };
-
-  const isEmpty = !selectedFilter && filters.length === 0;
-
-  if (!opened) {
-    return null;
-  } else if (isEmpty) {
-    return <EmptyState onCreateFilter={handleAddNewFilter} onClose={onClose} />;
-  } else if (selectedFilter) {
-    return (
-      <SqlVariablesProvider variables={variables}>
-        <DashboardFilterEditForm
-          filter={selectedFilter}
-          onSave={handleSaveFilter}
-          onCancel={() => setSelectedFilter(undefined)}
-          onClose={onClose}
-          isNew={selectedFilter.id === NEW_FILTER_ID}
-          source={source}
-          filters={filters}
-          showVariableOptions={showVariableOptions}
-        />
-      </SqlVariablesProvider>
-    );
-  } else {
-    return (
-      <DashboardFiltersList
-        filters={filters}
-        onEdit={setSelectedFilter}
-        onRemove={handleRemoveFilter}
-        onClose={onClose}
-        onAddNew={handleAddNewFilter}
-        isLoading={isLoading}
-        hideAppliesTo={!!source}
-        showVariableOptions={showVariableOptions}
-      />
-    );
-  }
-};
-
-export default DashboardFiltersModal;

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFiltersEmptyState.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFiltersEmptyState.tsx
@@ -1,0 +1,40 @@
+import { Button, Modal, Stack, Text, Title } from '@mantine/core';
+import { IconFilter } from '@tabler/icons-react';
+
+import { MODAL_SIZE } from './constants';
+
+interface DashboardFiltersEmptyStateProps {
+  onCreateFilter: () => void;
+  onClose: () => void;
+}
+
+export const DashboardFiltersEmptyState = ({
+  onCreateFilter,
+  onClose,
+}: DashboardFiltersEmptyStateProps) => {
+  return (
+    <Modal opened onClose={onClose} size={MODAL_SIZE}>
+      <Stack
+        align="center"
+        justify="center"
+        pt="lg"
+        pb="xl"
+        data-testid="dashboard-filters-empty-state"
+      >
+        <IconFilter />
+        <Title order={4}>No filters yet.</Title>
+        <Text size="sm" ta="center" px="xl">
+          Add filters to let viewers quickly narrow data on key columns. Saved
+          filters will stay with this dashboard.
+        </Text>
+        <Button
+          variant="primary"
+          onClick={onCreateFilter}
+          data-testid="add-filter-button"
+        >
+          Add new filter
+        </Button>
+      </Stack>
+    </Modal>
+  );
+};

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFiltersList.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFiltersList.tsx
@@ -1,0 +1,135 @@
+import {
+  getFilterVariableName,
+  isFilterBroadcastEnabled,
+  isFilterVariableEnabled,
+} from '@hyperdx/common-utils/dist/filters';
+import { DashboardFilter } from '@hyperdx/common-utils/dist/types';
+import {
+  Button,
+  Center,
+  Group,
+  Modal,
+  Stack,
+  UnstyledButton,
+} from '@mantine/core';
+import { IconPencil, IconRefresh, IconTrash } from '@tabler/icons-react';
+
+import { useSources } from '@/source';
+
+import { MODAL_SIZE } from './constants';
+import { DashboardFilterListItem } from './DashboardFiltersListItem';
+
+import styles from '@styles/DashboardFiltersModal.module.scss';
+
+interface DashboardFiltersListProps {
+  filters: DashboardFilter[];
+  isLoading?: boolean;
+  hideAppliesTo?: boolean;
+  /** Whether the broadcast / variable controls are available. */
+  showVariableOptions: boolean;
+  onEdit: (filter: DashboardFilter) => void;
+  onRemove: (id: string) => void;
+  onClose: () => void;
+  onAddNew: () => void;
+}
+
+export const DashboardFiltersList = ({
+  filters,
+  isLoading,
+  hideAppliesTo,
+  showVariableOptions,
+  onEdit,
+  onRemove,
+  onClose,
+  onAddNew,
+}: DashboardFiltersListProps) => {
+  const { data: sources } = useSources();
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      title={showVariableOptions ? 'Filters and Variables' : 'Filters'}
+      size={MODAL_SIZE}
+      className={styles.modal}
+    >
+      <Stack
+        className={styles.filtersContainer}
+        gap="xs"
+        data-testid="dashboard-filters-list"
+      >
+        {filters.map(filter => {
+          const queriedSourceName = sources?.find(
+            s => s.id === filter.source,
+          )?.name;
+          const appliedSourceNames = filter.appliesToSourceIds?.length
+            ? filter.appliesToSourceIds
+                .map(id => sources?.find(s => s.id === id)?.name)
+                .filter((name): name is string => !!name)
+            : undefined;
+          const appliedDisplay = appliedSourceNames
+            ? appliedSourceNames.join(', ')
+            : 'All sources';
+          const variableName =
+            showVariableOptions && isFilterVariableEnabled(filter)
+              ? getFilterVariableName(filter)
+              : undefined;
+          return (
+            <DashboardFilterListItem
+              key={filter.id}
+              name={filter.name}
+              nameSuffix={variableName ? ` ($${variableName})` : undefined}
+              queriedFrom={queriedSourceName ?? ''}
+              queriedFromTooltip="Source the dropdown values are queried from"
+              appliedTo={
+                !hideAppliesTo && isFilterBroadcastEnabled(filter)
+                  ? appliedDisplay
+                  : undefined
+              }
+              actions={
+                <>
+                  <UnstyledButton
+                    onClick={() => onEdit(filter)}
+                    className={styles.filterActionButton}
+                    data-testid={`edit-filter-button-${filter.name}`}
+                  >
+                    <IconPencil size={16} />
+                  </UnstyledButton>
+                  <UnstyledButton
+                    onClick={() => onRemove(filter.id)}
+                    className={`${styles.filterActionButton} ${styles.deleteButton}`}
+                    data-testid={`delete-filter-button-${filter.name}`}
+                  >
+                    <IconTrash size={16} />
+                  </UnstyledButton>
+                </>
+              }
+            />
+          );
+        })}
+        {isLoading && (
+          <Center>
+            <IconRefresh className="spin-animate" />
+          </Center>
+        )}
+      </Stack>
+
+      <Group justify="space-between" my="sm">
+        <Button
+          variant="secondary"
+          onClick={onClose}
+          data-testid="close-filters-button"
+        >
+          Close
+        </Button>
+        <Button
+          variant="primary"
+          onClick={onAddNew}
+          data-testid="add-filter-button"
+        >
+          Add new filter
+        </Button>
+      </Group>
+    </Modal>
+  );
+};

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFiltersListItem.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFiltersListItem.tsx
@@ -1,0 +1,77 @@
+import { Group, Paper, Text, Tooltip } from '@mantine/core';
+import { IconFilter, IconSearch } from '@tabler/icons-react';
+
+import styles from '@styles/DashboardFiltersModal.module.scss';
+
+interface DashboardFilterListItemProps {
+  /** Display name shown in the header and used in `data-testid` slugs. */
+  name: string;
+  /**
+   * Appended after `name` in the header (e.g. the ` ($token)` variable hint).
+   * Kept out of `name` so the `data-testid` slugs stay stable.
+   */
+  nameSuffix?: string;
+  /** Text shown next to the search icon (e.g. source name or column name). */
+  queriedFrom: string;
+  /** Tooltip on the search icon describing what `queriedFrom` represents. */
+  queriedFromTooltip: string;
+  /** Comma-joined source names this filter applies to, or undefined to hide the row. */
+  appliedTo?: string;
+  /** Optional trailing action buttons (edit / delete). Omit for readonly items. */
+  actions?: React.ReactNode;
+}
+
+/** Single card representing one filter in the modal's filter list. */
+export const DashboardFilterListItem = ({
+  name,
+  nameSuffix,
+  queriedFrom,
+  queriedFromTooltip,
+  appliedTo,
+  actions,
+}: DashboardFilterListItemProps) => (
+  <Paper
+    withBorder
+    className={styles.filterPaper}
+    p="xs"
+    variant="muted"
+    data-testid={`dashboard-filter-item-${name}`}
+  >
+    <Group justify="space-between" className={styles.filterHeader}>
+      <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+        <Text size="xs" truncate="end">
+          {name}
+          {nameSuffix}
+        </Text>
+      </Group>
+      {actions != null && <Group>{actions}</Group>}
+    </Group>
+    <Group gap="xs" wrap="nowrap">
+      <Tooltip label={queriedFromTooltip} withinPortal>
+        <IconSearch size={14} />
+      </Tooltip>
+      <Text size="xs" truncate="end">
+        {queriedFrom}
+      </Text>
+    </Group>
+    {appliedTo != null && (
+      <Group
+        gap="xs"
+        wrap="nowrap"
+        data-testid={`dashboard-filter-applies-to-${name}`}
+      >
+        <Tooltip
+          label="Sources this filter applies to"
+          withinPortal
+          multiline
+          maw={400}
+        >
+          <IconFilter size={14} style={{ flexShrink: 0 }} />
+        </Tooltip>
+        <Text size="xs" truncate="end">
+          {appliedTo}
+        </Text>
+      </Group>
+    )}
+  </Paper>
+);

--- a/packages/app/src/components/DashboardFiltersModal/constants.ts
+++ b/packages/app/src/components/DashboardFiltersModal/constants.ts
@@ -1,0 +1,1 @@
+export const MODAL_SIZE = 'lg';

--- a/packages/app/src/components/DashboardFiltersModal/index.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/index.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import {
+  ChartVariable,
+  DashboardFilter,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
+
+import { getStoredLanguage } from '@/components/SearchInput/SearchWhereInput';
+import { SqlVariablesProvider } from '@/components/SQLEditor/variableCompletions';
+
+import { DashboardFilterEditForm } from './DashboardFilterEditForm';
+import { DashboardFiltersEmptyState } from './DashboardFiltersEmptyState';
+import { DashboardFiltersList } from './DashboardFiltersList';
+
+interface DashboardFiltersEditModalProps {
+  opened: boolean;
+  filters: DashboardFilter[];
+  isLoading?: boolean;
+  source?: TSource;
+  /** Whether to offer the broadcast / variable controls. */
+  showVariableOptions: boolean;
+  /** The dashboard's variables, if any */
+  variables?: ChartVariable[];
+  onClose: () => void;
+  onSaveFilter: (filter: DashboardFilter) => void;
+  onRemoveFilter: (id: string) => void;
+}
+
+const NEW_FILTER_ID = 'new';
+
+const DashboardFiltersModal = ({
+  opened,
+  filters,
+  isLoading,
+  source,
+  showVariableOptions,
+  variables,
+  onClose,
+  onSaveFilter,
+  onRemoveFilter,
+}: DashboardFiltersEditModalProps) => {
+  const [selectedFilter, setSelectedFilter] = useState<DashboardFilter>();
+
+  useEffect(() => {
+    if (opened) {
+      setSelectedFilter(undefined);
+    }
+  }, [opened]);
+
+  const handleRemoveFilter = (id: string) => {
+    if (id === selectedFilter?.id) {
+      setSelectedFilter(filters.find(f => f.id !== id));
+    }
+    onRemoveFilter(id);
+  };
+
+  const handleAddNewFilter = () => {
+    setSelectedFilter({
+      id: NEW_FILTER_ID,
+      type: 'QUERY_EXPRESSION',
+      name: '',
+      expression: '',
+      source: source?.id ?? '',
+      where: '',
+      whereLanguage: getStoredLanguage() ?? 'sql',
+      isBroadcastEnabled: true,
+      isVariableEnabled: false,
+    });
+  };
+
+  const handleSaveFilter = (filter: DashboardFilter) => {
+    setSelectedFilter(undefined);
+    if (filter.id === NEW_FILTER_ID) {
+      const filterWithRealId = { ...filter, id: crypto.randomUUID() };
+      onSaveFilter(filterWithRealId);
+    } else {
+      onSaveFilter(filter);
+    }
+  };
+
+  const isEmpty = !selectedFilter && filters.length === 0;
+
+  if (!opened) {
+    return null;
+  } else if (isEmpty) {
+    return (
+      <DashboardFiltersEmptyState
+        onCreateFilter={handleAddNewFilter}
+        onClose={onClose}
+      />
+    );
+  } else if (selectedFilter) {
+    return (
+      <SqlVariablesProvider variables={variables}>
+        <DashboardFilterEditForm
+          filter={selectedFilter}
+          onSave={handleSaveFilter}
+          onCancel={() => setSelectedFilter(undefined)}
+          onClose={onClose}
+          isNew={selectedFilter.id === NEW_FILTER_ID}
+          source={source}
+          filters={filters}
+          showVariableOptions={showVariableOptions}
+        />
+      </SqlVariablesProvider>
+    );
+  } else {
+    return (
+      <DashboardFiltersList
+        filters={filters}
+        onEdit={setSelectedFilter}
+        onRemove={handleRemoveFilter}
+        onClose={onClose}
+        onAddNew={handleAddNewFilter}
+        isLoading={isLoading}
+        hideAppliesTo={!!source}
+        showVariableOptions={showVariableOptions}
+      />
+    );
+  }
+};
+
+export default DashboardFiltersModal;

--- a/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
+++ b/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
@@ -253,6 +253,12 @@ export default function SQLInlineEditor({
     if (parentRef == null) {
       return [];
     }
+    // A body-level parent is already outside every scroll container, so the
+    // tooltip should be free to use the whole viewport — CodeMirror's default
+    // space.
+    if (parentRef === parentRef.ownerDocument.body) {
+      return [tooltips({ parent: parentRef })];
+    }
     return [
       tooltips({
         parent: parentRef,

--- a/packages/app/src/components/SQLEditor/utils.ts
+++ b/packages/app/src/components/SQLEditor/utils.ts
@@ -122,6 +122,11 @@ export const createCodeMirrorStyleTheme = (maxEditorHeight?: string) =>
       background: 'transparent !important',
     },
     '& .cm-tooltip-autocomplete': {
+      // Set z-index to ensure that autocompletes which are portaled to the
+      // document body are above modals and drawers. The `!important` is
+      // necessary because CodeMirror's own `.cm-tooltip { z-index: 100 }`
+      // would otherwise override this rule.
+      zIndex: 'var(--mantine-z-index-max) !important',
       whiteSpace: 'nowrap',
       wordWrap: 'break-word',
       maxWidth: '100%',


### PR DESCRIPTION
## Summary

This PR refactors the dashboard filter [edit] modal into a few components and files. The existing file was getting large, conflicted with the downstream EE structure, and this refactor serves as preparation for additional types of filters being added in the near future.

One small fix was made in the process: the SQL input autocomplete is now portaled on the document body, so that it does not clip at the boundary of the dashboard filter modal.

### Screenshots or video

No behavior changes are expected.

With dashboard filters enabled:

https://github.com/user-attachments/assets/ac836da7-f7c2-4831-bc0c-dbd383ebcf01

With dashboard filters disabled, on the preset services dashboard:

https://github.com/user-attachments/assets/8ff8cc3a-af94-4732-9f18-e91c1e51e795

### How to test on Vercel preview

- Create a dashboard
- Add some filters/variables

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Related to HDX-5059
- Related PRs:
