### PR TITLE
[HDX-5247] Fix single-series histogram ORDER BY on grouped charts

### DIFF
--- a/.changeset/histogram-table-orderby.md
+++ b/.changeset/histogram-table-orderby.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+'@hyperdx/api': patch
+---
+
+Fixed single-series histogram charts failing with "Unknown expression or function identifier" when sorted by a group-by column or expression. The histogram translation packs group values into a single `group` Array, so the table default ORDER BY (the raw group-by text) referenced source columns that no longer exist in scope; matched sort items now address the packed array positionally.

--- a/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
+++ b/packages/common-utils/src/__tests__/__snapshots__/renderChartConfig.test.ts.snap
@@ -34,6 +34,96 @@ exports[`renderChartConfig containing CTE clauses should render a chart config C
 
 exports[`renderChartConfig event (log/trace) formula charts (inline single-query) appends the compiled formula column after the operand columns in one scan 1`] = `"SELECT countIf(SeverityText = 'error') AS "errors",count() AS "total",((coalesce(countIf(SeverityText = 'error'), 0) / nullif(coalesce(count(), 0), 0)) * 100) AS "Error rate",toStartOfInterval(toDateTime(timestamp), INTERVAL 1 minute) AS \`__hdx_time_bucket\` FROM default.otel_logs WHERE (timestamp >= fromUnixTimestamp64Milli(1739318400000) AND timestamp <= fromUnixTimestamp64Milli(1739491200000)) GROUP BY toStartOfInterval(toDateTime(timestamp), INTERVAL 1 minute) AS \`__hdx_time_bucket\` ORDER BY toStartOfInterval(toDateTime(timestamp), INTERVAL 1 minute) AS \`__hdx_time_bucket\` SETTINGS optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"`;
 
+exports[`renderChartConfig histogram metric queries ORDER BY on a grouped histogram (packed group array) sorts a table default orderBy (= groupBy text) positionally 1`] = `
+"WITH source AS (
+          SELECT
+            MetricName,
+            ExplicitBounds,
+            
+            group,
+            sumForEach(deltas) as rates
+          FROM (
+            SELECT
+              TimeUnix,
+              MetricName,
+              ExplicitBounds,
+               group,
+              attr_hash,
+              any(attr_hash) OVER prev_row AS prev_attr_hash,
+              count() OVER prev_row = 0 OR prev_attr_hash != attr_hash AS is_first_series_point,
+              any(bounds_hash) OVER prev_row AS prev_bounds_hash,
+              any(counts) OVER prev_row AS prev_counts,
+              counts,
+              multiIf(
+                  AggregationTemporality = 2 AND is_first_series_point, 
+                  arrayWithConstant(length(counts), toInt64(0)),
+
+                  AggregationTemporality = 1 
+                      OR bounds_hash != prev_bounds_hash 
+                      OR arrayExists((x) -> x.2 < x.1, arrayZip(prev_counts, counts)), 
+                  counts,
+
+                  counts - prev_counts
+              ) AS deltas
+            FROM (
+              SELECT
+                  TimeUnix,
+                  MetricName,
+                  AggregationTemporality,
+                  ExplicitBounds,
+                  ResourceAttributes,
+                  Attributes,[ResourceAttributes['service.name'], concat(ResourceAttributes['host.name'], '-x')] as group,
+                  cityHash64(ScopeAttributes, ResourceAttributes, Attributes) AS attr_hash,
+                  cityHash64(ExplicitBounds) AS bounds_hash,
+                  CAST(BucketCounts AS Array(Int64)) counts
+              FROM default.otel_metrics_histogram
+              WHERE (TimeUnix >= fromUnixTimestamp64Milli(1739318400000) AND TimeUnix <= fromUnixTimestamp64Milli(1765670400000)) AND ((MetricName = 'http.server.duration'))
+              ORDER BY group, attr_hash, TimeUnix ASC
+            )
+            WINDOW prev_row AS (
+             PARTITION BY group
+              ORDER BY attr_hash, TimeUnix
+              ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING
+            )
+          )
+          GROUP BY  MetricName, group, ExplicitBounds
+          
+          ),points AS (
+          SELECT
+            group,
+            MetricName,
+            arrayZipUnaligned(arrayCumSum(rates), ExplicitBounds) as point,
+            length(point) as n
+          FROM source
+          ),metrics AS (
+          SELECT
+            group,
+            MetricName,
+            point[n].1 AS total,
+            0.5 * total AS rank,
+            arrayFirstIndex(x -> if(x.1 > rank, 1, 0), point) AS upper_idx,
+            point[upper_idx].1 AS upper_count,
+            ifNull(point[upper_idx].2, inf) AS upper_bound,
+            CASE
+              WHEN upper_idx > 1 THEN point[upper_idx - 1].2
+              WHEN point[upper_idx].2 > 0 THEN 0
+              ELSE inf
+            END AS lower_bound,
+            if (
+              lower_bound = 0,
+              0,
+              point[upper_idx - 1].1
+            ) AS lower_count,
+            CASE
+                WHEN upper_bound = inf THEN point[upper_idx - 1].2
+                WHEN lower_bound = inf THEN point[1].2
+                ELSE lower_bound + (upper_bound - lower_bound) * ((rank - lower_count) / (upper_count - lower_count))
+            END AS "Value"
+          FROM points
+          WHERE length(point) > 1 AND total > 0
+          ) SELECT group, "Value" FROM metrics ORDER BY \`group\`[1],\`group\`[2] LIMIT 200 SETTINGS short_circuit_function_evaluation = 'force_enable', optimize_read_in_order = 0, cast_keep_nullable = 1, additional_result_filter = 'x != 2', count_distinct_implementation = 'uniqCombined64', async_insert_busy_timeout_min_ms = 20000"
+`;
+
 exports[`renderChartConfig histogram metric queries count should generate a count query with grouping and time bucketing 1`] = `
 "WITH source AS (
         SELECT

--- a/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
+++ b/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
@@ -4,6 +4,7 @@ import { ClickHouseClient } from '@clickhouse/client';
 import { convertCHDataTypeToJSType, JSDataType } from '@/clickhouse';
 import { ClickhouseClient as HdxClickhouseClient } from '@/clickhouse/node';
 import { Metadata, MetadataCache } from '@/core/metadata';
+import { convertToCategoricalChartConfig } from '@/core/utils';
 import {
   ChartConfigWithOptDateRange,
   DisplayType,
@@ -2352,6 +2353,33 @@ describe('queryChartConfig Integration Tests', () => {
           ['svc-c'],
           ['svc-b'],
           ['svc-a'],
+        ]);
+      });
+
+      it('sorts a categorical histogram chart with a multi-dimension group-by (HDX-5247)', async () => {
+        // convertToCategoricalChartConfig injects a structured orderBy whose
+        // second item's valueExpression is the whole group-by string; each
+        // comma piece must match its packed element like the string form.
+        const converted = convertToCategoricalChartConfig(
+          baseConfig({
+            displayType: DisplayType.Pie,
+            granularity: undefined,
+            select: [histQuantileSelect('grpsort.hist', 0.5)],
+            groupBy: "ServiceName, ResourceAttributes['service.name']",
+            seriesLimit: 10,
+          }) as Parameters<typeof convertToCategoricalChartConfig>[0],
+        );
+        const result = await runConfig(
+          converted as ChartConfigWithOptDateRange,
+        );
+
+        // Slices order by value DESC first — p50 interpolates to 20 (svc-b),
+        // 10 (svc-c), 5 (svc-a) — with the packed group pieces as tiebreak.
+        const data = result.data as Row[];
+        expect(data.map(r => col(r, 'group'))).toEqual([
+          ['svc-b', 'svc-b'],
+          ['svc-c', 'svc-c'],
+          ['svc-a', 'svc-a'],
         ]);
       });
 

--- a/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
+++ b/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
@@ -2300,6 +2300,34 @@ describe('queryChartConfig Integration Tests', () => {
         expect(Number(col(svcB, RATIO))).toBeCloseTo(6 / 25, 5);
       });
 
+      it('sorts a SINGLE-series histogram table on a raw expression group-by (HDX-5247)', async () => {
+        // Same packed-array scope as the all-histogram composed case, but on
+        // the single-series render path: the histogram translation leaves
+        // only [group, value] in scope, so the table default orderBy
+        // (= groupBy text) must be rewritten there too.
+        const result = await runConfig(
+          baseConfig({
+            displayType: DisplayType.Table,
+            granularity: undefined,
+            select: [histQuantileSelect('grpsort.hist', 0.5)],
+            groupBy: "ResourceAttributes['service.name']",
+            orderBy: "ResourceAttributes['service.name'] DESC",
+          }),
+        );
+
+        const data = result.data as Row[];
+        expect(data.map(r => col(r, 'group'))).toEqual([
+          ['svc-c'],
+          ['svc-b'],
+          ['svc-a'],
+        ]);
+        // svc-b's 10 observations are all in the (10, 30] bucket: p50 = 20.
+        expect(Number(col(data[1], 'quantile(grpsort.hist)'))).toBeCloseTo(
+          20,
+          5,
+        );
+      });
+
       it('sorts an all-histogram chart on a raw expression group-by via the packed group array', async () => {
         // With no scalar branch there are no individual group columns —
         // every branch packs the group values into the `group` Array, and

--- a/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
+++ b/packages/common-utils/src/__tests__/queryChartConfig.int.test.ts
@@ -2328,6 +2328,33 @@ describe('queryChartConfig Integration Tests', () => {
         );
       });
 
+      it('sorts a SINGLE-series histogram table by its group-by alias (HDX-5247)', async () => {
+        // The alias only exists inside the packing array literal — it never
+        // surfaces as a column in the translated scope — so alias-referencing
+        // sorts rewrite to the packed element like expression sorts do.
+        const result = await runConfig(
+          baseConfig({
+            displayType: DisplayType.Table,
+            granularity: undefined,
+            select: [histQuantileSelect('grpsort.hist', 0.5)],
+            groupBy: [
+              {
+                aggCondition: '',
+                valueExpression: "ResourceAttributes['service.name']",
+                alias: 'service',
+              },
+            ],
+            orderBy: [{ valueExpression: 'service', ordering: 'DESC' }],
+          }),
+        );
+
+        expect((result.data as Row[]).map(r => col(r, 'group'))).toEqual([
+          ['svc-c'],
+          ['svc-b'],
+          ['svc-a'],
+        ]);
+      });
+
       it('sorts an all-histogram chart on a raw expression group-by via the packed group array', async () => {
         // With no scalar branch there are no individual group columns —
         // every branch packs the group values into the `group` Array, and

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -1043,11 +1043,8 @@ describe('renderChartConfig', () => {
       });
     });
 
-    // HDX-5247: the translated histogram scope only projects
-    // [bucket?, group, value] — the user's group-by values live solely
-    // inside the packed `group` Array — so a table's default
-    // orderBy (= the raw groupBy text) must sort positionally on the array,
-    // not re-reference the source columns.
+    // HDX-5247: after histogram translation only [bucket?, group, value]
+    // survive in scope, so group-by sorts must address the packed array.
     describe('ORDER BY on a grouped histogram (packed group array)', () => {
       const histTableConfig = (
         overrides: Partial<ChartConfigWithOptDateRange>,
@@ -1101,18 +1098,21 @@ describe('renderChartConfig', () => {
       });
 
       it('sorts a plain group column positionally, keeping its direction', async () => {
-        // Even a bare column has no named passthrough — only the packed
-        // `group` Array survives the histogram translation.
-        const generatedSql = await renderChartConfig(
-          histTableConfig({
-            groupBy: [{ aggCondition: '', valueExpression: 'ServiceName' }],
-            orderBy: [{ valueExpression: 'ServiceName', ordering: 'DESC' }],
-          }),
-          mockMetadata,
-          querySettings,
-        );
-        const sql = parameterizedQueryToSql(generatedSql);
-        expect(sql).toContain('ORDER BY `group`[1] DESC');
+        // Even a bare column group-by has no named passthrough column when
+        // every branch is a histogram — only the packed `group` Array. A
+        // backtick-quoted reference matches the bare entry the same way.
+        for (const valueExpression of ['ServiceName', '`ServiceName`']) {
+          const generatedSql = await renderChartConfig(
+            histTableConfig({
+              groupBy: [{ aggCondition: '', valueExpression: 'ServiceName' }],
+              orderBy: [{ valueExpression, ordering: 'DESC' }],
+            }),
+            mockMetadata,
+            querySettings,
+          );
+          const sql = parameterizedQueryToSql(generatedSql);
+          expect(sql).toContain('ORDER BY `group`[1] DESC');
+        }
       });
 
       it('sorts a categorical (pie/bar) chart with a multi-dimension group-by positionally', async () => {

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -5,6 +5,7 @@ import {
   renderChartConfig,
   timeFilterExpr,
 } from '@/core/renderChartConfig';
+import { convertToCategoricalChartConfig } from '@/core/utils';
 import {
   BuilderChartConfig,
   ChartConfigWithOptDateRange,
@@ -1112,6 +1113,44 @@ describe('renderChartConfig', () => {
         );
         const sql = parameterizedQueryToSql(generatedSql);
         expect(sql).toContain('ORDER BY `group`[1] DESC');
+      });
+
+      it('sorts a categorical (pie/bar) chart with a multi-dimension group-by positionally', async () => {
+        // convertToCategoricalChartConfig injects a structured orderBy whose
+        // second item's valueExpression is the WHOLE group-by string —
+        // structured items are comma-split like the string form so each
+        // dimension matches its packed element.
+        const converted = convertToCategoricalChartConfig(
+          histTableConfig({
+            displayType: DisplayType.Pie,
+            seriesLimit: 10,
+            limit: undefined,
+            groupBy: "ServiceName, ResourceAttributes['service.name']",
+          }) as Parameters<typeof convertToCategoricalChartConfig>[0],
+        );
+        expect(converted.orderBy).toEqual([
+          { valueExpression: '"Value"', ordering: 'DESC' },
+          {
+            valueExpression: "ServiceName, ResourceAttributes['service.name']",
+            ordering: 'ASC',
+          },
+        ]);
+
+        const generatedSql = await renderChartConfig(
+          converted as ChartConfigWithOptDateRange,
+          mockMetadata,
+          querySettings,
+        );
+        const sql = parameterizedQueryToSql(generatedSql);
+        // "Value" resolves as the projected value column; the group pieces
+        // sort positionally, with the item's direction on the last piece
+        // only (matching how ClickHouse parses the raw `a, b ASC` text).
+        expect(sql).toContain(
+          'ORDER BY "Value" DESC,`group`[1],`group`[2] ASC',
+        );
+        expect(sql.slice(sql.indexOf('FROM metrics'))).not.toContain(
+          'ServiceName',
+        );
       });
 
       it('sorts by a group-by alias positionally (bare and quoted forms)', async () => {
@@ -4648,6 +4687,52 @@ describe('renderChartConfig', () => {
           const sql = parameterizedQueryToSql(generatedSql);
           expect(sql).toContain('ORDER BY `group`[1] ASC');
           expect(sql).not.toContain('__hdx_sort_');
+        });
+
+        it('splits a structured sort item carrying a multi-dimension expression', async () => {
+          // convertToCategoricalChartConfig injects the WHOLE group-by string
+          // as one structured item's valueExpression — each comma piece must
+          // match its packed element like the string form does, with the
+          // item's direction on the last piece only.
+          const generatedSql = await renderChartConfig(
+            {
+              ...baseMultiSeriesConfig,
+              displayType: DisplayType.Table,
+              granularity: undefined,
+              select: [
+                {
+                  aggFn: 'quantile',
+                  level: 0.5,
+                  aggCondition: '',
+                  aggConditionLanguage: 'sql',
+                  valueExpression: 'Value',
+                  metricName: 'metric.latency',
+                  metricType: MetricsDataType.Histogram,
+                },
+                {
+                  aggFn: 'quantile',
+                  level: 0.99,
+                  aggCondition: '',
+                  aggConditionLanguage: 'sql',
+                  valueExpression: 'Value',
+                  metricName: 'metric.latency',
+                  metricType: MetricsDataType.Histogram,
+                },
+              ],
+              groupBy: "ServiceName, ResourceAttributes['service.name']",
+              orderBy: [
+                {
+                  valueExpression:
+                    "ServiceName, ResourceAttributes['service.name']",
+                  ordering: 'DESC',
+                },
+              ],
+            },
+            mockMetadata,
+            querySettings,
+          );
+          const sql = parameterizedQueryToSql(generatedSql);
+          expect(sql).toContain('ORDER BY `group`[1],`group`[2] DESC');
         });
 
         it('rewrites the sort for a share_of_total ratio without HAVING', async () => {

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -1114,6 +1114,33 @@ describe('renderChartConfig', () => {
         expect(sql).toContain('ORDER BY `group`[1] DESC');
       });
 
+      it('sorts by a group-by alias positionally (bare and quoted forms)', async () => {
+        // The alias is defined inside the packing array literal in an inner
+        // CTE — it never surfaces as a column in the translated scope, so an
+        // alias-referencing sort must rewrite to the packed element too.
+        for (const orderBy of [
+          [{ valueExpression: 'service', ordering: 'DESC' as const }],
+          '"service" DESC',
+        ]) {
+          const generatedSql = await renderChartConfig(
+            histTableConfig({
+              groupBy: [
+                {
+                  aggCondition: '',
+                  valueExpression: "ResourceAttributes['service.name']",
+                  alias: 'service',
+                },
+              ],
+              orderBy,
+            }),
+            mockMetadata,
+            querySettings,
+          );
+          const sql = parameterizedQueryToSql(generatedSql);
+          expect(sql).toContain('ORDER BY `group`[1] DESC');
+        }
+      });
+
       it('leaves unmatched sort items (the value alias) untouched', async () => {
         const generatedSql = await renderChartConfig(
           histTableConfig({
@@ -4574,6 +4601,52 @@ describe('renderChartConfig', () => {
           );
           const sql = parameterizedQueryToSql(generatedSql);
           expect(sql).toContain('ORDER BY `group`[1] DESC');
+          expect(sql).not.toContain('__hdx_sort_');
+        });
+
+        it('sorts an all-histogram chart by a group-by alias through the packed array', async () => {
+          // In a packed scope the alias never surfaces as a column (unlike
+          // scalar branches, where alias sorts pass through untouched), so
+          // alias references rewrite to the packed element too.
+          const generatedSql = await renderChartConfig(
+            {
+              ...baseMultiSeriesConfig,
+              displayType: DisplayType.Table,
+              granularity: undefined,
+              select: [
+                {
+                  aggFn: 'quantile',
+                  level: 0.5,
+                  aggCondition: '',
+                  aggConditionLanguage: 'sql',
+                  valueExpression: 'Value',
+                  metricName: 'metric.latency',
+                  metricType: MetricsDataType.Histogram,
+                },
+                {
+                  aggFn: 'quantile',
+                  level: 0.99,
+                  aggCondition: '',
+                  aggConditionLanguage: 'sql',
+                  valueExpression: 'Value',
+                  metricName: 'metric.latency',
+                  metricType: MetricsDataType.Histogram,
+                },
+              ],
+              groupBy: [
+                {
+                  aggCondition: '',
+                  valueExpression: "ResourceAttributes['service.name']",
+                  alias: 'service',
+                },
+              ],
+              orderBy: [{ valueExpression: 'service', ordering: 'ASC' }],
+            },
+            mockMetadata,
+            querySettings,
+          );
+          const sql = parameterizedQueryToSql(generatedSql);
+          expect(sql).toContain('ORDER BY `group`[1] ASC');
           expect(sql).not.toContain('__hdx_sort_');
         });
 

--- a/packages/common-utils/src/__tests__/renderChartConfig.test.ts
+++ b/packages/common-utils/src/__tests__/renderChartConfig.test.ts
@@ -1041,6 +1041,125 @@ describe('renderChartConfig', () => {
         expect(actual).toMatchSnapshot();
       });
     });
+
+    // HDX-5247: the translated histogram scope only projects
+    // [bucket?, group, value] — the user's group-by values live solely
+    // inside the packed `group` Array — so a table's default
+    // orderBy (= the raw groupBy text) must sort positionally on the array,
+    // not re-reference the source columns.
+    describe('ORDER BY on a grouped histogram (packed group array)', () => {
+      const histTableConfig = (
+        overrides: Partial<ChartConfigWithOptDateRange>,
+      ): ChartConfigWithOptDateRange =>
+        ({
+          displayType: DisplayType.Table,
+          connection: 'test-connection',
+          metricTables: {
+            gauge: 'otel_metrics_gauge',
+            histogram: 'otel_metrics_histogram',
+            sum: 'otel_metrics_sum',
+            summary: 'otel_metrics_summary',
+            'exponential histogram': 'otel_metrics_exponential_histogram',
+          },
+          from: { databaseName: 'default', tableName: '' },
+          select: [
+            {
+              aggFn: 'quantile',
+              level: 0.5,
+              valueExpression: 'Value',
+              metricName: 'http.server.duration',
+              metricType: MetricsDataType.Histogram,
+            },
+          ],
+          where: '',
+          whereLanguage: 'sql',
+          timestampValueExpression: 'TimeUnix',
+          dateRange: [new Date('2025-02-12'), new Date('2025-12-14')],
+          limit: { limit: 200 },
+          ...overrides,
+        }) as ChartConfigWithOptDateRange;
+
+      it('sorts a table default orderBy (= groupBy text) positionally', async () => {
+        const EXPR_GROUP_BY =
+          "ResourceAttributes['service.name'], concat(ResourceAttributes['host.name'], '-x')";
+        const generatedSql = await renderChartConfig(
+          histTableConfig({
+            groupBy: EXPR_GROUP_BY,
+            orderBy: EXPR_GROUP_BY,
+          }),
+          mockMetadata,
+          querySettings,
+        );
+        const sql = parameterizedQueryToSql(generatedSql);
+        expect(sql).toMatchSnapshot();
+        expect(sql).toContain('ORDER BY `group`[1],`group`[2] LIMIT 200');
+        // The raw source expressions never reach the outer statement.
+        expect(sql.slice(sql.indexOf('FROM metrics'))).not.toContain(
+          'ResourceAttributes',
+        );
+      });
+
+      it('sorts a plain group column positionally, keeping its direction', async () => {
+        // Even a bare column has no named passthrough — only the packed
+        // `group` Array survives the histogram translation.
+        const generatedSql = await renderChartConfig(
+          histTableConfig({
+            groupBy: [{ aggCondition: '', valueExpression: 'ServiceName' }],
+            orderBy: [{ valueExpression: 'ServiceName', ordering: 'DESC' }],
+          }),
+          mockMetadata,
+          querySettings,
+        );
+        const sql = parameterizedQueryToSql(generatedSql);
+        expect(sql).toContain('ORDER BY `group`[1] DESC');
+      });
+
+      it('leaves unmatched sort items (the value alias) untouched', async () => {
+        const generatedSql = await renderChartConfig(
+          histTableConfig({
+            select: [
+              {
+                aggFn: 'quantile',
+                level: 0.5,
+                valueExpression: 'Value',
+                metricName: 'http.server.duration',
+                metricType: MetricsDataType.Histogram,
+                alias: 'p50',
+              },
+            ],
+            groupBy: [{ aggCondition: '', valueExpression: 'ServiceName' }],
+            orderBy: '"p50" DESC',
+          }),
+          mockMetadata,
+          querySettings,
+        );
+        const sql = parameterizedQueryToSql(generatedSql);
+        expect(sql).toContain('ORDER BY "p50" DESC');
+        expect(sql).not.toContain('`group`[1]');
+      });
+
+      it('rewrites the orderBy for an exponential histogram the same way', async () => {
+        const generatedSql = await renderChartConfig(
+          histTableConfig({
+            select: [
+              {
+                aggFn: 'quantile',
+                level: 0.5,
+                valueExpression: 'Value',
+                metricName: 'http.server.duration',
+                metricType: MetricsDataType.ExponentialHistogram,
+              },
+            ],
+            groupBy: "ResourceAttributes['service.name']",
+            orderBy: "ResourceAttributes['service.name'] DESC",
+          }),
+          mockMetadata,
+          querySettings,
+        );
+        const sql = parameterizedQueryToSql(generatedSql);
+        expect(sql).toContain('ORDER BY `group`[1] DESC');
+      });
+    });
   });
 
   describe('containing CTE clauses', () => {

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -96,7 +96,8 @@ const inlineNonNegativeInt = (value: number, label: string): string => {
   return String(value);
 };
 
-const unquoteIdentifier = (identifier: string): string => {
+/** Strip one level of `…` / "…" identifier quoting, if present. */
+export const unquoteIdentifier = (identifier: string): string => {
   if (
     (identifier.startsWith('`') && identifier.endsWith('`')) ||
     (identifier.startsWith('"') && identifier.endsWith('"'))

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -2518,7 +2518,10 @@ function parseSortSpecificationItems(
  * column, aliased, or expression: none resolve by name in this scope)
  * sorts as `group`[k+1]. GROUP_ALIAS is a grouping key, so the element
  * access is valid after GROUP BY ALL without an aggregate, and no
- * companion columns are involved.
+ * companion columns are involved. Sort items referencing a group-by entry
+ * by its ALIAS (bare or identifier-quoted) match too — the alias never
+ * surfaces as a column in a packed scope, unlike on scalar branches where
+ * it is a projected passthrough column and needs no rewriting.
  *
  * Anything else (value-column aliases, quoted output names, unparseable
  * items) is passed through unchanged.
@@ -2539,10 +2542,22 @@ function renderMultiSeriesOrderBy(
   let rewroteAny = false;
   const orderBy = parseSortSpecificationItems(sortSpecificationList).map(
     item => {
+      // Strip one level of identifier quoting so `"service"` / `` `service` ``
+      // compare equal to the bare alias text.
+      const unquoted =
+        item.expr != null
+          ? item.expr.trim().replace(/^"([^"]+)"$|^`([^`]+)`$/, '$1$2')
+          : undefined;
       const matched =
         item.expr != null
           ? groupEntries.find(
-              g => normalizeExprText(g.expr) === normalizeExprText(item.expr!),
+              g =>
+                normalizeExprText(g.expr) === normalizeExprText(item.expr!) ||
+                // Alias references only need rewriting in a packed scope; on
+                // scalar branches the alias is a projected column and the
+                // item must pass through untouched to keep working SQL
+                // byte-for-byte identical.
+                (groupsArePacked && g.alias != null && g.alias === unquoted),
             )
           : undefined;
       if (!matched) {

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -2463,14 +2463,23 @@ function groupByEntriesForSort(
 
 /**
  * Split a SortSpecificationList into per-item expression/direction pairs.
- * String items that don't parse as a plain `<expr> [ASC|DESC]` (e.g. with a
+ * Items that don't parse as a plain `<expr> [ASC|DESC]` (e.g. with a
  * NULLS FIRST suffix) keep only `raw` and are passed through untouched.
+ *
+ * Structured items run through the same comma-splitting as the string form:
+ * convertToCategoricalChartConfig injects a single item whose
+ * valueExpression is the WHOLE group-by string (e.g. "ServiceName,
+ * HttpStatus"), which must match the group entries piece-by-piece exactly
+ * like the table default (string) form does. The item's ordering attaches
+ * to the LAST piece only — that mirrors how ClickHouse parses the rendered
+ * text `a, b DESC` (a ASC, b DESC), so splitting never changes the sort
+ * semantics of an item that already rendered successfully.
  */
 function parseSortSpecificationItems(
   sortSpecificationList: SortSpecificationList,
 ): ParsedSortItem[] {
-  if (typeof sortSpecificationList === 'string') {
-    return splitAndTrimWithBracket(sortSpecificationList).map(piece => {
+  const parsePieces = (text: string): ParsedSortItem[] =>
+    splitAndTrimWithBracket(text).map(piece => {
       const match = piece.match(/^([\s\S]*?)\s+(ASC|DESC)$/i);
       if (match) {
         return {
@@ -2484,12 +2493,15 @@ function parseSortSpecificationItems(
       // a group-by expression — so the item safely falls through untouched.
       return { raw: piece, expr: piece };
     });
+
+  if (typeof sortSpecificationList === 'string') {
+    return parsePieces(sortSpecificationList);
   }
-  return sortSpecificationList.map(item => ({
-    raw: `${item.valueExpression} ${item.ordering === 'DESC' ? 'DESC' : 'ASC'}`,
-    expr: item.valueExpression,
-    ordering: item.ordering === 'DESC' ? 'DESC' : 'ASC',
-  }));
+  return sortSpecificationList.flatMap(item =>
+    parsePieces(
+      `${item.valueExpression} ${item.ordering === 'DESC' ? 'DESC' : 'ASC'}`,
+    ),
+  );
 }
 
 /**

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -10,7 +10,7 @@ import {
   translateExponentialHistogram,
   translateHistogram,
 } from '@/core/histogram';
-import { Metadata } from '@/core/metadata';
+import { Metadata, unquoteIdentifier } from '@/core/metadata';
 import {
   convertDateRangeToGranularityString,
   convertGranularityToSeconds,
@@ -2554,22 +2554,23 @@ function renderMultiSeriesOrderBy(
   let rewroteAny = false;
   const orderBy = parseSortSpecificationItems(sortSpecificationList).map(
     item => {
-      // Strip one level of identifier quoting so `"service"` / `` `service` ``
-      // compare equal to the bare alias text.
-      const unquoted =
-        item.expr != null
-          ? item.expr.trim().replace(/^"([^"]+)"$|^`([^`]+)`$/, '$1$2')
-          : undefined;
+      // Strip one level of identifier quoting on both sides so
+      // `` `ServiceName` `` / `"service"` compare equal to the bare text.
+      // (A quoted plain-column match still passes through raw in scalar
+      // mode below, so working SQL stays byte-for-byte identical there.)
+      const matchText = (s: string) =>
+        normalizeExprText(unquoteIdentifier(s.trim()));
       const matched =
         item.expr != null
           ? groupEntries.find(
               g =>
-                normalizeExprText(g.expr) === normalizeExprText(item.expr!) ||
+                matchText(g.expr) === matchText(item.expr!) ||
                 // Alias references only need rewriting in a packed scope; on
                 // scalar branches the alias is a projected column and the
-                // item must pass through untouched to keep working SQL
-                // byte-for-byte identical.
-                (groupsArePacked && g.alias != null && g.alias === unquoted),
+                // item must pass through untouched.
+                (groupsArePacked &&
+                  g.alias != null &&
+                  g.alias === unquoteIdentifier(item.expr!.trim())),
             )
           : undefined;
       if (!matched) {

--- a/packages/common-utils/src/core/renderChartConfig.ts
+++ b/packages/common-utils/src/core/renderChartConfig.ts
@@ -2302,6 +2302,24 @@ async function translateMetricChartConfig(
       valueAlias,
     };
 
+    // The translated scope only projects [bucket?, group, value] — the
+    // user's group-by values (plain columns included) exist solely inside
+    // the packed GROUP_ALIAS Array, so an ORDER BY repeating a group-by
+    // entry (the table default is orderBy = groupBy text) would fail with
+    // "Unknown identifier". Rewrite matched items to the positional
+    // element access `group`[k+1] (HDX-5247; same mechanism as the
+    // composed multi-series all-histogram path, see
+    // renderMultiSeriesOrderBy). Items are raw SQL only (no bind params),
+    // so joining their text yields a plain string-form orderBy.
+    const packedOrderBy =
+      restChartConfig.orderBy != null && groupBy
+        ? renderMultiSeriesOrderBy(
+            restChartConfig.orderBy,
+            groupByEntriesForSort(chartConfig.groupBy!),
+            { groupsArePacked: true },
+          )
+        : null;
+
     return {
       ...restChartConfig,
       with: isExponentialHistogram
@@ -2316,6 +2334,9 @@ async function translateMetricChartConfig(
         databaseName: '',
         tableName: 'metrics',
       },
+      orderBy: packedOrderBy
+        ? packedOrderBy.orderBy.map(item => item.sql).join(',')
+        : restChartConfig.orderBy,
       where: '', // clear up the condition since the where clause is already applied at the upstream CTE
       // Timeseries queries discard padded buckets here. Non-timeseries queries
       // scan only the visible range and have no time dimension to filter.
@@ -2424,6 +2445,23 @@ type ParsedSortItem = {
 };
 
 /**
+ * Normalize a config's group-by (string or structured list) into the
+ * expression/alias pairs the sort rewriting matches against. Entry order is
+ * significant: it matches both the scalar-branch projection order and the
+ * packing order of the GROUP_ALIAS Array.
+ */
+function groupByEntriesForSort(
+  groupBy: NonNullable<BuilderChartConfigWithOptDateRange['groupBy']>,
+): { expr: string; alias?: string }[] {
+  return typeof groupBy === 'string'
+    ? splitAndTrimWithBracket(groupBy).map(expr => ({ expr }))
+    : groupBy.map(entry => ({
+        expr: entry.valueExpression,
+        alias: entry.alias?.trim() ? entry.alias : undefined,
+      }));
+}
+
+/**
  * Split a SortSpecificationList into per-item expression/direction pairs.
  * String items that don't parse as a plain `<expr> [ASC|DESC]` (e.g. with a
  * NULLS FIRST suffix) keep only `raw` and are passed through untouched.
@@ -2487,6 +2525,10 @@ function parseSortSpecificationItems(
  *
  * Returns null when nothing needs rewriting so the caller can keep the
  * legacy rendering path (and its exact SQL text) for untouched configs.
+ *
+ * The packed mode is shared with the SINGLE-series histogram translation
+ * (translateMetricChartConfig), whose scope has the same shape: only the
+ * packed GROUP_ALIAS Array survives translation (HDX-5247).
  */
 function renderMultiSeriesOrderBy(
   sortSpecificationList: SortSpecificationList,
@@ -2717,14 +2759,7 @@ async function renderMultiSeriesMetricChartConfig(
     !ordersOnHavingWrapper
       ? renderMultiSeriesOrderBy(
           chartConfig.orderBy,
-          typeof chartConfig.groupBy === 'string'
-            ? splitAndTrimWithBracket(chartConfig.groupBy).map(expr => ({
-                expr,
-              }))
-            : chartConfig.groupBy!.map(entry => ({
-                expr: entry.valueExpression,
-                alias: entry.alias?.trim() ? entry.alias : undefined,
-              })),
+          groupByEntriesForSort(chartConfig.groupBy!),
           { groupsArePacked: allGroupsPacked },
         )
       : null;


### PR DESCRIPTION
## Summary

A **single-series** histogram or exponential-histogram chart grouped by any column or expression failed to sort with:

```
Unknown expression or function identifier `ResourceAttributes` in scope ...
```

Root cause: `translateMetricChartConfig`'s histogram branch packs the group-by values into the single `group` Array column and drops the individual group columns from the translated scope (`[bucket?, group, value]`), but left the user's `orderBy` untouched. `convertToTableChartConfig` defaults a table's ORDER BY to the raw groupBy text, so every grouped single-series histogram table hit this — plain group columns (e.g. `ServiceName`) included, since they don't survive translation by name either. Pre-existing bug; not a regression of HDX-5202 (different render path than the composed multi-series statement).

Fix: rewrite ORDER BY items matching a group-by entry at index k to the positional element access `` `group`[k+1] `` inside the histogram translation, reusing the packed-group mode `renderMultiSeriesOrderBy` gained in #3013 (packing order in `translateHistogram` matches group-by entry order). Unmatched items — e.g. the quoted value alias — pass through unchanged, and configs without a matched sort render identical SQL to before.

### How to test on Vercel preview

N/A — non-UI change (query generation in common-utils).

### Testing

- Unit tests + snapshot: expression group-by with table default orderBy, plain-column DESC, exponential histogram, and unmatched value-alias passthrough
- Integration test against real ClickHouse: single-series histogram table grouped by `ResourceAttributes['service.name']` with the raw-expression sort — correct row order and quantile values
- `renderChartConfig` unit suite (183) and `queryChartConfig` integration suite (64) pass; lint + tsc clean

### References

- Linear Issue: [HDX-5247](https://linear.app/clickhouse/issue/HDX-5247/single-series-histogram-table-grouped-by-an-expression-fails-order-by)
- Related PRs: #3013
- Error example: https://play.hyperdx.io/chart?source=975eb452c10479ad&where=&select=&whereLanguage=lucene&filters=%255B%255D&orderBy=&config={%22name%22:%22%22,%22select%22:[{%22aggFn%22:%22quantile%22,%22aggCondition%22:%22%22,%22aggConditionLanguage%22:%22lucene%22,%22valueExpression%22:%22Value%22,%22level%22:0.95,%22metricType%22:%22histogram%22,%22metricName%22:%22rpc.client.request.size%22}],%22where%22:%22%22,%22whereLanguage%22:%22lucene%22,%22displayType%22:%22table%22,%22granularity%22:%22auto%22,%22alignDateRangeToGranularity%22:true,%22source%22:%2213309faf9395257c%22,%22connection%22:%22local%22,%22groupBy%22:%22Attributes[%27rpc.method%27],Attributes[%27rpc.system%27]%22}

