### PR TITLE
feat: narrow the original search with a trace-id subquery when searching from a correlated event

### DIFF
--- a/.changeset/correlated-search-subquery.md
+++ b/.changeset/correlated-search-subquery.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+"Search for this value only" on an attribute of a correlated event (e.g. a log opened from a trace search) now searches the original source with a subquery on the correlated source's table.

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -131,6 +131,7 @@ import {
   useLocalStorage,
   usePrevious,
 } from '@/utils';
+import { buildCorrelatedSearchWhere } from '@/utils/correlatedSearch';
 
 import ChartSQLPreview, { SQLPreview } from './components/ChartSQLPreview';
 import DBSqlRowTableWithSideBar from './components/DBSqlRowTableWithSidebar';
@@ -1695,10 +1696,12 @@ export function DBSearchPage() {
       where,
       whereLanguage,
       source,
+      pivot,
     }: {
       where: SearchConfig['where'];
       whereLanguage: SearchConfig['whereLanguage'];
       source?: TSource;
+      pivot?: boolean;
     }) => {
       const qParams = new URLSearchParams({
         whereLanguage: whereLanguage || 'sql',
@@ -1708,11 +1711,29 @@ export function DBSearchPage() {
         liveInterval: interval.toString(),
       });
 
-      // When generating a search based on a different source,
-      // filters and select for the current source are not preserved.
-      if (source && source.id !== searchedSource?.id) {
+      if (source && pivot && source.id !== searchedSource?.id) {
+        // A deliberate pivot (e.g. the trace-level attributes above the
+        // waterfall): open the attribute's own source. Filters and select for
+        // the current source are not preserved.
         qParams.append('where', where || '');
         qParams.append('source', source.id);
+      } else if (source && searchedSource && source.id !== searchedSource.id) {
+        // For an event from a correlated source, "Search for this value only"
+        // becomes a trace-id subquery on the event's table rather than a pivot
+        // to the event's source: the searched source, select, and filters are
+        // kept, and — like the same-source action — the search box is replaced.
+        // If the subquery can't run (e.g. the event's table isn't on this
+        // connection), the query fails visibly where the user can edit it.
+        const correlatedWhere = buildCorrelatedSearchWhere({
+          searchedSource,
+          eventSource: source,
+          eventWhere: where || '',
+        });
+        qParams.set('whereLanguage', 'sql');
+        qParams.append('select', searchedConfig.select || '');
+        qParams.append('where', correlatedWhere);
+        qParams.append('filters', JSON.stringify(searchedConfig.filters ?? []));
+        qParams.append('source', searchedSource.id);
       } else {
         qParams.append('select', searchedConfig.select || '');
         qParams.append('where', where || searchedConfig.where || '');
@@ -1727,7 +1748,7 @@ export function DBSearchPage() {
       searchedConfig.filters,
       searchedConfig.select,
       searchedConfig.where,
-      searchedSource?.id,
+      searchedSource,
       searchedTimeRange,
     ],
   );

--- a/packages/app/src/components/DBHighlightedAttributesList.tsx
+++ b/packages/app/src/components/DBHighlightedAttributesList.tsx
@@ -17,8 +17,14 @@ export type HighlightedAttribute = {
 
 export function DBHighlightedAttributesList({
   attributes,
+  pivotToAttributeSource = false,
 }: {
   attributes: HighlightedAttribute[];
+  /**
+   * Search actions open the attribute's own source rather than narrowing the
+   * current search with a correlated condition on it.
+   */
+  pivotToAttributeSource?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -42,34 +48,47 @@ export function DBHighlightedAttributesList({
 
   return (
     <Flex wrap="wrap" gap="2px" mb="md" align="baseline">
-      {sortedAttributes.map(({ displayedKey, value, sql, lucene, source }) => (
-        <EventTag
-          displayedKey={displayedKey}
-          name={lucene ? lucene : sql}
-          nameLanguage={lucene ? 'lucene' : 'sql'}
-          value={value}
-          key={`${displayedKey}-${value}-${source.id}`}
-          {...(onPropertyAddClick && contextSource?.id === source.id
-            ? {
-                onPropertyAddClick,
-                sqlExpression: sql,
-              }
-            : {
-                onPropertyAddClick: undefined,
-                sqlExpression: undefined,
-              })}
-          generateSearchUrl={
-            generateSearchUrl
-              ? (query, queryLanguage) =>
-                  generateSearchUrl({
-                    where: query || '',
-                    whereLanguage: queryLanguage ?? 'lucene',
-                    source,
-                  })
-              : undefined
-          }
-        />
-      ))}
+      {sortedAttributes.map(({ displayedKey, value, sql, lucene, source }) => {
+        // A cross-source attribute's condition is composed into raw SQL
+        // against its source's table, so emit the SQL form — lucene text
+        // can't be embedded in SQL. Same-source attributes — and pivoting
+        // searches, which run against the attribute's own source — prefer
+        // lucene when available.
+        const useLucene =
+          !!lucene &&
+          (pivotToAttributeSource ||
+            contextSource == null ||
+            contextSource.id === source.id);
+        return (
+          <EventTag
+            displayedKey={displayedKey}
+            name={useLucene ? lucene : sql}
+            nameLanguage={useLucene ? 'lucene' : 'sql'}
+            value={value}
+            key={`${displayedKey}-${value}-${source.id}`}
+            {...(onPropertyAddClick && contextSource?.id === source.id
+              ? {
+                  onPropertyAddClick,
+                  sqlExpression: sql,
+                }
+              : {
+                  onPropertyAddClick: undefined,
+                  sqlExpression: undefined,
+                })}
+            generateSearchUrl={
+              generateSearchUrl
+                ? (query, queryLanguage) =>
+                    generateSearchUrl({
+                      where: query || '',
+                      whereLanguage: queryLanguage ?? 'lucene',
+                      source,
+                      pivot: pivotToAttributeSource,
+                    })
+                : undefined
+            }
+          />
+        );
+      })}
       {attributes.length > DEFAULT_ATTRIBUTES_TO_SHOW && (
         <Anchor size="xs" onClick={() => setIsExpanded(!isExpanded)}>
           {isExpanded ? 'Show Less' : `Show ${hiddenAttributesCount} More...`}

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -6,6 +6,7 @@ import { Accordion, Box, Flex, Text } from '@mantine/core';
 
 import { WithClause } from '@/hooks/useRowWhere';
 import { getEventBody } from '@/source';
+import { mergePath } from '@/utils';
 import { getHighlightedAttributesFromData } from '@/utils/highlightedAttributes';
 import { resolveRowTimestampAnchor } from '@/utils/rowTimestamps';
 
@@ -421,8 +422,15 @@ export function RowOverviewPanel({
                     ? ''
                     : jsonColumns?.includes(resourceAttributesExpression)
                       ? // If resource attributes is a JSON column, we need to cast the key to a string so we can run where X in Y queries
-                        `toString(${resourceAttributesExpression}.${key})`
-                      : `${resourceAttributesExpression}['${key}']`;
+                        `toString(${mergePath([resourceAttributesExpression, key], jsonColumns, mapColumns)})`
+                      : // Not a JSON column: assume Map access. Force mergePath's map
+                        // branch so the key is escaped and a numeric-looking key stays
+                        // a map subscript instead of an array index.
+                        mergePath(
+                          [resourceAttributesExpression, key],
+                          [],
+                          [resourceAttributesExpression],
+                        );
                   return (
                     <EventTag
                       {...(onPropertyAddClick

--- a/packages/app/src/components/DBRowOverviewPanel.tsx
+++ b/packages/app/src/components/DBRowOverviewPanel.tsx
@@ -47,8 +47,17 @@ export function RowOverviewPanel({
 }) {
   const contentPx = flush ? 0 : 'md';
   const { data } = useRowData({ source, rowId, aliasWith, dateRange });
-  const { onPropertyAddClick, generateSearchUrl, onOpenLinkedTrace } =
-    use(RowSidePanelContext);
+  const {
+    onPropertyAddClick,
+    generateSearchUrl,
+    onOpenLinkedTrace,
+    source: contextSource,
+  } = use(RowSidePanelContext);
+
+  // Whether this row's source differs from the one the surrounding search was
+  // built for (e.g. a log event opened from a trace search).
+  const isCrossSourceEvent =
+    contextSource != null && contextSource.id !== source.id;
 
   const highlightedAttributeValues = useMemo(() => {
     const attributeExpressions =
@@ -403,36 +412,45 @@ export function RowOverviewPanel({
             </Accordion.Control>
             <Accordion.Panel>
               <Flex wrap="wrap" gap="2px" mx={contentPx} mb="lg">
-                {Object.entries(resourceAttributes).map(([key, value]) => (
-                  <EventTag
-                    {...(onPropertyAddClick
-                      ? {
-                          onPropertyAddClick,
-                          sqlExpression:
-                            'resourceAttributesExpression' in source &&
-                            source.resourceAttributesExpression &&
-                            jsonColumns?.includes(
-                              source.resourceAttributesExpression,
-                            )
-                              ? // If resource attributes is a JSON column, we need to cast the key to a string so we can run where X in Y queries
-                                `toString(${source.resourceAttributesExpression}.${key})`
-                              : 'resourceAttributesExpression' in source
-                                ? `${source.resourceAttributesExpression}['${key}']`
-                                : '',
-                        }
-                      : {
-                          onPropertyAddClick: undefined,
-                          sqlExpression: undefined,
-                        })}
-                    generateSearchUrl={
-                      generateSearchUrl ? _generateSearchUrl : undefined
-                    }
-                    displayedKey={key}
-                    name={`${'resourceAttributesExpression' in source ? source.resourceAttributesExpression : ''}.${key}`}
-                    value={value as string}
-                    key={key}
-                  />
-                ))}
+                {Object.entries(resourceAttributes).map(([key, value]) => {
+                  const resourceAttributesExpression =
+                    'resourceAttributesExpression' in source
+                      ? source.resourceAttributesExpression
+                      : undefined;
+                  const sqlExpression = !resourceAttributesExpression
+                    ? ''
+                    : jsonColumns?.includes(resourceAttributesExpression)
+                      ? // If resource attributes is a JSON column, we need to cast the key to a string so we can run where X in Y queries
+                        `toString(${resourceAttributesExpression}.${key})`
+                      : `${resourceAttributesExpression}['${key}']`;
+                  return (
+                    <EventTag
+                      {...(onPropertyAddClick
+                        ? {
+                            onPropertyAddClick,
+                            sqlExpression,
+                          }
+                        : {
+                            onPropertyAddClick: undefined,
+                            sqlExpression: undefined,
+                          })}
+                      generateSearchUrl={
+                        generateSearchUrl ? _generateSearchUrl : undefined
+                      }
+                      displayedKey={key}
+                      // Cross-source conditions are composed into raw SQL
+                      // against the event's table, so emit the SQL form —
+                      // lucene text can't be embedded in SQL.
+                      {...(isCrossSourceEvent && sqlExpression
+                        ? { name: sqlExpression, nameLanguage: 'sql' as const }
+                        : {
+                            name: `${resourceAttributesExpression ?? ''}.${key}`,
+                          })}
+                      value={value as string}
+                      key={key}
+                    />
+                  );
+                })}
               </Flex>
             </Accordion.Panel>
           </Accordion.Item>

--- a/packages/app/src/components/DBRowSidePanel.tsx
+++ b/packages/app/src/components/DBRowSidePanel.tsx
@@ -94,10 +94,16 @@ export type RowSidePanelContextProps = {
     where,
     whereLanguage,
     source,
+    pivot,
   }: {
     where: SearchConfig['where'];
     whereLanguage: SearchConfig['whereLanguage'];
     source?: TSource;
+    /**
+     * Open the search on `source` itself rather than narrowing the current
+     * search with a correlated condition on it.
+     */
+    pivot?: boolean;
   }) => string;
   generateChartUrl?: (config: {
     aggFn: string;

--- a/packages/app/src/components/DBSearchPageFilters/utils.ts
+++ b/packages/app/src/components/DBSearchPageFilters/utils.ts
@@ -1,10 +1,9 @@
 // Utility functions for parsing and grouping map-like field names
 
-import SqlString from 'sqlstring';
 import { parseKeyPath } from '@hyperdx/common-utils/dist/core/metadata';
 import type { FilterState } from '@hyperdx/common-utils/dist/filters';
 
-import { mergePath } from '@/utils';
+import { mergePath, quoteIdentifierIfNeeded } from '@/utils';
 
 // Clean ClickHouse expressions to extract clean property paths
 export function cleanClickHouseExpression(key: string): string {
@@ -185,17 +184,6 @@ export function toClickHouseKeyExpression(key: string): string {
     [],
     [parsed.baseName],
   );
-}
-
-/**
- * Quote a single identifier if it isn't already a valid bare ClickHouse identifier.
- * @param id - The identifier to quote
- * @returns The quoted identifier if needed, otherwise the original identifier
- */
-function quoteIdentifierIfNeeded(id: string): string {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(id)
-    ? id
-    : SqlString.escapeId(id, true);
 }
 
 /**

--- a/packages/app/src/components/DBTraceWaterfallChart.tsx
+++ b/packages/app/src/components/DBTraceWaterfallChart.tsx
@@ -1486,7 +1486,10 @@ export function DBTraceWaterfallChartContainer({
         </Group>
       </Group>
       {!isFetching && !error && highlightedAttributeValues?.length > 0 && (
-        <DBHighlightedAttributesList attributes={highlightedAttributeValues} />
+        <DBHighlightedAttributesList
+          attributes={highlightedAttributeValues}
+          pivotToAttributeSource
+        />
       )}
       <div
         ref={timelineWrapperRef}

--- a/packages/app/src/components/__tests__/DBHighlightedAttributesList.test.tsx
+++ b/packages/app/src/components/__tests__/DBHighlightedAttributesList.test.tsx
@@ -8,19 +8,17 @@ import { fireEvent, screen } from '@testing-library/react';
 import { DBHighlightedAttributesList } from '@/components/DBHighlightedAttributesList';
 import { RowSidePanelContext } from '@/components/DBRowSidePanel';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 const traceSource = {
   id: 'trace-source',
   kind: SourceKind.Trace,
   name: 'Traces',
-} as TTraceSource;
+};
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 const logSource = {
   id: 'log-source',
   kind: SourceKind.Log,
   name: 'Logs',
-} as TLogSource;
+};
 
 describe('DBHighlightedAttributesList search conditions', () => {
   const renderList = async (
@@ -52,6 +50,7 @@ describe('DBHighlightedAttributesList search conditions', () => {
   };
 
   it('uses the lucene condition when the attribute belongs to the searched source', async () => {
+    // @ts-expect-error source type
     const generateSearchUrl = await renderList(traceSource, traceSource);
     expect(generateSearchUrl).toHaveBeenCalledWith({
       where: 'user.id:"123"',
@@ -62,6 +61,7 @@ describe('DBHighlightedAttributesList search conditions', () => {
   });
 
   it('uses the SQL condition for a cross-source attribute so the search page can build a trace-id subquery', async () => {
+    // @ts-expect-error source type
     const generateSearchUrl = await renderList(logSource, traceSource);
     expect(generateSearchUrl).toHaveBeenCalledWith({
       where: "SpanAttributes['user.id'] = '123'",
@@ -72,6 +72,7 @@ describe('DBHighlightedAttributesList search conditions', () => {
   });
 
   it('keeps the lucene condition when the context has no source', async () => {
+    // @ts-expect-error source type
     const generateSearchUrl = await renderList(logSource, undefined);
     expect(generateSearchUrl).toHaveBeenCalledWith({
       where: 'user.id:"123"',
@@ -82,6 +83,7 @@ describe('DBHighlightedAttributesList search conditions', () => {
   });
 
   it('keeps the lucene condition and requests a pivot when pivotToAttributeSource is set (trace-level attributes)', async () => {
+    // @ts-expect-error source type
     const generateSearchUrl = await renderList(logSource, traceSource, true);
     expect(generateSearchUrl).toHaveBeenCalledWith({
       where: 'user.id:"123"',

--- a/packages/app/src/components/__tests__/DBHighlightedAttributesList.test.tsx
+++ b/packages/app/src/components/__tests__/DBHighlightedAttributesList.test.tsx
@@ -1,0 +1,93 @@
+import {
+  SourceKind,
+  TLogSource,
+  TTraceSource,
+} from '@hyperdx/common-utils/dist/types';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { DBHighlightedAttributesList } from '@/components/DBHighlightedAttributesList';
+import { RowSidePanelContext } from '@/components/DBRowSidePanel';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+const traceSource = {
+  id: 'trace-source',
+  kind: SourceKind.Trace,
+  name: 'Traces',
+} as TTraceSource;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+const logSource = {
+  id: 'log-source',
+  kind: SourceKind.Log,
+  name: 'Logs',
+} as TLogSource;
+
+describe('DBHighlightedAttributesList search conditions', () => {
+  const renderList = async (
+    attributeSource: TTraceSource | TLogSource,
+    contextSource?: TTraceSource | TLogSource,
+    pivotToAttributeSource?: boolean,
+  ) => {
+    const generateSearchUrl = jest.fn(() => '/search?mock');
+    renderWithMantine(
+      <RowSidePanelContext value={{ generateSearchUrl, source: contextSource }}>
+        <DBHighlightedAttributesList
+          pivotToAttributeSource={pivotToAttributeSource}
+          attributes={[
+            {
+              source: attributeSource,
+              displayedKey: 'user.id',
+              value: '123',
+              sql: "SpanAttributes['user.id']",
+              lucene: 'user.id',
+            },
+          ]}
+        />
+      </RowSidePanelContext>,
+    );
+    // Open the chip's action popover, then render the search link.
+    fireEvent.click(screen.getByText('user.id:'));
+    await screen.findByText('Search This Value');
+    return generateSearchUrl;
+  };
+
+  it('uses the lucene condition when the attribute belongs to the searched source', async () => {
+    const generateSearchUrl = await renderList(traceSource, traceSource);
+    expect(generateSearchUrl).toHaveBeenCalledWith({
+      where: 'user.id:"123"',
+      whereLanguage: 'lucene',
+      source: traceSource,
+      pivot: false,
+    });
+  });
+
+  it('uses the SQL condition for a cross-source attribute so the search page can build a trace-id subquery', async () => {
+    const generateSearchUrl = await renderList(logSource, traceSource);
+    expect(generateSearchUrl).toHaveBeenCalledWith({
+      where: "SpanAttributes['user.id'] = '123'",
+      whereLanguage: 'sql',
+      source: logSource,
+      pivot: false,
+    });
+  });
+
+  it('keeps the lucene condition when the context has no source', async () => {
+    const generateSearchUrl = await renderList(logSource, undefined);
+    expect(generateSearchUrl).toHaveBeenCalledWith({
+      where: 'user.id:"123"',
+      whereLanguage: 'lucene',
+      source: logSource,
+      pivot: false,
+    });
+  });
+
+  it('keeps the lucene condition and requests a pivot when pivotToAttributeSource is set (trace-level attributes)', async () => {
+    const generateSearchUrl = await renderList(logSource, traceSource, true);
+    expect(generateSearchUrl).toHaveBeenCalledWith({
+      where: 'user.id:"123"',
+      whereLanguage: 'lucene',
+      source: logSource,
+      pivot: true,
+    });
+  });
+});

--- a/packages/app/src/components/__tests__/DBTracePanel.test.tsx
+++ b/packages/app/src/components/__tests__/DBTracePanel.test.tsx
@@ -206,9 +206,11 @@ describe('DBTracePanel', () => {
   });
 
   // The searched source is the trace source; the selected waterfall event may
-  // belong to the correlated log source. Search urls must target the event's
-  // own source, and filter actions (which mutate the searched source's query)
-  // must be gated off for cross-source events.
+  // belong to the correlated log source. The derived context must identify the
+  // event's own source to generateSearchUrl (the search page uses it to narrow
+  // the original search with a trace-id subquery on that source), and filter
+  // actions (which mutate the searched source's query) must be gated off for
+  // cross-source events.
   describe('span detail context for the selected event', () => {
     const renderWithSearchContext = () => {
       const generateSearchUrl = jest.fn(() => '/search?mock');
@@ -233,7 +235,7 @@ describe('DBTracePanel', () => {
       return { generateSearchUrl, onPropertyAddClick };
     };
 
-    it('targets the log source for a selected log event and gates filter actions', () => {
+    it('passes the log source for a selected log event and gates filter actions', () => {
       mockEventRowWhere = {
         id: 'log-1',
         type: SourceKind.Log,

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { formatDistanceToNowStrict } from 'date-fns';
 import numbro from 'numbro';
 import type { SetStateAction } from 'react';
+import SqlString from 'sqlstring';
 import TimestampNano from 'timestamp-nano';
 import { TableConnection } from '@hyperdx/common-utils/dist/core/metadata';
 import {
@@ -1148,6 +1149,17 @@ export const formatUptime = (seconds: number) => {
 // unescaped quote produces malformed SQL.
 const escapeSqlSingleQuoted = (v: string): string =>
   v.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/**
+ * Quote a single identifier if it isn't already a valid bare ClickHouse identifier.
+ * @param id - The identifier to quote
+ * @returns The quoted identifier if needed, otherwise the original identifier
+ */
+export function quoteIdentifierIfNeeded(id: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(id)
+    ? id
+    : SqlString.escapeId(id, true);
+}
 
 export const mergePath = (
   path: string[],

--- a/packages/app/src/utils/__tests__/correlatedSearch.test.ts
+++ b/packages/app/src/utils/__tests__/correlatedSearch.test.ts
@@ -1,0 +1,81 @@
+import {
+  SourceKind,
+  TLogSource,
+  TTraceSource,
+} from '@hyperdx/common-utils/dist/types';
+
+import { buildCorrelatedSearchWhere } from '@/utils/correlatedSearch';
+
+const traceSource: TTraceSource = {
+  kind: SourceKind.Trace,
+  id: 'trace-source',
+  name: 'Traces',
+  connection: 'conn-1',
+  from: { databaseName: 'default', tableName: 'otel_traces' },
+  timestampValueExpression: 'Timestamp',
+  defaultTableSelectExpression: 'Timestamp, SpanName',
+  traceIdExpression: 'TraceId',
+  spanIdExpression: 'SpanId',
+  parentSpanIdExpression: 'ParentSpanId',
+  spanNameExpression: 'SpanName',
+  spanKindExpression: 'SpanKind',
+  durationExpression: 'Duration',
+  durationPrecision: 9,
+};
+
+const logSource: TLogSource = {
+  kind: SourceKind.Log,
+  id: 'log-source',
+  name: 'Logs',
+  connection: 'conn-1',
+  from: { databaseName: 'default', tableName: 'otel_logs' },
+  timestampValueExpression: 'TimestampTime',
+  defaultTableSelectExpression: 'Timestamp, Body',
+  traceIdExpression: 'TraceId',
+};
+
+const build = (
+  overrides: Partial<Parameters<typeof buildCorrelatedSearchWhere>[0]> = {},
+) =>
+  buildCorrelatedSearchWhere({
+    searchedSource: traceSource,
+    eventSource: logSource,
+    eventWhere: "Body LIKE '%exception%'",
+    ...overrides,
+  });
+
+const SUBQUERY =
+  "TraceId IN (SELECT TraceId FROM default.otel_logs WHERE Body LIKE '%exception%')";
+
+describe('buildCorrelatedSearchWhere', () => {
+  it('builds a trace-id subquery on the event source', () => {
+    expect(build()).toBe(SUBQUERY);
+  });
+
+  it('supports the mirror direction (span condition on a log search)', () => {
+    expect(
+      build({
+        searchedSource: logSource,
+        eventSource: traceSource,
+        eventWhere: "SpanName = 'place order'",
+      }),
+    ).toBe(
+      "TraceId IN (SELECT TraceId FROM default.otel_traces WHERE SpanName = 'place order')",
+    );
+  });
+
+  it('builds the subquery even when the sources are on different connections (the query may fail, but the user can edit it)', () => {
+    expect(build({ eventSource: { ...logSource, connection: 'conn-2' } })).toBe(
+      SUBQUERY,
+    );
+  });
+
+  it('defaults a missing trace id expression to TraceId', () => {
+    expect(
+      build({
+        searchedSource: { ...traceSource, traceIdExpression: '' },
+        eventSource: { ...logSource, traceIdExpression: undefined },
+      }),
+    ).toBe(SUBQUERY);
+  });
+});

--- a/packages/app/src/utils/__tests__/correlatedSearch.test.ts
+++ b/packages/app/src/utils/__tests__/correlatedSearch.test.ts
@@ -70,6 +70,32 @@ describe('buildCorrelatedSearchWhere', () => {
     );
   });
 
+  it('backtick-quotes database and table names that are not bare identifiers', () => {
+    expect(
+      build({
+        eventSource: {
+          ...logSource,
+          from: { databaseName: 'my db', tableName: 'otel-logs' },
+        },
+      }),
+    ).toBe(
+      "TraceId IN (SELECT TraceId FROM `my db`.`otel-logs` WHERE Body LIKE '%exception%')",
+    );
+  });
+
+  it('doubles embedded backticks when quoting identifiers', () => {
+    expect(
+      build({
+        eventSource: {
+          ...logSource,
+          from: { databaseName: 'default', tableName: 'weird`table' },
+        },
+      }),
+    ).toBe(
+      "TraceId IN (SELECT TraceId FROM default.`weird``table` WHERE Body LIKE '%exception%')",
+    );
+  });
+
   it('defaults a missing trace id expression to TraceId', () => {
     expect(
       build({

--- a/packages/app/src/utils/correlatedSearch.ts
+++ b/packages/app/src/utils/correlatedSearch.ts
@@ -1,5 +1,7 @@
 import { TSource } from '@hyperdx/common-utils/dist/types';
 
+import { quoteIdentifierIfNeeded } from '@/utils';
+
 function getTraceIdExpression(source: TSource): string | undefined {
   return 'traceIdExpression' in source && source.traceIdExpression
     ? source.traceIdExpression
@@ -34,7 +36,12 @@ export function buildCorrelatedSearchWhere({
   const searchedTraceId = getTraceIdExpression(searchedSource) ?? 'TraceId';
   const eventTraceId = getTraceIdExpression(eventSource) ?? 'TraceId';
   const { databaseName, tableName } = eventSource.from ?? {};
-  const eventTable = databaseName ? `${databaseName}.${tableName}` : tableName;
+  const quotedTable = tableName
+    ? quoteIdentifierIfNeeded(tableName)
+    : tableName;
+  const eventTable = databaseName
+    ? `${quoteIdentifierIfNeeded(databaseName)}.${quotedTable}`
+    : quotedTable;
 
   return `${searchedTraceId} IN (SELECT ${eventTraceId} FROM ${eventTable} WHERE ${eventWhere.trim()})`;
 }

--- a/packages/app/src/utils/correlatedSearch.ts
+++ b/packages/app/src/utils/correlatedSearch.ts
@@ -1,0 +1,40 @@
+import { TSource } from '@hyperdx/common-utils/dist/types';
+
+function getTraceIdExpression(source: TSource): string | undefined {
+  return 'traceIdExpression' in source && source.traceIdExpression
+    ? source.traceIdExpression
+    : undefined;
+}
+
+/**
+ * Builds the where clause for a "Search for this value only" action on an
+ * event from a correlated source (e.g. a log attribute clicked while viewing
+ * a trace search), keeping the searched source instead of pivoting to the
+ * event's source. The condition is expressed as a plain SQL subquery on the
+ * shared trace id:
+ *
+ *   <searched tid> IN (SELECT <event tid> FROM <event table> WHERE <condition>)
+ *
+ * so it lands in the search box where the user can see and edit it. Like the
+ * same-source action, it replaces the search box; filters and select are
+ * preserved by the caller.
+ */
+export function buildCorrelatedSearchWhere({
+  searchedSource,
+  eventSource,
+  eventWhere,
+}: {
+  searchedSource: TSource;
+  eventSource: TSource;
+  /** SQL condition on the event's own source (e.g. the clicked attribute). */
+  eventWhere: string;
+}): string {
+  // Same default as buildDirectTraceWhereClause: assume the OTel column name
+  // when a source doesn't configure one.
+  const searchedTraceId = getTraceIdExpression(searchedSource) ?? 'TraceId';
+  const eventTraceId = getTraceIdExpression(eventSource) ?? 'TraceId';
+  const { databaseName, tableName } = eventSource.from ?? {};
+  const eventTable = databaseName ? `${databaseName}.${tableName}` : tableName;
+
+  return `${searchedTraceId} IN (SELECT ${eventTraceId} FROM ${eventTable} WHERE ${eventWhere.trim()})`;
+}

--- a/packages/app/tests/e2e/features/search/cross-source-search.spec.ts
+++ b/packages/app/tests/e2e/features/search/cross-source-search.spec.ts
@@ -40,8 +40,7 @@ test.describe(
         .first();
       await expect(logRow).toBeVisible({ timeout: 10_000 });
       await logRow.click();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      return searchedSourceId as string;
+      return searchedSourceId!;
     };
 
     // The generated search state, parsed from the URL the action navigated to.

--- a/packages/app/tests/e2e/features/search/cross-source-search.spec.ts
+++ b/packages/app/tests/e2e/features/search/cross-source-search.spec.ts
@@ -1,0 +1,134 @@
+import { Page } from '@playwright/test';
+
+import { SearchPage } from '../../page-objects/SearchPage';
+import { expect, test } from '../../utils/base-test';
+import { DEFAULT_TRACES_SOURCE_NAME } from '../../utils/constants';
+
+// "Search for this value only" on an event from a correlated source (a log
+// opened from a trace search) must not pivot the search to the log source.
+// It keeps the searched trace source and replaces the search box with a
+// trace-id subquery on the log table (HDX-5195).
+test.describe(
+  'Cross-source search from a trace waterfall',
+  { tag: '@search' },
+  () => {
+    let searchPage: SearchPage;
+
+    const tracePanel = (page: Page) => page.getByTestId('side-panel-tab-trace');
+
+    // Open trace-0's waterfall from a trace search and select its correlated
+    // log event, so the detail panel renders a cross-source (log) event.
+    // Returns the searched trace source's id (an ObjectId in full-stack mode),
+    // so the tests can assert the generated search kept it.
+    const openCorrelatedLogEvent = async (page: Page): Promise<string> => {
+      await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+      await searchPage.timePicker.selectRelativeTime('Last 1 days');
+      await searchPage.performSearch('TraceId:"trace-0"');
+      const searchedSourceId = new URL(page.url()).searchParams.get('source');
+      expect(searchedSourceId).toBeTruthy();
+
+      await expect(searchPage.table.firstRow).toBeVisible();
+      await searchPage.table.clickFirstRow();
+      await expect(searchPage.sidePanel.tabs).toBeVisible();
+      await searchPage.sidePanel.clickTab('trace');
+      await expect(tracePanel(page)).toBeVisible({ timeout: 10_000 });
+
+      // Log rows in the waterfall are marked by the correlated-log icon.
+      const logRow = tracePanel(page)
+        .locator('[role="button"]')
+        .filter({ has: page.locator('[aria-label="Correlated Log Line"]') })
+        .first();
+      await expect(logRow).toBeVisible({ timeout: 10_000 });
+      await logRow.click();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      return searchedSourceId as string;
+    };
+
+    // The generated search state, parsed from the URL the action navigated to.
+    const searchParamsFromUrl = (page: Page) =>
+      new URL(page.url()).searchParams;
+
+    test.beforeEach(async ({ page }) => {
+      searchPage = new SearchPage(page);
+      await searchPage.goto();
+    });
+
+    test('Column Values search action builds a trace-id subquery and stays on the trace source', async ({
+      page,
+    }) => {
+      const searchedSourceId = await openCorrelatedLogEvent(page);
+
+      await test.step("Trigger the search action on the log event's ServiceName", async () => {
+        await tracePanel(page).getByText('Column Values').first().click();
+
+        const line = tracePanel(page)
+          .getByTestId('json-viewer-line')
+          .filter({ has: page.getByText('ServiceName', { exact: true }) })
+          .first();
+        await expect(line).toBeVisible({ timeout: 10_000 });
+        await line.hover();
+        await line.getByTitle('Search for this value only').click();
+      });
+
+      await test.step('The search stays on the trace source with the subquery in the box', async () => {
+        // The seeded logs correlated to trace-0 all carry ServiceName
+        // 'api-server', so the condition is stable regardless of which log
+        // event the waterfall listed first.
+        await expect
+          .poll(() => searchParamsFromUrl(page).get('where'))
+          .toBe(
+            "TraceId IN (SELECT TraceId FROM default.e2e_otel_logs WHERE ServiceName = 'api-server')",
+          );
+        const params = searchParamsFromUrl(page);
+        expect(params.get('source')).toBe(searchedSourceId);
+        expect(params.get('whereLanguage')).toBe('sql');
+        await expect(searchPage.currentSource).toHaveValue(
+          DEFAULT_TRACES_SOURCE_NAME,
+        );
+      });
+
+      await test.step("The subquery executes and finds the parent trace's spans", async () => {
+        await searchPage.table.waitForRowsToPopulate();
+        await expect(searchPage.getTableError()).toHaveCount(0);
+      });
+    });
+
+    test('Overview attribute chip emits a SQL condition inside the subquery', async ({
+      page,
+    }) => {
+      const searchedSourceId = await openCorrelatedLogEvent(page);
+
+      await test.step('Search from a resource-attribute chip on the Overview tab', async () => {
+        // EventTag chips render as .bg-highlighted pills; the accordion
+        // sections are expanded by default.
+        const chip = tracePanel(page)
+          .locator('.bg-highlighted')
+          .filter({ hasText: 'environment' })
+          .first();
+        await chip.scrollIntoViewIfNeeded();
+        await expect(chip).toBeVisible({ timeout: 10_000 });
+        await chip.click();
+        await page
+          .getByRole('button', { name: 'Search This Value' })
+          .click({ timeout: 5_000 });
+      });
+
+      await test.step("The chip's condition lands in the subquery in SQL form, not lucene", async () => {
+        await expect
+          .poll(() => searchParamsFromUrl(page).get('where'))
+          .toBe(
+            "TraceId IN (SELECT TraceId FROM default.e2e_otel_logs WHERE ResourceAttributes['environment'] = 'test')",
+          );
+        const params = searchParamsFromUrl(page);
+        expect(params.get('source')).toBe(searchedSourceId);
+        expect(params.get('whereLanguage')).toBe('sql');
+        await expect(searchPage.currentSource).toHaveValue(
+          DEFAULT_TRACES_SOURCE_NAME,
+        );
+
+        await searchPage.table.waitForRowsToPopulate();
+        await expect(searchPage.getTableError()).toHaveCount(0);
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -252,9 +252,12 @@ function generateLogData(
     const service = SERVICES[i % SERVICES.length];
     const message = LOG_MESSAGES[i % LOG_MESSAGES.length];
     const traceId = i < 10 ? `trace-${i}` : ''; // Link first 10 logs to traces
+    // Trace-linked logs carry the trace's root span id; the waterfall drops
+    // logs without a SpanId, so a bare TraceId would never render there.
+    const spanId = traceId ? `span-${i}-0` : '';
 
     rows.push(
-      `('${timestampNs}', '${traceId}', '', 0, '${severity}', 0, '${service}', '${message}', '', {'service.name':'${service}','environment':'test'}, '', '', '', {}, {'request.id':'req-${i}','user.id':'user-${i % 5}'})`,
+      `('${timestampNs}', '${traceId}', '${spanId}', 0, '${severity}', 0, '${service}', '${message}', '', {'service.name':'${service}','environment':'test'}, '', '', '', {}, {'request.id':'req-${i}','user.id':'user-${i % 5}'})`,
     );
   }
 
@@ -309,9 +312,12 @@ function generateK8sLogData(
     const serviceName = SERVICES[podIdx % SERVICES.length];
 
     const traceId = i < 10 ? `trace-${i}` : '';
+    // Same as generateLogData: a SpanId is required for the log to appear in
+    // the trace waterfall.
+    const spanId = traceId ? `span-${i}-0` : '';
 
     rows.push(
-      `('${timestampNs}', '${traceId}', '', 0, '${severity}', 0, '${serviceName}', '${message}', '', {'k8s.cluster.name':'${cluster}','k8s.namespace.name':'${namespace}','k8s.node.name':'${node}','k8s.pod.name':'${podName}','k8s.pod.uid':'${podUid}','k8s.container.name':'${containerName}','service.name':'${podName}','environment':'test'}, '', '', '', {}, {'request.id':'req-${i}','container.id':'${containerName}'})`,
+      `('${timestampNs}', '${traceId}', '${spanId}', 0, '${severity}', 0, '${serviceName}', '${message}', '', {'k8s.cluster.name':'${cluster}','k8s.namespace.name':'${namespace}','k8s.node.name':'${node}','k8s.pod.name':'${podName}','k8s.pod.uid':'${podUid}','k8s.container.name':'${containerName}','service.name':'${podName}','environment':'test'}, '', '', '', {}, {'request.id':'req-${i}','container.id':'${containerName}'})`,
     );
   }
 


### PR DESCRIPTION
## Summary

<!--
Describe what changed and why.
Write for reviewers who may not be familiar with this area of the product.
-->

"Search for this value only" on an event from a correlated source (e.g. a log opened from a trace search) previously switched the search to the event's source (#2825), losing the original search's context. It now keeps the searched source, select, and filters, and replaces the search box with a trace-id subquery on the event's table in plain SQL the user can see and edit:

```sql
TraceId IN (SELECT TraceId FROM default.otel_logs WHERE Body LIKE '%exception%')
```

- Like the same-source action, the search box is replaced ("Search for this value **only**"); filter facets and select are kept. Works in both directions (log condition on a trace search, span condition on a log search).
- Attribute chips on cross-source events emit their SQL condition form, since lucene can't be embedded in the subquery's raw SQL.
- The trace-level attribute chips above the waterfall (#1356) keep their pivot-to-attribute-source behavior, now signalled explicitly via a `pivot` flag on `generateSearchUrl`.

### Screenshots or video


https://github.com/user-attachments/assets/46ddd213-5fcf-48c5-b4a5-1f601aa1fbbc



### How to test on Vercel preview

<!--
This section is consumed by the UI preview smoke-test agent
(.github/workflows/ui-preview-smoke.yml). For PRs touching packages/app,
fill it in carefully — the agent executes these steps verbatim against
the Vercel preview build (LOCAL_MODE, demo ClickHouse pre-configured).

Format:
  - Preview routes: comma-separated paths to open (e.g. /search, /chart).
  - Steps: numbered imperative actions, one per line. Reference UI elements
    by visible text or data-testid. The last step on each route should be
    an assertion ("Verify ...", "Confirm ...").
  - Skip this section (leave blank or write "N/A — non-UI change") if the
    PR does not change anything user-visible.
-->

**Preview routes:** `/search`

**Steps:**

1. Select the traces source, run a search, and open a trace row's side panel.
2. Open the Trace tab and click a correlated log event in the waterfall (marked with the log-line icon).
3. In the event detail panel, open the Column Values tab, hover a value row, and click the "Search for this value only" action.
4. Verify the search stays on the traces source with a `TraceId IN (SELECT ...)` SQL condition in the search box, and results load without a SQL error.

### References

- Linear Issue: Closes HDX-5195
- Related PRs:
    - #2825
    - #1356

