### PR TITLE
feat: Show warnings for invalid promql variable usage

### DIFF
--- a/.changeset/ninety-rockets-rest.md
+++ b/.changeset/ninety-rockets-rest.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+feat: Show warnings for invalid promql variable usage

--- a/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
@@ -22,6 +22,10 @@ import {
   DEFAULT_CODE_MIRROR_BASIC_SETUP,
 } from '@/components/SQLEditor/utils';
 import { usePromqlVariableCompletions } from '@/components/SQLEditor/variableCompletions';
+import {
+  useVariableValidation,
+  VariableIssueIndicator,
+} from '@/components/SQLEditor/variableValidation';
 
 import { createVariableCompletionSource } from './variableCompletionSource';
 
@@ -106,6 +110,7 @@ export default function PromQLEditor({
   const compartmentRef = useRef<Compartment>(new Compartment());
   const [isFocused, setIsFocused] = useState(false);
   const variableCompletions = usePromqlVariableCompletions();
+  const variableIssues = useVariableValidation(value, { language: 'promql' });
 
   const updateAutocomplete = useCallback(
     (viewRef: EditorView) => {
@@ -185,6 +190,8 @@ export default function PromQLEditor({
   }, []);
 
   const isExpanded = isFocused;
+  const isVariableWarningOnly =
+    variableIssues.errors.length === 0 && variableIssues.warnings.length > 0;
   const baseHeight = 36;
 
   return (
@@ -198,6 +205,8 @@ export default function PromQLEditor({
         shadow="none"
         className={cx(
           styles.paper,
+          variableIssues.errors.length > 0 ? styles.error : undefined,
+          isVariableWarningOnly ? styles.warning : undefined,
           isExpanded ? styles.expanded : undefined,
           !isExpanded ? styles.collapseFade : undefined,
         )}
@@ -225,6 +234,7 @@ export default function PromQLEditor({
             onClick={onClickCodeMirror}
           />
         </div>
+        <VariableIssueIndicator issues={variableIssues} />
       </Paper>
     </div>
   );

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -448,6 +448,18 @@ export class ChartEditorComponent {
   }
 
   /**
+   * The warning icon the PromQL expression input shows about the variables it
+   * references.
+   *
+   * Scoped to the editor form, which in PromQL mode renders the expression
+   * input and no WHERE inputs — so this is the only indicator inside it. The
+   * validation debounces, so assertions on it need a generous timeout.
+   */
+  promqlVariableWarning(): Locator {
+    return this.editorForm().getByTestId('variable-validation');
+  }
+
+  /**
    * Type `prefix` into the PromQL editor and return the labels its
    * autocomplete popup offers, once `settleOn` is among them.
    *

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -467,5 +467,69 @@ test.describe(
         }
       });
     });
+
+    /**
+     * What the input says when a reference is wrong. A PromQL expression is
+     * substituted client-side and shipped as text, so a mistake here is silent
+     * — Prometheus is handed `$nope` verbatim and answers with an empty or
+     * nonsensical series rather than an error the tile could show.
+     */
+    test('flags a variable reference the expression cannot use', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      const dashboardPage = new DashboardPage(page);
+      const editor = dashboardPage.chartEditor;
+      const indicator = editor.promqlVariableWarning();
+
+      /** Type `expression` and wait for the input to settle on `message`. */
+      const expectWarning = async (expression: string, message: RegExp) => {
+        await editor.replacePromqlExpression(expression);
+        await expect(indicator).toBeVisible({ timeout: 15000 });
+        await expect(indicator).toHaveAttribute('aria-label', message, {
+          timeout: 15000,
+        });
+      };
+
+      await test.step('Open a PromQL tile on a dashboard with a variable', async () => {
+        await createDashboardWithServiceVariable(dashboardPage);
+        await openPromqlTileEditor(dashboardPage);
+      });
+
+      await test.step('A typo names a variable that does not exist', async () => {
+        await expectWarning(
+          `${E2E_PROMQL_METRIC_NAME}{service=~"$nope"}`,
+          /references unknown variable \$nope.*Available variables: svc/,
+        );
+      });
+
+      await test.step('Correcting the name clears the warning', async () => {
+        // Also the regression guard for the checks that used to run on every
+        // language: this expression is what the tile above queries with, and
+        // the sqlstring-shaped rules would call it both wrongly quoted and
+        // NULL-before-selection.
+        await editor.replacePromqlExpression(
+          `${E2E_PROMQL_METRIC_NAME}{service=~"$svc"}`,
+        );
+        await expect(indicator).toBeHidden({ timeout: 15000 });
+      });
+
+      await test.step('A reference outside the quoted matcher value is flagged', async () => {
+        // `(api|web)` — and `.*` before anything is selected — parse only as a
+        // matcher value, so dropping the quotes breaks the expression.
+        await expectWarning(
+          `${E2E_PROMQL_METRIC_NAME}{service=~$svc}`,
+          /only valid inside a quoted matcher value/,
+        );
+      });
+
+      await test.step('A macro is flagged, since PromQL leaves it as written', async () => {
+        await expectWarning(
+          '$__filter(service, $svc)',
+          /no meaning in a PromQL expression/,
+        );
+      });
+    });
   },
 );

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -1784,4 +1784,87 @@ describe('validateVariableReferencesInTemplate', () => {
       ).toEqual({ errors: [], warnings: [] });
     });
   });
+
+  describe('a PromQL expression', () => {
+    const promql = (template: string, variables?: ChartVariable[]) =>
+      validate(template, variables, {
+        subject: 'This expression',
+        language: 'promql',
+      });
+
+    it('accepts the canonical matcher form', () => {
+      // The SQL-only checks would call this both quoted (an error) and
+      // unguarded (a warning); neither applies to the regex default.
+      expect(promql('up{service=~"$service"}', [SERVICE])).toEqual({
+        errors: [],
+        warnings: [],
+      });
+    });
+
+    it('accepts the braced and explicitly-formatted matcher forms', () => {
+      expect(promql('up{service=~"${service}"}', [SERVICE])).toEqual({
+        errors: [],
+        warnings: [],
+      });
+      expect(promql('up{service=~"${service:regex}"}', [SERVICE])).toEqual({
+        errors: [],
+        warnings: [],
+      });
+    });
+
+    it('still warns about a reference to a variable that does not exist', () => {
+      const { errors, warnings } = promql('up{service=~"$srvice"}', [
+        SERVICE,
+        variable('env', ['prod']),
+      ]);
+
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([
+        'This expression references unknown variable $srvice. Available variables: service, env.',
+      ]);
+    });
+
+    it('warns about a regex reference outside a quoted matcher value', () => {
+      const { errors, warnings } = promql('up{service=~$service}', [SERVICE]);
+
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([
+        '$service expands to a regular expression, which is only valid inside a quoted matcher value. Wrap it as {<label>=~"$service"}, or use ${service:csv} to interpolate the values as written.',
+      ]);
+    });
+
+    it('warns the same way about a reference pasted into a metric name', () => {
+      expect(promql('${service}_total', [SERVICE]).warnings).toHaveLength(1);
+    });
+
+    it('says nothing about a csv reference outside a literal, which is raw', () => {
+      expect(promql('sum by (${service:csv}) (up)', [SERVICE])).toEqual({
+        errors: [],
+        warnings: [],
+      });
+    });
+
+    it.each([
+      '$__filter(service, $service)',
+      '$__conditionalAll(up, $service)',
+    ])('errors on the macro %s, which is sent verbatim', template => {
+      expect(promql(template, [SERVICE])).toEqual({
+        errors: [
+          `${template.slice(0, template.indexOf('('))} has no meaning in a PromQL expression — ` +
+            'it is left as written and sent to Prometheus verbatim. Reference the ' +
+            'variable directly, as in {<label>=~"$service"}.',
+        ],
+        warnings: [],
+      });
+    });
+
+    it('warns rather than errors when no variables are in scope', () => {
+      expect(promql('up{service=~"$service"}', undefined)).toEqual({
+        errors: [],
+        warnings: [
+          'This expression references $service, but no variables are available here.',
+        ],
+      });
+    });
+  });
 });

--- a/packages/common-utils/src/__tests__/variables.test.ts
+++ b/packages/common-utils/src/__tests__/variables.test.ts
@@ -1665,15 +1665,15 @@ describe('validateVariableReferencesInTemplate', () => {
     });
 
     it('reports only the Lucene error there, where no macro expands at all', () => {
-      const { errors } = validate(
+      const { warnings } = validate(
         '$__filter(ServiceName, service)',
         [SERVICE],
         {
           language: 'lucene',
         },
       );
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain('has no meaning in a Lucene expression');
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('has no meaning in a Lucene expression');
     });
   });
 
@@ -1755,12 +1755,12 @@ describe('validateVariableReferencesInTemplate', () => {
       '$__conditionalAll(ServiceName = 1, $service)',
     ])('errors on the macro %s, which is left as literal text', template => {
       expect(validate(template, [SERVICE], { language: 'lucene' })).toEqual({
-        errors: [
+        warnings: [
           `${template.slice(0, template.indexOf('('))} has no meaning in a Lucene expression — ` +
             'it is left as written and matched as literal text. Switch this input to SQL, ' +
             'or reference the variable directly, as in <field>:$service.',
         ],
-        warnings: [],
+        errors: [],
       });
     });
 
@@ -1768,7 +1768,7 @@ describe('validateVariableReferencesInTemplate', () => {
       expect(
         validate('$__filter(ServiceName, $srvice)', [SERVICE], {
           language: 'lucene',
-        }).errors,
+        }).warnings,
       ).toEqual([
         '$__filter has no meaning in a Lucene expression — it is left as written ' +
           'and matched as literal text. Switch this input to SQL, or reference the ' +
@@ -1849,12 +1849,12 @@ describe('validateVariableReferencesInTemplate', () => {
       '$__conditionalAll(up, $service)',
     ])('errors on the macro %s, which is sent verbatim', template => {
       expect(promql(template, [SERVICE])).toEqual({
-        errors: [
+        warnings: [
           `${template.slice(0, template.indexOf('('))} has no meaning in a PromQL expression — ` +
             'it is left as written and sent to Prometheus verbatim. Reference the ' +
             'variable directly, as in {<label>=~"$service"}.',
         ],
-        warnings: [],
+        errors: [],
       });
     });
 

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -437,6 +437,15 @@ const LANGUAGE_SETTINGS: Record<TemplateLanguage, LanguageSettings> = {
   },
 };
 
+const SETTINGS_BY_LANGUAGE = new Map(Object.entries(LANGUAGE_SETTINGS));
+
+/** Get the settings for a template language, without an eslint warning */
+function languageSettings(language: TemplateLanguage): LanguageSettings {
+  const settings = SETTINGS_BY_LANGUAGE.get(language);
+  if (!settings) throw new Error(`Unknown template language '${language}'.`);
+  return settings;
+}
+
 const sqlNoOp = (name: string) =>
   `(1=1 /** no values selected for variable '${name}' */)`;
 
@@ -591,7 +600,7 @@ export function expandVariableToken(
     );
   }
 
-  const settings = LANGUAGE_SETTINGS[ctx.inputLanguage];
+  const settings = languageSettings(ctx.inputLanguage);
   const format = requestedFormat ?? settings.defaultFormat;
   const rendered = formatVariableValues(variable.values, format);
 
@@ -641,7 +650,7 @@ function getLuceneFormattedValues(
   if (token.kind === 'text' || token.kind === 'macro') return undefined;
   const requestedFormat = token.kind === 'braced' ? token.format : undefined;
 
-  const settings = LANGUAGE_SETTINGS[ctx.inputLanguage];
+  const settings = languageSettings(ctx.inputLanguage);
   if ((requestedFormat ?? settings.defaultFormat) !== 'lucene')
     return undefined;
   return ctx.variables.find(variable => variable.name === token.name)?.values;
@@ -843,7 +852,7 @@ export function substituteVariables(
     );
   }
 
-  if (LANGUAGE_SETTINGS[ctx.inputLanguage].disableMacros) {
+  if (languageSettings(ctx.inputLanguage).disableMacros) {
     return scanTemplateTokens(input, VARIABLE_MACRO_NAMES, {
       onMalformed: 'skip',
     })
@@ -1202,16 +1211,17 @@ export function validateVariableReferencesInTemplate(
     );
   }
 
-  // Macros are not supported in lucene
-  if (language === 'lucene') {
-    if (macroReferences.length > 0) {
-      const [{ name }] = macroReferences;
-      errors.push(
-        `${formatReferenceList(macroReferences)} has no meaning in a Lucene expression — it is left as written and matched as literal text. Switch this input to SQL, or reference the variable directly, as in <field>:$${name}.`,
-      );
-    }
-    // The two checks below are specific to the `sqlstring` default format.
-    return { errors, warnings };
+  const settings = languageSettings(language);
+
+  // A macro-less language leaves a macro exactly as written, so writing one can
+  // only ever have been a mistake.
+  if (settings.disableMacros && macroReferences.length > 0) {
+    const [{ name }] = macroReferences;
+    errors.push(
+      language === 'promql'
+        ? `${formatReferenceList(macroReferences)} has no meaning in a PromQL expression — it is left as written and sent to Prometheus verbatim. Reference the variable directly, as in {<label>=~"$${name}"}.`
+        : `${formatReferenceList(macroReferences)} has no meaning in a Lucene expression — it is left as written and matched as literal text. Switch this input to SQL, or reference the variable directly, as in <field>:$${name}.`,
+    );
   }
 
   // An unrecognized format throws during expansion, so it is already reported.
@@ -1221,27 +1231,48 @@ export function validateVariableReferencesInTemplate(
       (r.format == null || isVariableFormat(r.format)),
   );
 
-  const quoted = resolved.filter(
-    r => (r.format ?? 'sqlstring') === 'sqlstring' && r.inStringLiteral,
-  );
-  if (quoted.length > 0) {
-    const [{ name }] = quoted;
-    errors.push(
-      `${formatReferenceList(quoted)} is wrapped in quotes, but the default sqlstring format already quotes each value. Did you mean to use $__filter(<expression>, $${name}) or \${${name}:csv} instead?`,
+  // The two checks below are specific to SQL's `sqlstring` default format.
+  if (language === 'sql') {
+    const quoted = resolved.filter(
+      r =>
+        (r.format ?? settings.defaultFormat) === 'sqlstring' &&
+        r.inStringLiteral,
     );
+    if (quoted.length > 0) {
+      const [{ name }] = quoted;
+      errors.push(
+        `${formatReferenceList(quoted)} is wrapped in quotes, but the default sqlstring format already quotes each value. Did you mean to use $__filter(<expression>, $${name}) or \${${name}:csv} instead?`,
+      );
+    }
+
+    const unguarded = resolved.filter(
+      r =>
+        (r.format ?? settings.defaultFormat) === 'sqlstring' &&
+        !r.inStringLiteral &&
+        r.guardedBy !== r.name,
+    );
+    if (unguarded.length > 0) {
+      const [{ name }] = unguarded;
+      warnings.push(
+        `${formatReferenceList(unguarded)} has no valid empty-selection value — it renders as NULL before anything is selected. Prefer $__filter(<expression>, $${name}) or $__conditionalAll(<condition>, $${name}) so the query stays valid when no values are selected.`,
+      );
+    }
   }
 
-  const unguarded = resolved.filter(
-    r =>
-      (r.format ?? 'sqlstring') === 'sqlstring' &&
-      !r.inStringLiteral &&
-      r.guardedBy !== r.name,
-  );
-  if (unguarded.length > 0) {
-    const [{ name }] = unguarded;
-    warnings.push(
-      `${formatReferenceList(unguarded)} has no valid empty-selection value — it renders as NULL before anything is selected. Prefer $__filter(<expression>, $${name}) or $__conditionalAll(<condition>, $${name}) so the query stays valid when no values are selected.`,
+  // A regex expansion — PromQL's default — is only valid as a matcher value:
+  // both `(api|web)` and the empty-selection `.*` are syntax errors anywhere
+  // else, so `up{service=~$svc}` and `${svc}_total` are mistakes.
+  if (language === 'promql') {
+    const unquoted = resolved.filter(
+      r =>
+        (r.format ?? settings.defaultFormat) === 'regex' && !r.inStringLiteral,
     );
+    if (unquoted.length > 0) {
+      const [{ name }] = unquoted;
+      warnings.push(
+        `${formatReferenceList(unquoted)} expands to a regular expression, which is only valid inside a quoted matcher value. Wrap it as {<label>=~"$${name}"}, or use \${${name}:csv} to interpolate the values as written.`,
+      );
+    }
   }
 
   return { errors, warnings };

--- a/packages/common-utils/src/variables.ts
+++ b/packages/common-utils/src/variables.ts
@@ -1217,7 +1217,7 @@ export function validateVariableReferencesInTemplate(
   // only ever have been a mistake.
   if (settings.disableMacros && macroReferences.length > 0) {
     const [{ name }] = macroReferences;
-    errors.push(
+    warnings.push(
       language === 'promql'
         ? `${formatReferenceList(macroReferences)} has no meaning in a PromQL expression — it is left as written and sent to Prometheus verbatim. Reference the variable directly, as in {<label>=~"$${name}"}.`
         : `${formatReferenceList(macroReferences)} has no meaning in a Lucene expression — it is left as written and matched as literal text. Switch this input to SQL, or reference the variable directly, as in <field>:$${name}.`,


### PR DESCRIPTION
## Summary

This PR improves support for variables in promql by warnings to the promql input when variables are used incorrectly (eg. a non-existent variable is referenced, a macro is used, or the variable is not surrounded by quotes).

Note that this requires enabling the following feature toggles:

(In the UI)
- NEXT_PUBLIC_ENABLE_PROMQL=true
- NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true

(In the API)
- ENABLE_PROMQL=true
### Screenshots or video

<img width="1612" height="425" alt="Screenshot 2026-08-25 at 12 45 55 PM" src="https://github.com/user-attachments/assets/dae4ef75-b44b-4340-889d-7d9f1bdb0fef" />
<img width="1590" height="310" alt="Screenshot 2026-08-25 at 12 46 20 PM" src="https://github.com/user-attachments/assets/cd388153-91d5-4a77-9ce7-a2bce3e91b0c" />
<img width="1610" height="340" alt="Screenshot 2026-08-25 at 12 46 07 PM" src="https://github.com/user-attachments/assets/2103deb2-206f-44c0-af53-cafc891d730c" />

### How to test

- Create a PromQL source, the default.metrics_ts timeseries table should exist after enabling promql
- Create a dashboard and add a variable that queries instance IDs `ResourceAttributes['service.instance.id']` from the metrics gauge table
- Create a promql tile that references a variable, eg. `http_client_duration_milliseconds_count{instance=~"$Instance"}`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5064
- Related PRs:
