### PR TITLE
fix(app): key the What's new sparkle on the release, not the build

### DIFF
--- a/.changeset/whats-new-sparkle-release-version.md
+++ b/.changeset/whats-new-sparkle-release-version.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Stop the Help menu sparkling on every deploy. The "you haven't read the latest release notes" indicator compared the browser's last acknowledgement against `NEXT_PUBLIC_APP_VERSION`, which any deployment that stamps a build id into it (a git short SHA, a CI build number) changes on every deploy — so the nudge fired for every user every time whether a new release had been published or not. It now keys on the newest release version in the changelog, inlined at build time, and nudges only when that release is strictly newer than the one the browser has acknowledged, so a rollback no longer re-nudges everyone either.

--- a/packages/app/next.config.mjs
+++ b/packages/app/next.config.mjs
@@ -66,6 +66,22 @@ try {
   );
 }
 
+// The newest RELEASE version in the notes, which keys the Help-button "you
+// haven't read the latest release notes" sparkle.
+//
+// Deliberately not NEXT_PUBLIC_APP_VERSION: any deployment that stamps a build
+// id into that (a git short SHA, a CI build number) mints a new string on every
+// deploy, so the nudge fired for every user on every deploy whether the notes
+// had changed or not. This comes from the changelog headings instead, so it moves
+// only when a release is published.
+//
+// Read back from disk rather than off the object written above, so the fallback
+// path — regeneration failed and an earlier build's asset is being shipped — is
+// keyed to the asset that actually ships.
+const whatsNewVersion = JSON.parse(
+  readFileSync(join(__dirname, 'public', 'whats-new.json'), 'utf-8'),
+).releases[0]?.version;
+
 // Support legacy consumers of next-runtime-env that expect this value under window.__ENV
 process.env.NEXT_PUBLIC_APP_VERSION = version;
 
@@ -82,6 +98,9 @@ const nextConfig = {
   env: {
     // Ensures bundler-time replacements for client/server code that references this env var
     NEXT_PUBLIC_APP_VERSION: version,
+    // Inlined at build time rather than exposed through __ENV.js: builds that
+    // omit that script (static exports, embedded builds) still need the sparkle.
+    NEXT_PUBLIC_WHATS_NEW_VERSION: whatsNewVersion,
   },
   // External packages to prevent bundling issues (moved from experimental in Next.js 15+)
   // https://github.com/open-telemetry/opentelemetry-js/issues/4297#issuecomment-2285070503

--- a/packages/app/src/components/AppNav/AppNav.components.tsx
+++ b/packages/app/src/components/AppNav/AppNav.components.tsx
@@ -210,7 +210,15 @@ const AppNavVersionItem = ({ version }: { version?: string }) => {
   );
 };
 
