### PR TITLE
docs(agents): tell agents to write concisely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,34 @@ before stopping.
    them). Use the shared helpers in
    `packages/api/src/utils/instrumentation.ts`. See
    [`agent_docs/observability.md`](agent_docs/observability.md).
+8. **Communication**: Be concise and straightforward - in chat, in code
+   comments, in commits, and in PR descriptions. See
+   [Communication style](#communication-style) below.
+
+## Communication style
+
+Write plainly. This applies to everything you produce: chat replies, code
+comments, commit messages, PR descriptions, and docs.
+
+- **Lead with the answer.** State the result first, then the detail that
+  supports it. No preamble, no restating the request back at the reader.
+- **Cut filler.** Drop hedges ("it seems like", "essentially", "basically"),
+  intensifiers ("very", "extremely", "quite"), and throat-clearing ("in order
+  to" → "to"). Prefer short concrete words over long abstract ones.
+- **Keep summaries short.** A handful of bullets or a short paragraph. Don't
+  recap what the diff already shows, and don't restate one point in three
+  different phrasings.
+- **No self-narration.** Skip the play-by-play of your own process, the options
+  you rejected, and the victory lap ("Perfect!", "All done!"). Report what
+  changed and what is still broken.
+- **Comments explain _why_, not _what_.** The code already says what it does.
+  Omit the comment when the line is self-evident; write one when a choice needs
+  justification — a workaround, a non-obvious constraint, a ClickHouse quirk. No
+  banner comments, no ASCII section dividers, and no `// increment the counter`
+  restatements. This applies to test bodies too: don't narrate each step of a
+  test that already reads top-to-bottom.
+- **Say it straight.** If something is broken, unverified, or skipped, say so in
+  one sentence. Don't soften bad news and don't oversell partial work.
 
 ## Running Tests
 


### PR DESCRIPTION
## Why

Agent-authored summaries and code comments run long in a way that costs reviewer time: markdown-table recaps of tests the diff already shows, preamble before the answer, and step-by-step comments narrating code that already reads top-to-bottom. AGENTS.md had nothing to say about how agents write, only about what they build.

## What

A new Key Principle 8 plus a `## Communication style` section — six rules covering chat replies, code comments, commit messages, and PR descriptions. The one that matters most in review: comments explain *why*, not *what*, and that applies to test bodies too.

## Why it's a section and not a one-liner

I A/B tested it before committing, because "add a style rule to AGENTS.md" is easy to do and hard to know worked. Three arms, identical prompt (implement a sliding-window `RetryBudget` class + Jest tests, then summarize for a reviewer), run headless in separate worktrees off the same commit:

| Arm | Final-summary words |
|---|---|
| Unmodified AGENTS.md | 154 |
| One-line "be concise" principle | 147 (−4%) |
| Principle + full section | 111 (**−28%**) |

n=6 per arm for control and the full section, n=3 for the one-liner. The one-liner is indistinguishable from no instruction — the minimal-arm outputs kept the same tables and the same "Two new files, no changes to existing code" preamble as the control.

That's the reason the section is specific rather than short: "be concise" is an adjective the model already believes it satisfies. Naming the concrete habits to drop is what changed behavior.

## Caveats, stated plainly

- Small n, one task, run on Sonnet. The prose-length effect replicated across two independent rounds; treat the exact percentage as directional.
- **Comment density is not a claim I can support.** An early round showed a large drop, but it didn't replicate — control averaged 6.7 comment lines in one round and 2.7 in the next, ranging 0–10 across six runs. Pooled it trends lower (4.7 → 1.8) but the variance swamps it.
- The "cut filler" and "no self-narration" bullets are **untested**. Headless mode returns only the final message, where the base system prompt already suppresses "Perfect!"/"All done!". Those rules target interactive multi-turn chatter this harness can't observe. They're included on judgment, not evidence.

No changeset: agent guidance, not a change to a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)