### PR TITLE
feat: Support dashboard filters based on Prometheus label values

### DIFF
--- a/.changeset/promql-label-dashboard-filters.md
+++ b/.changeset/promql-label-dashboard-filters.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+feat: Support dashboard filters based on Prometheus label values

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3047,13 +3047,17 @@
           },
           {
             "$ref": "#/components/schemas/StaticListFilterInput"
+          },
+          {
+            "$ref": "#/components/schemas/PrometheusLabelFilterInput"
           }
         ],
         "discriminator": {
           "propertyName": "type",
           "mapping": {
             "QUERY_EXPRESSION": "#/components/schemas/QueryExpressionFilterInput",
-            "STATIC_LIST": "#/components/schemas/StaticListFilterInput"
+            "STATIC_LIST": "#/components/schemas/StaticListFilterInput",
+            "PROMETHEUS_LABEL": "#/components/schemas/PrometheusLabelFilterInput"
           }
         }
       },
@@ -3213,6 +3217,69 @@
             "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$",
             "description": "Token tiles reference this filter's selected value by, as\n`$variableName`. Must start with a letter and may contain only\nletters, numbers, and underscores. Defaults to the display name with\nwhitespace replaced by underscores and remaining illegal characters\nremoved, so a variable-enabled filter whose name derives nothing\nusable must send this field explicitly. Variable names must be unique\nacross a dashboard's variable-enabled filters. Names the variable\nonly, so the field is rejected when isVariableEnabled is not true, and\nis omitted from responses for such a filter.\n",
             "example": "environment"
+          }
+        }
+      },
+      "PrometheusLabelFilterInput": {
+        "type": "object",
+        "description": "A filter whose dropdown lists the values for a Prometheus label,\nread from a PromQL source over the dashboard's time range.\nSupports variable mode only.\n",
+        "required": [
+          "type",
+          "name",
+          "sourceId",
+          "label"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "PROMETHEUS_LABEL"
+            ],
+            "description": "Discriminator. Must be \"PROMETHEUS_LABEL\".",
+            "example": "PROMETHEUS_LABEL"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name for the dashboard filter",
+            "example": "Pod"
+          },
+          "sourceId": {
+            "type": "string",
+            "description": "Id of the PromQL source the label values are read from.\n",
+            "example": "65f5e4a3b9e77c001a123456"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024,
+            "description": "Label whose values populate the dropdown. Use \"__name__\" to list\nmetric names.\n",
+            "example": "pod"
+          },
+          "isBroadcastEnabled": {
+            "type": "boolean",
+            "enum": [
+              false
+            ],
+            "default": false,
+            "description": "Must be false or omitted.",
+            "example": false
+          },
+          "isVariableEnabled": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "default": true,
+            "description": "Must be true if provided, and is true when omitted. Tiles reference\nthe selection as `$variableName`.\n",
+            "example": true
+          },
+          "variableName": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$",
+            "description": "Token that tiles reference this filter's selected value by, as\n`$variableName`. Must start with a letter and may contain only\nletters, numbers, and underscores. Defaults to the display name with\nwhitespace replaced by underscores and remaining illegal characters\nremoved. Variable names must be unique across a dashboard's\nvariable-enabled filters.\n",
+            "example": "pod"
           }
         }
       },

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -1397,6 +1397,101 @@ describe('dashboard router', () => {
         expect(stored?.filters).toEqual([filter]);
       });
 
+      // The app PATCHes the whole dashboard on every edit, so re-checking a
+      // filter that was already accepted would let a deleted source block
+      // every later save. The dangling reference is surfaced per-filter at
+      // query time instead.
+      it("lets unrelated edits through after the filter's source is deleted", async () => {
+        const filter = makePromqlFilter();
+        const created = await agent
+          .post('/dashboards')
+          .send({ ...MOCK_DASHBOARD, filters: [filter] })
+          .expect(200);
+
+        await Source.findByIdAndDelete(promqlSourceId);
+
+        await agent
+          .patch(`/dashboards/${created.body.id}`)
+          .send({ name: 'Renamed', filters: [filter] })
+          .expect(200);
+
+        const stored = await Dashboard.findById(created.body.id).lean();
+        expect(stored?.name).toBe('Renamed');
+        expect(stored?.filters).toEqual([filter]);
+      });
+
+      // Only the source is exempt once accepted — everything else about the
+      // filter is still the client's to change, and still validated.
+      it('lets the label change while the source stays dangling', async () => {
+        const filter = makePromqlFilter();
+        const created = await agent
+          .post('/dashboards')
+          .send({ ...MOCK_DASHBOARD, filters: [filter] })
+          .expect(200);
+
+        await Source.findByIdAndDelete(promqlSourceId);
+
+        await agent
+          .patch(`/dashboards/${created.body.id}`)
+          .send({ filters: [{ ...filter, label: 'namespace' }] })
+          .expect(200);
+      });
+
+      it('still rejects a filter added by the PATCH itself', async () => {
+        const created = await agent
+          .post('/dashboards')
+          .send(MOCK_DASHBOARD)
+          .expect(200);
+
+        const source = new Types.ObjectId().toString();
+        const response = await agent
+          .patch(`/dashboards/${created.body.id}`)
+          .send({ filters: [makePromqlFilter({ source })] })
+          .expect(400);
+
+        expect(response.body.message).toContain(source);
+      });
+
+      // Converting a filter to this type is the same as adding one, as far as
+      // the gate is concerned: its source has never been through it.
+      it('still rejects a filter PATCHed over from another type', async () => {
+        const id = new Types.ObjectId().toString();
+        const created = await agent
+          .post('/dashboards')
+          .send({
+            ...MOCK_DASHBOARD,
+            filters: [
+              {
+                id,
+                type: 'QUERY_EXPRESSION' as const,
+                name: 'Service',
+                expression: 'ServiceName',
+                source: promqlSourceId,
+              },
+            ],
+          })
+          .expect(200);
+
+        const logSource = await Source.create({
+          kind: SourceKind.Log,
+          name: 'Converted Log Source',
+          team: team._id,
+          connection: new Types.ObjectId().toString(),
+          from: { databaseName: 'test_db', tableName: 'logs_table' },
+          timestampValueExpression: 'timestamp',
+          defaultTableSelectExpression: 'body',
+        });
+
+        await agent
+          .patch(`/dashboards/${created.body.id}`)
+          .send({
+            filters: [
+              makePromqlFilter({ id, source: logSource._id.toString() }),
+            ],
+          })
+          .expect(400);
+      });
+
       // The fetch is skipped entirely when no filter of this type is present,
       // so a queried filter naming a missing source still saves as before.
       it('leaves other filter types unvalidated', async () => {

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -1227,6 +1227,219 @@ describe('dashboard router', () => {
     );
   });
 
+  describe('promql-label filters', () => {
+    const createPromqlSource = () =>
+      Source.create({
+        kind: SourceKind.Promql,
+        name: 'Test PromQL Source',
+        team: team._id,
+        connection: new Types.ObjectId().toString(),
+        from: { databaseName: 'test_db', tableName: 'timeseries_table' },
+        timestampValueExpression: 'timestamp',
+      });
+
+    // The route rejects a filter naming anything but a live PromQL source, so
+    // every case here needs a real one.
+    let promqlSourceId: string;
+    beforeEach(async () => {
+      promqlSourceId = (await createPromqlSource())._id.toString();
+    });
+
+    const makePromqlFilter = (overrides = {}) => ({
+      id: new Types.ObjectId().toString(),
+      type: 'PROMETHEUS_LABEL' as const,
+      name: 'Pod',
+      source: promqlSourceId,
+      label: 'pod',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'pod',
+      ...overrides,
+    });
+
+    it('persists a promql-label filter on create and returns it on GET', async () => {
+      const filter = makePromqlFilter();
+
+      const created = await agent
+        .post('/dashboards')
+        .send({ ...MOCK_DASHBOARD, filters: [filter] })
+        .expect(200);
+
+      expect(created.body.filters).toEqual([filter]);
+
+      const stored = await Dashboard.findById(created.body.id).lean();
+      expect(stored?.filters).toEqual([filter]);
+      // Same reason as the static variant: an absent `expression` is what makes
+      // `$__filter($pod)` report that the expression must be passed explicitly.
+      expect(stored?.filters?.[0]).not.toHaveProperty('expression');
+    });
+
+    // Prometheus 3 allows UTF-8 label names, and a ClickHouse-backed source's
+    // tags map holds whatever the collector ingested.
+    it('persists a dotted OTel-shaped label', async () => {
+      const filter = makePromqlFilter({ label: 'k8s.pod.name' });
+
+      const created = await agent
+        .post('/dashboards')
+        .send({ ...MOCK_DASHBOARD, filters: [filter] })
+        .expect(200);
+
+      expect(created.body.filters).toEqual([filter]);
+    });
+
+    it('persists an updated label on PATCH', async () => {
+      const filter = makePromqlFilter();
+      const created = await agent
+        .post('/dashboards')
+        .send({ ...MOCK_DASHBOARD, filters: [filter] })
+        .expect(200);
+
+      const updatedFilter = { ...filter, label: 'namespace' };
+      await agent
+        .patch(`/dashboards/${created.body.id}`)
+        .send({ filters: [updatedFilter] })
+        .expect(200);
+
+      const stored = await Dashboard.findById(created.body.id).lean();
+      expect(stored?.filters).toEqual([updatedFilter]);
+    });
+
+    it.each([
+      ['broadcast enabled', { isBroadcastEnabled: true }],
+      ['broadcast unset', { isBroadcastEnabled: undefined }],
+      ['not variable-enabled', { isVariableEnabled: false }],
+      ['variables unset', { isVariableEnabled: undefined }],
+      ['no source', { source: undefined }],
+      ['no label', { label: undefined }],
+      ['an empty label', { label: '' }],
+    ])('rejects a promql-label filter with %s', async (_label, overrides) => {
+      await agent
+        .post('/dashboards')
+        .send({ ...MOCK_DASHBOARD, filters: [makePromqlFilter(overrides)] })
+        .expect(400);
+    });
+
+    // Resolving one of these reads the source's connection and db/table, which
+    // only a PromQL source carries — so unlike every other source reference on
+    // this route, a bad id is rejected rather than saved.
+    describe('source validation', () => {
+      it('rejects a filter naming a source that does not exist', async () => {
+        const source = new Types.ObjectId().toString();
+
+        const response = await agent
+          .post('/dashboards')
+          .send({ ...MOCK_DASHBOARD, filters: [makePromqlFilter({ source })] })
+          .expect(400);
+
+        expect(response.body.message).toContain(source);
+      });
+
+      it('rejects a filter naming a source of the wrong kind', async () => {
+        const logSource = await Source.create({
+          kind: SourceKind.Log,
+          name: 'Test Log Source',
+          team: team._id,
+          connection: new Types.ObjectId().toString(),
+          from: { databaseName: 'test_db', tableName: 'logs_table' },
+          timestampValueExpression: 'timestamp',
+          defaultTableSelectExpression: 'body',
+        });
+
+        const response = await agent
+          .post('/dashboards')
+          .send({
+            ...MOCK_DASHBOARD,
+            filters: [makePromqlFilter({ source: logSource._id.toString() })],
+          })
+          .expect(400);
+
+        expect(response.body.message).toContain(logSource._id.toString());
+      });
+
+      // The lookup is team-scoped, so another team's PromQL source is as good
+      // as absent.
+      it("rejects another team's PromQL source", async () => {
+        const otherTeamSource = await Source.create({
+          kind: SourceKind.Promql,
+          name: 'Other Team PromQL Source',
+          team: new Types.ObjectId(),
+          connection: new Types.ObjectId().toString(),
+          from: { databaseName: 'test_db', tableName: 'timeseries_table' },
+          timestampValueExpression: 'timestamp',
+        });
+
+        await agent
+          .post('/dashboards')
+          .send({
+            ...MOCK_DASHBOARD,
+            filters: [
+              makePromqlFilter({ source: otherTeamSource._id.toString() }),
+            ],
+          })
+          .expect(400);
+      });
+
+      it('rejects the source when PATCH introduces it, leaving the stored filter alone', async () => {
+        const filter = makePromqlFilter();
+        const created = await agent
+          .post('/dashboards')
+          .send({ ...MOCK_DASHBOARD, filters: [filter] })
+          .expect(200);
+
+        await agent
+          .patch(`/dashboards/${created.body.id}`)
+          .send({
+            filters: [{ ...filter, source: new Types.ObjectId().toString() }],
+          })
+          .expect(400);
+
+        const stored = await Dashboard.findById(created.body.id).lean();
+        expect(stored?.filters).toEqual([filter]);
+      });
+
+      // The fetch is skipped entirely when no filter of this type is present,
+      // so a queried filter naming a missing source still saves as before.
+      it('leaves other filter types unvalidated', async () => {
+        await agent
+          .post('/dashboards')
+          .send({
+            ...MOCK_DASHBOARD,
+            filters: [
+              {
+                id: new Types.ObjectId().toString(),
+                type: 'QUERY_EXPRESSION' as const,
+                name: 'Service',
+                expression: 'ServiceName',
+                source: new Types.ObjectId().toString(),
+              },
+            ],
+          })
+          .expect(200);
+      });
+    });
+
+    it('rejects a variable name it shares with another filter', async () => {
+      await agent
+        .post('/dashboards')
+        .send({
+          ...MOCK_DASHBOARD,
+          filters: [
+            makePromqlFilter({ variableName: 'pod' }),
+            {
+              id: new Types.ObjectId().toString(),
+              type: 'QUERY_EXPRESSION' as const,
+              name: 'Pod (logs)',
+              expression: 'PodName',
+              source: new Types.ObjectId().toString(),
+              isVariableEnabled: true,
+              variableName: 'pod',
+            },
+          ],
+        })
+        .expect(400);
+    });
+  });
+
   describe('preset dashboards', () => {
     const MOCK_SOURCE: Omit<Extract<TSource, { kind: 'log' }>, 'id'> = {
       kind: SourceKind.Log,

--- a/packages/api/src/routers/api/dashboards.ts
+++ b/packages/api/src/routers/api/dashboards.ts
@@ -8,7 +8,6 @@ import {
   DashboardFilter,
   DashboardSchema,
   DashboardWithoutIdSchema,
-  isPromqlSource,
   PresetDashboard,
   PresetDashboardFilterSchema,
   resolveChartPaletteToken,
@@ -35,6 +34,7 @@ import {
 import { getSources } from '@/controllers/sources';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
 import type { ObjectId } from '@/models';
+import { getPromqlLabelFilterSourceError } from '@/routers/external-api/v2/utils/dashboards';
 import { objectIdSchema } from '@/utils/zod';
 
 // create routes that will get and update dashboards
@@ -60,6 +60,21 @@ const addFilterIssues = (
   validateDashboardFilterOptionUniqueness(data.filters ?? [], ctx);
 };
 
+/** Returns new and updated PROMETHEUS_LABEL filters. */
+function filterChangedPromqlLabelFilters(
+  filters: DashboardFilter[],
+  existingFilters: DashboardFilter[],
+) {
+  const existingSourceById = new Map(
+    existingFilters
+      .filter(isPrometheusLabelFilter)
+      .map(filter => [filter.id, filter.source]),
+  );
+  return filters
+    .filter(isPrometheusLabelFilter)
+    .filter(filter => existingSourceById.get(filter.id) !== filter.source);
+}
+
 /**
  * Rejects PROMETHEUS_LABEL filters whose `source` is missing or is not a PromQL
  * source. Returns an error message, or null when there is nothing to reject.
@@ -67,21 +82,18 @@ const addFilterIssues = (
 async function validatePromqlLabelFilterSources(
   teamId: ObjectId,
   filters: DashboardFilter[] = [],
+  existingFilters?: DashboardFilter[],
 ): Promise<string | null> {
-  const promqlLabelFilters = filters.filter(isPrometheusLabelFilter);
+  const promqlLabelFilters = existingFilters
+    ? filterChangedPromqlLabelFilters(filters, existingFilters)
+    : filters.filter(isPrometheusLabelFilter);
   if (promqlLabelFilters.length === 0) return null;
 
   const sources = await getSources(teamId.toString());
-  const promqlSourceIds = new Set(
-    sources.filter(isPromqlSource).map(source => source._id.toString()),
+  return getPromqlLabelFilterSourceError(
+    sources,
+    promqlLabelFilters.map(filter => filter.source),
   );
-
-  const invalid = promqlLabelFilters
-    .filter(filter => !promqlSourceIds.has(filter.source))
-    .map(filter => filter.source);
-  if (invalid.length === 0) return null;
-
-  return `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${[...new Set(invalid)].join(', ')}`;
 }
 
 /**
@@ -184,6 +196,7 @@ router.patch(
       const sourceError = await validatePromqlLabelFilterSources(
         teamId,
         req.body.filters,
+        dashboard.filters ?? [],
       );
       if (sourceError != null) {
         return res.status(400).json({ message: sourceError });

--- a/packages/api/src/routers/api/dashboards.ts
+++ b/packages/api/src/routers/api/dashboards.ts
@@ -3,9 +3,12 @@ import {
   validateDashboardFilterOptionUniqueness,
   validateDashboardFilterVariableNames,
 } from '@hyperdx/common-utils/dist/dashboardValidation';
+import { isPrometheusLabelFilter } from '@hyperdx/common-utils/dist/filters';
 import {
+  DashboardFilter,
   DashboardSchema,
   DashboardWithoutIdSchema,
+  isPromqlSource,
   PresetDashboard,
   PresetDashboardFilterSchema,
   resolveChartPaletteToken,
@@ -29,7 +32,9 @@ import {
   getPresetDashboardFilters,
   updatePresetDashboardFilter,
 } from '@/controllers/presetDashboardFilters';
+import { getSources } from '@/controllers/sources';
 import { getNonNullUserWithTeam } from '@/middleware/auth';
+import type { ObjectId } from '@/models';
 import { objectIdSchema } from '@/utils/zod';
 
 // create routes that will get and update dashboards
@@ -54,6 +59,30 @@ const addFilterIssues = (
   validateDashboardFilterModes(data.filters ?? [], ctx);
   validateDashboardFilterOptionUniqueness(data.filters ?? [], ctx);
 };
+
+/**
+ * Rejects PROMETHEUS_LABEL filters whose `source` is missing or is not a PromQL
+ * source. Returns an error message, or null when there is nothing to reject.
+ */
+async function validatePromqlLabelFilterSources(
+  teamId: ObjectId,
+  filters: DashboardFilter[] = [],
+): Promise<string | null> {
+  const promqlLabelFilters = filters.filter(isPrometheusLabelFilter);
+  if (promqlLabelFilters.length === 0) return null;
+
+  const sources = await getSources(teamId.toString());
+  const promqlSourceIds = new Set(
+    sources.filter(isPromqlSource).map(source => source._id.toString()),
+  );
+
+  const invalid = promqlLabelFilters
+    .filter(filter => !promqlSourceIds.has(filter.source))
+    .map(filter => filter.source);
+  if (invalid.length === 0) return null;
+
+  return `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${[...new Set(invalid)].join(', ')}`;
+}
 
 /**
  * Heal legacy `chart-1`..`chart-10` tile colors from #2265 on the request
@@ -111,6 +140,14 @@ router.post(
       // dashboard to the provisioner.
       const dashboard = _.omit(req.body, 'provisioned');
 
+      const sourceError = await validatePromqlLabelFilterSources(
+        teamId,
+        req.body.filters,
+      );
+      if (sourceError != null) {
+        return res.status(400).json({ message: sourceError });
+      }
+
       const newDashboard = await createDashboard(teamId, dashboard, userId);
 
       res.json(newDashboard.toJSON());
@@ -143,6 +180,14 @@ router.patch(
       // Only omit undefined values, keep null (which signals field removal)
       // `provisioned` is server-owned — see the POST handler above.
       const updates = _.omitBy(_.omit(req.body, 'provisioned'), _.isUndefined);
+
+      const sourceError = await validatePromqlLabelFilterSources(
+        teamId,
+        req.body.filters,
+      );
+      if (sourceError != null) {
+        return res.status(400).json({ message: sourceError });
+      }
 
       const updatedDashboard = await updateDashboard(
         dashboardId,

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -1872,7 +1872,7 @@ describe('External API v2 Dashboards - new format', () => {
   });
 
   const server = getServer();
-  let agent, team, user, traceSource, metricSource, connection;
+  let agent, team, user, traceSource, metricSource, promqlSource, connection;
 
   beforeAll(async () => {
     await server.start();
@@ -1920,6 +1920,18 @@ describe('External API v2 Dashboards - new format', () => {
       timestampValueExpression: 'TimeUnix',
       connection: connection._id,
       name: 'Metrics',
+    });
+
+    promqlSource = await Source.create({
+      kind: SourceKind.Promql,
+      team: team._id,
+      from: {
+        databaseName: DEFAULT_DATABASE,
+        tableName: 'otel_metrics_timeseries',
+      },
+      timestampValueExpression: 'TimeUnix',
+      connection: connection._id,
+      name: 'PromQL',
     });
   });
 
@@ -5687,6 +5699,140 @@ describe('External API v2 Dashboards - new format', () => {
         expect(response.status).toBe(400);
         expect(JSON.stringify(response.body)).toContain(
           'Invalid discriminator value',
+        );
+      });
+    });
+
+    describe('promql-label filters', () => {
+      const promqlFilterInput = (overrides = {}) => ({
+        id: new ObjectId().toString(),
+        type: 'PROMETHEUS_LABEL' as const,
+        name: 'Pod',
+        sourceId: promqlSource._id.toString(),
+        label: 'pod',
+        isBroadcastEnabled: false,
+        isVariableEnabled: true,
+        variableName: 'pod',
+        ...overrides,
+      });
+
+      it('accepts a promql-label filter and round-trips it through GET', async () => {
+        const response = await sendFilters([promqlFilterInput()]);
+        expect(response.status).toBe(200);
+
+        const [filter] = response.body.data.filters;
+        expect(filter).toMatchObject({
+          type: 'PROMETHEUS_LABEL',
+          name: 'Pod',
+          sourceId: promqlSource._id.toString(),
+          label: 'pod',
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'pod',
+        });
+        // Stored internally as `source`; only `sourceId` is ever external.
+        expect(filter).not.toHaveProperty('source');
+        expect(filter).not.toHaveProperty('expression');
+
+        const getResponse = await authRequest(
+          'get',
+          `${BASE_URL}/${response.body.data.id}`,
+        ).expect(200);
+        expect(getResponse.body.data.filters).toEqual(
+          response.body.data.filters,
+        );
+      });
+
+      // Prometheus 3 allows UTF-8 label names, and a ClickHouse-backed source's
+      // tags hold whatever the collector ingested.
+      it('accepts a dotted OTel-shaped label', async () => {
+        const response = await sendFilters([
+          promqlFilterInput({ label: 'k8s.pod.name' }),
+        ]);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.filters[0].label).toBe('k8s.pod.name');
+      });
+
+      // Each mode flag accepts exactly one value, so omitting it fills that
+      // value in rather than falling back to the queried filter's defaults.
+      it('defaults the mode flags when they are omitted', async () => {
+        const response = await sendFilters([
+          promqlFilterInput({
+            isBroadcastEnabled: undefined,
+            isVariableEnabled: undefined,
+          }),
+        ]);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.filters[0]).toMatchObject({
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'pod',
+        });
+      });
+
+      // Resolving one of these reads the source's connection and db/table,
+      // which only a PromQL source carries. Mirrors the heatmap/formula gates.
+      it('rejects a source of the wrong kind', async () => {
+        const response = await sendFilters([
+          promqlFilterInput({ sourceId: traceSource._id.toString() }),
+        ]);
+
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${traceSource._id.toString()}`,
+        );
+      });
+
+      it('rejects a source that does not exist for the team', async () => {
+        const sourceId = new ObjectId().toString();
+        const response = await sendFilters([promqlFilterInput({ sourceId })]);
+
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          `Could not find the following source IDs: ${sourceId}`,
+        );
+      });
+
+      it.each([
+        ['broadcast enabled', { isBroadcastEnabled: true }],
+        ['not variable-enabled', { isVariableEnabled: false }],
+        ['no label', { label: undefined }],
+        ['an empty label', { label: '' }],
+        ['no sourceId', { sourceId: undefined }],
+      ])('rejects a promql-label filter with %s', async (_label, overrides) => {
+        const response = await sendFilters([promqlFilterInput(overrides)]);
+
+        expect(response.status).toBe(400);
+      });
+
+      it.each([
+        ['an expression', { expression: 'ServiceName' }],
+        ['an option list', { options: ['prod'] }],
+        ['a source', { source: '65f5e4a3b9e77c001a111111' }],
+        [
+          'applies-to sources',
+          { appliesToSourceIds: ['65f5e4a3b9e77c001a111111'] },
+        ],
+      ])(
+        'rejects a promql-label filter carrying %s',
+        async (_label, overrides) => {
+          const response = await sendFilters([promqlFilterInput(overrides)]);
+
+          expect(response.status).toBe(400);
+          expect(JSON.stringify(response.body)).toContain(
+            `Unrecognized key(s) in object: '${Object.keys(overrides)[0]}'`,
+          );
+        },
+      );
+
+      it('rejects a label on a queried filter', async () => {
+        const response = await sendFilters([filterInput({ label: 'pod' })]);
+
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          "Unrecognized key(s) in object: 'label'",
         );
       });
     });

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1761,11 +1761,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *       oneOf:
  *         - $ref: '#/components/schemas/QueryExpressionFilterInput'
  *         - $ref: '#/components/schemas/StaticListFilterInput'
+ *         - $ref: '#/components/schemas/PrometheusLabelFilterInput'
  *       discriminator:
  *         propertyName: type
  *         mapping:
  *           QUERY_EXPRESSION: '#/components/schemas/QueryExpressionFilterInput'
  *           STATIC_LIST: '#/components/schemas/StaticListFilterInput'
+ *           PROMETHEUS_LABEL: '#/components/schemas/PrometheusLabelFilterInput'
  *
  *     QueryExpressionFilterInput:
  *       type: object
@@ -1926,6 +1928,68 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *             only, so the field is rejected when isVariableEnabled is not true, and
  *             is omitted from responses for such a filter.
  *           example: "environment"
+ *
+ *     PrometheusLabelFilterInput:
+ *       type: object
+ *       description: |
+ *         A filter whose dropdown lists the values for a Prometheus label,
+ *         read from a PromQL source over the dashboard's time range.
+ *         Supports variable mode only.
+ *       required:
+ *         - type
+ *         - name
+ *         - sourceId
+ *         - label
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [PROMETHEUS_LABEL]
+ *           description: Discriminator. Must be "PROMETHEUS_LABEL".
+ *           example: "PROMETHEUS_LABEL"
+ *         name:
+ *           type: string
+ *           minLength: 1
+ *           description: Display name for the dashboard filter
+ *           example: "Pod"
+ *         sourceId:
+ *           type: string
+ *           description: |
+ *             Id of the PromQL source the label values are read from.
+ *           example: "65f5e4a3b9e77c001a123456"
+ *         label:
+ *           type: string
+ *           minLength: 1
+ *           maxLength: 1024
+ *           description: |
+ *             Label whose values populate the dropdown. Use "__name__" to list
+ *             metric names.
+ *           example: "pod"
+ *         isBroadcastEnabled:
+ *           type: boolean
+ *           enum: [false]
+ *           default: false
+ *           description: Must be false or omitted.
+ *           example: false
+ *         isVariableEnabled:
+ *           type: boolean
+ *           enum: [true]
+ *           default: true
+ *           description: |
+ *             Must be true if provided, and is true when omitted. Tiles reference
+ *             the selection as `$variableName`.
+ *           example: true
+ *         variableName:
+ *           type: string
+ *           maxLength: 64
+ *           pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+ *           description: |
+ *             Token that tiles reference this filter's selected value by, as
+ *             `$variableName`. Must start with a letter and may contain only
+ *             letters, numbers, and underscores. Defaults to the display name with
+ *             whitespace replaced by underscores and remaining illegal characters
+ *             removed. Variable names must be unique across a dashboard's
+ *             variable-enabled filters.
+ *           example: "pod"
  *
  *     Filter:
  *       allOf:

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -11,7 +11,10 @@ import {
   validateDashboardFilterVariableNames,
   validateDashboardTileContainerRefs,
 } from '@hyperdx/common-utils/dist/dashboardValidation';
-import { isQueryExpressionFilter } from '@hyperdx/common-utils/dist/filters';
+import {
+  isPrometheusLabelFilter,
+  isStaticListFilter,
+} from '@hyperdx/common-utils/dist/filters';
 import {
   isBuilderSavedChartConfig,
   isHeatmapCompatibleSource,
@@ -29,6 +32,7 @@ import {
   isLogSource,
   isOnClickDashboardById,
   isOnClickSearchById,
+  isPromqlSource,
   isTraceSource,
   NumberTileColorCondition,
   NumberTileColorConditionSchema,
@@ -1024,7 +1028,8 @@ function getMissingSources(
 
   if (filters?.length) {
     for (const filter of filters) {
-      if (isQueryExpressionFilter(filter)) {
+      // Every variant but the static one names a source.
+      if (!isStaticListFilter(filter)) {
         sourceIds.add(filter.sourceId);
       }
     }
@@ -1064,6 +1069,26 @@ function getHeatmapTilesWithIncompatibleSources(
   return [...heatmapSourceIds].filter(id => {
     const source = sourceById.get(id);
     return source !== undefined && !isHeatmapCompatibleSource(source);
+  });
+}
+
+/**
+ * Returns source IDs referenced by PROMETHEUS_LABEL filters that exist but are
+ * not PromQL sources.
+ */
+function getPromqlLabelFiltersWithIncompatibleSources(
+  sources: SourceForValidation[],
+  filters: (ExternalDashboardFilter | ExternalDashboardFilterWithId)[] = [],
+): string[] {
+  const referencedSourceIds = new Set<string>(
+    filters.filter(isPrometheusLabelFilter).map(f => f.sourceId),
+  );
+  if (referencedSourceIds.size === 0) return [];
+
+  const sourceById = new Map(sources.map(s => [s._id.toString(), s]));
+  return [...referencedSourceIds].filter(id => {
+    const source = sourceById.get(id);
+    return source !== undefined && !isPromqlSource(source);
   });
 }
 
@@ -1474,6 +1499,12 @@ export async function validateDashboardTiles(
   );
   if (formulaIncompatibleSources.length > 0) {
     return `Tiles with formulas require a Metric, Log, or Trace source. The following source IDs are not formula-capable: ${formulaIncompatibleSources.join(', ')}`;
+  }
+
+  const promqlLabelNonPromqlSources =
+    getPromqlLabelFiltersWithIncompatibleSources(sources, filters);
+  if (promqlLabelNonPromqlSources.length > 0) {
+    return `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${promqlLabelNonPromqlSources.join(', ')}`;
   }
 
   if (missingOnClickDashboards.length > 0) {

--- a/packages/api/src/routers/external-api/v2/utils/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/utils/dashboards.ts
@@ -1073,23 +1073,20 @@ function getHeatmapTilesWithIncompatibleSources(
 }
 
 /**
- * Returns source IDs referenced by PROMETHEUS_LABEL filters that exist but are
- * not PromQL sources.
+ * Returns an error message string if any of the referenced source IDs is not
+ * a valid PromQL source, or null if all of them are.
  */
-function getPromqlLabelFiltersWithIncompatibleSources(
+export function getPromqlLabelFilterSourceError(
   sources: SourceForValidation[],
-  filters: (ExternalDashboardFilter | ExternalDashboardFilterWithId)[] = [],
-): string[] {
-  const referencedSourceIds = new Set<string>(
-    filters.filter(isPrometheusLabelFilter).map(f => f.sourceId),
-  );
-  if (referencedSourceIds.size === 0) return [];
-
+  referencedSourceIds: string[],
+): string | null {
   const sourceById = new Map(sources.map(s => [s._id.toString(), s]));
-  return [...referencedSourceIds].filter(id => {
+  const invalid = [...new Set(referencedSourceIds)].filter(id => {
     const source = sourceById.get(id);
-    return source !== undefined && !isPromqlSource(source);
+    return source === undefined || !isPromqlSource(source);
   });
+  if (invalid.length === 0) return null;
+  return `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${invalid.join(', ')}`;
 }
 
 /**
@@ -1501,11 +1498,13 @@ export async function validateDashboardTiles(
     return `Tiles with formulas require a Metric, Log, or Trace source. The following source IDs are not formula-capable: ${formulaIncompatibleSources.join(', ')}`;
   }
 
-  const promqlLabelNonPromqlSources =
-    getPromqlLabelFiltersWithIncompatibleSources(sources, filters);
-  if (promqlLabelNonPromqlSources.length > 0) {
-    return `PROMETHEUS_LABEL filters require a PromQL source. The following source IDs are not PromQL sources: ${promqlLabelNonPromqlSources.join(', ')}`;
-  }
+  // Validate that PROMETHEUS_LABEL filters reference PromQL sources
+  const promqlLabelFilters = (filters ?? []).filter(isPrometheusLabelFilter);
+  const promqlLabelFilterError = getPromqlLabelFilterSourceError(
+    sources,
+    promqlLabelFilters.map(f => f.sourceId),
+  );
+  if (promqlLabelFilterError != null) return promqlLabelFilterError;
 
   if (missingOnClickDashboards.length > 0) {
     return `Could not find the following onClick dashboard IDs: ${missingOnClickDashboards.join(', ')}`;

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -1,7 +1,6 @@
 import {
   isFilterBroadcastEnabled,
   isFilterVariableEnabled,
-  isStaticListFilter,
 } from '@hyperdx/common-utils/dist/filters';
 import {
   AlertErrorType,
@@ -217,32 +216,53 @@ export function translateExternalChartToTileConfig(
 export function translateFilterToExternalFilter(
   filter: DashboardFilter,
 ): ExternalDashboardFilterWithId {
-  // Static filters require no translation
-  if (isStaticListFilter(filter)) return filter;
+  switch (filter.type) {
+    case 'STATIC_LIST':
+      return filter;
 
-  // Ignore variableName and appliesToSourceIds if the filter is not in a mode that uses them
-  const ignoredKeys = [
-    ...(isFilterVariableEnabled(filter) ? [] : (['variableName'] as const)),
-    ...(isFilterBroadcastEnabled(filter)
-      ? []
-      : (['appliesToSourceIds'] as const)),
-  ];
-  return {
-    ...omit(filter, 'source', ...ignoredKeys),
-    sourceId: filter.source.toString(),
-  };
+    case 'PROMETHEUS_LABEL':
+      return {
+        ...omit(filter, 'source'),
+        sourceId: filter.source.toString(),
+      };
+
+    case 'QUERY_EXPRESSION': {
+      // Ignore variableName and appliesToSourceIds if the filter is not in a mode that uses them
+      const ignoredKeys = [
+        ...(isFilterVariableEnabled(filter) ? [] : (['variableName'] as const)),
+        ...(isFilterBroadcastEnabled(filter)
+          ? []
+          : (['appliesToSourceIds'] as const)),
+      ];
+      return {
+        ...omit(filter, 'source', ...ignoredKeys),
+        sourceId: filter.source.toString(),
+      };
+    }
+
+    default:
+      filter satisfies never;
+      return filter;
+  }
 }
 
 export function translateExternalFilterToFilter(
   filter: ExternalDashboardFilterWithId,
 ): DashboardFilter {
-  // Static filters require no translation
-  if (isStaticListFilter(filter)) return filter;
+  switch (filter.type) {
+    case 'STATIC_LIST':
+      return filter;
 
-  return {
-    ...omit(filter, 'sourceId'),
-    source: filter.sourceId,
-  };
+    case 'PROMETHEUS_LABEL':
+      return { ...omit(filter, 'sourceId'), source: filter.sourceId };
+
+    case 'QUERY_EXPRESSION':
+      return { ...omit(filter, 'sourceId'), source: filter.sourceId };
+
+    default:
+      filter satisfies never;
+      return filter;
+  }
 }
 
 // Alert related types and transformations

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -18,6 +18,7 @@ import {
   OnClickDashboardSchema,
   OnClickExternalSchema,
   OnClickSearchSchema,
+  PromqlLabelDashboardFilterSchema,
   QueryExpressionDashboardFilterSchema,
   scheduleStartAtSchema,
   SearchConditionLanguageSchema as whereLanguageSchema,
@@ -153,11 +154,20 @@ const externalStaticListFilterShape = StaticListDashboardFilterSchema.extend({
   isVariableEnabled: z.literal(true).default(true),
 });
 
+const externalPromqlLabelFilterShape = PromqlLabelDashboardFilterSchema.omit({
+  source: true,
+}).extend({
+  sourceId: objectIdSchema,
+  isBroadcastEnabled: z.literal(false).default(false),
+  isVariableEnabled: z.literal(true).default(true),
+});
+
 export const externalDashboardFilterSchemaWithId = z.discriminatedUnion(
   'type',
   [
     externalQueryExpressionFilterShape.strict(),
     externalStaticListFilterShape.strict(),
+    externalPromqlLabelFilterShape.strict(),
   ],
 );
 
@@ -173,6 +183,7 @@ export type ExternalQueryExpressionFilterWithId = Extract<
 export const externalDashboardFilterSchema = z.discriminatedUnion('type', [
   externalQueryExpressionFilterShape.omit({ id: true }).strict(),
   externalStaticListFilterShape.omit({ id: true }).strict(),
+  externalPromqlLabelFilterShape.omit({ id: true }).strict(),
 ]);
 
 export type ExternalDashboardFilter = z.infer<

--- a/packages/app/src/DBDashboardImportPage.tsx
+++ b/packages/app/src/DBDashboardImportPage.tsx
@@ -20,6 +20,7 @@ import {
   isPrometheusLabelFilter,
   isQueryExpressionFilter,
   isStaticListFilter,
+  QUERY_EXPRESSION_FILTER_SOURCE_KINDS,
   type SavedFilterValueIssue,
   type SavedQueryIssue,
   validateDashboardFilterQueries,
@@ -402,14 +403,6 @@ const sourceBackedTemplateFilter = (filter: DashboardFilter | undefined) =>
 const queriedTemplateFilter = (filter: DashboardFilter | undefined) =>
   filter && isQueryExpressionFilter(filter) ? filter : undefined;
 
-/** Everything a queried filter can run its `SELECT` against. */
-const SQL_FILTER_SOURCE_KINDS = [
-  SourceKind.Log,
-  SourceKind.Trace,
-  SourceKind.Session,
-  SourceKind.Metric,
-];
-
 /**
  * The source kinds a filter of this type can read its dropdown values from, or
  * `undefined` for a filter that reads no source at all.
@@ -420,7 +413,7 @@ const filterSourceKinds = (
   isPrometheusLabelFilter(filter)
     ? [SourceKind.Promql]
     : isQueryExpressionFilter(filter)
-      ? SQL_FILTER_SOURCE_KINDS
+      ? QUERY_EXPRESSION_FILTER_SOURCE_KINDS
       : undefined;
 
 /**

--- a/packages/app/src/DBDashboardImportPage.tsx
+++ b/packages/app/src/DBDashboardImportPage.tsx
@@ -17,6 +17,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { convertToDashboardDocument } from '@hyperdx/common-utils/dist/core/utils';
 import {
   type DashboardFilterQueryIssue,
+  isPrometheusLabelFilter,
   isQueryExpressionFilter,
   isStaticListFilter,
   type SavedFilterValueIssue,
@@ -38,6 +39,7 @@ import {
   isOnClickSearchById,
   isTraceSource,
   SavedChartConfig,
+  SourceKind,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import {
@@ -400,6 +402,27 @@ const sourceBackedTemplateFilter = (filter: DashboardFilter | undefined) =>
 const queriedTemplateFilter = (filter: DashboardFilter | undefined) =>
   filter && isQueryExpressionFilter(filter) ? filter : undefined;
 
+/** Everything a queried filter can run its `SELECT` against. */
+const SQL_FILTER_SOURCE_KINDS = [
+  SourceKind.Log,
+  SourceKind.Trace,
+  SourceKind.Session,
+  SourceKind.Metric,
+];
+
+/**
+ * The source kinds a filter of this type can read its dropdown values from, or
+ * `undefined` for a filter that reads no source at all.
+ */
+const filterSourceKinds = (
+  filter: DashboardFilter,
+): SourceKind[] | undefined =>
+  isPrometheusLabelFilter(filter)
+    ? [SourceKind.Promql]
+    : isQueryExpressionFilter(filter)
+      ? SQL_FILTER_SOURCE_KINDS
+      : undefined;
+
 /**
  * One mapping select's value. Mantine's Select writes `null` when the user
  * clears a selection, so accept that and normalize it to ''.
@@ -414,7 +437,10 @@ const MappingValueSchema = z
  * the template rather than declared once because the form state is positional
  * (one entry per input tile/filter).
  */
-export function buildMappingFormSchema(input: DashboardTemplate) {
+export function buildMappingFormSchema(
+  input: DashboardTemplate,
+  sources?: readonly Pick<TSource, 'id' | 'kind'>[],
+) {
   return z
     .object({
       dashboardName: z.string().min(1, 'Enter a dashboard name'),
@@ -468,12 +494,31 @@ export function buildMappingFormSchema(input: DashboardTemplate) {
 
       input.filters?.forEach((filter, idx) => {
         if (isStaticListFilter(filter)) return;
-        if (data.filterSourceMappings?.[idx]) return;
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['filterSourceMappings', idx],
-          message: 'Select a source for this filter',
-        });
+        const mappedSourceId = data.filterSourceMappings?.[idx];
+        if (!mappedSourceId) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['filterSourceMappings', idx],
+            message: 'Select a source for this filter',
+          });
+          return;
+        }
+
+        const mappedSource = sources?.find(s => s.id === mappedSourceId);
+        const allowedKinds = filterSourceKinds(filter);
+        if (
+          allowedKinds &&
+          mappedSource &&
+          !allowedKinds.includes(mappedSource.kind)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['filterSourceMappings', idx],
+            message: isPrometheusLabelFilter(filter)
+              ? 'Select a PromQL source for this filter'
+              : 'Select a non-PromQL source for this filter',
+          });
+        }
       });
     });
 }
@@ -488,7 +533,10 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
   const { data: existingTags } = api.useTags();
   const [dashboardId] = useQueryState('dashboardId', parseAsString);
 
-  const formSchema = useMemo(() => buildMappingFormSchema(input), [input]);
+  const formSchema = useMemo(
+    () => buildMappingFormSchema(input, sources),
+    [input, sources],
+  );
 
   const { handleSubmit, getFieldState, control, setValue, getValues } =
     useForm<MappingFormState>({
@@ -1093,10 +1141,14 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
                       <SelectControlled
                         control={control}
                         name={`filterSourceMappings.${i}`}
-                        data={sources?.map(source => ({
-                          value: source.id,
-                          label: source.name,
-                        }))}
+                        data={sources
+                          ?.filter(source =>
+                            filterSourceKinds(filter)?.includes(source.kind),
+                          )
+                          .map(source => ({
+                            value: source.id,
+                            label: source.name,
+                          }))}
                         placeholder="Select a source"
                       />
                     </Table.Td>

--- a/packages/app/src/DBDashboardImportPage.tsx
+++ b/packages/app/src/DBDashboardImportPage.tsx
@@ -389,10 +389,13 @@ function resolveAppliesToSources(
   };
 }
 
+/** Returns the filter if it names a source, or `undefined` if it doesn't. */
+const sourceBackedTemplateFilter = (filter: DashboardFilter | undefined) =>
+  filter && !isStaticListFilter(filter) ? filter : undefined;
+
 /**
- * The query-expression half of a template filter, or `undefined` for a static
- * one. Only a queried filter references a source or an applies-to list, and
- * those references are the only thing this page remaps.
+ * The query-expression half of a template filter, or `undefined` for any other
+ * type. Only a queried filter broadcasts, so only it carries an applies-to list.
  */
 const queriedTemplateFilter = (filter: DashboardFilter | undefined) =>
   filter && isQueryExpressionFilter(filter) ? filter : undefined;
@@ -639,7 +642,9 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
       );
       if (idx !== -1) {
         prevFilterSourceMappingsRef.current = filterSourceMappings;
-        inputSourceName = queriedTemplateFilter(input.filters?.[idx])?.source;
+        inputSourceName = sourceBackedTemplateFilter(
+          input.filters?.[idx],
+        )?.source;
         selectedSourceId = filterSourceMappings[idx] ?? '';
       }
     }
@@ -673,7 +678,7 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
         ?.map((filter, index) => ({ filter, index }))
         .filter(
           ({ filter }) =>
-            queriedTemplateFilter(filter)?.source === inputSourceName,
+            sourceBackedTemplateFilter(filter)?.source === inputSourceName,
         )
         .map(({ index }) => `filterSourceMappings.${index}` as const) ?? [];
 
@@ -705,7 +710,7 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
     // the resolver's stripped-list index so it lines up with the form-state
     // array (which has unresolved template names dropped).
     input.filters?.forEach((filter, filterIdx) => {
-      if (isStaticListFilter(filter)) return;
+      if (!isQueryExpressionFilter(filter)) return;
       if (!filter.appliesToSourceIds?.includes(inputSourceName)) return;
       const key = `filterAppliesToSourceMappings.${filterIdx}` as const;
       if (getFieldState(key).isDirty) return;
@@ -1099,7 +1104,7 @@ export function Mapping({ input }: { input: DashboardTemplate }) {
                     <Table.Td />
                   </Table.Tr>
                 )}
-                {!isStaticListFilter(filter) &&
+                {isQueryExpressionFilter(filter) &&
                   !!filter.appliesToSourceIds?.length && (
                     <Table.Tr>
                       <Table.Td>{filter.name} (Filter)</Table.Td>

--- a/packages/app/src/__tests__/DBDashboardImportPage.test.tsx
+++ b/packages/app/src/__tests__/DBDashboardImportPage.test.tsx
@@ -2,6 +2,7 @@ import {
   type DashboardTemplate,
   DashboardTemplateSchema,
   DashboardWithoutIdSchema,
+  SourceKind,
 } from '@hyperdx/common-utils/dist/types';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
@@ -12,9 +13,10 @@ import { buildMappingFormSchema, Mapping } from '@/DBDashboardImportPage';
 // template tile with `source: 'Metrics'` resolves to `src-metrics`, etc. The
 // mock objects only need the fields the import path touches (id/name/kind).
 const mockSources = [
-  { id: 'src-metrics', name: 'Metrics', kind: 'metric' },
-  { id: 'src-traces', name: 'Traces', kind: 'trace' },
-  { id: 'src-logs', name: 'Logs', kind: 'log' },
+  { id: 'src-metrics', name: 'Metrics', kind: SourceKind.Metric },
+  { id: 'src-traces', name: 'Traces', kind: SourceKind.Trace },
+  { id: 'src-logs', name: 'Logs', kind: SourceKind.Log },
+  { id: 'src-promql', name: 'Prom', kind: SourceKind.Promql },
 ];
 const mockConnections = [{ id: 'conn-default', name: 'Default' }];
 const mockMutateAsync = jest.fn().mockResolvedValue({ id: 'dash-new' });
@@ -154,6 +156,65 @@ const unresolvedFilterSourceTemplate = DashboardTemplateSchema.parse({
   ],
 });
 
+// A PROMETHEUS_LABEL filter names its PromQL source the same way a queried
+// filter names a ClickHouse one, so the same name-matching auto-map applies.
+const promqlFilterTemplate = DashboardTemplateSchema.parse({
+  version: '0.1.0',
+  name: 'PromQL Label Filter',
+  tiles: [builderTile('tile-number', 'number', 'Metrics', 0)],
+  filters: [
+    {
+      id: 'filter-service',
+      type: 'PROMETHEUS_LABEL',
+      name: 'Service',
+      source: 'Prom',
+      label: 'service',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'svc',
+    },
+  ],
+});
+
+// A PROMETHEUS_LABEL filter naming a source that exists but is a log source.
+// The name match resolves it, the kind check rejects it, and the narrowed
+// dropdown no longer offers it — so the row renders empty and flagged.
+const promqlFilterOnLogSourceTemplate = DashboardTemplateSchema.parse({
+  version: '0.1.0',
+  name: 'PromQL Label Filter On Log Source',
+  tiles: [builderTile('tile-number', 'number', 'Metrics', 0)],
+  filters: [
+    {
+      id: 'filter-service',
+      type: 'PROMETHEUS_LABEL',
+      name: 'Service',
+      source: 'Logs',
+      label: 'service',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'svc',
+    },
+  ],
+});
+
+// The mirror of `promqlFilterTemplate`: a queried filter, whose dropdown query
+// is a SELECT and so cannot run against a PromQL source.
+const queriedFilterTemplate = DashboardTemplateSchema.parse({
+  version: '0.1.0',
+  name: 'Queried Filter',
+  tiles: [builderTile('tile-number', 'number', 'Metrics', 0)],
+  filters: [
+    {
+      id: 'filter-service',
+      type: 'QUERY_EXPRESSION',
+      name: 'Service',
+      expression: 'ServiceName',
+      source: 'Logs',
+      whereLanguage: 'sql',
+    },
+  ],
+});
+
 const markdownTileWithSource = (id: string, source: string, y: number) => ({
   id,
   x: 0,
@@ -280,6 +341,53 @@ describe('Dashboard import - all tile types', () => {
   });
 });
 
+describe('Dashboard import - PromQL label filter source', () => {
+  it('auto-maps the filter source by name and imports it as an id', async () => {
+    renderWithMantine(<Mapping input={promqlFilterTemplate} />);
+
+    const finish = await screen.findByRole('button', {
+      name: /finish import/i,
+    });
+    // The row's select shows the resolved source, not the "Select a source"
+    // placeholder, before anything is submitted.
+    expect(screen.getByDisplayValue('Prom')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(finish);
+    });
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const payload = mockMutateAsync.mock.calls[0][0];
+    expect(payload.filters[0]).toMatchObject({
+      type: 'PROMETHEUS_LABEL',
+      source: 'src-promql',
+      label: 'service',
+    });
+  });
+
+  it('does not offer a non-PromQL source, and blocks the import if one is mapped', async () => {
+    renderWithMantine(<Mapping input={promqlFilterOnLogSourceTemplate} />);
+
+    const finish = await screen.findByRole('button', {
+      name: /finish import/i,
+    });
+    // The name matched a log source, but the row's dropdown is narrowed to
+    // PromQL sources, so nothing renders it as the selection.
+    expect(screen.queryByDisplayValue('Logs')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(finish);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Select a PromQL source for this filter'),
+      ).toBeInTheDocument(),
+    );
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
 describe('Dashboard import - queried filter source is required', () => {
   it('blocks the import and flags the filter row when its source is unmapped', async () => {
     renderWithMantine(<Mapping input={unresolvedFilterSourceTemplate} />);
@@ -385,5 +493,62 @@ describe('Dashboard import - cleared mapping selects', () => {
     expect(
       result.error?.issues.map(issue => [issue.path.join('.'), issue.message]),
     ).toEqual([['tileSourceMappings.0', 'Select a source for this tile']]);
+  });
+});
+
+describe('Dashboard import - filter source kind', () => {
+  /** Omit `sources` to stand in for a workspace whose sources have not loaded. */
+  const issuesFor = (
+    template: DashboardTemplate,
+    sourceId: string,
+    sources?: typeof mockSources,
+  ) =>
+    buildMappingFormSchema(template, sources)
+      .safeParse({
+        dashboardName: template.name,
+        tags: [],
+        tileSourceMappings: ['src-metrics'],
+        connectionMappings: [''],
+        filterSourceMappings: [sourceId],
+      })
+      .error?.issues.map(issue => [issue.path.join('.'), issue.message]);
+
+  it('rejects a non-PromQL source for a PromQL label filter', () => {
+    expect(issuesFor(promqlFilterTemplate, 'src-logs', mockSources)).toEqual([
+      ['filterSourceMappings.0', 'Select a PromQL source for this filter'],
+    ]);
+  });
+
+  it('rejects a PromQL source for a queried filter', () => {
+    // The TimeSeries engine does not support SELECT, so the dropdown query
+    // this filter runs could never succeed against it.
+    expect(issuesFor(queriedFilterTemplate, 'src-promql', mockSources)).toEqual(
+      [
+        [
+          'filterSourceMappings.0',
+          'Select a non-PromQL source for this filter',
+        ],
+      ],
+    );
+  });
+
+  it('accepts each type on the kind it can read', () => {
+    expect(
+      issuesFor(promqlFilterTemplate, 'src-promql', mockSources),
+    ).toBeUndefined();
+    expect(
+      issuesFor(queriedFilterTemplate, 'src-logs', mockSources),
+    ).toBeUndefined();
+  });
+
+  it('still reports an unpicked source as unpicked, not as the wrong kind', () => {
+    expect(issuesFor(promqlFilterTemplate, '', mockSources)).toEqual([
+      ['filterSourceMappings.0', 'Select a source for this filter'],
+    ]);
+  });
+
+  it('does not flag a kind it cannot resolve, so a loading workspace is not an error', () => {
+    // `sources` unavailable: the id is real, we just cannot say what it is yet.
+    expect(issuesFor(promqlFilterTemplate, 'src-logs')).toBeUndefined();
   });
 });

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
@@ -12,6 +12,7 @@ import { IconAlertTriangle } from '@tabler/icons-react';
 
 import SelectControlled from '@/components/SelectControlled';
 import { SqlVariablesProvider } from '@/components/SQLEditor/variableCompletions';
+import { IS_PROMQL_ENABLED } from '@/config';
 import { useConfirm } from '@/useConfirm';
 import { useZIndex } from '@/zIndex';
 
@@ -22,6 +23,7 @@ import {
   toFormValues,
   toSavedFilter,
 } from './filterFormState';
+import { PromqlLabelFilterEditForm } from './PromqlLabelFilterEditForm';
 import { QueryExpressionFilterEditForm } from './QueryExpressionFilterEditForm';
 import { StaticListFilterEditForm } from './StaticListFilterEditForm';
 
@@ -31,6 +33,14 @@ const FILTER_TYPE_OPTIONS = [
     label: 'Queried values',
   },
   { value: DashboardFilterType.enum.STATIC_LIST, label: 'Static values' },
+  ...(IS_PROMQL_ENABLED
+    ? [
+        {
+          value: DashboardFilterType.enum.PROMETHEUS_LABEL,
+          label: 'PromQL label values',
+        },
+      ]
+    : []),
 ];
 
 interface DashboardFilterEditFormProps {
@@ -50,7 +60,7 @@ interface DashboardFilterEditFormProps {
 }
 
 /**
- * The editor for a single filter, of either type. One form covers both, so
+ * The editor for a single filter, of any type. One form covers them all, so
  * switching type keeps the fields they share. Which of the fields are actually
  * stored is settled by `toSavedFilter`, not by which editor happens to be
  * mounted.
@@ -141,8 +151,7 @@ export const DashboardFilterEditForm = ({
   );
 
   const isNew = !filter;
-  const isStaticListTypeAvailable = !!showVariableOptions;
-  const showTypeInput = isStaticListTypeAvailable;
+  const showTypeInput = !!showVariableOptions;
 
   return (
     <Modal
@@ -191,6 +200,11 @@ export const DashboardFilterEditForm = ({
 
           {formFilterType === 'STATIC_LIST' ? (
             <StaticListFilterEditForm
+              control={control}
+              otherFilters={otherFilters}
+            />
+          ) : formFilterType === 'PROMETHEUS_LABEL' ? (
+            <PromqlLabelFilterEditForm
               control={control}
               otherFilters={otherFilters}
             />

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFiltersList.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFiltersList.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mantine/core';
 import {
   IconBuildingBroadcastTower,
+  IconLabel,
   IconList,
   IconPencil,
   IconRefresh,
@@ -54,6 +55,14 @@ function getValuesAttribute(
         icon: <IconSearch size={14} />,
         tooltip: 'Source the dropdown values are queried from',
         label: sources?.find(s => s.id === filter.source)?.name ?? '',
+      };
+    case 'PROMETHEUS_LABEL':
+      return {
+        icon: <IconLabel size={14} />,
+        tooltip: 'PromQL source and label the dropdown values come from',
+        label: [sources?.find(s => s.id === filter.source)?.name, filter.label]
+          .filter(Boolean)
+          .join(' · '),
       };
     case 'STATIC_LIST': {
       const count = filter.options.length;

--- a/packages/app/src/components/DashboardFiltersModal/PromqlLabelFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/PromqlLabelFilterEditForm.tsx
@@ -1,0 +1,76 @@
+import { useFormState } from 'react-hook-form';
+import {
+  DashboardFilter,
+  isPromqlSource,
+  SourceKind,
+} from '@hyperdx/common-utils/dist/types';
+import { TextInput } from '@mantine/core';
+
+import { SourceSelectControlled } from '@/components/SourceSelect';
+import { useSources } from '@/source';
+
+import { CustomInputWrapper } from './CustomInputWrapper';
+import { FilterFormControl } from './filterFormState';
+import { VariableNameInput } from './VariableNameInput';
+
+interface PromqlLabelFilterEditFormProps {
+  control: FilterFormControl;
+  /** Filters other than the one being edited, used to keep variable names unique. */
+  otherFilters: DashboardFilter[];
+}
+
+/** Form describing a Prometheus label dashboard filter */
+export const PromqlLabelFilterEditForm = ({
+  control,
+  otherFilters,
+}: PromqlLabelFilterEditFormProps) => {
+  const { errors } = useFormState({ control });
+  const { data: sources } = useSources();
+
+  const validatePromqlSource = (value: string) => {
+    const source = sources?.find(s => s.id === value);
+    if (source && !isPromqlSource(source)) {
+      return 'Select a PromQL source';
+    }
+    return true;
+  };
+
+  return (
+    <>
+      <CustomInputWrapper
+        label="Data source"
+        tooltipText="The PromQL source that the label values are read from"
+      >
+        <SourceSelectControlled
+          control={control}
+          name="source"
+          data-testid="source-selector"
+          rules={{
+            required: 'Select a PromQL source',
+            validate: validatePromqlSource,
+          }}
+          comboboxProps={{ withinPortal: true }}
+          allowedSourceKinds={[SourceKind.Promql]}
+        />
+      </CustomInputWrapper>
+
+      <CustomInputWrapper
+        label="Label"
+        tooltipText="The Prometheus label whose values fill the dropdown. Use __name__ to list metric names."
+        error={errors.label}
+      >
+        <TextInput
+          placeholder="e.g. instance, job, or __name__"
+          data-testid="filter-label-input"
+          {...control.register('label', {
+            required: true,
+            validate: value =>
+              value.trim().length > 0 || 'This field is required',
+          })}
+        />
+      </CustomInputWrapper>
+
+      <VariableNameInput control={control} otherFilters={otherFilters} />
+    </>
+  );
+};

--- a/packages/app/src/components/DashboardFiltersModal/QueryExpressionFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/QueryExpressionFilterEditForm.tsx
@@ -6,7 +6,10 @@ import {
   useWatch,
 } from 'react-hook-form';
 import { TableConnection } from '@hyperdx/common-utils/dist/core/metadata';
-import { hasFilterEffect } from '@hyperdx/common-utils/dist/filters';
+import {
+  hasFilterEffect,
+  QUERY_EXPRESSION_FILTER_SOURCE_KINDS,
+} from '@hyperdx/common-utils/dist/filters';
 import {
   DashboardFilter,
   MetricsDataType,
@@ -138,12 +141,7 @@ export const QueryExpressionFilterEditForm = ({
           onSchemaPreview={() => setIsSourceSchemaPreviewOpen(true)}
           isSchemaPreviewEnabled={isSourceSchemaPreviewEnabled(source)}
           disabled={!!presetSource}
-          allowedSourceKinds={[
-            SourceKind.Log,
-            SourceKind.Trace,
-            SourceKind.Session,
-            SourceKind.Metric,
-          ]}
+          allowedSourceKinds={QUERY_EXPRESSION_FILTER_SOURCE_KINDS}
         />
         <SourceSchemaPreview
           source={source}
@@ -244,12 +242,7 @@ export const QueryExpressionFilterEditForm = ({
               data-testid="applies-to-source-selector"
               comboboxProps={{ withinPortal: true }}
               placeholder="All sources"
-              allowedSourceKinds={[
-                SourceKind.Log,
-                SourceKind.Trace,
-                SourceKind.Session,
-                SourceKind.Metric,
-              ]}
+              allowedSourceKinds={QUERY_EXPRESSION_FILTER_SOURCE_KINDS}
             />
           </CustomInputWrapper>
         </Box>

--- a/packages/app/src/components/DashboardFiltersModal/__tests__/DashboardFiltersModal.test.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/__tests__/DashboardFiltersModal.test.tsx
@@ -304,6 +304,16 @@ describe('DashboardFiltersModal', () => {
     expect(onSaveFilter.mock.calls[0][0]).not.toHaveProperty('options');
   });
 
+  it('omits the PromQL type where PromQL is disabled', async () => {
+    const { user } = renderModal();
+
+    await user.click(screen.getByTestId('add-filter-button'));
+    await user.click(screen.getByTestId('filter-type-picker'));
+
+    expect(await screen.findByText('Static values')).toBeInTheDocument();
+    expect(screen.queryByText('PromQL label values')).toBeNull();
+  });
+
   it('hides the type picker where variables are unavailable', async () => {
     const { user } = renderModal({ showVariableOptions: false });
 

--- a/packages/app/src/components/DashboardFiltersModal/__tests__/filterFormState.test.ts
+++ b/packages/app/src/components/DashboardFiltersModal/__tests__/filterFormState.test.ts
@@ -51,6 +51,31 @@ describe('toFormValues', () => {
       isVariableEnabled: true,
     });
   });
+
+  it('seeds the shared source field from a stored PromQL label filter', () => {
+    const values = toFormValues({
+      id: 'a',
+      type: 'PROMETHEUS_LABEL',
+      name: 'Job',
+      source: 'prom',
+      label: 'job',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'job',
+    });
+
+    expect(values).toMatchObject({
+      id: 'a',
+      type: 'PROMETHEUS_LABEL',
+      source: 'prom',
+      label: 'job',
+      variableName: 'job',
+      expression: '',
+      options: [],
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+    });
+  });
 });
 
 describe('toSavedFilter', () => {
@@ -100,6 +125,45 @@ describe('toSavedFilter', () => {
       isBroadcastEnabled: true,
       isVariableEnabled: false,
     });
+  });
+
+  it('keeps only the PromQL fields on a PromQL label filter', () => {
+    const saved = toSavedFilter(
+      formValues({
+        type: 'PROMETHEUS_LABEL',
+        name: 'Job',
+        source: 'prom',
+        label: '  job  ',
+        // Left behind by the other editors before the type was switched.
+        expression: 'Env',
+        where: 'x = 1',
+        options: ['prod'],
+      }),
+    );
+
+    expect(saved).toEqual({
+      id: 'a',
+      type: 'PROMETHEUS_LABEL',
+      name: 'Job',
+      source: 'prom',
+      label: 'job',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'Job',
+    });
+  });
+
+  it('rejects a PromQL label filter without a source', () => {
+    expect(() =>
+      toSavedFilter(
+        formValues({
+          type: 'PROMETHEUS_LABEL',
+          name: 'Job',
+          source: '',
+          label: 'job',
+        }),
+      ),
+    ).toThrow();
   });
 
   it('rejects values the schema cannot accept', () => {

--- a/packages/app/src/components/DashboardFiltersModal/filterFormState.ts
+++ b/packages/app/src/components/DashboardFiltersModal/filterFormState.ts
@@ -7,6 +7,7 @@ import {
 import {
   DashboardFilter,
   DashboardFilterSchema,
+  PromqlLabelDashboardFilter,
   QueryExpressionDashboardFilter,
   StaticListDashboardFilter,
 } from '@hyperdx/common-utils/dist/types';
@@ -24,6 +25,10 @@ export type FilterFormValues = {
   Omit<
     StaticListDashboardFilter,
     'type' | 'isBroadcastEnabled' | 'isVariableEnabled'
+  > &
+  Omit<
+    PromqlLabelDashboardFilter,
+    'type' | 'isBroadcastEnabled' | 'isVariableEnabled'
   >;
 
 export type FilterFormControl = Control<FilterFormValues>;
@@ -34,6 +39,7 @@ export const toFormValues = (
 ): FilterFormValues => {
   const queried = filter?.type === 'QUERY_EXPRESSION' ? filter : undefined;
   const staticList = filter?.type === 'STATIC_LIST' ? filter : undefined;
+  const promqlLabel = filter?.type === 'PROMETHEUS_LABEL' ? filter : undefined;
 
   return {
     id: filter?.id ?? crypto.randomUUID(),
@@ -45,7 +51,7 @@ export const toFormValues = (
 
     // QUERY_EXPRESSION fields
     expression: queried?.expression ?? '',
-    source: queried?.source ?? presetSourceId ?? '',
+    source: queried?.source ?? promqlLabel?.source ?? presetSourceId ?? '',
     sourceMetricType: queried?.sourceMetricType,
     where: queried?.where ?? '',
     whereLanguage: queried?.whereLanguage ?? getStoredLanguage() ?? 'sql',
@@ -53,6 +59,9 @@ export const toFormValues = (
 
     // STATIC_LIST fields
     options: staticList?.options ?? [],
+
+    // PROMETHEUS_LABEL fields
+    label: promqlLabel?.label ?? '',
   };
 };
 
@@ -62,6 +71,16 @@ export const toSavedFilter = (values: FilterFormValues): DashboardFilter => {
     return DashboardFilterSchema.parse({
       ...values,
       options: values.options.map(option => option.trim()),
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: getFilterVariableName(values),
+    });
+  }
+
+  if (values.type === 'PROMETHEUS_LABEL') {
+    return DashboardFilterSchema.parse({
+      ...values,
+      label: values.label.trim(),
       isBroadcastEnabled: false,
       isVariableEnabled: true,
       variableName: getFilterVariableName(values),

--- a/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
+++ b/packages/app/src/hooks/__tests__/useDashboardFilterValues.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   DashboardFilter,
+  PromqlLabelDashboardFilter,
   SourceKind,
   StaticListDashboardFilter,
   TSource,
@@ -11,7 +12,18 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useDashboardFilterValues } from '@/hooks/useDashboardFilterValues';
 
 const mockGetKeyValues = jest.fn();
+const mockLabelValues = jest.fn();
 let mockSourcesData: Partial<TSource>[];
+
+// Only the PromQL client is stubbed; the rest of the module stays real,
+// since the ClickHouse client below reads `api.useMe` from it.
+jest.mock('@/api', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/api'),
+  prometheusApi: {
+    labelValues: (...args: unknown[]) => mockLabelValues(...args),
+  },
+}));
 
 // Untyped factories, so partial mocks need no unsafe type assertions.
 jest.mock('@/source', () => ({
@@ -46,6 +58,17 @@ describe('useDashboardFilterValues', () => {
     variableName: 'tier',
   };
 
+  const promqlFilter: PromqlLabelDashboardFilter = {
+    id: 'promql1',
+    type: 'PROMETHEUS_LABEL',
+    name: 'Job',
+    source: 'promql-source',
+    label: 'job',
+    isBroadcastEnabled: false,
+    isVariableEnabled: true,
+    variableName: 'job',
+  };
+
   const queriedFilter: DashboardFilter = {
     id: 'queried1',
     type: 'QUERY_EXPRESSION',
@@ -72,7 +95,16 @@ describe('useDashboardFilterValues', () => {
           tableName: 'logs',
         },
       },
+      {
+        id: 'promql-source',
+        kind: SourceKind.Promql,
+        name: 'Prometheus',
+        connection: 'clickhouse-conn',
+        from: { databaseName: 'telemetry', tableName: 'metrics' },
+      },
     ];
+    mockLabelValues.mockReset();
+    mockLabelValues.mockResolvedValue({ status: 'success', data: ['api'] });
     mockGetKeyValues.mockReset();
     mockGetKeyValues.mockImplementation(({ keys }: { keys: string[] }) =>
       Promise.resolve(
@@ -128,6 +160,45 @@ describe('useDashboardFilterValues', () => {
         ['queried1', { values: ['production', 'staging'], isLoading: false }],
         ['static1', { values: ['low', 'medium', 'high'], isLoading: false }],
       ]),
+    );
+  });
+
+  it('merges PromQL label values into the same map', async () => {
+    const { result } = renderHook(
+      () =>
+        useDashboardFilterValues({
+          filters: [staticFilter, queriedFilter, promqlFilter],
+          dateRange: mockDateRange,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.data.get('promql1')).toEqual({
+      values: ['api'],
+      isLoading: false,
+    });
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('surfaces a PromQL label error without implicating the other filters', async () => {
+    mockLabelValues.mockRejectedValue(new Error('connection refused'));
+
+    const { result } = renderHook(
+      () =>
+        useDashboardFilterValues({
+          filters: [staticFilter, queriedFilter, promqlFilter],
+          dateRange: mockDateRange,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.erroredFilterIds).toEqual(new Set(['promql1']));
+    expect(result.current.filterErrorMessages.get('promql1')).toBe(
+      'connection refused',
     );
   });
 

--- a/packages/app/src/hooks/__tests__/usePromqlLabelFilterValues.test.tsx
+++ b/packages/app/src/hooks/__tests__/usePromqlLabelFilterValues.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import {
+  PromqlLabelDashboardFilter,
+  SourceKind,
+  TSource,
+} from '@hyperdx/common-utils/dist/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { usePromqlLabelFilterValues } from '@/hooks/usePromqlLabelFilterValues';
+
+const mockLabelValues = jest.fn();
+let mockSourcesData: Partial<TSource>[];
+
+jest.mock('@/api', () => ({
+  prometheusApi: {
+    labelValues: (...args: unknown[]) => mockLabelValues(...args),
+  },
+}));
+jest.mock('@/source', () => ({
+  useSources: () => ({ data: mockSourcesData, isLoading: false }),
+}));
+
+const filter = (
+  overrides: Partial<PromqlLabelDashboardFilter> = {},
+): PromqlLabelDashboardFilter => ({
+  id: 'promql1',
+  type: 'PROMETHEUS_LABEL',
+  name: 'Job',
+  source: 'promql-source',
+  label: 'job',
+  isBroadcastEnabled: false,
+  isVariableEnabled: true,
+  ...overrides,
+});
+
+// 2024-01-01T00:00:00Z .. 2024-01-02T00:00:00Z
+const DATE_RANGE: [Date, Date] = [
+  new Date('2024-01-01T00:00:00Z'),
+  new Date('2024-01-02T00:00:00Z'),
+];
+
+describe('usePromqlLabelFilterValues', () => {
+  let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+  const renderFilters = (filters: PromqlLabelDashboardFilter[]) =>
+    renderHook(
+      () => usePromqlLabelFilterValues({ filters, dateRange: DATE_RANGE }),
+      { wrapper },
+    );
+
+  beforeEach(() => {
+    mockSourcesData = [
+      {
+        id: 'promql-source',
+        kind: SourceKind.Promql,
+        name: 'Prometheus',
+        connection: 'clickhouse-conn',
+        from: { databaseName: 'telemetry', tableName: 'metrics' },
+      },
+      {
+        id: 'logs-source',
+        kind: SourceKind.Log,
+        name: 'Logs',
+        connection: 'clickhouse-conn',
+        from: { databaseName: 'telemetry', tableName: 'logs' },
+      },
+    ];
+    mockLabelValues.mockReset();
+    mockLabelValues.mockResolvedValue({
+      status: 'success',
+      data: ['api', 'web'],
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  it('queries the filter source with the date range in whole seconds', async () => {
+    const { result } = renderFilters([filter()]);
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledTimes(1);
+    expect(mockLabelValues).toHaveBeenCalledWith({
+      label: 'job',
+      connectionId: 'clickhouse-conn',
+      database: 'telemetry',
+      table: 'metrics',
+      start: 1704067200,
+      end: 1704153600,
+    });
+    expect(result.current.data.get('promql1')).toEqual({
+      values: ['api', 'web'],
+      isLoading: false,
+    });
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('resolves two filters over the same source and label in one call', async () => {
+    const { result } = renderFilters([
+      filter(),
+      filter({ id: 'promql2', name: 'Job copy' }),
+    ]);
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledTimes(1);
+    expect(result.current.data.get('promql2')).toEqual({
+      values: ['api', 'web'],
+      isLoading: false,
+    });
+  });
+
+  it('queries separately for a different label on the same source', async () => {
+    const { result } = renderFilters([
+      filter(),
+      filter({ id: 'promql2', label: 'instance' }),
+    ]);
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledTimes(2);
+    expect(mockLabelValues).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'instance' }),
+    );
+  });
+
+  it('marks a filter errored, but interactive, when the lookup fails', async () => {
+    mockLabelValues.mockRejectedValue(new Error('connection refused'));
+
+    const { result } = renderFilters([filter()]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.erroredFilterIds).toEqual(new Set(['promql1']));
+    expect(result.current.filterErrorMessages.get('promql1')).toBe(
+      'connection refused',
+    );
+    expect(result.current.data.get('promql1')).toEqual({
+      values: [],
+      isLoading: false,
+    });
+  });
+
+  it('surfaces an error response body as the filter error', async () => {
+    mockLabelValues.mockResolvedValue({
+      status: 'error',
+      error: 'bad_data: invalid label',
+    });
+
+    const { result } = renderFilters([filter()]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.filterErrorMessages.get('promql1')).toBe(
+      'bad_data: invalid label',
+    );
+  });
+
+  it('errors a filter whose source is missing or is not a PromQL source', async () => {
+    const { result } = renderFilters([
+      filter({ id: 'missing', source: 'gone' }),
+      filter({ id: 'wrong-kind', source: 'logs-source' }),
+    ]);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mockLabelValues).not.toHaveBeenCalled();
+    expect(result.current.erroredFilterIds).toEqual(
+      new Set(['missing', 'wrong-kind']),
+    );
+    expect(result.current.data.get('missing')).toEqual({
+      values: [],
+      isLoading: false,
+    });
+  });
+
+  it('reuses the last values as placeholders when the date range moves', async () => {
+    const { result, rerender } = renderHook(
+      ({ dateRange }: { dateRange: [Date, Date] }) =>
+        usePromqlLabelFilterValues({ filters: [filter()], dateRange }),
+      { wrapper, initialProps: { dateRange: DATE_RANGE } },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    mockLabelValues.mockResolvedValue({ status: 'success', data: ['api'] });
+    rerender({
+      dateRange: [
+        new Date('2024-01-01T06:00:00Z'),
+        new Date('2024-01-02T06:00:00Z'),
+      ],
+    });
+
+    expect(result.current.data.get('promql1')?.values).toEqual(['api', 'web']);
+
+    await waitFor(() =>
+      expect(result.current.data.get('promql1')?.values).toEqual(['api']),
+    );
+  });
+});

--- a/packages/app/src/hooks/useDashboardFilterValues.tsx
+++ b/packages/app/src/hooks/useDashboardFilterValues.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { FilterSelection } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
+  isPrometheusLabelFilter,
   isQueryExpressionFilter,
   isStaticListFilter,
 } from '@hyperdx/common-utils/dist/filters';
@@ -9,6 +10,7 @@ import {
   DashboardFilter,
 } from '@hyperdx/common-utils/dist/types';
 
+import { usePromqlLabelFilterValues } from './usePromqlLabelFilterValues';
 import { useQueriedDashboardFilterValues } from './useQueriedDashboardFilterValues';
 import { useStaticDashboardFilterValues } from './useStaticDashboardFilterValues';
 
@@ -38,10 +40,11 @@ export function useDashboardFilterValues({
   /** The dashboard's variables and their current selections, if any */
   variables?: ChartVariable[];
 }): DashboardFilterValuesResult {
-  const [queriedFilters, staticFilters] = useMemo(
+  const [queriedFilters, staticFilters, promqlLabelFilters] = useMemo(
     () => [
       filters.filter(isQueryExpressionFilter),
       filters.filter(isStaticListFilter),
+      filters.filter(isPrometheusLabelFilter),
     ],
     [filters],
   );
@@ -57,22 +60,55 @@ export function useDashboardFilterValues({
     filters: staticFilters,
   });
 
+  const promqlLabelValues = usePromqlLabelFilterValues({
+    filters: promqlLabelFilters,
+    dateRange,
+  });
+
   const data = useMemo(
-    () => new Map([...queriedValues.data, ...staticValues.data]),
-    [queriedValues.data, staticValues.data],
+    () =>
+      new Map([
+        ...queriedValues.data,
+        ...staticValues.data,
+        ...promqlLabelValues.data,
+      ]),
+    [queriedValues.data, staticValues.data, promqlLabelValues.data],
   );
 
   // The queried hook reports isLoading/isFetching true while sources load even
   // when it was handed no filters at all; only let it speak for itself when it
   // actually has filters to resolve.
   const hasQueriedFilters = queriedFilters.length > 0;
+  const hasPromqlLabelFilters = promqlLabelFilters.length > 0;
+
+  const erroredFilterIds = useMemo(
+    () =>
+      new Set([
+        ...queriedValues.erroredFilterIds,
+        ...promqlLabelValues.erroredFilterIds,
+      ]),
+    [queriedValues.erroredFilterIds, promqlLabelValues.erroredFilterIds],
+  );
+
+  const filterErrorMessages = useMemo(
+    () =>
+      new Map([
+        ...queriedValues.filterErrorMessages,
+        ...promqlLabelValues.filterErrorMessages,
+      ]),
+    [queriedValues.filterErrorMessages, promqlLabelValues.filterErrorMessages],
+  );
 
   return {
     data,
-    erroredFilterIds: queriedValues.erroredFilterIds,
-    filterErrorMessages: queriedValues.filterErrorMessages,
-    isLoading: hasQueriedFilters && queriedValues.isLoading,
-    isFetching: hasQueriedFilters && queriedValues.isFetching,
-    isError: queriedValues.isError,
+    erroredFilterIds,
+    filterErrorMessages,
+    isLoading:
+      (hasQueriedFilters && queriedValues.isLoading) ||
+      (hasPromqlLabelFilters && promqlLabelValues.isLoading),
+    isFetching:
+      (hasQueriedFilters && queriedValues.isFetching) ||
+      (hasPromqlLabelFilters && promqlLabelValues.isFetching),
+    isError: queriedValues.isError || promqlLabelValues.isError,
   };
 }

--- a/packages/app/src/hooks/useDashboardFilters.tsx
+++ b/packages/app/src/hooks/useDashboardFilters.tsx
@@ -16,7 +16,6 @@ import {
   getFilterExpression,
   isFilterBroadcastEnabled,
   isQueryExpressionFilter,
-  isStaticListFilter,
 } from '@hyperdx/common-utils/dist/filters';
 import {
   ChartVariable,
@@ -215,13 +214,14 @@ const useDashboardFilters = (filters: DashboardFilter[]) => {
       const queries: Filter[] = [];
       for (const filter of filters) {
         if (!predicate(filter)) continue;
-        if (isStaticListFilter(filter)) continue;
+        const expression = getFilterExpression(filter);
+        if (expression == null) continue;
         const selection = selectionByFilterId.get(filter.id);
         if (!selection) continue;
         // Wrap keys in `toString()` to support JSON/Dynamic-type columns.
         // All keys can be stringified, since filter select values are stringified as well.
         const emitted = filtersToQuery(
-          { [filter.expression]: selection },
+          { [expression]: selection },
           { stringifyKeys: true },
         );
         for (const query of emitted) {

--- a/packages/app/src/hooks/usePresetDashboardFilters.tsx
+++ b/packages/app/src/hooks/usePresetDashboardFilters.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { isStaticListFilter } from '@hyperdx/common-utils/dist/filters';
+import { isQueryExpressionFilter } from '@hyperdx/common-utils/dist/filters';
 import {
   DashboardFilter,
   PresetDashboard,
@@ -52,8 +52,9 @@ export default function usePresetDashboardFilters({
 
   const handleSaveFilter = useCallback(
     (dashboardFilter: DashboardFilter) => {
-      // Preset dashboards are broadcast-only, so static list filters are not supported.
-      if (isStaticListFilter(dashboardFilter)) return;
+      // Preset dashboards are broadcast-only, so variable-only filter types
+      // (static lists, PromQL labels) are not supported.
+      if (!isQueryExpressionFilter(dashboardFilter)) return;
 
       const presetDashboardFilter = {
         ...dashboardFilter,

--- a/packages/app/src/hooks/usePromqlLabelFilterValues.tsx
+++ b/packages/app/src/hooks/usePromqlLabelFilterValues.tsx
@@ -1,0 +1,148 @@
+import { useMemo } from 'react';
+import {
+  isPromqlSource,
+  PromqlLabelDashboardFilter,
+} from '@hyperdx/common-utils/dist/types';
+import {
+  useQueries,
+  useQueryClient,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import { prometheusApi } from '@/api';
+import { useSources } from '@/source';
+import { mapKeyBy } from '@/utils';
+
+type LabelValuesCall = {
+  filterId: string;
+  connectionId: string;
+  database?: string;
+  table?: string;
+  label: string;
+};
+
+const SOURCE_ERROR =
+  'This filter points at a source that no longer exists, or is not a PromQL source.';
+
+export function usePromqlLabelFilterValues({
+  filters,
+  dateRange,
+}: {
+  filters: PromqlLabelDashboardFilter[];
+  dateRange: [Date, Date];
+}) {
+  const { data: sources, isLoading: isLoadingSources } = useSources();
+  const sourcesById = useMemo(() => mapKeyBy(sources ?? [], 'id'), [sources]);
+
+  // Round the date range, since the API accepts whole seconds
+  const startSec = Math.floor(dateRange[0].getTime() / 1000);
+  const endSec = Math.ceil(dateRange[1].getTime() / 1000);
+
+  const { calls, unresolvedFilterIds } = useMemo(() => {
+    const resolved: LabelValuesCall[] = [];
+    const unresolved: string[] = [];
+
+    for (const filter of filters) {
+      const source = sourcesById.get(filter.source);
+      if (!source || !isPromqlSource(source)) {
+        // While sources are still loading every filter looks unresolved; hold
+        // off on calling that an error until the list has actually arrived.
+        if (!isLoadingSources) unresolved.push(filter.id);
+        continue;
+      }
+      resolved.push({
+        filterId: filter.id,
+        connectionId: source.connection,
+        database: source.from.databaseName,
+        table: source.from.tableName,
+        label: filter.label,
+      });
+    }
+
+    return { calls: resolved, unresolvedFilterIds: unresolved };
+  }, [filters, sourcesById, isLoadingSources]);
+
+  const queryClient = useQueryClient();
+
+  const results: UseQueryResult<string[]>[] = useQueries({
+    queries: calls.map(call => {
+      // Everything but the time bounds, so a range change can reuse the last
+      // values as placeholders instead of blanking the dropdown.
+      const queryKeyPrefix = [
+        'dashboard-filter-promql-label-values',
+        call.connectionId,
+        call.database,
+        call.table,
+        call.label,
+      ];
+      return {
+        queryKey: [...queryKeyPrefix, startSec, endSec],
+        placeholderData: () => {
+          const cached = queryClient
+            .getQueriesData<string[]>({ queryKey: queryKeyPrefix })
+            .map(([key, data]) => ({ key, data }))
+            .filter(({ data }) => !!data)
+            .toSorted((a, b) => {
+              const aTime =
+                queryClient.getQueryState(a.key)?.dataUpdatedAt ?? 0;
+              const bTime =
+                queryClient.getQueryState(b.key)?.dataUpdatedAt ?? 0;
+              return bTime - aTime;
+            });
+          return cached[0]?.data;
+        },
+        staleTime: 1000 * 60 * 5,
+        queryFn: async (): Promise<string[]> => {
+          const resp = await prometheusApi.labelValues({
+            label: call.label,
+            connectionId: call.connectionId,
+            database: call.database,
+            table: call.table,
+            start: startSec,
+            end: endSec,
+          });
+          if (resp.status === 'error') {
+            throw new Error(resp.error ?? 'Label values query failed');
+          }
+          return resp.data ?? [];
+        },
+      };
+    }),
+  });
+
+  return useMemo(() => {
+    const data = new Map<string, { values: string[]; isLoading: boolean }>();
+    const erroredFilterIds = new Set<string>();
+    const filterErrorMessages = new Map<string, string>();
+
+    results.forEach((result, index) => {
+      const call = calls[index];
+      if (!call) return;
+      data.set(call.filterId, {
+        values: result.data ?? [],
+        isLoading: result.isLoading,
+      });
+      if (result.isError) {
+        erroredFilterIds.add(call.filterId);
+        if (result.error instanceof Error) {
+          filterErrorMessages.set(call.filterId, result.error.message);
+        }
+      }
+    });
+
+    for (const filterId of unresolvedFilterIds) {
+      data.set(filterId, { values: [], isLoading: false });
+      erroredFilterIds.add(filterId);
+      filterErrorMessages.set(filterId, SOURCE_ERROR);
+    }
+
+    return {
+      data,
+      erroredFilterIds,
+      filterErrorMessages,
+      isLoading: isLoadingSources || results.some(r => r.isLoading),
+      isFetching: isLoadingSources || results.some(r => r.isFetching),
+      isError: erroredFilterIds.size > 0,
+    };
+  }, [results, calls, unresolvedFilterIds, isLoadingSources]);
+}

--- a/packages/app/tests/e2e/features/dashboard-promql-label-filters.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-promql-label-filters.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * A `PROMETHEUS_LABEL` dashboard filter fills its dropdown with the values of
+ * one Prometheus label, read from a PromQL source and scoped to the dashboard's
+ * time range. Like `STATIC_LIST` it carries no SQL expression, so it is a
+ * dashboard variable and nothing else.
+ *
+ * Values come from `E2E_PROMQL_TABLE`, seeded with one `service`-labelled series
+ * per entry in `SERVICES` (see seed-clickhouse.ts).
+ */
+import { DisplayType } from '@hyperdx/common-utils/dist/types';
+import type { Page } from '@playwright/test';
+
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { SERVICES } from '../seed-clickhouse';
+import { expect, test } from '../utils/base-test';
+import {
+  DEFAULT_LOGS_SOURCE_NAME,
+  E2E_PROMQL_METRIC_NAME,
+  PROMQL_SOURCE_NAME,
+} from '../utils/constants';
+
+/** The dropdown sorts, so the seeded services arrive in this order. */
+const SORTED_SERVICES = [...SERVICES].sort((a, b) => a.localeCompare(b));
+
+type FilterEntry =
+  | { type: 'sql'; condition: string }
+  | { type: 'variable'; name: string; values: string[] };
+
+/** The `filters=` param, decoded. `null` when the param is absent. */
+const filtersParam = (page: Page): FilterEntry[] | null => {
+  const raw = new URL(page.url()).searchParams.get('filters');
+  if (raw === null) return null;
+  return JSON.parse(decodeURIComponent(raw));
+};
+
+/** Wait for the param to settle on `expected` — nuqs writes it asynchronously. */
+const expectFiltersParam = async (page: Page, expected: FilterEntry[]) => {
+  await expect(async () => {
+    expect(filtersParam(page)).toEqual(expected);
+  }).toPass({ timeout: 10000 });
+};
+
+test.describe(
+  'PromQL label dashboard filters',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    let dashboardPage: DashboardPage;
+
+    test.beforeEach(async ({ page }) => {
+      dashboardPage = new DashboardPage(page);
+      await dashboardPage.goto();
+    });
+
+    test('authors a filter with a source and label, and no expression or broadcast controls', async () => {
+      test.setTimeout(90000);
+
+      await test.step('Open the add-filter form and pick the PromQL type', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.openAddFilterForm();
+        await expect(dashboardPage.getFilterTypePicker()).toBeVisible();
+        // Filled before the switch: the display name belongs to every type, so
+        // changing type must not discard it.
+        await dashboardPage.getFilterNameInput().fill('Service');
+        await dashboardPage.selectFilterType('PromQL label values');
+        await expect(dashboardPage.getFilterNameInput()).toHaveValue('Service');
+      });
+
+      await test.step('Only the fields a PromQL label filter has are rendered', async () => {
+        const form = dashboardPage.getFilterForm();
+        await expect(dashboardPage.getFilterLabelInput()).toBeVisible();
+        await expect(form.getByTestId('source-selector')).toBeVisible();
+        // Always a variable, so the name is asked for rather than unlocked by
+        // a checkbox.
+        await expect(dashboardPage.variableNameInput).toBeVisible();
+
+        await expect(dashboardPage.getFilterOptionsInput()).toHaveCount(0);
+        await expect(
+          form.getByTestId('applies-to-source-selector'),
+        ).toHaveCount(0);
+        await expect(form.getByTestId('filter-broadcast-checkbox')).toHaveCount(
+          0,
+        );
+        await expect(
+          form.getByTestId('filter-variable-enabled-checkbox'),
+        ).toHaveCount(0);
+        // Covers both the filter expression and the dropdown values filter:
+        // each is a CodeMirror editor, and this form has neither.
+        await expect(form.locator('div.cm-editor')).toHaveCount(0);
+      });
+
+      await test.step('Only PromQL sources are offered', async () => {
+        await dashboardPage.filtersSourceSelector.click();
+        await expect(
+          dashboardPage.getFilterOption(PROMQL_SOURCE_NAME),
+        ).toBeVisible();
+        await expect(
+          dashboardPage.getFilterOption(DEFAULT_LOGS_SOURCE_NAME),
+        ).toHaveCount(0);
+        await dashboardPage.getFilterOption(PROMQL_SOURCE_NAME).click();
+      });
+
+      await test.step('The saved filter is summarized by its source and label', async () => {
+        await dashboardPage.getFilterLabelInput().fill('service');
+        await dashboardPage.variableNameInput.fill('svc');
+        await dashboardPage.page.getByTestId('save-filter-button').click();
+
+        const item = dashboardPage.getFilterItemByName('Service');
+        await expect(item).toBeVisible();
+        await expect(item).toContainText(`${PROMQL_SOURCE_NAME} · service`);
+        await expect(item).toContainText('($svc)');
+      });
+    });
+
+    test('lists the label values and stores the selection by variable name', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      await test.step('Create a PromQL Service filter', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addPromqlLabelFilterToDashboard(
+          'Service',
+          PROMQL_SOURCE_NAME,
+          'service',
+          { variableName: 'svc' },
+        );
+        await dashboardPage.closeFiltersModal();
+      });
+
+      await test.step('The dropdown offers every seeded service', async () => {
+        await dashboardPage.openFilterDropdown('Service');
+        await expect(async () => {
+          expect(await dashboardPage.getOpenFilterDropdownOptions()).toEqual(
+            SORTED_SERVICES,
+          );
+        }).toPass({ timeout: 20000 });
+        await page.keyboard.press('Escape');
+      });
+
+      await test.step('Selecting a value writes a variable-keyed entry', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await expectFiltersParam(page, [
+          { type: 'variable', name: 'svc', values: ['accounting'] },
+        ]);
+      });
+
+      await test.step('The selection survives a reload', async () => {
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+        await expect(
+          dashboardPage.getFilterPill('Service', 'accounting'),
+        ).toBeVisible({ timeout: 20000 });
+      });
+    });
+
+    test('lists metric names when the label is __name__', async ({ page }) => {
+      test.setTimeout(90000);
+
+      await dashboardPage.createNewDashboard();
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.addPromqlLabelFilterToDashboard(
+        'Metric',
+        PROMQL_SOURCE_NAME,
+        '__name__',
+        { variableName: 'metric' },
+      );
+      await dashboardPage.closeFiltersModal();
+
+      await dashboardPage.openFilterDropdown('Metric');
+      await expect(async () => {
+        expect(await dashboardPage.getOpenFilterDropdownOptions()).toContain(
+          E2E_PROMQL_METRIC_NAME,
+        );
+      }).toPass({ timeout: 20000 });
+      await page.keyboard.press('Escape');
+    });
+
+    test('narrows a raw SQL tile by the selected value', async () => {
+      test.setTimeout(120000);
+      const chartName = `E2E PromQL Filter Tile ${Date.now()}`;
+      // The seeded `service` label values are the same strings the logs carry
+      // as ServiceName, so a selection here narrows a query over the logs table.
+      const sql = `SELECT ServiceName, count() AS count FROM default.e2e_otel_logs WHERE Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp <= fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__conditionalAll(ServiceName IN $svc, $svc) GROUP BY ServiceName LIMIT 200`;
+
+      await test.step('Create a PromQL Service filter and select one value', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addPromqlLabelFilterToDashboard(
+          'Service',
+          PROMQL_SOURCE_NAME,
+          'service',
+          { variableName: 'svc' },
+        );
+        await dashboardPage.closeFiltersModal();
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+      });
+
+      await test.step('Add a raw SQL tile that references the variable', async () => {
+        await dashboardPage.addTile();
+        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+        await dashboardPage.chartEditor.waitForDataToLoad();
+        await dashboardPage.chartEditor.setChartType(DisplayType.Table);
+        await dashboardPage.chartEditor.setChartName(chartName);
+        await dashboardPage.chartEditor.switchToSqlMode();
+        await dashboardPage.chartEditor.typeSqlQuery(sql);
+        await dashboardPage.chartEditor.runQuery(false);
+        await dashboardPage.saveTile();
+      });
+
+      await test.step('The tile shows only the selected service', async () => {
+        const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+        await expect(
+          tile.getByTitle('accounting', { exact: true }),
+        ).toBeVisible({ timeout: 20000 });
+        await expect(tile.getByTitle('frontend', { exact: true })).toHaveCount(
+          0,
+        );
+      });
+
+      await test.step('Changing the selection re-renders the tile', async () => {
+        await dashboardPage.toggleFilterValue('Service', 'accounting');
+        await dashboardPage.toggleFilterValue('Service', 'frontend');
+
+        const tile = dashboardPage.getTiles().filter({ hasText: chartName });
+        await expect(tile.getByTitle('frontend', { exact: true })).toBeVisible({
+          timeout: 20000,
+        });
+        await expect(
+          tile.getByTitle('accounting', { exact: true }),
+        ).toHaveCount(0);
+      });
+    });
+
+    test('round-trips the source and label through an edit', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      await test.step('Create a PromQL Service filter', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addPromqlLabelFilterToDashboard(
+          'Service',
+          PROMQL_SOURCE_NAME,
+          'service',
+          { variableName: 'svc' },
+        );
+      });
+
+      await test.step('Reopening the form shows what was saved', async () => {
+        await dashboardPage.openEditFilterForm('Service');
+        await expect(dashboardPage.getFilterLabelInput()).toHaveValue(
+          'service',
+        );
+        await expect(dashboardPage.filtersSourceSelector).toHaveValue(
+          PROMQL_SOURCE_NAME,
+        );
+        await expect(dashboardPage.variableNameInput).toHaveValue('svc');
+      });
+
+      await test.step('A changed label is saved and survives a reload', async () => {
+        await dashboardPage.getFilterLabelInput().fill('__name__');
+        await page.getByTestId('save-filter-button').click();
+        await expect(
+          dashboardPage.getFilterItemByName('Service'),
+        ).toContainText(`${PROMQL_SOURCE_NAME} · __name__`);
+        await dashboardPage.closeFiltersModal();
+
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+        await dashboardPage.openFilterDropdown('Service');
+        await expect(async () => {
+          expect(await dashboardPage.getOpenFilterDropdownOptions()).toContain(
+            E2E_PROMQL_METRIC_NAME,
+          );
+        }).toPass({ timeout: 20000 });
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -1282,8 +1282,10 @@ export class DashboardPage {
     return this.page.getByTestId('filter-type-picker');
   }
 
-  /** Switch the add-filter form between the queried and static value types. */
-  async selectFilterType(label: 'Queried values' | 'Static values') {
+  /** Switch the add-filter form between the available value types. */
+  async selectFilterType(
+    label: 'Queried values' | 'Static values' | 'PromQL label values',
+  ) {
     await this.getFilterTypePicker().click();
     await this.getFilterOption(label).click();
   }
@@ -1346,6 +1348,44 @@ export class DashboardPage {
     await nameInput.waitFor({ state: 'visible', timeout: 10000 });
     await nameInput.fill(name);
     await this.fillFilterOptions(options);
+    if (variableOptions?.variableName !== undefined) {
+      await this.variableNameInput.fill(variableOptions.variableName);
+    }
+    await this.page.getByTestId('save-filter-button').click();
+    await this.getFilterItemByName(name).waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  /** The PromQL filter form's label field. */
+  getFilterLabelInput(): Locator {
+    return this.page.getByTestId('filter-label-input');
+  }
+
+  /**
+   * Add a dashboard filter whose dropdown lists the values of one Prometheus
+   * label. Like the static variant it shares only the display name and variable
+   * name with a queried filter — there is no expression or broadcast mode, and
+   * the source must be a PromQL one.
+   *
+   * Assumes the Edit Filters modal is already open; leaves it open on the
+   * filters list, having waited for the new filter to land there so a slow
+   * save cannot race the next add.
+   */
+  async addPromqlLabelFilterToDashboard(
+    name: string,
+    sourceName: string,
+    label: string,
+    variableOptions?: { variableName?: string },
+  ) {
+    await this.addFiltersButton.click();
+    await this.selectFilterType('PromQL label values');
+    const nameInput = this.getFilterNameInput();
+    await nameInput.waitFor({ state: 'visible', timeout: 10000 });
+    await nameInput.fill(name);
+    await this.selectFilterSource(sourceName);
+    await this.getFilterLabelInput().fill(label);
     if (variableOptions?.variableName !== undefined) {
       await this.variableNameInput.fill(variableOptions.variableName);
     }

--- a/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
+++ b/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
@@ -7,6 +7,7 @@ import {
 import { FilterState, filtersToQuery } from '@/filters';
 import type {
   DashboardFilterValue,
+  PromqlLabelDashboardFilter,
   QueryExpressionDashboardFilter,
   StaticListDashboardFilter,
 } from '@/types';
@@ -32,6 +33,20 @@ const staticFilter = (
   isBroadcastEnabled: false,
   isVariableEnabled: true,
   variableName: 'env',
+  ...overrides,
+});
+
+const promqlFilter = (
+  overrides: Partial<PromqlLabelDashboardFilter> = {},
+): PromqlLabelDashboardFilter => ({
+  id: 'f1',
+  type: 'PROMETHEUS_LABEL',
+  name: 'Pod',
+  source: 'promql',
+  label: 'pod',
+  isBroadcastEnabled: false,
+  isVariableEnabled: true,
+  variableName: 'pod',
   ...overrides,
 });
 
@@ -346,6 +361,13 @@ describe('dashboardFilterValues', () => {
       });
     });
 
+    it('keys a promql-label filter by its variable name', () => {
+      expect(filterSelectionKey(promqlFilter())).toEqual({
+        kind: 'variable',
+        name: 'pod',
+      });
+    });
+
     // Unreachable through the write paths — a static filter is variable-only by
     // construction — but it has no expression to fall back to, so the key stays
     // variable-kind even when no name can be derived from it.
@@ -425,13 +447,29 @@ describe('dashboardFilterValues', () => {
       );
     });
 
-    it('returns undefined for an expressionless filter with no variable entry', () => {
+    it('resolves a promql-label filter from its variable entry', () => {
       const parsed = parseDashboardFilterValues([
-        { type: 'sql', condition: "ServiceName IN ('legacy')" },
+        { type: 'variable', name: 'pod', values: ['api-0'] },
       ]);
 
-      expect(resolveFilterSelection(staticFilter(), parsed)).toBeUndefined();
+      expect(resolveFilterSelection(promqlFilter(), parsed)).toEqual(
+        included('api-0'),
+      );
     });
+
+    it.each([
+      ['static-list', staticFilter()],
+      ['promql-label', promqlFilter()],
+    ])(
+      'returns undefined for an expressionless %s filter with no variable entry',
+      (_label, expressionless) => {
+        const parsed = parseDashboardFilterValues([
+          { type: 'sql', condition: "ServiceName IN ('legacy')" },
+        ]);
+
+        expect(resolveFilterSelection(expressionless, parsed)).toBeUndefined();
+      },
+    );
 
     it('resolves two filters sharing an expression independently', () => {
       const parsed = parseDashboardFilterValues([

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -705,6 +705,23 @@ describe('filters', () => {
       ).toEqual([]);
     });
 
+    it('skips a promql-label filter, which has no ClickHouse values query', () => {
+      expect(
+        validateDashboardFilterQueries([
+          {
+            id: 'f1',
+            type: 'PROMETHEUS_LABEL',
+            name: 'Pod',
+            source: 'promql',
+            label: 'pod',
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'pod',
+          },
+        ]),
+      ).toEqual([]);
+    });
+
     it('accepts a valid lucene where clause', () => {
       expect(
         validateDashboardFilterQueries([
@@ -1481,9 +1498,24 @@ describe('filters', () => {
       expect(getFilterExpression(queried)).toBe('ServiceName');
     });
 
+    const promqlLabel: DashboardFilter = {
+      id: 'f3',
+      type: 'PROMETHEUS_LABEL',
+      name: 'Pod',
+      source: 'promql',
+      label: 'pod',
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+    };
+
     it('rejects a static-list filter, which names no column', () => {
       expect(isQueryExpressionFilter(staticList)).toBe(false);
       expect(getFilterExpression(staticList)).toBeUndefined();
+    });
+
+    it('rejects a promql-label filter, which names a label rather than a column', () => {
+      expect(isQueryExpressionFilter(promqlLabel)).toBe(false);
+      expect(getFilterExpression(promqlLabel)).toBeUndefined();
     });
   });
 
@@ -1524,6 +1556,20 @@ describe('filters', () => {
           type: 'STATIC_LIST',
           name: 'Environment',
           options: ['prod'],
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for a promql-label filter, which has no column', () => {
+      expect(
+        getFilterBroadcastTarget({
+          id: 'f3',
+          type: 'PROMETHEUS_LABEL',
+          name: 'Pod',
+          source: 'promql',
+          label: 'pod',
           isBroadcastEnabled: false,
           isVariableEnabled: true,
         }),

--- a/packages/common-utils/src/__tests__/utils.test.ts
+++ b/packages/common-utils/src/__tests__/utils.test.ts
@@ -1331,6 +1331,55 @@ describe('utils', () => {
       ]);
     });
 
+    it('should export a promql-label filter with its source id remapped to a name', () => {
+      const sources: TSource[] = [
+        {
+          id: 'source1',
+          name: 'Prom',
+          connection: 'connection1',
+          kind: SourceKind.Promql,
+          from: { databaseName: 'db1', tableName: 'timeseries_table' },
+          timestampValueExpression: 'Timestamp',
+        },
+      ];
+
+      const dashboard: z.infer<typeof DashboardSchema> = {
+        id: 'dashboard1',
+        name: 'PromQL Filter Dashboard',
+        tags: [],
+        tiles: [],
+        filters: [
+          {
+            id: 'filter-promql',
+            type: 'PROMETHEUS_LABEL',
+            name: 'Pod',
+            source: 'source1',
+            label: 'pod',
+            isBroadcastEnabled: false,
+            isVariableEnabled: true,
+            variableName: 'pod',
+          },
+        ],
+      };
+
+      const template = convertToDashboardTemplate(dashboard, sources);
+
+      expect(template.filters).toEqual([
+        {
+          id: 'filter-promql',
+          type: 'PROMETHEUS_LABEL',
+          name: 'Pod',
+          source: 'Prom',
+          label: 'pod',
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'pod',
+        },
+      ]);
+      // Only queried filters broadcast, so no applies-to key is stamped on.
+      expect('appliesToSourceIds' in template.filters![0]).toBe(false);
+    });
+
     // A `STATIC_LIST` filter references nothing in the workspace at all, so it
     // must survive export untouched — in particular `source` must stay absent
     // rather than being stamped with the empty string the name lookup returns

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 export { default as objectHash } from 'object-hash';
 
-import { isStaticListFilter } from '@/filters';
+import { isQueryExpressionFilter, isStaticListFilter } from '@/filters';
 import { isBuilderSavedChartConfig, isRawSqlSavedChartConfig } from '@/guards';
 import { MacroExpansionError, MalformedMacroArgsError } from '@/macroErrors';
 import {
@@ -709,13 +709,16 @@ export function convertToDashboardTemplate(
     // Extract name from source or default to '' if not found
     filter.source =
       sources.find(source => source.id === filter.source)?.name ?? '';
-    if (filter.appliesToSourceIds?.length) {
-      const remapped = filter.appliesToSourceIds
-        .map(id => sources.find(source => source.id === id)?.name)
-        .filter((name): name is string => !!name && name.length > 0);
-      filter.appliesToSourceIds = remapped.length > 0 ? remapped : undefined;
-    } else {
-      filter.appliesToSourceIds = undefined;
+
+    if (isQueryExpressionFilter(filter)) {
+      if (filter.appliesToSourceIds?.length) {
+        const remapped = filter.appliesToSourceIds
+          .map(id => sources.find(source => source.id === id)?.name)
+          .filter((name): name is string => !!name && name.length > 0);
+        filter.appliesToSourceIds = remapped.length > 0 ? remapped : undefined;
+      } else {
+        filter.appliesToSourceIds = undefined;
+      }
     }
     return filter;
   };

--- a/packages/common-utils/src/dashboardFilterValues.ts
+++ b/packages/common-utils/src/dashboardFilterValues.ts
@@ -4,7 +4,6 @@ import {
   getFilterExpression,
   getFilterVariableName,
   isFilterVariableEnabled,
-  isStaticListFilter,
   parseQuery,
 } from '@/filters';
 import {
@@ -119,7 +118,9 @@ export function filterSelectionKey(
 ):
   | { kind: 'variable'; name: string }
   | { kind: 'expression'; expression: string } {
-  if (isStaticListFilter(filter)) {
+  const expression = getFilterExpression(filter);
+
+  if (expression == null) {
     return { kind: 'variable', name: getFilterVariableName(filter) ?? '' };
   }
 
@@ -128,7 +129,7 @@ export function filterSelectionKey(
     if (name) return { kind: 'variable', name };
   }
 
-  return { kind: 'expression', expression: filter.expression };
+  return { kind: 'expression', expression };
 }
 
 /**

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -787,8 +787,8 @@ export function validateDashboardFilterQueries(
   ).map(declaration => ({ ...declaration, values: [] }));
 
   for (const filter of filters) {
-    // A static filter has no values query to validate.
-    if (isStaticListFilter(filter)) continue;
+    // Only ClickHouse-queried filters carry a values query to validate.
+    if (!isQueryExpressionFilter(filter)) continue;
     const where = filter.where ?? '';
     if (!where.trim()) continue;
     const language = filter.whereLanguage ?? 'sql';
@@ -863,6 +863,13 @@ export function isStaticListFilter<T extends { type: DashboardFilterKind }>(
   return filter.type === 'STATIC_LIST';
 }
 
+/** Type guard for PROMETHEUS_LABEL type filters. */
+export function isPrometheusLabelFilter<
+  T extends { type: DashboardFilterKind },
+>(filter: T): filter is Extract<T, { type: 'PROMETHEUS_LABEL' }> {
+  return filter.type === 'PROMETHEUS_LABEL';
+}
+
 /** The SQL expression associated with the filter, if any. */
 export function getFilterExpression(
   filter: DashboardFilter,
@@ -874,7 +881,7 @@ export function getFilterExpression(
 export function getFilterBroadcastTarget(
   filter: DashboardFilter,
 ): { expression: string; appliesToSourceIds?: string[] } | undefined {
-  if (!isFilterBroadcastEnabled(filter) || isStaticListFilter(filter))
+  if (!isQueryExpressionFilter(filter) || !isFilterBroadcastEnabled(filter))
     return undefined;
   return {
     expression: filter.expression,

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -9,6 +9,7 @@ import {
   DashboardFilter,
   DashboardFilterValue,
   Filter,
+  SourceKind,
 } from '@/types';
 import { getVariableReferences, substituteVariables } from '@/variables';
 
@@ -848,6 +849,14 @@ export function isFilterVariableEnabled(filter: {
 
 /** The discriminant every dashboard-filter shape carries. */
 export type DashboardFilterKind = DashboardFilter['type'];
+
+/** The source kinds a QUERY_EXPRESSION filter can run its `SELECT` against. */
+export const QUERY_EXPRESSION_FILTER_SOURCE_KINDS: SourceKind[] = [
+  SourceKind.Log,
+  SourceKind.Trace,
+  SourceKind.Session,
+  SourceKind.Metric,
+];
 
 /** Type guard for QUERY_EXPRESSION type filters. */
 export function isQueryExpressionFilter<

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1893,7 +1893,11 @@ export const DashboardContainerSchema = z.object({
 export type DashboardContainer = z.infer<typeof DashboardContainerSchema>;
 
 /** Type of dashboard filter, determining how its dropdown values are populated. */
-export const DashboardFilterType = z.enum(['QUERY_EXPRESSION', 'STATIC_LIST']);
+export const DashboardFilterType = z.enum([
+  'QUERY_EXPRESSION',
+  'STATIC_LIST',
+  'PROMETHEUS_LABEL',
+]);
 
 /** Allowed variable names for dashboard filters. Alphanumeric + underscore, must start with a letter. */
 export const DASHBOARD_VARIABLE_NAME_PATTERN = '[a-zA-Z][a-zA-Z0-9_]*';
@@ -1959,9 +1963,26 @@ export const StaticListDashboardFilterSchema = dashboardFilterBaseSchema.extend(
   },
 );
 
+/** Sanity bound on a persisted label name; Prometheus itself imposes no limit. */
+export const PROMETHEUS_LABEL_NAME_MAX_LENGTH = 1024;
+
+/** A filter whose dropdown lists the values of a Prometheus label */
+export const PromqlLabelDashboardFilterSchema =
+  dashboardFilterBaseSchema.extend({
+    type: z.literal(DashboardFilterType.enum.PROMETHEUS_LABEL),
+    /** ID of a PromQL source to query */
+    source: z.string().min(1),
+    /** Label whose values populate the dropdown. */
+    label: z.string().min(1).max(PROMETHEUS_LABEL_NAME_MAX_LENGTH),
+    // Variable-only: there is no SQL expression to broadcast
+    isBroadcastEnabled: z.literal(false),
+    isVariableEnabled: z.literal(true),
+  });
+
 export const DashboardFilterSchema = z.discriminatedUnion('type', [
   QueryExpressionDashboardFilterSchema,
   StaticListDashboardFilterSchema,
+  PromqlLabelDashboardFilterSchema,
 ]);
 
 export type QueryExpressionDashboardFilter = z.infer<
@@ -1969,6 +1990,9 @@ export type QueryExpressionDashboardFilter = z.infer<
 >;
 export type StaticListDashboardFilter = z.infer<
   typeof StaticListDashboardFilterSchema
+>;
+export type PromqlLabelDashboardFilter = z.infer<
+  typeof PromqlLabelDashboardFilterSchema
 >;
 export type DashboardFilter = z.infer<typeof DashboardFilterSchema>;
 


### PR DESCRIPTION
## Summary

This PR adds support for dashboard filters that display drop-down values queried from a PromQL source's `<label>/values` endpoint. Such filters can be referenced as variables.

This PR includes schema updates, external and internal API support, import/export support, and relevant UI updates, along with tests.

MCP support is not present at this time because MCP generally does not yet support PromQL.

### Screenshots or video


https://github.com/user-attachments/assets/cc0bd772-2143-474e-bc58-5bfb3aac14f5

<img width="520" height="266" alt="Screenshot 2026-09-01 at 9 47 38 AM" src="https://github.com/user-attachments/assets/0643fdfd-7f3a-44d1-9b8b-f0013dd3249d" />

<img width="520" height="266" alt="Screenshot 2026-09-01 at 9 47 38 AM" src="https://github.com/user-attachments/assets/92d59dd0-cb5a-48a7-a92c-cb9412fd1e6a" />

### How to test locally

1. Setup a PromQL source based on the metrics_ts timeseries table on local
2. Create a dashboard and add a promql label tile based on a label like `instance`
3. Add a promql tile and reference the filter as a variable, to filter the series

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5111
- Related PRs:
