### PR TITLE
fix: Expand variables prior to navigating to search page via drill-down

### DIFF
--- a/.changeset/expand-variables-in-drilldown-links.md
+++ b/.changeset/expand-variables-in-drilldown-links.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Expand variables prior to navigating to search page via drill-down

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -36,6 +36,7 @@ import {
   TMetricSource,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
+import { substituteChartConfigVariables } from '@hyperdx/common-utils/dist/variables';
 import { notifications } from '@mantine/notifications';
 
 import DateRangeIndicator from './components/charts/DateRangeIndicator';
@@ -1151,12 +1152,30 @@ export const convertV1ChartConfigToV2 = (
 };
 
 /**
+ * Expand a builder config's variable references, falling back to the config as
+ * written when one of them can't be expanded (a malformed reference, or a macro
+ * naming a variable the dashboard doesn't declare).
+ *
+ * Idempotent: the result carries `variables: undefined`, so expanding again at
+ * an inner layer is a no-op.
+ */
+export function expandVariablesOrLeaveRaw<
+  T extends Parameters<typeof substituteChartConfigVariables>[0],
+>(config: T): T {
+  try {
+    return substituteChartConfigVariables(config);
+  } catch {
+    return config;
+  }
+}
+
+/**
  * Build search URL for viewing events based on group-by values
  * Used by both chart clicks and table row clicks
  */
 export function buildEventsSearchUrl({
   source,
-  config,
+  config: rawConfig,
   dateRange,
   groupFilters,
   valueRangeFilter,
@@ -1170,6 +1189,13 @@ export function buildEventsSearchUrl({
   if (!source?.id) {
     return null;
   }
+
+  // The destination page has no variable machinery, so every expression must be
+  // final SQL/Lucene before it goes in the URL.
+  const config = expandVariablesOrLeaveRaw({
+    ...rawConfig,
+    whereLanguage: rawConfig.whereLanguage || 'lucene',
+  });
 
   const isMetricChart = isMetricChartConfig(config);
   if (isMetricChart) {
@@ -1328,7 +1354,7 @@ function extractGroupColumns(
 export function buildTableRowSearchUrl({
   row,
   source,
-  config,
+  config: rawConfig,
   dateRange,
 }: {
   row: Record<string, any>;
@@ -1339,6 +1365,10 @@ export function buildTableRowSearchUrl({
   if (!source?.id) {
     return null;
   }
+
+  // The row keys are result-set column names, so they're already expanded — the
+  // group-by expressions have to be expanded here to match them.
+  const config = expandVariablesOrLeaveRaw(rawConfig);
 
   // Extract group-by column names and build filters from row values
   const groupFilters: Array<{ column: string; value: any }> = [];

--- a/packages/app/src/ChartUtils.tsx
+++ b/packages/app/src/ChartUtils.tsx
@@ -1159,7 +1159,7 @@ export const convertV1ChartConfigToV2 = (
  * Idempotent: the result carries `variables: undefined`, so expanding again at
  * an inner layer is a no-op.
  */
-export function expandVariablesOrLeaveRaw<
+export function tryExpandConfigVariables<
   T extends Parameters<typeof substituteChartConfigVariables>[0],
 >(config: T): T {
   try {
@@ -1192,7 +1192,7 @@ export function buildEventsSearchUrl({
 
   // The destination page has no variable machinery, so every expression must be
   // final SQL/Lucene before it goes in the URL.
-  const config = expandVariablesOrLeaveRaw({
+  const config = tryExpandConfigVariables({
     ...rawConfig,
     whereLanguage: rawConfig.whereLanguage || 'lucene',
   });
@@ -1368,7 +1368,7 @@ export function buildTableRowSearchUrl({
 
   // The row keys are result-set column names, so they're already expanded — the
   // group-by expressions have to be expanded here to match them.
-  const config = expandVariablesOrLeaveRaw(rawConfig);
+  const config = tryExpandConfigVariables(rawConfig);
 
   // Extract group-by column names and build filters from row values
   const groupFilters: Array<{ column: string; value: any }> = [];

--- a/packages/app/src/__tests__/eventsSearchUrl.test.ts
+++ b/packages/app/src/__tests__/eventsSearchUrl.test.ts
@@ -1,0 +1,227 @@
+import {
+  BuilderChartConfigWithDateRange,
+  ChartVariable,
+  DisplayType,
+  SourceKind,
+  TLogSource,
+} from '@hyperdx/common-utils/dist/types';
+
+import { buildEventsSearchUrl, buildTableRowSearchUrl } from '@/ChartUtils';
+
+const dateRange: [Date, Date] = [
+  new Date('2026-01-01T00:00:00.000Z'),
+  new Date('2026-01-01T01:00:00.000Z'),
+];
+
+const logSource = {
+  id: 'logs',
+  name: 'Logs',
+  kind: SourceKind.Log,
+  connection: 'clickhouse',
+  from: { databaseName: 'default', tableName: 'otel_logs' },
+  timestampValueExpression: 'Timestamp',
+  defaultTableSelectExpression: 'Timestamp, Body',
+} satisfies TLogSource;
+
+const svc = (values: string[]): ChartVariable[] => [
+  { name: 'svc', expression: 'ServiceName', values },
+];
+
+const builderConfig = {
+  displayType: DisplayType.Line,
+  connection: 'clickhouse',
+  from: { databaseName: 'default', tableName: 'otel_logs' },
+  select: [
+    {
+      aggFn: 'count',
+      aggCondition: '',
+      aggConditionLanguage: 'lucene',
+      valueExpression: '',
+    },
+  ],
+  where: '',
+  whereLanguage: 'sql',
+  filters: [],
+  timestampValueExpression: 'Timestamp',
+  dateRange,
+} satisfies BuilderChartConfigWithDateRange;
+
+const searchParams = (url: string | null) => {
+  expect(url).not.toBeNull();
+  return new URL(url ?? '', 'http://localhost').searchParams;
+};
+
+const buildUrl = (
+  overrides: Partial<BuilderChartConfigWithDateRange>,
+  extra?: Parameters<typeof buildEventsSearchUrl>[0]['valueRangeFilter'],
+) =>
+  buildEventsSearchUrl({
+    source: logSource,
+    config: { ...builderConfig, ...overrides },
+    dateRange,
+    valueRangeFilter: extra,
+  });
+
+describe('buildEventsSearchUrl variable expansion', () => {
+  it('expands $__filter in a SQL where clause', () => {
+    const url = buildUrl({
+      where: '$__filter(ServiceName, $svc)',
+      variables: svc(['api']),
+    });
+
+    expect(searchParams(url).get('where')).toBe("(ServiceName IN ('api'))");
+    expect(url).not.toContain('$');
+  });
+
+  it('expands the one-argument $__filter form via the variable expression', () => {
+    expect(
+      searchParams(
+        buildUrl({
+          where: '$__filter($svc)',
+          variables: svc(['api']),
+        }),
+      ).get('where'),
+    ).toBe("(toString(ServiceName) IN ('api'))");
+  });
+
+  it('expands bare and braced references in a SQL where clause', () => {
+    expect(
+      searchParams(
+        buildUrl({
+          where: 'ServiceName IN ($svc)',
+          variables: svc(['api', 'web']),
+        }),
+      ).get('where'),
+    ).toBe("ServiceName IN ('api', 'web')");
+
+    expect(
+      searchParams(
+        buildUrl({
+          where: "hasAny(splitByChar(',', '${svc:csv}'), [ServiceName])",
+          variables: svc(['api', 'web']),
+        }),
+      ).get('where'),
+    ).toBe("hasAny(splitByChar(',', 'api,web'), [ServiceName])");
+  });
+
+  it('expands references in a Lucene where clause using the Lucene format', () => {
+    const params = searchParams(
+      buildUrl({
+        where: 'ServiceName:$svc',
+        whereLanguage: 'lucene',
+        variables: svc(['api', 'web']),
+      }),
+    );
+
+    expect(params.get('where')).toBe('ServiceName:("api" OR "web")');
+    expect(params.get('whereLanguage')).toBe('lucene');
+  });
+
+  it('emits the empty-selection form rather than dropping the predicate', () => {
+    expect(
+      searchParams(
+        buildUrl({
+          where: '$__filter(ServiceName, $svc)',
+          variables: svc([]),
+        }),
+      ).get('where'),
+    ).toBe("(1=1 /** no values selected for variable 'svc' */)");
+
+    expect(
+      searchParams(
+        buildUrl({
+          where: 'ServiceName:$svc',
+          whereLanguage: 'lucene',
+          variables: svc([]),
+        }),
+      ).get('where'),
+    ).toBe('ServiceName:("")');
+  });
+
+  it('expands a promoted single-series aggCondition in its own language', () => {
+    const sqlSeries = searchParams(
+      buildUrl({
+        select: [
+          {
+            ...builderConfig.select[0],
+            aggCondition: '$__filter(ServiceName, $svc)',
+            aggConditionLanguage: 'sql',
+          },
+        ],
+        variables: svc(['api']),
+      }),
+    );
+    expect(sqlSeries.get('where')).toBe("(ServiceName IN ('api'))");
+    expect(sqlSeries.get('whereLanguage')).toBe('sql');
+
+    const luceneSeries = searchParams(
+      buildUrl({
+        select: [
+          {
+            ...builderConfig.select[0],
+            aggCondition: 'ServiceName:$svc',
+            aggConditionLanguage: 'lucene',
+          },
+        ],
+        variables: svc(['api']),
+      }),
+    );
+    expect(luceneSeries.get('where')).toBe('ServiceName:("api")');
+    expect(luceneSeries.get('whereLanguage')).toBe('lucene');
+  });
+
+  it('leaves a config without variables untouched', () => {
+    expect(
+      buildUrl({ where: 'ServiceName = $svc', whereLanguage: 'sql' }),
+    ).toBe(
+      '/search?source=logs&where=ServiceName+%3D+%24svc&whereLanguage=sql&filters=%5B%5D&isLive=false&from=1767225600000&to=1767229200000',
+    );
+  });
+
+  it('falls back to the clause as written when expansion fails', () => {
+    expect(
+      searchParams(
+        buildUrl({
+          where: '$__filter(ServiceName, $nope)',
+          variables: svc(['api']),
+        }),
+      ).get('where'),
+    ).toBe('$__filter(ServiceName, $nope)');
+  });
+});
+
+describe('buildTableRowSearchUrl variable expansion', () => {
+  const tableConfig = {
+    ...builderConfig,
+    displayType: DisplayType.Table,
+    select: [
+      {
+        aggFn: 'avg' as const,
+        aggCondition: '',
+        aggConditionLanguage: 'lucene' as const,
+        valueExpression: '${durCol:csv}',
+      },
+    ],
+    groupBy: [{ valueExpression: '${groupCol:csv}' }],
+    variables: [
+      { name: 'groupCol', values: ['ServiceName'] },
+      { name: 'durCol', values: ['Duration'] },
+    ],
+  } satisfies BuilderChartConfigWithDateRange;
+
+  it('matches the expanded group-by column against the row key', () => {
+    const params = searchParams(
+      buildTableRowSearchUrl({
+        row: { ServiceName: 'api', 'avg(Duration)': 100 },
+        source: logSource,
+        config: tableConfig,
+        dateRange,
+      }),
+    );
+
+    expect(JSON.parse(params.get('filters') ?? '')).toEqual([
+      { type: 'sql', condition: "ServiceName IN ('api')" },
+      { type: 'sql', condition: 'Duration BETWEEN 95 AND 105' },
+    ]);
+  });
+});

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -23,16 +23,14 @@ import {
   TSource,
   validateAlertScheduleOffsetMinutes,
 } from '@hyperdx/common-utils/dist/types';
-import {
-  filterReferencedVariables,
-  substituteChartConfigVariables,
-} from '@hyperdx/common-utils/dist/variables';
+import { filterReferencedVariables } from '@hyperdx/common-utils/dist/variables';
 
 import {
   convertToCategoricalChartConfig,
   convertToNumberChartConfig,
   convertToTableChartConfig,
   convertToTimeChartConfig,
+  expandVariablesOrLeaveRaw,
 } from '@/ChartUtils';
 import { ChartEditorFormState } from '@/components/ChartEditor/types';
 import { getFirstTimestampValueExpression } from '@/source';
@@ -168,21 +166,6 @@ export function resolvePreviewVariables({
   return hasAlert
     ? referenced.map(variable => ({ ...variable, values: [] }))
     : referenced;
-}
-
-/**
- * Expand a builder config's variable references, falling back to the config as
- * written when one of them can't be expanded (a malformed reference, or a macro
- * naming a variable the dashboard doesn't declare).
- */
-function expandVariablesOrLeaveRaw<
-  T extends Parameters<typeof substituteChartConfigVariables>[0],
->(config: T): T {
-  try {
-    return substituteChartConfigVariables(config);
-  } catch {
-    return config;
-  }
 }
 
 export function buildSampleEventsConfig(

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -30,7 +30,7 @@ import {
   convertToNumberChartConfig,
   convertToTableChartConfig,
   convertToTimeChartConfig,
-  expandVariablesOrLeaveRaw,
+  tryExpandConfigVariables,
 } from '@/ChartUtils';
 import { ChartEditorFormState } from '@/components/ChartEditor/types';
 import { getFirstTimestampValueExpression } from '@/source';
@@ -186,7 +186,7 @@ export function buildSampleEventsConfig(
   // The series' agg conditions become `filters` below, and `filters` is
   // deliberately not scanned for variable references. So expand the variables
   // here, building the filters in the sample events config below.
-  const config = expandVariablesOrLeaveRaw(queriedConfig);
+  const config = tryExpandConfigVariables(queriedConfig);
 
   return {
     ...config,

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -31,10 +31,10 @@ import {
   buildEventsSearchUrl,
   ChartKeyJoiner,
   convertToTimeChartConfig,
-  expandVariablesOrLeaveRaw,
   formatResponseForTimeChart,
   getPreviousDateRange,
   shouldFillNullsWithZero,
+  tryExpandConfigVariables,
   useTimeChartSettings,
 } from '@/ChartUtils';
 import { ChartAnnotation } from '@/components/charts/chartAnnotations';
@@ -723,7 +723,7 @@ function DBTimeChartComponent({
       // and handed to buildEventsSearchUrl must be final SQL/Lucene.
       // `whereLanguage` is pinned to buildEventsSearchUrl's default first, since
       // expansion below leaves nothing for it to expand.
-      const expandedConfig = expandVariablesOrLeaveRaw({
+      const expandedConfig = tryExpandConfigVariables({
         ...config,
         whereLanguage: config.whereLanguage || 'lucene',
       });

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -31,6 +31,7 @@ import {
   buildEventsSearchUrl,
   ChartKeyJoiner,
   convertToTimeChartConfig,
+  expandVariablesOrLeaveRaw,
   formatResponseForTimeChart,
   getPreviousDateRange,
   shouldFillNullsWithZero,
@@ -718,6 +719,15 @@ function DBTimeChartComponent({
         return null;
       }
 
+      // The search page has no variable machinery, so the expressions read here
+      // and handed to buildEventsSearchUrl must be final SQL/Lucene.
+      // `whereLanguage` is pinned to buildEventsSearchUrl's default first, since
+      // expansion below leaves nothing for it to expand.
+      const expandedConfig = expandVariablesOrLeaveRaw({
+        ...config,
+        whereLanguage: config.whereLanguage || 'lucene',
+      });
+
       // Parse the series key to extract group values
       const seriesKeys = seriesKey?.split(ChartKeyJoiner);
       const groupFilters = decodeSeriesGroupFilters({
@@ -739,23 +749,26 @@ function DBTimeChartComponent({
       // `select` — skip the value-range filter rather than misattributing a
       // formula value to an operand's expression. (With operands shown, the
       // operand columns still map by index and formula columns fall past the
-      // `< config.select.length` bound below.)
+      // `< expandedConfig.select.length` bound below.)
       const operandsHidden =
-        isBuilderChartConfig(config) &&
-        (config.formulas?.length ?? 0) > 0 &&
-        config.showOperandSeries === false;
+        isBuilderChartConfig(expandedConfig) &&
+        (expandedConfig.formulas?.length ?? 0) > 0 &&
+        expandedConfig.showOperandSeries === false;
 
       if (
         seriesValue &&
         !operandsHidden &&
-        Array.isArray(config.select) &&
-        config.select.length > 0
+        Array.isArray(expandedConfig.select) &&
+        expandedConfig.select.length > 0
       ) {
         // Determine which value column to filter on
         let valueExpression: string | undefined;
 
-        if ((isSingleValueColumn ?? true) && config.select.length === 1) {
-          const firstSelect = config.select[0];
+        if (
+          (isSingleValueColumn ?? true) &&
+          expandedConfig.select.length === 1
+        ) {
+          const firstSelect = expandedConfig.select[0];
           const aggFn =
             typeof firstSelect === 'string' ? undefined : firstSelect.aggFn;
           // Only add value range filter if the aggregation is attributable
@@ -777,9 +790,9 @@ function DBTimeChartComponent({
           if (
             valueColumnIndex != null &&
             valueColumnIndex >= 0 &&
-            valueColumnIndex < config.select.length
+            valueColumnIndex < expandedConfig.select.length
           ) {
-            const selectItem = config.select[valueColumnIndex];
+            const selectItem = expandedConfig.select[valueColumnIndex];
             const aggFn =
               typeof selectItem === 'string' ? undefined : selectItem.aggFn;
             // Only add value range filter if the aggregation is attributable
@@ -811,7 +824,7 @@ function DBTimeChartComponent({
 
       return buildEventsSearchUrl({
         source,
-        config,
+        config: expandedConfig,
         dateRange: [from, to],
         groupFilters,
         valueRangeFilter,

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -4,6 +4,7 @@ import { Locator } from '@playwright/test';
 import { AlertsPage } from '../page-objects/AlertsPage';
 import { DashboardPage } from '../page-objects/DashboardPage';
 import { DashboardsListPage } from '../page-objects/DashboardsListPage';
+import { SearchPage } from '../page-objects/SearchPage';
 import { getApiUrl, getSources } from '../utils/api-helpers';
 import { expect, test } from '../utils/base-test';
 import {
@@ -2148,6 +2149,96 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
           await expect(
             tile.getByTitle('accounting', { exact: true }),
           ).toBeVisible();
+        });
+      },
+    );
+
+    test(
+      'expands variables in the chart drilldown search link',
+      { tag: '@full-stack' },
+      async () => {
+        test.setTimeout(90000);
+        const chartName = `E2E Builder Drilldown Tile ${Date.now()}`;
+
+        await test.step('Create a dashboard with a selected variable value', async () => {
+          await dashboardPage.createNewDashboard();
+          await addServiceVariable();
+          await dashboardPage.clickFilterOption('Service', 'accounting');
+          await dashboardPage.page.keyboard.press('Escape');
+          // The drilldown searches the clicked bucket only. Auto granularity
+          // over the default hour gives one-minute buckets, and the seeded logs
+          // put an `accounting` row down roughly every 3.6 minutes — so most
+          // buckets are legitimately empty and the search below would have
+          // nothing to show. A 30-minute bucket always holds several.
+          await dashboardPage.changeGranularity('30 Minutes Granularity');
+        });
+
+        await test.step('Save a builder line tile whose WHERE uses $__filter', async () => {
+          await dashboardPage.addTile();
+          await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+          await dashboardPage.chartEditor.waitForDataToLoad();
+          await dashboardPage.chartEditor.setChartType(DisplayType.Line);
+          await dashboardPage.chartEditor.setChartName(chartName);
+          await dashboardPage.chartEditor.selectSource(
+            DEFAULT_LOGS_SOURCE_NAME,
+          );
+          await dashboardPage.chartEditor.setSqlWhere(
+            '$__filter(ServiceName, $svc)',
+          );
+          await dashboardPage.chartEditor.runQuery();
+          await dashboardPage.saveTile();
+        });
+
+        const link = dashboardPage.page.getByTestId('chart-view-events-link');
+
+        await test.step('Pin the tooltip and read the View All Events link', async () => {
+          const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+          const chart = tile.locator('.recharts-responsive-container');
+          await expect(chart).toBeVisible({ timeout: 30000 });
+
+          // Recharts only pins on a click that lands on a bucket, so the click
+          // itself is part of what gets retried.
+          await expect(async () => {
+            await chart.click();
+            await expect(link).toBeVisible({ timeout: 2000 });
+          }).toPass({ timeout: 30000 });
+
+          const href = (await link.getAttribute('href')) ?? '';
+          const params = new URL(href, 'http://localhost').searchParams;
+          expect(params.get('where')).toBe("(ServiceName IN ('accounting'))");
+          expect(decodeURIComponent(href)).not.toContain('$svc');
+        });
+
+        await test.step('Following the link searches on the expanded predicate', async () => {
+          // The href assertion above only proves what was written. Following it
+          // is what proves the expansion is SQL the search page can actually
+          // run — an unexpanded `$__filter(...)` reaches ClickHouse verbatim
+          // and errors, because the destination has no variable machinery.
+          const popupPromise = dashboardPage.page.waitForEvent('popup');
+          await link.click();
+          const searchTab = await popupPromise;
+          const searchPage = new SearchPage(searchTab);
+
+          await expect(searchTab).toHaveURL(/\/search\?/, { timeout: 15000 });
+          expect(new URL(searchTab.url()).searchParams.get('where')).toBe(
+            "(ServiceName IN ('accounting'))",
+          );
+
+          await expect(searchPage.table.firstRow).toBeVisible({
+            timeout: 30000,
+          });
+          await expect(searchTab.getByTestId('chart-error-state')).toHaveCount(
+            0,
+          );
+
+          // ServiceName is a column of the E2E Logs default select, so every
+          // rendered row names its service.
+          const rowTexts = await searchPage.table.getRows().allInnerTexts();
+          expect(rowTexts.filter(text => !text.includes('accounting'))).toEqual(
+            [],
+          );
+
+          await searchTab.close();
         });
       },
     );


### PR DESCRIPTION
## Summary

This PR ensures that variables and macros are expanded prior to generating a drill-down link to the search page (in dashboard tables and line charts). The search page does not support variables, so variables cannot be sent to the search page.

Macros are expanded to `(1=1)` when the variable has no selected value, as they are in other cases. This is a little ugly in the search page WHERE input, but is necessary to ensure queries remain valid (eg. `ServiceName = 'a' AND $__filter(ServiceName)` cannot become `ServiceName = 'a' AND`).

### Screenshots or video

Table row passes series level filter to search page:

<img width="1530" height="1073" alt="Screenshot 2026-08-26 at 12 36 29 PM" src="https://github.com/user-attachments/assets/bf14964d-3564-4942-96a9-d469b37bbfe7" />
<img width="1597" height="104" alt="Screenshot 2026-08-26 at 12 36 46 PM" src="https://github.com/user-attachments/assets/e051b9fb-f7b8-4a78-abfb-8bc4101b3c9e" />


### How to test on Vercel preview

- Create a dashboard and add a variable or two
- Create some charts that reference the variable(s)
- Click "View All Events" on the time chart tooltip or click a table row to navigate to the search page

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5168
- Related PRs:
