### PR TITLE
feat: Support a custom template for PromQL series legends

### DIFF
--- a/.changeset/promql-legend-template.md
+++ b/.changeset/promql-legend-template.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+---
+
+feat: Support a custom template for PromQL series legends

--- a/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
+++ b/packages/app/src/components/ChartDisplaySettingsDrawer.tsx
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import {
+  UnknownTemplateHelperError,
+  validateTemplate,
+} from '@hyperdx/common-utils/dist/core/handlebarsEnv';
+import {
   ChartConfigWithDateRange,
   DisplayType,
+  MAX_LEGEND_TEMPLATE_LENGTH,
   NumberFormat,
 } from '@hyperdx/common-utils/dist/types';
 import {
@@ -30,7 +35,7 @@ import {
   stripLocalIds,
 } from './ColorRulesEditor';
 import { ColorSwatchInput } from './ColorSwatchInput';
-import { CheckBoxControlled } from './InputControlled';
+import { CheckBoxControlled, TextInputControlled } from './InputControlled';
 import { DEFAULT_NUMBER_FORMAT, NumberFormatForm } from './NumberFormat';
 
 export type ChartConfigDisplaySettings = Pick<
@@ -53,6 +58,9 @@ export type ChartConfigDisplaySettings = Pick<
   // for the authoritative semantics. The editor clears to `null` (not
   // `undefined`) so the cleared state survives JSON round-tripping via the URL.
   seriesLimit?: number | null;
+  // PromQL-only: Handlebars template over each series' Prometheus label set
+  // that renders the legend/tooltip name.
+  legendTemplate?: string;
 };
 
 /**
@@ -97,6 +105,7 @@ function applyDefaultSettings(
     // Coerce to null so `reset` clears the input; undefined leaves the
     // previously registered field value in place.
     seriesLimit: settings.seriesLimit ?? null,
+    legendTemplate: settings.legendTemplate ?? '',
     color: settings.color,
     colorRules: settings.colorRules
       ? attachLocalIds(settings.colorRules)
@@ -165,8 +174,9 @@ export default function ChartDisplaySettingsDrawer({
         },
         hasDirtyFields,
       );
+      // Close only on successful validation
+      onClose();
     })();
-    onClose();
   }, [onChange, handleSubmit, onClose, settings.numberFormat, dirtyFields]);
 
   const resetToDefaults = useCallback(() => {
@@ -188,6 +198,10 @@ export default function ChartDisplaySettingsDrawer({
   // excluded — its series come from Prometheus, not this pipeline.
   const showSeriesLimit = isTimeChart && configType !== 'promql';
   const isRawSqlTimeChart = showSeriesLimit && configType === 'sql';
+
+  // Every PromQL display except Number surfaces the series name
+  const showLegendTemplate =
+    configType === 'promql' && displayType !== DisplayType.Number;
 
   // On pie/bar builder charts, seriesLimit becomes a plain SQL LIMIT on the
   // number of slices/bars; raw SQL configs author their own LIMIT directly.
@@ -291,6 +305,40 @@ export default function ChartDisplaySettingsDrawer({
                 />
               </Box>
             )}
+            <Divider />
+          </>
+        )}
+
+        {showLegendTemplate && (
+          <>
+            <Box>
+              <TextInputControlled
+                control={control}
+                name="legendTemplate"
+                size="xs"
+                label="Legend template"
+                description="Handlebars template rendered with each series' Prometheus labels. Leave empty for the default legend. Additional labels will be added if the template does not produce unique labels for each series."
+                placeholder="e.g. {{namespace}} - {{pod}}"
+                data-testid="legend-template-input"
+                rules={{
+                  validate: value => {
+                    if (typeof value !== 'string' || !value) return true;
+                    const trimmed = value.trim();
+                    if (trimmed.length > MAX_LEGEND_TEMPLATE_LENGTH) {
+                      return `Template is too long (${trimmed.length} characters, max ${MAX_LEGEND_TEMPLATE_LENGTH})`;
+                    }
+                    try {
+                      validateTemplate(trimmed);
+                      return true;
+                    } catch (err) {
+                      return err instanceof UnknownTemplateHelperError
+                        ? err.message
+                        : 'Invalid Handlebars template';
+                    }
+                  },
+                }}
+              />
+            </Box>
             <Divider />
           </>
         )}

--- a/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
+++ b/packages/app/src/components/ChartEditor/__tests__/utils.test.ts
@@ -200,6 +200,16 @@ describe('convertFormStateToSavedChartConfig', () => {
     expect(result.source).toBe('source-log');
   });
 
+  it('drops the PromQL-only legendTemplate from builder configs', () => {
+    const form: ChartEditorFormState = {
+      displayType: DisplayType.Line,
+      series: [seriesItem],
+      legendTemplate: '{{pod}}',
+    };
+    const result = convertFormStateToSavedChartConfig(form, logSource);
+    expect(result).not.toHaveProperty('legendTemplate');
+  });
+
   it('uses form.select string for Search displayType', () => {
     const form: ChartEditorFormState = {
       displayType: DisplayType.Search,

--- a/packages/app/src/components/ChartEditor/utils.ts
+++ b/packages/app/src/components/ChartEditor/utils.ts
@@ -204,6 +204,7 @@ export function convertFormStateToSavedChartConfig(
       promqlExpression: form.promqlExpression ?? '',
       connection: form.connection ?? '',
       source: form.source || undefined,
+      legendTemplate: form.legendTemplate?.trim() || undefined,
     };
 
     return promqlConfig;
@@ -238,7 +239,7 @@ export function convertFormStateToSavedChartConfig(
 
   if (form.displayType === DisplayType.Markdown) {
     const config: BuilderSavedChartConfig = {
-      ...omit(form, ['series', 'configType', 'sqlTemplate']),
+      ...omit(form, ['series', 'configType', 'sqlTemplate', 'legendTemplate']),
       select: [],
       where: form.where ?? '',
       source: source?.id ?? form.source ?? '',
@@ -249,7 +250,7 @@ export function convertFormStateToSavedChartConfig(
   if (source) {
     // Merge the series and select fields back together, and prevent the series field from being submitted
     const config: BuilderSavedChartConfig = {
-      ...omit(form, ['series', 'configType', 'sqlTemplate']),
+      ...omit(form, ['series', 'configType', 'sqlTemplate', 'legendTemplate']),
       select: isStringSelectDisplayType(form.displayType)
         ? typeof form.select === 'string'
           ? form.select
@@ -285,6 +286,7 @@ export function convertFormStateToChartConfig(
       connection: source?.connection ?? form.connection ?? '',
       source: form.source || undefined,
       from: source?.from,
+      legendTemplate: form.legendTemplate?.trim() || undefined,
     };
 
     return { ...promqlConfig, dateRange };
@@ -340,7 +342,7 @@ export function convertFormStateToChartConfig(
     const isSelectEmpty = !mergedSelect || mergedSelect.length === 0;
 
     const newConfig: ChartConfigWithDateRange = {
-      ...omit(form, ['series', 'configType', 'sqlTemplate']),
+      ...omit(form, ['series', 'configType', 'sqlTemplate', 'legendTemplate']),
       from: source.from,
       timestampValueExpression: source.timestampValueExpression,
       dateRange,

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -282,6 +282,7 @@ export default function EditTimeChartForm({
     color,
     colorRules,
     backgroundChart,
+    legendTemplate,
   ] = useWatch({
     control,
     name: [
@@ -296,6 +297,7 @@ export default function EditTimeChartForm({
       'color',
       'colorRules',
       'backgroundChart',
+      'legendTemplate',
     ],
   });
 
@@ -326,6 +328,7 @@ export default function EditTimeChartForm({
       color,
       colorRules,
       backgroundChart,
+      legendTemplate,
     }),
     [
       alignDateRangeToGranularity,
@@ -339,6 +342,7 @@ export default function EditTimeChartForm({
       color,
       colorRules,
       backgroundChart,
+      legendTemplate,
     ],
   );
 
@@ -670,6 +674,7 @@ export default function EditTimeChartForm({
         color,
         colorRules,
         backgroundChart,
+        legendTemplate,
       }: ChartConfigDisplaySettings,
       isDirty: boolean,
     ) => {
@@ -692,6 +697,10 @@ export default function EditTimeChartForm({
       setValue('color', color);
       setValue('colorRules', colorRules);
       setValue('backgroundChart', backgroundChart);
+      // Empty string (not undefined) so the cleared state survives the URL round-trip.
+      if (configType === 'promql') {
+        setValue('legendTemplate', legendTemplate ?? '');
+      }
       // Display settings live in a separate drawer form, so RHF can't track
       // them. Latch dirty state only when the drawer reports actual changes.
       if (isDirty) {
@@ -700,7 +709,7 @@ export default function EditTimeChartForm({
       }
       onSubmit();
     },
-    [setValue, onDirtyChange, onSubmit],
+    [setValue, onDirtyChange, onSubmit, configType],
   );
 
   const handleUpdateHeatmapSettings = useCallback(

--- a/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
+++ b/packages/app/src/components/__tests__/ChartDisplaySettingsDrawer.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { DisplayType } from '@hyperdx/common-utils/dist/types';
+import {
+  DisplayType,
+  MAX_LEGEND_TEMPLATE_LENGTH,
+} from '@hyperdx/common-utils/dist/types';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -565,6 +568,76 @@ describe('ChartDisplaySettingsDrawer', () => {
         color: 'chart-blue',
         numberFormat: { output: 'currency' },
       });
+    });
+  });
+
+  describe('legend template', () => {
+    const promqlProps = {
+      ...baseProps,
+      configType: 'promql' as const,
+      displayType: DisplayType.Line,
+    };
+
+    it('blocks Apply when the template exceeds the persisted length cap', async () => {
+      const onChange = jest.fn();
+      const onClose = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer
+          {...promqlProps}
+          onChange={onChange}
+          onClose={onClose}
+        />,
+      );
+
+      const tooLong = 'a'.repeat(MAX_LEGEND_TEMPLATE_LENGTH + 1);
+      await user.click(screen.getByTestId('legend-template-input'));
+      await user.paste(tooLong);
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(
+        screen.getByText(
+          `Template is too long (${MAX_LEGEND_TEMPLATE_LENGTH + 1} characters, max ${MAX_LEGEND_TEMPLATE_LENGTH})`,
+        ),
+      ).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('accepts a template exactly at the cap', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer {...promqlProps} onChange={onChange} />,
+      );
+
+      const atCap = 'a'.repeat(MAX_LEGEND_TEMPLATE_LENGTH);
+      await user.click(screen.getByTestId('legend-template-input'));
+      await user.paste(atCap);
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toMatchObject({
+        legendTemplate: atCap,
+      });
+    });
+
+    it('measures the trimmed value, matching what gets persisted', async () => {
+      const onChange = jest.fn();
+      const user = userEvent.setup();
+
+      renderWithMantine(
+        <ChartDisplaySettingsDrawer {...promqlProps} onChange={onChange} />,
+      );
+
+      const padded = `  ${'a'.repeat(MAX_LEGEND_TEMPLATE_LENGTH)}  `;
+      await user.click(screen.getByTestId('legend-template-input'));
+      await user.paste(padded);
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
+++ b/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
@@ -10,6 +10,7 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { prometheusApi } from '@/api';
 import { useClickhouseClient } from '@/clickhouse';
 import {
   appendChunk,
@@ -67,6 +68,16 @@ jest.mock('../useMVOptimizationExplanation', () => ({
     data: undefined,
     isLoading: false,
   }),
+}));
+
+// Mock prometheusApi for the PromQL query path, keeping the rest of the
+// module (useMetadata calls api.useMe at render time).
+jest.mock('@/api', () => ({
+  __esModule: true,
+  ...jest.requireActual('@/api'),
+  prometheusApi: {
+    queryRange: jest.fn(),
+  },
 }));
 
 // Create a mock ChartConfig
@@ -376,6 +387,72 @@ describe('useChartConfig', () => {
       } as unknown as jest.Mocked<ClickhouseClient>;
 
       jest.mocked(useClickhouseClient).mockReturnValue(mockClickhouseClient);
+    });
+
+    describe('promql configs', () => {
+      const createPromqlConfig = (
+        overrides: Partial<ChartConfigWithOptDateRange> = {},
+      ): ChartConfigWithOptDateRange =>
+        ({
+          configType: 'promql',
+          promqlExpression: 'e2e_service_up',
+          connection: 'foo',
+          dateRange: [
+            new Date('2023-01-10 00:00:00'),
+            new Date('2023-01-10 01:00:00'),
+          ],
+          ...overrides,
+        }) as ChartConfigWithOptDateRange;
+
+      const matrixResponse = {
+        status: 'success' as const,
+        data: {
+          resultType: 'matrix' as const,
+          result: [
+            {
+              metric: { __name__: 'e2e_service_up', service: 'accounting' },
+              values: [[1673308800, '1']] as [number, string][],
+            },
+            {
+              metric: { __name__: 'e2e_service_up', service: 'api-server' },
+              values: [[1673308800, '2']] as [number, string][],
+            },
+          ],
+        },
+      };
+
+      it('renders series names from the legend template', async () => {
+        jest.mocked(prometheusApi.queryRange).mockResolvedValue(matrixResponse);
+
+        const config = createPromqlConfig({
+          legendTemplate: 'svc:{{service}}',
+        });
+        const { result } = renderHook(() => useQueriedChartConfig(config), {
+          wrapper,
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(
+          result.current.data?.data.map((r: any) => r.series_name),
+        ).toEqual(['svc:accounting', 'svc:api-server']);
+      });
+
+      it('uses the default label-set name without a legend template', async () => {
+        jest.mocked(prometheusApi.queryRange).mockResolvedValue(matrixResponse);
+
+        const { result } = renderHook(
+          () => useQueriedChartConfig(createPromqlConfig()),
+          { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(
+          result.current.data?.data.map((r: any) => r.series_name),
+        ).toEqual([
+          'e2e_service_up{service="accounting"}',
+          'e2e_service_up{service="api-server"}',
+        ]);
+      });
     });
 
     it('fetches data without chunking when no dateRange is provided', async () => {

--- a/packages/app/src/hooks/useChartConfig.tsx
+++ b/packages/app/src/hooks/useChartConfig.tsx
@@ -12,6 +12,10 @@ import {
   renderChartConfig,
 } from '@hyperdx/common-utils/dist/core/renderChartConfig';
 import {
+  renderSeriesNames,
+  SeriesNameInput,
+} from '@hyperdx/common-utils/dist/core/seriesNameTemplate';
+import {
   convertDateRangeToGranularityString,
   hasPositiveSeriesLimit,
 } from '@hyperdx/common-utils/dist/core/utils';
@@ -383,14 +387,25 @@ export function useQueriedChartConfig(
           if (vs.size > 1) distinguishingKeys.add(k);
         }
 
-        const data: Record<string, string | number>[] = [];
-        for (const series of allSeries) {
+        const seriesInputs: SeriesNameInput[] = allSeries.map(series => {
           const metricName = series.metric.__name__ ?? '';
           const labels = Object.entries(series.metric)
             .filter(([k]) => k !== '__name__' && distinguishingKeys.has(k))
             .map(([k, v]) => `${k}="${v}"`)
             .join(', ');
-          const seriesName = labels ? `${metricName}{${labels}}` : metricName;
+          return {
+            labels: series.metric,
+            fallback: labels ? `${metricName}{${labels}}` : metricName,
+          };
+        });
+        const legendTemplate = config.legendTemplate?.trim();
+        const seriesNames = legendTemplate
+          ? renderSeriesNames(legendTemplate, seriesInputs)
+          : seriesInputs.map(s => s.fallback);
+
+        const data: Record<string, string | number>[] = [];
+        for (const [i, series] of allSeries.entries()) {
+          const seriesName = seriesNames[i];
 
           for (const [ts, val] of series.values) {
             data.push({

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -1085,6 +1085,17 @@ export class ChartEditorComponent {
   }
 
   /**
+   * Set the "Legend template" value in the Display Settings drawer (PromQL
+   * charts only). Opens the drawer, fills the input, then applies and closes.
+   */
+  async setLegendTemplate(template: string) {
+    await this.openDisplaySettings();
+    const drawer = this.page.getByRole('dialog', { name: 'Display Settings' });
+    await drawer.getByTestId('legend-template-input').fill(template);
+    await this.applyDisplaySettings();
+  }
+
+  /**
    * Open the Display Settings drawer and wait for it to become visible.
    */
   async openDisplaySettings() {

--- a/packages/app/tests/e2e/features/promql-legend-template.spec.ts
+++ b/packages/app/tests/e2e/features/promql-legend-template.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * PromQL legend templates: a Handlebars template on the tile config renders
+ * each series' Prometheus labels into the legend name in place of the default
+ * `metric{label="value"}` form.
+ *
+ * The seed gives `e2e_service_up` one series per `SERVICES` entry, labelled
+ * `service`, so `{{service}}` resolves to a known set of short names.
+ */
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { expect, test } from '../utils/base-test';
+import { E2E_PROMQL_METRIC_NAME, PROMQL_SOURCE_NAME } from '../utils/constants';
+
+test.describe(
+  'PromQL legend template',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    test('renders, round-trips, validates, and clears', async ({ page }) => {
+      test.setTimeout(120000);
+
+      const dashboardPage = new DashboardPage(page);
+      const editor = dashboardPage.chartEditor;
+      const legend = page.locator('.recharts-legend-wrapper').first();
+      const drawer = page.getByRole('dialog', { name: 'Display Settings' });
+
+      await test.step('Create a dashboard with a PromQL tile', async () => {
+        await dashboardPage.goto();
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.addTile();
+        await expect(editor.nameInput).toBeVisible();
+        await editor.waitForDataToLoad();
+        await editor.switchToPromqlMode();
+        await editor.selectPromqlSource(PROMQL_SOURCE_NAME);
+        await editor.setChartName('PromQL legend tile');
+        // Two known series: the full metric has one per seeded service, and
+        // the legend only shows a subset when there are many.
+        await editor.replacePromqlExpression(
+          `${E2E_PROMQL_METRIC_NAME}{service=~"accounting|api-server"}`,
+        );
+      });
+
+      await test.step('Set a legend template and save', async () => {
+        await editor.setLegendTemplate('svc:{{service}}');
+        await editor.save();
+        await expect(dashboardPage.getTiles()).toHaveCount(1, {
+          timeout: 10000,
+        });
+      });
+
+      await test.step('The legend shows templated series names', async () => {
+        for (const service of ['accounting', 'api-server']) {
+          await expect(legend.getByText(`svc:${service}`)).toBeVisible({
+            timeout: 30000,
+          });
+        }
+        // The default `e2e_service_up{service="…"}` form is gone.
+        await expect(legend.getByText(/service="/)).toHaveCount(0);
+      });
+
+      await test.step('The template round-trips in the editor', async () => {
+        await dashboardPage.editTile(0);
+        await expect(editor.nameInput).toBeVisible();
+        await editor.openDisplaySettings();
+        await expect(drawer.getByTestId('legend-template-input')).toHaveValue(
+          'svc:{{service}}',
+        );
+      });
+
+      await test.step('An invalid template keeps the drawer open with an error', async () => {
+        await drawer.getByTestId('legend-template-input').fill('{{unclosed');
+        await drawer
+          .getByRole('button', { name: 'Apply', exact: true })
+          .click();
+        await expect(
+          drawer.getByText('Invalid Handlebars template'),
+        ).toBeVisible();
+        await expect(drawer).toBeVisible();
+      });
+
+      await test.step('Clearing the template restores the default legend', async () => {
+        await drawer.getByTestId('legend-template-input').fill('');
+        await drawer
+          .getByRole('button', { name: 'Apply', exact: true })
+          .click();
+        await drawer.waitFor({ state: 'hidden', timeout: 5000 });
+        await editor.save();
+        await expect(dashboardPage.getTiles()).toHaveCount(1, {
+          timeout: 10000,
+        });
+        // Matched on the tail: the legend truncates the middle past 35
+        // characters, and `e2e_service_up{service="…"}` exceeds that.
+        await expect(legend.getByText('accounting"}')).toBeVisible({
+          timeout: 30000,
+        });
+      });
+    });
+  },
+);

--- a/packages/common-utils/src/__tests__/types.test.ts
+++ b/packages/common-utils/src/__tests__/types.test.ts
@@ -9,6 +9,7 @@ import {
   DashboardFilterValueSchema,
   DashboardSchema,
   DerivedColumnSchema,
+  MAX_LEGEND_TEMPLATE_LENGTH,
   MetricFormulaSchema,
   PresetDashboard,
   PresetDashboardFilterSchema,
@@ -902,5 +903,29 @@ describe('formulas on saved chart configs', () => {
     });
 
     expect(parsed).not.toHaveProperty('formulas');
+  });
+});
+
+describe('PromQL legend templates on saved chart configs', () => {
+  const promqlConfig = (legendTemplate: string) => ({
+    configType: 'promql' as const,
+    promqlExpression: 'up',
+    connection: 'conn-1',
+    legendTemplate,
+  });
+
+  // The editor rejects an over-long template inline using the same constant;
+  // if these drift, a template the editor accepts fails the dashboard save.
+  it('caps legendTemplate at MAX_LEGEND_TEMPLATE_LENGTH', () => {
+    expect(
+      SavedChartConfigSchema.safeParse(
+        promqlConfig('a'.repeat(MAX_LEGEND_TEMPLATE_LENGTH)),
+      ).success,
+    ).toBe(true);
+    expect(
+      SavedChartConfigSchema.safeParse(
+        promqlConfig('a'.repeat(MAX_LEGEND_TEMPLATE_LENGTH + 1)),
+      ).success,
+    ).toBe(false);
   });
 });

--- a/packages/common-utils/src/core/__tests__/handlebarsEnv.test.ts
+++ b/packages/common-utils/src/core/__tests__/handlebarsEnv.test.ts
@@ -1,0 +1,130 @@
+import {
+  clearTemplateCache,
+  compileLenient,
+  compileStrict,
+  UnknownTemplateHelperError,
+  validateTemplate,
+} from '@/core/handlebarsEnv';
+
+describe.each([
+  ['compileStrict', compileStrict],
+  ['compileLenient', compileLenient],
+])('%s', (_name, compile) => {
+  beforeEach(() => clearTemplateCache());
+
+  it('throws on a syntax error at compile time, not render time', () => {
+    expect(() => compile('{{#if')).toThrow();
+  });
+
+  it('rethrows the memoized error on every later call', () => {
+    const first = (() => {
+      try {
+        compile('{{unclosed');
+      } catch (err) {
+        return err;
+      }
+    })();
+    expect(first).toBeInstanceOf(Error);
+    expect(() => compile('{{unclosed')).toThrow(first as Error);
+  });
+
+  it('returns the same delegate for a repeated template', () => {
+    expect(compile('{{a}}')).toBe(compile('{{a}}'));
+  });
+
+  it.each([
+    '{{uppercase a}}',
+    '{{#if a}}y{{/if}}',
+    '{{#each a}}y{{/each}}',
+    '{{#bogus}}y{{/bogus}}',
+  ])('rejects the unregistered helper in %s', template => {
+    expect(() => compile(template)({ a: [1] })).toThrow();
+  });
+});
+
+describe('compileStrict', () => {
+  beforeEach(() => clearTemplateCache());
+
+  it('throws when rendering a template with a missing key', () => {
+    expect(() => compileStrict('{{a}}')({})).toThrow(/not defined/);
+  });
+
+  it('reports an unknown helper as an unresolved name', () => {
+    // Strict lookup fails before helperMissing runs, so the lenient path's
+    // UnknownTemplateHelperError isn't reachable here.
+    expect(() => compileStrict('{{uppercase a}}')({ a: 'x' })).toThrow(
+      /"uppercase" not defined/,
+    );
+  });
+});
+
+describe('compileLenient', () => {
+  beforeEach(() => clearTemplateCache());
+
+  it('renders missing keys as empty', () => {
+    expect(compileLenient('a={{missing}}')({})).toBe('a=');
+  });
+
+  it('names the helper in an unknown-helper error', () => {
+    expect(() => compileLenient('{{uppercase a}}')({ a: 'x' })).toThrow(
+      UnknownTemplateHelperError,
+    );
+    expect(() => compileLenient('{{uppercase a}}')({ a: 'x' })).toThrow(
+      /Unknown helper: "uppercase"/,
+    );
+  });
+
+  it.each([
+    '{{#if a}}y{{/if}}',
+    '{{#each a}}y{{/each}}',
+    '{{#bogus}}y{{/bogus}}',
+  ])('reports the unregistered block helper in %s by name', template => {
+    expect(() => compileLenient(template)({ a: [1] })).toThrow(
+      UnknownTemplateHelperError,
+    );
+  });
+
+  it('caches independently of the strict variant', () => {
+    const lenient = compileLenient('{{a}}');
+    expect(lenient).not.toBe(compileStrict('{{a}}'));
+    expect(lenient({})).toBe('');
+  });
+});
+
+describe('validateTemplate', () => {
+  it('accepts a plain string with no handlebars expressions', () => {
+    expect(() => validateTemplate('just a string')).not.toThrow();
+  });
+
+  it('accepts templates that reference variables without a known context', () => {
+    expect(() => validateTemplate('svc={{ServiceName}}')).not.toThrow();
+    expect(() => validateTemplate('{{a}} {{b}} {{c.d.e}}')).not.toThrow();
+  });
+
+  it('accepts templates using registered helpers', () => {
+    expect(() =>
+      validateTemplate('{{default missing "fallback"}}'),
+    ).not.toThrow();
+    expect(() => validateTemplate('{{floor n}}')).not.toThrow();
+  });
+
+  it('throws on malformed template syntax', () => {
+    expect(() => validateTemplate('{{#if')).toThrow();
+    expect(() => validateTemplate('{{unclosed')).toThrow();
+    expect(() => validateTemplate('{{#if x}}no-close')).toThrow();
+  });
+
+  it('throws a named error on an unknown helper', () => {
+    expect(() => validateTemplate('{{bogus n}}')).toThrow(
+      UnknownTemplateHelperError,
+    );
+    expect(() => validateTemplate('{{#if x}}y{{/if}}')).toThrow(
+      UnknownTemplateHelperError,
+    );
+  });
+
+  it('does not throw when a referenced variable is absent (non-strict mode)', () => {
+    // Strict mode would throw MissingTemplateVariableError here; validate must not.
+    expect(() => validateTemplate('{{missing}}')).not.toThrow();
+  });
+});

--- a/packages/common-utils/src/core/__tests__/linkTemplate.test.ts
+++ b/packages/common-utils/src/core/__tests__/linkTemplate.test.ts
@@ -1,13 +1,12 @@
+import { clearTemplateCache } from '@/core/handlebarsEnv';
 import {
-  clearLinkTemplateCache,
   LinkTemplateError,
   MissingTemplateVariableError,
   renderLinkTemplate,
-  validateTemplate,
 } from '@/core/linkTemplate';
 
 describe('renderLinkTemplate', () => {
-  beforeEach(() => clearLinkTemplateCache());
+  beforeEach(() => clearTemplateCache());
 
   it('substitutes row column values', () => {
     expect(
@@ -51,34 +50,5 @@ describe('renderLinkTemplate', () => {
 
   it('does not HTML-escape output', () => {
     expect(renderLinkTemplate('{{v}}', { v: '<&>' })).toBe('<&>');
-  });
-});
-
-describe('validateTemplate', () => {
-  it('accepts a plain string with no handlebars expressions', () => {
-    expect(() => validateTemplate('just a string')).not.toThrow();
-  });
-
-  it('accepts templates that reference variables without a known context', () => {
-    expect(() => validateTemplate('svc={{ServiceName}}')).not.toThrow();
-    expect(() => validateTemplate('{{a}} {{b}} {{c.d.e}}')).not.toThrow();
-  });
-
-  it('accepts templates using registered helpers', () => {
-    expect(() =>
-      validateTemplate('{{default missing "fallback"}}'),
-    ).not.toThrow();
-    expect(() => validateTemplate('{{floor n}}')).not.toThrow();
-  });
-
-  it('throws on malformed template syntax', () => {
-    expect(() => validateTemplate('{{#if')).toThrow();
-    expect(() => validateTemplate('{{unclosed')).toThrow();
-    expect(() => validateTemplate('{{#if x}}no-close')).toThrow();
-  });
-
-  it('does not throw when a referenced variable is absent (non-strict mode)', () => {
-    // Strict mode would throw MissingTemplateVariableError here; validate must not.
-    expect(() => validateTemplate('{{missing}}')).not.toThrow();
   });
 });

--- a/packages/common-utils/src/core/__tests__/seriesNameTemplate.test.ts
+++ b/packages/common-utils/src/core/__tests__/seriesNameTemplate.test.ts
@@ -1,0 +1,139 @@
+import { clearTemplateCache } from '@/core/handlebarsEnv';
+import {
+  renderSeriesNames,
+  renderSeriesNameTemplate,
+} from '@/core/seriesNameTemplate';
+
+describe('renderSeriesNameTemplate', () => {
+  beforeEach(() => clearTemplateCache());
+
+  it('substitutes label values', () => {
+    expect(
+      renderSeriesNameTemplate(
+        '{{namespace}}/{{pod}}',
+        { namespace: 'prod', pod: 'a-123' },
+        'fallback',
+      ),
+    ).toBe('prod/a-123');
+  });
+
+  it('resolves __name__', () => {
+    expect(
+      renderSeriesNameTemplate(
+        '{{__name__}}',
+        { __name__: 'http_requests_total' },
+        'fallback',
+      ),
+    ).toBe('http_requests_total');
+  });
+
+  it('renders missing labels as empty (non-strict)', () => {
+    expect(
+      renderSeriesNameTemplate(
+        '{{namespace}}/{{missing}}',
+        { namespace: 'prod' },
+        'fallback',
+      ),
+    ).toBe('prod/');
+  });
+
+  it('falls back when the rendered output is blank', () => {
+    expect(renderSeriesNameTemplate('{{missing}}', {}, 'fallback')).toBe(
+      'fallback',
+    );
+    expect(renderSeriesNameTemplate('  {{missing}}  ', {}, 'fallback')).toBe(
+      'fallback',
+    );
+  });
+
+  it('trims the rendered output', () => {
+    expect(
+      renderSeriesNameTemplate('  {{pod}}  ', { pod: 'a-123' }, 'fallback'),
+    ).toBe('a-123');
+  });
+
+  it('falls back on syntax errors, repeatably', () => {
+    expect(
+      renderSeriesNameTemplate('{{unclosed', { pod: 'a' }, 'fallback'),
+    ).toBe('fallback');
+    // Failed compiles are cached; the second call must not throw either.
+    expect(
+      renderSeriesNameTemplate('{{unclosed', { pod: 'a' }, 'fallback'),
+    ).toBe('fallback');
+  });
+
+  it('resolves non-identifier keys via segment literals', () => {
+    expect(
+      renderSeriesNameTemplate(
+        '{{[some-label]}}',
+        { 'some-label': 'value' },
+        'fallback',
+      ),
+    ).toBe('value');
+  });
+
+  it('does not HTML-escape label values', () => {
+    expect(renderSeriesNameTemplate('{{v}}', { v: 'a<b&c' }, 'fallback')).toBe(
+      'a<b&c',
+    );
+  });
+
+  it('supports the default helper', () => {
+    expect(
+      renderSeriesNameTemplate('{{default pod "unknown"}}', {}, 'fallback'),
+    ).toBe('unknown');
+    expect(
+      renderSeriesNameTemplate(
+        '{{default pod "unknown"}}',
+        { pod: 'a-123' },
+        'fallback',
+      ),
+    ).toBe('a-123');
+  });
+
+  it('supports the floor helper', () => {
+    expect(
+      renderSeriesNameTemplate('{{floor n}}', { n: '3.7' }, 'fallback'),
+    ).toBe('3');
+  });
+});
+
+describe('renderSeriesNames', () => {
+  beforeEach(() => clearTemplateCache());
+
+  it('passes unique names through unchanged', () => {
+    expect(
+      renderSeriesNames('{{pod}}', [
+        { labels: { pod: 'a' }, fallback: 'up{pod="a"}' },
+        { labels: { pod: 'b' }, fallback: 'up{pod="b"}' },
+      ]),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('disambiguates every colliding series with its fallback', () => {
+    expect(
+      renderSeriesNames('{{namespace}}', [
+        { labels: { namespace: 'prod', pod: 'a' }, fallback: 'up{pod="a"}' },
+        { labels: { namespace: 'prod', pod: 'b' }, fallback: 'up{pod="b"}' },
+        { labels: { namespace: 'dev', pod: 'c' }, fallback: 'up{pod="c"}' },
+      ]),
+    ).toEqual(['prod (up{pod="a"})', 'prod (up{pod="b"})', 'dev']);
+  });
+
+  it('dedupes per-series fallbacks against successful renders', () => {
+    // Both blank renders fall back; the fallbacks themselves are unique so
+    // they pass through, while matching successful renders still collide.
+    expect(
+      renderSeriesNames('{{missing}}', [
+        { labels: {}, fallback: 'up{pod="a"}' },
+        { labels: {}, fallback: 'up{pod="b"}' },
+      ]),
+    ).toEqual(['up{pod="a"}', 'up{pod="b"}']);
+    expect(
+      renderSeriesNames('{{pod}}', [
+        { labels: { pod: 'up{pod="b"}' }, fallback: 'up{pod="a"}' },
+        { labels: {}, fallback: 'up{pod="b"}' },
+      ]),
+    ).toEqual(['up{pod="b"} (up{pod="a"})', 'up{pod="b"} (up{pod="b"})']);
+  });
+});

--- a/packages/common-utils/src/core/handlebarsEnv.ts
+++ b/packages/common-utils/src/core/handlebarsEnv.ts
@@ -1,0 +1,136 @@
+import Handlebars from 'handlebars';
+
+const hb = Handlebars.create();
+
+// Remove built-in helpers so templates only have access to the custom helpers registered below.
+for (const name of Object.keys(hb.helpers)) {
+  hb.unregisterHelper(name);
+}
+
+/** Thrown when a template calls a helper that isn't registered here. */
+export class UnknownTemplateHelperError extends Error {
+  constructor(public helper: string) {
+    super(`Unknown helper: "${helper}"`);
+    this.name = 'UnknownTemplateHelperError';
+  }
+}
+
+hb.registerHelper('default', (value: unknown, fallback: unknown) => {
+  if (value == null || value === '') return fallback ?? '';
+  return value;
+});
+
+/**
+ * Rounds a number or numeric string down to the nearest integer. Returns an
+ * empty string when the input is null, undefined, or not parseable as a
+ * finite number.
+ */
+hb.registerHelper('floor', (value: unknown): string => {
+  if (value == null || value === '') return '';
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  if (!Number.isFinite(num)) return '';
+  return String(Math.floor(num));
+});
+
+/** Reads the helper name off the trailing options argument Handlebars passes. */
+function helperName(args: unknown[]): string {
+  const options = args.at(-1);
+  if (options != null && typeof options === 'object' && 'name' in options) {
+    const { name } = options;
+    if (typeof name === 'string') return name;
+  }
+  return 'unknown';
+}
+
+// Handlebars passes only the options object for a bare `{{name}}`, which is a
+// context lookup that should render empty, and passes the call's params for
+// `{{name arg}}`, which can only have meant a helper.
+hb.registerHelper('helperMissing', (...args: unknown[]) => {
+  if (args.length === 1) return '';
+  throw new UnknownTemplateHelperError(helperName(args));
+});
+
+hb.registerHelper('blockHelperMissing', (...args: unknown[]) => {
+  throw new UnknownTemplateHelperError(helperName(args));
+});
+
+// The compiler assumes these built-ins exist and emits direct calls to them,
+// which crash on `undefined` now that they're unregistered. Marking them
+// unknown routes `{{#if x}}` through helperMissing/blockHelperMissing instead,
+// so an unsupported helper reports itself by name.
+const KNOWN_HELPERS = {
+  each: false,
+  if: false,
+  unless: false,
+  with: false,
+  log: false,
+  lookup: false,
+};
+
+function parseAndCompile(
+  template: string,
+  strict: boolean,
+): HandlebarsTemplateDelegate {
+  // hb.compile() defers parsing until the first render, which would push
+  // syntax errors out to every render call. Parse up front and hand compile()
+  // the AST instead, so a malformed template fails here, once.
+  // Output is URLs and plain-text legends, so never HTML-escape.
+  return hb.compile(hb.parse(template), {
+    strict,
+    noEscape: true,
+    knownHelpers: KNOWN_HELPERS,
+  });
+}
+
+type CompileResult =
+  | { delegate: HandlebarsTemplateDelegate }
+  | { error: unknown };
+
+const strictCache = new Map<string, CompileResult>();
+const lenientCache = new Map<string, CompileResult>();
+
+function compileCached(
+  cache: Map<string, CompileResult>,
+  template: string,
+  strict: boolean,
+): HandlebarsTemplateDelegate {
+  let result = cache.get(template);
+  if (!result) {
+    try {
+      result = { delegate: parseAndCompile(template, strict) };
+    } catch (error) {
+      result = { error };
+    }
+    cache.set(template, result);
+  }
+  if ('error' in result) throw result.error;
+  return result.delegate;
+}
+
+/**
+ * Compile a template whose render throws if it references a key that isn't in
+ * the context.
+ */
+export function compileStrict(template: string): HandlebarsTemplateDelegate {
+  return compileCached(strictCache, template, true);
+}
+
+/**
+ * Compile a template whose render leaves missing keys empty. Throws on invalid
+ * syntax.
+ */
+export function compileLenient(template: string): HandlebarsTemplateDelegate {
+  return compileCached(lenientCache, template, false);
+}
+
+/** Validates a template for Handlebars syntax errors and unknown helpers, without checking for missing variables (since the context may not be known). */
+export function validateTemplate(template: string) {
+  // Note: We don't cache the compiled template here because the compiled template will not be used outside of this validation.
+  const compiled = parseAndCompile(template, false);
+  compiled({}); // Empty context since we're just checking for syntax errors, not missing variables.
+}
+
+export const clearTemplateCache = () => {
+  strictCache.clear();
+  lenientCache.clear();
+};

--- a/packages/common-utils/src/core/linkTemplate.ts
+++ b/packages/common-utils/src/core/linkTemplate.ts
@@ -1,31 +1,4 @@
-import Handlebars from 'handlebars';
-
-const hb = Handlebars.create();
-
-// Cache compiled templates to avoid the overhead of recompiling on every render.
-const compiledTemplateCache = new Map<string, HandlebarsTemplateDelegate>();
-
-// Remove built-in helpers so templates only have access to the custom helpers registered below.
-for (const name of Object.keys(hb.helpers)) {
-  hb.unregisterHelper(name);
-}
-
-hb.registerHelper('default', (value: unknown, fallback: unknown) => {
-  if (value == null || value === '') return fallback ?? '';
-  return value;
-});
-
-/**
- * Rounds a number or numeric string down to the nearest integer. Returns an
- * empty string when the input is null, undefined, or not parseable as a
- * finite number.
- */
-hb.registerHelper('floor', (value: unknown): string => {
-  if (value == null || value === '') return '';
-  const num = typeof value === 'number' ? value : parseFloat(String(value));
-  if (!Number.isFinite(num)) return '';
-  return String(Math.floor(num));
-});
+import { compileStrict } from '@/core/handlebarsEnv';
 
 export class LinkTemplateError extends Error {
   constructor(message: string) {
@@ -53,18 +26,13 @@ export function renderLinkTemplate(
   template: string,
   ctx: Record<string, unknown>,
 ): string {
-  let compiled = compiledTemplateCache.get(template);
-  if (!compiled) {
-    try {
-      // Strict mode throws when a template references a context key that isn't set.
-      // Don't escape output as HTML since we're rendering URLs, not HTML.
-      compiled = hb.compile(template, { strict: true, noEscape: true });
-      compiledTemplateCache.set(template, compiled);
-    } catch (err) {
-      throw new LinkTemplateError(
-        err instanceof Error ? err.message : String(err),
-      );
-    }
+  let compiled;
+  try {
+    compiled = compileStrict(template);
+  } catch (err) {
+    throw new LinkTemplateError(
+      err instanceof Error ? err.message : String(err),
+    );
   }
   try {
     return compiled(ctx);
@@ -103,15 +71,4 @@ export function renderUrlTemplate(
     encoded[key] = stringifyAndEncode(value);
   }
   return renderLinkTemplate(template, encoded);
-}
-
-export const clearLinkTemplateCache = () => {
-  compiledTemplateCache.clear();
-};
-
-/** Validates a template for Handlebars syntax errors, without checking for missing variables (since the context may not be known). */
-export function validateTemplate(template: string) {
-  // Note: We don't cache the compiled template here because the compiled template will not be used outside of this validation.
-  const compiled = hb.compile(template, { strict: false, noEscape: true });
-  compiled({}); // Empty context since we're just checking for syntax errors, not missing variables.
 }

--- a/packages/common-utils/src/core/linkUrlBuilder.ts
+++ b/packages/common-utils/src/core/linkUrlBuilder.ts
@@ -8,12 +8,12 @@ import type {
   OnClickSearch,
 } from '@/types';
 
+import { validateTemplate } from './handlebarsEnv';
 import {
   LinkTemplateError,
   MissingTemplateVariableError,
   renderLinkTemplate,
   renderUrlTemplate,
-  validateTemplate,
 } from './linkTemplate';
 
 export type LinkBuildResult =

--- a/packages/common-utils/src/core/seriesNameTemplate.ts
+++ b/packages/common-utils/src/core/seriesNameTemplate.ts
@@ -1,0 +1,48 @@
+import { compileLenient } from '@/core/handlebarsEnv';
+
+export interface SeriesNameInput {
+  /** Full Prometheus label set for the series, including __name__. */
+  labels: Record<string, string>;
+  /** Unique, default name used when the template errors, renders blank, or collides. */
+  fallback: string;
+}
+
+/**
+ * Render one series' legend name from a Handlebars template and its
+ * Prometheus label set. Never throws: compile/runtime errors and
+ * blank output fall back to `fallback`.
+ */
+export function renderSeriesNameTemplate(
+  template: string,
+  labels: Record<string, string>,
+  fallback: string,
+): string {
+  try {
+    const rendered = compileLenient(template)(labels).trim();
+    return rendered || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Render legend names for a whole result set. Series whose rendered names
+ * collide are disambiguated by appending their (unique) fallback name, since
+ * downstream chart formatting keys rows by series name and would silently
+ * merge same-named series.
+ */
+export function renderSeriesNames(
+  template: string,
+  series: SeriesNameInput[],
+): string[] {
+  const rendered = series.map(s =>
+    renderSeriesNameTemplate(template, s.labels, s.fallback),
+  );
+  const counts = new Map<string, number>();
+  for (const name of rendered) {
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return rendered.map((name, i) =>
+    (counts.get(name) ?? 0) > 1 ? `${name} (${series.at(i)?.fallback})` : name,
+  );
+}

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1670,6 +1670,8 @@ const RawSqlChartConfigSchema = RawSqlBaseChartConfigSchema.extend({
 
 export type RawSqlChartConfig = z.infer<typeof RawSqlChartConfigSchema>;
 
+export const MAX_LEGEND_TEMPLATE_LENGTH = 1024;
+
 /** Base schema for PromQL chart configs (persisted fields) */
 const PromqlBaseChartConfigSchema = SharedChartSettingsSchema.extend({
   configType: z.literal('promql'),
@@ -1677,6 +1679,7 @@ const PromqlBaseChartConfigSchema = SharedChartSettingsSchema.extend({
   connection: z.string(),
   source: z.string().optional(),
   step: z.string().optional(),
+  legendTemplate: z.string().max(MAX_LEGEND_TEMPLATE_LENGTH).optional(),
 });
 
 /** Schema describing PromQL chart configs with runtime-only fields */


### PR DESCRIPTION
## Summary

This PR introduces a new display setting for promql charts which allows the user to specify a Handlebars template that is used to produce legend and tooltip strings identifying each series.

If the template references missing labels, the reference will be rendered as blank. If the template results in an empty or non-unique string, then the full set of distinguishing labels will be used as the fallback.

### Screenshots or video

This is useful because by default HyperDX shows a legend string that includes all distinguishing labels for each series, which can result in long and difficult to read legends:

<img width="1292" height="424" alt="Screenshot 2026-09-01 at 2 01 17 PM" src="https://github.com/user-attachments/assets/029c19cc-f0ca-49c2-82e7-799b9428fffc" />

Now a user can specify the template, and a friendlier label is generated:

<img width="1286" height="429" alt="Screenshot 2026-09-01 at 2 01 25 PM" src="https://github.com/user-attachments/assets/ce30a67b-1e6c-4b2b-af83-20800f8394fe" />

https://github.com/user-attachments/assets/9e2d4ea4-daa3-48dc-8006-7bb98ea255a6

### How to test locally

1. Setup a PromQL source against the metrics_ts timeseries table locally
2. Create a dashboard, add a tile, and set a legend template

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5172
- Related PRs:
