### PR TITLE
feat: Add generated PromQL preview

### DIFF
--- a/.changeset/popular-badgers-exist.md
+++ b/.changeset/popular-badgers-exist.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/common-utils": patch
+"@hyperdx/app": patch
+---
+
+feat: Add generated PromQL preview

--- a/packages/app/src/components/ChartSQLPreview.tsx
+++ b/packages/app/src/components/ChartSQLPreview.tsx
@@ -1,12 +1,10 @@
-import { useState } from 'react';
-import CopyToClipboard from 'react-copy-to-clipboard';
 import { format } from '@hyperdx/common-utils/dist/sqlFormatter';
 import { ChartConfigWithOptDateRange } from '@hyperdx/common-utils/dist/types';
-import { Button, Paper, Text, useMantineColorScheme } from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { Paper, Text, useMantineColorScheme } from '@mantine/core';
 import { keepPreviousData } from '@tanstack/react-query';
 import CodeMirror, { EditorView } from '@uiw/react-codemirror';
 
+import PreviewCopyButton from '@/components/PreviewCopyButton';
 import { useRenderedSqlChartConfig } from '@/hooks/useChartConfig';
 import { clickhouseSql } from '@/utils/codeMirror';
 
@@ -19,36 +17,6 @@ function tryFormat(data?: string) {
   } catch {
     return data;
   }
-}
-
-function CopyButton({
-  text = '',
-  size = 'md',
-}: {
-  text?: string;
-  size?: 'xs' | 'md';
-}) {
-  const [copied, setCopied] = useState(false);
-
-  const iconSize = size === 'xs' ? 14 : 16;
-  const buttonSize = size === 'xs' ? 'compact-xs' : 'sm';
-
-  return (
-    <CopyToClipboard text={text ?? ''} onCopy={() => setCopied(true)}>
-      <Button
-        variant={copied ? 'light' : 'default'}
-        size={buttonSize}
-        className="position-absolute top-0 end-0"
-      >
-        {copied ? (
-          <IconCheck size={iconSize} className="me-2" />
-        ) : (
-          <IconCopy size={iconSize} className="me-2" />
-        )}
-        {copied ? 'Copied!' : 'Copy'}
-      </Button>
-    </CopyToClipboard>
-  );
 }
 
 export function SQLPreview({
@@ -85,7 +53,9 @@ export function SQLPreview({
         ]}
         editable={false}
       />
-      {enableCopy && <CopyButton text={displayed} size={copyButtonSize} />}
+      {enableCopy && (
+        <PreviewCopyButton text={displayed} size={copyButtonSize} />
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -11,7 +11,7 @@ import {
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import { Accordion, Divider, Stack, Text } from '@mantine/core';
-import { IconCode, IconList } from '@tabler/icons-react';
+import { IconList } from '@tabler/icons-react';
 import { SortingState } from '@tanstack/react-table';
 
 import { buildTableRowSearchUrl } from '@/ChartUtils';
@@ -32,6 +32,7 @@ import DBTableChart from '@/components/DBTableChart';
 import { DBTimeChart } from '@/components/DBTimeChart';
 import EmptyState from '@/components/EmptyState';
 import PatternTable from '@/components/PatternTable';
+import PromQLPreview from '@/components/PromQLEditor/PromQLPreview';
 import {
   getEventBody,
   getFirstTimestampValueExpression,
@@ -42,7 +43,15 @@ import {
   sortingStateToOrderByString,
 } from '@/utils';
 
-import { buildSampleEventsConfig, isQueryReady } from './utils';
+import { QueryPreviewAccordion } from './QueryPreviewAccordion';
+import {
+  buildRenderedPromqlExpression,
+  buildSampleEventsConfig,
+  isQueryReady,
+} from './utils';
+
+/** Why a preview accordion is empty before its tile has been run. */
+const RUN_TO_PREVIEW = 'Run the query to see the preview';
 
 function HeatmapPreview({
   config,
@@ -131,6 +140,7 @@ type ChartPreviewPanelProps = {
   chartConfigForExplanations?: ChartConfigWithOptTimestamp;
   showGeneratedSql: boolean;
   showSampleEvents: boolean;
+  showGeneratedPromql: boolean;
   dbTimeChartConfig?: ChartConfigWithDateRange;
   setValue: (name: 'orderBy', value: string) => void;
   onSubmit: () => void;
@@ -147,11 +157,17 @@ export function ChartPreviewPanel({
   chartConfigForExplanations,
   showGeneratedSql,
   showSampleEvents,
+  showGeneratedPromql,
   dbTimeChartConfig,
   setValue,
   onSubmit,
 }: ChartPreviewPanelProps) {
   const [isSampleEventsOpen, setIsSampleEventsOpen] = useState(false);
+
+  const renderedPromql = useMemo(
+    () => buildRenderedPromqlExpression(queriedConfig),
+    [queriedConfig],
+  );
 
   const queryReady = !!isQueryReady(queriedConfig);
 
@@ -407,31 +423,43 @@ export function ChartPreviewPanel({
               </Accordion.Item>
             </Accordion>
           )}
-          <Accordion defaultValue="">
-            <Accordion.Item value={'SQL'}>
-              <Accordion.Control icon={<IconCode size={16} />}>
-                <Text size="sm" style={{ alignSelf: 'center' }}>
-                  Generated SQL
-                </Text>
-              </Accordion.Control>
-              <Accordion.Panel>
-                {queryReady &&
-                  chartConfigForExplanations != null &&
-                  (activeTab === 'heatmap' &&
-                  isBuilderChartConfig(chartConfigForExplanations) ? (
-                    <HeatmapSQLPreview
-                      config={chartConfigForExplanations}
-                      dateRange={dateRange}
-                    />
-                  ) : (
-                    <ChartSQLPreview
-                      config={chartConfigForExplanations}
-                      enableCopy
-                    />
-                  ))}
-              </Accordion.Panel>
-            </Accordion.Item>
-          </Accordion>
+          <QueryPreviewAccordion
+            value="SQL"
+            label="Generated SQL"
+            disabledReason={
+              queryReady && chartConfigForExplanations != null
+                ? undefined
+                : RUN_TO_PREVIEW
+            }
+          >
+            {chartConfigForExplanations != null &&
+              (activeTab === 'heatmap' &&
+              isBuilderChartConfig(chartConfigForExplanations) ? (
+                <HeatmapSQLPreview
+                  config={chartConfigForExplanations}
+                  dateRange={dateRange}
+                />
+              ) : (
+                <ChartSQLPreview
+                  config={chartConfigForExplanations}
+                  enableCopy
+                />
+              ))}
+          </QueryPreviewAccordion>
+        </>
+      )}
+      {showGeneratedPromql && (
+        <>
+          <Divider mt="md" />
+          <QueryPreviewAccordion
+            value="promql"
+            label="Generated PromQL"
+            disabledReason={
+              renderedPromql == null ? RUN_TO_PREVIEW : renderedPromql.error
+            }
+          >
+            <PromQLPreview expression={renderedPromql?.expression ?? ''} />
+          </QueryPreviewAccordion>
         </>
       )}
     </>

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -953,6 +953,7 @@ export default function EditTimeChartForm({
         chartConfigForExplanations={chartConfigForExplanations}
         showGeneratedSql={showGeneratedSql}
         showSampleEvents={showSampleEvents}
+        showGeneratedPromql={isPromqlInput}
         dbTimeChartConfig={dbTimeChartConfig}
         setValue={(name, value) => setValue(name, value)}
         onSubmit={onSubmit}

--- a/packages/app/src/components/DBEditTimeChartForm/QueryPreviewAccordion.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/QueryPreviewAccordion.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+import { Accordion, Box, Text, Tooltip } from '@mantine/core';
+import { IconCode } from '@tabler/icons-react';
+
+/** The collapsed accordion the preview panel shows a tile's query in. */
+export function QueryPreviewAccordion({
+  value,
+  label,
+  disabledReason,
+  children,
+}: {
+  /** The accordion item's key — arbitrary, but it must be non-empty. */
+  value: string;
+  label: string;
+  /** Why there is nothing to show. Set means the control is disabled. */
+  disabledReason?: string;
+  children: ReactNode;
+}) {
+  const isDisabled = disabledReason != null;
+
+  return (
+    <Accordion defaultValue="">
+      <Accordion.Item value={value}>
+        {/* The tooltip hangs off the wrapper Box rather than the control itself
+         * because a disabled Accordion.Control emits none of the pointer events
+         * that would open it*/}
+        <Tooltip
+          label={disabledReason}
+          disabled={!isDisabled}
+          position="top-start"
+        >
+          <Box>
+            <Accordion.Control
+              icon={<IconCode size={16} />}
+              disabled={isDisabled}
+              style={isDisabled ? { pointerEvents: 'none' } : undefined}
+            >
+              <Text size="sm" style={{ alignSelf: 'center' }}>
+                {label}
+              </Text>
+            </Accordion.Control>
+          </Box>
+        </Tooltip>
+        <Accordion.Panel>{isDisabled ? null : children}</Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  );
+}

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
-import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import {
+  ChartConfigWithDateRange,
+  ChartVariable,
+  SourceKind,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ChartPreviewPanel } from '@/components/DBEditTimeChartForm/ChartPreviewPanel';
 
 jest.mock('@/components/ChartSQLPreview', () => ({
   __esModule: true,
   default: () => <div data-testid="chart-sql-preview">Chart SQL Preview</div>,
+}));
+
+// CodeMirror doesn't render meaningfully in jsdom, so the preview is stubbed
+// down to the expression it is handed — which is what these tests are about.
+jest.mock('@/components/PromQLEditor/PromQLPreview', () => ({
+  __esModule: true,
+  default: ({ expression }: { expression: string }) => (
+    <div data-testid="chart-promql-preview">{expression}</div>
+  ),
 }));
 
 jest.mock('@/components/DBTimeChart', () => ({
@@ -89,6 +104,7 @@ const renderPanel = (
       activeTab="time"
       showGeneratedSql={false}
       showSampleEvents={false}
+      showGeneratedPromql={false}
       setValue={jest.fn()}
       onSubmit={jest.fn()}
       {...overrides}
@@ -197,6 +213,18 @@ describe('ChartPreviewPanel', () => {
       expect(screen.queryByText('Generated SQL')).not.toBeInTheDocument();
     });
 
+    it('should disable the Generated SQL control before a query has run', () => {
+      renderPanel({
+        queriedConfig: undefined,
+        showGeneratedSql: true,
+        activeTab: 'time',
+      });
+
+      expect(
+        screen.getByRole('button', { name: /Generated SQL/ }),
+      ).toBeDisabled();
+    });
+
     it('should show Sample Matched Events when showSampleEvents is true', () => {
       renderPanel({
         queriedConfig: baseBuilderConfig,
@@ -234,6 +262,160 @@ describe('ChartPreviewPanel', () => {
       // queries (bounds first, then bucketed counts).
       expect(screen.getByText(/Bounds query/i)).toBeInTheDocument();
       expect(screen.getByText(/Heatmap query/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('generated PromQL section', () => {
+    const EXPRESSION = 'e2e_service_up{service=~"$svc"}';
+
+    // What the editor hands the panel after a run: `resolvePreviewVariables`
+    // has already narrowed `variables` to the ones this expression references,
+    // and left it undefined off a dashboard.
+    const promqlConfig = (
+      overrides: {
+        promqlExpression?: string;
+        variables?: ChartVariable[];
+      } = {},
+    ): ChartConfigWithDateRange => ({
+      configType: 'promql',
+      promqlExpression: EXPRESSION,
+      connection: 'default',
+      from: { databaseName: 'default', tableName: 'metrics' },
+      dateRange,
+      ...overrides,
+    });
+
+    const generatedPromqlControl = () =>
+      screen.getByRole('button', { name: /Generated PromQL/ });
+
+    const openGeneratedPromql = () => userEvent.click(generatedPromqlControl());
+
+    it('is absent outside PromQL mode', () => {
+      renderPanel({
+        queriedConfig: baseBuilderConfig,
+        showGeneratedPromql: false,
+      });
+
+      expect(screen.queryByText('Generated PromQL')).not.toBeInTheDocument();
+    });
+
+    it('is disabled until the tile has been queried', () => {
+      // Present from the moment the editor enters PromQL mode: an accordion
+      // that appeared only on the first successful run would read as a missing
+      // feature rather than as an empty one.
+      renderPanel({ queriedConfig: undefined, showGeneratedPromql: true });
+
+      expect(generatedPromqlControl()).toBeDisabled();
+    });
+
+    it('says why it is disabled on hover', async () => {
+      renderPanel({ queriedConfig: undefined, showGeneratedPromql: true });
+
+      // Hovering the wrapper, not the control: the control is inert while
+      // disabled, which is the whole reason the tooltip hangs off the wrapper.
+      const wrapper = generatedPromqlControl().parentElement;
+      expect(wrapper).not.toBeNull();
+      await userEvent.hover(wrapper!);
+
+      expect(
+        await screen.findByText('Run the query to see the preview'),
+      ).toBeInTheDocument();
+    });
+
+    it('is disabled while the last query was of another kind', () => {
+      // Switching an already-queried builder tile to PromQL: the config on
+      // hand describes a query this panel can't render as PromQL.
+      renderPanel({
+        queriedConfig: baseBuilderConfig,
+        showGeneratedPromql: true,
+      });
+
+      expect(generatedPromqlControl()).toBeDisabled();
+    });
+
+    it('shows the expression as written when no variables are in scope', async () => {
+      // Off a dashboard nothing is substituted, but the panel still states
+      // what ran — the same terms the generated SQL is shown on.
+      renderPanel({
+        queriedConfig: promqlConfig(),
+        showGeneratedPromql: true,
+      });
+      await openGeneratedPromql();
+
+      expect(screen.getByTestId('chart-promql-preview')).toHaveTextContent(
+        EXPRESSION,
+      );
+    });
+
+    it('is enabled when the expression references none of the variables', () => {
+      // `[]` is a dashboard with variables, none of which this expression
+      // references.
+      renderPanel({
+        queriedConfig: promqlConfig({
+          promqlExpression: 'e2e_service_up',
+          variables: [],
+        }),
+        showGeneratedPromql: true,
+      });
+
+      expect(generatedPromqlControl()).toBeEnabled();
+    });
+
+    it('shows the expression with its variables expanded', async () => {
+      renderPanel({
+        queriedConfig: promqlConfig({
+          variables: [{ name: 'svc', values: ['api', 'web'] }],
+        }),
+        showGeneratedPromql: true,
+      });
+      await openGeneratedPromql();
+
+      // A regex alternation, promql's default format — the string that
+      // actually goes to Prometheus, not the template the input holds.
+      expect(screen.getByTestId('chart-promql-preview')).toHaveTextContent(
+        'e2e_service_up{service=~"(api|web)"}',
+      );
+    });
+
+    it('renders an empty selection as the match-everything regex', async () => {
+      renderPanel({
+        queriedConfig: promqlConfig({
+          variables: [{ name: 'svc', values: [] }],
+        }),
+        showGeneratedPromql: true,
+      });
+      await openGeneratedPromql();
+
+      expect(screen.getByTestId('chart-promql-preview')).toHaveTextContent(
+        'e2e_service_up{service=~".*"}',
+      );
+    });
+
+    it('is disabled when substitution throws', async () => {
+      // `json` is not a format substitution knows, so it raises rather than
+      // guessing. The query path raises on the same expression, so nothing
+      // ran — showing the template would claim an expression Prometheus never
+      // saw.
+      renderPanel({
+        queriedConfig: promqlConfig({
+          promqlExpression: 'up{service=~"${svc:json}"}',
+          variables: [{ name: 'svc', values: ['api'] }],
+        }),
+        showGeneratedPromql: true,
+      });
+
+      expect(generatedPromqlControl()).toBeDisabled();
+
+      const wrapper = generatedPromqlControl().parentElement;
+      expect(wrapper).not.toBeNull();
+      await userEvent.hover(wrapper!);
+
+      expect(
+        await screen.findByText(/Variables could not be expanded/),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('chart-promql-preview'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -23,7 +23,10 @@ import {
   TSource,
   validateAlertScheduleOffsetMinutes,
 } from '@hyperdx/common-utils/dist/types';
-import { filterReferencedVariables } from '@hyperdx/common-utils/dist/variables';
+import {
+  filterReferencedVariables,
+  substitutePromqlChartConfigVariables,
+} from '@hyperdx/common-utils/dist/variables';
 
 import {
   convertToCategoricalChartConfig,
@@ -165,6 +168,37 @@ export function resolvePreviewVariables({
   return hasAlert
     ? referenced.map(variable => ({ ...variable, values: [] }))
     : referenced;
+}
+
+/** A PromQL tile's substituted expression, or why there isn't one. */
+export type RenderedPromqlExpression =
+  | { expression: string; error?: never }
+  | { expression?: never; error: string };
+
+/** The expression a PromQL tile is queried with, with variables substituted. */
+export function buildRenderedPromqlExpression(
+  queriedConfig: ChartConfigWithDateRange | undefined,
+): RenderedPromqlExpression | undefined {
+  if (queriedConfig == null || !isPromqlChartConfig(queriedConfig)) {
+    return undefined;
+  }
+
+  try {
+    return {
+      expression:
+        substitutePromqlChartConfigVariables(queriedConfig).promqlExpression,
+    };
+  } catch (e) {
+    // Substitution throws on an unrecognized format such as `${svc:json}`. The
+    // query path substitutes the same way, so nothing reached Prometheus —
+    // showing the template here would claim an expression that never ran.
+    return {
+      error:
+        e instanceof Error
+          ? `Variables could not be expanded: ${e.message}`
+          : 'Variables could not be expanded.',
+    };
+  }
 }
 
 export function buildSampleEventsConfig(

--- a/packages/app/src/components/PreviewCopyButton.tsx
+++ b/packages/app/src/components/PreviewCopyButton.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import { Button } from '@mantine/core';
+import { IconCheck, IconCopy } from '@tabler/icons-react';
+
+/**
+ * The Copy/Copied! button the read-only query previews overlay on their
+ * top-right corner. Positioned absolutely, so it expects a positioned ancestor.
+ */
+export default function PreviewCopyButton({
+  text = '',
+  size = 'md',
+}: {
+  text?: string;
+  size?: 'xs' | 'md';
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const iconSize = size === 'xs' ? 14 : 16;
+  const buttonSize = size === 'xs' ? 'compact-xs' : 'sm';
+
+  return (
+    <CopyToClipboard text={text ?? ''} onCopy={() => setCopied(true)}>
+      <Button
+        variant={copied ? 'light' : 'default'}
+        size={buttonSize}
+        className="position-absolute top-0 end-0"
+      >
+        {copied ? (
+          <IconCheck size={iconSize} className="me-2" />
+        ) : (
+          <IconCopy size={iconSize} className="me-2" />
+        )}
+        {copied ? 'Copied!' : 'Copy'}
+      </Button>
+    </CopyToClipboard>
+  );
+}

--- a/packages/app/src/components/PromQLEditor/PromQLPreview.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLPreview.tsx
@@ -1,0 +1,47 @@
+import { Paper, useMantineColorScheme } from '@mantine/core';
+import { PromQLExtension } from '@prometheus-io/codemirror-promql';
+import CodeMirror, { EditorView } from '@uiw/react-codemirror';
+
+import PreviewCopyButton from '@/components/PreviewCopyButton';
+import { DEFAULT_CODE_MIRROR_BASIC_SETUP } from '@/components/SQLEditor/utils';
+
+// Highlighting only — this editor is never editable, so the extension's
+// completion sources never run and it needs none of `PromQLEditor`'s wiring.
+const promqlExtension = new PromQLExtension();
+
+/**
+ * A read-only view of a PromQL expression: the PromQL analogue of
+ * `SQLPreview`, used to show the expression after variable substitution.
+ */
+export default function PromQLPreview({
+  expression,
+  enableCopy = true,
+}: {
+  expression: string;
+  enableCopy?: boolean;
+}) {
+  const { colorScheme } = useMantineColorScheme();
+
+  return (
+    <Paper
+      flex="auto"
+      shadow="none"
+      radius="sm"
+      style={{ overflow: 'hidden' }}
+      p="xs"
+      data-testid="chart-promql-preview"
+    >
+      <div className="position-relative">
+        <CodeMirror
+          indentWithTab={false}
+          value={expression}
+          theme={colorScheme === 'dark' ? 'dark' : 'light'}
+          basicSetup={DEFAULT_CODE_MIRROR_BASIC_SETUP}
+          extensions={[promqlExtension.asExtension(), EditorView.lineWrapping]}
+          editable={false}
+        />
+        {enableCopy && <PreviewCopyButton text={expression} size="xs" />}
+      </div>
+    </Paper>
+  );
+}

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -429,8 +429,9 @@ export class ChartEditorComponent {
   /**
    * Replace the entire contents of the PromQL expression editor.
    *
-   * The same `.cm-editor` locator as the SQL template: PromQL mode renders one
-   * CodeMirror and no "Generated SQL" accordion, so `.first()` is that editor.
+   * The same `.cm-editor` locator as the SQL template, and `.first()` for the
+   * same reason: the expression input is above the preview panel, whose
+   * "Generated PromQL" accordion holds a second, read-only CodeMirror.
    */
   async replacePromqlExpression(expression: string) {
     const content = this.page.locator('.cm-editor .cm-content').first();
@@ -591,6 +592,54 @@ export class ChartEditorComponent {
    */
   async getGeneratedSqlText(): Promise<string> {
     const text = await this.generatedSqlContent().innerText();
+    return text.replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * Expand the "Generated PromQL" accordion in the preview panel, where a
+   * PromQL tile shows what "Generated SQL" shows for the other kinds. Safe to
+   * call when it is already open.
+   *
+   * Rendered off the *queried* config, like that one, so it only appears once
+   * the tile has been run.
+   */
+  async openGeneratedPromql() {
+    const control = this.generatedPromqlControl();
+    await control.waitFor({ state: 'visible', timeout: 10000 });
+    if ((await control.getAttribute('aria-expanded')) !== 'true') {
+      await control.click();
+    }
+    await this.generatedPromqlContent().waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  /**
+   * The "Generated PromQL" accordion's control. Present for the whole time the
+   * editor is in PromQL mode, and disabled until a PromQL query has run.
+   */
+  generatedPromqlControl(): Locator {
+    return this.page.getByRole('button', { name: 'Generated PromQL' });
+  }
+
+  /**
+   * CodeMirror content of the "Generated PromQL" preview.
+   *
+   * Its own test id rather than `.cm-editor` with an index: the editor page
+   * can hold several CodeMirror instances, and which ordinal this one takes
+   * depends on the mode the editor is in.
+   */
+  generatedPromqlContent(): Locator {
+    return this.page.getByTestId('chart-promql-preview').locator('.cm-content');
+  }
+
+  /**
+   * The generated PromQL as a single whitespace-collapsed line. Substitution is
+   * debounced by 300ms, so assert on it with `toPass` or an expect timeout.
+   */
+  async getGeneratedPromqlText(): Promise<string> {
+    const text = await this.generatedPromqlContent().innerText();
     return text.replace(/\s+/g, ' ').trim();
   }
 

--- a/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-filter-variables.spec.ts
@@ -531,5 +531,87 @@ test.describe(
         );
       });
     });
+
+    /**
+     * What the tile will actually query. Substitution happens client-side and
+     * the result is shipped to Prometheus as text, so the expression a user
+     * writes is never the one that runs — and a PromQL tile has no "Generated
+     * SQL" panel where the difference would otherwise show.
+     */
+    test('previews the expression that will be sent to Prometheus', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      const dashboardPage = new DashboardPage(page);
+      const editor = dashboardPage.chartEditor;
+
+      /**
+       * Type `expression` and query with it. The preview reads the *queried*
+       * config, exactly as the Generated SQL panel does, so an expression that
+       * has only been typed is not yet the one shown.
+       */
+      const queryWith = async (expression: string) => {
+        await editor.replacePromqlExpression(expression);
+        // The completion popup sits over the editor, where it would intercept
+        // the run click. (`dismissCompletion` is no use here: it clears the
+        // editor.)
+        await page
+          .locator('.cm-tooltip-autocomplete')
+          .waitFor({ state: 'hidden', timeout: 10000 });
+        // Not waiting on a rendered chart: an exact-match matcher below
+        // deliberately selects no series, so there is nothing to draw.
+        await editor.runQuery(false);
+      };
+
+      /** The panel repaints on its own schedule, so read it until it settles. */
+      const expectGeneratedPromql = async (expected: string) => {
+        await expect(async () => {
+          expect(await editor.getGeneratedPromqlText()).toBe(expected);
+        }).toPass({ timeout: 15000 });
+      };
+
+      await test.step('Select two services on a dashboard with a variable', async () => {
+        await createDashboardWithServiceVariable(dashboardPage);
+        // Chosen before the tile is opened: the editor covers the filter bar,
+        // so this is the only point at which the selection can be set.
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await dashboardPage.toggleFilterValue('Service', 'api-server');
+      });
+
+      await test.step('Before a run, the accordion says why it is empty', async () => {
+        await openPromqlTileEditor(dashboardPage);
+
+        // Offered from the moment the editor enters PromQL mode, so it doesn't
+        // read as a missing feature while there is nothing to show.
+        await expect(editor.generatedPromqlControl()).toBeDisabled();
+      });
+
+      await test.step('The preview expands the selection', async () => {
+        await queryWith(`${E2E_PROMQL_METRIC_NAME}{service=~"$svc"}`);
+
+        await editor.openGeneratedPromql();
+        await expectGeneratedPromql(
+          `${E2E_PROMQL_METRIC_NAME}{service=~"(accounting|api-server)"}`,
+        );
+      });
+
+      await test.step('The input still holds the template', async () => {
+        // The preview is a view of the query, not a rewrite of the expression:
+        // the tile is saved with the reference so it re-renders on every
+        // selection change.
+        expect(await editor.getPromqlEditorText()).toContain('$svc');
+        expect(await editor.getGeneratedPromqlText()).not.toContain('$svc');
+      });
+
+      await test.step('It follows the format the reference asks for', async () => {
+        // `csv` is the raw-interpolation form, so this is a preview of an
+        // exact-match matcher rather than the default regex alternation.
+        await queryWith(`${E2E_PROMQL_METRIC_NAME}{service="\${svc:csv}"}`);
+        await expectGeneratedPromql(
+          `${E2E_PROMQL_METRIC_NAME}{service="accounting,api-server"}`,
+        );
+      });
+    });
   },
 );


### PR DESCRIPTION
## Summary

This PR adds a preview panel to the promql chart editor, similar to the existing Generated SQL preview panel. This allows the user to see the PromQL with variables substituted.

This PR also includes a couple of refactors to share parts of the preview component / accordion with the SQL version. 

### Screenshots or video

<img width="1463" height="932" alt="Screenshot 2026-08-25 at 1 46 01 PM" src="https://github.com/user-attachments/assets/90eea1e5-f480-4bf0-8cda-797853bf11e8" />
<img width="1437" height="1136" alt="Screenshot 2026-08-25 at 1 46 17 PM" src="https://github.com/user-attachments/assets/e2bb3b03-99b6-42a0-9c89-151da1892de9" />
<img width="1459" height="862" alt="Screenshot 2026-08-25 at 1 46 10 PM" src="https://github.com/user-attachments/assets/ab6cf2fd-cef0-45ae-8248-45a8d3a67c84" />

### How to test

- Create a PromQL source, the default.metrics_ts timeseries table should exist after enabling promql
- Create a dashboard and add a variable that queries instance IDs `ResourceAttributes['service.instance.id']` from the metrics gauge table
- Create a promql tile that references a variable, eg. `http_client_duration_milliseconds_count{instance=~"$Instance"}`

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-4903
- Related PRs:
