### PR TITLE
feat: Add completions for PromQL variables

### DIFF
--- a/.changeset/early-tables-try.md
+++ b/.changeset/early-tables-try.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+feat: Add completions for PromQL variables

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -35,7 +35,7 @@ import {
 import { getStoredLanguage } from '@/components/SearchInput';
 import { type SQLCompletion } from '@/components/SQLEditor/utils';
 import {
-  buildVariableCompletions,
+  buildSqlVariableCompletions,
   toMacroCompletion,
 } from '@/components/SQLEditor/variableCompletions';
 import { toAlertChannels } from '@/utils/alerts';
@@ -69,7 +69,7 @@ export function buildRawSqlCompletions({
   return [
     ...paramCompletions,
     ...MACRO_SUGGESTIONS.map(toMacroCompletion),
-    ...buildVariableCompletions(variables),
+    ...buildSqlVariableCompletions(variables),
   ];
 }
 

--- a/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
@@ -21,6 +21,9 @@ import {
   createCodeMirrorStyleTheme,
   DEFAULT_CODE_MIRROR_BASIC_SETUP,
 } from '@/components/SQLEditor/utils';
+import { usePromqlVariableCompletions } from '@/components/SQLEditor/variableCompletions';
+
+import { createVariableCompletionSource } from './variableCompletionSource';
 
 import styles from '@/components/SQLEditor/SQLInlineEditor.module.scss';
 
@@ -102,20 +105,33 @@ export default function PromQLEditor({
   const ref = useRef<ReactCodeMirrorRef>(null);
   const compartmentRef = useRef<Compartment>(new Compartment());
   const [isFocused, setIsFocused] = useState(false);
+  const variableCompletions = usePromqlVariableCompletions();
 
   const updateAutocomplete = useCallback(
     (viewRef: EditorView) => {
-      if (!metricNames || metricNames.length === 0) return;
+      const override: CompletionSource[] = [];
+
+      if (variableCompletions.length > 0) {
+        override.push(createVariableCompletionSource(variableCompletions));
+      }
+
+      if (metricNames?.length) {
+        override.push(debounceAndPruneAutocompleteResults(metricNames));
+      }
+
+      // PromQL's own function/keyword completion, re-registered explicitly.
+      // `PromQLExtension.asExtension()` registers it through
+      // `language.data.of({ autocomplete })`, which an `override` array
+      // replaces outright — so without this it is silently lost.
+      override.push(context => promqlExtension.getComplete().promQL(context));
 
       viewRef.dispatch({
         effects: compartmentRef.current.reconfigure(
-          autocompletion({
-            override: [debounceAndPruneAutocompleteResults(metricNames)],
-          }),
+          autocompletion({ override }),
         ),
       });
     },
-    [metricNames],
+    [metricNames, variableCompletions],
   );
 
   useEffect(() => {
@@ -132,7 +148,7 @@ export default function PromQLEditor({
       // PromQL syntax highlighting
       promqlExtension.asExtension(),
 
-      // Metric name autocomplete (via compartment for hot-swapping)
+      // Autocomplete sources (via compartment for hot-swapping)
       // eslint-disable-next-line react-hooks/refs
       compartmentRef.current.of([]),
 

--- a/packages/app/src/components/PromQLEditor/__tests__/variableCompletionSource.test.ts
+++ b/packages/app/src/components/PromQLEditor/__tests__/variableCompletionSource.test.ts
@@ -1,0 +1,90 @@
+import { Completion, CompletionContext } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+
+import { createVariableCompletionSource } from '@/components/PromQLEditor/variableCompletionSource';
+
+const TEST_COMPLETIONS: Completion[] = [
+  { label: '$env', type: 'variable' },
+  { label: '${env}', type: 'variable' },
+  { label: '${env:regex}', type: 'variable' },
+  { label: '${env:csv}', type: 'variable' },
+];
+
+/**
+ * Runs the source and returns what CodeMirror acts on: the replacement range
+ * and the filter pattern. CodeMirror filters options against — and on accept
+ * replaces — the whole [from, to] span, so `pattern` is `doc.slice(from, to)`,
+ * not just the text behind the cursor.
+ */
+function getResult(
+  doc: string,
+  pos: number,
+): { from: number; to: number; pattern: string } | null {
+  const source = createVariableCompletionSource(TEST_COMPLETIONS);
+  const state = EditorState.create({ doc });
+  const result = source(new CompletionContext(state, pos, false));
+  if (result == null || typeof result !== 'object' || !('from' in result)) {
+    return null;
+  }
+  const to = result.to ?? pos;
+  return { from: result.from, to, pattern: doc.slice(result.from, to) };
+}
+
+describe('createVariableCompletionSource', () => {
+  it.each([
+    {
+      name: 'cursor before the closing brace stops at it',
+      doc: '${env}_total',
+      pos: 5, // ${env|}_total
+      expected: { from: 0, to: 6, pattern: '${env}' },
+    },
+    {
+      name: 'half-typed braced name consumes the auto-closed brace',
+      doc: '${en}',
+      pos: 4, // ${en|}
+      expected: { from: 0, to: 5, pattern: '${en}' },
+    },
+    {
+      name: 'braced form consumes the format suffix and closing brace',
+      doc: '${en:csv}',
+      pos: 4, // ${en|:csv}
+      expected: { from: 0, to: 9, pattern: '${en:csv}' },
+    },
+    {
+      name: '$ typed before a label selector leaves the selector alone',
+      doc: 'metric${a="1"}',
+      pos: 7, // metric$|{a="1"}
+      expected: { from: 6, to: 7, pattern: '$' },
+    },
+    {
+      name: 'bare name inside a subquery stops before the step',
+      doc: 'rate(x[$i:1m])',
+      pos: 9, // rate(x[$i|:1m])
+      expected: { from: 7, to: 9, pattern: '$i' },
+    },
+    {
+      name: 'cursor mid-way through a bare name covers the whole name',
+      doc: '$env',
+      pos: 2, // $e|nv
+      expected: { from: 0, to: 4, pattern: '$env' },
+    },
+    {
+      name: 'bare reference followed by an adjacent reference stops at it',
+      doc: '$env$other',
+      pos: 4, // $env|$other
+      expected: { from: 0, to: 4, pattern: '$env' },
+    },
+  ])('$name', ({ doc, pos, expected }) => {
+    expect(getResult(doc, pos)).toEqual(expected);
+  });
+
+  it.each([
+    { name: 'no $ under the cursor', doc: 'metric_name', pos: 11 },
+    // `.` terminates a bare reference, so the token under the cursor
+    // (`other`) contains no `$` and the source yields to the other sources.
+    { name: 'after a dot following a reference', doc: '$svc.other', pos: 10 },
+    { name: 'empty document', doc: '', pos: 0 },
+  ])('returns null with $name', ({ doc, pos }) => {
+    expect(getResult(doc, pos)).toBeNull();
+  });
+});

--- a/packages/app/src/components/PromQLEditor/variableCompletionSource.ts
+++ b/packages/app/src/components/PromQLEditor/variableCompletionSource.ts
@@ -1,0 +1,51 @@
+import { Completion, CompletionSource } from '@codemirror/autocomplete';
+
+// Characters that make up a substitution reference: word chars for the name
+// (DASHBOARD_VARIABLE_NAME_PATTERN allows nothing outside `[a-zA-Z0-9_]`),
+// and `$`, `{`, `}` and `:` for the sigil, the delimiters and the `:format`
+// suffix.
+//
+// PromQL's own completion matches `[\w.:]+`, which cannot see a leading `$` —
+// hence a separate source rather than widening that one.
+const VARIABLE_CHAR = '[\\w{}:$]';
+const VARIABLE_BEFORE = new RegExp(`${VARIABLE_CHAR}+`);
+const VARIABLE_VALID_FOR = new RegExp(`^\\$${VARIABLE_CHAR}*$`);
+
+// The rest of the reference ahead of the cursor. CodeMirror filters options
+// against — and on accept replaces — the whole [from, to] span, so these must
+// cover the remainder of the reference and nothing past it: in the braced
+// form the rest of the name/format up to and including the first `}`, so
+// accepting `${svc}` over a half-typed `${sv}` doesn't leave a stray `}`
+// while `${env}_total` stops before `_total`; in the bare form just the rest
+// of the name, since `:` and `{` after a bare name belong to the
+// surrounding PromQL, not the reference.
+const VARIABLE_AFTER_BRACED = /^[\w:]*\}?/;
+const VARIABLE_AFTER_BARE = /^\w*/;
+
+/**
+ * Completes dashboard variable references, and only those: without a `$` under
+ * the cursor this returns null and leaves the popup to the metric-name and
+ * built-in PromQL sources.
+ */
+export const createVariableCompletionSource: (
+  completions: Completion[],
+) => CompletionSource = completions => context => {
+  const prefix = context.matchBefore(VARIABLE_BEFORE);
+  if (prefix == null) return null;
+
+  const dollar = prefix.text.lastIndexOf('$');
+  if (dollar < 0) return null;
+
+  const after =
+    prefix.text[dollar + 1] === '{'
+      ? VARIABLE_AFTER_BRACED
+      : VARIABLE_AFTER_BARE;
+  const suffix = context.state.doc.sliceString(context.pos).match(after);
+
+  return {
+    from: prefix.from + dollar,
+    to: context.pos + (suffix?.[0].length ?? 0),
+    options: completions,
+    validFor: VARIABLE_VALID_FOR,
+  };
+};

--- a/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
+++ b/packages/app/src/components/SQLEditor/SQLInlineEditor.tsx
@@ -42,7 +42,7 @@ import {
   createCodeMirrorStyleTheme,
   DEFAULT_CODE_MIRROR_BASIC_SETUP,
 } from './utils';
-import { useVariableCompletions } from './variableCompletions';
+import { useSqlVariableCompletions } from './variableCompletions';
 import {
   useVariableValidation,
   VariableIssueIndicator,
@@ -165,7 +165,7 @@ export default function SQLInlineEditor({
   // Dashboard variables in scope, offered alongside the column identifiers, and
   // checked for the references that won't expand. This editor's content is
   // always SQL — `language` only drives the switch.
-  const variableCompletions = useVariableCompletions({
+  const variableCompletions = useSqlVariableCompletions({
     enabled: enableVariables,
   });
   const variableIssues = useVariableValidation(value, {

--- a/packages/app/src/components/SQLEditor/__tests__/promqlVariableCompletions.test.ts
+++ b/packages/app/src/components/SQLEditor/__tests__/promqlVariableCompletions.test.ts
@@ -1,0 +1,115 @@
+import { ChartVariable } from '@hyperdx/common-utils/dist/types';
+
+import { buildPromqlVariableCompletions } from '@/components/SQLEditor/variableCompletions';
+
+const SERVICE: ChartVariable = {
+  name: 'service',
+  values: ['api', 'web'],
+  expression: 'ServiceName',
+};
+
+const completions = (variables: ChartVariable[] | undefined) =>
+  buildPromqlVariableCompletions(variables);
+
+const labels = (variables: ChartVariable[] | undefined) =>
+  completions(variables).map(completion => completion.label);
+
+const find = (variables: ChartVariable[], label: string) =>
+  completions(variables).find(completion => completion.label === label);
+
+/** The rendered help for a completion, whether it is a string or a Node. */
+const infoOf = (variables: ChartVariable[], label: string) => {
+  const { info } = find(variables, label) ?? {};
+  if (typeof info !== 'function') return info;
+  const rendered = info();
+  return rendered instanceof HTMLElement ? rendered : undefined;
+};
+
+/** The second line of a completion's help — what it expands to right now. */
+const footnoteOf = (variables: ChartVariable[], label: string) => {
+  const info = infoOf(variables, label);
+  // A plain string means the completion has no second line at all.
+  if (typeof info !== 'object') return undefined;
+  return (
+    info?.querySelector('.cm-completionInfo-footnote')?.textContent ?? undefined
+  );
+};
+
+describe('buildPromqlVariableCompletions', () => {
+  it.each([
+    ['off a dashboard', undefined],
+    ['on a dashboard that defines none', [] as ChartVariable[]],
+  ])('offers nothing %s', (_label, variables) => {
+    expect(buildPromqlVariableCompletions(variables)).toEqual([]);
+  });
+
+  it('offers every PromQL-valid reference form, most useful first', () => {
+    expect(labels([SERVICE])).toEqual([
+      '$service',
+      '${service}',
+      '${service:regex}',
+      '${service:csv}',
+    ]);
+  });
+
+  it('inserts each form exactly as labelled', () => {
+    expect(find([SERVICE], '${service}')?.apply).toBe('${service}');
+    expect(find([SERVICE], '${service:regex}')?.apply).toBe('${service:regex}');
+  });
+
+  it('withholds the variable macros, which PromQL leaves as written', () => {
+    // Substitution is macro-less for promql, so a suggested `$__filter(...)`
+    // would reach Prometheus verbatim and fail to parse.
+    expect(labels([SERVICE])).not.toContain('$__filter');
+    expect(labels([SERVICE])).not.toContain('$__conditionalAll');
+    expect(labels([SERVICE])).not.toContain('$__filter($service)');
+  });
+
+  it('withholds the formats that emit SQL or Lucene syntax', () => {
+    // Still honoured if hand-typed — just never suggested, because neither
+    // `'api', 'web'` nor `("api" OR "web")` parses inside a PromQL expression.
+    expect(labels([SERVICE])).not.toContain('${service:sqlstring}');
+    expect(labels([SERVICE])).not.toContain('${service:lucene}');
+  });
+
+  it('offers the same set of forms for every variable', () => {
+    expect(labels([SERVICE, { name: 'env', values: ['prod'] }])).toEqual([
+      '$service',
+      '${service}',
+      '${service:regex}',
+      '${service:csv}',
+      '$env',
+      '${env}',
+      '${env:regex}',
+      '${env:csv}',
+    ]);
+  });
+
+  it.each([
+    ['$service', 'Expands to: (api|web)'],
+    ['${service}', 'Expands to: (api|web)'],
+    ['${service:regex}', 'Expands to: (api|web)'],
+    ['${service:csv}', 'Expands to: api,web'],
+  ])('shows what %s expands to under promql, not sql', (label, expected) => {
+    expect(footnoteOf([SERVICE], label)).toBe(expected);
+  });
+
+  it('previews the empty selection as the match-everything regex', () => {
+    // The reason the regex format is PromQL's default: with nothing selected a
+    // `=~` matcher still matches, rather than becoming NULL as it would in SQL.
+    const unselected: ChartVariable = { ...SERVICE, values: [] };
+    expect(footnoteOf([unselected], '$service')).toBe('Expands to: .*');
+    expect(footnoteOf([unselected], '${service:regex}')).toBe('Expands to: .*');
+    expect(footnoteOf([unselected], '${service:csv}')).toBe(
+      'Expands to: (empty string)',
+    );
+  });
+
+  it('puts the expansion on its own line, not appended to the prose', () => {
+    const info = infoOf([SERVICE], '$service');
+    if (typeof info !== 'object') throw new Error('expected rendered markup');
+    const footnote = info?.querySelector('.cm-completionInfo-footnote');
+    expect(info?.firstChild).not.toBe(footnote);
+    expect(info?.firstChild?.textContent).not.toContain('Expands to:');
+  });
+});

--- a/packages/app/src/components/SQLEditor/__tests__/variableCompletions.test.ts
+++ b/packages/app/src/components/SQLEditor/__tests__/variableCompletions.test.ts
@@ -2,7 +2,7 @@ import { ChartVariable } from '@hyperdx/common-utils/dist/types';
 
 import {
   buildLuceneVariableSuggestions,
-  buildVariableCompletions,
+  buildSqlVariableCompletions,
   expandLuceneVariablesForEnglishDisplay,
 } from '@/components/SQLEditor/variableCompletions';
 
@@ -13,11 +13,11 @@ const SERVICE: ChartVariable = {
 };
 
 const labels = (variables: ChartVariable[] | undefined) =>
-  buildVariableCompletions(variables).map(completion => completion.label);
+  buildSqlVariableCompletions(variables).map(completion => completion.label);
 
 /** The second line of a completion's help — what it expands to right now. */
 const footnoteOf = (variables: ChartVariable[], label: string) => {
-  const { info } = buildVariableCompletions(variables).find(
+  const { info } = buildSqlVariableCompletions(variables).find(
     completion => completion.label === label,
   ) ?? { info: undefined };
   if (typeof info !== 'function') return undefined;
@@ -29,12 +29,12 @@ const footnoteOf = (variables: ChartVariable[], label: string) => {
   );
 };
 
-describe('buildVariableCompletions', () => {
+describe('buildSqlVariableCompletions', () => {
   it.each([
     ['off a dashboard', undefined],
     ['on a dashboard that defines none', [] as ChartVariable[]],
   ])('offers nothing %s', (_label, variables) => {
-    expect(buildVariableCompletions(variables)).toEqual([]);
+    expect(buildSqlVariableCompletions(variables)).toEqual([]);
   });
 
   it('offers the variable macros and every reference form', () => {

--- a/packages/app/src/components/SQLEditor/variableCompletions.tsx
+++ b/packages/app/src/components/SQLEditor/variableCompletions.tsx
@@ -6,6 +6,7 @@ import {
 import { ChartVariable } from '@hyperdx/common-utils/dist/types';
 import {
   substituteVariables,
+  TemplateLanguage,
   VARIABLE_FORMATS,
   VariableFormat,
 } from '@hyperdx/common-utils/dist/variables';
@@ -21,16 +22,17 @@ const VARIABLE_FORMAT_DESCRIPTIONS: Record<VariableFormat, string> = {
     'An OR of quoted terms, for Lucene inputs. e.g. ("a" OR "b" OR "c"). Quote the reference (field:"$var") for exact-match behavior. Leave unquoted (field:$var) for substring matching.',
 };
 
-/** What `snippet` expands to in SQL against the variable's current selection. */
-function describeSqlVariableExpansion(
+/** What `snippet` expands to against the variable's current selection. */
+function describeVariableExpansion(
   snippet: string,
   variable: ChartVariable,
+  language: TemplateLanguage,
 ): string | undefined {
   let expansion: string;
   try {
     expansion = substituteVariables(snippet, {
       variables: [variable],
-      inputLanguage: 'sql',
+      inputLanguage: language,
     });
   } catch {
     return undefined;
@@ -75,77 +77,118 @@ export const toMacroCompletion = ({
   type: 'function',
 });
 
-/** Every reference form of one variable, each with its current expansion. */
-function referenceCompletions(variable: ChartVariable): SQLCompletion[] {
-  const { name } = variable;
-
-  /** A static description and an expansion preview given the current selection */
-  const help = (snippet: string, description: string) => {
-    const expansion = describeSqlVariableExpansion(snippet, variable);
-    return expansion ? completionInfo(description, expansion) : description;
+/**
+ * Builds one variable's reference completions, previewed under `language`.
+ *
+ * Every form is inserted exactly as labelled and previews what it expands to
+ * against the current selection; what differs between languages is only which
+ * forms are offered and what the prose says about them.
+ */
+function variableCompletionFactory(
+  variable: ChartVariable,
+  language: TemplateLanguage,
+) {
+  return (
+    label: string,
+    description: string,
+    overrides?: Partial<SQLCompletion>,
+  ): SQLCompletion => {
+    const expansion = describeVariableExpansion(label, variable, language);
+    return {
+      label,
+      apply: label,
+      detail: 'variable',
+      info: expansion ? completionInfo(description, expansion) : description,
+      type: 'variable',
+      ...overrides,
+    };
   };
+}
+
+/** Every reference form available in SQL for the given variable, each with its current expansion. */
+function getSqlVariableCompletions(variable: ChartVariable): SQLCompletion[] {
+  const { name } = variable;
+  const buildCompletion = variableCompletionFactory(variable, 'sql');
 
   return [
     ...(variable.expression
       ? [
-          {
-            label: `$__filter($${name})`,
-            apply: `$__filter($${name})`,
-            detail: 'variable filter',
-            info: help(
-              `$__filter($${name})`,
-              `Filters by the ${name} variable using its defined expression. Matches every row when no values are selected for the variable.`,
-            ),
-            type: 'function',
-          },
+          buildCompletion(
+            `$__filter($${name})`,
+            `Filters by the ${name} variable using its defined expression. Matches every row when no values are selected for the variable.`,
+            { detail: 'variable filter', type: 'function' },
+          ),
         ]
       : []),
-    {
-      label: `$${name}`,
-      apply: `$${name}`,
-      detail: 'variable',
-      info: help(
-        `$${name}`,
-        `The selected values of ${name}, in the default sqlstring format. Has no valid empty state — prefer $__filter(<expression>, $${name}).`,
+    buildCompletion(
+      `$${name}`,
+      `The selected values of ${name}, in the default sqlstring format. Has no valid empty state — prefer $__filter(<expression>, $${name}).`,
+    ),
+    buildCompletion(
+      `\${${name}}`,
+      `The same as $${name}, but delimited — use it when the reference runs into following word characters, as in \${${name}}_total.`,
+    ),
+    ...VARIABLE_FORMATS.map(format =>
+      buildCompletion(
+        `\${${name}:${format}}`,
+        VARIABLE_FORMAT_DESCRIPTIONS[format],
       ),
-      type: 'variable',
-    },
-    {
-      label: `\${${name}}`,
-      apply: `\${${name}}`,
-      detail: 'variable',
-      info: help(
-        `\${${name}}`,
-        `The same as $${name}, but delimited — use it when the reference runs into following word characters, as in \${${name}}_total.`,
-      ),
-      type: 'variable',
-    },
-    ...VARIABLE_FORMATS.map((format): SQLCompletion => {
-      const reference = `\${${name}:${format}}`;
-      return {
-        label: reference,
-        apply: reference,
-        detail: 'variable',
-        info: help(reference, VARIABLE_FORMAT_DESCRIPTIONS[format]),
-        type: 'variable',
-      };
-    }),
+    ),
   ];
 }
 
 /**
- * Auto-completions for the variables available to a query: the variable
- * macros, then every reference form of each variable.
+ * Auto-completions for the variables available to a SQL query: the
+ * variable macros, then every reference form of each variable.
  */
-export function buildVariableCompletions(
+export function buildSqlVariableCompletions(
   variables: ChartVariable[] | undefined,
 ): SQLCompletion[] {
   if (!variables?.length) return [];
 
   return [
     ...VARIABLE_MACRO_SUGGESTIONS.map(toMacroCompletion),
-    ...variables.flatMap(referenceCompletions),
+    ...variables.flatMap(getSqlVariableCompletions),
   ];
+}
+
+/** Every reference form available in PromQL for the given variable, each with its current expansion. */
+function getPromqlVariableCompletions(
+  variable: ChartVariable,
+): SQLCompletion[] {
+  const { name } = variable;
+  const reference = variableCompletionFactory(variable, 'promql');
+
+  return [
+    reference(
+      `$${name}`,
+      `The selected values of ${name} as a regex alternation, for use inside a matcher such as {label=~"$${name}"}. Matches everything when nothing is selected.`,
+    ),
+    reference(
+      `\${${name}}`,
+      `The same as $${name}, but delimited — use it when the reference runs into following word characters.`,
+    ),
+    reference(
+      `\${${name}:regex}`,
+      'The default format, written out. A regex alternation, escaped for the string literal it sits in. e.g. (a|b|c)',
+    ),
+    reference(
+      `\${${name}:csv}`,
+      'Comma-separated and unquoted, with no escaping. Use it to interpolate something that is not a matcher value, such as a metric or label name.',
+    ),
+  ];
+}
+
+/**
+ * Auto-completions for the variables available to a PromQL expression: every
+ * PromQL-valid reference form of each variable.
+ */
+export function buildPromqlVariableCompletions(
+  variables: ChartVariable[] | undefined,
+): SQLCompletion[] {
+  if (!variables?.length) return [];
+
+  return variables.flatMap(getPromqlVariableCompletions);
 }
 
 /** One bare `$name` suggestion for a Lucene input. */
@@ -244,11 +287,21 @@ export function useChartVariables({
 }
 
 /** Variable completions for a SQL input inside a `SqlVariablesProvider`. */
-export function useVariableCompletions(
+export function useSqlVariableCompletions(
   options?: VariableSupportOptions,
 ): SQLCompletion[] {
   const variables = useChartVariables(options);
-  return useMemo(() => buildVariableCompletions(variables), [variables]);
+  return useMemo(() => buildSqlVariableCompletions(variables), [variables]);
+}
+
+/**
+ * Variable completions for a PromQL input inside a `SqlVariablesProvider`.
+ */
+export function usePromqlVariableCompletions(
+  options?: VariableSupportOptions,
+): SQLCompletion[] {
+  const variables = useChartVariables(options);
+  return useMemo(() => buildPromqlVariableCompletions(variables), [variables]);
 }
 
 /** Variable suggestions for a Lucene input inside a `SqlVariablesProvider`. */

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -442,6 +442,75 @@ export class ChartEditorComponent {
     await this.page.keyboard.type(expression);
   }
 
+  /** Read the current text of the PromQL expression editor. */
+  async getPromqlEditorText(): Promise<string> {
+    return this.page.locator('.cm-editor .cm-content').first().innerText();
+  }
+
+  /**
+   * Type `prefix` into the PromQL editor and return the labels its
+   * autocomplete popup offers, once `settleOn` is among them.
+   *
+   * Waiting on a known label rather than on the popup is what makes this
+   * safe to read as a whole: three sources feed the popup — dashboard
+   * variables, metric names and PromQL's own functions and keywords — and the
+   * metric-name one debounces, so the list repaints after first appearing.
+   *
+   * The prefix is re-typed until the label shows up, rather than waited on in
+   * place: the metric names arrive from a query, and the source that reads
+   * them only joins the `override` array once they do. A popup opened before
+   * that lists the other two sources and never repaints on its own, so only a
+   * fresh input event can pick the metric names up.
+   *
+   * Assert the result with `toContain` rather than comparing it whole: which
+   * of PromQL's built-ins fuzzy-match a short prefix is not worth pinning.
+   */
+  async readPromqlCompletions(
+    prefix: string,
+    settleOn: string,
+  ): Promise<string[]> {
+    const options = this.completionOptions();
+    await expect(async () => {
+      // Only on a retry, and only if the last attempt left the popup up: it
+      // covers the editor, so `replacePromqlExpression`'s click would land on
+      // an option instead. Unconditional dismissal would send keystrokes
+      // before the editor has been focused at all.
+      if (await this.page.locator('.cm-tooltip-autocomplete').isVisible()) {
+        await this.dismissCompletion();
+      }
+      await this.replacePromqlExpression(prefix);
+      await expect(options.filter({ hasText: settleOn })).not.toHaveCount(0, {
+        timeout: 5000,
+      });
+    }).toPass({ timeout: 30000 });
+    return options.allInnerTexts();
+  }
+
+  /**
+   * Type `prefix` into the PromQL editor, accept the suggestion labelled
+   * `label`, and return the resulting expression.
+   *
+   * Verifies that what a completion inserts is well-formed: the replace range
+   * reaches forward over the rest of the reference, so the `}` the editor
+   * auto-inserts after `${` is inside it and `apply` has to supply its own.
+   */
+  async acceptPromqlCompletion(prefix: string, label: string): Promise<string> {
+    await this.replacePromqlExpression(prefix);
+
+    const option = this.page
+      .locator('.cm-tooltip-autocomplete > ul > li')
+      .filter({ has: this.page.getByText(label, { exact: true }) })
+      .first();
+    await option.waitFor({ state: 'visible', timeout: 10000 });
+    await option.click();
+
+    const text = await this.getPromqlEditorText();
+    // Accepting can immediately re-open the popup on the inserted text, which
+    // would intercept the next caller's click.
+    await this.dismissCompletion();
+    return text;
+  }
+
   /**
    * Switch the chart editor from SQL back to Builder mode.
    */
@@ -568,7 +637,7 @@ export class ChartEditorComponent {
    * Escape also closes it, but it bubbles to the tile modal and pops the
    * discard-changes dialog.
    */
-  async dismissSqlCompletion() {
+  async dismissCompletion() {
     await this.page.keyboard.press(
       process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
     );
@@ -578,11 +647,26 @@ export class ChartEditorComponent {
       .waitFor({ state: 'hidden', timeout: 10000 });
   }
 
-  /** Labels currently offered by the SQL autocomplete popup. */
-  sqlCompletionOptions(): Locator {
+  /** `dismissCompletion` under its original, SQL-specific name. */
+  async dismissSqlCompletion() {
+    await this.dismissCompletion();
+  }
+
+  /**
+   * Labels currently offered by the autocomplete popup.
+   *
+   * Not scoped to a particular editor: CodeMirror portals the tooltip out of
+   * the editor it belongs to, and only one is ever open at a time.
+   */
+  completionOptions(): Locator {
     return this.page.locator(
       '.cm-tooltip-autocomplete > ul > li .cm-completionLabel',
     );
+  }
+
+  /** `completionOptions` under its original, SQL-specific name. */
+  sqlCompletionOptions(): Locator {
+    return this.completionOptions();
   }
 
   /**

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -274,6 +274,35 @@ test.describe(
   'Dashboard variables in a PromQL tile',
   { tag: ['@dashboard', '@full-stack'] },
   () => {
+    /** A fresh dashboard with a Service filter exposed as `$svc`. */
+    const createDashboardWithServiceVariable = async (
+      dashboardPage: DashboardPage,
+    ) => {
+      await dashboardPage.goto();
+      await dashboardPage.createNewDashboard();
+
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.addFilterToDashboard(
+        'Service',
+        DEFAULT_LOGS_SOURCE_NAME,
+        'ServiceName',
+        undefined,
+        undefined,
+        { variableName: 'svc' },
+      );
+      await expect(dashboardPage.getFilterItemByName('Service')).toBeVisible();
+      await dashboardPage.closeFiltersModal();
+    };
+
+    /** Open a new tile's editor in PromQL mode, on the PromQL source. */
+    const openPromqlTileEditor = async (dashboardPage: DashboardPage) => {
+      await dashboardPage.addTile();
+      await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+      await dashboardPage.chartEditor.waitForDataToLoad();
+      await dashboardPage.chartEditor.switchToPromqlMode();
+      await dashboardPage.chartEditor.selectPromqlSource(PROMQL_SOURCE_NAME);
+    };
+
     test('narrows the queried series to the selected values', async ({
       page,
     }) => {
@@ -297,32 +326,12 @@ test.describe(
         await expect(seriesAreas).toHaveCount(count, { timeout: 30000 });
       };
 
-      await test.step('Create a dashboard with a Service filter exposed as $svc', async () => {
-        await dashboardPage.goto();
-        await dashboardPage.createNewDashboard();
-
-        await dashboardPage.openEditFiltersModal();
-        await dashboardPage.addFilterToDashboard(
-          'Service',
-          DEFAULT_LOGS_SOURCE_NAME,
-          'ServiceName',
-          undefined,
-          undefined,
-          { variableName: 'svc' },
-        );
-        await expect(
-          dashboardPage.getFilterItemByName('Service'),
-        ).toBeVisible();
-        await dashboardPage.closeFiltersModal();
-      });
+      await test.step('Create a dashboard with a Service filter exposed as $svc', () =>
+        createDashboardWithServiceVariable(dashboardPage));
 
       await test.step('Add a PromQL tile referencing $svc', async () => {
-        await dashboardPage.addTile();
-        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
-        await dashboardPage.chartEditor.waitForDataToLoad();
+        await openPromqlTileEditor(dashboardPage);
         await dashboardPage.chartEditor.setChartName('PromQL tile');
-        await dashboardPage.chartEditor.switchToPromqlMode();
-        await dashboardPage.chartEditor.selectPromqlSource(PROMQL_SOURCE_NAME);
         await dashboardPage.chartEditor.replacePromqlExpression(
           `${E2E_PROMQL_METRIC_NAME}{service=~"$svc"}`,
         );
@@ -364,6 +373,98 @@ test.describe(
         await dashboardPage.toggleFilterValue('Service', 'accounting');
         await dashboardPage.toggleFilterValue('Service', 'api-server');
         await expectSeriesCount(SERVICES.length);
+      });
+    });
+
+    /**
+     * The expression above is only writable if the editor tells you the
+     * variable exists. Three completion sources share the PromQL input —
+     * dashboard variables, metric names and PromQL's own functions and
+     * keywords — and CodeMirror's `override` replaces language-registered
+     * sources outright, so a mistake here silently costs one of the three.
+     */
+    test('offers the dashboard variables alongside metrics and functions', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      const dashboardPage = new DashboardPage(page);
+      const editor = dashboardPage.chartEditor;
+
+      await test.step('Open a PromQL tile on a dashboard with a variable', async () => {
+        await createDashboardWithServiceVariable(dashboardPage);
+        await openPromqlTileEditor(dashboardPage);
+      });
+
+      await test.step('A $ reference offers every PromQL-valid form', async () => {
+        const labels = await editor.readPromqlCompletions('$sv', '${svc:csv}');
+        expect(labels).toEqual(
+          expect.arrayContaining(['$svc', '${svc}', '${svc:regex}']),
+        );
+
+        // Withheld on purpose: `'api', 'web'` and `("api" OR "web")` are SQL
+        // and Lucene syntax that no PromQL expression can parse, and the
+        // macros expand to SQL predicates that promql leaves as written.
+        expect(labels).not.toContain('${svc:sqlstring}');
+        expect(labels).not.toContain('${svc:lucene}');
+        expect(labels).not.toContain('$__filter');
+        expect(labels).not.toContain('$__conditionalAll');
+
+        await editor.dismissCompletion();
+      });
+
+      await test.step("The reference's expansion is previewed in its help", async () => {
+        await editor.replacePromqlExpression('$svc');
+        const info = page.locator('.cm-completionInfo');
+        await info.waitFor({ state: 'visible', timeout: 10000 });
+
+        // Nothing is selected on this dashboard, and regex is promql's default
+        // format — so the bare reference previews the match-everything state
+        // that makes the tile above valid before anything is picked.
+        await expect(info.locator('.cm-completionInfo-footnote')).toHaveText(
+          'Expands to: .*',
+        );
+
+        await editor.dismissCompletion();
+      });
+
+      await test.step('Metric names and PromQL built-ins still complete', async () => {
+        // The regression this feature could cause. Every source in the input
+        // has to be listed in the one `override` array, including the
+        // function/keyword source `PromQLExtension.asExtension()` registers
+        // through language data — which `override` replaces outright.
+        const metrics = await editor.readPromqlCompletions(
+          E2E_PROMQL_METRIC_NAME.slice(0, 5),
+          E2E_PROMQL_METRIC_NAME,
+        );
+        expect(metrics).toContain(E2E_PROMQL_METRIC_NAME);
+        await editor.dismissCompletion();
+
+        const functions = await editor.readPromqlCompletions('rat', 'rate');
+        expect(functions).toContain('rate');
+        await editor.dismissCompletion();
+      });
+
+      await test.step('Accepting a completion inserts well-formed text', async () => {
+        // The replace range reaches forward over the rest of the reference,
+        // which includes the `}` the editor auto-inserts after `${` — so
+        // `apply` has to carry its own closing brace rather than rely on it.
+        for (const [prefix, label, expected] of [
+          ['${', '${svc}', '${svc}'],
+          ['${', '${svc:regex}', '${svc:regex}'],
+          ['$sv', '$svc', '$svc'],
+          // The canonical form, typed the way a user would: the auto-closed
+          // `"` and `}` sit after the cursor and must survive the insert.
+          [
+            `${E2E_PROMQL_METRIC_NAME}{service=~"$sv`,
+            '$svc',
+            `${E2E_PROMQL_METRIC_NAME}{service=~"$svc"}`,
+          ],
+        ]) {
+          expect(await editor.acceptPromqlCompletion(prefix, label)).toBe(
+            expected,
+          );
+        }
       });
     });
   },

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -399,7 +399,7 @@ export function expandTemplate(
 
 // -- Variable expansion -----------------------------------------------------
 
-type TemplateLanguage = NonNullable<SearchConditionLanguage>;
+export type TemplateLanguage = NonNullable<SearchConditionLanguage>;
 
 export type VariableContext = {
   variables: ChartVariable[];


### PR DESCRIPTION
## Summary

This PR improves support for variables in promql by adding variable reference completions to the promql editor.

Note that this requires enabling the following feature toggles:

(In the UI)
- NEXT_PUBLIC_ENABLE_PROMQL=true
- NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true

(In the API)
- ENABLE_PROMQL=true
### Screenshots or video

https://github.com/user-attachments/assets/f8241135-6a7c-427e-872c-b55fd9ee99b2

### How to test

- Create a PromQL source, the default.metrics_ts timeseries table should exist after enabling promql
- Create a dashboard and add a variable that queries instance IDs `ResourceAttributes['service.instance.id']` from the metrics gauge table
- Create a promql tile that references a variable, eg. `http_client_duration_milliseconds_count{instance=~"$Instance"}`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Related to HDX-5064
- Related PRs:
