### PR TITLE
docs: grep-first rule for shared code + advisory duplication count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,13 @@ directory:
 - `agent_docs/tech_stack.md` - Technology stack details and component patterns
 - `agent_docs/development.md` - Development workflows, testing, and common tasks
 - `agent_docs/code_style.md` - Code patterns and best practices. **Read this
-  before writing or planning any `packages/app` UI change**, not just while
+  before writing or planning any `packages/app` UI change, and before adding a
+  type, Zod schema, helper, or component in any package**, not just while
   typing code. It carries required patterns that are invisible from the
   surrounding file (sentence-case UI text, mandated Button/ActionIcon variants,
-  `useConfirm` for confirmation dialogs, `EmptyState`), so copying the
-  conventions of the component you are editing is not sufficient.
+  `useConfirm` for confirmation dialogs, `EmptyState`, and where shared code
+  already lives), so copying the conventions of the component you are editing is
+  not sufficient.
 - `agent_docs/observability.md` - Instrumentation standards (tracing, metrics,
   context) and the shared helpers (read when adding or changing a feature)
 
@@ -88,7 +90,13 @@ before stopping.
 1. **Multi-tenancy**: All data is scoped to `Team` - ensure proper filtering
 2. **Type safety**: Use TypeScript strictly; Zod schemas for validation
 3. **Existing patterns**: Follow established patterns in the codebase - explore
-   similar files before implementing
+   similar files before implementing. **Before you define a type, Zod schema,
+   helper, or component, grep for one that already exists.** Search for the
+   operation it performs (`bucket`, `valid.*url`, `split.*trim`) - not the name
+   you were about to give it, because names differ. Look in
+   `packages/common-utils/src/` first, then the package you are editing. If you
+   find it, import or alias it; do not add a second definition. See
+   `agent_docs/code_style.md` → "Before you add a type, schema, or helper"
 4. **Component size**: Keep files under 300 lines; break down large components
 5. **UI Components**: Use custom Button/ActionIcon variants (`primary`,
    `secondary`, `danger`), `useConfirm` for "are you sure?" dialogs rather than

--- a/agent_docs/README.md
+++ b/agent_docs/README.md
@@ -15,10 +15,11 @@ Instead of stuffing all instructions into `AGENTS.md` (which goes into every con
 - **`architecture.md`** - System architecture, data models, service relationships, security patterns
 - **`tech_stack.md`** - Technology choices, UI component patterns, library usage
 - **`development.md`** - Development workflows, testing strategy, common tasks, debugging
-- **`code_style.md`** - Code patterns and best practices (read only when actively coding)
+- **`code_style.md`** - Code patterns and best practices. Read before adding a type, Zod schema, helper, or component in any package (grep-first rule, plus a map of what already lives in `common-utils`), and before any `packages/app` UI change.
 - **`page_layout.md`** - PageHeader, PageLayout, and consistent page chrome (titles, actions, tool pages)
 - **`data_viz_colors.md`** - Chart, heatmap, and semantic status colors. Read before adding or changing any color in a chart, sparkline, heatmap, legend, or status pill.
 - **`themes.md`** - How the brand theme system (HyperDX vs ClickStack) and color mode (light/dark/system) work. Read before changing anything in `packages/app/src/theme/`, adding semantic CSS variables, or touching brand-conditional UI.
+- **`observability.md`** - Instrumentation standards (tracing, metrics, context) and the shared helpers. Read when adding or changing a feature.
 - **`evals.md`** - MCP eval framework: dual-slot setup, running A/B comparisons between branches, interpreting results. Read before running evals or benchmarking MCP changes.
 
 ## Usage Pattern

--- a/agent_docs/code_style.md
+++ b/agent_docs/code_style.md
@@ -15,8 +15,84 @@
 
 - **Single Responsibility**: One clear purpose per component/function
 - **File Size**: Max 300 lines - refactor when approaching limit
-- **DRY**: Reuse existing functionality; consolidate duplicates
+- **DRY**: Grep for an existing implementation before adding a type, schema,
+  helper, or component - see "Before you add a type, schema, or helper" below
+  (REQUIRED)
 - **In-Context Learning**: Explore similar files before implementing
+
+## Before you add a type, schema, or helper (REQUIRED)
+
+**Grep for an existing implementation before you define a new type, Zod schema,
+helper function, or React component.** Search for the _operation_ — splitting a
+list, bucketing a timestamp, validating a URL, formatting a duration — not for
+the name you were about to give it. Names differ; operations don't.
+
+```bash
+# Two or three words for the operation, as alternates. Runs in ~20ms.
+grep -rniE "export (const|function|type|interface|enum) [a-zA-Z]*(bucket|interval|granular)" \
+  packages/common-utils/src packages/app/src packages/api/src \
+  --include='*.ts' --include='*.tsx'
+```
+
+Search order: the file you are editing, then `packages/common-utils/src/`, then
+the rest of your package. `common-utils` has **no root barrel** — no
+`src/index.ts`, and its `package.json` declares no entry point, which is why
+every import is a deep `@hyperdx/common-utils/dist/...` path. `src/types.ts`
+alone is ~2,850 lines and 280+ exports. You cannot discover what exists by
+reading an index; grep is the index.
+
+### Where shared code already lives
+
+Nine modules carry ~90% of all cross-package imports:
+
+| Import path | Holds |
+|-------------|-------|
+| `.../dist/types` | Every shared Zod schema and its inferred type: sources, alerts, dashboards, tiles, webhooks, chart configs, `SQLInterval`, `MetricsDataType`, `StacktraceFrame` |
+| `.../dist/core/utils` | Time-bucket and granularity math (`toStartOfInterval`, `timeBucketByGranularity`, `convertGranularityToSeconds`), string splitting (`splitAndTrimCSV`, `splitAndTrimWithBracket`, `escapeSqlString`), `hashCode`, `parseJSON`, `formatDate` |
+| `.../dist/core/metadata` | ClickHouse table/column introspection — `Metadata`, `getMetadata`, `parseKeyPath`, `unquoteIdentifier` |
+| `.../dist/clickhouse` (`/node`, `/browser`) | Query client, `ChSql`/`chSql`/`concatChSql`, CH↔JS type conversion |
+| `.../dist/core/renderChartConfig` | `ChartConfig` → SQL |
+| `.../dist/filters` | Filter state, serialization, and validation (`FilterState`, `filtersToQuery`, `parseQuery`) |
+| `.../dist/guards` | Chart-config and source type guards (`isBuilderChartConfig`, `isRawSqlChartConfig`, `isHeatmapCompatibleSource`) |
+| `.../dist/validation` | `isValidUrl`, `isValidSlackUrl`, password validators |
+| `.../dist/variables` | Dashboard variable resolution and template expansion |
+
+Package-local homes, searched second: `packages/app/src/utils.ts`,
+`packages/app/src/types.ts`, `packages/app/src/ChartUtils.tsx`,
+`packages/api/src/utils/`.
+
+### What to do once you find it
+
+| Situation | Do this |
+|-----------|---------|
+| Canonical version exists and fits | Import it. Delete the copy you were writing. |
+| Exists, but you want a local name | Alias-shim it — `packages/app/src/types.ts:9`, `export type NumberFormat = _NumberFormat;`. Never retype the definition. |
+| Exists, but the shape is _almost_ right | Derive from it (`Pick`, `Omit`, `.extend()`, `Alert & { … }`) or parameterize the canonical one. One source of truth. |
+| Shared logic between two components | Factor it into a sibling module — `packages/app/src/components/sourceSelectUtils.tsx:51` (`useFilteredSortedSourceItems`, shared by `SourceSelect` and `SourceMultiSelect`). |
+| Two genuinely must coexist | Doc-comment _why_, and name the twin. `packages/common-utils/src/types.ts:571-582` does this for the Mongoose `IWebhook` (`packages/api/src/models/webhook.ts:17`) vs the JSON-serialized `WebhookSchema`. |
+
+Not acceptable: a second definition with no alias, no doc comment explaining the
+twin, and no test pinning the two together.
+
+### Marking a whole-file port
+
+When an entire file has to be copied across packages — `packages/cli` does this
+for the components listed under "Web Frontend Alignment" in
+[`packages/cli/AGENTS.md`](../packages/cli/AGENTS.md) — head it with an
+`@source` tag naming the origin, one tag per origin file:
+
+```ts
+/**
+ * Source helper functions.
+ *
+ * @source packages/app/src/source.ts
+ */
+```
+
+`scripts/ci/ratchet.mjs` counts these so the total stays visible in CI. That
+count is advisory, not a gate: annotating a port never fails the build, and
+stripping the tag to go green hides the copy instead of removing it. Lower it by
+moving the shared code into `common-utils`, then run `yarn ratchet:update`.
 
 ## React Patterns
 

--- a/agent_docs/development.md
+++ b/agent_docs/development.md
@@ -254,7 +254,10 @@ yarn run lint
 - **Controllers**: `packages/api/src/controllers/`
 - **Pages**: `packages/app/pages/`
 - **Components**: `packages/app/src/`
-- **Shared Utils**: `packages/common-utils/src/`
+- **Shared Utils**: `packages/common-utils/src/` — no root barrel, so imports are
+  deep `@hyperdx/common-utils/dist/...` paths. See
+  [`code_style.md`](code_style.md#where-shared-code-already-lives) for the module
+  map and the grep-first rule before you add a helper.
 
 ## Vercel Preview Deployments (Inline API)
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -214,6 +214,10 @@ consistent:
 | `shared/chartData`    | `ChartUtils`                     | Response shaping ports            |
 | `shared/formatNumber` | `utils.ts` + `source.ts`         | formatNumber + format resolution  |
 
+Ported files carry an `@source packages/app/...` tag naming their origin. Keep
+the tag when you edit one and add a tag when you add a port — see
+[`agent_docs/code_style.md`](../../agent_docs/code_style.md#marking-a-whole-file-port).
+
 Key expression mappings from the web frontend's `getConfig()`:
 
 - `Timestamp` → `displayedTimestampValueExpression` (NOT

--- a/scripts/ci/__tests__/ratchet.test.mjs
+++ b/scripts/ci/__tests__/ratchet.test.mjs
@@ -41,7 +41,7 @@ test('counts escape hatches across a package, not just src/', () => {
     },
   });
   assert.deepEqual(collectCounts(root), {
-    app: { 'as-any': 1, 'ts-ignore': 1, 'eslint-disable': 1 },
+    app: { 'as-any': 1, 'ts-ignore': 1, 'eslint-disable': 1, '@source': 0 },
   });
 });
 
@@ -92,6 +92,24 @@ test('above baseline fails', () => {
   );
   assert.equal(failed, true);
   assert.match(messages.join('\n'), /app\/as-any: 3 > baseline 2/);
+});
+
+test('an advisory pattern above baseline warns instead of failing', () => {
+  const { failed, messages } = compare(
+    { cli: { 'as-any': 0, 'ts-ignore': 0, 'eslint-disable': 0, '@source': 38 } },
+    { cli: { 'as-any': 0, 'ts-ignore': 0, 'eslint-disable': 0, '@source': 37 } },
+  );
+  assert.equal(failed, false);
+  assert.match(messages.join('\n'), /! cli\/@source: 38 > baseline 37/);
+});
+
+test('an advisory rise does not mask a gated pattern rising too', () => {
+  const { failed, messages } = compare(
+    { cli: { 'as-any': 1, 'ts-ignore': 0, 'eslint-disable': 0, '@source': 38 } },
+    { cli: { 'as-any': 0, 'ts-ignore': 0, 'eslint-disable': 0, '@source': 37 } },
+  );
+  assert.equal(failed, true);
+  assert.match(messages.join('\n'), /x cli\/as-any: 1 > baseline 0/);
 });
 
 test('at baseline passes quietly', () => {

--- a/scripts/ci/ratchet-baseline.json
+++ b/scripts/ci/ratchet-baseline.json
@@ -2,31 +2,37 @@
   "api": {
     "as-any": 91,
     "ts-ignore": 0,
-    "eslint-disable": 32
+    "eslint-disable": 32,
+    "@source": 0
   },
   "app": {
     "as-any": 215,
     "ts-ignore": 0,
-    "eslint-disable": 146
+    "eslint-disable": 146,
+    "@source": 0
   },
   "cli": {
     "as-any": 0,
     "ts-ignore": 0,
-    "eslint-disable": 1
+    "eslint-disable": 1,
+    "@source": 37
   },
   "common-utils": {
     "as-any": 116,
     "ts-ignore": 0,
-    "eslint-disable": 39
+    "eslint-disable": 39,
+    "@source": 0
   },
   "hdx-eval": {
     "as-any": 0,
     "ts-ignore": 0,
-    "eslint-disable": 1
+    "eslint-disable": 1,
+    "@source": 0
   },
   "otel-collector": {
     "as-any": 0,
     "ts-ignore": 0,
-    "eslint-disable": 0
+    "eslint-disable": 0,
+    "@source": 0
   }
 }

--- a/scripts/ci/ratchet.mjs
+++ b/scripts/ci/ratchet.mjs
@@ -6,6 +6,7 @@
  *   improvement in). Non-fatal so an improvement can never turn `main` red —
  *   e.g. when two count-lowering PRs merge close together and `main`'s
  *   committed baseline briefly sits above the real count.
+ * Advisory patterns (see ADVISORY) are counted and reported but never fail.
  */
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -17,7 +18,23 @@ export const PATTERNS = {
   'as-any': /\bas any\b/g,
   'ts-ignore': /@ts-ignore/g,
   'eslint-disable': /eslint-disable/g,
+  // Duplication licensed by comment. `@source` marks code copied from another
+  // package (mostly packages/cli/src/shared today, plus a handful under
+  // src/components, src/utils and src/api).
+  '@source': /@source packages\//g,
 };
+
+/**
+ * Counted and reported, never fatal.
+ *
+ * `@source` is a doc comment, not an escape hatch. Deleting an `as any` or an
+ * `eslint-disable` forces the underlying problem to surface; deleting an
+ * `@source` line removes the record of a copy, not the copy. Gating on it would
+ * only teach people to stop annotating their ports — the one behaviour that
+ * makes the duplication findable. So the number is tracked and surfaced, and
+ * lowering it means moving the code into `common-utils`.
+ */
+export const ADVISORY = new Set(['@source']);
 
 // Generated, vendored or build output — not ours to ratchet.
 const SKIP_DIRS = new Set([
@@ -128,7 +145,11 @@ export function compare(current, baseline) {
     for (const name of Object.keys(PATTERNS)) {
       const now = current[pkg][name];
       const max = baseline[pkg]?.[name] ?? 0;
-      if (now > max) {
+      if (now > max && ADVISORY.has(name)) {
+        messages.push(
+          `! ${pkg}/${name}: ${now} > baseline ${max} — advisory; move the copy into common-utils if you can, then run \`yarn ratchet:update\``,
+        );
+      } else if (now > max) {
         failed = true;
         messages.push(
           `x ${pkg}/${name}: ${now} > baseline ${max} — remove the new occurrence(s)`,
@@ -163,14 +184,14 @@ function main() {
   }
 
   const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
-  const { failed, improved, messages } = compare(current, baseline);
+  const { failed, messages } = compare(current, baseline);
   for (const message of messages) {
     (message.startsWith('x ') ? console.error : console.warn)(message);
   }
   if (failed) return 1;
   console.log(
-    improved
-      ? 'ratchet ok: some counts are below baseline (see above)'
+    messages.length
+      ? 'ratchet ok: nothing above a gated baseline (see notes above)'
       : 'ratchet ok: all escape-hatch counts at baseline',
   );
   return 0;


### PR DESCRIPTION
## Summary

Trying to cut down on duplicated code. Two parts:

**Grep-first rule** (`agent_docs/code_style.md`) — before adding a type, schema, helper, or component, grep for the operation it performs, not the name you'd give it. `common-utils` has no root barrel, so there's no index to read; the doc adds a map of the nine modules holding ~90% of cross-package imports.

**A check** (`scripts/ci/ratchet.mjs`) — the ratchet now counts `@source packages/...` markers on files ported wholesale into `packages/cli`. 37 today. Advisory only: it warns, never fails. Gating it would just teach people to drop the marker, since deleting the comment removes the record of a copy, not the copy.

No existing duplicates are removed here.

### How to test on Vercel preview

N/A — non-UI change.

### References

- Linear Issue: n/a
- Related PRs: n/a
