### PR TITLE
feat: add reverse span links, show span link detail

### DIFF
--- a/.changeset/reverse-span-links.md
+++ b/.changeset/reverse-span-links.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': minor
+---
+
+Show reverse span links and resolved span-link details in the span detail Overview panel.

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -7,6 +7,7 @@ import { Accordion, Box, Flex, Text } from '@mantine/core';
 import { WithClause } from '@/hooks/useRowWhere';
 import { getEventBody } from '@/source';
 import { getHighlightedAttributesFromData } from '@/utils/highlightedAttributes';
+import { resolveRowTimestampAnchor } from '@/utils/rowTimestamps';
 
 import {
   getJSONColumnNames,
@@ -18,8 +19,10 @@ import { RowSidePanelContext } from './DBRowSidePanel';
 import DBRowSidePanelHeader from './DBRowSidePanelHeader';
 import EventTag from './EventTag';
 import { ExceptionSubpanel } from './ExceptionSubpanel';
+import { useLinkedSpanDetails, useReverseSpanLinks } from './linkedSpans';
 import { NetworkPropertySubpanel } from './NetworkPropertyPanel';
 import { SpanEventsSubpanel } from './SpanEventsSubpanel';
+import { SpanLinkedFromSubpanel } from './SpanLinkedFromSubpanel';
 import { getValidSpanLinks, SpanLinksSubpanel } from './SpanLinksSubpanel';
 
 const EMPTY_OBJ = {};
@@ -191,9 +194,37 @@ export function RowOverviewPanel({
     );
   }, [firstRow?.__hdx_span_events]);
 