-export const AppNavHelpMenu = ({ version }: { version?: string }) => {
+// `version` is the running build. `whatsNewVersion` is the newest release in
+// the notes and drives the sparkle — see useWhatsNewUnseen.
+export const AppNavHelpMenu = ({
+  version,
+  whatsNewVersion,
+}: {
+  version?: string;
+  whatsNewVersion?: string;
+}) => {
   const { isCollapsed } = React.use(AppNavContext);
   const [
     shortcutsOpened,
@@ -223,8 +231,10 @@ export const AppNavHelpMenu = ({ version }: { version?: string }) => {
     whatsNewDrawerOpened,
     { open: openWhatsNewDrawer, close: closeWhatsNewDrawer },
   ] = useDisclosure(false);
-  // Sparkle the Help button when there's a release this browser hasn't seen.
-  const [hasUnseenWhatsNew, markWhatsNewSeen] = useWhatsNewUnseen(version);
+  // Sparkle the Help button when a release newer than the one this browser
+  // acknowledged has been published.
+  const [hasUnseenWhatsNew, markWhatsNewSeen] =
+    useWhatsNewUnseen(whatsNewVersion);
   // Opening the menu marks the release seen, which clears hasUnseenWhatsNew in
   // the same tick — so the menu has to render off a snapshot taken at open time.
   // Passing hasUnseenWhatsNew straight down gives a sparkle that never appears.

--- a/packages/app/src/components/AppNav/AppNav.tsx
+++ b/packages/app/src/components/AppNav/AppNav.tsx
@@ -53,6 +53,12 @@ import { AppNavFeedback } from './AppNavFeedback';
 
 import styles from './AppNav.module.scss';
 
+// Newest release version in the notes, inlined by next.config.mjs. Separate from
+// APP_VERSION on purpose: this one answers "what is the latest release?", which
+// is what the Help sparkle is for, while APP_VERSION answers "what build is
+// this?" and carries a build id that moves on every deploy.
+const WHATS_NEW_VERSION = process.env.NEXT_PUBLIC_WHATS_NEW_VERSION;
+
 // Reo.dev client ID for our usage tracking. USAGE_STATS_ENABLED is the opt-out.
 const REO_CLIENT_ID = '38b2e79cdb32fa7';
 
@@ -476,7 +482,10 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
             )}
 
             {/* Help */}
-            <AppNavHelpMenu version={APP_VERSION} />
+            <AppNavHelpMenu
+              version={APP_VERSION}
+              whatsNewVersion={WHATS_NEW_VERSION}
+            />
 
             {/* Feedback */}
             <AppNavFeedback />

--- a/packages/app/src/components/AppNav/__tests__/parse-whats-new.test.ts
+++ b/packages/app/src/components/AppNav/__tests__/parse-whats-new.test.ts
@@ -257,3 +257,41 @@ describe('whats-new.json contract', () => {
     expect(whatsNewSchema.parse(payload).releases.length).toBeGreaterThan(0);
   });
 });
+
+// The Help-button sparkle is keyed on releases[0].version (next.config.mjs
+// inlines it as NEXT_PUBLIC_WHATS_NEW_VERSION), and it nudges only when that
+// version is strictly newer than the one the browser acknowledged. So the payload
+// leading with the NEWEST release is what makes the nudge fire at all — if the
+// order ever inverted, the key would go backwards and no one would be nudged
+// again. Nothing above pins the ordering.
+describe('whats-new.json release ordering', () => {
+  const numeric = (v: string) =>
+    v.split('.').map(n => Number.parseInt(n, 10) || 0);
+
+  const isDescending = (a: string, b: string) => {
+    const [x, y] = [numeric(a), numeric(b)];
+    for (let i = 0; i < 3; i++) {
+      if (x[i] !== y[i]) return x[i] > y[i];
+    }
+    return false;
+  };
+
+  it('leads with the newest release in the real changelog', () => {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+    const { releases } = parseWhatsNew(changelog, { maxReleases: 5 });
+
+    expect(releases.length).toBeGreaterThan(1);
+    releases.slice(1).forEach(older => {
+      expect(isDescending(releases[0].version, older.version)).toBe(true);
+    });
+  });
+
+  it('keeps every version in descending order', () => {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+    const { releases } = parseWhatsNew(changelog, { maxReleases: 5 });
+
+    releases.slice(1).forEach((release, i) => {
+      expect(isDescending(releases[i].version, release.version)).toBe(true);
+    });
+  });
+});

--- a/packages/app/src/components/AppNav/__tests__/useWhatsNewUnseen.test.tsx
+++ b/packages/app/src/components/AppNav/__tests__/useWhatsNewUnseen.test.tsx
@@ -10,36 +10,82 @@ describe('useWhatsNewUnseen', () => {
   });
 
   it('nudges on a first-ever visit (nothing acknowledged yet)', () => {
-    const { result } = renderHook(() => useWhatsNewUnseen('2.31.0'));
+    const { result } = renderHook(() => useWhatsNewUnseen('2.37.0'));
     expect(result.current[0]).toBe(true);
     // Does not write until the user actually opens the menu (markSeen).
     expect(window.localStorage.getItem(SEEN_KEY)).toBeNull();
   });
 
