### PR TITLE
feat: Support static custom value filters in MCP

### DIFF
--- a/.changeset/good-buttons-eat.md
+++ b/.changeset/good-buttons-eat.md
@@ -1,0 +1,7 @@
+---
+"@hyperdx/api": patch
+"@hyperdx/app": patch
+"@hyperdx/common-utils": patch
+---
+
+feat: Support static filters in MCP

--- a/packages/api/src/mcp/__tests__/dashboards/getDashboard.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/getDashboard.int.test.ts
@@ -53,6 +53,39 @@ describe('MCP Dashboard Tools - clickstack_get_dashboard', () => {
     expect(output.tiles).toEqual([]);
   });
 
+  it('returns a static list filter saved outside MCP, with a derived variable name', async () => {
+    // Seeded directly through the model, i.e. as the UI/REST API persists it,
+    // to prove readability does not depend on the MCP save path.
+    const dashboard = await new Dashboard({
+      name: 'Static filter dashboard',
+      tiles: [],
+      team: ctx.team._id,
+      filters: [
+        {
+          id: 'static-1',
+          type: 'STATIC_LIST',
+          name: 'Deploy Env',
+          options: ['prod', 'staging'],
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+        },
+      ],
+    }).save();
+
+    const result = await callTool(ctx.client!, 'clickstack_get_dashboard', {
+      id: dashboard._id.toString(),
+    });
+
+    expect(result.isError).toBeFalsy();
+    const output = JSON.parse(getFirstText(result));
+    expect(output.filters[0]).toMatchObject({
+      id: 'static-1',
+      type: 'STATIC_LIST',
+      options: ['prod', 'staging'],
+      variableName: 'Deploy_Env',
+    });
+  });
+
   it('should return error for non-existent dashboard id', async () => {
     const fakeId = '000000000000000000000000';
     const result = await callTool(ctx.client!, 'clickstack_get_dashboard', {

--- a/packages/api/src/mcp/__tests__/dashboards/patchDashboard.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/patchDashboard.int.test.ts
@@ -1016,6 +1016,84 @@ describe('MCP Dashboard Tools - clickstack_patch_dashboard', () => {
       const output = JSON.parse(getFirstText(patchResult));
       expect(output.warnings).toBeUndefined();
     });
+
+    it('resolves variables declared by a static list filter', async () => {
+      const sourceId = ctx.traceSource._id.toString();
+      const connectionId = ctx.connection._id.toString();
+      const createResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        {
+          name: 'Patch static variable',
+          tiles: [
+            {
+              name: 'Builder Tile',
+              config: {
+                displayType: 'number',
+                sourceId,
+                select: [{ aggFn: 'count' }],
+              },
+            },
+          ],
+          filters: [
+            {
+              type: 'STATIC_LIST',
+              name: 'Environment',
+              options: ['prod', 'staging'],
+              variableName: 'env',
+            },
+          ],
+        },
+      );
+      expect(createResult.isError).toBeFalsy();
+      const created = JSON.parse(getFirstText(createResult));
+
+      const declaredResult = await callTool(
+        ctx.client!,
+        'clickstack_patch_dashboard',
+        {
+          dashboardId: created.id,
+          tileId: created.tiles[0].id,
+          tile: {
+            name: 'Errors',
+            config: {
+              configType: 'sql',
+              displayType: 'table',
+              connectionId,
+              sourceId,
+              sqlTemplate: macroSql('env'),
+            },
+          },
+        },
+      );
+      expect(declaredResult.isError).toBeFalsy();
+      const declared = JSON.parse(getFirstText(declaredResult));
+      expect(declared.warnings).toBeUndefined();
+
+      const unknownResult = await callTool(
+        ctx.client!,
+        'clickstack_patch_dashboard',
+        {
+          dashboardId: created.id,
+          tileId: created.tiles[0].id,
+          tile: {
+            name: 'Errors',
+            config: {
+              configType: 'sql',
+              displayType: 'table',
+              connectionId,
+              sourceId,
+              sqlTemplate: macroSql('tenant'),
+            },
+          },
+        },
+      );
+      expect(unknownResult.isError).toBeFalsy();
+      const unknown = JSON.parse(getFirstText(unknownResult));
+      const warnings: string[] = unknown.warnings ?? [];
+      expect(warnings.join('\n')).toContain("unknown variable 'tenant'");
+      expect(warnings.join('\n')).toContain('Available variables: env');
+    });
   });
 
   // Patches replace a single tile without going through the save_dashboard

--- a/packages/api/src/mcp/__tests__/dashboards/queryTile.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/queryTile.int.test.ts
@@ -1023,6 +1023,105 @@ describe('MCP Dashboard Tools - clickstack_query_tile', () => {
       expect(result.isError).toBe(true);
       expect(getFirstText(result)).toContain('Available variables: service');
     });
+
+    describe('static list filters', () => {
+      const staticSqlTile = () => ({
+        name: 'Rows by service (static)',
+        config: {
+          configType: 'sql',
+          displayType: 'table',
+          connectionId: ctx.connection._id.toString(),
+          sourceId: logSourceId,
+          sqlTemplate:
+            'SELECT ServiceName, count() AS c FROM $__sourceTable ' +
+            'WHERE $__timeFilter(Timestamp) AND $__filter(ServiceName, $svc) ' +
+            'GROUP BY ServiceName ORDER BY ServiceName LIMIT 10',
+        },
+      });
+
+      const saveStaticDashboard = async () => {
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Static variable tiles',
+            tiles: [staticSqlTile()],
+            filters: [
+              {
+                type: 'STATIC_LIST',
+                name: 'Service',
+                options: ['checkout', 'payments', 'ghost'],
+                variableName: 'svc',
+              },
+            ],
+          },
+        );
+        expect(result.isError).toBeFalsy();
+        return JSON.parse(getFirstText(result));
+      };
+
+      it('narrows a tile when variableValues selects a static option', async () => {
+        const dashboard = await saveStaticDashboard();
+
+        const unselected = await callTool(
+          ctx.client!,
+          'clickstack_query_tile',
+          {
+            dashboardId: dashboard.id,
+            tileId: dashboard.tiles[0].id,
+            startTime,
+            endTime,
+          },
+        );
+        expect(unselected.isError).toBeFalsy();
+        expect(rowsOf(getFirstText(unselected))).toHaveLength(2);
+
+        const selected = await callTool(ctx.client!, 'clickstack_query_tile', {
+          dashboardId: dashboard.id,
+          tileId: dashboard.tiles[0].id,
+          startTime,
+          endTime,
+          variableValues: [{ name: 'svc', values: ['checkout'] }],
+        });
+        expect(selected.isError).toBeFalsy();
+        const rows = rowsOf(getFirstText(selected));
+        expect(rows).toHaveLength(1);
+        expect(rows[0].ServiceName).toBe('checkout');
+      });
+
+      it('treats an empty selection as nothing selected', async () => {
+        const dashboard = await saveStaticDashboard();
+
+        const result = await callTool(ctx.client!, 'clickstack_query_tile', {
+          dashboardId: dashboard.id,
+          tileId: dashboard.tiles[0].id,
+          startTime,
+          endTime,
+          variableValues: [{ name: 'svc', values: [] }],
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(rowsOf(getFirstText(result))).toHaveLength(2);
+      });
+
+      it('rejects a value outside the declared options', async () => {
+        const dashboard = await saveStaticDashboard();
+
+        const result = await callTool(ctx.client!, 'clickstack_query_tile', {
+          dashboardId: dashboard.id,
+          tileId: dashboard.tiles[0].id,
+          startTime,
+          endTime,
+          variableValues: [{ name: 'svc', values: ['not-a-service'] }],
+        });
+
+        expect(result.isError).toBe(true);
+        const text = getFirstText(result);
+        expect(text).toContain('"svc"');
+        expect(text).toContain('"not-a-service"');
+        expect(text).toContain('checkout, payments, ghost');
+      });
+    });
   });
 
   describe('categorical (bar) tile series limit', () => {

--- a/packages/api/src/mcp/__tests__/dashboards/queryTiles.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/queryTiles.int.test.ts
@@ -550,5 +550,48 @@ describe('MCP Dashboard Tools - clickstack_query_tiles', () => {
       expect(result.isError).toBe(true);
       expect(getFirstText(result)).toContain('Available variables: (none)');
     });
+
+    it('rejects a value outside a static filter options', async () => {
+      const sourceId = ctx.traceSource._id.toString();
+      const createResult = await callTool(
+        ctx.client!,
+        'clickstack_save_dashboard',
+        {
+          name: 'Batch static filter test',
+          tiles: [
+            {
+              name: 'Count',
+              config: {
+                displayType: 'number',
+                sourceId,
+                select: [{ aggFn: 'count' }],
+              },
+            },
+          ],
+          filters: [
+            {
+              type: 'STATIC_LIST',
+              name: 'Environment',
+              options: ['prod', 'staging'],
+              variableName: 'env',
+            },
+          ],
+        },
+      );
+      expect(createResult.isError).toBeFalsy();
+      const dashboard = JSON.parse(getFirstText(createResult));
+
+      const result = await callTool(ctx.client!, 'clickstack_query_tiles', {
+        dashboardId: dashboard.id,
+        ...wideRange(),
+        variableValues: [{ name: 'env', values: ['dev'] }],
+      });
+
+      expect(result.isError).toBe(true);
+      const text = getFirstText(result);
+      expect(text).toContain('"env"');
+      expect(text).toContain('"dev"');
+      expect(text).toContain('prod, staging');
+    });
   });
 });

--- a/packages/api/src/mcp/__tests__/dashboards/saveDashboard.int.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/saveDashboard.int.test.ts
@@ -2571,6 +2571,266 @@ describe('MCP Dashboard Tools - clickstack_save_dashboard', () => {
       });
     });
 
+    describe('static list filters', () => {
+      const staticFilter = (overrides: Record<string, unknown> = {}) => ({
+        type: 'STATIC_LIST' as const,
+        name: 'Environment',
+        options: ['prod', 'staging', 'dev'],
+        variableName: 'env',
+        ...overrides,
+      });
+
+      it('round-trips a static filter through create, get, and save', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+
+        // Mode flags deliberately omitted: they default server-side.
+        const createResult = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Static filter round-trip',
+            tiles: [traceTile(sourceId)],
+            filters: [staticFilter()],
+          },
+        );
+        expect(createResult.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(createResult));
+        expect(created.filters[0]).toMatchObject({
+          type: 'STATIC_LIST',
+          options: ['prod', 'staging', 'dev'],
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'env',
+        });
+        expect(created.filters[0].id).toBeDefined();
+
+        const getResult = await callTool(
+          ctx.client!,
+          'clickstack_get_dashboard',
+          { id: created.id },
+        );
+        const fetched = JSON.parse(getFirstText(getResult));
+        expect(fetched.filters[0]).toMatchObject({
+          type: 'STATIC_LIST',
+          options: ['prod', 'staging', 'dev'],
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+          variableName: 'env',
+        });
+
+        // Feed the get response straight back in — this is the round-trip
+        // that a QUERY_EXPRESSION-only filter schema rejected.
+        const updateResult = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            id: created.id,
+            name: fetched.name,
+            tiles: [traceTile(sourceId)],
+            filters: fetched.filters,
+          },
+        );
+        expect(updateResult.isError).toBeFalsy();
+        const updated = JSON.parse(getFirstText(updateResult));
+        expect(updated.filters[0]).toMatchObject({
+          id: fetched.filters[0].id,
+          type: 'STATIC_LIST',
+          options: ['prod', 'staging', 'dev'],
+        });
+      });
+
+      it('derives the variable name from the display name when omitted', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Static derived variable name',
+            tiles: [traceTile(sourceId)],
+            filters: [
+              staticFilter({ name: 'Deploy Env', variableName: undefined }),
+            ],
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(result));
+        expect(created.filters[0].variableName).toBe('Deploy_Env');
+      });
+
+      it('ignores mode flags passed on a static filter', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Broadcasting static filter',
+            tiles: [traceTile(sourceId)],
+            filters: [
+              staticFilter({
+                isBroadcastEnabled: true,
+                isVariableEnabled: false,
+              }),
+            ],
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(result));
+        expect(created.filters[0]).toMatchObject({
+          isBroadcastEnabled: false,
+          isVariableEnabled: true,
+        });
+      });
+
+      it('rejects empty options', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Empty options',
+            tiles: [traceTile(sourceId)],
+            filters: [staticFilter({ options: [] })],
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain('options');
+      });
+
+      it('rejects duplicate options', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Duplicate options',
+            tiles: [traceTile(sourceId)],
+            filters: [staticFilter({ options: ['prod', 'prod'] })],
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain(
+          'repeats the option "prod"; options must be unique',
+        );
+      });
+
+      it('rejects a static and a query filter claiming the same variable name', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Cross-type duplicate variable names',
+            tiles: [traceTile(sourceId)],
+            filters: [
+              staticFilter(),
+              {
+                type: 'QUERY_EXPRESSION',
+                name: 'Environment (queried)',
+                expression: "ResourceAttributes['env']",
+                sourceId,
+                whereLanguage: 'sql',
+                isBroadcastEnabled: false,
+                isVariableEnabled: true,
+                variableName: 'env',
+              },
+            ],
+          },
+        );
+
+        expect(result.isError).toBe(true);
+        expect(getFirstText(result)).toContain(
+          'Variable names must be unique: "env"',
+        );
+      });
+
+      it('strips stray query-expression fields from a static filter', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        // The MCP members are non-strict like every other schema in the
+        // file, so a stray field is dropped rather than rejected.
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Static filter with stray fields',
+            tiles: [traceTile(sourceId)],
+            filters: [staticFilter({ expression: 'ServiceName', sourceId })],
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(result));
+        expect(created.filters[0].expression).toBeUndefined();
+        expect(created.filters[0].sourceId).toBeUndefined();
+      });
+
+      it('does not warn about a tile referencing the static variable', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Tile references static variable',
+            tiles: [
+              {
+                name: 'Per-env count',
+                x: 0,
+                y: 0,
+                w: 6,
+                h: 3,
+                config: {
+                  displayType: 'line' as const,
+                  sourceId,
+                  select: [
+                    {
+                      aggFn: 'count' as const,
+                      where: "$__filter(ResourceAttributes['env'], $env)",
+                      whereLanguage: 'sql' as const,
+                    },
+                  ],
+                },
+              },
+            ],
+            filters: [staticFilter()],
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(result));
+        expect(created.warnings ?? []).toEqual([]);
+      });
+
+      it('accepts a dependent filter chaining off a static variable', async () => {
+        const sourceId = ctx.traceSource._id.toString();
+        const result = await callTool(
+          ctx.client!,
+          'clickstack_save_dashboard',
+          {
+            name: 'Dependent filter on static variable',
+            tiles: [traceTile(sourceId)],
+            filters: [
+              staticFilter(),
+              {
+                type: 'QUERY_EXPRESSION',
+                name: 'Service',
+                expression: 'ServiceName',
+                sourceId,
+                whereLanguage: 'sql',
+                where: "$__filter(ResourceAttributes['env'], $env)",
+              },
+            ],
+          },
+        );
+
+        expect(result.isError).toBeFalsy();
+        const created = JSON.parse(getFirstText(result));
+        expect(created.warnings ?? []).toEqual([]);
+      });
+    });
+
     it('should round-trip a table tile that uses a having clause', async () => {
       // mcpTableTileSchema exposes `having` so the service_detail
       // example's "Top Error Messages" pattern (groupBy StatusMessage

--- a/packages/api/src/mcp/__tests__/dashboards/validation.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/validation.test.ts
@@ -566,39 +566,52 @@ describe('mcpFiltersParam variable fields', () => {
     });
   });
 
-  it.each([
-    ['a space', 'has space'],
-    ['a leading digit', '1service'],
-    ['a leading underscore', '_service'],
-    ['a dash', 'service-name'],
-  ])('rejects a variableName with %s', (_label, variableName) => {
-    const result = mcpFiltersParam.safeParse([
-      {
-        type: 'QUERY_EXPRESSION',
-        name: 'Service',
-        expression: 'ServiceName',
-        sourceId,
-        whereLanguage: 'sql',
-        isVariableEnabled: true,
-        variableName,
-      },
-    ]);
-    expect(result.success).toBe(false);
-  });
+  const filterWithVariableName = {
+    QUERY_EXPRESSION: (variableName: string) => ({
+      type: 'QUERY_EXPRESSION',
+      name: 'Service',
+      expression: 'ServiceName',
+      sourceId,
+      whereLanguage: 'sql',
+      isVariableEnabled: true,
+      variableName,
+    }),
+    STATIC_LIST: (variableName: string) => ({
+      type: 'STATIC_LIST',
+      name: 'Environment',
+      options: ['prod', 'staging'],
+      variableName,
+    }),
+  };
 
-  it('rejects a variableName over the length limit', () => {
-    const result = mcpFiltersParam.safeParse([
-      {
-        type: 'QUERY_EXPRESSION',
-        name: 'Service',
-        expression: 'ServiceName',
-        sourceId,
-        whereLanguage: 'sql',
-        isVariableEnabled: true,
-        variableName: `v${'a'.repeat(DASHBOARD_VARIABLE_NAME_MAX_LENGTH)}`,
-      },
-    ]);
-    expect(result.success).toBe(false);
+  describe.each(['QUERY_EXPRESSION', 'STATIC_LIST'] as const)('%s', type => {
+    it.each([
+      ['a space', 'has space'],
+      ['a leading digit', '1service'],
+      ['a leading underscore', '_service'],
+      ['a dash', 'service-name'],
+    ])('rejects a variableName with %s', (_label, variableName) => {
+      const result = mcpFiltersParam.safeParse([
+        filterWithVariableName[type](variableName),
+      ]);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a variableName over the length limit', () => {
+      const result = mcpFiltersParam.safeParse([
+        filterWithVariableName[type](
+          `v${'a'.repeat(DASHBOARD_VARIABLE_NAME_MAX_LENGTH)}`,
+        ),
+      ]);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid variableName', () => {
+      const parsed = mcpFiltersParam.parse([
+        filterWithVariableName[type]('my_var1'),
+      ]);
+      expect(parsed[0]).toMatchObject({ variableName: 'my_var1' });
+    });
   });
 
   it('accepts a filter that omits every variable field', () => {
@@ -611,8 +624,8 @@ describe('mcpFiltersParam variable fields', () => {
         whereLanguage: 'sql',
       },
     ]);
-    expect(parsed[0].isVariableEnabled).toBeUndefined();
-    expect(parsed[0].isBroadcastEnabled).toBeUndefined();
+    expect(parsed[0]).not.toHaveProperty('isVariableEnabled');
+    expect(parsed[0]).not.toHaveProperty('isBroadcastEnabled');
   });
 });
 

--- a/packages/api/src/mcp/__tests__/dashboards/variables.test.ts
+++ b/packages/api/src/mcp/__tests__/dashboards/variables.test.ts
@@ -28,6 +28,23 @@ const variableFilter = filter({
   variableName: 'service',
 });
 
+function staticFilter(
+  overrides: Partial<
+    Extract<ExternalDashboardFilterWithId, { type: 'STATIC_LIST' }>
+  > = {},
+): ExternalDashboardFilterWithId {
+  return {
+    id: new mongoose.Types.ObjectId().toString(),
+    type: 'STATIC_LIST',
+    name: 'Environment',
+    options: ['prod', 'staging', 'dev'],
+    isBroadcastEnabled: false,
+    isVariableEnabled: true,
+    variableName: 'env',
+    ...overrides,
+  };
+}
+
 describe('resolveDashboardVariables', () => {
   it('returns an empty array for a dashboard with no filters', () => {
     // Empty, not undefined: an empty array still registers $__filter and
@@ -111,6 +128,116 @@ describe('resolveDashboardVariables', () => {
     expect(resolved.error).toContain('Available variables: (none)');
   });
 
+  it('declares a variable for a static filter', () => {
+    expect(resolveDashboardVariables([staticFilter()], undefined)).toEqual({
+      variables: [{ name: 'env', expression: undefined, values: [] }],
+    });
+  });
+
+  it('applies a selection within a static filter options', () => {
+    expect(
+      resolveDashboardVariables(
+        [staticFilter()],
+        [{ name: 'env', values: ['prod', 'dev'] }],
+      ),
+    ).toEqual({
+      variables: [
+        { name: 'env', expression: undefined, values: ['prod', 'dev'] },
+      ],
+    });
+  });
+
+  it('accepts an empty selection for a static filter', () => {
+    expect(
+      resolveDashboardVariables(
+        [staticFilter()],
+        [{ name: 'env', values: [] }],
+      ),
+    ).toEqual({
+      variables: [{ name: 'env', expression: undefined, values: [] }],
+    });
+  });
+
+  it('rejects a value outside a static filter options', () => {
+    const resolved = resolveDashboardVariables(
+      [staticFilter()],
+      [{ name: 'env', values: ['prod', 'prod-2'] }],
+    );
+
+    if (!('error' in resolved)) throw new Error('expected an error');
+    expect(resolved.error).toContain('"env"');
+    expect(resolved.error).toContain('"prod-2"');
+    expect(resolved.error).not.toContain('"prod"');
+    expect(resolved.error).toContain('prod, staging, dev');
+  });
+
+  it('collects every offending variable into one error', () => {
+    const tier = staticFilter({
+      name: 'Tier',
+      options: ['free', 'paid'],
+      variableName: 'tier',
+    });
+
+    const resolved = resolveDashboardVariables(
+      [staticFilter(), tier],
+      [
+        { name: 'env', values: ['nope'] },
+        { name: 'tier', values: ['enterprise'] },
+      ],
+    );
+
+    if (!('error' in resolved)) throw new Error('expected an error');
+    expect(resolved.error).toContain('"env"');
+    expect(resolved.error).toContain('"tier"');
+  });
+
+  it('leaves query-expression variables unconstrained', () => {
+    expect(
+      resolveDashboardVariables(
+        [variableFilter],
+        [{ name: 'service', values: ['anything-at-all'] }],
+      ),
+    ).toEqual({
+      variables: [
+        {
+          name: 'service',
+          expression: 'ServiceName',
+          values: ['anything-at-all'],
+        },
+      ],
+    });
+  });
+
+  it('truncates the options preview in the error', () => {
+    const options = Array.from({ length: 25 }, (_, i) => `opt${i}`);
+    const resolved = resolveDashboardVariables(
+      [staticFilter({ options })],
+      [{ name: 'env', values: ['nope'] }],
+    );
+
+    if (!('error' in resolved)) throw new Error('expected an error');
+    expect(resolved.error).toContain('… and 5 more');
+    expect(resolved.error).not.toContain('opt24');
+  });
+
+  it('polices the options of the filter that owns a duplicated name', () => {
+    const shadowed = staticFilter({ variableName: 'service' });
+    expect(
+      resolveDashboardVariables(
+        [variableFilter, shadowed],
+        [{ name: 'service', values: ['not-an-option'] }],
+      ),
+    ).toEqual({
+      variables: [
+        {
+          name: 'service',
+          expression: 'ServiceName',
+          values: ['not-an-option'],
+        },
+      ],
+    });
+  });
+
   it('lets the last entry win on a repeated name', () => {
     const resolved = resolveDashboardVariables(
       [variableFilter],
@@ -152,6 +279,17 @@ describe('withResolvedFilterVariableNames', () => {
 
     expect(withResolvedFilterVariableNames([noExplicitName])).toEqual([
       { ...noExplicitName, variableName: 'Service_Name' },
+    ]);
+  });
+
+  it('fills in the derived name on a static filter', () => {
+    const noExplicitName = staticFilter({
+      name: 'Deploy Env',
+      variableName: undefined,
+    });
+
+    expect(withResolvedFilterVariableNames([noExplicitName])).toEqual([
+      { ...noExplicitName, variableName: 'Deploy_Env' },
     ]);
   });
 });

--- a/packages/api/src/mcp/prompts/dashboards/content.ts
+++ b/packages/api/src/mcp/prompts/dashboards/content.ts
@@ -112,6 +112,8 @@ Apply these before calling clickstack_save_dashboard. Each rule is enforced by t
 
 9c. TO CHAIN ONE DROPDOWN OFF ANOTHER, REFERENCE A VARIABLE IN THE DOWNSTREAM FILTER'S OWN where. A filter's where scopes the values ITS dropdown offers and is never applied to a tile, so a dashboard can pick a service and then offer only that service's endpoints: filters: [{ name: "Service", expression: "ServiceName", isVariableEnabled: true, variableName: "service", ... }, { name: "Endpoint", expression: "SpanName", whereLanguage: "sql", where: "$__filter(ServiceName, $service)", ... }]. Only the upstream filter needs isVariableEnabled, and it can keep broadcasting because its value is read by a dropdown rather than a tile. Use $__filter here too so the downstream dropdown lists everything until a service is picked; a bare $service leaves it empty.
 
+9d. USE A STATIC_LIST FILTER WHEN THE DROPDOWN SHOULD OFFER A FIXED HAND-AUTHORED LIST. When the values are a business list (environments, tenants, tiers) or a curated subset rather than derivable from the data, declare filters: [{ type: "STATIC_LIST", name, options: ["prod", "staging"], variableName }]. It takes no expression, sourceId, or where, and it is always variable-only (there is nothing to broadcast), so tiles must reference $variableName, typically via $__filter(<expression>, $<variableName>) with the column passed explicitly (the one-argument $__filter($var) form fails because the filter has no expression of its own).
+
 10. UPDATE IS REPLACE, NOT MERGE. clickstack_save_dashboard with an id overwrites tiles, containers, and filters in their entirety. Call clickstack_get_dashboard first when you only want to add or rename one entry; do not send a partial set or you will silently drop everything you omitted.
 
 11. GROUP RELATED TILES INTO CONTAINERS. REQUIRED at five or more tiles, no exceptions. An ungrouped wall of nine or ten tiles is a readability failure even when each tile is correct in isolation. Containers are the right way to introduce structure; markdown tiles for section labels are not.
@@ -172,7 +174,9 @@ Dashboards open with a 15-minute default window. There is no dashboard-level fie
 - Adding a redundant format specifier such as \${var:sqlstring}, or omitting a needed one such as \${var:regex} inside match() and \${var:csv} inside a literal.
 - Using $__filter or $__conditionalAll in a Lucene where (they are matched as literal text; switch to whereLanguage: "sql", or write ServiceName:$var).
 - Chaining a filter's where off a filter that is not variable-enabled. Only isVariableEnabled: true publishes the $variableName token; without it the reference resolves to nothing and the downstream dropdown is unscoped or empty.
-- Referencing a filter's OWN variable in its where. That narrows its dropdown to the values already picked, so the rest of the options vanish from a multi-select. Reference a sibling filter's variable instead.`;
+- Referencing a filter's OWN variable in its where. That narrows its dropdown to the values already picked, so the rest of the options vanish from a multi-select. Reference a sibling filter's variable instead.
+- Mixing filter-type fields: expression/sourceId/where belong to QUERY_EXPRESSION filters, options to STATIC_LIST filters.
+- Expecting a STATIC_LIST filter to broadcast. It cannot; a tile must reference its $variableName (via $__filter with the column passed explicitly) or nothing changes when the user picks a value.`;
 }
 
 export function buildDashboardExamplesPrompt(
@@ -1125,7 +1129,9 @@ Rules:
 
 Optional dashboard-level filter declarations. Each entry adds a dropdown to the dashboard header. Use this for focused per-dimension dashboards (per-service, per-tenant, per-endpoint) instead of hardcoding the dimension into every tile's where clause.
 
-A filter does one of two things with the value the user picks, or both:
+Two filter types: QUERY_EXPRESSION queries its dropdown values from a source column, while STATIC_LIST declares them inline as a hand-authored options list and is always variable-only (see the static filter shape below).
+
+A QUERY_EXPRESSION filter does one of two things with the value the user picks, or both:
 
   BROADCAST (isBroadcastEnabled, ON by default)
     The value is ANDed onto every in-scope tile automatically. Tiles need no wiring at all. This is the right choice in most cases.
@@ -1135,10 +1141,10 @@ A filter does one of two things with the value the user picks, or both:
 
 Pick ONE. A filter with both modes on applies the value twice, once implicitly to every in-scope tile and once wherever a tile references it, which double-filters and is hard to reason about. Enable both only when you deliberately want the automatic scoping AND a tile that reads the raw value somewhere a plain AND cannot go, or when the variable is read only by another filter's dropdown query rather than by a tile (see DEPENDENT FILTERS).
 
-Filter shape:
-  { type, name, expression, sourceId, where?, whereLanguage?, appliesToSourceIds?, isBroadcastEnabled?, isVariableEnabled?, variableName? }
+Query-expression filter shape:
+  { type: "QUERY_EXPRESSION", name, expression, sourceId, where?, whereLanguage?, appliesToSourceIds?, isBroadcastEnabled?, isVariableEnabled?, variableName? }
 
-  type                 "QUERY_EXPRESSION" (the only currently supported type).
+  type                 "QUERY_EXPRESSION": the dropdown values are queried from a source column.
   name                 Human label shown in the filter dropdown (e.g. "Service").
   expression           Column or attribute path the filter scopes (e.g. "ServiceName" or "SpanAttributes['tenant.id']").
   sourceId             Which source the dropdown VALUES are queried from. Independent of which tiles get filtered (see appliesToSourceIds below).
@@ -1149,6 +1155,18 @@ Filter shape:
   isBroadcastEnabled   Omit or set to true to enable broadcasting. Set false for a variable-only filter.
   isVariableEnabled    Set true to expose the value as $variableName.
   variableName         The token tiles reference. Must match [a-zA-Z][a-zA-Z0-9_]* and be at most 64 characters, and must be unique across the dashboard's variable-enabled filters. Defaults to the display name with whitespace turned into underscores and remaining illegal characters dropped, so "Service Name" becomes $Service_Name and a label with nothing token-safe in it (a non-ASCII name, for instance) must set this field explicitly. Rejected when isVariableEnabled is not true.
+
+Static filter shape:
+  { type: "STATIC_LIST", name, options, variableName? }
+
+  options              1-1000 unique, non-empty strings the dropdown offers, in display order.
+
+  No expression, sourceId, where, or appliesToSourceIds: the list is hand-authored, nothing is queried. It has no mode flags either. A static filter is always variable-only, so tiles must reference $variableName for the selection to have any effect. Pass the column explicitly in macros ($__filter(<expression>, $<variableName>)); the one-argument $__filter($var) form fails because the filter has no expression of its own.
+
+Example (static list):
+  filters: [
+    { type: "STATIC_LIST", name: "Environment", options: ["prod", "staging", "dev"], variableName: "env" }
+  ]
 
 Example (broadcast to every tile, the common case):
   filters: [
@@ -1170,7 +1188,7 @@ When a value is picked in the dropdown, the renderer combines it with each in-sc
 
 == DASHBOARD VARIABLES ==
 
-A filter with isVariableEnabled: true publishes its selected value to tile queries under variableName. Nothing happens until a tile references it: variables are opt-in per tile, while broadcast is automatic.
+A filter with isVariableEnabled: true publishes its selected value to tile queries under variableName. STATIC_LIST filters are always variable-enabled, so every one of them publishes its selection this way. Nothing happens until a tile references it: variables are opt-in per tile, while broadcast is automatic.
 
 REACH FOR A VARIABLE WHEN BROADCAST CANNOT DO THE JOB. Broadcast plus a builder tile covers the ordinary "scope this dashboard to one service" case with no per-tile wiring and no way to get it wrong. A variable is worth the extra plumbing when:
   - the predicate is not a plain equality (NOT IN, LIKE, a regex match, a range)
@@ -1248,6 +1266,7 @@ VALIDATING
 
 clickstack_query_tile and clickstack_query_tiles expand variables with an EMPTY selection by default, which is what a freshly-opened dashboard looks like. Optionally, pass variableValues to check that a tile narrows correctly once something is picked:
   variableValues: [{ name: "service", values: ["checkout"] }]
+For a STATIC_LIST filter's variable, every supplied value must be one of the filter's declared options; the dashboard UI can never select anything else, so other values are rejected.
 Both tools report variable problems under "warnings". Alerts on a tile always evaluate with every variable empty, so a tile carrying an alert must stay correct with nothing selected.
 
 == TABLE TILE LINKING (config.onClick) ==

--- a/packages/api/src/mcp/tools/dashboards/saveDashboard.ts
+++ b/packages/api/src/mcp/tools/dashboards/saveDashboard.ts
@@ -17,11 +17,7 @@ import {
   updateDashboardBodySchema,
   validateDashboardTiles,
 } from '@/routers/external-api/v2/utils/dashboards';
-import type {
-  ExternalDashboardFilter,
-  ExternalDashboardFilterWithId,
-  ExternalDashboardTileWithId,
-} from '@/utils/zod';
+import type { ExternalDashboardTileWithId } from '@/utils/zod';
 import {
   MAX_TAG_LENGTH,
   MAX_TAGS,
@@ -29,6 +25,7 @@ import {
   tagsSchema,
 } from '@/utils/zod';
 
+import type { McpDashboardFilter } from './schemas';
 import { mcpContainersParam, mcpFiltersParam, mcpTilesParam } from './schemas';
 import {
   getFilterVariableWarnings,
@@ -117,31 +114,24 @@ export function registerSaveDashboard({
 // response into a create payload (or omit the id on a new filter added
 // during update) without hitting a confusing strict-validation rejection.
 function stripFilterIds(
-  filters:
-    | (ExternalDashboardFilter | ExternalDashboardFilterWithId)[]
-    | undefined,
-): ExternalDashboardFilter[] | undefined {
+  filters: McpDashboardFilter[] | undefined,
+): McpDashboardFilter[] | undefined {
   if (!filters) return undefined;
   return filters.map(filter => {
-    const { id: _id, ...rest } = filter as ExternalDashboardFilterWithId;
-    return rest as ExternalDashboardFilter;
+    const { id: _id, ...rest } = filter;
+    return rest as McpDashboardFilter;
   });
 }
 
 function assignFilterIds(
-  filters:
-    | (ExternalDashboardFilter | ExternalDashboardFilterWithId)[]
-    | undefined,
-): ExternalDashboardFilterWithId[] | undefined {
+  filters: McpDashboardFilter[] | undefined,
+): McpDashboardFilter[] | undefined {
   if (!filters) return undefined;
-  return filters.map(filter => {
-    const withId = filter as ExternalDashboardFilterWithId;
-    if (typeof withId.id === 'string' && withId.id.length > 0) return withId;
-    return {
-      ...filter,
-      id: new mongoose.Types.ObjectId().toString(),
-    } as ExternalDashboardFilterWithId;
-  });
+  return filters.map(filter =>
+    typeof filter.id === 'string' && filter.id.length > 0
+      ? filter
+      : { ...filter, id: new mongoose.Types.ObjectId().toString() },
+  );
 }
 
 async function createDashboard({
@@ -159,9 +149,7 @@ async function createDashboard({
   inputTiles: unknown[];
   tags: string[] | undefined;
   containers: DashboardContainer[] | undefined;
-  inputFilters:
-    | (ExternalDashboardFilter | ExternalDashboardFilterWithId)[]
-    | undefined;
+  inputFilters: McpDashboardFilter[] | undefined;
 }) {
   const parsed = createDashboardBodySchema.safeParse({
     name,
@@ -261,9 +249,7 @@ async function updateDashboard({
   inputTiles: unknown[];
   tags: string[] | undefined;
   containers: DashboardContainer[] | undefined;
-  inputFilters:
-    | (ExternalDashboardFilter | ExternalDashboardFilterWithId)[]
-    | undefined;
+  inputFilters: McpDashboardFilter[] | undefined;
 }) {
   const parsed = updateDashboardBodySchema.safeParse({
     name,

--- a/packages/api/src/mcp/tools/dashboards/schemas.ts
+++ b/packages/api/src/mcp/tools/dashboards/schemas.ts
@@ -8,6 +8,7 @@ import {
   ChartPaletteTokenSchema,
   DASHBOARD_CONTAINER_ID_MAX,
   DASHBOARD_MAX_CONTAINERS,
+  DASHBOARD_STATIC_FILTER_MAX_OPTIONS,
   DASHBOARD_VARIABLE_NAME_MAX_LENGTH,
   DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED,
   DashboardContainerSchema,
@@ -15,6 +16,7 @@ import {
   MetricsDataType,
   NumberTileColorConditionSchema,
   SearchConditionTrimmedLanguageSchema,
+  StaticListDashboardFilterSchema,
 } from '@hyperdx/common-utils/dist/types';
 import { z } from 'zod';
 
@@ -1136,31 +1138,49 @@ export const mcpTilesParam = z
       '"numberFormat": { "output": "duration", "factor": 0.000000001 } } }',
   );
 
-const mcpDashboardFilterSchema = z
-  .object({
-    id: z
-      .string()
-      .optional()
-      .describe(
-        'Filter identity. ' +
-          'On UPDATE of an existing dashboard, every filter in the array MUST carry ' +
-          'an id: pass the exact id returned by clickstack_get_dashboard for any filter ' +
-          'you are keeping (so saved values bound to it stay attached), and generate ' +
-          'a fresh random hex/ObjectId string for any filter you are adding in this ' +
-          'update. Omitting `id` on an existing filter would orphan its saved values; ' +
-          'reusing an existing id for a new filter would silently overwrite the old ' +
-          'one. On CREATE (no top-level `id` on the dashboard call), filter `id` may ' +
-          'be omitted and one will be generated server-side.',
-      ),
-    // TODO: Add static value filter type when variables are supported in MCP
-    type: DashboardFilterType.extract(['QUERY_EXPRESSION']).describe(
-      'Filter type. Currently only "QUERY_EXPRESSION" is supported.',
+const VARIABLE_NAME_DESCRIPTION =
+  "Token that tiles reference this filter's selected value by, eg. $variableName. " +
+  'Must start with a letter and may contain only letters, numbers, and ' +
+  `underscores, up to ${DASHBOARD_VARIABLE_NAME_MAX_LENGTH} characters. ` +
+  'A default is determined based on the display name. ' +
+  "Must be unique across the dashboard's variable-enabled filters.";
+
+const variableNameSchema = z
+  .string()
+  .max(DASHBOARD_VARIABLE_NAME_MAX_LENGTH)
+  .regex(DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED)
+  .optional();
+const mcpDashboardFilterBaseShape = {
+  id: z
+    .string()
+    .optional()
+    .describe(
+      'Filter identity. ' +
+        'On UPDATE of an existing dashboard, every filter in the array MUST carry ' +
+        'an id: pass the exact id returned by clickstack_get_dashboard for any filter ' +
+        'you are keeping (so saved values bound to it stay attached), and generate ' +
+        'a fresh random hex/ObjectId string for any filter you are adding in this ' +
+        'update. Omitting `id` on an existing filter would orphan its saved values; ' +
+        'reusing an existing id for a new filter would silently overwrite the old ' +
+        'one. On CREATE (no top-level `id` on the dashboard call), filter `id` may ' +
+        'be omitted and one will be generated server-side.',
     ),
-    name: z
-      .string()
-      .min(1)
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      'Human-readable filter label shown in the dashboard filter bar dropdown.',
+    ),
+  variableName: variableNameSchema.describe(VARIABLE_NAME_DESCRIPTION),
+};
+
+const mcpQueryExpressionFilterSchema = z
+  .object({
+    ...mcpDashboardFilterBaseShape,
+    type: z
+      .literal(DashboardFilterType.enum.QUERY_EXPRESSION)
       .describe(
-        'Human-readable filter label shown in the dashboard filter bar dropdown.',
+        'Filter type discriminator for a filter whose dropdown values are queried from a source column (expression + sourceId).',
       ),
     expression: z
       .string()
@@ -1239,22 +1259,12 @@ const mcpDashboardFilterSchema = z
           "tile's sqlTemplate). Another filter's `where` can reference it too, which " +
           "chains that filter's dropdown off this one.",
       ),
-    variableName: z
-      .string()
-      .max(DASHBOARD_VARIABLE_NAME_MAX_LENGTH)
-      .regex(DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED)
-      .optional()
-      .describe(
-        "Token tiles reference this filter's selected value by, eg. $variableName. " +
-          'Must start with a letter and may contain only letters, numbers, and ' +
-          `underscores, up to ${DASHBOARD_VARIABLE_NAME_MAX_LENGTH} characters. ` +
-          'A default is determined based on the display name. ' +
-          "Must be unique across the dashboard's variable-enabled filters. " +
-          'Rejected when isVariableEnabled is not true.',
-      ),
+    variableName: variableNameSchema.describe(
+      `${VARIABLE_NAME_DESCRIPTION} Rejected when isVariableEnabled is not true.`,
+    ),
   })
   .describe(
-    'A dashboard-level filter the user can adjust in the dashboard filter bar. ' +
+    'A dashboard filter whose dropdown values are queried from a source. ' +
       'Each filter binds a label/name to a column expression on a source. ' +
       'Every filter either broadcasts its selected value to matching tiles as a ' +
       'condition (isBroadcastEnabled, the default), exposes it to tile queries as a ' +
@@ -1262,6 +1272,40 @@ const mcpDashboardFilterSchema = z
       "Filters are also the contract for row-click navigation: a table tile's " +
       'onClick.filters[i].expression must match a filter declared here for the value to land.',
   );
+
+const mcpStaticListFilterSchema = z
+  .object({
+    ...mcpDashboardFilterBaseShape,
+    type: z
+      .literal(DashboardFilterType.enum.STATIC_LIST)
+      .describe(
+        'Filter type discriminator for a filter whose dropdown offers a fixed hand-authored list; no source query.',
+      ),
+    options: StaticListDashboardFilterSchema.shape.options.describe(
+      'The values the dropdown offers, in display order. ' +
+        `1-${DASHBOARD_STATIC_FILTER_MAX_OPTIONS} unique, non-empty strings.`,
+    ),
+  })
+  .describe(
+    'A variable-only dashboard filter whose dropdown offers a hand-authored options ' +
+      'list. Use it when the values are a fixed business list (environments, tiers, ' +
+      'regions) rather than derivable from the data. The selected value reaches tiles ' +
+      'only as $variableName — typically via $__filter(<expression>, $<variableName>) ' +
+      'with the column passed explicitly, since the filter has no expression of its own.',
+  );
+
+const mcpDashboardFilterSchema = z
+  .discriminatedUnion('type', [
+    mcpQueryExpressionFilterSchema,
+    mcpStaticListFilterSchema,
+  ])
+  .describe(
+    'A dashboard-level filter the user can adjust in the dashboard filter bar. ' +
+      'Two types: QUERY_EXPRESSION queries its dropdown values from a source column; ' +
+      'STATIC_LIST declares them inline and is always variable-only.',
+  );
+
+export type McpDashboardFilter = z.infer<typeof mcpDashboardFilterSchema>;
 
 export const mcpFiltersParam = z
   .array(mcpDashboardFilterSchema)
@@ -1271,7 +1315,10 @@ export const mcpFiltersParam = z
       'If another tile\'s onClick targets THIS dashboard with `filters: [{ expression: "X", ... }]`, ' +
       'this array MUST declare a filter whose `expression` is "X". Otherwise the value is ' +
       'dropped on arrival and the destination opens unfiltered.\n\n' +
-      'Each filter runs in one of two modes (or both). BROADCAST (the default) applies the ' +
+      'Two filter types: QUERY_EXPRESSION queries its dropdown values from a source column, ' +
+      'while STATIC_LIST declares them inline via `options` and is always variable-only ' +
+      '(it has no expression to broadcast).\n\n' +
+      'A QUERY_EXPRESSION filter runs in one of two modes (or both). BROADCAST (the default) applies the ' +
       'selected value as a condition on matching tiles with no per-tile wiring. VARIABLE ' +
       '(isVariableEnabled) exposes the value to tile queries as $variableName, which the tile ' +
       'must reference explicitly. Prefer broadcast; reach for a variable in advanced cases. ' +
@@ -1300,6 +1347,15 @@ export const mcpFiltersParam = z
       ']\n' +
       'A tile then uses it as $__filter(ServiceName, $service) in a SQL where clause, which ' +
       'expands to 1=1 while nothing is selected.\n\n' +
+      'Example (static list: fixed hand-authored values, always a variable, no source query):\n' +
+      '[\n' +
+      '  { "type": "STATIC_LIST", "name": "Environment",\n' +
+      '    "options": ["prod", "staging", "dev"], "variableName": "env" }\n' +
+      ']\n' +
+      "A tile references it as $__filter(ResourceAttributes['deployment.environment'], $env). " +
+      'Always pass the column explicitly: the one-argument $__filter($env) form reuses the ' +
+      "filter's own expression, which a static filter does not have. Prefer STATIC_LIST when " +
+      'the values are a fixed business list or a curated subset rather than derivable from the data.\n\n' +
       "Example (dependent filter: the Endpoint dropdown only lists the selected service's " +
       'endpoints):\n' +
       '[\n' +

--- a/packages/api/src/mcp/tools/dashboards/variables.ts
+++ b/packages/api/src/mcp/tools/dashboards/variables.ts
@@ -1,7 +1,9 @@
 import {
   getDashboardVariableDeclarations,
+  getDashboardVariableFilters,
   getFilterVariableName,
   isFilterVariableEnabled,
+  isStaticListFilter,
 } from '@hyperdx/common-utils/dist/filters';
 import type { ChartVariable } from '@hyperdx/common-utils/dist/types';
 import { z } from 'zod';
@@ -24,7 +26,8 @@ export const mcpVariableValuesParam = z
       values: z
         .array(z.string())
         .describe(
-          'Values to treat as selected. An empty array means nothing is selected for this variable.',
+          'Values to treat as selected. An empty array means nothing is selected for this variable. ' +
+            "For a STATIC_LIST filter's variable, every value must be one of the filter's declared options.",
         ),
     }),
   )
@@ -78,12 +81,52 @@ export function resolveDashboardVariables(
     };
   }
 
+  // A static filter's dropdown can only ever offer its declared options, so a
+  // simulated selection outside them can never occur in the UI — reject it as
+  // a typo rather than running a query the dashboard cannot produce.
+  const staticOptionsByName = buildStaticOptionsByName(filters);
+  const optionErrors = variableValues.flatMap(({ name, values }) => {
+    const options = staticOptionsByName.get(name);
+    if (!options) return [];
+    const invalid = values.filter(value => !options.includes(value));
+    if (invalid.length === 0) return [];
+    return [
+      `Variable "${name}" belongs to a STATIC_LIST filter and only accepts its declared ` +
+        `options; value(s) ${invalid.map(value => `"${value}"`).join(', ')} are not among them. ` +
+        `Declared options: ${formatOptionsPreview(options)}. See the filter's options via ` +
+        'clickstack_get_dashboard, or change them with clickstack_save_dashboard.',
+    ];
+  });
+  if (optionErrors.length > 0) {
+    return { error: optionErrors.join('\n') };
+  }
+
   // Override the default empty selection with the given variableValues
   for (const { name, values } of variableValues) {
     byName.get(name)!.values = values;
   }
 
   return { variables };
+}
+
+/** Options of each static filter, keyed by the variable name it answers to. */
+function buildStaticOptionsByName(
+  filters: ExternalDashboardFilter[] | undefined,
+): Map<string, string[]> {
+  const optionsByName = new Map<string, string[]>();
+  for (const { filter, name } of getDashboardVariableFilters(filters)) {
+    if (isStaticListFilter(filter)) optionsByName.set(name, filter.options);
+  }
+  return optionsByName;
+}
+
+const OPTIONS_PREVIEW_LIMIT = 20;
+
+// Options allow up to 1000 entries of 10k characters each; keep the error legible.
+function formatOptionsPreview(options: string[]): string {
+  const preview = options.slice(0, OPTIONS_PREVIEW_LIMIT).join(', ');
+  const remaining = options.length - OPTIONS_PREVIEW_LIMIT;
+  return remaining > 0 ? `${preview}, … and ${remaining} more` : preview;
 }
 
 /** Set a derived variableName on filters without explicit variable names, so the agent doesn't guess. */

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -912,14 +912,22 @@ export type DashboardVariableDeclaration = Pick<
   'name' | 'expression'
 >;
 
+/** Minimal projection of fields necessary to extract the variables a dashboard declares. */
+export type FilterForVariableDeclaration = {
+  name: string;
+  expression?: string;
+  variableName?: string;
+  isVariableEnabled?: boolean;
+};
+
 /**
  * The variable-enabled filters a dashboard declares, paired with the name each
  * one answers to, in filter order.
  */
-export function getDashboardVariableFilters(
-  filters: DashboardFilter[] | undefined,
-): { filter: DashboardFilter; name: string }[] {
-  const results: { filter: DashboardFilter; name: string }[] = [];
+export function getDashboardVariableFilters<
+  T extends FilterForVariableDeclaration,
+>(filters: T[] | undefined): { filter: T; name: string }[] {
+  const results: { filter: T; name: string }[] = [];
   const takenNames = new Set<string>();
 
   for (const filter of filters ?? []) {
@@ -936,33 +944,14 @@ export function getDashboardVariableFilters(
   return results;
 }
 
-/** Minimal projection of fields necessary to extract the variables a dashboard declares. */
-export type FilterForVariableDeclaration = {
-  name: string;
-  expression?: string;
-  variableName?: string;
-  isVariableEnabled?: boolean;
-};
-
 /** The variables a dashboard declares, in filter order. */
 export function getDashboardVariableDeclarations(
   filters: FilterForVariableDeclaration[] | undefined,
 ): DashboardVariableDeclaration[] {
-  const declarations: DashboardVariableDeclaration[] = [];
-  const takenNames = new Set<string>();
-
-  for (const filter of filters ?? []) {
-    if (!isFilterVariableEnabled(filter)) continue;
-
-    // There shouldn't be any duplicate names, but if there are then the first one wins.
-    const name = getFilterVariableName(filter);
-    if (!name || takenNames.has(name)) continue;
-    takenNames.add(name);
-
-    declarations.push({ name, expression: filter.expression });
-  }
-
-  return declarations;
+  return getDashboardVariableFilters(filters).map(({ filter, name }) => ({
+    name,
+    expression: filter.expression,
+  }));
 }
 
 export type ResolvedFilterValuesQuery = {

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1904,6 +1904,7 @@ export const DASHBOARD_VARIABLE_NAME_PATTERN_ANCHORED = new RegExp(
   `^${DASHBOARD_VARIABLE_NAME_PATTERN}$`,
 );
 export const DASHBOARD_VARIABLE_NAME_MAX_LENGTH = 64;
+export const DASHBOARD_STATIC_FILTER_MAX_OPTIONS = 1000;
 
 /** Fields carried by every dashboard filter, whatever its type. */
 const dashboardFilterBaseSchema = z.object({
@@ -1956,7 +1957,10 @@ export const QueryExpressionDashboardFilterSchema =
 export const StaticListDashboardFilterSchema = dashboardFilterBaseSchema.extend(
   {
     type: z.literal(DashboardFilterType.enum.STATIC_LIST),
-    options: z.array(z.string().min(1).max(10000)).min(1).max(1000),
+    options: z
+      .array(z.string().min(1).max(10000))
+      .min(1)
+      .max(DASHBOARD_STATIC_FILTER_MAX_OPTIONS),
     isBroadcastEnabled: z.literal(false),
     isVariableEnabled: z.literal(true),
   },


### PR DESCRIPTION
## Summary

This PR updates the MCP dashboard schemas / prompts so that they support the new static_list type filters.

### Screenshots or video

<img width="1533" height="188" alt="Screenshot 2026-09-02 at 11 41 22 AM" src="https://github.com/user-attachments/assets/42d19ccf-c189-45cc-83eb-b9912e64a9d2" />

<img width="657" height="516" alt="Screenshot 2026-09-02 at 11 42 05 AM" src="https://github.com/user-attachments/assets/c8db2c85-65ca-4448-a539-4ab25e138b4b" />

### How to test locally

1. Connect via MCP
2. Ask the agent to build a dashboard with a static filter

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5059
- Related PRs:
