### PR TITLE
feat(app): unify alert actions and make the alert source legible

### DIFF
--- a/.changeset/alert-detail-ux.md
+++ b/.changeset/alert-detail-ux.md
@@ -1,0 +1,15 @@
+---
+'@hyperdx/app': minor
+---
+
+feat(alerts): tidy the alert detail header and its properties block
+
+Edit, Delete and Terraform export move behind the same overflow menu the
+alerts list uses, so the header no longer spreads four buttons across the top
+and both surfaces offer the same actions. The link to what the alert watches
+becomes an icon beside the alert name, where it reads as part of the alert's
+identity rather than another action.
+
+The properties block splits configuration from provenance: the creator now
+sits with the created and updated timestamps in a dimmed line beneath, instead
+of competing with the alert's settings.

--- a/.changeset/alerts-summary-ux.md
+++ b/.changeset/alerts-summary-ux.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/app': minor
+---
+
+feat(alerts): edit from the alerts list, filter by alert source, and label the source icons
+
+The alerts page row menu now opens the alert editor directly, so changing a
+threshold no longer means navigating to the alert first. The source icon on
+each row gets a tooltip and accessible label naming what it watches ("Saved
+search" / "Dashboard tile"), and a new filter narrows the list by that source
+— free-text search matches it too, so typing "tile" works without touching the
+dropdown. Team settings tabs gain icons.

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -2,20 +2,19 @@ import * as React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { AlertInterval, AlertSource } from '@hyperdx/common-utils/dist/types';
+import { AlertInterval } from '@hyperdx/common-utils/dist/types';
 import {
+  ActionIcon,
   Anchor,
   Breadcrumbs,
-  Button,
   Container,
   Group,
   Skeleton,
   Stack,
   Text,
+  Tooltip,
 } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
-import { IconExternalLink, IconPencil } from '@tabler/icons-react';
-import { useQueryClient } from '@tanstack/react-query';
+import { IconExternalLink } from '@tabler/icons-react';
 
 import { AckAlert } from '@/components/alerts/AckAlert';
 import { AlertDetailChart } from '@/components/alerts/AlertDetailChart';
@@ -23,14 +22,17 @@ import { AlertDetailProperties } from '@/components/alerts/AlertDetailProperties
 import { AlertNote } from '@/components/alerts/AlertDetails';
 import { AlertEvaluationsTable } from '@/components/alerts/AlertEvaluationsTable';
 import { AlertHistoryCardList } from '@/components/alerts/AlertHistoryCards';
+import { AlertRowMenu } from '@/components/alerts/AlertRowMenu';
 import { AlertStateBadge } from '@/components/alerts/AlertStateBadge';
-import { EditAlertModal } from '@/components/alerts/EditAlertModal';
-import ConfirmDeleteMenu from '@/components/ConfirmDeleteMenu';
 import EmptyState from '@/components/EmptyState';
 import { PageHeader } from '@/components/PageHeader';
 import { TimePicker } from '@/components/TimePicker';
 import { IS_ALERT_DETAILS_ENABLED } from '@/config';
-import { getAlertDisplayName, getAlertSourceUrl } from '@/utils/alerts';
+import {
+  getAlertDisplayName,
+  getAlertSourceLabel,
+  getAlertSourceUrl,
+} from '@/utils/alerts';
 
 import { useBrandDisplayName } from './theme/ThemeProvider';
 import api from './api';
@@ -80,35 +82,7 @@ function AlertProperties({ alert }: { alert: AlertsPageItem }) {
 
 function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
   const alertUrl = getAlertSourceUrl(alert);
-  const brandName = useBrandDisplayName();
   const router = useRouter();
-  const queryClient = useQueryClient();
-  const deleteAlert = api.useDeleteAlert();
-  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
-
-  const onDeleteAlert = React.useCallback(async () => {
-    try {
-      await deleteAlert.mutateAsync(alert._id);
-      notifications.show({
-        color: 'green',
-        message: 'Alert deleted!',
-        autoClose: 5000,
-      });
-      // The alerts list and the source-bound edit surfaces (saved search
-      // modal / dashboard tile editor) all render this alert.
-      queryClient.invalidateQueries({ queryKey: api.getAlertsQueryKey() });
-      queryClient.invalidateQueries({ queryKey: ['saved-search'] });
-      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
-      router.push('/alerts');
-    } catch (error) {
-      console.error('Failed to delete alert:', error);
-      notifications.show({
-        color: 'red',
-        message: `Something went wrong. Please contact ${brandName} team.`,
-        autoClose: 5000,
-      });
-    }
-  }, [alert._id, brandName, deleteAlert, queryClient, router]);
 
   // Interval-dependent, but fixed for the page lifetime: the body only
   // mounts once the alert has loaded, and useNewTimeQuery reads the initial
@@ -169,34 +143,42 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
           <Group gap="sm">
             {alert.state != null && <AlertStateBadge state={alert.state} />}
             <Text fw={500}>{getAlertDisplayName(alert)}</Text>
+            {alertUrl && (
+              /* Next to the name rather than in the actions row: it navigates
+                 to what the alert watches, so it belongs with the identity,
+                 not with the verbs acting on the alert. */
+              <Tooltip
+                label={`Open ${getAlertSourceLabel(alert).toLowerCase()}`}
+                withArrow
+              >
+                <ActionIcon
+                  component={Link}
+                  href={alertUrl}
+                  variant="subtle"
+                  color="gray"
+                  size="md"
+                  aria-label={`Open ${getAlertSourceLabel(alert).toLowerCase()}`}
+                  data-testid="open-alert-source"
+                >
+                  <IconExternalLink size={16} />
+                </ActionIcon>
+              </Tooltip>
+            )}
           </Group>
         }
         actions={
           <Group gap="sm" wrap="nowrap">
             <AckAlert alert={alert} />
-            <Button
-              data-testid="edit-alert-button"
-              variant="secondary"
-              size="compact-sm"
-              leftSection={<IconPencil size={14} />}
-              onClick={() => setIsEditModalOpen(true)}
-            >
-              Edit alert
-            </Button>
-            <ConfirmDeleteMenu onDelete={onDeleteAlert} />
-            {alertUrl && (
-              <Button
-                component={Link}
-                href={alertUrl}
-                variant="secondary"
-                size="compact-sm"
-                rightSection={<IconExternalLink size={14} />}
-              >
-                {alert.source === AlertSource.TILE
-                  ? 'Open dashboard tile'
-                  : 'Open saved search'}
-              </Button>
-            )}
+            {/* Edit, Terraform export and Delete live behind one overflow
+                control, shared with the alerts list so both surfaces offer the
+                same actions. The menu's own source-link item is suppressed:
+                this page carries that link next to the title instead. */}
+            <AlertRowMenu
+              alert={alert}
+              alertName={getAlertDisplayName(alert)}
+              dateRange={searchedTimeRange}
+              onDeleted={() => router.push('/alerts')}
+            />
             <TimePicker
               inputValue={displayedTimeInputValue}
               setInputValue={setDisplayedTimeInputValue}
@@ -204,12 +186,6 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
             />
           </Group>
         }
-      />
-      <EditAlertModal
-        alert={alert}
-        opened={isEditModalOpen}
-        onClose={() => setIsEditModalOpen(false)}
-        dateRange={searchedTimeRange}
       />
       <div style={{ overflow: 'auto', flexGrow: 1 }}>
         <Container size="xl" py="md">

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -155,7 +155,6 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
                   component={Link}
                   href={alertUrl}
                   variant="subtle"
-                  color="gray"
                   size="md"
                   aria-label={`Open ${getAlertSourceLabel(alert).toLowerCase()}`}
                   data-testid="open-alert-source"

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -22,6 +22,7 @@ import { PageHeader } from '@/components/PageHeader';
 import {
   getAlertCreatorLabel,
   getAlertDisplayName,
+  getAlertSourceLabel,
   getAlertTags,
 } from '@/utils/alerts';
 
@@ -38,6 +39,7 @@ export default function AlertsPage() {
   const [search, setSearch] = useQueryState('search');
   const [tagFilter, setTagFilter] = useQueryState('tag');
   const [creatorFilter, setCreatorFilter] = useQueryState('creator');
+  const [sourceFilter, setSourceFilter] = useQueryState('alertSource');
 
   const allTags = React.useMemo(() => {
     const tags = new Set<string>();
@@ -54,8 +56,19 @@ export default function AlertsPage() {
     return Array.from(creators).sort();
   }, [alerts]);
 
+  // Only the source types actually present, so the filter never offers an
+  // option that yields an empty list.
+  const allSources = React.useMemo(() => {
+    const sources = new Set<string>();
+    alerts.forEach(a => sources.add(getAlertSourceLabel(a)));
+    return Array.from(sources).sort();
+  }, [alerts]);
+
   const filteredAlerts = React.useMemo(() => {
     let result = alerts;
+    if (sourceFilter) {
+      result = result.filter(a => getAlertSourceLabel(a) === sourceFilter);
+    }
     if (tagFilter) {
       result = result.filter(a => getAlertTags(a).includes(tagFilter));
     }
@@ -67,13 +80,24 @@ export default function AlertsPage() {
       result = result.filter(
         a =>
           getAlertDisplayName(a).toLowerCase().includes(q) ||
+          // So "tile" / "saved search" narrow the list the same way the type
+          // filter does, without having to reach for the dropdown.
+          getAlertSourceLabel(a)
+            .toLowerCase()
+            .split(' ')
+            .some(word => word.startsWith(q)) ||
           getAlertTags(a).some(t => t.toLowerCase().includes(q)),
       );
     }
     return result;
-  }, [alerts, search, tagFilter, creatorFilter]);
+  }, [alerts, search, tagFilter, creatorFilter, sourceFilter]);
 
-  const hasFilters = !!(search?.trim() || tagFilter || creatorFilter);
+  const hasFilters = !!(
+    search?.trim() ||
+    tagFilter ||
+    creatorFilter ||
+    sourceFilter
+  );
 
   return (
     <div
@@ -121,6 +145,23 @@ export default function AlertsPage() {
                 miw={100}
                 data-testid="alerts-search-input"
               />
+              {(allSources.length > 1 || sourceFilter) && (
+                <Select
+                  placeholder="Filter by alert source"
+                  // A filter carried in from the URL may name a source no
+                  // current alert has; keep it selectable so it can be cleared.
+                  data={
+                    sourceFilter && !allSources.includes(sourceFilter)
+                      ? [...allSources, sourceFilter]
+                      : allSources
+                  }
+                  value={sourceFilter}
+                  onChange={v => setSourceFilter(v)}
+                  clearable
+                  style={{ maxWidth: 220 }}
+                  data-testid="alerts-source-filter"
+                />
+              )}
               {allTags.length > 0 && (
                 <Select
                   placeholder="Filter by tag"

--- a/packages/app/src/TeamPage.tsx
+++ b/packages/app/src/TeamPage.tsx
@@ -14,7 +14,15 @@ import {
   TextInput,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconPencil } from '@tabler/icons-react';
+import {
+  IconAdjustmentsHorizontal,
+  IconApi,
+  IconDatabase,
+  IconPencil,
+  IconPlug,
+  IconShieldLock,
+  IconUsers,
+} from '@tabler/icons-react';
 
 import { PageHeader } from './components/PageHeader';
 import ApiKeysSection from './components/TeamSettings/ApiKeysSection';
@@ -34,6 +42,7 @@ import { APP_CONTENT_SCROLL_CONTAINER_ID, withAppNav } from './layout';
 type TeamTab = {
   value: string;
   label: string;
+  icon: ReactNode;
   sections: {
     id: string;
     // Always a function of whether this tab is the visible one. Mantine `Tabs`
@@ -106,6 +115,7 @@ export default function TeamPage() {
     {
       value: 'data',
       label: 'Data',
+      icon: <IconDatabase size={16} />,
       sections: [
         {
           id: 'team-data-sources',
@@ -120,6 +130,7 @@ export default function TeamPage() {
     {
       value: 'team',
       label: 'Members',
+      icon: <IconUsers size={16} />,
       sections: [
         {
           id: 'team-members',
@@ -132,6 +143,7 @@ export default function TeamPage() {
           {
             value: 'access',
             label: 'Access',
+            icon: <IconShieldLock size={16} />,
             sections: [
               {
                 id: 'team-access-security-policies',
@@ -148,6 +160,7 @@ export default function TeamPage() {
     {
       value: 'api-agents',
       label: 'API & Agents',
+      icon: <IconApi size={16} />,
       sections: [
         {
           id: 'team-api-agents-api-keys',
@@ -172,6 +185,7 @@ export default function TeamPage() {
     {
       value: 'integrations',
       label: 'Integrations',
+      icon: <IconPlug size={16} />,
       sections: [
         {
           id: 'team-integrations-webhooks',
@@ -182,6 +196,7 @@ export default function TeamPage() {
     {
       value: 'advanced',
       label: 'Query Settings',
+      icon: <IconAdjustmentsHorizontal size={16} />,
       sections: [
         {
           id: 'team-advanced-query-settings',
@@ -333,7 +348,11 @@ export default function TeamPage() {
             <Tabs value={activeTab} onChange={handleTabChange}>
               <Tabs.List>
                 {tabs.map(tab => (
-                  <Tabs.Tab key={tab.value} value={tab.value}>
+                  <Tabs.Tab
+                    key={tab.value}
+                    value={tab.value}
+                    leftSection={tab.icon}
+                  >
                     {tab.label}
                   </Tabs.Tab>
                 ))}

--- a/packages/app/src/components/alerts/AlertDetailProperties.tsx
+++ b/packages/app/src/components/alerts/AlertDetailProperties.tsx
@@ -29,7 +29,7 @@ function PropertyRow({
 
 /**
  * Full alert metadata block for the alert detail page: the shared one-line
- * summary (threshold, schedule, targets, creator) plus every other persisted
+ * summary (threshold, schedule, targets) plus every other persisted
  * property — name, message template, group-by, schedule anchor/offset,
  * acknowledgement, tags, and created/updated timestamps. Rows render only
  * when the field is set.
@@ -101,19 +101,22 @@ export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
             </Group>
           </PropertyRow>
         )}
-        <PropertyRow label="Created" testId="alert-property-created">
-          <Text size="xs" c="dimmed" component="span">
-            <FormatTime value={alert.createdAt} format="withYear" />
-            {alert.updatedAt && alert.updatedAt !== alert.createdAt && (
-              <>
-                {' '}
-                · Updated{' '}
-                <FormatTime value={alert.updatedAt} format="withYear" />
-              </>
-            )}
-          </Text>
-        </PropertyRow>
       </div>
+      {/* Provenance, not configuration: the creator joins the timestamps in
+          one dimmed sub-heading line rather than competing with the alert's
+          settings above. */}
+      <Text size="xs" c="dimmed" mt="xs" data-testid="alert-property-created">
+        {alert.createdBy && (
+          <>Created by {alert.createdBy.name || alert.createdBy.email} · </>
+        )}
+        <FormatTime value={alert.createdAt} format="withYear" />
+        {alert.updatedAt && alert.updatedAt !== alert.createdAt && (
+          <>
+            {' '}
+            · Updated <FormatTime value={alert.updatedAt} format="withYear" />
+          </>
+        )}
+      </Text>
     </div>
   );
 }

--- a/packages/app/src/components/alerts/AlertDetails.tsx
+++ b/packages/app/src/components/alerts/AlertDetails.tsx
@@ -8,6 +8,8 @@ import {
   Flex,
   Group,
   Stack,
+  Text,
+  Tooltip,
   UnstyledButton,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
@@ -28,6 +30,7 @@ import { IS_ALERT_DETAILS_ENABLED } from '@/config';
 import type { AlertsPageItem } from '@/types';
 import {
   getAlertDisplayName,
+  getAlertSourceLabel,
   getAlertSourceUrl,
   getAlertTags,
 } from '@/utils/alerts';
@@ -122,27 +125,48 @@ export const AlertDetails = React.memo(function AlertDetails({
 
   const alertUrl = React.useMemo(() => getAlertSourceUrl(alert), [alert]);
 
-  const alertIcon = (() => {
+  const sourceLabel = getAlertSourceLabel(alert);
+
+  // The glyph alone doesn't say what it watches; the tooltip (and its
+  // accessible label) names it. `span` wrapper: Tooltip needs an element that
+  // forwards a ref, which the icon components don't.
+  const sourceGlyph = (() => {
     switch (alert.source) {
       case AlertSource.TILE:
-        return <IconChartLine size={14} />;
+        return <IconChartLine size={14} aria-hidden="true" />;
       case AlertSource.SAVED_SEARCH:
-        return <IconTableRow size={14} />;
+        return <IconTableRow size={14} aria-hidden="true" />;
       default:
-        return <IconHelpCircle size={14} />;
+        return <IconHelpCircle size={14} aria-hidden="true" />;
     }
   })();
 
-  const linkTitle = React.useMemo(() => {
-    switch (alert.source) {
-      case AlertSource.TILE:
-        return 'Dashboard tile';
-      case AlertSource.SAVED_SEARCH:
-        return 'Saved search';
-      default:
-        return '';
-    }
-  }, [alert]);
+  // Only labelled when the source actually resolves — same guard as
+  // `linkTitle`, so an alert whose source is gone doesn't get a confident
+  // "Unknown source" tooltip where the rest of the row stays silent.
+  const alertIcon = alert.source ? (
+    <Tooltip label={sourceLabel} withArrow position="top">
+      <span
+        role="img"
+        aria-label={sourceLabel}
+        style={{ display: 'inline-flex' }}
+        data-testid={`alert-source-icon-${alert._id}`}
+      >
+        {sourceGlyph}
+      </span>
+    </Tooltip>
+  ) : (
+    <span
+      style={{ display: 'inline-flex' }}
+      data-testid={`alert-source-icon-${alert._id}`}
+    >
+      {sourceGlyph}
+    </span>
+  );
+
+  // Empty for an unresolvable source: AlertRowMenu lowercases this into
+  // "Open <source>" and falls back to its own wording when blank.
+  const linkTitle = alert.source ? sourceLabel : '';
 
   return (
     <div data-testid={`alert-card-${alert._id}`} className={styles.alertRow}>
@@ -184,6 +208,11 @@ export const AlertDetails = React.memo(function AlertDetails({
             </Link>
           </div>
           <AlertPropertiesSummary alert={alert} />
+          {alert.createdBy && (
+            <Text size="xs" c="dimmed" data-testid="alert-created-by">
+              Created by {alert.createdBy.name || alert.createdBy.email}
+            </Text>
+          )}
           {getAlertTags(alert).length > 0 && (
             <Group gap={4}>
               {getAlertTags(alert).map(tag => (

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -13,6 +13,8 @@ import {
 } from '@/utils/alerts';
 import { getWebhookChannelIcon } from '@/utils/webhookIcons';
 
+import styles from '@styles/AlertsPage.module.scss';
+
 /**
  * Targets listed inline before the rest collapse into a "+N more" tooltip.
  * An alert can carry up to MAX_ALERT_CHANNELS, which would push the creator
@@ -176,13 +178,8 @@ export function AlertPropertiesSummary({
     alert.thresholdType;
 
   return (
-    // Segments wrap as whole phrases: each is nowrap, so a narrow container
-    // breaks between them rather than splitting "Notify via" down the middle.
-    <div
-      className="fs-8 d-flex gap-2 align-items-center"
-      style={{ flexWrap: 'wrap', rowGap: 4 }}
-    >
-      <span style={{ whiteSpace: 'nowrap' }}>
+    <div className={`fs-8 ${styles.propertiesSummary}`}>
+      <span className={styles.propertySegment}>
         If value {thresholdLabel}{' '}
         <span className="fw-bold">{alert.threshold}</span>
         {isRangeThresholdType(alert.thresholdType) && (
@@ -195,14 +192,14 @@ export function AlertPropertiesSummary({
       {isDetail && (
         <>
           <span>&middot;</span>
-          <span style={{ whiteSpace: 'nowrap' }}>
+          <span className={styles.propertySegment}>
             Evaluates every {alert.interval}
           </span>
           {alert.numConsecutiveWindows != null &&
             alert.numConsecutiveWindows > 1 && (
               <>
                 <span>&middot;</span>
-                <span style={{ whiteSpace: 'nowrap' }}>
+                <span className={styles.propertySegment}>
                   Fires after {alert.numConsecutiveWindows} consecutive windows
                 </span>
               </>

--- a/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
+++ b/packages/app/src/components/alerts/AlertPropertiesSummary.tsx
@@ -160,8 +160,11 @@ function NotificationTargets({
 
 /**
  * One-line alert metadata summary: threshold condition, optional evaluation
- * schedule, notification targets, and creator. Shared between the alerts
- * page rows and the alert detail page header.
+ * schedule, and notification targets — configuration only.
+ *
+ * The creator is deliberately absent: it is provenance, not configuration, and
+ * at equal weight it crowded the line into a second row that broke mid-phrase.
+ * Each surface renders it as its own dimmed sub-line instead.
  */
 export function AlertPropertiesSummary({
   alert,
@@ -173,8 +176,13 @@ export function AlertPropertiesSummary({
     alert.thresholdType;
 
   return (
-    <div className="fs-8 d-flex gap-2 align-items-center">
-      <span>
+    // Segments wrap as whole phrases: each is nowrap, so a narrow container
+    // breaks between them rather than splitting "Notify via" down the middle.
+    <div
+      className="fs-8 d-flex gap-2 align-items-center"
+      style={{ flexWrap: 'wrap', rowGap: 4 }}
+    >
+      <span style={{ whiteSpace: 'nowrap' }}>
         If value {thresholdLabel}{' '}
         <span className="fw-bold">{alert.threshold}</span>
         {isRangeThresholdType(alert.thresholdType) && (
@@ -187,12 +195,14 @@ export function AlertPropertiesSummary({
       {isDetail && (
         <>
           <span>&middot;</span>
-          <span>Evaluates every {alert.interval}</span>
+          <span style={{ whiteSpace: 'nowrap' }}>
+            Evaluates every {alert.interval}
+          </span>
           {alert.numConsecutiveWindows != null &&
             alert.numConsecutiveWindows > 1 && (
               <>
                 <span>&middot;</span>
-                <span>
+                <span style={{ whiteSpace: 'nowrap' }}>
                   Fires after {alert.numConsecutiveWindows} consecutive windows
                 </span>
               </>
@@ -201,14 +211,6 @@ export function AlertPropertiesSummary({
       )}
       <span>&middot;</span>
       <NotificationTargets alert={alert} showNames={isDetail} />
-      {alert.createdBy && (
-        <>
-          <span>&middot;</span>
-          <span>
-            Created by {alert.createdBy.name || alert.createdBy.email}
-          </span>
-        </>
-      )}
     </div>
   );
 }

--- a/packages/app/src/components/alerts/AlertRowMenu.tsx
+++ b/packages/app/src/components/alerts/AlertRowMenu.tsx
@@ -34,6 +34,14 @@ type AlertRowMenuProps = {
    * for an alert whose source can't be resolved, so callers may pass one.
    */
   alertName?: string;
+  /**
+   * Range for the edit modal's threshold preview. Callers with a picked range
+   * (the detail page) pass it; a list row has none and falls back to one
+   * derived from the alert's interval.
+   */
+  dateRange?: [Date, Date];
+  /** Runs after a successful delete, e.g. to navigate away from a detail page. */
+  onDeleted?: () => void;
 };
 
 /**
@@ -51,6 +59,8 @@ export function AlertRowMenu({
   alertUrl,
   linkTitle,
   alertName,
+  dateRange,
+  onDeleted,
 }: AlertRowMenuProps) {
   // `||`, not `??`: the empty string these arrive as for an unresolvable
   // source is not nullish, and would read as "Open " and "Delete ?".
@@ -80,14 +90,15 @@ export function AlertRowMenu({
     enabled: terraformOpened,
   });
 
-  // The edit modal's threshold preview needs a range; derive one from the
-  // alert's own interval (a list row has no picked range). Recomputed when the
-  // modal opens so a long-lived list doesn't preview a stale window.
-  const previewRange = React.useMemo(
+  // The edit modal's threshold preview needs a range. Callers with a picked
+  // one pass it; otherwise derive from the alert's interval, recomputed when
+  // the modal opens so a long-lived list doesn't preview a stale window.
+  const derivedRange = React.useMemo(
     () => intervalToDateRange(alert.interval),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- editOpened refreshes the window
     [alert.interval, editOpened],
   );
+  const previewRange = dateRange ?? derivedRange;
 
   // Eligibility comes from the shared predicate rather than an inline source
   // check, so this and the bulk export can't diverge on which alerts the
@@ -115,6 +126,7 @@ export function AlertRowMenu({
       queryClient.invalidateQueries({ queryKey: api.getAlertsQueryKey() });
       queryClient.invalidateQueries({ queryKey: ['saved-search'] });
       queryClient.invalidateQueries({ queryKey: ['dashboards'] });
+      onDeleted?.();
     } catch (error) {
       console.error('Failed to delete alert:', error);
       notifications.show({
@@ -123,7 +135,15 @@ export function AlertRowMenu({
         autoClose: 5000,
       });
     }
-  }, [alert._id, brandName, confirm, deleteAlert, name, queryClient]);
+  }, [
+    alert._id,
+    brandName,
+    confirm,
+    deleteAlert,
+    name,
+    onDeleted,
+    queryClient,
+  ]);
 
   return (
     <>

--- a/packages/app/src/components/alerts/AlertRowMenu.tsx
+++ b/packages/app/src/components/alerts/AlertRowMenu.tsx
@@ -7,17 +7,20 @@ import {
   IconBrandTerraform,
   IconDots,
   IconExternalLink,
+  IconPencil,
   IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import api from '@/api';
+import { EditAlertModal } from '@/components/alerts/EditAlertModal';
 import { TerraformHelperPanel } from '@/components/Iac/TerraformHelperPanel';
 import { useTerraformSnippets } from '@/components/Iac/useTerraformSnippets';
 import { IS_IAC_EXPORT_ENABLED } from '@/config';
 import { useBrandDisplayName } from '@/theme/ThemeProvider';
 import type { AlertsPageItem } from '@/types';
 import { useConfirm } from '@/useConfirm';
+import { intervalToDateRange } from '@/utils/alerts';
 
 type AlertRowMenuProps = {
   alert: AlertsPageItem;
@@ -54,6 +57,7 @@ export function AlertRowMenu({
   const name = alertName?.trim() || 'this alert';
   const sourceLabel = linkTitle?.trim().toLowerCase() || 'source';
   const [terraformOpened, setTerraformOpened] = React.useState(false);
+  const [editOpened, setEditOpened] = React.useState(false);
   const confirm = useConfirm();
   const queryClient = useQueryClient();
   const brandName = useBrandDisplayName();
@@ -75,6 +79,15 @@ export function AlertRowMenu({
     resource,
     enabled: terraformOpened,
   });
+
+  // The edit modal's threshold preview needs a range; derive one from the
+  // alert's own interval (a list row has no picked range). Recomputed when the
+  // modal opens so a long-lived list doesn't preview a stale window.
+  const previewRange = React.useMemo(
+    () => intervalToDateRange(alert.interval),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- editOpened refreshes the window
+    [alert.interval, editOpened],
+  );
 
   // Eligibility comes from the shared predicate rather than an inline source
   // check, so this and the bulk export can't diverge on which alerts the
@@ -126,6 +139,13 @@ export function AlertRowMenu({
           </ActionIcon>
         </Menu.Target>
         <Menu.Dropdown>
+          <Menu.Item
+            leftSection={<IconPencil size={16} />}
+            onClick={() => setEditOpened(true)}
+            data-testid={`alert-edit-${alert._id}`}
+          >
+            Edit alert
+          </Menu.Item>
           {alertUrl && (
             <Menu.Item
               component={Link}
@@ -155,6 +175,12 @@ export function AlertRowMenu({
         </Menu.Dropdown>
       </Menu>
       {/* Outside the dropdown, which unmounts on close. */}
+      <EditAlertModal
+        alert={alert}
+        opened={editOpened}
+        onClose={() => setEditOpened(false)}
+        dateRange={previewRange}
+      />
       <Modal
         opened={terraformOpened}
         onClose={() => setTerraformOpened(false)}

--- a/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
@@ -65,6 +65,23 @@ describe('AlertPropertiesSummary notification targets', () => {
     });
   });
 
+  // Both surfaces render the creator as their own dimmed sub-line, so the
+  // shared summary stays configuration-only.
+  it.each(['row', 'detail'] as const)(
+    'omits the creator in the %s variant',
+    variant => {
+      const withCreator = {
+        ...baseAlert,
+        createdBy: { name: 'Ada', email: 'ada@x.test' },
+      } satisfies AlertsPageItem;
+      renderWithMantine(
+        <AlertPropertiesSummary alert={withCreator} variant={variant} />,
+      );
+
+      expect(screen.queryByText(/Created by/)).not.toBeInTheDocument();
+    },
+  );
+
   describe('detail page', () => {
     it('names the single target of a legacy single-channel alert', () => {
       renderWithMantine(

--- a/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
@@ -27,6 +27,14 @@ jest.mock('@/config', () => ({
   BASE_PATH: '',
 }));
 
+// The edit modal pulls in the whole alert form (queries, editors, target
+// picker); this suite is about the menu, so stub it down to an open/closed
+// marker.
+jest.mock('@/components/alerts/EditAlertModal', () => ({
+  EditAlertModal: ({ opened }: { opened: boolean }) =>
+    opened ? <div data-testid="edit-alert-modal" /> : null,
+}));
+
 const confirm = jest.fn().mockResolvedValue(true);
 jest.mock('@/useConfirm', () => ({ useConfirm: () => confirm }));
 jest.mock('@/theme/ThemeProvider', () => ({
@@ -89,6 +97,29 @@ describe('AlertRowMenu', () => {
     renderMenu(<AlertRowMenu alert={tileAlert} />);
 
     expect(screen.getByTestId('alert-row-menu-alert-2')).toBeInTheDocument();
+  });
+
+  it('opens the edit modal from the menu', async () => {
+    renderMenu(<AlertRowMenu alert={savedSearchAlert} />);
+
+    expect(screen.queryByTestId('edit-alert-modal')).not.toBeInTheDocument();
+    await openMenu('alert-row-menu-alert-1');
+    // Same rationale as openMenu's own wait: under parallel workers the
+    // dropdown's transition can lag behind the menu role appearing.
+    const editItem = await screen.findByTestId(
+      'alert-edit-alert-1',
+      undefined,
+      {
+        timeout: 5000,
+      },
+    );
+    await userEvent.click(editItem);
+
+    expect(
+      await screen.findByTestId('edit-alert-modal', undefined, {
+        timeout: 5000,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('offers Terraform export for a saved-search alert', async () => {

--- a/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
@@ -78,6 +78,12 @@ function renderMenu(ui: React.ReactElement) {
 // Wait for the dropdown itself: Mantine mounts it through a transition, so a
 // bare click leaves the items absent and every "item is missing" assertion
 // passes for the wrong reason.
+// openMenu alone waits up to 5s for the dropdown, which is the whole default
+// per-test budget — under parallel workers a slow transition times out the
+// test before its assertions run. Give every test in this file headroom above
+// that internal wait.
+jest.setTimeout(15_000);
+
 const openMenu = async (testId: string) => {
   await userEvent.click(screen.getByTestId(testId));
   // Generous timeout: the transition competes with the rest of the suite

--- a/packages/app/src/utils/__tests__/alerts.test.ts
+++ b/packages/app/src/utils/__tests__/alerts.test.ts
@@ -1,4 +1,7 @@
+import { AlertSource } from '@hyperdx/common-utils/dist/types';
+
 import {
+  getAlertSourceLabel,
   normalizeNoOpAlertScheduleFields,
   toAlertChannels,
 } from '@/utils/alerts';
@@ -160,5 +163,24 @@ describe('toAlertChannels', () => {
       wh('a'),
       email,
     ]);
+  });
+});
+
+describe('getAlertSourceLabel', () => {
+  it('names each source kind', () => {
+    expect(getAlertSourceLabel({ source: AlertSource.SAVED_SEARCH })).toBe(
+      'Saved search',
+    );
+    expect(getAlertSourceLabel({ source: AlertSource.TILE })).toBe(
+      'Dashboard tile',
+    );
+  });
+
+  // The row's tooltip, the alerts-page filter and free-text search all read
+  // this, so an unresolvable source has to yield something printable rather
+  // than undefined leaking into a label.
+  it('falls back for a missing source', () => {
+    expect(getAlertSourceLabel({})).toBe('Unknown source');
+    expect(getAlertSourceLabel({ source: null })).toBe('Unknown source');
   });
 });

--- a/packages/app/src/utils/alerts.ts
+++ b/packages/app/src/utils/alerts.ts
@@ -238,6 +238,24 @@ export function normalizeNoOpAlertScheduleFields<
   return normalizedAlert as T;
 }
 
+/**
+ * Human label for what an alert watches. Shared by the row's source icon
+ * tooltip, the alerts-page source filter, and free-text search, so all three
+ * agree on the wording a user sees and types.
+ */
+export function getAlertSourceLabel(alert: {
+  source?: AlertSource | null;
+}): string {
+  switch (alert.source) {
+    case AlertSource.TILE:
+      return 'Dashboard tile';
+    case AlertSource.SAVED_SEARCH:
+      return 'Saved search';
+    default:
+      return 'Unknown source';
+  }
+}
+
 export function getAlertDisplayName(alert: AlertsPageItem): string {
   if (alert.source === AlertSource.TILE && alert.dashboard) {
     const tile = alert.dashboard.tiles.find(t => t.id === alert.tileId);

--- a/packages/app/styles/AlertsPage.module.scss
+++ b/packages/app/styles/AlertsPage.module.scss
@@ -84,3 +84,17 @@
     color: var(--color-text);
   }
 }
+
+/* The properties line wraps between whole phrases, never inside one: without
+   this a narrow header split "Notify via" across two lines. */
+.propertiesSummary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  row-gap: 4px;
+}
+
+.propertySegment {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Alert actions were split across two surfaces that disagreed: the list could delete and export to Terraform but not edit, the detail page could edit and delete but not export, and each had its own delete confirmation. Nothing on a list row said whether an alert watched a saved search or a dashboard tile — the icon carried that distinction silently. This gives both surfaces the same overflow menu and makes the alert's source legible and filterable.

https://github.com/user-attachments/assets/91155292-59a0-457e-9863-d3e8706130d3


### What changed

**Alerts list**

- **Edit from the row menu.** The overflow menu opens the existing alert editor in place, so changing a threshold no longer means navigating into the alert first.
- **Source is legible and filterable.** Each row's source icon gains a tooltip and accessible label ("Saved search" / "Dashboard tile"), a filter narrows the list to one source, and free-text search matches the source label too, so typing "tile" works without opening the dropdown.
- **Creator demoted** out of the properties line into its own dimmed sub-line; the remaining segments no longer break mid-phrase.

**Alert detail page**

- **Edit, Delete and Terraform export** move into that same shared menu. Terraform export is new to this page.
- **The source link becomes an icon beside the alert name**, with a tooltip naming the destination.
- **The properties block separates configuration from provenance**: the creator joins the created and updated timestamps in a dimmed line beneath.

Team settings tabs also gain icons.

### Key decisions

**One shared menu, not two parallel ones.** The detail page's own edit modal, delete handler and confirmation are deleted in favour of the list's. Two surfaces maintaining separate action sets is how they drifted apart. The menu takes an optional `dateRange` (the detail page has a picked range for the editor's threshold preview; a list row does not, and derives one from the alert's evaluation interval) and an `onDeleted` callback so the page can navigate away after deletion.

**"Alert source", not "type" or "source".** "Type" already means detection type (anomaly vs static threshold) in the alerts UI, and a bare "source" reads as a data source (Logs/Traces/Metrics). The filter is labelled "Filter by alert source" and its query param is `alertSource`.

**One label helper, three consumers.** The tooltip, the filter options, and search all call `getAlertSourceLabel`. The filter compares against the label text, so if these drifted the filter would silently match nothing.

**Creator out of the shared summary entirely.** Both surfaces render it themselves now. Keeping it in the shared line at equal weight with the alert's configuration is what pushed the line into a second row that wrapped mid-phrase.

**Source link beside the title, not among the actions.** It navigates to the alert's subject, so it belongs with the identity rather than the verbs acting on the alert. The menu's own source-link item is suppressed on that page to avoid offering it twice.

### Impact

Frontend only, no API or schema changes. The detail page's delete confirmation changes from `ConfirmDeleteMenu` to the shared `useConfirm` dialog, and deletion returns you to `/alerts`. The filter's value is a human-readable label carried in the URL (`?alertSource=Saved%20search`), so renaming a label invalidates shared links.

Two commits, one per surface, if that reads more easily than the combined diff.

<details>
<summary>Implementation detail</summary>

- The empty state distinguishes "No alerts" from "No matching alerts" via `hasFilters`, which now includes the source filter.
- The filter renders when more than one source kind is present, or whenever a value is active — otherwise a stale URL value would hide the control while still excluding every alert, with no way to clear it.
- Source matching in search is whole-token prefix, not substring: both labels contain an "s", so a substring match on a single character matched everything.
- The labelled icon uses `role="img"` (naming is not exposed on a role-less span) and the glyphs are `aria-hidden`.
- Delete keeps the same query invalidations (`alerts`, `saved-search`, `dashboards`) as the removed detail-page handler; navigation moved into `onDeleted`.
- Known limitation, unchanged here: neither delete path invalidates the single-alert query key, so back-navigation renders cached data until the refetch 404s.
- The edit modal now mounts per row on the alerts list. Its queries are key-shared so there is no fetch storm, but the modal state lives inside a virtualised row — Mantine's scroll lock makes unmount-while-open unlikely, though hoisting one modal above the virtualiser would remove the risk entirely.
- Tests: `getAlertSourceLabel` including its fallback, the menu opening the editor, and the summary omitting the creator in both variants. Full app suite passes (3385).

</details>
