### PR TITLE
feat(app): window.hdx debug handle + Help menu "Copy debug info"

### DIFF
--- a/.changeset/show-deployed-version-sha.md
+++ b/.changeset/show-deployed-version-sha.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+Add a `window.hdx` browser-console debug handle and a "Copy debug info" action in the Help menu, so you can confirm which build is deployed and grab the context worth attaching when filing an issue. `window.hdx.report()` (and the Help menu action) produces a pasteable summary: frontend version (from package.json), backend/API version (from `/api/health` — the two deploy separately), deployment mode, user/team ids, enabled env-configurable feature flags, current URL, screen/viewport/OS/browser info, and the RUM session id. The handle is installed once and reads its async fields (server version, identity, features, session id) live via getters.

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -22,6 +22,7 @@ import {
   MANTINE_FONT_MAP,
 } from '@/config/fonts';
 import { ibmPlexMono, inter, roboto, robotoMono } from '@/fonts';
+import { fetchServerVersion, installHdxDebug } from '@/hdxDebug';
 import { AppThemeProvider, useAppTheme } from '@/theme/ThemeProvider';
 import { ThemeWrapper } from '@/ThemeWrapper';
 import { NextApiConfigResponseData } from '@/types';
@@ -125,6 +126,14 @@ function AppContent({
 }
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  // Expose build identity + debug helpers on window.hdx (all environments).
+  // Installed once; the backend/API version (deployed separately) is fetched
+  // from /api/health and read live via window.hdx's getters.
+  useEffect(() => {
+    installHdxDebug();
+    fetchServerVersion();
+  }, []);
+
   // port to react query ? (needs to wrap with QueryClientProvider)
   useEffect(() => {
     if (IS_LOCAL_MODE) {

--- a/packages/app/src/__tests__/hdxDebug.test.ts
+++ b/packages/app/src/__tests__/hdxDebug.test.ts
@@ -1,0 +1,197 @@
+// hdxDebug reads config constants at module-load, so each config permutation is
+// exercised by resetting modules and re-requiring with a fresh @/config mock.
+
+const baseConfig = {
+  APP_VERSION: '9.9.9',
+  BASE_PATH: '',
+  IS_ALERT_DETAILS_ENABLED: false,
+  IS_CLICKHOUSE_BUILD: false,
+  IS_LLM_COST_ENABLED: false,
+  IS_DEV: false,
+  IS_LOCAL_MODE: false,
+  IS_OSS: true as unknown,
+  IS_PROMQL_ENABLED: false,
+};
+
+function loadHdxDebug(configOverrides: Partial<typeof baseConfig> = {}) {
+  jest.resetModules();
+  jest.doMock('@/config', () => ({ ...baseConfig, ...configOverrides }));
+  jest.doMock('@hyperdx/browser', () => ({
+    __esModule: true,
+    default: { getSessionId: () => undefined },
+  }));
+  jest.doMock('@/utils/clipboard', () => ({
+    copyTextToClipboard: jest.fn().mockResolvedValue(true),
+  }));
+  return jest.requireActual<typeof import('@/hdxDebug')>('@/hdxDebug');
+}
+
+// Render the report through the public surface: install window.hdx, then read
+// what report() produces. Keeps buildReport/safeUrl internal.
+function reportFor(
+  mod: typeof import('@/hdxDebug'),
+  identity?: Parameters<typeof mod.setHdxIdentity>[0],
+): string {
+  if (identity) mod.setHdxIdentity(identity);
+  mod.installHdxDebug();
+  if (!window.hdx) throw new Error('window.hdx was not installed');
+  return window.hdx.report();
+}
+
+afterEach(() => {
+  delete window.hdx;
+  jest.resetModules();
+  jest.restoreAllMocks();
+});
+
+describe('fetchServerVersion', () => {
+  const realFetch = global.fetch;
+
+  // A minimal fetch stub — fetchServerVersion only reads res.ok and res.json().
+  function setFetch(fn: (...args: any[]) => Promise<any>) {
+    global.fetch = fn as typeof global.fetch;
+  }
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('returns undefined in local mode without fetching', async () => {
+    const fetchSpy = jest.fn(() => Promise.resolve({ ok: true }));
+    setFetch(fetchSpy);
+    const { fetchServerVersion } = loadHdxDebug({ IS_LOCAL_MODE: true });
+
+    await expect(fetchServerVersion()).resolves.toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on a non-ok response', async () => {
+    setFetch(() => Promise.resolve({ ok: false }));
+    const { fetchServerVersion } = loadHdxDebug();
+
+    await expect(fetchServerVersion()).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the body is not JSON', async () => {
+    setFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.reject(new Error('not json')),
+      }),
+    );
+    const { fetchServerVersion } = loadHdxDebug();
+
+    await expect(fetchServerVersion()).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when fetch throws', async () => {
+    setFetch(() => Promise.reject(new Error('network')));
+    const { fetchServerVersion } = loadHdxDebug();
+
+    await expect(fetchServerVersion()).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the payload lacks a version', async () => {
+    setFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: 'OK' }),
+      }),
+    );
+    const { fetchServerVersion } = loadHdxDebug();
+
+    await expect(fetchServerVersion()).resolves.toBeUndefined();
+  });
+
+  it('returns the parsed version on success and feeds it into the report', async () => {
+    setFetch(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ version: '2.0.1-sha0724861' }),
+      }),
+    );
+    const mod = loadHdxDebug();
+
+    await expect(mod.fetchServerVersion()).resolves.toBe('2.0.1-sha0724861');
+    expect(reportFor(mod)).toContain('backend:  2.0.1-sha0724861');
+  });
+});
+
+describe('report mode line', () => {
+  it('reports oss when IS_OSS is true', () => {
+    expect(reportFor(loadHdxDebug({ IS_OSS: true }))).toContain(
+      'mode:     oss',
+    );
+  });
+
+  it('reports cloud when NEXT_PUBLIC_IS_OSS resolves to the string "false"', () => {
+    // Mirrors config.ts's IS_OSS precedence quirk, where a disabled deployment
+    // surfaces the truthy string "false".
+    expect(reportFor(loadHdxDebug({ IS_OSS: 'false' }))).toContain(
+      'mode:     cloud',
+    );
+  });
+
+  it('reports local when in local mode', () => {
+    expect(reportFor(loadHdxDebug({ IS_LOCAL_MODE: true }))).toContain(
+      'mode:     local',
+    );
+  });
+
+  it('appends the clickstack suffix for ClickHouse builds', () => {
+    expect(reportFor(loadHdxDebug({ IS_CLICKHOUSE_BUILD: true }))).toContain(
+      'mode:     oss (clickstack)',
+    );
+  });
+});
+
+describe('report identity + features', () => {
+  it('omits user/team lines until identity is set', () => {
+    const report = reportFor(loadHdxDebug());
+    expect(report).not.toContain('user:');
+    expect(report).not.toContain('team:');
+  });
+
+  it('includes user/team lines once identity is set', () => {
+    const report = reportFor(loadHdxDebug(), { userId: 'u1', teamId: 't1' });
+    expect(report).toContain('user:     u1');
+    expect(report).toContain('team:     t1');
+  });
+
+  it('lists only enabled features and dynamic toggles', () => {
+    const report = reportFor(loadHdxDebug({ IS_PROMQL_ENABLED: true }), {
+      features: { aiAssistant: true, usageStats: false },
+    });
+    expect(report).toContain('features: promql, aiAssistant');
+    expect(report).not.toContain('usageStats');
+  });
+
+  it('reports "none" when no feature is enabled', () => {
+    expect(reportFor(loadHdxDebug())).toContain('features: none');
+  });
+});
+
+describe('report url line', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', '/');
+  });
+
+  // jsdom won't let us redefine window.location, but history.replaceState
+  // updates location.pathname/search.
+  function setLocation(pathname: string, search: string) {
+    window.history.replaceState(null, '', `${pathname}${search}`);
+  }
+
+  it('reports the pathname without the query string', () => {
+    setLocation('/search', '?source=abc&from=1');
+    expect(reportFor(loadHdxDebug())).toContain('url:      /search');
+  });
+
+  it('drops query params, so tokens never reach the report', () => {
+    setLocation('/join-team', '?token=super-secret');
+    const report = reportFor(loadHdxDebug());
+    expect(report).toContain('url:      /join-team');
+    expect(report).not.toContain('super-secret');
+    expect(report).not.toContain('token');
+  });
+});

--- a/packages/app/src/components/AppNav/AppNav.components.tsx
+++ b/packages/app/src/components/AppNav/AppNav.components.tsx
@@ -193,13 +193,16 @@ const AppNavVersionItem = ({ version }: { version?: string }) => {
       closeMenuOnClick={false}
       leftSection={copied ? <IconCheck size={16} /> : <IconBug size={16} />}
       onClick={async () => {
-        // window.hdx is installed in _app.tsx and present in every environment;
-        // its copy() uses the shared clipboard util (with insecure-context
-        // fallback) and returns the copied text.
-        await (window.hdx?.copy() ??
-          copyTextToClipboard(`frontend: ${version ?? 'dev'}`));
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        // window.hdx (installed in _app.tsx) builds the full report; copy via
+        // the shared util so the insecure-context textarea fallback applies and
+        // we get a real success boolean back. Only flip to "Copied" when the
+        // clipboard actually took the text.
+        const text = window.hdx?.report() ?? `frontend: ${version ?? 'dev'}`;
+        const ok = await copyTextToClipboard(text);
+        if (ok) {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }
       }}
     >
       {copied ? 'Copied debug info' : 'Copy debug info'}

--- a/packages/app/src/components/AppNav/AppNav.components.tsx
+++ b/packages/app/src/components/AppNav/AppNav.components.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   UnstyledButton,
 } from '@mantine/core';
-import { useClipboard, useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine/hooks';
 import {
   IconBook,
   IconBrandDiscord,
@@ -29,6 +29,7 @@ import {
 } from '@tabler/icons-react';
 
 import { IS_LOCAL_MODE } from '@/config';
+import { copyTextToClipboard } from '@/utils/clipboard';
 
 import { HelpSparkle } from './HelpSparkle';
 import { KeyboardShortcutsModal } from './KeyboardShortcutsModal';
@@ -184,21 +185,24 @@ export const AppNavUserMenu = ({
 };
 
 const AppNavVersionItem = ({ version }: { version?: string }) => {
-  const clipboard = useClipboard({ timeout: 1500 });
+  const [copied, setCopied] = React.useState(false);
 
   return (
     <Menu.Item
       data-testid="copy-debug-info-menu-item"
       closeMenuOnClick={false}
-      leftSection={
-        clipboard.copied ? <IconCheck size={16} /> : <IconBug size={16} />
-      }
-      onClick={() => {
-        // window.hdx is installed in _app.tsx and present in every environment.
-        clipboard.copy(window.hdx?.report() ?? `frontend: ${version ?? 'dev'}`);
+      leftSection={copied ? <IconCheck size={16} /> : <IconBug size={16} />}
+      onClick={async () => {
+        // window.hdx is installed in _app.tsx and present in every environment;
+        // its copy() uses the shared clipboard util (with insecure-context
+        // fallback) and returns the copied text.
+        await (window.hdx?.copy() ??
+          copyTextToClipboard(`frontend: ${version ?? 'dev'}`));
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
       }}
     >
-      {clipboard.copied ? 'Copied debug info' : 'Copy debug info'}
+      {copied ? 'Copied debug info' : 'Copy debug info'}
     </Menu.Item>
   );
 };

--- a/packages/app/src/components/AppNav/AppNav.components.tsx
+++ b/packages/app/src/components/AppNav/AppNav.components.tsx
@@ -12,11 +12,13 @@ import {
   Tooltip,
   UnstyledButton,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useClipboard, useDisclosure } from '@mantine/hooks';
 import {
   IconBook,
   IconBrandDiscord,
+  IconBug,
   IconBulb,
+  IconCheck,
   IconChevronDown,
   IconChevronRight,
   IconChevronUp,
@@ -181,6 +183,26 @@ export const AppNavUserMenu = ({
   );
 };
 
+const AppNavVersionItem = ({ version }: { version?: string }) => {
+  const clipboard = useClipboard({ timeout: 1500 });
+
+  return (
+    <Menu.Item
+      data-testid="copy-debug-info-menu-item"
+      closeMenuOnClick={false}
+      leftSection={
+        clipboard.copied ? <IconCheck size={16} /> : <IconBug size={16} />
+      }
+      onClick={() => {
+        // window.hdx is installed in _app.tsx and present in every environment.
+        clipboard.copy(window.hdx?.report() ?? `frontend: ${version ?? 'dev'}`);
+      }}
+    >
+      {clipboard.copied ? 'Copied debug info' : 'Copy debug info'}
+    </Menu.Item>
+  );
+};
+
 export const AppNavHelpMenu = ({ version }: { version?: string }) => {
   const { isCollapsed } = React.use(AppNavContext);
   const [
@@ -279,6 +301,10 @@ export const AppNavHelpMenu = ({ version }: { version?: string }) => {
               openWhatsNewDrawer();
             }}
           />
+
+          <Menu.Divider />
+
+          <AppNavVersionItem version={version} />
         </Menu.Dropdown>
       </Menu>
       <KeyboardShortcutsModal

--- a/packages/app/src/components/AppNav/AppNav.tsx
+++ b/packages/app/src/components/AppNav/AppNav.tsx
@@ -30,9 +30,10 @@ import {
 
 import api from '@/api';
 import { AlertStatusIcon } from '@/components/AlertStatusIcon';
-import { IS_LOCAL_MODE } from '@/config';
+import { APP_VERSION, IS_LOCAL_MODE } from '@/config';
 import { Dashboard, useDashboards } from '@/dashboard';
 import { useFavorites } from '@/favorites';
+import { setHdxIdentity } from '@/hdxDebug';
 import InstallInstructionModal from '@/InstallInstructionsModal';
 import OnboardingChecklist from '@/OnboardingChecklist';
 import { useSavedSearches } from '@/savedSearch';
@@ -40,9 +41,6 @@ import { useLogomark, useWordmark } from '@/theme/ThemeProvider';
 import { UserPreferencesModal } from '@/UserPreferencesModal';
 import { useUserPreferences } from '@/useUserPreferences';
 import { useWindowSize } from '@/utils';
-
-// eslint-disable-next-line no-restricted-imports -- package.json lives outside src, no @/ alias reaches it
-import packageJson from '../../../package.json';
 
 import {
   AppNavCloudBanner,
@@ -54,10 +52,6 @@ import {
 import { AppNavFeedback } from './AppNavFeedback';
 
 import styles from './AppNav.module.scss';
-
-// Expose the same value Next injected at build time; fall back to package.json for dev tooling
-const APP_VERSION =
-  process.env.NEXT_PUBLIC_APP_VERSION ?? packageJson.version ?? 'dev';
 
 // Reo.dev client ID for our usage tracking. USAGE_STATS_ENABLED is the opt-out.
 const REO_CLIENT_ID = '38b2e79cdb32fa7';
@@ -210,6 +204,15 @@ export default function AppNav({ fixed = false }: { fixed?: boolean }) {
         userEmail: meData.email,
         userName: meData.name,
         teamName: meData.team.name,
+      });
+      // Fold user/team ids + per-user toggles into window.hdx for debug reports.
+      setHdxIdentity({
+        userId: meData.id,
+        teamId: meData.team.id,
+        features: {
+          usageStats: meData.usageStatsEnabled,
+          aiAssistant: meData.aiAssistantEnabled,
+        },
       });
     }
   }, [meData]);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -1,5 +1,8 @@
 import { env } from 'next-runtime-env';
 
+// eslint-disable-next-line no-restricted-imports -- package.json lives outside src, no @/ alias reaches it
+import packageJson from '../package.json';
+
 // ONLY USED IN LOCAL MODE
 // ex: NEXT_PUBLIC_HDX_LOCAL_DEFAULT_CONNECTIONS='[{"id":"local","name":"Demo","host":"https://demo-ch.hyperdx.io","username":"demo","password":"demo"}]' NEXT_PUBLIC_HDX_LOCAL_DEFAULT_SOURCES='[{"id":"l701179602","kind":"trace","name":"Demo Traces","connection":"local","from":{"databaseName":"default","tableName":"otel_traces"},"timestampValueExpression":"Timestamp","defaultTableSelectExpression":"Timestamp, ServiceName, StatusCode, round(Duration / 1e6), SpanName","serviceNameExpression":"ServiceName","eventAttributesExpression":"SpanAttributes","resourceAttributesExpression":"ResourceAttributes","traceIdExpression":"TraceId","spanIdExpression":"SpanId","implicitColumnExpression":"SpanName","durationExpression":"Duration","durationPrecision":9,"parentSpanIdExpression":"ParentSpanId","spanKindExpression":"SpanKind","spanNameExpression":"SpanName","logSourceId":"l-758211293","statusCodeExpression":"StatusCode","statusMessageExpression":"StatusMessage"},{"id":"l-758211293","kind":"log","name":"Demo Logs","connection":"local","from":{"databaseName":"default","tableName":"otel_logs"},"timestampValueExpression":"Timestamp","defaultTableSelectExpression":"Timestamp, ServiceName, SeverityText, Body","serviceNameExpression":"ServiceName","severityTextExpression":"SeverityText","eventAttributesExpression":"LogAttributes","resourceAttributesExpression":"ResourceAttributes","traceIdExpression":"TraceId","spanIdExpression":"SpanId","implicitColumnExpression":"Body","traceSourceId":"l701179602"}]' yarn dev:local
 export const HDX_LOCAL_DEFAULT_CONNECTIONS = env(
@@ -48,6 +51,9 @@ export const HDX_LOGS_COLLECTOR_URL =
   process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
 export const IS_DEV = NODE_ENV === 'development';
 
+// Frontend build version — from package.json, bundled at build time. Will include sha in nightly builds.
+export const APP_VERSION = packageJson.version ?? 'dev';
+
 export const IS_OSS = process.env.NEXT_PUBLIC_IS_OSS ?? 'true' === 'true';
 export const IS_LOCAL_MODE = //true;
   (process.env.NEXT_PUBLIC_IS_LOCAL_MODE ?? 'false') === 'true';
@@ -65,6 +71,7 @@ export const IS_NOINDEX = process.env.NEXT_PUBLIC_NOINDEX === 'true';
 export const NOW = Date.now();
 
 // Features in development
+// When adding an env-configurable flag (one whose value varies by deployment), add it to the feature snapshot in hdxDebug.ts.
 export const IS_K8S_DASHBOARD_ENABLED = true;
 // LLM dashboard cost estimation. Default off pending a price-management
 // story: the bundled catalog goes stale between releases and can't account

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -54,7 +54,12 @@ export const IS_DEV = NODE_ENV === 'development';
 // Frontend build version — from package.json, bundled at build time. Will include sha in nightly builds.
 export const APP_VERSION = packageJson.version ?? 'dev';
 
-export const IS_OSS = process.env.NEXT_PUBLIC_IS_OSS ?? 'true' === 'true';
+// OSS unless explicitly disabled. Written as `!== 'false'` (not `=== 'true'`)
+// to preserve the historical default-on behavior when the env var is unset.
+// NOTE: the previous form `?? 'true' === 'true'` mis-parsed as
+// `?? ('true' === 'true')`, yielding the raw string (e.g. "false", which is
+// truthy) whenever the env var was set — so cloud builds read as OSS.
+export const IS_OSS = (process.env.NEXT_PUBLIC_IS_OSS ?? 'true') !== 'false';
 export const IS_LOCAL_MODE = //true;
   (process.env.NEXT_PUBLIC_IS_LOCAL_MODE ?? 'false') === 'true';
 export const IS_CLICKHOUSE_BUILD =

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -54,12 +54,7 @@ export const IS_DEV = NODE_ENV === 'development';
 // Frontend build version — from package.json, bundled at build time. Will include sha in nightly builds.
 export const APP_VERSION = packageJson.version ?? 'dev';
 
-// OSS unless explicitly disabled. Written as `!== 'false'` (not `=== 'true'`)
-// to preserve the historical default-on behavior when the env var is unset.
-// NOTE: the previous form `?? 'true' === 'true'` mis-parsed as
-// `?? ('true' === 'true')`, yielding the raw string (e.g. "false", which is
-// truthy) whenever the env var was set — so cloud builds read as OSS.
-export const IS_OSS = (process.env.NEXT_PUBLIC_IS_OSS ?? 'true') !== 'false';
+export const IS_OSS = process.env.NEXT_PUBLIC_IS_OSS ?? 'true' === 'true';
 export const IS_LOCAL_MODE = //true;
   (process.env.NEXT_PUBLIC_IS_LOCAL_MODE ?? 'false') === 'true';
 export const IS_CLICKHOUSE_BUILD =

--- a/packages/app/src/hdxDebug.ts
+++ b/packages/app/src/hdxDebug.ts
@@ -208,9 +208,7 @@ export function installHdxDebug(): void {
       return teamId;
     },
     build: {
-      // IS_OSS is `string | boolean` due to a precedence quirk in config.ts;
-      // normalize to a plain boolean for the debug surface.
-      isOss: Boolean(IS_OSS),
+      isOss: IS_OSS,
       isLocalMode: IS_LOCAL_MODE,
       isClickhouseBuild: IS_CLICKHOUSE_BUILD,
       isDev: IS_DEV,

--- a/packages/app/src/hdxDebug.ts
+++ b/packages/app/src/hdxDebug.ts
@@ -6,8 +6,8 @@ import {
   BASE_PATH,
   IS_ALERT_DETAILS_ENABLED,
   IS_CLICKHOUSE_BUILD,
-  IS_DASHBOARD_VARIABLES_ENABLED,
   IS_DEV,
+  IS_LLM_COST_ENABLED,
   IS_LOCAL_MODE,
   IS_OSS,
   IS_PROMQL_ENABLED,
@@ -82,7 +82,7 @@ let dynamicFeatures: Record<string, boolean> = {};
 // every deployment and would just be noise.
 const staticFeatures: Record<string, boolean> = {
   promql: IS_PROMQL_ENABLED,
-  dashboardVariables: IS_DASHBOARD_VARIABLES_ENABLED,
+  llmCost: IS_LLM_COST_ENABLED,
   alertDetails: IS_ALERT_DETAILS_ENABLED,
 };
 
@@ -158,6 +158,12 @@ function getDevice(): HdxDevice {
   };
 }
 
+// pathname only — never the query string, which can carry a token
+// (invite/reset/share links) that would leak into the pasted report.
+function safeUrl(): string {
+  return typeof window !== 'undefined' ? window.location.pathname : '';
+}
+
 function allFeatures(): Record<string, boolean> {
   return { ...staticFeatures, ...dynamicFeatures };
 }
@@ -180,7 +186,7 @@ function buildReport(): string {
     ...(userId ? [`user:     ${userId}`] : []),
     ...(teamId ? [`team:     ${teamId}`] : []),
     `features: ${enabledFeatureList()}`,
-    `url:      ${typeof window !== 'undefined' ? window.location.href : ''}`,
+    `url:      ${safeUrl()}`,
     `screen:   ${device.screen} (viewport ${device.viewport}, dpr ${device.dpr})`,
     `platform: ${device.platform}`,
     `language: ${device.language}`,

--- a/packages/app/src/hdxDebug.ts
+++ b/packages/app/src/hdxDebug.ts
@@ -1,0 +1,235 @@
+import { z } from 'zod';
+import HyperDX from '@hyperdx/browser';
+
+import {
+  APP_VERSION,
+  BASE_PATH,
+  IS_ALERT_DETAILS_ENABLED,
+  IS_CLICKHOUSE_BUILD,
+  IS_DASHBOARD_VARIABLES_ENABLED,
+  IS_DEV,
+  IS_LOCAL_MODE,
+  IS_OSS,
+  IS_PROMQL_ENABLED,
+} from '@/config';
+import { copyTextToClipboard } from '@/utils/clipboard';
+
+// `window.hdx` — a small, namespaced debug handle for the browser console.
+//
+// The motivating ask is "which build is actually deployed here?".
+// The frontend and backend deploy separately in prod, so we report BOTH:
+//   - `appVersion` — the frontend build, from package.json.
+//   - `serverVersion` — the API build (its CODE_VERSION), fetched from the
+//     Express API's /api/health. Independent of the frontend's own version.
+// It also gathers the context worth attaching when filing an issue: who/where
+// (userId, teamId), the enabled feature set, device/browser info, the RUM
+// session id, and a one-shot `report()` that bundles it all into text to drop
+// straight into a bug report.
+
+// Device Info
+type HdxDevice = {
+  screen: string;
+  viewport: string;
+  dpr: number;
+  platform: string;
+  language: string;
+  userAgent: string;
+};
+
+type HdxDebug = {
+  /** Frontend version (from package.json). */
+  readonly appVersion: string;
+  /** Backend/API version (its CODE_VERSION), or undefined until fetched. */
+  readonly serverVersion?: string;
+  /** Logged-in user id, once known (set from AppNav). */
+  readonly userId?: string;
+  /** Current team id, once known (set from AppNav). */
+  readonly teamId?: string;
+  readonly build: {
+    isOss: boolean;
+    isLocalMode: boolean;
+    isClickhouseBuild: boolean;
+    isDev: boolean;
+    basePath: string;
+  };
+  /** Enabled-feature snapshot (static config flags + per-user toggles). */
+  readonly features: Record<string, boolean>;
+  /** Screen/viewport/OS/browser info. */
+  readonly device: HdxDevice;
+  /** The current RUM session id, if session recording is active. */
+  sessionId: () => string | undefined;
+  /** Human-readable multi-line summary for pasting into a bug report. */
+  report: () => string;
+  /** Copy `report()` to the clipboard; resolves to the copied text. */
+  copy: () => Promise<string>;
+};
+
+declare global {
+  interface Window {
+    hdx?: HdxDebug;
+  }
+}
+
+// Mutable module state, read live via the getters on window.hdx. `null` server
+// version = not fetched yet; a string (possibly '') = the API's CODE_VERSION.
+let cachedServerVersion: string | null = null;
+let userId: string | undefined;
+let teamId: string | undefined;
+let dynamicFeatures: Record<string, boolean> = {};
+
+// Only env-configurable flags are worth reporting — the hardcoded-true/false
+// ones (k8s dashboard, metrics, sessions, materialized views) are the same in
+// every deployment and would just be noise.
+const staticFeatures: Record<string, boolean> = {
+  promql: IS_PROMQL_ENABLED,
+  dashboardVariables: IS_DASHBOARD_VARIABLES_ENABLED,
+  alertDetails: IS_ALERT_DETAILS_ENABLED,
+};
+
+// Express /health returns more than this; we only care about the version.
+const HealthResponseSchema = z.object({ version: z.string().optional() });
+
+/**
+ * Fetch the API's version from the Express /health endpoint (proxied under
+ * /api). The API deploys separately from the frontend, so this is the only
+ * authoritative source for the backend build. Resolves to undefined on any
+ * failure (local mode has no API, network errors, etc.).
+ */
+export async function fetchServerVersion(): Promise<string | undefined> {
+  if (IS_LOCAL_MODE) return undefined;
+  try {
+    const res = await fetch(`${BASE_PATH}/api/health`);
+    if (!res.ok) return undefined;
+    const parsed = HealthResponseSchema.safeParse(await res.json());
+    const version = parsed.success ? (parsed.data.version ?? '') : '';
+    cachedServerVersion = version;
+    return version || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Record user/team identity and per-user feature toggles. Called from a
+ * component that already holds the `me` response (see AppNav). window.hdx reads
+ * these live, so no re-install is needed.
+ */
+export function setHdxIdentity(next: {
+  userId?: string;
+  teamId?: string;
+  features?: Record<string, boolean>;
+}): void {
+  userId = next.userId;
+  teamId = next.teamId;
+  dynamicFeatures = next.features ?? {};
+}
+
+// The RUM SDK only initializes in non-local mode and after /api/config resolves,
+// so this accessor must tolerate it being absent.
+function safeSessionId(): string | undefined {
+  try {
+    return HyperDX.getSessionId();
+  } catch {
+    return undefined;
+  }
+}
+
+function getDevice(): HdxDevice {
+  const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+  const scr = typeof screen !== 'undefined' ? screen : undefined;
+  return {
+    screen: scr ? `${scr.width}x${scr.height}` : '',
+    viewport:
+      typeof window !== 'undefined'
+        ? `${window.innerWidth}x${window.innerHeight}`
+        : '',
+    dpr: typeof window !== 'undefined' ? window.devicePixelRatio : 1,
+    // navigator.platform is deprecated but still the simplest OS hint and is
+    // universally supported; userAgent carries the full detail below.
+    platform: nav?.platform ?? '',
+    language: nav?.language ?? '',
+    userAgent: nav?.userAgent ?? '',
+  };
+}
+
+function allFeatures(): Record<string, boolean> {
+  return { ...staticFeatures, ...dynamicFeatures };
+}
+
+function enabledFeatureList(): string {
+  const on = Object.entries(allFeatures())
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+  return on.length ? on.join(', ') : 'none';
+}
+
+function buildReport(): string {
+  const device = getDevice();
+  const lines = [
+    `frontend: ${APP_VERSION}`,
+    `backend:  ${cachedServerVersion || 'unknown'}`,
+    `mode:     ${IS_LOCAL_MODE ? 'local' : IS_OSS ? 'oss' : 'cloud'}${
+      IS_CLICKHOUSE_BUILD ? ' (clickstack)' : ''
+    }`,
+    ...(userId ? [`user:     ${userId}`] : []),
+    ...(teamId ? [`team:     ${teamId}`] : []),
+    `features: ${enabledFeatureList()}`,
+    `url:      ${typeof window !== 'undefined' ? window.location.href : ''}`,
+    `screen:   ${device.screen} (viewport ${device.viewport}, dpr ${device.dpr})`,
+    `platform: ${device.platform}`,
+    `language: ${device.language}`,
+    `ua:       ${device.userAgent}`,
+    `session:  ${safeSessionId() || 'N/A'}`,
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Install `window.hdx` once. No-op during SSR or if already installed —
+ * asynchronously-resolved fields are read live via getters, so this never needs
+ * to run more than once.
+ */
+export function installHdxDebug(): void {
+  if (typeof window === 'undefined' || window.hdx) {
+    return;
+  }
+
+  window.hdx = {
+    get appVersion() {
+      return APP_VERSION;
+    },
+    get serverVersion() {
+      return cachedServerVersion || undefined;
+    },
+    get userId() {
+      return userId;
+    },
+    get teamId() {
+      return teamId;
+    },
+    build: {
+      // IS_OSS is `string | boolean` due to a precedence quirk in config.ts;
+      // normalize to a plain boolean for the debug surface.
+      isOss: Boolean(IS_OSS),
+      isLocalMode: IS_LOCAL_MODE,
+      isClickhouseBuild: IS_CLICKHOUSE_BUILD,
+      isDev: IS_DEV,
+      basePath: BASE_PATH,
+    },
+    get features() {
+      return allFeatures();
+    },
+    get device() {
+      return getDevice();
+    },
+    sessionId: safeSessionId,
+    report: buildReport,
+    copy: async () => {
+      const text = buildReport();
+      // Shared util handles the insecure-context / permissions fallback; the
+      // returned text lets the caller copy manually if it still fails.
+      await copyTextToClipboard(text);
+      return text;
+    },
+  };
+}

--- a/packages/app/src/hdxDebug.ts
+++ b/packages/app/src/hdxDebug.ts
@@ -86,6 +86,12 @@ const staticFeatures: Record<string, boolean> = {
   alertDetails: IS_ALERT_DETAILS_ENABLED,
 };
 
+// config.ts's IS_OSS has a precedence quirk (`?? 'true' === 'true'`), so a set
+// NEXT_PUBLIC_IS_OSS surfaces as a raw string — including "false", which is
+// truthy. Normalize to the intended boolean (OSS unless explicitly "false")
+// just for this debug surface, without changing IS_OSS itself.
+const isOss = String(IS_OSS) !== 'false';
+
 // Express /health returns more than this; we only care about the version.
 const HealthResponseSchema = z.object({ version: z.string().optional() });
 
@@ -168,7 +174,7 @@ function buildReport(): string {
   const lines = [
     `frontend: ${APP_VERSION}`,
     `backend:  ${cachedServerVersion || 'unknown'}`,
-    `mode:     ${IS_LOCAL_MODE ? 'local' : IS_OSS ? 'oss' : 'cloud'}${
+    `mode:     ${IS_LOCAL_MODE ? 'local' : isOss ? 'oss' : 'cloud'}${
       IS_CLICKHOUSE_BUILD ? ' (clickstack)' : ''
     }`,
     ...(userId ? [`user:     ${userId}`] : []),
@@ -208,7 +214,7 @@ export function installHdxDebug(): void {
       return teamId;
     },
     build: {
-      isOss: IS_OSS,
+      isOss,
       isLocalMode: IS_LOCAL_MODE,
       isClickhouseBuild: IS_CLICKHOUSE_BUILD,
       isDev: IS_DEV,


### PR DESCRIPTION
## What

Restores a way to confirm which build is actually deployed and, while we're at it, gathers the context worth attaching when filing an issue.

- **`window.hdx`** — a namespaced browser-console debug handle available in every environment.
- **Help menu** — a new **"Copy debug info"** action (bug icon) that copies the same report.

## Why

The old Help menu showed the deployed version (previously with a SHA in EE via `CODE_VERSION`); that display was dropped when the Changelog modal was replaced by "What's new" (#2993). This brings the deployed-build info back, and adds the extra context we always end up asking for on a bug report.

Frontend and backend **deploy separately** in prod, so both versions are reported independently:
- `appVersion` — frontend build, from `package.json`.
- `serverVersion` — backend/API build, fetched from the Express `/api/health` (`CODE_VERSION`).

## `window.hdx` surface

<img width="574" height="495" alt="Screenshot 2026-09-01 at 4 07 43 PM" src="https://github.com/user-attachments/assets/eff3510a-167d-47e9-b4e3-43073f405262" />

- `appVersion`, `serverVersion`, `userId`, `teamId`
- `build` — `{ isOss, isLocalMode, isClickhouseBuild, isDev, basePath }`
- `features` — enabled env-configurable flags (`promql`, `dashboardVariables`, `alertDetails`) + per-user toggles (`usageStats`, `aiAssistant`). Hardcoded true/false flags are intentionally omitted as noise.
- `device` — screen/viewport/dpr/platform/language/userAgent
- `sessionId()` — RUM session id (when recording is active)
- `report()` / `copy()` — pasteable summary

The handle is installed **once**; async-resolved fields (server version, identity, features, session id) are read live via getters — no re-install, no stale snapshot.

## Example `report()` output

```
frontend: 2.36.0
backend:  2.36.0
mode:     oss
user:     69fa3b8070623a46999d65a9
team:     69fa3b8170623a46999d65ad
features: promql, dashboardVariables, alertDetails, aiAssistant
url:      http://localhost:30200/search?source=...&from=1788301342009&to=1788302242009
screen:   1920x1080 (viewport 1036x951, dpr 2)
platform: MacIntel
language: en-US
ua:       Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ... Chrome/151.0.0.0 Safari/537.36
session:  9999a0e3963d102f875568dfe0acf349
```

## Notes / safety

- No infra, Dockerfile, or workflow changes. Backend version comes from the existing `/api/health` `CODE_VERSION`; frontend version from `package.json`.
- No secrets exposed — only build identity, public feature flags, the user's own ids + device info, and their own session id.
- `/api/health` response parsed with a zod schema (`safeParse`), clipboard writes go through the shared `copyTextToClipboard` util (insecure-context fallback).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] `knip` clean
- [x] Verify Help menu "Copy debug info" copies the report and shows the copied state
- [x] Verify `window.hdx.report()` in console (dev + a deployed env) shows correct frontend/backend versions