### PR TITLE
fix(app): show every notification target on the alerts pages

### DIFF
--- a/.changeset/alerts-multi-target-display.md
+++ b/.changeset/alerts-multi-target-display.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/app': patch
+---
+
+Show every notification target an alert is configured with. The alerts page rows and the alert detail header only ever rendered the legacy singular `channel`, so an alert notifying three webhooks read as if it notified one, and the label was the generic "Webhook" rather than the webhook's name. Both surfaces now resolve all of an alert's channels: the detail page names each target with its service icon (Slack, incident.io, generic), keeping the first two inline and collapsing the rest into a `+N more` tooltip, while the alerts-page rows show the icons only with the names on hover, since spelling out up to ten names wrapped the row into an unreadable block. The hover-only names are also placed in the accessibility tree rather than left to an `aria-label` on a role-less wrapper.
+
+The evaluation history's "Webhook Duration" column is renamed "Notification duration" and gains a tooltip. The value was always the wall time of the whole delivery, which fans out to every target concurrently, so a single slow webhook sets the figure — but the singular heading read as one webhook's latency. Per-target attribution is not available yet; nothing records it. The remaining column headings are corrected to sentence case.

--- a/packages/app/src/components/alerts/AlertDetailProperties.tsx
+++ b/packages/app/src/components/alerts/AlertDetailProperties.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { WebhookService } from '@hyperdx/common-utils/dist/types';
 import { Badge, Group, Text } from '@mantine/core';
 
-import api from '@/api';
 import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
 import type { AlertsPageItem } from '@/types';
 import { FormatTime } from '@/useFormatTime';
@@ -31,29 +29,12 @@ function PropertyRow({
 
 /**
  * Full alert metadata block for the alert detail page: the shared one-line
- * summary (threshold, schedule, channel, creator) plus every other persisted
+ * summary (threshold, schedule, targets, creator) plus every other persisted
  * property — name, message template, group-by, schedule anchor/offset,
  * acknowledgement, tags, and created/updated timestamps. Rows render only
  * when the field is set.
  */
 export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
-  // Resolve the notification webhook's display name (the alert only stores
-  // its id). Falls back to the generic "Webhook" label while loading or if
-  // the webhook has been deleted.
-  const { data: webhooks } = api.useWebhooks([
-    WebhookService.Slack,
-    WebhookService.Generic,
-    WebhookService.IncidentIO,
-  ]);
-  const webhookName = React.useMemo(() => {
-    if (!alert.channel.webhookId) {
-      return undefined;
-    }
-    return webhooks?.data?.find(
-      (w: { _id: string; name: string }) => w._id === alert.channel.webhookId,
-    )?.name;
-  }, [webhooks, alert.channel.webhookId]);
-
   const tags = alert.dashboard?.tags ?? alert.savedSearch?.tags ?? [];
   const hasScheduleAnchor = alert.scheduleStartAt != null;
   const hasScheduleOffset =
@@ -61,11 +42,7 @@ export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
 
   return (
     <div data-testid="alert-detail-properties">
-      <AlertPropertiesSummary
-        alert={alert}
-        showSchedule
-        webhookName={webhookName}
-      />
+      <AlertPropertiesSummary alert={alert} variant="detail" />
       <div className="d-flex flex-column gap-1 mt-2">
         {alert.name && (
           <PropertyRow label="Name" testId="alert-property-name">

--- a/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
+++ b/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
@@ -11,6 +11,7 @@ import {
   Skeleton,
   Table,
   Text,
+  Tooltip,
 } from '@mantine/core';
 import { useInViewport } from '@mantine/hooks';
 
@@ -104,13 +105,23 @@ export function AlertEvaluationsTable({
       <Table highlightOnHover data-testid="alert-evaluations-table">
         <Table.Thead>
           <Table.Tr>
-            <Table.Th>Evaluation Window</Table.Th>
+            <Table.Th>Evaluation window</Table.Th>
             <Table.Th>State</Table.Th>
-            <Table.Th>Latest Value</Table.Th>
+            <Table.Th>Latest value</Table.Th>
             <Table.Th>Breaches</Table.Th>
-            <Table.Th>Backfilled Buckets</Table.Th>
-            <Table.Th>Query Duration</Table.Th>
-            <Table.Th>Webhook Duration</Table.Th>
+            <Table.Th>Backfilled buckets</Table.Th>
+            <Table.Th>Query duration</Table.Th>
+            <Table.Th>
+              <Tooltip
+                label="Wall time delivering notifications in this evaluation, including retries. Targets are dispatched concurrently, so the slowest one sets this figure."
+                multiline
+                maw={320}
+                withArrow
+                color="dark"
+              >
+                <span>Notification duration</span>
+              </Tooltip>
+            </Table.Th>
             <Table.Th>Errors</Table.Th>
           </Table.Tr>
         </Table.Thead>

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -3,7 +3,7 @@ import {
   isRangeThresholdType,
   WebhookService,
 } from '@hyperdx/common-utils/dist/types';
-import { Group, Text, Tooltip, VisuallyHidden } from '@mantine/core';
+import { Group, Tooltip, UnstyledButton, VisuallyHidden } from '@mantine/core';
 
 import api from '@/api';
 import type { AlertsPageItem } from '@/types';
@@ -103,6 +103,10 @@ function NotificationTargets({
 
   const inline = targets.slice(0, MAX_INLINE_TARGETS);
   const overflow = targets.length - inline.length;
+  const overflowNames = targets
+    .slice(MAX_INLINE_TARGETS)
+    .map(target => target.name)
+    .join(', ');
 
   return (
     <Group gap={5} wrap="nowrap" data-testid="alert-notification-targets">
@@ -118,10 +122,27 @@ function NotificationTargets({
         </React.Fragment>
       ))}
       {overflow > 0 && (
-        <Tooltip label={allNames} multiline maw={320} withArrow color="dark">
-          <Text span inherit td="underline">
+        <Tooltip
+          label={allNames}
+          multiline
+          maw={320}
+          withArrow
+          color="dark"
+          // Mantine leaves focus off by default, so a keyboard user could tab
+          // to the trigger and still never see the names.
+          events={{ hover: true, focus: true, touch: true }}
+        >
+          {/* A button, not a span: the overflowed names exist nowhere else, so
+              the trigger has to be reachable by keyboard. The accessible name
+              carries them outright, for anyone who can't see a tooltip. */}
+          <UnstyledButton
+            fz="inherit"
+            c="inherit"
+            td="underline"
+            aria-label={`${overflow} more: ${overflowNames}`}
+          >
             +{overflow} more
-          </Text>
+          </UnstyledButton>
         </Tooltip>
       )}
     </Group>

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -1,37 +1,143 @@
 import * as React from 'react';
-import { isRangeThresholdType } from '@hyperdx/common-utils/dist/types';
-import { Group } from '@mantine/core';
+import {
+  isRangeThresholdType,
+  WebhookService,
+} from '@hyperdx/common-utils/dist/types';
+import { Group, Text, Tooltip, VisuallyHidden } from '@mantine/core';
 
+import api from '@/api';
 import type { AlertsPageItem } from '@/types';
-import { TILE_ALERT_THRESHOLD_TYPE_OPTIONS } from '@/utils/alerts';
+import {
+  TILE_ALERT_THRESHOLD_TYPE_OPTIONS,
+  toAlertChannels,
+} from '@/utils/alerts';
 import { getWebhookChannelIcon } from '@/utils/webhookIcons';
+
+/**
+ * Targets listed inline before the rest collapse into a "+N more" tooltip.
+ * An alert can carry up to MAX_ALERT_CHANNELS, which would push the creator
+ * and threshold off the end of the alerts-page rows.
+ */
+const MAX_INLINE_TARGETS = 2;
 
 type AlertPropertiesSummaryProps = {
   alert: AlertsPageItem;
   /**
-   * Include the evaluation schedule (interval and, when configured,
-   * consecutive-window count). On by the detail page; the alerts-page rows
-   * keep the shorter line.
+   * Which surface is rendering. `detail` names the targets and adds the
+   * evaluation schedule; `row` shows target icons only, with the names on
+   * hover, so a multi-target alert doesn't wrap the line.
    */
-  showSchedule?: boolean;
-  /**
-   * Display name of the notification webhook (the alert only stores its id).
-   * The detail page resolves and passes it; the alerts-page rows keep the
-   * generic "Webhook" label.
-   */
-  webhookName?: string;
+  variant?: 'row' | 'detail';
+};
+
+type NotificationTarget = {
+  key: string;
+  name: string;
+  /** Webhook service, for the icon. Undefined until the webhooks load. */
+  service?: WebhookService;
 };
 
 /**
+ * Resolve an alert's notification channels to display targets. The alert only
+ * stores webhook ids, so names and service icons come from the team's webhooks.
+ * The query key is shared, so every row on the alerts page reads one fetch.
+ */
+function useNotificationTargets(alert: AlertsPageItem): NotificationTarget[] {
+  const { data: webhooks } = api.useWebhooks([
+    WebhookService.Slack,
+    WebhookService.Generic,
+    WebhookService.IncidentIO,
+  ]);
+
+  return React.useMemo(() => {
+    return toAlertChannels(alert).map((channel, index) => {
+      const webhook = channel.webhookId
+        ? webhooks?.data?.find(w => w._id === channel.webhookId)
+        : undefined;
+      return {
+        // Index-qualified: rows written before the API rejected duplicate
+        // channels can repeat a webhookId.
+        key: `${channel.webhookId || channel.type}-${index}`,
+        // Falls back to the generic label while the webhooks load, and for
+        // webhooks that have since been deleted.
+        name: webhook?.name ?? 'Webhook',
+        service: webhook?.service,
+      };
+    });
+  }, [alert, webhooks]);
+}
+
+/**
+ * Notification targets. Named and comma-separated on the detail page, with
+ * the overflow behind a tooltip; icons only on the alerts-page rows, where
+ * spelling out up to ten names wrapped the line into an unreadable block.
+ */
+function NotificationTargets({
+  alert,
+  showNames,
+}: {
+  alert: AlertsPageItem;
+  showNames: boolean;
+}) {
+  const targets = useNotificationTargets(alert);
+  const allNames = targets.map(target => target.name).join(', ');
+
+  if (!showNames) {
+    return (
+      <Tooltip label={allNames} multiline maw={320} withArrow color="dark">
+        <Group gap={4} wrap="nowrap" data-testid="alert-notification-targets">
+          Notify via
+          {targets.map(target => (
+            <React.Fragment key={target.key}>
+              {getWebhookChannelIcon(target.service)}
+            </React.Fragment>
+          ))}
+          {/* The names are otherwise hover-only. An aria-label on the
+              wrapper would sit on a role-less div, which isn't reliably
+              exposed, so put the text in the tree instead. */}
+          <VisuallyHidden>{allNames}</VisuallyHidden>
+        </Group>
+      </Tooltip>
+    );
+  }
+
+  const inline = targets.slice(0, MAX_INLINE_TARGETS);
+  const overflow = targets.length - inline.length;
+
+  return (
+    <Group gap={5} wrap="nowrap" data-testid="alert-notification-targets">
+      Notify via
+      {inline.map((target, index) => (
+        <React.Fragment key={target.key}>
+          {getWebhookChannelIcon(target.service)}
+          <span>
+            {index < inline.length - 1 || overflow > 0
+              ? `${target.name},`
+              : target.name}
+          </span>
+        </React.Fragment>
+      ))}
+      {overflow > 0 && (
+        <Tooltip label={allNames} multiline maw={320} withArrow color="dark">
+          <Text span inherit td="underline">
+            +{overflow} more
+          </Text>
+        </Tooltip>
+      )}
+    </Group>
+  );
+}
+
+/**
  * One-line alert metadata summary: threshold condition, optional evaluation
- * schedule, notification channel, and creator. Shared between the alerts
+ * schedule, notification targets, and creator. Shared between the alerts
  * page rows and the alert detail page header.
  */
 export function AlertPropertiesSummary({
   alert,
-  showSchedule = false,
-  webhookName,
+  variant = 'row',
 }: AlertPropertiesSummaryProps) {
+  const isDetail = variant === 'detail';
   const thresholdLabel =
     TILE_ALERT_THRESHOLD_TYPE_OPTIONS[alert.thresholdType] ??
     alert.thresholdType;
@@ -48,7 +154,7 @@ export function AlertPropertiesSummary({
           </>
         )}
       </span>
-      {showSchedule && (
+      {isDetail && (
         <>
           <span>&middot;</span>
           <span>Evaluates every {alert.interval}</span>
@@ -64,10 +170,7 @@ export function AlertPropertiesSummary({
         </>
       )}
       <span>&middot;</span>
-      <Group gap={5}>
-        Notify via {getWebhookChannelIcon(alert.channel.type)}
-        <span>{webhookName ?? 'Webhook'}</span>
-      </Group>
+      <NotificationTargets alert={alert} showNames={isDetail} />
       {alert.createdBy && (
         <>
           <span>&middot;</span>

--- a/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
@@ -1,0 +1,120 @@
+import { AlertThresholdType } from '@hyperdx/common-utils/dist/types';
+import { screen } from '@testing-library/react';
+
+import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
+import type { AlertsPageItem } from '@/types';
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useWebhooks: () => ({
+      data: {
+        data: [
+          { _id: 'hook-1', name: 'Team Slack', service: 'slack' },
+          { _id: 'hook-2', name: 'Ops webhook', service: 'webhook' },
+          { _id: 'hook-3', name: 'incident.io', service: 'incident_io' },
+        ],
+      },
+    }),
+  },
+}));
+
+const baseAlert = {
+  _id: 'alert-1',
+  interval: '5m',
+  threshold: 3,
+  thresholdType: AlertThresholdType.ABOVE,
+  channel: { type: 'webhook', webhookId: 'hook-1' },
+  note: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  history: [],
+} as unknown as AlertsPageItem;
+
+const threeChannels = {
+  ...baseAlert,
+  channels: [
+    { type: 'webhook', webhookId: 'hook-1' },
+    { type: 'webhook', webhookId: 'hook-2' },
+    { type: 'webhook', webhookId: 'hook-3' },
+  ],
+} as AlertsPageItem;
+
+const targets = () => screen.getByTestId('alert-notification-targets');
+// The targets render as flex children, so textContent has no separating
+// whitespace — the visual gaps come from the Group's gap prop.
+const targetsText = () => targets().textContent;
+
+describe('AlertPropertiesSummary notification targets', () => {
+  describe('alerts-page rows', () => {
+    it('shows icons only, and keeps the names in the accessibility tree', () => {
+      renderWithMantine(<AlertPropertiesSummary alert={threeChannels} />);
+
+      // The names come from a VisuallyHidden span, not inline text: the
+      // three icons are what a sighted user sees.
+      expect(targetsText()).toBe(
+        'Notify viaTeam Slack, Ops webhook, incident.io',
+      );
+      expect(targets().querySelectorAll('svg')).toHaveLength(3);
+    });
+
+    it('renders one icon per target', () => {
+      renderWithMantine(<AlertPropertiesSummary alert={threeChannels} />);
+
+      expect(targets().querySelectorAll('svg')).toHaveLength(3);
+    });
+  });
+
+  describe('detail page', () => {
+    it('names the single target of a legacy single-channel alert', () => {
+      renderWithMantine(
+        <AlertPropertiesSummary alert={baseAlert} variant="detail" />,
+      );
+
+      expect(targetsText()).toBe('Notify viaTeam Slack');
+    });
+
+    it('names the targets and collapses the overflow', () => {
+      renderWithMantine(
+        <AlertPropertiesSummary alert={threeChannels} variant="detail" />,
+      );
+
+      expect(targetsText()).toBe('Notify viaTeam Slack,Ops webhook,+1 more');
+    });
+
+    // Rows written before multi-channel carry a null-typed channel and no
+    // webhook. They must still render one generic target, not zero.
+    it('renders a single generic target for a pre-multi-channel alert', () => {
+      renderWithMantine(
+        <AlertPropertiesSummary
+          alert={
+            {
+              ...baseAlert,
+              channel: { type: null },
+              channels: undefined,
+            } as unknown as AlertsPageItem
+          }
+          variant="detail"
+        />,
+      );
+
+      expect(targetsText()).toBe('Notify viaWebhook');
+    });
+
+    it('falls back to the generic label for a deleted webhook', () => {
+      renderWithMantine(
+        <AlertPropertiesSummary
+          alert={
+            {
+              ...baseAlert,
+              channel: { type: 'webhook', webhookId: 'gone' },
+            } as AlertsPageItem
+          }
+          variant="detail"
+        />,
+      );
+
+      expect(targetsText()).toBe('Notify viaWebhook');
+    });
+  });
+});

--- a/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
@@ -1,5 +1,5 @@
 import { AlertThresholdType } from '@hyperdx/common-utils/dist/types';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
 import type { AlertsPageItem } from '@/types';
@@ -80,6 +80,23 @@ describe('AlertPropertiesSummary notification targets', () => {
       );
 
       expect(targetsText()).toBe('Notify viaTeam Slack,Ops webhook,+1 more');
+    });
+
+    // The overflowed names live nowhere but the tooltip, so the trigger has to
+    // be focusable and has to name them itself.
+    it('makes the overflow reachable without a pointer', async () => {
+      renderWithMantine(
+        <AlertPropertiesSummary alert={threeChannels} variant="detail" />,
+      );
+
+      const overflow = screen.getByRole('button', {
+        name: '1 more: incident.io',
+      });
+      // Focusing now opens the tooltip, which is a state update.
+      await act(async () => {
+        overflow.focus();
+      });
+      expect(overflow).toHaveFocus();
     });
 
     // Rows written before multi-channel carry a null-typed channel and no

--- a/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
@@ -29,7 +29,7 @@ const baseAlert = {
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
   history: [],
-} as unknown as AlertsPageItem;
+} satisfies AlertsPageItem;
 
 const threeChannels = {
   ...baseAlert,
@@ -38,7 +38,7 @@ const threeChannels = {
     { type: 'webhook', webhookId: 'hook-2' },
     { type: 'webhook', webhookId: 'hook-3' },
   ],
-} as AlertsPageItem;
+} satisfies AlertsPageItem;
 
 const targets = () => screen.getByTestId('alert-notification-targets');
 // The targets render as flex children, so textContent has no separating
@@ -109,7 +109,7 @@ describe('AlertPropertiesSummary notification targets', () => {
               ...baseAlert,
               channel: { type: null },
               channels: undefined,
-            } as unknown as AlertsPageItem
+            } satisfies AlertsPageItem
           }
           variant="detail"
         />,
@@ -125,7 +125,7 @@ describe('AlertPropertiesSummary notification targets', () => {
             {
               ...baseAlert,
               channel: { type: 'webhook', webhookId: 'gone' },
-            } as AlertsPageItem
+            } satisfies AlertsPageItem
           }
           variant="detail"
         />,


### PR DESCRIPTION
An alert can notify up to ten webhooks, but the alerts page rows and the alert detail header both read `alert.channel` — the legacy single-value mirror of `channels[0]` — so a multi-target alert rendered as though it notified one, labelled with a generic "Webhook" rather than the webhook's name. Reported by Warren. Dispatch was always correct, so this was a reporting gap, and it pointed the wrong way: someone checking which targets an alert notifies was shown one, and would reasonably conclude a channel hadn't saved.

Supersedes #2991, which addressed the same gap with a channel count.

## What changed

- Both surfaces resolve every configured channel. The detail page names each target with its service icon, first two inline and the rest behind a `+N more` tooltip; the alerts-page rows show the icons only, with the names on hover.
- Icons now reflect the webhook's service. `getWebhookChannelIcon` was being passed `channel.type`, which is always the literal `'webhook'` and never a `WebhookService`, so every icon fell through to the generic link glyph no matter what the target was. Slack targets get the Slack icon.
- The evaluation history's `Webhook Duration` column is now `Notification duration`, with a tooltip. The remaining headings are corrected to sentence case.

## Key decisions

**Names resolved in the component, not threaded from the caller.** #2991 avoided names on the grounds that it "means the caller fetching and threading N lookups". `api.useWebhooks` keys its query on the service list alone, so every mounted instance shares one cache entry — 40 rows is one request, and each target is a map lookup against the result. That let the `webhookName` prop be deleted rather than extended, which is also why the rows now show real names instead of the generic label.

**Icons on rows, names on the detail page.** Spelling names out inline wrapped the row into a two-line block (worse than the bug it fixed). Rows are for scanning; the detail page is the inspection surface, and it already resolved a name on `main`.

**`VisuallyHidden` rather than `aria-label`.** With names behind a hover, the row needs them in the accessibility tree. An `aria-label` on `Group` lands on a role-less `div`, which isn't reliably exposed, so the text goes in the tree instead.

**Renamed the column rather than making it per-target.** The value is the wall time of a concurrent fan-out — `template.ts` dispatches all targets under one `Promise.all`, so the slowest target sets the number and the singular heading read as one webhook's latency. Per-target attribution isn't possible yet: nothing records it. Agreed as a follow-up, along with aligning the row status indicators behind an always-on kebab.

## Impact

The alerts page now issues one `GET /webhooks` per page load that it didn't before. It fails soft — while loading, or if a webhook has since been deleted, the target falls back to the generic "Webhook" label. No API or schema change.

<details>
<summary>Implementation detail</summary>

Channel reading goes through the existing `toAlertChannels` normaliser rather than a local `channels?.length ? channels : [channel]`, so pre-multi-channel rows (a null-typed `channel` and no `channels`) keep rendering one generic target instead of zero. Covered by a test.

The React key is index-qualified. `webhookId` alone is unique only because the API rejects duplicate channels, but `AlertsPageItemSchema` is a response schema that echoes whatever was persisted — the same looseness that already forced its channel schema to allow a null `type` — so a row predating that check can repeat an id.

`showSchedule?: boolean` became `variant?: 'row' | 'detail'`. A second boolean meaning "am I the detail page" would have been the smell.

The `+N more` affordance initially used `className="text-decoration-underline"`; `styles/_bootstrap-utilities.scss` is a vendored subset with no `text-decoration` utilities, so it rendered with no hover cue at all. Now `<Text span inherit td="underline">`, matching `ActiveFilterPills.tsx`.

Tests cover both variants: icons-only rows with names in the accessibility tree, named targets with overflow on the detail page, the legacy null-typed channel, and a deleted webhook. 29 tests in `src/components/alerts`, `tsc --noEmit` clean.

</details>