-  const hasSpanLinks = useMemo(() => {
-    return getValidSpanLinks(firstRow?.__hdx_span_links).length > 0;
+  const validSpanLinks = useMemo(() => {
+    return getValidSpanLinks(firstRow?.__hdx_span_links);
   }, [firstRow?.__hdx_span_links]);
+  const hasSpanLinks = validSpanLinks.length > 0;
+
+  const rowMeta = data?.meta;
+  const linkAnchorDate = useMemo(
+    () =>
+      resolveRowTimestampAnchor({
+        timestampValueExpression: source.timestampValueExpression,
+        row: firstRow,
+        meta: rowMeta,
+      }),
+    [source.timestampValueExpression, firstRow, rowMeta],
+  );
+
+  const rowTraceId = firstRow?.__hdx_trace_id;
+  const rowSpanId = firstRow?.__hdx_span_id;
+
+  const { links: reverseSpanLinks } = useReverseSpanLinks({
+    source,
+    traceId: typeof rowTraceId === 'string' ? rowTraceId : undefined,
+    spanId: typeof rowSpanId === 'string' ? rowSpanId : undefined,
+    anchorDate: linkAnchorDate,
+  });
+
+  const { details: linkedSpanDetails } = useLinkedSpanDetails({
+    source,
+    links: validSpanLinks,
+    anchorDate: linkAnchorDate,
+  });
 
   const mainContentColumn = getEventBody(source);
   const mainContent = isString(firstRow?.['__hdx_body'])
@@ -226,6 +257,7 @@ export function RowOverviewPanel({
           'exception',
           'spanEvents',
           'spanLinks',
+          'linkedFrom',
           'network',
           'resourceAttributes',
           'eventAttributes',
@@ -328,14 +360,33 @@ export function RowOverviewPanel({
         {hasSpanLinks && (
           <Accordion.Item value="spanLinks">
             <Accordion.Control>
-              <Text size="sm" ps="md">
+              <Text size="sm" ps={contentPx}>
                 Span Links
               </Text>
             </Accordion.Control>
             <Accordion.Panel>
-              <Box px="md">
+              <Box ps={contentPx}>
                 <SpanLinksSubpanel
                   spanLinks={firstRow?.__hdx_span_links}
+                  linkedSpanDetails={linkedSpanDetails}
+                  onOpenTrace={onOpenLinkedTrace}
+                />
+              </Box>
+            </Accordion.Panel>
+          </Accordion.Item>
+        )}
+
+        {reverseSpanLinks.length > 0 && (
+          <Accordion.Item value="linkedFrom">
+            <Accordion.Control>
+              <Text size="sm" ps={contentPx}>
+                Linked from
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Box ps={contentPx}>
+                <SpanLinkedFromSubpanel
+                  links={reverseSpanLinks}
                   onOpenTrace={onOpenLinkedTrace}
                 />
               </Box>

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -625,6 +625,20 @@ export const DBRowSidePanelInner = ({
         ]),
         SqlString.format('?=?', [SqlString.raw(spanIdExpression), link.SpanId]),
       ].join(' AND ');
+      // A link often points right back at the row one level up (forward and
+      // reverse span links come in pairs). Pop back to that breadcrumb instead
+      // of pushing an endless A <-> B trail. Only when no nav drilldown sits
+      // on top: popOne would pop the nav entry, not the source frame.
+      const topFrame =
+        sourceStack.length > 0 ? sourceStack[sourceStack.length - 1] : null;
+      if (
+        navStack.length === 0 &&
+        topFrame?.originRowId != null &&
+        topFrame.originRowId === rowId
+      ) {
+        popOne();
+        return;
+      }
       // Mark this frame so its breadcrumb switches from the `Trace <id>`
       // fallback below to the landed span name once the row loads.
       spanLinkFrameRowIdsRef.current.add(rowId);
@@ -634,6 +648,10 @@ export const DBRowSidePanelInner = ({
         label: `Trace ${link.TraceId.slice(0, 8)}`,
         sourceKind: traceSourceData.kind as SourceKind,
         aliasWith: [],
+        // The current row's canonical trace/span row id: the exact string a
+        // link hop targeting this row would compute, so the pop-back check
+        // above can compare by equality.
+        originRowId: traceSpanRowId,
       });
     },
     [
@@ -641,6 +659,10 @@ export const DBRowSidePanelInner = ({
       traceIdExpression,
       spanIdExpression,
       handleSourceStackPush,
+      sourceStack,
+      navStack,
+      popOne,
+      traceSpanRowId,
     ],
   );
 

--- a/packages/app/src/components/DBRowSidePanel.types.ts
+++ b/packages/app/src/components/DBRowSidePanel.types.ts
@@ -38,6 +38,12 @@ const SourceFrameSchema = z.object({
    * trace) leave it unset.
    */
   focusTimestamp: z.string().optional(),
+  /**
+   * Row id of the row displayed when this frame was pushed, in the same
+   * canonical form a navigation back to that row would use. Rows one hop
+   * apart somtimes reference each other (e.g. span links).
+   */
+  originRowId: z.string().optional(),
 });
 
 export type SourceFrame = z.infer<typeof SourceFrameSchema>;

--- a/packages/app/src/components/SpanLinkedFromSubpanel.tsx
+++ b/packages/app/src/components/SpanLinkedFromSubpanel.tsx
@@ -1,0 +1,130 @@
+import { ErrorBoundary } from 'react-error-boundary';
+import { Anchor, Button, Stack, Tooltip } from '@mantine/core';
+import {
+  IconArrowUpRight,
+  IconChevronDown,
+  IconChevronUp,
+} from '@tabler/icons-react';
+
+import { SectionWrapper, useShowMoreRows } from './ExceptionSubpanel';
+import {
+  LinkedSpanDetails,
+  linkedSpanKey,
+  LinkedSpanMetaLine,
+} from './linkedSpans';
+import { SpanLinkData } from './SpanLinksSubpanel';
+
+function LinkedSpanRow({
+  link,
+  onOpenTrace,
+}: {
+  link: LinkedSpanDetails;
+  onOpenTrace?: (link: SpanLinkData) => void;
+}) {
+  return (
+    <Stack gap={4}>
+      <Tooltip
+        withArrow
+        position="top"
+        maw={420}
+        multiline
+        label={
+          <div className="font-monospace" style={{ fontSize: 11 }}>
+            <div style={{ wordBreak: 'break-all' }}>Trace: {link.TraceId}</div>
+            <div style={{ wordBreak: 'break-all' }}>Span: {link.SpanId}</div>
+          </div>
+        }
+      >
+        <Anchor
+          component="button"
+          type="button"
+          data-testid="linked-from-open-span"
+          onClick={() =>
+            onOpenTrace?.({
+              TraceId: link.TraceId,
+              SpanId: link.SpanId,
+              TraceState: '',
+              Attributes: {},
+            })
+          }
+          size="sm"
+          fw={500}
+          className="d-inline-flex align-items-center"
+        >
+          <IconArrowUpRight size={14} className="me-1" />
+          {link.spanName || 'Open span'}
+        </Anchor>
+      </Tooltip>
+      <LinkedSpanMetaLine details={link} />
+    </Stack>
+  );
+}
+
+export const SpanLinkedFromSubpanel = ({
+  links,
+  onOpenTrace,
+}: {
+  links: LinkedSpanDetails[];
+  onOpenTrace?: (link: SpanLinkData) => void;
+}) => {
+  const { handleToggleMoreRows, hiddenRowsCount, visibleRows, isExpanded } =
+    useShowMoreRows({
+      rows: links,
+      maxRows: 5,
+    });
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <SectionWrapper>
+        <ErrorBoundary
+          onError={err => {
+            console.error(err);
+          }}
+          fallbackRender={() => (
+            <div className="text-danger px-2 py-1 m-2 fs-7 font-monospace bg-danger-transparent p-4">
+              An error occurred while rendering linked spans
+            </div>
+          )}
+        >
+          <Stack gap="sm" px="xs" py="xs">
+            {visibleRows.map((link, index) => (
+              <div
+                key={linkedSpanKey(link.TraceId, link.SpanId)}
+                data-testid="linked-from-row"
+                className={
+                  index > 0 ? 'pt-2 border-top border-dark' : undefined
+                }
+              >
+                <LinkedSpanRow link={link} onOpenTrace={onOpenTrace} />
+              </div>
+            ))}
+          </Stack>
+        </ErrorBoundary>
+
+        {hiddenRowsCount ? (
+          <Button
+            variant="secondary"
+            size="xs"
+            my="sm"
+            onClick={handleToggleMoreRows}
+          >
+            {isExpanded ? (
+              <>
+                <IconChevronUp size={14} className="me-2" /> Hide spans
+              </>
+            ) : (
+              <>
+                <IconChevronDown size={14} className="me-2" />
+                Show {hiddenRowsCount} more spans
+              </>
+            )}
+          </Button>
+        ) : null}
+      </SectionWrapper>
+    </div>
+  );
+};

--- a/packages/app/src/components/SpanLinksSubpanel.tsx
+++ b/packages/app/src/components/SpanLinksSubpanel.tsx
@@ -9,6 +9,11 @@ import {
 
 import EventTag from './EventTag';
 import { SectionWrapper, useShowMoreRows } from './ExceptionSubpanel';
+import {
+  LinkedSpanDetails,
+  linkedSpanKey,
+  LinkedSpanMetaLine,
+} from './linkedSpans';
 
 // Make sure SpanLinkData implements Record<string, unknown>
 export interface SpanLinkData extends Record<string, unknown> {
@@ -37,9 +42,11 @@ export function getValidSpanLinks(
 
 function SpanLinkRow({
   link,
+  details,
   onOpenTrace,
 }: {
   link: SpanLinkData;
+  details?: LinkedSpanDetails;
   onOpenTrace?: (link: SpanLinkData) => void;
 }) {
   const attributeEntries = Object.entries(link.Attributes ?? {});
@@ -71,9 +78,11 @@ function SpanLinkRow({
           className="d-inline-flex align-items-center"
         >
           <IconArrowUpRight size={14} className="me-1" />
-          Open trace
+          {details?.spanName || 'Open trace'}
         </Anchor>
       </Tooltip>
+
+      {details ? <LinkedSpanMetaLine details={details} /> : null}
 
       {hasChips ? (
         <Flex wrap="wrap" gap="2px" align="baseline">
@@ -104,9 +113,14 @@ function SpanLinkRow({
 
 export const SpanLinksSubpanel = ({
   spanLinks,
+  linkedSpanDetails,
   onOpenTrace,
 }: {
   spanLinks?: Record<string, unknown>[] | null;
+  // Resolved details for the spans the links point to, keyed by
+  // `linkedSpanKey`. Links without an entry render with the bare
+  // "Open trace" fallback.
+  linkedSpanDetails?: Map<string, LinkedSpanDetails>;
   onOpenTrace?: (link: SpanLinkData) => void;
 }) => {
   const links = useMemo(() => getValidSpanLinks(spanLinks), [spanLinks]);
@@ -148,7 +162,13 @@ export const SpanLinksSubpanel = ({
                   index > 0 ? 'pt-2 border-top border-dark' : undefined
                 }
               >
-                <SpanLinkRow link={link} onOpenTrace={onOpenTrace} />
+                <SpanLinkRow
+                  link={link}
+                  details={linkedSpanDetails?.get(
+                    linkedSpanKey(link.TraceId, link.SpanId),
+                  )}
+                  onOpenTrace={onOpenTrace}
+                />
               </div>
             ))}
           </Stack>

--- a/packages/app/src/components/__tests__/DBRowOverviewPanel.linkedFrom.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowOverviewPanel.linkedFrom.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import { screen } from '@testing-library/react';
+
+const mockUseRowData = jest.fn();
+jest.mock('../DBRowDataPanel', () => ({
+  __esModule: true,
+  useRowData: (args: unknown) => mockUseRowData(args),
+  getJSONColumnNames: () => [],
+  getMapColumnNames: () => [],
+}));
+
+jest.mock('../DBRowSidePanel', () => {
+  const { createContext } = jest.requireActual('react');
+  return {
+    __esModule: true,
+    RowSidePanelContext: createContext({}),
+  };
+});
+
+jest.mock('../DBRowJsonViewer', () => ({
+  __esModule: true,
+  DBRowJsonViewer: () => null,
+}));
+jest.mock('../DBRowSidePanelHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../EventTag', () => ({ __esModule: true, default: () => null }));
+jest.mock('../ExceptionSubpanel', () => ({
+  __esModule: true,
+  ExceptionSubpanel: () => null,
+}));
+jest.mock('../NetworkPropertyPanel', () => ({
+  __esModule: true,
+  NetworkPropertySubpanel: () => null,
+}));
+jest.mock('../SpanEventsSubpanel', () => ({
+  __esModule: true,
+  SpanEventsSubpanel: () => null,
+}));
+const mockSpanLinksSubpanel = jest.fn();
+jest.mock('../SpanLinksSubpanel', () => ({
+  __esModule: true,
+  getValidSpanLinks: jest.requireActual('../SpanLinksSubpanel')
+    .getValidSpanLinks,
+  SpanLinksSubpanel: (props: unknown) => {
+    mockSpanLinksSubpanel(props);
+    return null;
+  },
+}));
+
+const mockUseReverseSpanLinks = jest.fn();
+const mockUseLinkedSpanDetails = jest.fn();
+jest.mock('../linkedSpans', () => ({
+  __esModule: true,
+  useReverseSpanLinks: (args: unknown) => mockUseReverseSpanLinks(args),
+  useLinkedSpanDetails: (args: unknown) => mockUseLinkedSpanDetails(args),
+  linkedSpanKey: (traceId: string, spanId: string) => `${traceId}:${spanId}`,
+  LinkedSpanMetaLine: () => null,
+}));
+jest.mock('../SpanLinkedFromSubpanel', () => ({
+  __esModule: true,
+  SpanLinkedFromSubpanel: () => <div data-testid="linked-from-subpanel" />,
+}));
+
+jest.mock('@/source', () => ({
+  __esModule: true,
+  getEventBody: () => undefined,
+}));
+jest.mock('@/utils/highlightedAttributes', () => ({
+  __esModule: true,
+  getHighlightedAttributesFromData: () => [],
+}));
+
+const ANCHOR = new Date('2024-01-02T12:00:00.000Z');
+jest.mock('@/utils/rowTimestamps', () => ({
+  __esModule: true,
+  resolveRowTimestampAnchor: () => new Date('2024-01-02T12:00:00.000Z'),
+}));
+
+import { RowOverviewPanel } from '@/components/DBRowOverviewPanel';
+
+const TRACE_SOURCE: TSource = {
+  id: 'trace-src',
+  name: 'Traces',
+  kind: SourceKind.Trace,
+  connection: 'conn-1',
+  from: { databaseName: 'default', tableName: 'otel_traces' },
+  timestampValueExpression: 'Timestamp',
+  defaultTableSelectExpression: 'Timestamp, SpanName',
+  traceIdExpression: 'TraceId',
+  spanIdExpression: 'SpanId',
+  parentSpanIdExpression: 'ParentSpanId',
+  spanNameExpression: 'SpanName',
+  spanKindExpression: 'SpanKind',
+  durationExpression: 'Duration',
+  durationPrecision: 9,
+  spanLinksValueExpression: 'Links',
+};
+
+const ROW = {
+  __hdx_trace_id: 'trace-1',
+  __hdx_span_id: 'span-1',
+};
+
+const LINK = {
+  TraceId: 'other-trace',
+  SpanId: 'other-span',
+  spanName: 'consume message',
+};
+
+describe('RowOverviewPanel linked-from section', () => {
+  beforeEach(() => {
+    mockUseRowData.mockReset();
+    mockUseReverseSpanLinks.mockReset();
+    mockUseLinkedSpanDetails.mockReset();
+    mockUseLinkedSpanDetails.mockReturnValue({ details: new Map() });
+    mockUseRowData.mockReturnValue({ data: { data: [ROW], meta: [] } });
+  });
+
+  it('shows the section when reverse links exist', () => {
+    mockUseReverseSpanLinks.mockReturnValue({ links: [LINK] });
+
+    renderWithMantine(
+      <RowOverviewPanel source={TRACE_SOURCE} rowId="SpanId='span-1'" />,
+    );
+
+    expect(screen.getByText('Linked from')).toBeInTheDocument();
+    expect(screen.getByTestId('linked-from-subpanel')).toBeInTheDocument();
+
+    expect(mockUseReverseSpanLinks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: TRACE_SOURCE,
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        anchorDate: ANCHOR,
+      }),
+    );
+  });
+
+  it('hides the section when there are no reverse links', () => {
+    mockUseReverseSpanLinks.mockReturnValue({ links: [] });
+
+    renderWithMantine(
+      <RowOverviewPanel source={TRACE_SOURCE} rowId="SpanId='span-1'" />,
+    );
+
+    expect(screen.queryByText('Linked from')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('linked-from-subpanel'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes undefined ids when the row lacks trace/span context', () => {
+    mockUseRowData.mockReturnValue({ data: { data: [{}], meta: [] } });
+    mockUseReverseSpanLinks.mockReturnValue({ links: [] });
+
+    renderWithMantine(
+      <RowOverviewPanel source={TRACE_SOURCE} rowId="SpanId='span-1'" />,
+    );
+
+    expect(mockUseReverseSpanLinks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: undefined,
+        spanId: undefined,
+      }),
+    );
+  });
+
+  it("resolves the row's forward links and passes details to the span links panel", () => {
+    const spanLink = {
+      TraceId: 'linked-trace',
+      SpanId: 'linked-span',
+      TraceState: '',
+      Attributes: {},
+    };
+    mockUseRowData.mockReturnValue({
+      data: { data: [{ ...ROW, __hdx_span_links: [spanLink] }], meta: [] },
+    });
+    mockUseReverseSpanLinks.mockReturnValue({ links: [] });
+    const details = new Map([
+      ['linked-trace:linked-span', { TraceId: 'linked-trace' }],
+    ]);
+    mockUseLinkedSpanDetails.mockReturnValue({ details });
+
+    renderWithMantine(
+      <RowOverviewPanel source={TRACE_SOURCE} rowId="SpanId='span-1'" />,
+    );
+
+    expect(mockUseLinkedSpanDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: TRACE_SOURCE,
+        links: [spanLink],
+        anchorDate: ANCHOR,
+      }),
+    );
+    expect(mockSpanLinksSubpanel).toHaveBeenCalledWith(
+      expect.objectContaining({ linkedSpanDetails: details }),
+    );
+  });
+});

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinks.test.tsx
@@ -79,12 +79,27 @@ const TRACE_SOURCE = {
   spanIdExpression: 'SpanId',
 };
 
+// A log source stack frames can resolve to. Unlike a trace source, its
+// Overview (and thus the span-link rows) renders as a top-level side panel
+// tab, so pop-back tests can click a link while a frame is active without
+// going through the mocked-away trace waterfall.
+const STACK_LOG_SOURCE = {
+  id: 'stack-log-src',
+  kind: 'log',
+  traceSourceId: 'trace-src',
+  resourceAttributesExpression: 'ResourceAttributes',
+};
+
 jest.mock('@/source', () => ({
   __esModule: true,
   getEventBody: () => undefined,
 
   useSource: ({ id }: { id: string | null }) =>
-    id === 'trace-src' ? { data: TRACE_SOURCE } : { data: undefined },
+    id === 'trace-src'
+      ? { data: TRACE_SOURCE }
+      : id === 'stack-log-src'
+        ? { data: STACK_LOG_SOURCE }
+        : { data: undefined },
 }));
 
 jest.mock('../DBSessionPanel', () => ({
@@ -127,6 +142,23 @@ jest.mock('../ServiceMap/ServiceMapSidePanel', () => ({
 jest.mock('../TimelineChart/utils', () => ({
   __esModule: true,
   renderMs: () => '',
+}));
+// The linked-span lookups issue real queries through useQueriedChartConfig,
+// whose providers this harness doesn't set up.
+jest.mock('../linkedSpans', () => ({
+  __esModule: true,
+  useReverseSpanLinks: () => ({ links: [], isLoading: false, error: null }),
+  useLinkedSpanDetails: () => ({
+    details: new Map(),
+    isLoading: false,
+    error: null,
+  }),
+  linkedSpanKey: (traceId: string, spanId: string) => `${traceId}:${spanId}`,
+  LinkedSpanMetaLine: () => null,
+}));
+jest.mock('../SpanLinkedFromSubpanel', () => ({
+  __esModule: true,
+  SpanLinkedFromSubpanel: () => null,
 }));
 jest.mock('../DrawerUtils', () => ({
   __esModule: true,
@@ -222,6 +254,88 @@ describe('DBRowSidePanelInner, span link "Open trace" push wiring (HDX-3191)', (
     // matching handleSourceStackPush's Trace-vs-Overview routing.
     expect(setterFor('sidePanelNavStack')).toHaveBeenCalledWith([]);
     expect(setterFor('sidePanelTab')).toHaveBeenCalledWith('trace');
+  });
+
+  it('stamps the canonical origin row id onto the pushed frame', () => {
+    mockUseRowData.mockReturnValue({
+      data: {
+        data: [
+          {
+            __hdx_span_links: [LINK],
+            __hdx_trace_id: 'origin-trace',
+            __hdx_span_id: 'origin-span',
+          },
+        ],
+        meta: [],
+      },
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+    });
+
+    renderInner('row-1');
+
+    fireEvent.click(screen.getByTestId('span-link-open-trace'));
+
+    const pushedStack = setterFor('sidePanelSourceStack').mock.calls[0][0];
+    expect(pushedStack[0]).toMatchObject({
+      originRowId: [
+        SqlString.format('?=?', [SqlString.raw('TraceId'), 'origin-trace']),
+        SqlString.format('?=?', [SqlString.raw('SpanId'), 'origin-span']),
+      ].join(' AND '),
+    });
+  });
+
+  it('pops back to the previous breadcrumb when the link targets the span it was pushed from', () => {
+    // One frame deep, and that frame remembers it was entered from the exact
+    // span this link points at: A -> B, now B links back to A.
+    mockQueryStore['sidePanelSourceStack'] = [
+      {
+        sourceId: 'stack-log-src',
+        rowId: 'TraceId=whatever',
+        aliasWith: [],
+        label: 'Trace bbbb',
+        sourceKind: 'log',
+        // The canonical row id a hop targeting LINK's span would compute.
+        originRowId: [
+          SqlString.format('?=?', [SqlString.raw('TraceId'), LINK.TraceId]),
+          SqlString.format('?=?', [SqlString.raw('SpanId'), LINK.SpanId]),
+        ].join(' AND '),
+        originTab: 'overview',
+      },
+    ];
+    mockQueryStore['sidePanelStackRoot'] = 'row-1';
+
+    renderInner('row-1');
+
+    fireEvent.click(screen.getByTestId('span-link-open-trace'));
+
+    expect(setterFor('sidePanelSourceStack')).toHaveBeenCalledTimes(1);
+    expect(setterFor('sidePanelSourceStack')).toHaveBeenCalledWith([]);
+    // The level we return to gets its tab back.
+    expect(setterFor('sidePanelTab')).toHaveBeenCalledWith('overview');
+  });
+
+  it('pushes normally when the link targets a span other than the previous breadcrumb', () => {
+    mockQueryStore['sidePanelSourceStack'] = [
+      {
+        sourceId: 'stack-log-src',
+        rowId: 'TraceId=whatever',
+        aliasWith: [],
+        label: 'Trace bbbb',
+        sourceKind: 'log',
+        originRowId: "TraceId='some-other-trace' AND SpanId='some-other-span'",
+      },
+    ];
+    mockQueryStore['sidePanelStackRoot'] = 'row-1';
+
+    renderInner('row-1');
+
+    fireEvent.click(screen.getByTestId('span-link-open-trace'));
+
+    const pushedStack = setterFor('sidePanelSourceStack').mock.calls[0][0];
+    expect(pushedStack).toHaveLength(2);
   });
 
   it('does not push when the current row has no resolvable trace source', () => {

--- a/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
+++ b/packages/app/src/components/__tests__/DBRowSidePanel.spanLinksBreadcrumb.test.tsx
@@ -105,6 +105,23 @@ jest.mock('../TimelineChart/utils', () => ({
   __esModule: true,
   renderMs: () => '',
 }));
+// The linked-span lookups issue real queries through useQueriedChartConfig,
+// whose providers this harness doesn't set up.
+jest.mock('../linkedSpans', () => ({
+  __esModule: true,
+  useReverseSpanLinks: () => ({ links: [], isLoading: false, error: null }),
+  useLinkedSpanDetails: () => ({
+    details: new Map(),
+    isLoading: false,
+    error: null,
+  }),
+  linkedSpanKey: (traceId: string, spanId: string) => `${traceId}:${spanId}`,
+  LinkedSpanMetaLine: () => null,
+}));
+jest.mock('../SpanLinkedFromSubpanel', () => ({
+  __esModule: true,
+  SpanLinkedFromSubpanel: () => null,
+}));
 jest.mock('../DrawerUtils', () => ({
   __esModule: true,
   DrawerFullWidthToggle: () => null,

--- a/packages/app/src/components/__tests__/SpanLinkedFromSubpanel.test.tsx
+++ b/packages/app/src/components/__tests__/SpanLinkedFromSubpanel.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { LinkedSpanDetails } from '@/components/linkedSpans';
+import { SpanLinkedFromSubpanel } from '@/components/SpanLinkedFromSubpanel';
+
+describe('SpanLinkedFromSubpanel', () => {
+  const LINK: LinkedSpanDetails = {
+    TraceId: 'eeee5555ffff6666aaaa7777bbbb8888',
+    SpanId: '5555666677778888',
+    spanName: 'consume message',
+    serviceName: 'consumer-svc',
+    timestamp: '2024-01-02 12:00:01',
+    durationMs: 42,
+  };
+
+  it('renders nothing when there are no links', () => {
+    const { container } = renderWithMantine(
+      <SpanLinkedFromSubpanel links={[]} />,
+    );
+    // The Mantine provider injects <style> nodes; the component itself must
+    // contribute no elements.
+    expect(container.querySelector('div')).toBeNull();
+    expect(screen.queryByTestId('linked-from-row')).not.toBeInTheDocument();
+  });
+
+  it('renders the referencing span with service and duration', () => {
+    renderWithMantine(<SpanLinkedFromSubpanel links={[LINK]} />);
+
+    expect(screen.getByText('consume message')).toBeInTheDocument();
+    expect(screen.getByText('consumer-svc')).toBeInTheDocument();
+    expect(screen.getByText('42ms')).toBeInTheDocument();
+  });
+
+  it('falls back to "Open span" when the span name is missing', () => {
+    renderWithMantine(
+      <SpanLinkedFromSubpanel links={[{ ...LINK, spanName: undefined }]} />,
+    );
+
+    expect(screen.getByText('Open span')).toBeInTheDocument();
+  });
+
+  it('calls onOpenTrace with the referencing trace/span pair', () => {
+    const onOpenTrace = jest.fn();
+    renderWithMantine(
+      <SpanLinkedFromSubpanel links={[LINK]} onOpenTrace={onOpenTrace} />,
+    );
+
+    fireEvent.click(screen.getByText('consume message'));
+
+    expect(onOpenTrace).toHaveBeenCalledTimes(1);
+    expect(onOpenTrace).toHaveBeenCalledWith({
+      TraceId: LINK.TraceId,
+      SpanId: LINK.SpanId,
+      TraceState: '',
+      Attributes: {},
+    });
+  });
+
+  it('collapses long lists behind a show-more button', () => {
+    const links = Array.from({ length: 7 }, (_, i) => ({
+      ...LINK,
+      SpanId: `span-${i}`,
+      spanName: `span ${i}`,
+    }));
+    renderWithMantine(<SpanLinkedFromSubpanel links={links} />);
+
+    expect(screen.getAllByTestId('linked-from-row')).toHaveLength(5);
+
+    fireEvent.click(screen.getByText('Show 2 more spans'));
+
+    expect(screen.getAllByTestId('linked-from-row')).toHaveLength(7);
+  });
+});

--- a/packages/app/src/components/__tests__/SpanLinksSubpanel.test.tsx
+++ b/packages/app/src/components/__tests__/SpanLinksSubpanel.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from '@testing-library/react';
 
+import { linkedSpanKey } from '@/components/linkedSpans';
 import {
   getValidSpanLinks,
   SpanLinksSubpanel,
@@ -137,6 +138,68 @@ describe('SpanLinksSubpanel', () => {
     expect(
       screen.getByText('No span links available for this trace'),
     ).toBeInTheDocument();
+  });
+
+  it('shows resolved span details in place of the bare Open trace action', () => {
+    const linkedSpanDetails = new Map([
+      [
+        linkedSpanKey(LINK_A.TraceId, LINK_A.SpanId),
+        {
+          TraceId: LINK_A.TraceId,
+          SpanId: LINK_A.SpanId,
+          spanName: 'publish message',
+          serviceName: 'producer-svc',
+          durationMs: 3,
+        },
+      ],
+    ]);
+
+    renderWithMantine(
+      <SpanLinksSubpanel
+        spanLinks={[LINK_A, LINK_B]}
+        linkedSpanDetails={linkedSpanDetails}
+      />,
+    );
+
+    // LINK_A resolved: span name replaces the action label, meta line shows.
+    expect(screen.getByText('publish message')).toBeInTheDocument();
+    expect(screen.getByText('producer-svc')).toBeInTheDocument();
+    expect(screen.getByText('3ms')).toBeInTheDocument();
+    // LINK_B unresolved: bare fallback, and its chips still render.
+    expect(screen.getByText('Open trace')).toBeInTheDocument();
+    // Attributes keep rendering on resolved links too.
+    expect(screen.getByText('link.kind: child_of')).toBeInTheDocument();
+  });
+
+  it('opens the trace from a resolved link with the original link payload', () => {
+    const onOpenTrace = jest.fn();
+    const linkedSpanDetails = new Map([
+      [
+        linkedSpanKey(LINK_A.TraceId, LINK_A.SpanId),
+        {
+          TraceId: LINK_A.TraceId,
+          SpanId: LINK_A.SpanId,
+          spanName: 'publish message',
+        },
+      ],
+    ]);
+
+    renderWithMantine(
+      <SpanLinksSubpanel
+        spanLinks={[LINK_A]}
+        linkedSpanDetails={linkedSpanDetails}
+        onOpenTrace={onOpenTrace}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('publish message'));
+
+    expect(onOpenTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TraceId: LINK_A.TraceId,
+        SpanId: LINK_A.SpanId,
+      }),
+    );
   });
 });
 

--- a/packages/app/src/components/__tests__/linkedSpans.test.tsx
+++ b/packages/app/src/components/__tests__/linkedSpans.test.tsx
@@ -1,0 +1,367 @@
+import { SourceKind, TTraceSource } from '@hyperdx/common-utils/dist/types';
+import { renderHook } from '@testing-library/react';
+
+import {
+  getLinkedSpansConfig,
+  getReverseSpanLinksConfig,
+  LINKED_SPAN_ALIASES,
+  linkedSpanKey,
+  useLinkedSpanDetails,
+  useReverseSpanLinks,
+} from '@/components/linkedSpans';
+
+const mockUseQueriedChartConfig = jest.fn();
+jest.mock('@/hooks/useChartConfig', () => ({
+  __esModule: true,
+  useQueriedChartConfig: (config: unknown, options: unknown) =>
+    mockUseQueriedChartConfig(config, options),
+}));
+
+const TRACE_SOURCE: TTraceSource = {
+  id: 'trace-source',
+  kind: SourceKind.Trace,
+  name: 'Traces',
+  connection: 'conn-1',
+  from: { databaseName: 'default', tableName: 'otel_traces' },
+  timestampValueExpression: 'Timestamp',
+  defaultTableSelectExpression: 'Timestamp, SpanName',
+  traceIdExpression: 'TraceId',
+  spanIdExpression: 'SpanId',
+  parentSpanIdExpression: 'ParentSpanId',
+  spanNameExpression: 'SpanName',
+  spanKindExpression: 'SpanKind',
+  serviceNameExpression: 'ServiceName',
+  durationExpression: 'Duration',
+  durationPrecision: 9,
+  spanLinksValueExpression: 'Links',
+};
+
+const TRACE_ID = 'aaaa1111bbbb2222cccc3333dddd4444';
+const SPAN_ID = '1111222233334444';
+const ANCHOR = new Date('2024-01-02T12:00:00.000Z');
+
+const EXPECTED_SELECT = [
+  {
+    valueExpression: 'Timestamp',
+    alias: LINKED_SPAN_ALIASES.TIMESTAMP,
+  },
+  {
+    valueExpression: 'TraceId',
+    alias: LINKED_SPAN_ALIASES.TRACE_ID,
+  },
+  { valueExpression: 'SpanId', alias: LINKED_SPAN_ALIASES.SPAN_ID },
+  { valueExpression: 'SpanName', alias: LINKED_SPAN_ALIASES.BODY },
+  {
+    valueExpression: 'ServiceName',
+    alias: LINKED_SPAN_ALIASES.SERVICE_NAME,
+  },
+  {
+    valueExpression: '(Duration)/1e6',
+    alias: LINKED_SPAN_ALIASES.DURATION_MS,
+  },
+];
+
+describe('getReverseSpanLinksConfig', () => {
+  it('builds an index-friendly has() conjunct plus an exact-pair arrayExists', () => {
+    const config = getReverseSpanLinksConfig({
+      source: TRACE_SOURCE,
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.where).toBe(
+      `has(Links.SpanId, '${SPAN_ID}') AND arrayExists((lt, ls) -> lt = '${TRACE_ID}' AND ls = '${SPAN_ID}', Links.TraceId, Links.SpanId)`,
+    );
+    expect(config?.whereLanguage).toBe('sql');
+  });
+
+  it('escapes quotes in trace and span ids', () => {
+    const config = getReverseSpanLinksConfig({
+      source: TRACE_SOURCE,
+      traceId: "trace'--",
+      spanId: "span'--",
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.where).toContain("'span\\'--'");
+    expect(config?.where).toContain("'trace\\'--'");
+    expect(config?.where).not.toContain("'span'--'");
+  });
+
+  it('bounds the search to -1h/+24h around the anchor', () => {
+    const config = getReverseSpanLinksConfig({
+      source: TRACE_SOURCE,
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.dateRange).toEqual([
+      new Date('2024-01-02T11:00:00.000Z'),
+      new Date('2024-01-03T12:00:00.000Z'),
+    ]);
+    expect(config?.timestampValueExpression).toBe('Timestamp');
+    expect(config?.limit).toEqual({ limit: 50 });
+  });
+
+  it('selects display fields under stable aliases', () => {
+    const config = getReverseSpanLinksConfig({
+      source: TRACE_SOURCE,
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.select).toEqual(EXPECTED_SELECT);
+  });
+
+  it('omits optional select fields the source does not define', () => {
+    const config = getReverseSpanLinksConfig({
+      source: {
+        ...TRACE_SOURCE,
+        // @ts-expect-error string type
+        spanNameExpression: undefined,
+        serviceNameExpression: undefined,
+        // @ts-expect-error string type
+        durationExpression: undefined,
+      },
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.select).toEqual(EXPECTED_SELECT.slice(0, 3));
+  });
+
+  it.each([
+    ['log source', { source: { ...TRACE_SOURCE, kind: SourceKind.Log } }],
+    [
+      'missing spanLinksValueExpression',
+      { source: { ...TRACE_SOURCE, spanLinksValueExpression: undefined } },
+    ],
+    [
+      'missing traceIdExpression',
+      { source: { ...TRACE_SOURCE, traceIdExpression: undefined } },
+    ],
+    ['missing traceId', { traceId: undefined }],
+    ['missing spanId', { spanId: undefined }],
+    ['missing anchorDate', { anchorDate: undefined }],
+  ])('returns null on %s', (_label, overrides) => {
+    expect(
+      getReverseSpanLinksConfig({
+        source: TRACE_SOURCE,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        anchorDate: ANCHOR,
+        ...(overrides as object),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('getLinkedSpansConfig', () => {
+  const LINKS = [
+    { TraceId: 'trace-a', SpanId: 'span-a' },
+    { TraceId: 'trace-b', SpanId: 'span-b' },
+  ];
+
+  it('matches trace ids for index pruning and exact pairs via tuple IN', () => {
+    const config = getLinkedSpansConfig({
+      source: TRACE_SOURCE,
+      links: LINKS,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.where).toBe(
+      "TraceId IN ('trace-a', 'trace-b') AND (TraceId, SpanId) IN (('trace-a', 'span-a'), ('trace-b', 'span-b'))",
+    );
+    expect(config?.whereLanguage).toBe('sql');
+    expect(config?.select).toEqual(EXPECTED_SELECT);
+  });
+
+  it('dedupes repeated links', () => {
+    const config = getLinkedSpansConfig({
+      source: TRACE_SOURCE,
+      links: [LINKS[0], LINKS[0], LINKS[1]],
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.where).toBe(
+      "TraceId IN ('trace-a', 'trace-b') AND (TraceId, SpanId) IN (('trace-a', 'span-a'), ('trace-b', 'span-b'))",
+    );
+  });
+
+  it('bounds the search to -24h/+1h around the anchor (links point backwards in time)', () => {
+    const config = getLinkedSpansConfig({
+      source: TRACE_SOURCE,
+      links: LINKS,
+      anchorDate: ANCHOR,
+    });
+
+    expect(config?.dateRange).toEqual([
+      new Date('2024-01-01T12:00:00.000Z'),
+      new Date('2024-01-02T13:00:00.000Z'),
+    ]);
+    expect(config?.limit).toEqual({ limit: 50 });
+  });
+
+  it.each([
+    ['no links', { links: [] }],
+    ['log source', { source: { ...TRACE_SOURCE, kind: SourceKind.Log } }],
+    ['missing anchorDate', { anchorDate: undefined }],
+  ])('returns null on %s', (_label, overrides) => {
+    expect(
+      getLinkedSpansConfig({
+        source: TRACE_SOURCE,
+        links: LINKS,
+        anchorDate: ANCHOR,
+        ...(overrides as object),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('useReverseSpanLinks', () => {
+  beforeEach(() => {
+    mockUseQueriedChartConfig.mockReset();
+  });
+
+  it('disables the query when the config cannot be built', () => {
+    mockUseQueriedChartConfig.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() =>
+      useReverseSpanLinks({
+        source: TRACE_SOURCE,
+        traceId: undefined,
+        spanId: SPAN_ID,
+        anchorDate: ANCHOR,
+      }),
+    );
+
+    expect(result.current.links).toEqual([]);
+    expect(mockUseQueriedChartConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('maps result rows and drops rows missing ids or matching the current span', () => {
+    mockUseQueriedChartConfig.mockReturnValue({
+      data: {
+        data: [
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: 'other-trace',
+            [LINKED_SPAN_ALIASES.SPAN_ID]: 'other-span',
+            [LINKED_SPAN_ALIASES.BODY]: 'process message',
+            [LINKED_SPAN_ALIASES.SERVICE_NAME]: 'consumer',
+            [LINKED_SPAN_ALIASES.TIMESTAMP]: '2024-01-02 12:00:01',
+            [LINKED_SPAN_ALIASES.DURATION_MS]: 12.5,
+          },
+          // The span being viewed (self-link) is filtered out.
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: TRACE_ID,
+            [LINKED_SPAN_ALIASES.SPAN_ID]: SPAN_ID,
+          },
+          // Rows without string ids can't be navigated to.
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: 'trace-without-span-id',
+          },
+          // Duplicate (TraceId, SpanId) pairs collapse to one entry.
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: 'other-trace',
+            [LINKED_SPAN_ALIASES.SPAN_ID]: 'other-span',
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useReverseSpanLinks({
+        source: TRACE_SOURCE,
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        anchorDate: ANCHOR,
+      }),
+    );
+
+    expect(result.current.links).toEqual([
+      {
+        TraceId: 'other-trace',
+        SpanId: 'other-span',
+        spanName: 'process message',
+        serviceName: 'consumer',
+        timestamp: '2024-01-02 12:00:01',
+        durationMs: 12.5,
+      },
+    ]);
+    expect(mockUseQueriedChartConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+});
+
+describe('useLinkedSpanDetails', () => {
+  beforeEach(() => {
+    mockUseQueriedChartConfig.mockReset();
+  });
+
+  it('disables the query when there are no links', () => {
+    mockUseQueriedChartConfig.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() =>
+      useLinkedSpanDetails({
+        source: TRACE_SOURCE,
+        links: [],
+        anchorDate: ANCHOR,
+      }),
+    );
+
+    expect(result.current.details.size).toBe(0);
+    expect(mockUseQueriedChartConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('maps result rows into a lookup keyed by trace/span pair', () => {
+    mockUseQueriedChartConfig.mockReturnValue({
+      data: {
+        data: [
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: 'trace-a',
+            [LINKED_SPAN_ALIASES.SPAN_ID]: 'span-a',
+            [LINKED_SPAN_ALIASES.BODY]: 'publish message',
+            [LINKED_SPAN_ALIASES.SERVICE_NAME]: 'producer',
+            [LINKED_SPAN_ALIASES.TIMESTAMP]: '2024-01-02 11:59:59',
+            [LINKED_SPAN_ALIASES.DURATION_MS]: 3.25,
+          },
+          {
+            [LINKED_SPAN_ALIASES.TRACE_ID]: 'trace-without-span-id',
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useLinkedSpanDetails({
+        source: TRACE_SOURCE,
+        links: [{ TraceId: 'trace-a', SpanId: 'span-a' }],
+        anchorDate: ANCHOR,
+      }),
+    );
+
+    expect(result.current.details.size).toBe(1);
+    expect(
+      result.current.details.get(linkedSpanKey('trace-a', 'span-a')),
+    ).toEqual({
+      TraceId: 'trace-a',
+      SpanId: 'span-a',
+      spanName: 'publish message',
+      serviceName: 'producer',
+      timestamp: '2024-01-02 11:59:59',
+      durationMs: 3.25,
+    });
+  });
+});

--- a/packages/app/src/components/linkedSpans.tsx
+++ b/packages/app/src/components/linkedSpans.tsx
@@ -1,0 +1,420 @@
+import { useMemo } from 'react';
+import SqlString from 'sqlstring';
+import {
+  BuilderChartConfigWithDateRange,
+  SourceKind,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
+import { Group, Text } from '@mantine/core';
+
+import { useQueriedChartConfig } from '@/hooks/useChartConfig';
+import {
+  getDisplayedTimestampValueExpression,
+  getDurationMsExpression,
+  getEventBody,
+} from '@/source';
+import { FormatTime } from '@/useFormatTime';
+
+import { renderMs } from './TimelineChart/utils';
+import type { SpanLinkData } from './SpanLinksSubpanel';
+
+export const LINKED_SPAN_ALIASES = {
+  TIMESTAMP: '__hdx_timestamp',
+  TRACE_ID: '__hdx_trace_id',
+  SPAN_ID: '__hdx_span_id',
+  BODY: '__hdx_body',
+  SERVICE_NAME: '__hdx_service_name',
+  DURATION_MS: '__hdx_duration_ms',
+} as const;
+
+// A span link usually crosses trace boundaries in one time direction:
+// consumers referencing a producer span run at/after it — sometimes hours
+// later (queues, batch jobs) — while the spans a link points *to* ran at or
+// before the linking span. Each direction searches a window skewed that way,
+// with a small allowance for clock skew. The window is the primary
+// performance mechanism: it drives partition/primary-key pruning, and there
+// is deliberately no unbounded fallback.
+const SKEW_MS = 60 * 60 * 1000;
+const LINK_HORIZON_MS = 24 * 60 * 60 * 1000;
+
+const MAX_LINKED_SPANS = 50;
+
+export interface LinkedSpanDetails {
+  TraceId: string;
+  SpanId: string;
+  spanName?: string;
+  serviceName?: string;
+  timestamp?: string;
+  durationMs?: number;
+}
+
+// Requirements shared by both lookup directions; returns null when the source
+// can't support either query (also gates out non-trace sources).
+function getLinkedSpanSourceExpressions(source: TSource) {
+  if (source.kind !== SourceKind.Trace) {
+    return null;
+  }
+  const timestampExpr = source.timestampValueExpression?.trim();
+  if (!timestampExpr || !source.traceIdExpression || !source.spanIdExpression) {
+    return null;
+  }
+  return {
+    timestampExpr,
+    traceIdExpression: source.traceIdExpression,
+    spanIdExpression: source.spanIdExpression,
+    spanLinksExpression: source.spanLinksValueExpression?.trim() || undefined,
+  };
+}
+
+function getLinkedSpanSelect(
+  source: TSource,
+  exprs: { traceIdExpression: string; spanIdExpression: string },
+) {
+  const eventBodyExpr = getEventBody(source);
+  return [
+    {
+      valueExpression: getDisplayedTimestampValueExpression(source),
+      alias: LINKED_SPAN_ALIASES.TIMESTAMP,
+    },
+    {
+      valueExpression: exprs.traceIdExpression,
+      alias: LINKED_SPAN_ALIASES.TRACE_ID,
+    },
+    {
+      valueExpression: exprs.spanIdExpression,
+      alias: LINKED_SPAN_ALIASES.SPAN_ID,
+    },
+    ...(eventBodyExpr
+      ? [
+          {
+            valueExpression: eventBodyExpr,
+            alias: LINKED_SPAN_ALIASES.BODY,
+          },
+        ]
+      : []),
+    ...(source.kind === SourceKind.Trace && source.serviceNameExpression
+      ? [
+          {
+            valueExpression: source.serviceNameExpression,
+            alias: LINKED_SPAN_ALIASES.SERVICE_NAME,
+          },
+        ]
+      : []),
+    ...(source.kind === SourceKind.Trace && source.durationExpression
+      ? [
+          {
+            valueExpression: getDurationMsExpression(source),
+            alias: LINKED_SPAN_ALIASES.DURATION_MS,
+          },
+        ]
+      : []),
+  ];
+}
+
+export function getReverseSpanLinksConfig({
+  source,
+  traceId,
+  spanId,
+  anchorDate,
+}: {
+  source: TSource;
+  traceId: string | undefined;
+  spanId: string | undefined;
+  anchorDate: Date | undefined;
+}): BuilderChartConfigWithDateRange | null {
+  const exprs = getLinkedSpanSourceExpressions(source);
+  if (
+    !exprs ||
+    !exprs.spanLinksExpression ||
+    !traceId ||
+    !spanId ||
+    anchorDate == null
+  ) {
+    return null;
+  }
+
+  const linkTraceIdExpr = SqlString.raw(`${exprs.spanLinksExpression}.TraceId`);
+  const linkSpanIdExpr = SqlString.raw(`${exprs.spanLinksExpression}.SpanId`);
+  // The WHERE has two conjuncts with different jobs:
+  // - `has(Links.SpanId, x)`: cheap filter, and the only shape a bloom_filter
+  //   skipping index can serve (an `arrayExists` lambda cannot).
+  // - `arrayExists(...)`: exact match on the (TraceId, SpanId) pair, since
+  //   `has()` alone would match the span id linked from any trace.
+  //
+  // No index serves the `has()` today — the default ClickStack schema has
+  // none on Links.SpanId — so this lookup is bounded only by its dateRange
+  // (a scan of ~2 daily partitions). If that gets slow (~1B spans/day),
+  // adding to otel_traces:
+  //   INDEX idx_link_span_id Links.SpanId TYPE bloom_filter(0.001)
+  // lets ClickHouse skip nearly all granules with no app change.
+  const where = SqlString.format(
+    'has(?, ?) AND arrayExists((lt, ls) -> lt = ? AND ls = ?, ?, ?)',
+    [linkSpanIdExpr, spanId, traceId, spanId, linkTraceIdExpr, linkSpanIdExpr],
+  );
+
+  return {
+    connection: source.connection,
+    from: source.from,
+    select: getLinkedSpanSelect(source, exprs),
+    where,
+    whereLanguage: 'sql',
+    timestampValueExpression: exprs.timestampExpr,
+    dateRange: [
+      new Date(anchorDate.getTime() - SKEW_MS),
+      new Date(anchorDate.getTime() + LINK_HORIZON_MS),
+    ],
+    orderBy: [
+      {
+        valueExpression: LINKED_SPAN_ALIASES.TIMESTAMP,
+        ordering: 'ASC',
+      },
+    ],
+    limit: { limit: MAX_LINKED_SPANS },
+  };
+}
+
+export function getLinkedSpansConfig({
+  source,
+  links,
+  anchorDate,
+}: {
+  source: TSource;
+  links: Pick<SpanLinkData, 'TraceId' | 'SpanId'>[];
+  anchorDate: Date | undefined;
+}): BuilderChartConfigWithDateRange | null {
+  const exprs = getLinkedSpanSourceExpressions(source);
+  if (!exprs || anchorDate == null || links.length === 0) {
+    return null;
+  }
+
+  const seen = new Set<string>();
+  const pairs: [string, string][] = [];
+  for (const link of links) {
+    const key = linkedSpanKey(link.TraceId, link.SpanId);
+    if (!seen.has(key)) {
+      seen.add(key);
+      pairs.push([link.TraceId, link.SpanId]);
+    }
+    if (pairs.length >= MAX_LINKED_SPANS) {
+      break;
+    }
+  }
+
+  const traceIdExpr = SqlString.raw(exprs.traceIdExpression);
+  const spanIdExpr = SqlString.raw(exprs.spanIdExpression);
+  // The plain trace-id IN is servable by the default schema's bloom_filter
+  // index on TraceId; the tuple IN pins the exact (TraceId, SpanId) pairs.
+  const where = SqlString.format('? IN (?) AND (?, ?) IN (?)', [
+    traceIdExpr,
+    pairs.map(([linkTraceId]) => linkTraceId),
+    traceIdExpr,
+    spanIdExpr,
+    pairs,
+  ]);
+
+  return {
+    connection: source.connection,
+    from: source.from,
+    select: getLinkedSpanSelect(source, exprs),
+    where,
+    whereLanguage: 'sql',
+    timestampValueExpression: exprs.timestampExpr,
+    dateRange: [
+      new Date(anchorDate.getTime() - LINK_HORIZON_MS),
+      new Date(anchorDate.getTime() + SKEW_MS),
+    ],
+    limit: { limit: MAX_LINKED_SPANS },
+  };
+}
+
+export function linkedSpanKey(traceId: string, spanId: string) {
+  return `${traceId}:${spanId}`;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+// ClickHouse's JSON format can quote 64-bit numerics, so a duration may
+// arrive as either a number or a numeric string.
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string' && value !== '' && !isNaN(Number(value))) {
+    return Number(value);
+  }
+  return undefined;
+}
+
+function mapLinkedSpanRow(
+  row: Record<string, unknown>,
+): LinkedSpanDetails | null {
+  const linkTraceId = row[LINKED_SPAN_ALIASES.TRACE_ID];
+  const linkSpanId = row[LINKED_SPAN_ALIASES.SPAN_ID];
+  if (typeof linkTraceId !== 'string' || typeof linkSpanId !== 'string') {
+    return null;
+  }
+  return {
+    TraceId: linkTraceId,
+    SpanId: linkSpanId,
+    spanName: asString(row[LINKED_SPAN_ALIASES.BODY]),
+    serviceName: asString(row[LINKED_SPAN_ALIASES.SERVICE_NAME]),
+    timestamp: asString(row[LINKED_SPAN_ALIASES.TIMESTAMP]),
+    durationMs: asNumber(row[LINKED_SPAN_ALIASES.DURATION_MS]),
+  };
+}
+
+function usePlaceholderConfig(source: TSource) {
+  // Never fetched (the query is disabled while the real config is null);
+  // exists only so useQueriedChartConfig always receives a structurally valid
+  // config.
+  return useMemo<BuilderChartConfigWithDateRange>(
+    () => ({
+      connection: source.connection,
+      from: source.from,
+      select: [{ valueExpression: '1' }],
+      where: '0=1',
+      whereLanguage: 'sql',
+      timestampValueExpression: source.timestampValueExpression,
+      dateRange: [new Date(0), new Date(0)],
+      limit: { limit: 0 },
+    }),
+    [source],
+  );
+}
+
+export function useReverseSpanLinks({
+  source,
+  traceId,
+  spanId,
+  anchorDate,
+  enabled = true,
+}: {
+  source: TSource;
+  traceId: string | undefined;
+  spanId: string | undefined;
+  anchorDate: Date | undefined;
+  enabled?: boolean;
+}) {
+  const config = useMemo(
+    () => getReverseSpanLinksConfig({ source, traceId, spanId, anchorDate }),
+    [source, traceId, spanId, anchorDate],
+  );
+
+  const placeholderConfig = usePlaceholderConfig(source);
+  const queryResult = useQueriedChartConfig(config ?? placeholderConfig, {
+    queryKey: ['reverse-span-links', config],
+    enabled: enabled && config != null,
+  });
+
+  const links = useMemo<LinkedSpanDetails[]>(() => {
+    const rows = queryResult.data?.data ?? [];
+    // Also serves rendering: the (TraceId, SpanId) pair doubles as the React
+    // list key, so it must be unique.
+    const seen = new Set<string>();
+    return rows.flatMap(row => {
+      const mapped = mapLinkedSpanRow(row);
+      if (mapped == null) {
+        return [];
+      }
+      // A span whose links include itself would otherwise list the span the
+      // user is already looking at.
+      if (mapped.TraceId === traceId && mapped.SpanId === spanId) {
+        return [];
+      }
+      const key = linkedSpanKey(mapped.TraceId, mapped.SpanId);
+      if (seen.has(key)) {
+        return [];
+      }
+      seen.add(key);
+      return [mapped];
+    });
+  }, [queryResult.data, traceId, spanId]);
+
+  return {
+    links,
+    isLoading: queryResult.isLoading,
+    error: queryResult.error,
+  };
+}
+
+/**
+ * Resolves the spans a row's forward span links point to, so the link list
+ * can show details (span name, service, duration) instead of bare ids.
+ * Returns a map keyed by `linkedSpanKey`; links whose target span isn't found
+ * (outside the window, TTL'd out) are simply absent.
+ */
+export function useLinkedSpanDetails({
+  source,
+  links,
+  anchorDate,
+  enabled = true,
+}: {
+  source: TSource;
+  links: Pick<SpanLinkData, 'TraceId' | 'SpanId'>[];
+  anchorDate: Date | undefined;
+  enabled?: boolean;
+}) {
+  const config = useMemo(
+    () => getLinkedSpansConfig({ source, links, anchorDate }),
+    [source, links, anchorDate],
+  );
+
+  const placeholderConfig = usePlaceholderConfig(source);
+  const queryResult = useQueriedChartConfig(config ?? placeholderConfig, {
+    queryKey: ['linked-span-details', config],
+    enabled: enabled && config != null,
+  });
+
+  const details = useMemo(() => {
+    const map = new Map<string, LinkedSpanDetails>();
+    for (const row of queryResult.data?.data ?? []) {
+      const mapped = mapLinkedSpanRow(row);
+      if (mapped != null) {
+        const key = linkedSpanKey(mapped.TraceId, mapped.SpanId);
+        if (!map.has(key)) {
+          map.set(key, mapped);
+        }
+      }
+    }
+    return map;
+  }, [queryResult.data]);
+
+  return {
+    details,
+    isLoading: queryResult.isLoading,
+    error: queryResult.error,
+  };
+}
+
+export function LinkedSpanMetaLine({
+  details,
+}: {
+  details: LinkedSpanDetails;
+}) {
+  const hasDuration =
+    details.durationMs != null && !isNaN(Number(details.durationMs));
+  if (!details.serviceName && !hasDuration && !details.timestamp) {
+    return null;
+  }
+  return (
+    <Group gap="sm" wrap="wrap">
+      {details.serviceName ? (
+        <Text size="xs" c="dimmed">
+          {details.serviceName}
+        </Text>
+      ) : null}
+      {hasDuration ? (
+        <Text size="xs" c="dimmed">
+          {renderMs(Number(details.durationMs))}
+        </Text>
+      ) : null}
+      {details.timestamp ? (
+        <Text size="xs" c="dimmed">
+          <FormatTime value={details.timestamp} format="withMs" />
+        </Text>
+      ) : null}
+    </Group>
+  );
+}

--- a/packages/app/src/components/linkedSpans.tsx
+++ b/packages/app/src/components/linkedSpans.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import SqlString from 'sqlstring';
 import {
   BuilderChartConfigWithDateRange,
-  SourceKind,
+  isTraceSource,
   TSource,
+  TTraceSource,
 } from '@hyperdx/common-utils/dist/types';
 import { Group, Text } from '@mantine/core';
 
@@ -51,7 +52,7 @@ export interface LinkedSpanDetails {
 // Requirements shared by both lookup directions; returns null when the source
 // can't support either query (also gates out non-trace sources).
 function getLinkedSpanSourceExpressions(source: TSource) {
-  if (source.kind !== SourceKind.Trace) {
+  if (!isTraceSource(source)) {
     return null;
   }
   const timestampExpr = source.timestampValueExpression?.trim();
@@ -59,6 +60,7 @@ function getLinkedSpanSourceExpressions(source: TSource) {
     return null;
   }
   return {
+    source,
     timestampExpr,
     traceIdExpression: source.traceIdExpression,
     spanIdExpression: source.spanIdExpression,
@@ -66,10 +68,7 @@ function getLinkedSpanSourceExpressions(source: TSource) {
   };
 }
 
-function getLinkedSpanSelect(
-  source: TSource,
-  exprs: { traceIdExpression: string; spanIdExpression: string },
-) {
+function getLinkedSpanSelect(source: TTraceSource) {
   const eventBodyExpr = getEventBody(source);
   return [
     {
@@ -77,11 +76,11 @@ function getLinkedSpanSelect(
       alias: LINKED_SPAN_ALIASES.TIMESTAMP,
     },
     {
-      valueExpression: exprs.traceIdExpression,
+      valueExpression: source.traceIdExpression,
       alias: LINKED_SPAN_ALIASES.TRACE_ID,
     },
     {
-      valueExpression: exprs.spanIdExpression,
+      valueExpression: source.spanIdExpression,
       alias: LINKED_SPAN_ALIASES.SPAN_ID,
     },
     ...(eventBodyExpr
@@ -92,7 +91,7 @@ function getLinkedSpanSelect(
           },
         ]
       : []),
-    ...(source.kind === SourceKind.Trace && source.serviceNameExpression
+    ...(source.serviceNameExpression
       ? [
           {
             valueExpression: source.serviceNameExpression,
@@ -100,7 +99,7 @@ function getLinkedSpanSelect(
           },
         ]
       : []),
-    ...(source.kind === SourceKind.Trace && source.durationExpression
+    ...(source.durationExpression
       ? [
           {
             valueExpression: getDurationMsExpression(source),
@@ -155,7 +154,7 @@ export function getReverseSpanLinksConfig({
   return {
     connection: source.connection,
     from: source.from,
-    select: getLinkedSpanSelect(source, exprs),
+    select: getLinkedSpanSelect(exprs.source),
     where,
     whereLanguage: 'sql',
     timestampValueExpression: exprs.timestampExpr,
@@ -215,7 +214,7 @@ export function getLinkedSpansConfig({
   return {
     connection: source.connection,
     from: source.from,
-    select: getLinkedSpanSelect(source, exprs),
+    select: getLinkedSpanSelect(exprs.source),
     where,
     whereLanguage: 'sql',
     timestampValueExpression: exprs.timestampExpr,

--- a/packages/app/tests/e2e/components/SidePanelComponent.ts
+++ b/packages/app/tests/e2e/components/SidePanelComponent.ts
@@ -198,6 +198,46 @@ export class SidePanelComponent {
   }
 
   /**
+   * A clickable span row in the trace waterfall, matched by its label text.
+   * Clicking it opens the span detail panel (Overview tab).
+   */
+  getWaterfallSpan(name: string) {
+    return this.panelContainer
+      .locator('[role="button"]')
+      .filter({ hasText: name });
+  }
+
+  async clickWaterfallSpan(name: string) {
+    await this.getWaterfallSpan(name).first().click({ timeout: 10_000 });
+  }
+
+  /**
+   * Rows in the span detail's "Span Links" section. Each row's open action
+   * (`span-link-open-trace`) shows the linked span's name once the target
+   * span is resolved, or "Open trace" as the unresolved fallback.
+   */
+  get spanLinkRows() {
+    return this.panelContainer.getByTestId('span-link-row');
+  }
+
+  get spanLinkOpenActions() {
+    return this.panelContainer.getByTestId('span-link-open-trace');
+  }
+
+  /**
+   * Rows in the span detail's "Linked from" section (spans whose links
+   * reference the selected span), and the per-row action that opens the
+   * referencing span's trace.
+   */
+  get linkedFromRows() {
+    return this.panelContainer.getByTestId('linked-from-row');
+  }
+
+  get linkedFromOpenActions() {
+    return this.panelContainer.getByTestId('linked-from-open-span');
+  }
+
+  /**
    * Close the side panel (if it has a close button)
    */
   async close() {

--- a/packages/app/tests/e2e/features/span-links.spec.ts
+++ b/packages/app/tests/e2e/features/span-links.spec.ts
@@ -1,0 +1,84 @@
+import { SearchPage } from '../page-objects/SearchPage';
+import { SPAN_LINK_SEED } from '../seed-clickhouse';
+import { expect, test } from '../utils/base-test';
+import { DEFAULT_TRACES_SOURCE_NAME } from '../utils/constants';
+
+const { producer, consumer } = SPAN_LINK_SEED;
+
+// The seed writes a producer span and, in a different trace, a consumer span
+// whose Links reference it. These tests exercise both directions of span-link
+// resolution in the span detail panel, plus the breadcrumb pop-back on A <-> B
+// hops.
+test.describe('Span links', { tag: '@traces' }, () => {
+  let searchPage: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    searchPage = new SearchPage(page);
+    await searchPage.goto();
+    await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+    await searchPage.timePicker.selectRelativeTime('Last 1 days');
+  });
+
+  // Search a span by id, open its row, and select it in the trace waterfall so
+  // the span detail panel (Overview) is showing.
+  async function openSpanDetail(spanId: string, spanName: string) {
+    await searchPage.performSearch(`SpanId:"${spanId}"`);
+    await expect(searchPage.table.firstRow).toBeVisible();
+    await searchPage.table.clickFirstRow();
+    await expect(searchPage.sidePanel.container).toBeVisible();
+    await searchPage.sidePanel.clickWaterfallSpan(spanName);
+  }
+
+  test('span links resolve the linked span and navigate to its trace', async () => {
+    await openSpanDetail(consumer.spanId, consumer.spanName);
+
+    await test.step('link shows the resolved producer details', async () => {
+      const linkRow = searchPage.sidePanel.spanLinkRows.first();
+      await expect(linkRow).toContainText(producer.spanName);
+      await expect(linkRow).toContainText(producer.serviceName);
+      // The link's attributes still render alongside the resolved details.
+      await expect(linkRow).toContainText('link.kind: follows_from');
+    });
+
+    await test.step('clicking the link lands on the producer trace', async () => {
+      await searchPage.sidePanel.spanLinkOpenActions.first().click();
+
+      await expect(
+        searchPage.sidePanel.getWaterfallSpan(producer.spanName).first(),
+      ).toBeVisible();
+      // One level deep: root (consumer) + pushed frame (producer).
+      await expect(searchPage.sidePanel.getBreadcrumb(1)).toBeVisible();
+    });
+  });
+
+  test('linked from lists referencing spans and pops back on a return hop', async () => {
+    await openSpanDetail(producer.spanId, producer.spanName);
+
+    await test.step('producer shows the consumer under Linked from', async () => {
+      const linkedFromRow = searchPage.sidePanel.linkedFromRows.first();
+      await expect(linkedFromRow).toContainText(consumer.spanName);
+      await expect(linkedFromRow).toContainText(consumer.serviceName);
+    });
+
+    await test.step('hop to the consumer pushes a breadcrumb', async () => {
+      await searchPage.sidePanel.linkedFromOpenActions.first().click();
+
+      await expect(
+        searchPage.sidePanel.getWaterfallSpan(consumer.spanName).first(),
+      ).toBeVisible();
+      await expect(searchPage.sidePanel.getBreadcrumb(1)).toBeVisible();
+    });
+
+    await test.step('following the link back pops instead of pushing', async () => {
+      await searchPage.sidePanel.clickWaterfallSpan(consumer.spanName);
+      await searchPage.sidePanel.spanLinkOpenActions.first().click();
+
+      await expect(
+        searchPage.sidePanel.getWaterfallSpan(producer.spanName).first(),
+      ).toBeVisible();
+      // Back at the root producer view: the trail did not grow to a third
+      // level, it collapsed back to no breadcrumbs at all.
+      await expect(searchPage.sidePanel.getBreadcrumb(1)).toBeHidden();
+    });
+  });
+});

--- a/packages/app/tests/e2e/fixtures/e2e-fixtures.json
+++ b/packages/app/tests/e2e/fixtures/e2e-fixtures.json
@@ -48,6 +48,7 @@
       "parentSpanIdExpression": "ParentSpanId",
       "spanKindExpression": "SpanKind",
       "spanNameExpression": "SpanName",
+      "spanLinksValueExpression": "Links",
       "logSourceId": "E2E Logs",
       "statusCodeExpression": "StatusCode",
       "statusMessageExpression": "StatusMessage",

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -376,6 +376,39 @@ function generateTraceData(
   return rows.join(',\n');
 }
 
+// Cross-trace span-link pair: a consumer span in its own trace whose Links
+// reference a producer span in another trace. Exercises both directions of
+// span-link resolution in the span detail panel (resolved "Span Links"
+// details and the reverse "Linked from" section). Exported so specs can
+// search for these spans by name.
+export const SPAN_LINK_SEED = {
+  producer: {
+    traceId: 'e2e-link-producer-trace',
+    spanId: 'e2e-link-producer-span',
+    spanName: 'E2E Link Producer Publish',
+    serviceName: 'link-producer-svc',
+  },
+  consumer: {
+    traceId: 'e2e-link-consumer-trace',
+    spanId: 'e2e-link-consumer-span',
+    spanName: 'E2E Link Consumer Process',
+    serviceName: 'link-consumer-svc',
+  },
+} as const;
+
+function generateSpanLinkTraces(seedRef: number): string {
+  const { producer, consumer } = SPAN_LINK_SEED;
+  // Producer runs first; the consumer picks the message up 30s later and
+  // links back — inside both lookup windows (reverse −1h/+24h from the
+  // producer, forward −24h/+1h from the consumer).
+  const producerNs = (seedRef - 60_000) * 1_000_000;
+  const consumerNs = (seedRef - 30_000) * 1_000_000;
+  return [
+    `('${producerNs}', '${producer.traceId}', '${producer.spanId}', '', '', '${producer.spanName}', 'SPAN_KIND_PRODUCER', '${producer.serviceName}', {'service.name':'${producer.serviceName}','environment':'test'}, '', '', {}, 12000000, 'STATUS_CODE_OK', '', [], [], [], [], [], [], [])`,
+    `('${consumerNs}', '${consumer.traceId}', '${consumer.spanId}', '', '', '${consumer.spanName}', 'SPAN_KIND_CONSUMER', '${consumer.serviceName}', {'service.name':'${consumer.serviceName}','environment':'test'}, '', '', {}, 34000000, 'STATUS_CODE_OK', '', [], [], [], ['${producer.traceId}'], ['${producer.spanId}'], [''], [{'link.kind':'follows_from'}])`,
+  ].join(',\n');
+}
+
 function generateSessionData(
   count: number,
   startMs: number,
@@ -898,6 +931,19 @@ export async function seedClickHouse(): Promise<void> {
     ) VALUES ${generateTraceData(numDataPoints, startMs, endMs)}
   `);
   console.log(`  Inserted ${numDataPoints} trace spans`);
+
+  // Insert the cross-trace span-link pair (producer + consumer)
+  console.log('  Inserting span-link trace pair...');
+  await client.query(`
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_TRACES_TABLE} (
+      Timestamp, TraceId, SpanId, ParentSpanId, TraceState, SpanName, SpanKind,
+      ServiceName, ResourceAttributes, ScopeName, ScopeVersion, SpanAttributes,
+      Duration, StatusCode, StatusMessage, \`Events.Timestamp\`, \`Events.Name\`,
+      \`Events.Attributes\`, \`Links.TraceId\`, \`Links.SpanId\`, \`Links.TraceState\`,
+      \`Links.Attributes\`
+    ) VALUES ${generateSpanLinkTraces(seedRef)}
+  `);
+  console.log('  Inserted span-link trace pair');
 
   // Insert session trace data (spans with rum.sessionId for session tracking)
   console.log('  Inserting session trace data...');


### PR DESCRIPTION
## Summary

Span links were only usable from the consumer side: a span showed the links it carries, as bare "Open trace" actions. There was no way to start from a producer span and find the consumer spans that link back to it.

- New **"Linked from"** section in the span Overview panel listing spans whose links reference the selected span. Each entry shows the referencing span's name, service, duration, and timestamp, with the same open-trace navigation as forward links.
- The existing **Span Links** section now resolves each link's target span and shows the same details instead of a bare "Open trace" action (which remains the fallback when the target can't be found).
- Since forward and reverse links come in pairs, clicking a link that targets the span you just hopped from pops back to the previous breadcrumb instead of growing the trail forever on A ↔ B hops. `SourceFrame` gains an optional, source-agnostic `originRowId` for this.
- Both lookups run through `useQueriedChartConfig` bounded to a time window anchored on the selected span, skewed in the direction links point in time: referencing spans run at/after the span (−1h/+24h), linked-to spans ran at/before it (−24h/+1h).

### Screenshots or video

<!--
If this PR includes UI changes, include screenshots or a short video.
For new features, "Before" can be omitted.

Omit this section if the PR does not contain any UI changes.
-->


https://github.com/user-attachments/assets/63caa6ca-e4fb-4a20-9f8c-c0d011b9a412


### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** `/search`

**Steps:**

1. Find a span that has some links (search `Links.SpanId != []`)
2. Open the span and scroll to the span link section, navigate to the linked span.
3. Check the reverse linking on the linked to span, as shown in the video.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5042
- GitHub Issue: Closes https://github.com/hyperdxio/hyperdx/issues/2828
- Related PRs:
    - https://github.com/hyperdxio/hyperdx/pull/2463
    - https://github.com/hyperdxio/hyperdx/pull/2868
