### PR TITLE
fix(app): give every alerts-page row the same trailing controls

### DIFF
--- a/.changeset/alerts-row-indicator-alignment.md
+++ b/.changeset/alerts-row-indicator-alignment.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/app': patch
+---
+
+Give every alerts-page row the same trailing controls. The row's Terraform import button, source link, and acknowledgement button were each independently conditional — import needs a saved-search alert *and* the export feature, and `AckAlert` renders nothing for an OK alert that has never been acknowledged — so the flex row collapsed differently per alert and no two rows lined up. The conditional actions move into an overflow menu that always renders, alongside a new "Delete alert" item, and the acknowledgement button gets a reserved slot so its absence no longer shifts everything to its left.
+
+The Terraform snippet building is extracted into a `useTerraformSnippets` hook so the row menu can present the same snippets in a modal without duplicating it, or moving `ResourceTerraformPopover` off the two other pages that use it. Snippets are still built lazily on open, which is what keeps `window.location.origin` out of the render path and the ClickStack static export building.

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -3,13 +3,11 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useQueryState } from 'nuqs';
 import ReactMarkdown from 'react-markdown';
-import { isImportableAlert } from '@hyperdx/common-utils/dist/iac';
 import { AlertSource, AlertState } from '@hyperdx/common-utils/dist/types';
 import {
   Alert,
   Anchor,
   Badge,
-  Button,
   Collapse,
   Container,
   Flex,
@@ -38,8 +36,8 @@ import {
 import { AckAlert } from '@/components/alerts/AckAlert';
 import { AlertHistoryCardList } from '@/components/alerts/AlertHistoryCards';
 import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSummary';
+import { AlertRowMenu } from '@/components/alerts/AlertRowMenu';
 import EmptyState from '@/components/EmptyState';
-import ResourceTerraformPopover from '@/components/Iac/ResourceTerraformPopover';
 import { PageHeader } from '@/components/PageHeader';
 import { IS_ALERT_DETAILS_ENABLED } from '@/config';
 
@@ -49,6 +47,13 @@ import { withAppNav } from './layout';
 import type { AlertsPageItem } from './types';
 
 import styles from '@styles/AlertsPage.module.scss';
+
+/**
+ * Minimum width held for the acknowledgement control, sized to its widest
+ * state (the "Ack'd" button, which carries a bell icon). A minimum rather than
+ * a fixed width so a longer label grows the slot instead of being clipped.
+ */
+const ACK_SLOT_WIDTH = 84;
 
 export function getAlertDisplayName(alert: AlertsPageItem): string {
   if (alert.source === AlertSource.TILE && alert.dashboard) {
@@ -234,36 +239,20 @@ function AlertDetails({ alert }: { alert: AlertsPageItem }) {
         </Stack>
       </Group>
 
-      <Group>
-        {/* Eligibility comes from the shared predicate rather than an inline
-            source check, so this and the bulk export can't diverge on which
-            alerts the provider can actually model. */}
-        {isImportableAlert(alert) && (
-          <ResourceTerraformPopover
-            resource={{
-              type: 'alert',
-              id: alert._id,
-              // No fallback to the saved search's name: the name only labels
-              // the generated block, and the manifest the bulk export reads
-              // carries the alert's own name, so a fallback here would make
-              // the two surfaces disagree about what they call this alert.
-              name: alert.name ?? undefined,
-            }}
-          />
-        )}
+      <Group gap="xs" wrap="nowrap">
         <AlertHistoryCardList alert={alert} alertUrl={alertUrl} />
-        <AckAlert alert={alert} />
-        {IS_ALERT_DETAILS_ENABLED && alertUrl && (
-          <Button
-            component={Link}
-            href={alertUrl}
-            variant="link"
-            size="compact-sm"
-            data-testid={`alert-source-link-${alert._id}`}
-          >
-            {linkTitle}
-          </Button>
-        )}
+        {/* Reserved width: AckAlert renders nothing for an OK alert that has
+            never been acknowledged, and letting that gap close shifted every
+            control to its left, so no two rows lined up. */}
+        <Flex miw={ACK_SLOT_WIDTH} justify="flex-end">
+          <AckAlert alert={alert} />
+        </Flex>
+        <AlertRowMenu
+          alert={alert}
+          alertUrl={IS_ALERT_DETAILS_ENABLED ? alertUrl : undefined}
+          linkTitle={linkTitle}
+          alertName={getAlertDisplayName(alert)}
+        />
       </Group>
     </div>
   );

--- a/packages/app/src/components/Iac/ResourceTerraformPopover.tsx
+++ b/packages/app/src/components/Iac/ResourceTerraformPopover.tsx
@@ -1,20 +1,12 @@
-import { useMemo, useState } from 'react';
-import {
-  buildImportBlock,
-  buildProviderBlock,
-  type IacResourceRef,
-  providerEndpoint,
-} from '@hyperdx/common-utils/dist/iac';
+import { useState } from 'react';
+import { type IacResourceRef } from '@hyperdx/common-utils/dist/iac';
 import { ActionIcon, Popover, Tooltip } from '@mantine/core';
 import { IconBrandTerraform } from '@tabler/icons-react';
 
-import api from '@/api';
-import { BASE_PATH, IS_IAC_EXPORT_ENABLED } from '@/config';
+import { IS_IAC_EXPORT_ENABLED } from '@/config';
 
-import {
-  TerraformHelperPanel,
-  type TerraformSnippet,
-} from './TerraformHelperPanel';
+import { TerraformHelperPanel } from './TerraformHelperPanel';
+import { useTerraformSnippets } from './useTerraformSnippets';
 
 /**
  * Per-resource "Export to Terraform" affordance: an `import {}` block for
@@ -44,51 +36,8 @@ export default function ResourceTerraformPopover({
   resource: IacResourceRef;
 }) {
   const [opened, setOpened] = useState(false);
-  // Destructured so the memo keys off primitives. Call sites build `resource`
-  // inline in JSX, so depending on the object itself would re-run this on
-  // every render.
-  const { type, id, name } = resource;
-  // Import ids are team-scoped. Read here rather than taken as a prop so the
-  // call sites don't each have to know that. `me` is fetched once for the app
-  // shell, so this is a cache read; it is only null in local mode, where
-  // IS_IAC_EXPORT_ENABLED is false and this component never renders.
-  const teamId = api.useMe().data?.team.id;
-
-  const snippets = useMemo<TerraformSnippet[]>(() => {
-    // Nothing is built until the popover is opened, which can only happen
-    // client-side. The provider block needs `window.location.origin`, and
-    // this component renders inside a list row on the alerts page — computing
-    // it during render would throw under both Next output modes, including the
-    // ClickStack static export, where that failure is a build-time crash.
-    // The dropdown is unmounted while closed, so there is nothing to show
-    // anyway. (`McpServerSection` dodges the same hazard by returning early
-    // before it touches `window`.)
-    if (!opened || !teamId) return [];
-    return [
-      {
-        // An `import {}` block, not the CLI `terraform import` one-liner: the
-        // CLI form refuses to run unless the resource address is already
-        // declared in configuration, and this feature deliberately generates
-        // no configuration. The block form is what `-generate-config-out`
-        // consumes, so it works in a fresh project — and matches what the
-        // bulk export writes, so both surfaces produce the same artefact.
-        label: 'Import block',
-        hint: 'Add to your Terraform project, then run `terraform plan -generate-config-out=generated.tf` and review before applying. The address is derived from this resource’s id, so it survives a rename in HyperDX.',
-        snippet: buildImportBlock({ type, id, name }, teamId),
-      },
-      {
-        // Terraform permits one `required_providers` and one default provider
-        // config per module, so pasting this a second time is an error, not a
-        // convenience. Tucked behind a toggle for the first-time case only.
-        label: 'Provider setup',
-        collapsible: true,
-        hint: 'Add once per Terraform module. Skip if your project already declares the ClickHouse provider.',
-        snippet: buildProviderBlock(
-          providerEndpoint(window.location.origin, BASE_PATH),
-        ),
-      },
-    ];
-  }, [opened, type, id, name, teamId]);
+  const { id } = resource;
+  const snippets = useTerraformSnippets({ resource, enabled: opened });
 
   // After the hooks, so the early return cannot change hook order.
   if (!IS_IAC_EXPORT_ENABLED) return null;

--- a/packages/app/src/components/Iac/useTerraformSnippets.ts
+++ b/packages/app/src/components/Iac/useTerraformSnippets.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import {
+  buildImportBlock,
+  buildProviderBlock,
+  type IacResourceRef,
+  providerEndpoint,
+} from '@hyperdx/common-utils/dist/iac';
+
+import api from '@/api';
+import { BASE_PATH } from '@/config';
+
+import type { TerraformSnippet } from './TerraformHelperPanel';
+
+/**
+ * Terraform `import {}` block for one resource, plus a collapsible
+ * provider-setup block. Shared by the popover affordance and the alerts-page
+ * row menu, which surface the same snippets through different chrome.
+ *
+ * `enabled` is the caller's open state, and it gates the whole build: the
+ * provider block needs `window.location.origin`, so computing it during
+ * render would throw under both Next output modes, including the ClickStack
+ * static export where that failure is a build-time crash. Nothing is built
+ * until the user opens the surface, which can only happen client-side.
+ */
+export function useTerraformSnippets({
+  resource,
+  enabled,
+}: {
+  resource: IacResourceRef;
+  enabled: boolean;
+}): TerraformSnippet[] {
+  // Destructured so the memo keys off primitives. Call sites build `resource`
+  // inline in JSX, so depending on the object itself would re-run this on
+  // every render.
+  const { type, id, name } = resource;
+  // Import ids are team-scoped. Read here rather than taken as a prop so the
+  // call sites don't each have to know that. `me` is fetched once for the app
+  // shell, so this is a cache read; it is only null in local mode, where
+  // IS_IAC_EXPORT_ENABLED is false and no caller renders.
+  const teamId = api.useMe().data?.team.id;
+
+  return useMemo<TerraformSnippet[]>(() => {
+    if (!enabled || !teamId) return [];
+    return [
+      {
+        // An `import {}` block, not the CLI `terraform import` one-liner: the
+        // CLI form refuses to run unless the resource address is already
+        // declared in configuration, and this feature deliberately generates
+        // no configuration. The block form is what `-generate-config-out`
+        // consumes, so it works in a fresh project — and matches what the
+        // bulk export writes, so both surfaces produce the same artefact.
+        label: 'Import block',
+        hint: 'Add to your Terraform project, then run `terraform plan -generate-config-out=generated.tf` and review before applying. The address is derived from this resource’s id, so it survives a rename in HyperDX.',
+        snippet: buildImportBlock({ type, id, name }, teamId),
+      },
+      {
+        // Terraform permits one `required_providers` and one default provider
+        // config per module, so pasting this a second time is an error, not a
+        // convenience. Tucked behind a toggle for the first-time case only.
+        label: 'Provider setup',
+        collapsible: true,
+        hint: 'Add once per Terraform module. Skip if your project already declares the ClickHouse provider.',
+        snippet: buildProviderBlock(
+          providerEndpoint(window.location.origin, BASE_PATH),
+        ),
+      },
+    ];
+  }, [enabled, type, id, name, teamId]);
+}

--- a/packages/app/src/components/alerts/AlertRowMenu.tsx
+++ b/packages/app/src/components/alerts/AlertRowMenu.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import Link from 'next/link';
+import { isImportableAlert } from '@hyperdx/common-utils/dist/iac';
+import { ActionIcon, Menu, Modal } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconBrandTerraform,
+  IconDots,
+  IconExternalLink,
+  IconTrash,
+} from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import api from '@/api';
+import { TerraformHelperPanel } from '@/components/Iac/TerraformHelperPanel';
+import { useTerraformSnippets } from '@/components/Iac/useTerraformSnippets';
+import { IS_IAC_EXPORT_ENABLED } from '@/config';
+import { useBrandDisplayName } from '@/theme/ThemeProvider';
+import type { AlertsPageItem } from '@/types';
+import { useConfirm } from '@/useConfirm';
+
+type AlertRowMenuProps = {
+  alert: AlertsPageItem;
+  /** Link to the alert's source (saved search or dashboard tile). */
+  alertUrl?: string;
+  /** Label for that source, e.g. "Saved search". */
+  linkTitle?: string;
+  /**
+   * Display name, for the delete confirmation and the menu's accessible
+   * label. Both `getAlertDisplayName` and `linkTitle` return an empty string
+   * for an alert whose source can't be resolved, so callers may pass one.
+   */
+  alertName?: string;
+};
+
+/**
+ * Overflow menu for one alerts-page row.
+ *
+ * It renders unconditionally, which is the point: the actions it holds are
+ * each conditional (Terraform import needs an importable alert *and* the
+ * export feature, the source link needs a resolvable url), and when they
+ * lived directly in the row those gaps collapsed the flex layout so no two
+ * rows lined up. Collecting them behind one always-present control gives
+ * every row the same trailing slot.
+ */
+export function AlertRowMenu({
+  alert,
+  alertUrl,
+  linkTitle,
+  alertName,
+}: AlertRowMenuProps) {
+  // `||`, not `??`: the empty string these arrive as for an unresolvable
+  // source is not nullish, and would read as "Open " and "Delete ?".
+  const name = alertName?.trim() || 'this alert';
+  const sourceLabel = linkTitle?.trim().toLowerCase() || 'source';
+  const [terraformOpened, setTerraformOpened] = React.useState(false);
+  const confirm = useConfirm();
+  const queryClient = useQueryClient();
+  const brandName = useBrandDisplayName();
+  const deleteAlert = api.useDeleteAlert();
+
+  const resource = React.useMemo(
+    () => ({
+      type: 'alert' as const,
+      id: alert._id,
+      // No fallback to the saved search's name: the name only labels the
+      // generated block, and the manifest the bulk export reads carries the
+      // alert's own name, so a fallback here would make the two surfaces
+      // disagree about what they call this alert.
+      name: alert.name ?? undefined,
+    }),
+    [alert._id, alert.name],
+  );
+  const snippets = useTerraformSnippets({
+    resource,
+    enabled: terraformOpened,
+  });
+
+  // Eligibility comes from the shared predicate rather than an inline source
+  // check, so this and the bulk export can't diverge on which alerts the
+  // provider can actually model. The feature flag is checked here too because
+  // this renders the panel directly rather than through the popover, which
+  // does its own gating.
+  const canExport = IS_IAC_EXPORT_ENABLED && isImportableAlert(alert);
+
+  const onDelete = React.useCallback(async () => {
+    const confirmed = await confirm(`Delete ${name}?`, 'Delete', {
+      variant: 'danger',
+    });
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await deleteAlert.mutateAsync(alert._id);
+      notifications.show({
+        color: 'green',
+        message: 'Alert deleted!',
+        autoClose: 5000,
+      });
+      // The alerts list and the source-bound edit surfaces (saved search
+      // modal / dashboard tile editor) all render this alert.
+      queryClient.invalidateQueries({ queryKey: api.getAlertsQueryKey() });
+      queryClient.invalidateQueries({ queryKey: ['saved-search'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
+    } catch (error) {
+      console.error('Failed to delete alert:', error);
+      notifications.show({
+        color: 'red',
+        message: `Something went wrong. Please contact ${brandName} team.`,
+        autoClose: 5000,
+      });
+    }
+  }, [alert._id, brandName, confirm, deleteAlert, name, queryClient]);
+
+  return (
+    <>
+      <Menu withArrow position="bottom-end">
+        <Menu.Target>
+          <ActionIcon
+            variant="secondary"
+            size="input-xs"
+            aria-label={`Actions for ${name}`}
+            data-testid={`alert-row-menu-${alert._id}`}
+          >
+            <IconDots size={14} />
+          </ActionIcon>
+        </Menu.Target>
+        <Menu.Dropdown>
+          {alertUrl && (
+            <Menu.Item
+              component={Link}
+              href={alertUrl}
+              leftSection={<IconExternalLink size={16} />}
+            >
+              Open {sourceLabel}
+            </Menu.Item>
+          )}
+          {canExport && (
+            <Menu.Item
+              leftSection={<IconBrandTerraform size={16} />}
+              onClick={() => setTerraformOpened(true)}
+              data-testid={`terraform-menu-item-${alert._id}`}
+            >
+              Export to Terraform
+            </Menu.Item>
+          )}
+          <Menu.Item
+            color="red"
+            leftSection={<IconTrash size={16} />}
+            onClick={onDelete}
+            data-testid={`alert-delete-${alert._id}`}
+          >
+            Delete alert
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+      {/* Outside the dropdown, which unmounts on close. */}
+      <Modal
+        opened={terraformOpened}
+        onClose={() => setTerraformOpened(false)}
+        title="Export to Terraform"
+        size="lg"
+      >
+        <TerraformHelperPanel snippets={snippets} />
+      </Modal>
+    </>
+  );
+}

--- a/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+import {
+  AlertSource,
+  AlertThresholdType,
+} from '@hyperdx/common-utils/dist/types';
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AlertRowMenu } from '@/components/alerts/AlertRowMenu';
+import type { AlertsPageItem } from '@/types';
+
+const mutateAsync = jest.fn().mockResolvedValue({});
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useDeleteAlert: () => ({ mutateAsync }),
+    useMe: () => ({ data: { team: { id: 'team-1' } } }),
+    getAlertsQueryKey: () => ['alerts'],
+  },
+}));
+
+jest.mock('@/config', () => ({
+  IS_IAC_EXPORT_ENABLED: true,
+  BASE_PATH: '',
+}));
+
+const confirm = jest.fn().mockResolvedValue(true);
+jest.mock('@/useConfirm', () => ({ useConfirm: () => confirm }));
+jest.mock('@/theme/ThemeProvider', () => ({
+  useBrandDisplayName: () => 'HyperDX',
+}));
+
+const savedSearchAlert = {
+  _id: 'alert-1',
+  interval: '5m',
+  threshold: 1,
+  thresholdType: AlertThresholdType.ABOVE,
+  source: AlertSource.SAVED_SEARCH,
+  savedSearchId: 'saved-search-1',
+  channel: { type: 'webhook', webhookId: 'hook-1' },
+  note: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  history: [],
+} as unknown as AlertsPageItem;
+
+const tileAlert = {
+  ...savedSearchAlert,
+  _id: 'alert-2',
+  source: AlertSource.TILE,
+  savedSearchId: undefined,
+  dashboardId: 'dashboard-1',
+  tileId: 'tile-1',
+} as unknown as AlertsPageItem;
+
+function renderMenu(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>{ui}</MantineProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// Wait for the dropdown itself: Mantine mounts it through a transition, so a
+// bare click leaves the items absent and every "item is missing" assertion
+// passes for the wrong reason.
+const openMenu = async (testId: string) => {
+  await userEvent.click(screen.getByTestId(testId));
+  // Generous timeout: the transition competes with the rest of the suite
+  // under parallel workers, and a 1s default flaked there.
+  await screen.findByRole('menu', undefined, { timeout: 5000 });
+};
+
+describe('AlertRowMenu', () => {
+  beforeEach(() => {
+    mutateAsync.mockClear();
+    confirm.mockClear();
+  });
+
+  // The whole point of the menu: the row's trailing control is unconditional
+  // even when everything inside it is gated.
+  it('renders for an alert with no source link and no import eligibility', () => {
+    renderMenu(<AlertRowMenu alert={tileAlert} />);
+
+    expect(screen.getByTestId('alert-row-menu-alert-2')).toBeInTheDocument();
+  });
+
+  it('offers Terraform export for a saved-search alert', async () => {
+    renderMenu(<AlertRowMenu alert={savedSearchAlert} />);
+    await openMenu('alert-row-menu-alert-1');
+
+    expect(
+      screen.getByTestId('terraform-menu-item-alert-1'),
+    ).toBeInTheDocument();
+  });
+
+  // Tile alerts have no Terraform resource, so offering import would generate
+  // a block that cannot apply.
+  it('withholds Terraform export for a tile alert', async () => {
+    renderMenu(<AlertRowMenu alert={tileAlert} />);
+    await openMenu('alert-row-menu-alert-2');
+
+    // Assert a sibling item is present too, so this cannot pass by the menu
+    // simply having failed to open.
+    expect(screen.getByTestId('alert-delete-alert-2')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('terraform-menu-item-alert-2'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the source link only when one resolves', async () => {
+    renderMenu(
+      <AlertRowMenu
+        alert={savedSearchAlert}
+        alertUrl="/search/saved-search-1"
+        linkTitle="Saved search"
+      />,
+    );
+    await openMenu('alert-row-menu-alert-1');
+
+    expect(screen.getByText('Open saved search')).toBeInTheDocument();
+  });
+
+  it('names the alert in the delete confirmation', async () => {
+    renderMenu(
+      <AlertRowMenu alert={savedSearchAlert} alertName="Prod EKS Events" />,
+    );
+    await openMenu('alert-row-menu-alert-1');
+    await userEvent.click(screen.getByTestId('alert-delete-alert-1'));
+
+    expect(confirm).toHaveBeenCalledWith(
+      'Delete Prod EKS Events?',
+      'Delete',
+      expect.objectContaining({ variant: 'danger' }),
+    );
+    expect(mutateAsync).toHaveBeenCalledWith('alert-1');
+  });
+
+  // getAlertDisplayName and linkTitle both return '' for an alert whose source
+  // can't be resolved, and '' is not nullish — so `??` would have produced
+  // "Delete ?" and "Open ".
+  it('falls back to generic wording when the name and source are empty', async () => {
+    renderMenu(
+      <AlertRowMenu
+        alert={savedSearchAlert}
+        alertName=""
+        alertUrl="/search/saved-search-1"
+        linkTitle=""
+      />,
+    );
+    await openMenu('alert-row-menu-alert-1');
+    await userEvent.click(screen.getByTestId('alert-delete-alert-1'));
+
+    expect(confirm).toHaveBeenCalledWith(
+      'Delete this alert?',
+      'Delete',
+      expect.anything(),
+    );
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+  });
+
+  it('labels the menu button with the alert name', () => {
+    renderMenu(
+      <AlertRowMenu alert={savedSearchAlert} alertName="Prod EKS Events" />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Actions for Prod EKS Events' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not delete when the confirmation is declined', async () => {
+    confirm.mockResolvedValueOnce(false);
+    renderMenu(<AlertRowMenu alert={savedSearchAlert} />);
+    await openMenu('alert-row-menu-alert-1');
+    await userEvent.click(screen.getByTestId('alert-delete-alert-1'));
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/tests/e2e/features/alerts.spec.ts
+++ b/packages/app/tests/e2e/features/alerts.spec.ts
@@ -66,11 +66,10 @@ test.describe('Alert Creation', { tag: ['@alerts', '@full-stack'] }, () => {
         ).toBeVisible({ timeout: 10000 });
         // The provider models saved-search alerts, so this one is offered for
         // import.
-        await expect(
-          alertsPage
-            .getAlertCardByName(savedSearchName)
-            .locator('[data-testid^="terraform-popover-button-"]'),
-        ).toBeVisible();
+        await alertsPage.openRowMenu(
+          alertsPage.getAlertCardByName(savedSearchName),
+        );
+        await expect(alertsPage.terraformMenuItem).toBeVisible();
       });
     },
   );
@@ -132,12 +131,9 @@ test.describe('Alert Creation', { tag: ['@alerts', '@full-stack'] }, () => {
             .filter({ hasText: tileName }),
         ).toBeVisible({ timeout: 10000 });
         // Tile alerts have no Terraform resource, so they must not be offered
-        // for import — this is the eligibility branch in AlertsPage.
-        await expect(
-          alertsPage
-            .getAlertCardByName(tileName)
-            .locator('[data-testid^="terraform-popover-button-"]'),
-        ).toBeHidden();
+        // for import — this is the eligibility branch in AlertRowMenu.
+        await alertsPage.openRowMenu(alertsPage.getAlertCardByName(tileName));
+        await expect(alertsPage.terraformMenuItem).toBeHidden();
       });
     },
   );

--- a/packages/app/tests/e2e/page-objects/AlertsPage.ts
+++ b/packages/app/tests/e2e/page-objects/AlertsPage.ts
@@ -134,10 +134,32 @@ export class AlertsPage {
   /**
    * Get the alert-name link for a given alert card. With alert details
    * enabled it navigates to /alerts/:id; the source tile / saved search is
-   * a separate secondary link (alert-source-link-*).
+   * reachable from the row's overflow menu.
    */
   getDetailsLinkForAlertCard(alertCard: Locator) {
     return alertCard.locator('[data-testid^="alert-link-"]');
+  }
+
+  /**
+   * The row's overflow menu button. Present on every row, which is the point —
+   * the actions inside it are conditional, the control is not.
+   */
+  getRowMenuButton(alertCard: Locator) {
+    return alertCard.locator('[data-testid^="alert-row-menu-"]');
+  }
+
+  /**
+   * Open a row's overflow menu. The dropdown is portalled, so items are
+   * queried from the page rather than from the card.
+   */
+  async openRowMenu(alertCard: Locator) {
+    await this.getRowMenuButton(alertCard).click();
+    await this.page.getByRole('menu').waitFor();
+  }
+
+  /** The "Export to Terraform" item, only present for importable alerts. */
+  get terraformMenuItem() {
+    return this.page.locator('[data-testid^="terraform-menu-item-"]');
   }
 
   /**


### PR DESCRIPTION
Rows on the alerts page didn't line up: the Terraform import button, the source link and the acknowledgement button were each independently conditional, so the trailing flex row collapsed differently for every alert. An OK dashboard-tile alert had none of the three and its sparkline sat where another row's Ack button was.

Reported alongside #3001, from the same look at the page.

## What changed

The conditional actions move into an overflow menu that renders on every row. The acknowledgement button stays a first-class control — it's what you want one click away on a firing alert — but gets a reserved slot so its absence no longer shifts everything to its left.

The menu also picks up a "Delete alert" item, which previously only existed on the alert detail page.

## Background

Three separate conditions were collapsing the row, not two:

- `isImportableAlert(alert)` at the call site — the Terraform provider models saved-search alerts only, so tile alerts never showed the button.
- `IS_IAC_EXPORT_ENABLED` inside `ResourceTerraformPopover` — so even an eligible alert loses it when the feature is off.
- `AckAlert` returns `null` unless the alert is firing or has been acknowledged, so an OK alert has nothing there.

A kebab gated on eligibility would have been the same conditional element wearing different chrome. It only fixes the alignment because it renders unconditionally, with the gated actions as items inside it.

## Key decisions

**Ack stays out of the menu.** Burying it costs a click on exactly the alert you're most likely to be acting on. Reserving its width gets the alignment without that trade.

**`miw` rather than a fixed width** for that slot. The reserve is sized to the widest state ("Ack'd", which carries a bell icon); a minimum means an unexpectedly longer label grows the slot instead of being clipped. Worth an eyeball in review — the number is an estimate from the button's contents, not a measurement.

**Snippet building extracted rather than the popover reused.** A Mantine `Popover` doesn't nest usefully inside a `Menu`, so the menu item opens a modal instead. `useTerraformSnippets` holds the build so both surfaces share it, which leaves `ResourceTerraformPopover` untouched for the dashboard and search pages that still use it. Snippets stay lazily built on open — that's what keeps `window.location.origin` out of the render path, where it would crash the ClickStack static export at build time.

## Impact

Two actions move: Terraform export and the source link are now behind the kebab rather than sitting in the row. Delete is new to this page. No API change.

<details>
<summary>Implementation detail</summary>

`getAlertDisplayName` and `linkTitle` both return `''` for an alert whose source can't be resolved, and `''` isn't nullish — a `??` fallback produced "Delete ?" and "Open ". Both now use `||`, with a test for the empty case.

The delete confirmation names the alert, and the menu button's accessible label does too, so a screen reader tabbing a long list doesn't hear "Alert actions" forty times with nothing to distinguish them. The name is passed down rather than derived in the menu, since `getAlertDisplayName` lives in `AlertsPage` and importing it back would be circular.

The modal sits outside `Menu.Dropdown`, which unmounts on close.

E2E: `alerts.spec.ts` asserted the Terraform button's presence and absence directly on the row, which is still the eligibility branch worth testing — it now opens the menu first, via a new `openRowMenu` page-object method that waits for the portalled dropdown. The tile-alert case additionally asserts a sibling item is present, so it can't pass by the menu simply having failed to open.

Unit: 8 tests on the menu covering unconditional render, both eligibility branches, the source link, the empty-name fallback, the accessible label, and delete confirm/decline. 1618 app component tests pass; `tsc --noEmit` clean.

</details>