-  it('nudges when the stored version differs from the current one', () => {
-    window.localStorage.setItem(SEEN_KEY, '2.30.0');
-    const { result } = renderHook(() => useWhatsNewUnseen('2.31.0'));
+  it('nudges when a newer release has been published', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.36.0');
+    const { result } = renderHook(() => useWhatsNewUnseen('2.37.0'));
     expect(result.current[0]).toBe(true);
   });
 
-  it('does not nudge when the stored version matches', () => {
-    window.localStorage.setItem(SEEN_KEY, '2.31.0');
-    const { result } = renderHook(() => useWhatsNewUnseen('2.31.0'));
+  it('does not nudge when the acknowledged release is the current one', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.37.0');
+    const { result } = renderHook(() => useWhatsNewUnseen('2.37.0'));
     expect(result.current[0]).toBe(false);
   });
 
-  it('markSeen clears the nudge and persists the current version', () => {
-    window.localStorage.setItem(SEEN_KEY, '2.30.0');
-    const { result } = renderHook(() => useWhatsNewUnseen('2.31.0'));
+  // The regression this hook exists to prevent: deployments that stamp a build
+  // id into the app version re-sparkled every user on every deploy.
+  it('does not nudge across deploys that publish no new release', () => {
+    const first = renderHook(() => useWhatsNewUnseen('2.37.0'));
+    act(() => first.result.current[1]());
+    expect(first.result.current[0]).toBe(false);
+
+    const redeployed = renderHook(() => useWhatsNewUnseen('2.37.0'));
+    expect(redeployed.result.current[0]).toBe(false);
+  });
+
+  // Strictly newer, not merely different: a rollback must not re-nudge everyone
+  // with notes they have already read.
+  it('does not nudge after a rollback to an older release', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.37.0');
+    const { result } = renderHook(() => useWhatsNewUnseen('2.36.0'));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('compares numerically, not lexically', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.9.0');
+    const newer = renderHook(() => useWhatsNewUnseen('2.10.0'));
+    expect(newer.result.current[0]).toBe(true);
+
+    window.localStorage.setItem(SEEN_KEY, '2.10.0');
+    const older = renderHook(() => useWhatsNewUnseen('2.9.0'));
+    expect(older.result.current[0]).toBe(false);
+  });
+
+  it('compares patch and minor components, not just major', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.37.0');
+    const patch = renderHook(() => useWhatsNewUnseen('2.37.1'));
+    expect(patch.result.current[0]).toBe(true);
+  });
+
+  // Rollout case: browsers carry a build-stamped value written by the old code.
+  it('treats a build-stamped value for the same release as already seen', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.37.0-sha0724861');
+    const same = renderHook(() => useWhatsNewUnseen('2.37.0'));
+    expect(same.result.current[0]).toBe(false);
+
+    window.localStorage.setItem(SEEN_KEY, '2.36.0-sha0724861');
+    const next = renderHook(() => useWhatsNewUnseen('2.37.0'));
+    expect(next.result.current[0]).toBe(true);
+  });
+
+  it('markSeen clears the nudge and persists the current release', () => {
+    window.localStorage.setItem(SEEN_KEY, '2.36.0');
+    const { result } = renderHook(() => useWhatsNewUnseen('2.37.0'));
     expect(result.current[0]).toBe(true);
 
     act(() => result.current[1]());
 
     expect(result.current[0]).toBe(false);
-    expect(window.localStorage.getItem(SEEN_KEY)).toBe('2.31.0');
+    expect(window.localStorage.getItem(SEEN_KEY)).toBe('2.37.0');
   });
 
-  it('does nothing until a version is known', () => {
+  it('does nothing until a release version is known', () => {
     const { result } = renderHook(() => useWhatsNewUnseen(undefined));
     expect(result.current[0]).toBe(false);
     expect(window.localStorage.getItem(SEEN_KEY)).toBeNull();

--- a/packages/app/src/components/AppNav/useWhatsNewUnseen.ts
+++ b/packages/app/src/components/AppNav/useWhatsNewUnseen.ts
@@ -1,17 +1,38 @@
 import { useCallback, useEffect, useState } from 'react';
 
-// Client-only "have they seen the latest release?" nudge. The latest release is
-// just the running app version (whats-new.json's version === APP_VERSION, both
-// baked from package.json at build), so no fetch is needed — we compare the
-// version to the last one this browser acknowledged.
+// Client-only "have they read the latest release notes?" nudge, needing no
+// fetch: the key is the newest release version in the notes, inlined at build
+// time (see next.config.mjs).
+//
+// Deliberately not the app version. A deployment that stamps a build id into
+// NEXT_PUBLIC_APP_VERSION mints a new version on every deploy, which sparkled
+// Help for every user every time whether the notes had changed or not.
 const SEEN_KEY = 'hdx-whats-new-seen';
 
+// Compares the X.Y.Z prefix numerically, because '2.9.0' > '2.10.0' as strings
+// while 2.10.0 is the newer release.
+//
+// parseInt stops at the first non-digit, so a build-stamped value left in
+// localStorage by an older build ('2.37.0-sha0724861') compares equal to
+// '2.37.0' — a browser that already read that release's notes is not nudged
+// again just because the key's shape changed.
+const isNewerRelease = (version: string, seen: string) => {
+  const parts = (v: string) =>
+    v.split('.').map(n => Number.parseInt(n, 10) || 0);
+  const [a, b] = [parts(version), parts(seen)];
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+};
+
 /**
- * Returns whether the current release is unseen (drives the Help-button
- * sparkle) plus a `markSeen` to call when the user opens the Help menu.
+ * Returns whether a release newer than the last one this browser acknowledged
+ * has been published (drives the Help-button sparkle) plus a `markSeen` to call
+ * when the user opens the Help menu.
  *
- * A browser that has never acknowledged a version is treated as unseen, so the
- * indicator shows once until the menu is opened (then it's marked seen).
+ * Strictly newer, not merely different, so a rollback does not re-nudge everyone
+ * with notes they have already read.
  */
 export const useWhatsNewUnseen = (
   version?: string,
@@ -21,7 +42,8 @@ export const useWhatsNewUnseen = (
   useEffect(() => {
     if (!version) return;
     try {
-      // Never-seen (null) !== version, so a fresh browser shows the indicator.
+      const seen = window.localStorage.getItem(SEEN_KEY);
+      // A browser that has never acknowledged anything is nudged once.
       //
       // set-state-in-effect is disabled deliberately: localStorage is an external
       // system and this is a read-once-after-hydration sync of it, which is the
@@ -30,7 +52,7 @@ export const useWhatsNewUnseen = (
       // so deriving the sparkle during the first render would mismatch the SSR
       // markup and get thrown away on hydration.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setHasUnseen(window.localStorage.getItem(SEEN_KEY) !== version);
+      setHasUnseen(seen === null || isNewerRelease(version, seen));
     } catch {
       // localStorage can throw (private mode, disabled storage) — just don't
       // nudge rather than break the nav.

--- a/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
@@ -70,25 +70,17 @@ function renderMenu(ui: React.ReactElement) {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MantineProvider>{ui}</MantineProvider>
+      <MantineProvider env="test">{ui}</MantineProvider>
     </QueryClientProvider>,
   );
 }
 
-// Wait for the dropdown itself: Mantine mounts it through a transition, so a
-// bare click leaves the items absent and every "item is missing" assertion
-// passes for the wrong reason.
-// openMenu alone waits up to 5s for the dropdown, which is the whole default
-// per-test budget — under parallel workers a slow transition times out the
-// test before its assertions run. Give every test in this file headroom above
-// that internal wait.
-jest.setTimeout(15_000);
-
+// renderMenu passes env="test", so the dropdown mounts synchronously with no
+// transition to wait on. The wait stays as a guard: if that ever stops holding,
+// every "item is missing" assertion would pass for the wrong reason.
 const openMenu = async (testId: string) => {
   await userEvent.click(screen.getByTestId(testId));
-  // Generous timeout: the transition competes with the rest of the suite
-  // under parallel workers, and a 1s default flaked there.
-  await screen.findByRole('menu', undefined, { timeout: 5000 });
+  await screen.findByRole('menu');
 };
 
 describe('AlertRowMenu', () => {
@@ -110,22 +102,9 @@ describe('AlertRowMenu', () => {
 
     expect(screen.queryByTestId('edit-alert-modal')).not.toBeInTheDocument();
     await openMenu('alert-row-menu-alert-1');
-    // Same rationale as openMenu's own wait: under parallel workers the
-    // dropdown's transition can lag behind the menu role appearing.
-    const editItem = await screen.findByTestId(
-      'alert-edit-alert-1',
-      undefined,
-      {
-        timeout: 5000,
-      },
-    );
-    await userEvent.click(editItem);
+    await userEvent.click(screen.getByTestId('alert-edit-alert-1'));
 
-    expect(
-      await screen.findByTestId('edit-alert-modal', undefined, {
-        timeout: 5000,
-      }),
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('edit-alert-modal')).toBeInTheDocument();
   });
 
   it('offers Terraform export for a saved-search alert', async () => {
@@ -192,6 +171,10 @@ describe('AlertRowMenu', () => {
       />,
     );
     await openMenu('alert-row-menu-alert-1');
+
+    // Assert on the menu contents before clicking, which closes the dropdown.
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+
     await userEvent.click(screen.getByTestId('alert-delete-alert-1'));
 
     expect(confirm).toHaveBeenCalledWith(
@@ -199,7 +182,6 @@ describe('AlertRowMenu', () => {
       'Delete',
       expect.anything(),
     );
-    expect(screen.getByText('Open source')).toBeInTheDocument();
   });
 
   it('labels the menu button with the alert name', () => {

--- a/packages/app/tests/e2e/core/navigation.spec.ts
+++ b/packages/app/tests/e2e/core/navigation.spec.ts
@@ -318,7 +318,7 @@ test.describe('Navigation', { tag: ['@core'] }, () => {
       }),
     );
 
-    // A browser that has never acknowledged a version counts as unseen. Cleared
+    // A browser that has never acknowledged a release counts as unseen. Cleared
     // explicitly because the shared auth storage state may carry the key over.
     await page.evaluate(() =>
       window.localStorage.removeItem('hdx-whats-new-seen'),


### PR DESCRIPTION
The Help button sparkles when there are release notes you haven't read. It was sparkling for everyone on every deploy, because the "have you seen this?" key was `NEXT_PUBLIC_APP_VERSION` — and any deployment that stamps a build id into that value mints a new version string on every deploy, so the nudge fired whether or not a new release had been published. Upstream builds set it to the plain `package.json` version so they don't hit this, but a deployment that appends a git short SHA or a CI build number does, and once a nudge fires on every deploy it stops meaning anything.

The key is now the newest release version in the changelog, read from the generated `whats-new.json` in `next.config.mjs` and inlined as `NEXT_PUBLIC_WHATS_NEW_VERSION`. It comes from the changelog headings rather than the build, so it moves only when a release is actually published. It's inlined through `nextConfig.env` rather than `__ENV.js` on purpose: the static-export and embedded builds omit that script and they need the sparkle too.

The comparison is strictly-newer rather than merely-different, which is what stops a rollback re-nudging everyone with notes they have already read. It compares the `X.Y.Z` components numerically, because `'2.9.0' > '2.10.0'` as strings while 2.10.0 is the newer release. `parseInt` stopping at the first non-digit also handles the rollout: a browser carrying a build-stamped value written by the current code (`2.37.0-sha0724861`) compares equal to `2.37.0`, so someone who has already read that release's notes is not nudged again just because the key's shape changed.

The tests in `useWhatsNewUnseen.test.tsx` cover the rollback case, the numeric-not-lexical comparison, and that rollout path. The two added to `parse-whats-new.test.ts` pin release ordering, which nothing pinned before and which the nudge now depends on — if the payload ever stopped leading with the newest release, the key would go backwards and nobody would be nudged again.

One thing worth knowing rather than discovering: a notes edit that doesn't move the version — a typo fix or a late-added highlight to the release already published — won't re-nudge. That's the deliberate trade-off for not re-nudging on a rollback, and the version is the honest signal of "there is a new release to read about".
