### PR TITLE
feat: Substitute variables in PromQL charts

### DIFF
--- a/.changeset/promql-dashboard-variables.md
+++ b/.changeset/promql-dashboard-variables.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+---
+
+feat: Support variable substitution in PromQL charts

--- a/docker/clickhouse/local/init-db-e2e.sh
+++ b/docker/clickhouse/local/init-db-e2e.sh
@@ -464,4 +464,7 @@ GROUP BY
     ColumnIdentifier,
     Key,
     Timestamp;
+
+-- PromQL fixture.
+CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_promql ENGINE = TimeSeries;
 EOFSQL

--- a/packages/api/.env.e2e
+++ b/packages/api/.env.e2e
@@ -21,3 +21,6 @@ OPAMP_PORT=${HDX_E2E_OPAMP_PORT:-20320}
 
 # Disable usage stats for e2e tests
 USAGE_STATS_ENABLED=false
+
+# Allow PromQL queries in e2e tests.
+ENABLE_PROMQL=true

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -105,8 +105,8 @@ export default defineConfig({
         {
           // Full UI: Alerts + Dashboards. Not local mode; Alerts enabled;
           command: USE_DEV
-            ? `SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true next dev --webpack`
-            : `SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true yarn build && SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true yarn start`,
+            ? `SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true NEXT_PUBLIC_ENABLE_PROMQL=true next dev --webpack`
+            : `SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true NEXT_PUBLIC_ENABLE_PROMQL=true yarn build && SERVER_URL=http://localhost:${API_PORT} PORT=${APP_PORT} NEXT_DIST_DIR=.next-e2e NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true NEXT_PUBLIC_ENABLE_ALERT_DETAILS=true NEXT_PUBLIC_ENABLE_PROMQL=true yarn start`,
           port: parseInt(APP_PORT, 10),
           reuseExistingServer: !process.env.CI,
           timeout: APP_SERVER_STARTUP_TIMEOUT_MS,

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -550,7 +550,7 @@ const Tile = ({
   // changes to `tileVariables`.
   const serializedTileVariables = useMemo(
     () =>
-      !!variables && !isPromqlSavedChartConfig(chart.config)
+      variables
         ? JSON.stringify(filterReferencedVariables(chart.config, variables))
         : undefined,
     [chart.config, variables],
@@ -570,6 +570,7 @@ const Tile = ({
           connection: source.connection,
           dateRange,
           granularity,
+          variables: tileVariables,
         });
       }
       return;

--- a/packages/app/src/components/ChartEditor/PromqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/PromqlChartEditor.tsx
@@ -25,11 +25,15 @@ export default function PromqlChartEditor({
 
   const sourceId = useWatch({ control, name: 'source' });
   const { data: source } = useSource({ id: sourceId });
-  const connectionId = source?.connection;
+  // The form can still hold a non-PromQL source right after switching a tile
+  // into PromQL mode (the picker above only restricts future selections), and
+  // the metric-name lookup reads a TimeSeries engine table, so it would fail
+  // against any other source's table.
+  const promqlSource = source?.kind === SourceKind.Promql ? source : undefined;
   const { data: metricNames } = usePromqlMetricNames(
-    connectionId,
-    source?.from.databaseName,
-    source?.from.tableName,
+    promqlSource?.connection,
+    promqlSource?.from.databaseName,
+    promqlSource?.from.tableName,
   );
 
   return (

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -12,10 +12,7 @@ import {
   displayTypeSupportsBuilderAlerts,
   displayTypeSupportsRawSqlAlerts,
 } from '@hyperdx/common-utils/dist/core/utils';
-import {
-  isPromqlChartConfig,
-  isRawSqlSavedChartConfig,
-} from '@hyperdx/common-utils/dist/guards';
+import { isRawSqlSavedChartConfig } from '@hyperdx/common-utils/dist/guards';
 import {
   ChartConfigWithDateRange,
   ChartVariable,
@@ -375,7 +372,7 @@ export default function EditTimeChartForm({
 
   // Attach variables so that variable references can be validated and expanded in the preview
   const previewConfig = useMemo(() => {
-    if (queriedConfig == null || isPromqlChartConfig(queriedConfig)) {
+    if (queriedConfig == null) {
       return queriedConfig;
     }
     return {
@@ -395,7 +392,6 @@ export default function EditTimeChartForm({
 
   // Casting because `useWatch` returns a deep partial type, but we know that the
   // form state is complete due to default values set above.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const watchedForm = useWatch({ control }) as ChartEditorFormState;
   const [debouncedForm] = useDebouncedValue(watchedForm, 300);
   const additionalAlertWarnings = useMemo(() => {

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/utils.test.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/utils.test.ts
@@ -14,6 +14,7 @@ import {
   computeDbTimeChartConfig,
   displayTypeToActiveTab,
   isQueryReady,
+  resolvePreviewVariables,
   seriesToFilters,
   TABS_WITH_GENERATED_SQL,
 } from '@/components/DBEditTimeChartForm/utils';
@@ -283,6 +284,54 @@ describe('computeDbTimeChartConfig', () => {
     expect(result!.from).toBe(builderConfig.from);
     // @ts-expect-error union types..
     expect(result!.select).toBe(builderConfig.select);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePreviewVariables
+// ---------------------------------------------------------------------------
+
+describe('resolvePreviewVariables', () => {
+  const variables = [
+    { name: 'service', values: ['api'] },
+    { name: 'env', values: ['prod'] },
+  ];
+
+  const promqlConfig: ChartConfigWithDateRange = {
+    configType: 'promql',
+    promqlExpression: 'up{service=~"$service"}',
+    connection: 'local',
+    dateRange,
+  };
+
+  it('returns undefined when there are no variables in scope', () => {
+    expect(
+      resolvePreviewVariables({
+        config: promqlConfig,
+        variables: undefined,
+        hasAlert: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps the variables a PromQL expression references', () => {
+    expect(
+      resolvePreviewVariables({
+        config: promqlConfig,
+        variables,
+        hasAlert: false,
+      }),
+    ).toEqual([{ name: 'service', values: ['api'] }]);
+  });
+
+  it('drops the selections when the tile has an alert', () => {
+    expect(
+      resolvePreviewVariables({
+        config: promqlConfig,
+        variables,
+        hasAlert: true,
+      }),
+    ).toEqual([{ name: 'service', values: [] }]);
   });
 });
 

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -148,7 +148,6 @@ export function computeDbTimeChartConfig(
 
 /**
  * Returns the dashboard variables a chart preview should use.
- * - PromQL configs don't yet support variables, so they resolve to an empty set
  * - Alerts always run with empty variable selections, so they resolve to each referenced variable with an empty `values` array.
  * - Otherwise, variables are filtered to only those referenced by the chart config.
  */

--- a/packages/app/src/components/SQLEditor/variableCompletions.tsx
+++ b/packages/app/src/components/SQLEditor/variableCompletions.tsx
@@ -5,7 +5,7 @@ import {
 } from '@hyperdx/common-utils/dist/macros';
 import { ChartVariable } from '@hyperdx/common-utils/dist/types';
 import {
-  substituteWithContext,
+  substituteVariables,
   VARIABLE_FORMATS,
   VariableFormat,
 } from '@hyperdx/common-utils/dist/variables';
@@ -28,9 +28,8 @@ function describeSqlVariableExpansion(
 ): string | undefined {
   let expansion: string;
   try {
-    expansion = substituteWithContext(snippet, {
+    expansion = substituteVariables(snippet, {
       variables: [variable],
-      defaultFormat: 'sqlstring',
       inputLanguage: 'sql',
     });
   } catch {
@@ -158,11 +157,7 @@ export type LuceneVariableSuggestion = {
 
 /** Expand references the way a Lucene expression is expanded at query time. */
 const substituteLucene = (text: string, variables: ChartVariable[]) =>
-  substituteWithContext(text, {
-    variables,
-    defaultFormat: 'lucene',
-    inputLanguage: 'lucene',
-  });
+  substituteVariables(text, { variables, inputLanguage: 'lucene' });
 
 /**
  * Suggestions for a Lucene expression: the bare `$name` reference of each

--- a/packages/app/src/hooks/useChartConfig.tsx
+++ b/packages/app/src/hooks/useChartConfig.tsx
@@ -27,6 +27,7 @@ import {
   ChartConfigWithOptDateRange,
   QuerySettings,
 } from '@hyperdx/common-utils/dist/types';
+import { substitutePromqlChartConfigVariables } from '@hyperdx/common-utils/dist/variables';
 import {
   useQuery,
   useQueryClient,
@@ -323,6 +324,9 @@ export function useQueriedChartConfig(
     queryFn: async context => {
       // PromQL queries go through the Prometheus API route, not ClickHouse proxy
       if (isPromqlChartConfig(config) && config.dateRange) {
+        // Expand dashboard variables in the PromQL expression before sending to Prometheus API.
+        const { promqlExpression } =
+          substitutePromqlChartConfigVariables(config);
         const [startDate, endDate] = config.dateRange;
         const startSec = startDate.getTime() / 1000;
         const endSec = endDate.getTime() / 1000;
@@ -348,7 +352,7 @@ export function useQueriedChartConfig(
         }
 
         const resp = await prometheusApi.queryRange({
-          query: config.promqlExpression,
+          query: promqlExpression,
           start: startSec,
           end: endSec,
           step: stepStr,

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -398,6 +398,51 @@ export class ChartEditorComponent {
   }
 
   /**
+   * Switch the chart editor to PromQL mode. Only offered when the app is run
+   * with NEXT_PUBLIC_ENABLE_PROMQL=true (the e2e webServer sets it).
+   *
+   * Matched exactly: "SQL" is a substring of the PromQL label, so a
+   * `has-text("SQL")` selector would resolve to both.
+   */
+  async switchToPromqlMode() {
+    const label = this.page
+      .locator('.mantine-SegmentedControl-label')
+      .filter({ hasText: /^PromQL$/ });
+    await label.waitFor({ state: 'visible', timeout: 5000 });
+    await label.click();
+  }
+
+  /**
+   * Select the PromQL editor's data source.
+   *
+   * Located by role rather than by the `source-selector` test id: that id is on
+   * the builder's source select (ChartEditorControls), and PromQL mode renders
+   * its own `SourceSelectControlled` which doesn't carry it.
+   */
+  async selectPromqlSource(sourceName: string) {
+    await this.page.getByRole('combobox', { name: 'Data Source' }).click();
+    await this.page
+      .getByRole('option', { name: sourceName, exact: true })
+      .click();
+  }
+
+  /**
+   * Replace the entire contents of the PromQL expression editor.
+   *
+   * The same `.cm-editor` locator as the SQL template: PromQL mode renders one
+   * CodeMirror and no "Generated SQL" accordion, so `.first()` is that editor.
+   */
+  async replacePromqlExpression(expression: string) {
+    const content = this.page.locator('.cm-editor .cm-content').first();
+    await content.click();
+    await this.page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+    );
+    await this.page.keyboard.press('Delete');
+    await this.page.keyboard.type(expression);
+  }
+
+  /**
    * Switch the chart editor from SQL back to Builder mode.
    */
   async switchToBuilderMode() {

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -17,12 +17,9 @@ import { SERVICES } from '../seed-clickhouse';
 import { expect, test } from '../utils/base-test';
 import {
   DEFAULT_LOGS_SOURCE_NAME,
-  E2E_CLICKHOUSE_DATABASE,
   E2E_PROMQL_METRIC_NAME,
-  E2E_PROMQL_TABLE,
   PROMQL_SOURCE_NAME,
 } from '../utils/constants';
-import { runMongoshScript } from '../utils/db-helpers';
 
 /** Severities `accounting` logs carry, and the two it does not. */
 const ACCOUNTING_SEVERITIES = ['warn', 'debug'];
@@ -277,22 +274,6 @@ test.describe(
   'Dashboard variables in a PromQL tile',
   { tag: ['@dashboard', '@full-stack'] },
   () => {
-    /**
-     * The source lives in the shared `sources` collection, so anything left in
-     * it is visible to every later spec's source pickers — the enumeration
-     * failure that keeps it out of e2e-fixtures.json in the first place (see
-     * `PROMQL_SOURCE_NAME`). Removing it here bounds that exposure to this
-     * test's own run.
-     */
-    test.afterAll(() => {
-      runMongoshScript(
-        [
-          "use('hyperdx-e2e');",
-          `db.sources.deleteMany({ name: ${JSON.stringify(PROMQL_SOURCE_NAME)} });`,
-        ].join('\n'),
-      );
-    });
-
     test('narrows the queried series to the selected values', async ({
       page,
     }) => {
@@ -315,31 +296,6 @@ test.describe(
       const expectSeriesCount = async (count: number) => {
         await expect(seriesAreas).toHaveCount(count, { timeout: 30000 });
       };
-
-      await test.step('Create the PromQL source', async () => {
-        // Inserted rather than built in the source form, and created here
-        // rather than shipped in e2e-fixtures.json: a PromQL source is visible
-        // to every spec's source pickers, where the app's field fetch fails
-        // against a TimeSeries table. `afterAll` above deletes it again.
-        const out = runMongoshScript(
-          [
-            "use('hyperdx-e2e');",
-            'const team = db.teams.findOne();',
-            'const connection = db.connections.findOne();',
-            'print(JSON.stringify(db.sources.updateOne(',
-            `  { name: ${JSON.stringify(PROMQL_SOURCE_NAME)} },`,
-            '  { $set: { team: team._id, connection: connection._id,',
-            "      kind: 'promql', disabled: false,",
-            `      from: { databaseName: '${E2E_CLICKHOUSE_DATABASE}', tableName: '${E2E_PROMQL_TABLE}' },`,
-            "      timestampValueExpression: 'timestamp' } },",
-            '  { upsert: true }',
-            ')));',
-          ].join('\n'),
-        );
-        expect(out).toMatch(
-          /"(upsertedCount":1|modifiedCount":1|matchedCount":1)/,
-        );
-      });
 
       await test.step('Create a dashboard with a Service filter exposed as $svc', async () => {
         await dashboardPage.goto();

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -13,8 +13,16 @@
  * `api-server` (index 0) only info and error.
  */
 import { DashboardPage } from '../page-objects/DashboardPage';
+import { SERVICES } from '../seed-clickhouse';
 import { expect, test } from '../utils/base-test';
-import { DEFAULT_LOGS_SOURCE_NAME } from '../utils/constants';
+import {
+  DEFAULT_LOGS_SOURCE_NAME,
+  E2E_CLICKHOUSE_DATABASE,
+  E2E_PROMQL_METRIC_NAME,
+  E2E_PROMQL_TABLE,
+  PROMQL_SOURCE_NAME,
+} from '../utils/constants';
+import { runMongoshScript } from '../utils/db-helpers';
 
 /** Severities `accounting` logs carry, and the two it does not. */
 const ACCOUNTING_SEVERITIES = ['warn', 'debug'];
@@ -253,6 +261,153 @@ test.describe(
           'aria-label',
           /no meaning in a Lucene expression/,
         );
+      });
+    });
+  },
+);
+
+/**
+ * A PromQL tile interpolates the dashboard's variables into its expression.
+ *
+ * The seed gives `e2e_service_up` one series per `SERVICES` entry, labelled
+ * `service` with the same values the logs carry in `ServiceName`, so the
+ * dashboard filter's selections line up with the metric's labels.
+ */
+test.describe(
+  'Dashboard variables in a PromQL tile',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    /**
+     * The source lives in the shared `sources` collection, so anything left in
+     * it is visible to every later spec's source pickers — the enumeration
+     * failure that keeps it out of e2e-fixtures.json in the first place (see
+     * `PROMQL_SOURCE_NAME`). Removing it here bounds that exposure to this
+     * test's own run.
+     */
+    test.afterAll(() => {
+      runMongoshScript(
+        [
+          "use('hyperdx-e2e');",
+          `db.sources.deleteMany({ name: ${JSON.stringify(PROMQL_SOURCE_NAME)} });`,
+        ].join('\n'),
+      );
+    });
+
+    test('narrows the queried series to the selected values', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      const dashboardPage = new DashboardPage(page);
+
+      // The time chart is a recharts AreaChart, so each returned series is one
+      // `<g class="recharts-area">`.
+      const seriesAreas = page
+        .locator('.recharts-responsive-container')
+        .first()
+        .locator('.recharts-area');
+
+      /**
+       * Retried rather than snapshotted: the tile refetches on its own
+       * schedule, so a single read can land before the selection change has
+       * been queried.
+       */
+      const expectSeriesCount = async (count: number) => {
+        await expect(seriesAreas).toHaveCount(count, { timeout: 30000 });
+      };
+
+      await test.step('Create the PromQL source', async () => {
+        // Inserted rather than built in the source form, and created here
+        // rather than shipped in e2e-fixtures.json: a PromQL source is visible
+        // to every spec's source pickers, where the app's field fetch fails
+        // against a TimeSeries table. `afterAll` above deletes it again.
+        const out = runMongoshScript(
+          [
+            "use('hyperdx-e2e');",
+            'const team = db.teams.findOne();',
+            'const connection = db.connections.findOne();',
+            'print(JSON.stringify(db.sources.updateOne(',
+            `  { name: ${JSON.stringify(PROMQL_SOURCE_NAME)} },`,
+            '  { $set: { team: team._id, connection: connection._id,',
+            "      kind: 'promql', disabled: false,",
+            `      from: { databaseName: '${E2E_CLICKHOUSE_DATABASE}', tableName: '${E2E_PROMQL_TABLE}' },`,
+            "      timestampValueExpression: 'timestamp' } },",
+            '  { upsert: true }',
+            ')));',
+          ].join('\n'),
+        );
+        expect(out).toMatch(
+          /"(upsertedCount":1|modifiedCount":1|matchedCount":1)/,
+        );
+      });
+
+      await test.step('Create a dashboard with a Service filter exposed as $svc', async () => {
+        await dashboardPage.goto();
+        await dashboardPage.createNewDashboard();
+
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { variableName: 'svc' },
+        );
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('Add a PromQL tile referencing $svc', async () => {
+        await dashboardPage.addTile();
+        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+        await dashboardPage.chartEditor.waitForDataToLoad();
+        await dashboardPage.chartEditor.setChartName('PromQL tile');
+        await dashboardPage.chartEditor.switchToPromqlMode();
+        await dashboardPage.chartEditor.selectPromqlSource(PROMQL_SOURCE_NAME);
+        await dashboardPage.chartEditor.replacePromqlExpression(
+          `${E2E_PROMQL_METRIC_NAME}{service=~"$svc"}`,
+        );
+        await dashboardPage.chartEditor.save();
+        await expect(dashboardPage.getTiles()).toHaveCount(1, {
+          timeout: 10000,
+        });
+      });
+
+      await test.step('With nothing selected, every series comes back', async () => {
+        // The empty selection renders as `.*`, so the tile is a valid query
+        // that constrains nothing before anything is picked.
+        await expectSeriesCount(SERVICES.length);
+      });
+
+      await test.step('Selecting one service narrows it to that series', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expectSeriesCount(1);
+      });
+
+      await test.step('Selecting a second widens it to an alternation', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'api-server');
+        await expectSeriesCount(2);
+
+        // Assert *which* two, so this can't pass on an unrelated pair: with
+        // more than one series the legend qualifies each by its label.
+        //
+        // Matched on the tail rather than the whole name: the legend truncates
+        // the middle past 35 characters, and `e2e_service_up{service="…"}` is
+        // over that for both. The `"}` keeps this from matching the filter
+        // dropdown's own bare `accounting` entry.
+        const legend = page.locator('.recharts-legend-wrapper').first();
+        for (const service of ['accounting', 'api-server']) {
+          await expect(legend.getByText(`${service}"}`)).toBeVisible();
+        }
+      });
+
+      await test.step('Clearing the selection restores every series', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await dashboardPage.toggleFilterValue('Service', 'api-server');
+        await expectSeriesCount(SERVICES.length);
       });
     });
   },

--- a/packages/app/tests/e2e/fixtures/e2e-fixtures.json
+++ b/packages/app/tests/e2e/fixtures/e2e-fixtures.json
@@ -246,6 +246,17 @@
       "spanIdExpression": "SpanId",
       "implicitColumnExpression": "Body",
       "displayedTimestampValueExpression": "Timestamp"
+    },
+    {
+      "id": "E2E PromQL",
+      "kind": "promql",
+      "name": "E2E PromQL",
+      "connection": "local",
+      "from": {
+        "databaseName": "default",
+        "tableName": "e2e_promql"
+      },
+      "timestampValueExpression": "timestamp"
     }
   ]
 }

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -21,6 +21,8 @@ import {
   E2E_METADATA_MV_LOGS_TABLE,
   E2E_METRICS_GAUGE_TABLE,
   E2E_METRICS_SUM_TABLE,
+  E2E_PROMQL_METRIC_NAME,
+  E2E_PROMQL_TABLE,
   E2E_SESSIONS_TABLE,
   E2E_TRACES_MV_TABLE,
   E2E_TRACES_TABLE,
@@ -989,7 +991,66 @@ export async function seedClickHouse(): Promise<void> {
     `  Inserted ${METADATA_MV_ROWS.length} metadata-MV source entries`,
   );
 
+  // PromQL series: one per service, labelled with the same `ServiceName` values
+  // the logs carry, so a dashboard filter on ServiceName selects values that
+  // actually match a `service` label here.
+  console.log('  Inserting PromQL series...');
+  await seedPromqlSeries(client, startMs, endMs);
+  console.log(`  Inserted ${SERVICES.length} PromQL series`);
+
   console.log('ClickHouse seeding complete');
+}
+
+/**
+ * Seed one `E2E_PROMQL_METRIC_NAME` series per service into the TimeSeries
+ * table, through the `timeSeries*` table functions that expose its inner
+ * tables (the engine names those after the table's UUID, so they can't be
+ * addressed directly).
+ *
+ * A series' identity lives in the tags table while its samples live in the data
+ * table, tied together by `id`. Rather than recompute the engine's
+ * `reinterpretAsUUID(sipHash128(metric_name, all_tags))` here — where drifting
+ * from the schema would silently orphan every sample — the samples select their
+ * `id` back out of the tags table.
+ */
+async function seedPromqlSeries(
+  client: ReturnType<typeof createClickHouseClient>,
+  startMs: number,
+  endMs: number,
+) {
+  const ts = (part: 'Tags' | 'Data' | 'Metrics') =>
+    `timeSeries${part}('${E2E_CLICKHOUSE_DATABASE}', '${E2E_PROMQL_TABLE}')`;
+
+  await client.query(`
+    INSERT INTO FUNCTION ${ts('Metrics')} (metric_family_name, type, unit, help)
+    VALUES ('${E2E_PROMQL_METRIC_NAME}', 'gauge', '', 'E2E service liveness')
+  `);
+
+  const tagRows = SERVICES.map(
+    service =>
+      `('${E2E_PROMQL_METRIC_NAME}', map('service', '${service}'), ` +
+      `map('__name__', '${E2E_PROMQL_METRIC_NAME}', 'service', '${service}'), ` +
+      `fromUnixTimestamp64Milli(toInt64(${startMs})), fromUnixTimestamp64Milli(toInt64(${endMs})))`,
+  ).join(',\n');
+
+  await client.query(`
+    INSERT INTO FUNCTION ${ts('Tags')} (metric_name, tags, all_tags, min_time, max_time)
+    VALUES ${tagRows}
+  `);
+
+  // One sample a minute across the seeded window, for every series.
+  const stepMs = 60000;
+  const sampleCount = Math.max(1, Math.floor((endMs - startMs) / stepMs));
+  await client.query(`
+    INSERT INTO FUNCTION ${ts('Data')} (id, timestamp, value)
+    SELECT
+      t.id,
+      fromUnixTimestamp64Milli(toInt64(${startMs} + (n * ${stepMs}))),
+      1
+    FROM ${ts('Tags')} AS t
+    CROSS JOIN (SELECT number AS n FROM numbers(${sampleCount})) AS steps
+    WHERE t.metric_name = '${E2E_PROMQL_METRIC_NAME}'
+  `);
 }
 
 // Allow running directly for testing

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -2,6 +2,12 @@ export const DEFAULT_SESSIONS_SOURCE_NAME = 'E2E Sessions';
 export const DEFAULT_TRACES_SOURCE_NAME = 'E2E Traces';
 export const DEFAULT_METRICS_SOURCE_NAME = 'E2E Metrics';
 export const DEFAULT_LOGS_SOURCE_NAME = 'E2E Logs';
+// Deliberately not in `e2e-fixtures.json`: a source pointing at a TimeSeries
+// table makes the app's field fetch fail (`SELECT is not supported by storage
+// TimeSeries yet`) on every page that enumerates sources, which pushed
+// borderline waits in dashboard.spec over their timeouts. The PromQL spec
+// creates it for itself instead.
+export const PROMQL_SOURCE_NAME = 'E2E PromQL';
 
 // Log source deliberately left without a correlated metric source, so tests can
 // exercise the "not correlated" paths (the search side panel's infrastructure
@@ -47,6 +53,13 @@ export const E2E_TRACES_MV_TABLE = 'e2e_otel_traces_1m';
 export const E2E_SESSIONS_TABLE = 'e2e_hyperdx_sessions';
 export const E2E_METRICS_GAUGE_TABLE = 'e2e_otel_metrics_gauge';
 export const E2E_METRICS_SUM_TABLE = 'e2e_otel_metrics_sum';
+// TimeSeries-engine table backing the PromQL source. `prometheusQueryRange`,
+// which the API's PromQL path calls, reads only this engine — the otel_metrics_*
+// tables above are not usable for PromQL. The seeder writes through the
+// timeSeries* table functions, which take this same table name.
+export const E2E_PROMQL_TABLE = 'e2e_promql';
+/** The one metric name seeded into the PromQL table, one series per service. */
+export const E2E_PROMQL_METRIC_NAME = 'e2e_service_up';
 // A second database holding OTEL-shaped metric tables, so the metric table
 // autofill tests can switch the source form's database and see tables detected
 // from the new one. The table names differ from the `default` database's so an

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -2,11 +2,6 @@ export const DEFAULT_SESSIONS_SOURCE_NAME = 'E2E Sessions';
 export const DEFAULT_TRACES_SOURCE_NAME = 'E2E Traces';
 export const DEFAULT_METRICS_SOURCE_NAME = 'E2E Metrics';
 export const DEFAULT_LOGS_SOURCE_NAME = 'E2E Logs';
-// Deliberately not in `e2e-fixtures.json`: a source pointing at a TimeSeries
-// table makes the app's field fetch fail (`SELECT is not supported by storage
-// TimeSeries yet`) on every page that enumerates sources, which pushed
-// borderline waits in dashboard.spec over their timeouts. The PromQL spec
-// creates it for itself instead.
 export const PROMQL_SOURCE_NAME = 'E2E PromQL';
 
 // Log source deliberately left without a correlated metric source, so tests can

--- a/packages/common-utils/src/__tests__/macros.test.ts
+++ b/packages/common-utils/src/__tests__/macros.test.ts
@@ -462,6 +462,17 @@ describe('replaceMacros with variables', () => {
       ).toBe("SELECT '$100 $nope'");
     });
 
+    it('escapes a regex reference for the SQL literal it sits in', () => {
+      // Raw SQL and the chart builder share one substitution path, so both get
+      // a pattern ClickHouse's literal parser hands to the regex engine intact.
+      expect(
+        replaceMacros({
+          sqlTemplate: "WHERE match(msg, '${service:regex}')",
+          variables: [{ name: 'service', values: ['v1.2'] }],
+        }),
+      ).toBe("WHERE match(msg, 'v1\\\\.2')");
+    });
+
     it('treats an empty variables array as a provided context', () => {
       expect(() =>
         replaceMacros({
@@ -492,6 +503,20 @@ describe('replaceMacros with variables', () => {
           variables: nested,
         }),
       ).toBe(`WHERE ${timeFilterOn('Timestamp')}`);
+    });
+
+    it('leaves a csv column expression unescaped, quotes and all', () => {
+      // `csv` is the raw escape hatch: it carries identifiers, and escaping a
+      // column expression for the surrounding literal would corrupt it.
+      expect(
+        replaceMacros({
+          sqlTemplate: 'WHERE $__timeFilter(${mapCol:csv})',
+          variables: [
+            ...nested,
+            { name: 'mapCol', values: ["toDateTime(Attributes['ts'])"] },
+          ],
+        }),
+      ).toBe(`WHERE ${timeFilterOn("toDateTime(Attributes['ts'])")}`);
     });
 
     it('renders a bare reference in the quoted sqlstring format', () => {

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -8,10 +8,10 @@ import {
   getVariableReferences,
   hasVariableMacro,
   substituteChartConfigVariables,
-  substituteVariablesForLanguage,
-  substituteWithContext,
+  substitutePromqlChartConfigVariables,
+  substituteVariables,
   validateVariableReferencesInTemplate,
-  type VariableContext,
+  VariableContext,
 } from '@/variables';
 
 const variable = (
@@ -24,14 +24,13 @@ const variable = (
  * `substituteWithContext` with the SQL-ish defaults, so each case only spells
  * out the part of the context it is exercising.
  */
-const substituteVariables = (
+const substituteVariablesSql = (
   input: string,
   variables: ChartVariable[],
   overrides: Partial<Omit<VariableContext, 'variables'>> = {},
 ) =>
-  substituteWithContext(input, {
+  substituteVariables(input, {
     variables,
-    defaultFormat: 'sqlstring',
     inputLanguage: 'sql',
     ...overrides,
   });
@@ -133,28 +132,30 @@ describe('substituteVariables', () => {
   describe('bare references', () => {
     it('substitutes with the sqlstring format by default', () => {
       expect(
-        substituteVariables('WHERE ServiceName IN ($service)', [SERVICE]),
+        substituteVariablesSql('WHERE ServiceName IN ($service)', [SERVICE]),
       ).toBe("WHERE ServiceName IN ('api', 'web')");
     });
 
     it('substitutes NULL when nothing is selected', () => {
       expect(
-        substituteVariables('WHERE ServiceName IN ($service)', [EMPTY_SERVICE]),
+        substituteVariablesSql('WHERE ServiceName IN ($service)', [
+          EMPTY_SERVICE,
+        ]),
       ).toBe('WHERE ServiceName IN (NULL)');
     });
 
     it('leaves an unknown name verbatim', () => {
-      expect(substituteVariables("SELECT '$notAVariable'", [SERVICE])).toBe(
+      expect(substituteVariablesSql("SELECT '$notAVariable'", [SERVICE])).toBe(
         "SELECT '$notAVariable'",
       );
     });
 
     it('matches names maximally so a longer name is not partially replaced', () => {
-      expect(substituteVariables('$service_name', [SERVICE])).toBe(
+      expect(substituteVariablesSql('$service_name', [SERVICE])).toBe(
         '$service_name',
       );
       expect(
-        substituteVariables('$service_name', [
+        substituteVariablesSql('$service_name', [
           SERVICE,
           variable('service_name', ['checkout']),
         ]),
@@ -162,49 +163,32 @@ describe('substituteVariables', () => {
     });
 
     it('leaves a lone $ and $-digit sequences alone', () => {
-      expect(substituteVariables('SELECT $, $1, x$', [SERVICE])).toBe(
+      expect(substituteVariablesSql('SELECT $, $1, x$', [SERVICE])).toBe(
         'SELECT $, $1, x$',
       );
     });
 
-    it('applies the caller-provided default format', () => {
+    it("applies the language's default format", () => {
       expect(
-        substituteVariables('{service="$service"}', [SERVICE], {
-          defaultFormat: 'regex',
+        substituteVariables('{service="$service"}', {
+          variables: [SERVICE],
+          inputLanguage: 'promql',
         }),
       ).toBe('{service="(api|web)"}');
     });
   });
 
   describe('inputLanguage', () => {
-    // `defaultFormat` says how a reference's values are rendered;
-    // `inputLanguage` says what will parse the result. Only the latter turns on
-    // the Lucene handling, so the two stay independently settable.
-    it('renders lucene values without any lucene handling by default', () => {
-      // Values render as lucene terms, but the template is still treated as
-      // SQL: no quoted-reference rewrite, and the macros expand.
-      expect(
-        substituteVariables('ServiceName:"$service"', [SERVICE], {
-          defaultFormat: 'lucene',
-        }),
-      ).toBe('ServiceName:"("api" OR "web")"');
-      expect(
-        substituteVariables('$__filter(ServiceName, $service)', [SERVICE], {
-          defaultFormat: 'lucene',
-        }),
-      ).toBe("(ServiceName IN ('api', 'web'))");
-    });
-
     it('turns on the lucene handling when the input is lucene', () => {
       expect(
-        substituteVariables('ServiceName:"$service"', [SERVICE], {
-          defaultFormat: 'lucene',
+        substituteVariables('ServiceName:"$service"', {
+          variables: [SERVICE],
           inputLanguage: 'lucene',
         }),
       ).toBe('(ServiceName:"api" OR ServiceName:"web")');
       expect(
-        substituteVariables('$__filter(ServiceName, $service)', [SERVICE], {
-          defaultFormat: 'lucene',
+        substituteVariables('$__filter(ServiceName, $service)', {
+          variables: [SERVICE],
           inputLanguage: 'lucene',
         }),
       ).toBe('$__filter(ServiceName, $service)');
@@ -214,8 +198,8 @@ describe('substituteVariables', () => {
       // The rewrite is per-reference: it only applies where the values would
       // render as lucene terms in the first place.
       expect(
-        substituteVariables('ServiceName:"${service:csv}"', [SERVICE], {
-          defaultFormat: 'lucene',
+        substituteVariables('ServiceName:"${service:csv}"', {
+          variables: [SERVICE],
           inputLanguage: 'lucene',
         }),
       ).toBe('ServiceName:"api,web"');
@@ -224,7 +208,9 @@ describe('substituteVariables', () => {
 
   describe('braced references', () => {
     it('substitutes ${name} with the default format', () => {
-      expect(substituteVariables('${service}', [SERVICE])).toBe("'api', 'web'");
+      expect(substituteVariablesSql('${service}', [SERVICE])).toBe(
+        "'api', 'web'",
+      );
     });
 
     it.each([
@@ -233,49 +219,51 @@ describe('substituteVariables', () => {
       ['csv', 'api,web'],
       ['lucene', '("api" OR "web")'],
     ])('substitutes ${name:%s}', (format, expected) => {
-      expect(substituteVariables(`\${service:${format}}`, [SERVICE])).toBe(
+      expect(substituteVariablesSql(`\${service:${format}}`, [SERVICE])).toBe(
         expected,
       );
     });
 
     it('leaves an unknown name verbatim, format and all', () => {
-      expect(substituteVariables('${other:csv}', [SERVICE])).toBe(
+      expect(substituteVariablesSql('${other:csv}', [SERVICE])).toBe(
         '${other:csv}',
       );
     });
 
     it('throws on an unknown format for a known name', () => {
-      expect(() => substituteVariables('${service:json}', [SERVICE])).toThrow(
-        "Unknown variable format 'json'",
-      );
+      expect(() =>
+        substituteVariablesSql('${service:json}', [SERVICE]),
+      ).toThrow("Unknown variable format 'json'");
     });
 
     it('leaves a malformed brace expression as plain text', () => {
-      expect(substituteVariables('${not a name}', [SERVICE])).toBe(
+      expect(substituteVariablesSql('${not a name}', [SERVICE])).toBe(
         '${not a name}',
       );
-      expect(substituteVariables('${service', [SERVICE])).toBe('${service');
+      expect(substituteVariablesSql('${service', [SERVICE])).toBe('${service');
     });
   });
 
   describe('$__filter', () => {
     it('expands the two-argument form against the given expression', () => {
       expect(
-        substituteVariables('WHERE $__filter(ServiceName, $service)', [
+        substituteVariablesSql('WHERE $__filter(ServiceName, $service)', [
           SERVICE,
         ]),
       ).toBe("WHERE (ServiceName IN ('api', 'web'))");
     });
 
     it('expands the one-argument form using the variable expression', () => {
-      expect(substituteVariables('WHERE $__filter($service)', [SERVICE])).toBe(
-        "WHERE (toString(ServiceName) IN ('api', 'web'))",
-      );
+      expect(
+        substituteVariablesSql('WHERE $__filter($service)', [SERVICE]),
+      ).toBe("WHERE (toString(ServiceName) IN ('api', 'web'))");
     });
 
     it('rejects a name argument written without its $', () => {
       expect(() =>
-        substituteVariables('WHERE $__filter(ServiceName, service)', [SERVICE]),
+        substituteVariablesSql('WHERE $__filter(ServiceName, service)', [
+          SERVICE,
+        ]),
       ).toThrow(
         "Macro '$__filter' requires its variable argument to be written as a " +
           "reference, as in $__filter(<expression>, $service) — got 'service'.",
@@ -284,13 +272,13 @@ describe('substituteVariables', () => {
 
     it('rejects a bare name in the one-argument form too', () => {
       expect(() =>
-        substituteVariables('WHERE $__filter(service)', [SERVICE]),
+        substituteVariablesSql('WHERE $__filter(service)', [SERVICE]),
       ).toThrow('as in $__filter($service)');
     });
 
     it('rejects a braced name argument', () => {
       expect(() =>
-        substituteVariables('WHERE $__filter(ServiceName, ${service})', [
+        substituteVariablesSql('WHERE $__filter(ServiceName, ${service})', [
           SERVICE,
         ]),
       ).toThrow("as in $__filter(<expression>, $name) — got '${service}'");
@@ -298,7 +286,7 @@ describe('substituteVariables', () => {
 
     it('expands to a no-op predicate when nothing is selected', () => {
       expect(
-        substituteVariables('WHERE $__filter(ServiceName, $service)', [
+        substituteVariablesSql('WHERE $__filter(ServiceName, $service)', [
           EMPTY_SERVICE,
         ]),
       ).toBe("WHERE (1=1 /** no values selected for variable 'service' */)");
@@ -306,22 +294,24 @@ describe('substituteVariables', () => {
 
     it('substitutes references nested in the expression argument', () => {
       expect(
-        substituteVariables("WHERE $__filter(concat(col, '$env'), $service)", [
-          SERVICE,
-          variable('env', ['prod']),
-        ]),
+        substituteVariablesSql(
+          "WHERE $__filter(concat(col, '$env'), $service)",
+          [SERVICE, variable('env', ['prod'])],
+        ),
       ).toBe("WHERE (concat(col, ''prod'') IN ('api', 'web'))");
     });
 
     it('throws when the named variable does not exist', () => {
       expect(() =>
-        substituteVariables('WHERE $__filter(ServiceName, $nope)', [SERVICE]),
+        substituteVariablesSql('WHERE $__filter(ServiceName, $nope)', [
+          SERVICE,
+        ]),
       ).toThrow("Macro '$__filter' references unknown variable 'nope'");
     });
 
     it('throws on the one-argument form when the variable has no expression', () => {
       expect(() =>
-        substituteVariables('WHERE $__filter($service)', [
+        substituteVariablesSql('WHERE $__filter($service)', [
           variable('service', ['api']),
         ]),
       ).toThrow("Macro '$__filter($service)' requires the variable's filter");
@@ -329,7 +319,7 @@ describe('substituteVariables', () => {
 
     it('throws on a bad argument count', () => {
       expect(() =>
-        substituteVariables('$__filter(a, b, $c)', [SERVICE]),
+        substituteVariablesSql('$__filter(a, b, $c)', [SERVICE]),
       ).toThrow("Macro 'filter' expects 1-2 argument(s), but got 3");
     });
   });
@@ -339,14 +329,14 @@ describe('substituteVariables', () => {
       expect(
         substituteVariables(
           "WHERE $__conditionalAll(ServiceName = 'api', $service)",
-          [SERVICE],
+          { variables: [SERVICE], inputLanguage: 'sql' },
         ),
       ).toBe("WHERE (ServiceName = 'api')");
     });
 
     it('emits a no-op predicate when nothing is selected', () => {
       expect(
-        substituteVariables(
+        substituteVariablesSql(
           "WHERE $__conditionalAll(ServiceName = 'api', $service)",
           [EMPTY_SERVICE],
         ),
@@ -355,7 +345,7 @@ describe('substituteVariables', () => {
 
     it('substitutes references inside the condition', () => {
       expect(
-        substituteVariables(
+        substituteVariablesSql(
           'WHERE $__conditionalAll(ServiceName IN ($service), $service)',
           [SERVICE],
         ),
@@ -364,7 +354,7 @@ describe('substituteVariables', () => {
 
     it('rejects a name argument written without its $', () => {
       expect(() =>
-        substituteVariables(
+        substituteVariablesSql(
           "WHERE $__conditionalAll(ServiceName = 'api', service)",
           [SERVICE],
         ),
@@ -376,7 +366,7 @@ describe('substituteVariables', () => {
 
     it('expands a variable macro nested in the condition', () => {
       expect(
-        substituteVariables(
+        substituteVariablesSql(
           'WHERE $__conditionalAll(NOT $__filter(ServiceName, $service), $env)',
           [SERVICE, variable('env', ['prod'])],
         ),
@@ -385,7 +375,7 @@ describe('substituteVariables', () => {
 
     it('expands a nested reference exactly once', () => {
       expect(
-        substituteVariables('$__conditionalAll(col = $a, $service)', [
+        substituteVariablesSql('$__conditionalAll(col = $a, $service)', [
           SERVICE,
           variable('a', ['$service']),
         ]),
@@ -394,20 +384,21 @@ describe('substituteVariables', () => {
 
     it('throws when the named variable does not exist', () => {
       expect(() =>
-        substituteVariables('$__conditionalAll(x = 1, $nope)', [SERVICE]),
+        substituteVariablesSql('$__conditionalAll(x = 1, $nope)', [SERVICE]),
       ).toThrow("Macro '$__conditionalAll' references unknown variable 'nope'");
     });
 
     it('throws on a bad argument count', () => {
-      expect(() => substituteVariables('$__conditionalAll(x = 1)', [SERVICE])) //
-        .toThrow("Macro 'conditionalAll' expects 2 argument(s), but got 1");
+      expect(() =>
+        substituteVariablesSql('$__conditionalAll(x = 1)', [SERVICE]),
+      ).toThrow("Macro 'conditionalAll' expects 2 argument(s), but got 1");
     });
   });
 
   describe('argument parsing', () => {
     it('handles a close paren inside a quoted argument', () => {
       expect(
-        substituteVariables("$__conditionalAll(col = 'a)b', $service)", [
+        substituteVariablesSql("$__conditionalAll(col = 'a)b', $service)", [
           SERVICE,
         ]),
       ).toBe("(col = 'a)b')");
@@ -415,7 +406,7 @@ describe('substituteVariables', () => {
 
     it('handles an open paren and a comma inside a quoted argument', () => {
       expect(
-        substituteVariables("$__conditionalAll(col = 'a,(b', $service)", [
+        substituteVariablesSql("$__conditionalAll(col = 'a,(b', $service)", [
           SERVICE,
         ]),
       ).toBe("(col = 'a,(b')");
@@ -423,7 +414,7 @@ describe('substituteVariables', () => {
 
     it('handles nested parens in the condition', () => {
       expect(
-        substituteVariables(
+        substituteVariablesSql(
           '$__conditionalAll(has(splitByChar(:, col), 1), $service)',
           [SERVICE],
         ),
@@ -432,14 +423,14 @@ describe('substituteVariables', () => {
 
     it('throws when the argument list is never closed', () => {
       expect(() =>
-        substituteVariables('$__filter(ServiceName, service', [SERVICE]),
+        substituteVariablesSql('$__filter(ServiceName, service', [SERVICE]),
       ).toThrow(MalformedMacroArgsError);
     });
   });
 
   it('does not re-expand values that themselves look like references', () => {
     expect(
-      substituteVariables('$a $b', [
+      substituteVariablesSql('$a $b', [
         variable('a', ['$b']),
         variable('b', ['literal']),
       ]),
@@ -448,7 +439,9 @@ describe('substituteVariables', () => {
 
   it('leaves non-variable macros untouched', () => {
     expect(
-      substituteVariables('WHERE $__timeFilter(ts) AND $__filters', [SERVICE]),
+      substituteVariablesSql('WHERE $__timeFilter(ts) AND $__filters', [
+        SERVICE,
+      ]),
     ).toBe('WHERE $__timeFilter(ts) AND $__filters');
   });
 
@@ -456,61 +449,62 @@ describe('substituteVariables', () => {
     // Standard macros exist in the raw SQL path (`replaceMacros`) alone, so
     // there is no argument to recurse into — the reference is plain text.
     expect(
-      substituteVariables('WHERE $__timeFilter(${service:csv})', [SERVICE]),
+      substituteVariablesSql('WHERE $__timeFilter(${service:csv})', [SERVICE]),
     ).toBe('WHERE $__timeFilter(api,web)');
   });
 
   it('does not treat $__filters as the $__filter macro', () => {
-    expect(substituteVariables('$__filters', [SERVICE])).toBe('$__filters');
+    expect(substituteVariablesSql('$__filters', [SERVICE])).toBe('$__filters');
   });
 });
 
-describe('substituteVariablesForLanguage', () => {
+describe('substituteVariables per language', () => {
   it('expands references as SQL strings and macros as predicates for sql', () => {
     expect(
-      substituteVariablesForLanguage(
+      substituteVariables(
         'ServiceName IN ($service) AND $__filter(ServiceName, $service)',
-        [SERVICE],
-        'sql',
+        { variables: [SERVICE], inputLanguage: 'sql' },
       ),
     ).toBe("ServiceName IN ('api', 'web') AND (ServiceName IN ('api', 'web'))");
   });
 
   it('expands references in the lucene format for lucene', () => {
     expect(
-      substituteVariablesForLanguage(
-        'ServiceName:$service',
-        [SERVICE],
-        'lucene',
-      ),
+      substituteVariables('ServiceName:$service', {
+        variables: [SERVICE],
+        inputLanguage: 'lucene',
+      }),
     ).toBe('ServiceName:("api" OR "web")');
   });
 
   it('leaves macros as written in a lucene expression', () => {
     expect(
-      substituteVariablesForLanguage(
-        '$__filter(ServiceName, $service)',
-        [SERVICE],
-        'lucene',
-      ),
+      substituteVariables('$__filter(ServiceName, $service)', {
+        variables: [SERVICE],
+        inputLanguage: 'lucene',
+      }),
     ).toBe('$__filter(ServiceName, $service)');
   });
 
   it('renders an empty selection in each language', () => {
     expect(
-      substituteVariablesForLanguage(
-        'ServiceName IN ($service)',
-        [EMPTY_SERVICE],
-        'sql',
-      ),
+      substituteVariables('ServiceName IN ($service)', {
+        variables: [EMPTY_SERVICE],
+        inputLanguage: 'sql',
+      }),
     ).toBe('ServiceName IN (NULL)');
     expect(
-      substituteVariablesForLanguage(
-        'ServiceName:$service',
-        [EMPTY_SERVICE],
-        'lucene',
-      ),
+      substituteVariables('ServiceName:$service', {
+        variables: [EMPTY_SERVICE],
+        inputLanguage: 'lucene',
+      }),
     ).toBe('ServiceName:("")');
+    expect(
+      substituteVariables('up{service=~"$service"}', {
+        variables: [EMPTY_SERVICE],
+        inputLanguage: 'promql',
+      }),
+    ).toBe('up{service=~".*"}');
   });
 
   describe('quoted references expand to exact matches', () => {
@@ -519,7 +513,7 @@ describe('substituteVariablesForLanguage', () => {
     // where a group-internal `("a")` becomes a substring match. The distributed
     // shapes below are pinned end-to-end in queryParser.test.ts.
     const expand = (template: string, variables: ChartVariable[] = [SERVICE]) =>
-      substituteVariablesForLanguage(template, variables, 'lucene');
+      substituteVariables(template, { variables, inputLanguage: 'lucene' });
 
     it('is opt-in: quoting distributes the field, leaving it grouped does not', () => {
       expect(expand('ServiceName:"$service"')).toBe(
@@ -773,6 +767,148 @@ describe('substituteVariablesForLanguage', () => {
   });
 });
 
+describe('substituteVariables for promql', () => {
+  const promql = (input: string, variables: ChartVariable[]) =>
+    substituteVariables(input, { variables, inputLanguage: 'promql' });
+
+  /** `up{service=~"…"}` with `service` selecting the given values. */
+  const matcher = (values: string[]) =>
+    promql('up{service=~"$service"}', [variable('service', values)]);
+
+  describe('escaping a value for the matcher it sits in', () => {
+    it('matches anything when nothing is selected, so the tile stays valid', () => {
+      expect(matcher([])).toBe('up{service=~".*"}');
+    });
+
+    it('emits a single value as-is', () => {
+      expect(matcher(['api'])).toBe('up{service=~"api"}');
+    });
+
+    it('emits an alternation for several values', () => {
+      expect(matcher(['api', 'web'])).toBe('up{service=~"(api|web)"}');
+    });
+
+    it('double-escapes a regex metacharacter for the string literal around it', () => {
+      // `v1\.2` in the RE2 pattern, so it matches `v1.2` and not `v1x2`.
+      expect(matcher(['v1.2'])).toBe('up{service=~"v1\\\\.2"}');
+    });
+
+    it('escapes a double quote with a single backslash, unlike Grafana', () => {
+      // `\\"` would close the PromQL string literal early.
+      expect(matcher(['a"b'])).toBe('up{service=~"a\\"b"}');
+    });
+
+    it('escapes a backslash twice over — once as a regex, once as a string', () => {
+      // Value `a\b` -> pattern `a\\b` -> literal `a\\\\b`.
+      expect(matcher(['a\\b'])).toBe('up{service=~"a\\\\\\\\b"}');
+    });
+
+    it("leaves ' alone, which is not an RE2 metacharacter and invalid to escape here", () => {
+      expect(matcher(["o'brien"])).toBe('up{service=~"o\'brien"}');
+    });
+
+    it('handles a value needing every layer at once', () => {
+      expect(matcher(['a."b\\c', 'web'])).toBe(
+        'up{service=~"(a\\\\.\\"b\\\\\\\\c|web)"}',
+      );
+    });
+  });
+
+  describe('behaviour', () => {
+    it('uses the regex format for an unformatted reference', () => {
+      expect(promql('${service}', [SERVICE])).toBe('(api|web)');
+      expect(promql('$service', [SERVICE])).toBe('(api|web)');
+    });
+
+    it('still honours an explicitly requested format', () => {
+      expect(promql('${service:csv}', [SERVICE])).toBe('api,web');
+      expect(promql('${service:sqlstring}', [SERVICE])).toBe("'api', 'web'");
+    });
+
+    it('leaves the variable macros exactly as written, arguments and all', () => {
+      expect(promql('$__filter(ServiceName, $service)', [SERVICE])).toBe(
+        '$__filter(ServiceName, $service)',
+      );
+      expect(promql('$__conditionalAll(x == 1, $service)', [SERVICE])).toBe(
+        '$__conditionalAll(x == 1, $service)',
+      );
+    });
+
+    it('leaves an unknown name verbatim', () => {
+      expect(promql('up{service=~"$nope"}', [SERVICE])).toBe(
+        'up{service=~"$nope"}',
+      );
+    });
+
+    it('does not substitute inside a # comment', () => {
+      expect(promql('# see $service\nup', [SERVICE])).toBe(
+        '# see $service\nup',
+      );
+    });
+
+    it('does not re-expand a selected value that looks like a reference', () => {
+      expect(
+        promql('$a $b', [variable('a', ['$b']), variable('b', ['literal'])]),
+      ).toBe('\\\\$b literal');
+    });
+  });
+});
+
+describe('substituteVariables regex escaping for sql', () => {
+  const sqlMatch = (values: string[]) =>
+    substituteVariables("match(x, '${service:regex}')", {
+      variables: [variable('service', values)],
+      inputLanguage: 'sql',
+    });
+
+  it('leaves an ordinary alternation byte-identical', () => {
+    expect(sqlMatch(['api', 'web'])).toBe("match(x, '(api|web)')");
+  });
+
+  it("doubles the regex escape so ClickHouse's literal parser keeps it", () => {
+    // Before: `'a\.b'`, where CH drops the unknown escape and `a.b` matches `axb`.
+    expect(sqlMatch(['a.b'])).toBe("match(x, 'a\\\\.b')");
+  });
+
+  it('escapes a single quote, which used to end the literal early', () => {
+    expect(sqlMatch(["a'b"])).toBe("match(x, 'a''b')");
+  });
+
+  it('escapes a backslash so the pattern gets a literal one', () => {
+    expect(sqlMatch(['a\\b'])).toBe("match(x, 'a\\\\\\\\b')");
+  });
+
+  it('renders the empty selection as an unconstrained pattern', () => {
+    expect(sqlMatch([])).toBe("match(x, '.*')");
+  });
+});
+
+describe('substituteVariables formats the language must not re-escape', () => {
+  it.each(['sql', 'promql'] as const)(
+    'leaves the sqlstring format self-quoted in %s',
+    language => {
+      expect(
+        substituteVariables('${service:sqlstring}', {
+          variables: [SERVICE],
+          inputLanguage: language,
+        }),
+      ).toBe("'api', 'web'");
+    },
+  );
+
+  it.each(['sql', 'promql'] as const)(
+    'keeps the csv format raw in %s, since it carries identifiers',
+    language => {
+      expect(
+        substituteVariables('${service:csv}', {
+          variables: [variable('service', ["a'b.c"])],
+          inputLanguage: language,
+        }),
+      ).toBe("a'b.c");
+    },
+  );
+});
+
 describe('getVariableReferences', () => {
   it('returns an empty list for a template with no references', () => {
     expect(getVariableReferences('SELECT 1 FROM t')).toEqual([]);
@@ -889,19 +1025,26 @@ describe('getVariableReferences', () => {
     });
 
     it('leaves a reference inside a comment unsubstituted', () => {
-      expect(substituteVariables('-- see $service\nSELECT 1', [SERVICE])).toBe(
-        '-- see $service\nSELECT 1',
-      );
-      expect(substituteVariables('/* $service */ SELECT 1', [SERVICE])).toBe(
-        '/* $service */ SELECT 1',
-      );
+      expect(
+        substituteVariables('-- see $service\nSELECT 1', {
+          variables: [SERVICE],
+          inputLanguage: 'sql',
+        }),
+      ).toBe('-- see $service\nSELECT 1');
+      expect(
+        substituteVariables('/* $service */ SELECT 1', {
+          variables: [SERVICE],
+          inputLanguage: 'sql',
+        }),
+      ).toBe('/* $service */ SELECT 1');
     });
 
     it('substitutes normally after a comment ends', () => {
       expect(
-        substituteVariables('-- see $service\nWHERE a IN ($service)', [
-          SERVICE,
-        ]),
+        substituteVariables('-- see $service\nWHERE a IN ($service)', {
+          variables: [SERVICE],
+          inputLanguage: 'sql',
+        }),
       ).toBe("-- see $service\nWHERE a IN ('api', 'web')");
     });
   });
@@ -1106,17 +1249,17 @@ describe('filterReferencedVariables', () => {
     );
   });
 
-  it('returns an empty array for a PromQL config even when its expression mentions a variable', () => {
+  it('keeps the variables a PromQL expression references', () => {
     expect(
       filterReferencedVariables(
         {
           configType: 'promql',
-          promqlExpression: 'up{service="$service"}',
+          promqlExpression: 'up{service=~"$service"}',
           connection: 'local',
         },
         variables,
       ),
-    ).toEqual([]);
+    ).toEqual([SERVICE]);
   });
 
   it('keeps the variables a builder config references, across every expression field', () => {
@@ -1167,17 +1310,22 @@ describe('getAlertVariableWarning', () => {
     ).toBeUndefined();
   });
 
-  it('says nothing for a PromQL config, which cannot use variables', () => {
+  // Unreachable in practice — PromQL displays don't support alerts at all — but
+  // the warning is produced from the same reference walk as every other config.
+  it('names the variables a PromQL expression references', () => {
     expect(
       getAlertVariableWarning(
         {
           configType: 'promql',
-          promqlExpression: 'up{service="$service"}',
+          promqlExpression: 'up{service=~"$service"}',
           connection: 'local',
         },
         variables,
       ),
-    ).toBeUndefined();
+    ).toBe(
+      'This tile references $service. Alerts run with every dashboard variable ' +
+        'in its empty state, not the values selected here.',
+    );
   });
 
   it('names only the variables the raw SQL references', () => {
@@ -1360,6 +1508,42 @@ describe('substituteChartConfigVariables', () => {
         }),
       ).where,
     ).toBe("(1=1 /** no values selected for variable 'service' */)");
+  });
+});
+
+describe('substitutePromqlChartConfigVariables', () => {
+  const promqlConfig = (
+    promqlExpression: string,
+    variables?: ChartVariable[],
+  ) => ({
+    configType: 'promql' as const,
+    promqlExpression,
+    connection: 'local',
+    variables,
+  });
+
+  it('returns the config untouched when there is no variable context', () => {
+    const config = promqlConfig('up{service=~"$service"}');
+    expect(substitutePromqlChartConfigVariables(config)).toBe(config);
+  });
+
+  it('expands the expression and consumes the variables', () => {
+    expect(
+      substitutePromqlChartConfigVariables(
+        promqlConfig('up{service=~"$service"}', [SERVICE]),
+      ),
+    ).toMatchObject({
+      promqlExpression: 'up{service=~"(api|web)"}',
+      variables: undefined,
+    });
+  });
+
+  it('renders an empty selection as an unconstrained matcher', () => {
+    expect(
+      substitutePromqlChartConfigVariables(
+        promqlConfig('up{service=~"$service"}', [EMPTY_SERVICE]),
+      ).promqlExpression,
+    ).toBe('up{service=~".*"}');
   });
 });
 
@@ -1551,13 +1735,17 @@ describe('validateVariableReferencesInTemplate', () => {
 
     it('accepts a bare reference: the lucene format has a valid empty state', () => {
       expect(
-        validate('ServiceName:$service', [SERVICE], { language: 'lucene' }),
+        validate('ServiceName:$service', [SERVICE], {
+          language: 'lucene',
+        }),
       ).toEqual({ errors: [], warnings: [] });
     });
 
     it('accepts a quoted reference: quoting opts into exact matches', () => {
       expect(
-        validate('ServiceName:"$service"', [SERVICE], { language: 'lucene' }),
+        validate('ServiceName:"$service"', [SERVICE], {
+          language: 'lucene',
+        }),
       ).toEqual({ errors: [], warnings: [] });
     });
 

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -10,10 +10,7 @@ import {
   DashboardFilterValue,
   Filter,
 } from '@/types';
-import {
-  getVariableReferences,
-  substituteVariablesForLanguage,
-} from '@/variables';
+import { getVariableReferences, substituteVariables } from '@/variables';
 
 export type FilterState = {
   [key: string]: {
@@ -937,7 +934,10 @@ export function resolveFilterValuesWhere(
 
   try {
     return {
-      where: substituteVariablesForLanguage(where, variables, whereLanguage),
+      where: substituteVariables(where, {
+        variables,
+        inputLanguage: whereLanguage,
+      }),
       whereLanguage,
     };
   } catch (e) {

--- a/packages/common-utils/src/macros.ts
+++ b/packages/common-utils/src/macros.ts
@@ -478,7 +478,6 @@ export function replaceMacros(
 
   const variableContext: VariableContext | undefined = variables && {
     variables,
-    defaultFormat: 'sqlstring',
     inputLanguage: 'sql',
   };
 

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1620,6 +1620,7 @@ const PromqlChartConfigSchema = PromqlBaseChartConfigSchema.extend({
   from: z
     .object({ databaseName: z.string(), tableName: z.string() })
     .optional(),
+  variables: z.array(ChartVariableSchema).optional(),
 });
 
 export type PromqlChartConfig = z.infer<typeof PromqlChartConfigSchema>;

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -41,6 +41,10 @@ const escapeRegexValue = (value: string) =>
 const escapeLuceneValue = (value: string) =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
+/** Escape `\` and `"` so a value survives inside a double-quoted PromQL string. */
+const escapePromqlStringValue = (value: string) =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
 /**
  * Render a variable's selected values in the requested format. Every format
  * has an "empty selection" rendering that keeps the surrounding query valid.
@@ -395,12 +399,42 @@ export function expandTemplate(
 
 // -- Variable expansion -----------------------------------------------------
 
+type TemplateLanguage = NonNullable<SearchConditionLanguage>;
+
 export type VariableContext = {
   variables: ChartVariable[];
-  /** Format used by references that don't request one. */
+  /** The language the renderer will parse this template as. */
+  inputLanguage: TemplateLanguage;
+};
+
+type LanguageSettings = {
+  /** Format used by a reference that doesn't request one. */
   defaultFormat: VariableFormat;
-  /** The language whatever consumes the result will parse it as. */
-  inputLanguage: NonNullable<SearchConditionLanguage>;
+  /**
+   * Leaves `$__filter` / `$__conditionalAll` exactly as written. They expand to
+   * SQL predicates, so they have no meaning in a Lucene or PromQL expression.
+   */
+  disableMacros?: boolean;
+  /**
+   * Escapes a `regex`-format expansion for the string literal it always sits
+   * inside. Only `regex` needs this: `sqlstring` and `lucene` quote and escape
+   * themselves, and `csv` is the raw escape hatch that carries identifiers.
+   */
+  escapeRegexForLiteral?: (rendered: string) => string;
+};
+
+/** Settings controlling how variables and templates are expanded for each template language. */
+const LANGUAGE_SETTINGS: Record<TemplateLanguage, LanguageSettings> = {
+  sql: {
+    defaultFormat: 'sqlstring',
+    escapeRegexForLiteral: rendered => escapeSqlString(rendered),
+  },
+  lucene: { defaultFormat: 'lucene', disableMacros: true },
+  promql: {
+    defaultFormat: 'regex',
+    disableMacros: true,
+    escapeRegexForLiteral: escapePromqlStringValue,
+  },
 };
 
 const sqlNoOp = (name: string) =>
@@ -557,14 +591,17 @@ export function expandVariableToken(
     );
   }
 
-  return formatVariableValues(
-    variable.values,
-    requestedFormat ?? ctx.defaultFormat,
-  );
+  const settings = LANGUAGE_SETTINGS[ctx.inputLanguage];
+  const format = requestedFormat ?? settings.defaultFormat;
+  const rendered = formatVariableValues(variable.values, format);
+
+  return format === 'regex' && settings.escapeRegexForLiteral
+    ? settings.escapeRegexForLiteral(rendered)
+    : rendered;
 }
 
-/** Expand the given token without applying lucene-specific rewrites. */
-function expandTokenWithoutLuceneRewrites(
+/** Expand the given token if it's a variable, otherwise return the raw text. */
+function expandVariableOnly(
   token: TemplateToken,
   ctx: VariableContext,
 ): string {
@@ -603,7 +640,10 @@ function getLuceneFormattedValues(
 ): string[] | undefined {
   if (token.kind === 'text' || token.kind === 'macro') return undefined;
   const requestedFormat = token.kind === 'braced' ? token.format : undefined;
-  if ((requestedFormat ?? ctx.defaultFormat) !== 'lucene') return undefined;
+
+  const settings = LANGUAGE_SETTINGS[ctx.inputLanguage];
+  if ((requestedFormat ?? settings.defaultFormat) !== 'lucene')
+    return undefined;
   return ctx.variables.find(variable => variable.name === token.name)?.values;
 }
 
@@ -716,9 +756,7 @@ function substituteTokensWithLuceneRewrites(
     token => getLuceneFormattedValues(token, ctx) != null,
   );
   if (!anyRewritable) {
-    return tokens
-      .map(token => expandTokenWithoutLuceneRewrites(token, ctx))
-      .join('');
+    return tokens.map(token => expandVariableOnly(token, ctx)).join('');
   }
 
   // Build the sentinel string, a string with all variable references replaced by
@@ -745,9 +783,7 @@ function substituteTokensWithLuceneRewrites(
     ast = lucene.parse(sentinelString);
   } catch {
     // If the lucene is not valid, fall back to the non-rewrite path
-    return tokens
-      .map(token => expandTokenWithoutLuceneRewrites(token, ctx))
-      .join('');
+    return tokens.map(token => expandVariableOnly(token, ctx)).join('');
   }
 
   // Get the offset of every term's text in the sentinel string.
@@ -776,7 +812,7 @@ function substituteTokensWithLuceneRewrites(
       const untouched = decodeSpecialTokensToSource(
         sentinelString.slice(runStart, region.offset),
       );
-      const expanded = expandTokenWithoutLuceneRewrites(region.token, ctx);
+      const expanded = expandVariableOnly(region.token, ctx);
       rewrittenOutput += untouched + expanded;
       runStart = region.offset + region.sentinel.length;
     }
@@ -786,14 +822,15 @@ function substituteTokensWithLuceneRewrites(
 }
 
 /**
- * Expand variable references and the variable macros in a template fragment.
+ * Expand variable references and the variable macros in a template fragment,
+ * for the language its renderer will parse it as. Macro expansion is performed
+ * only for SQL templates. Default formats and escaping depend on the language.
  *
- * Standard macros (`$__timeFilter` and friends) are *not* known here, so they
- * pass through as text — raw SQL goes through `replaceMacros`, which scans for
- * both sets in one pass. This entry point is for the surfaces that only carry
- * variables (chart-builder where/having, PromQL expressions).
+ * Only variable-related macros are expanded here - the full suite of macros
+ * (eg. `$__timeFilter`) are supported only for raw SQL chart types, and are
+ * handled elsewhere.
  */
-export function substituteWithContext(
+export function substituteVariables(
   input: string,
   ctx: VariableContext,
 ): string {
@@ -806,26 +843,18 @@ export function substituteWithContext(
     );
   }
 
+  if (LANGUAGE_SETTINGS[ctx.inputLanguage].disableMacros) {
+    return scanTemplateTokens(input, VARIABLE_MACRO_NAMES, {
+      onMalformed: 'skip',
+    })
+      .map(token => expandVariableOnly(token, ctx))
+      .join('');
+  }
+
   return expandTemplate(input, {
     macroNames: VARIABLE_MACRO_NAMES,
     expandMacro: token => expandVariableToken(token, ctx),
     expandReference: token => expandVariableToken(token, ctx),
-  });
-}
-
-/**
- * Expand a template for the language its renderer will parse it as, rendering
- * values in the format that language reads.
- */
-export function substituteVariablesForLanguage(
-  input: string,
-  variables: ChartVariable[],
-  inputLanguage: NonNullable<SearchConditionLanguage>,
-): string {
-  return substituteWithContext(input, {
-    variables,
-    defaultFormat: inputLanguage === 'lucene' ? 'lucene' : 'sqlstring',
-    inputLanguage,
   });
 }
 
@@ -934,11 +963,34 @@ export function substituteChartConfigVariables<
 
   const substituted = mapBuilderVariableTemplates(
     config,
-    (template, language) =>
-      substituteVariablesForLanguage(template, variables, language),
+    (template, inputLanguage) =>
+      substituteVariables(template, { variables, inputLanguage }),
   );
 
   return { ...substituted, variables: undefined };
+}
+
+/**
+ * Expand the variable references in a PromQL config's expression, returning it
+ * with `variables` consumed. `variables` being undefined means this is a no-op.
+ *
+ * Dropping `variables` from the result ensures a config can't be substituted
+ * twice, the same way `substituteChartConfigVariables` does.
+ */
+export function substitutePromqlChartConfigVariables<
+  T extends { promqlExpression: string; variables?: ChartVariable[] },
+>(config: T): T {
+  const { variables } = config;
+  if (variables == null) return config;
+
+  return {
+    ...config,
+    promqlExpression: substituteVariables(config.promqlExpression, {
+      variables,
+      inputLanguage: 'promql',
+    }),
+    variables: undefined,
+  };
 }
 
 /**
@@ -1106,7 +1158,7 @@ export function validateVariableReferencesInTemplate(
   // Attempt to expand macros, so that errors during expansion can be surfaced.
   if (variables != null && hasVariableMacro(template)) {
     try {
-      substituteVariablesForLanguage(template, variables, language);
+      substituteVariables(template, { variables, inputLanguage: language });
     } catch (e) {
       // Surface only MacroExpansionError, anything else is a bug the user can't act
       // on, or could be from the user typing an incomplete template
@@ -1227,8 +1279,7 @@ export function filterReferencedVariables(
   if ('configType' in config && config.configType === 'sql') {
     names = getReferencedVariableNames(config.sqlTemplate);
   } else if ('configType' in config && config.configType === 'promql') {
-    // PromQL queries don't support variables yet.
-    return [];
+    names = getReferencedVariableNames(config.promqlExpression);
   } else {
     names = getBuilderVariableReferences(config).map(
       reference => reference.name,


### PR DESCRIPTION
## Summary

This PR extends variable substitution to PromQL charts. E2E has been updated to seed a Timeseries engine table for validating the variable substitution.

Note that this requires enabling the following feature toggles:

(In the UI)
- NEXT_PUBLIC_ENABLE_PROMQL=true
- NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true

(In the API)
- ENABLE_PROMQL=true

### Screenshots or video

<img width="1430" height="774" alt="Screenshot 2026-08-25 at 11 40 24 AM" src="https://github.com/user-attachments/assets/6852ff6e-acc9-4b40-a8fc-9005fa9d8630" />
<img width="1502" height="581" alt="Screenshot 2026-08-25 at 11 35 30 AM" src="https://github.com/user-attachments/assets/b9409b34-c2f6-48ba-9a42-ac01acedcbf7" />
<img width="1477" height="556" alt="Screenshot 2026-08-25 at 11 35 21 AM" src="https://github.com/user-attachments/assets/58d10918-3021-43aa-aba4-b342880f0b7c" />
<img width="1493" height="567" alt="Screenshot 2026-08-25 at 11 35 17 AM" src="https://github.com/user-attachments/assets/dcbfea55-b3d2-4a87-93c7-f4a2889287ac" />

### How to test 

- Create a PromQL source, the default.metrics_ts timeseries table should exist after enabling promql
- Create a dashboard and add a variable that queries instance IDs `ResourceAttributes['service.instance.id']` from the metrics gauge table
- Create a promql tile that references a variable, eg. `http_client_duration_milliseconds_count{instance=~"$Instance"}`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5063
- Related PRs:
