### PR TITLE
fix: Reliably show service and level in pattern sample drawer

### DIFF
--- a/.changeset/pattern-flyout-servicename.md
+++ b/.changeset/pattern-flyout-servicename.md
@@ -2,4 +2,4 @@
 '@hyperdx/app': patch
 ---
 
-fix: Reliably show service name in pattern sample drawer
+fix: Reliably show service name and level in pattern sample drawer

--- a/.changeset/pattern-flyout-servicename.md
+++ b/.changeset/pattern-flyout-servicename.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: Reliably show service name in pattern sample drawer

--- a/docker/clickhouse/local/init-db-e2e.sh
+++ b/docker/clickhouse/local/init-db-e2e.sh
@@ -465,6 +465,25 @@ GROUP BY
     Key,
     Timestamp;
 
+-- ---------------------------------------------------------------------------
+-- Generic Logs source (HDX-5274)
+-- ---------------------------------------------------------------------------
+-- A log table with a custom ServiceName column, which is deliberately NOT
+-- part of the sort/primary key.
+CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_custom_service_name
+(
+  \`Timestamp\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+  \`AppName\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`SeverityText\` LowCardinality(String) CODEC(ZSTD(1)),
+  \`Body\` String CODEC(ZSTD(1)),
+  \`LogAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1))
+)
+ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp)
+TTL toDateTime(Timestamp) + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
 -- PromQL fixture.
 CREATE TABLE IF NOT EXISTS ${DATABASE}.e2e_promql ENGINE = TimeSeries;
 EOFSQL

--- a/packages/app/src/components/AISummarizePatternButton.tsx
+++ b/packages/app/src/components/AISummarizePatternButton.tsx
@@ -2,10 +2,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
+  LEVEL_COLUMN_ALIAS,
   Pattern,
   PATTERN_COLUMN_ALIAS,
   SERVICE_NAME_COLUMN_ALIAS,
-  SEVERITY_TEXT_COLUMN_ALIAS,
 } from '@/hooks/usePatterns';
 
 import AISummaryPanel from './aiSummarize/AISummaryPanel';
@@ -31,11 +31,11 @@ function buildRowDataFromSample(pattern: Pattern): {
     rowData: {
       __hdx_body: sample[PATTERN_COLUMN_ALIAS],
       ServiceName: sample[SERVICE_NAME_COLUMN_ALIAS],
-      __hdx_severity_text: sample[SEVERITY_TEXT_COLUMN_ALIAS],
+      __hdx_severity_text: sample[LEVEL_COLUMN_ALIAS],
       // Pass through any other fields the sample may have (attributes, etc.)
       ...sample,
     },
-    severityText: sample[SEVERITY_TEXT_COLUMN_ALIAS],
+    severityText: sample[LEVEL_COLUMN_ALIAS],
   };
 }
 

--- a/packages/app/src/components/AISummarizePatternButton.tsx
+++ b/packages/app/src/components/AISummarizePatternButton.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Pattern,
   PATTERN_COLUMN_ALIAS,
+  SERVICE_NAME_COLUMN_ALIAS,
   SEVERITY_TEXT_COLUMN_ALIAS,
 } from '@/hooks/usePatterns';
 
@@ -20,16 +21,16 @@ import {
  * Build a synthetic RowData from the first sample event so the summary
  * generators can extract OTel facts (service, severity, body, etc.).
  */
-function buildRowDataFromSample(
-  pattern: Pattern,
-  serviceNameExpression: string,
-): { rowData: RowData; severityText?: string } {
+function buildRowDataFromSample(pattern: Pattern): {
+  rowData: RowData;
+  severityText?: string;
+} {
   const sample = pattern.samples[0];
   if (!sample) return { rowData: {} };
   return {
     rowData: {
       __hdx_body: sample[PATTERN_COLUMN_ALIAS],
-      ServiceName: sample[serviceNameExpression],
+      ServiceName: sample[SERVICE_NAME_COLUMN_ALIAS],
       __hdx_severity_text: sample[SEVERITY_TEXT_COLUMN_ALIAS],
       // Pass through any other fields the sample may have (attributes, etc.)
       ...sample,
@@ -40,10 +41,8 @@ function buildRowDataFromSample(
 
 export default function AISummarizePatternButton({
   pattern,
-  serviceNameExpression,
 }: {
   pattern: Pattern;
-  serviceNameExpression: string;
 }) {
   const [result, setResult] = useState<{
     text: string;
@@ -79,10 +78,7 @@ export default function AISummarizePatternButton({
     }
     setIsGenerating(true);
     setIsOpen(true);
-    const { rowData, severityText } = buildRowDataFromSample(
-      pattern,
-      serviceNameExpression,
-    );
+    const { rowData, severityText } = buildRowDataFromSample(pattern);
     timerRef.current = setTimeout(() => {
       setResult(
         generatePatternSummary(
@@ -95,14 +91,11 @@ export default function AISummarizePatternButton({
       setIsGenerating(false);
       timerRef.current = null;
     }, 1800);
-  }, [pattern, serviceNameExpression, result]);
+  }, [pattern, result]);
 
   const handleRegenerate = useCallback(() => {
     setIsGenerating(true);
-    const { rowData, severityText } = buildRowDataFromSample(
-      pattern,
-      serviceNameExpression,
-    );
+    const { rowData, severityText } = buildRowDataFromSample(pattern);
     timerRef.current = setTimeout(() => {
       setResult(
         generatePatternSummary(
@@ -115,7 +108,7 @@ export default function AISummarizePatternButton({
       setIsGenerating(false);
       timerRef.current = null;
     }, 1200);
-  }, [pattern, serviceNameExpression]);
+  }, [pattern]);
 
   const handleDismiss = useCallback(() => {
     dismissEasterEgg();

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -37,7 +37,6 @@ import {
 import {
   BuilderChartConfigWithDateRange,
   SelectList,
-  SourceKind,
   TSource,
 } from '@hyperdx/common-utils/dist/types';
 import {
@@ -88,7 +87,7 @@ import useRowWhere, {
   WithClause,
 } from '@/hooks/useRowWhere';
 import { useTableSearch } from '@/hooks/useTableSearch';
-import { useSource } from '@/source';
+import { getLevelExpression, useSource } from '@/source';
 import {
   MIN_COLUMN_WIDTH,
   MIN_LAST_COLUMN_WIDTH,
@@ -136,7 +135,6 @@ const SPECIAL_VALUES = {
 const ACCESSOR_MAP: Record<string, AccessorFn> = {
   duration: row =>
     row.duration >= 0 ? row.duration : SPECIAL_VALUES.not_available,
-  severityText: row => row.severityText ?? row.statusCode,
   default: (row, column) => row[column],
 };
 
@@ -595,10 +593,7 @@ export const RawLogTable = memo(
                     <PatternTrendChart
                       data={value.data}
                       dateRange={value.dateRange}
-                      color={logLevelColor(
-                        info.row.original.severityText ??
-                          info.row.original.statusCode,
-                      )}
+                      color={logLevelColor(info.row.original.level)}
                     />
                   </div>
                 );
@@ -1740,10 +1735,7 @@ function DBSqlRowTableComponent({
     config,
     samples: DENOISE_SAMPLE_SIZE,
     bodyValueExpression: patternColumn ?? '',
-    severityTextExpression:
-      (source?.kind === SourceKind.Log
-        ? source.severityTextExpression
-        : undefined) ?? '',
+    levelExpression: getLevelExpression(source),
     totalCount: undefined,
     enabled: denoiseResults,
   });

--- a/packages/app/src/components/PatternSidePanel.tsx
+++ b/packages/app/src/components/PatternSidePanel.tsx
@@ -9,11 +9,11 @@ import AISummarizePatternButton from '@/components/AISummarizePatternButton';
 import DBRowSidePanel from '@/components/DBRowSidePanel';
 import { RawLogTable } from '@/components/DBRowTable';
 import { DrawerBody, DrawerHeader } from '@/components/DrawerUtils';
-import { Pattern } from '@/hooks/usePatterns';
 import {
+  LEVEL_COLUMN_ALIAS,
+  Pattern,
   PATTERN_COLUMN_ALIAS,
   SERVICE_NAME_COLUMN_ALIAS,
-  SEVERITY_TEXT_COLUMN_ALIAS,
   TIMESTAMP_COLUMN_ALIAS,
 } from '@/hooks/usePatterns';
 import useRowWhere, { RowWhereResult } from '@/hooks/useRowWhere';
@@ -46,7 +46,7 @@ export default function PatternSidePanel({
       new Map<string, { _type: JSDataType | null }>([
         [TIMESTAMP_COLUMN_ALIAS, { _type: JSDataType.Date }],
         [PATTERN_COLUMN_ALIAS, { _type: JSDataType.String }],
-        [SEVERITY_TEXT_COLUMN_ALIAS, { _type: JSDataType.String }],
+        [LEVEL_COLUMN_ALIAS, { _type: JSDataType.String }],
         [SERVICE_NAME_COLUMN_ALIAS, { _type: JSDataType.String }],
       ]),
     [],
@@ -56,7 +56,7 @@ export default function PatternSidePanel({
     () => ({
       [TIMESTAMP_COLUMN_ALIAS]: 'Timestamp',
       [SERVICE_NAME_COLUMN_ALIAS]: 'Service',
-      [SEVERITY_TEXT_COLUMN_ALIAS]: 'level',
+      [LEVEL_COLUMN_ALIAS]: 'Level',
       [PATTERN_COLUMN_ALIAS]: 'Body',
     }),
     [],
@@ -66,7 +66,7 @@ export default function PatternSidePanel({
     return [
       TIMESTAMP_COLUMN_ALIAS,
       SERVICE_NAME_COLUMN_ALIAS,
-      SEVERITY_TEXT_COLUMN_ALIAS,
+      LEVEL_COLUMN_ALIAS,
       PATTERN_COLUMN_ALIAS,
     ];
   }, []);

--- a/packages/app/src/components/PatternSidePanel.tsx
+++ b/packages/app/src/components/PatternSidePanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { JSDataType } from '@hyperdx/common-utils/dist/clickhouse';
-import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
+import { TSource } from '@hyperdx/common-utils/dist/types';
 import { Button, Card, Drawer, Stack, Text } from '@mantine/core';
 
 import { IsolatedChartSyncProvider } from '@/chartSync';
@@ -12,6 +12,7 @@ import { DrawerBody, DrawerHeader } from '@/components/DrawerUtils';
 import { Pattern } from '@/hooks/usePatterns';
 import {
   PATTERN_COLUMN_ALIAS,
+  SERVICE_NAME_COLUMN_ALIAS,
   SEVERITY_TEXT_COLUMN_ALIAS,
   TIMESTAMP_COLUMN_ALIAS,
 } from '@/hooks/usePatterns';
@@ -40,38 +41,35 @@ export default function PatternSidePanel({
   const [selectedRowWhere, setSelectedRowWhere] =
     React.useState<RowWhereResult | null>(null);
 
-  const serviceNameExpression =
-    ((source?.kind === SourceKind.Log || source?.kind === SourceKind.Trace) &&
-      source.serviceNameExpression) ||
-    'Service';
+  const columnTypeMap = React.useMemo(
+    () =>
+      new Map<string, { _type: JSDataType | null }>([
+        [TIMESTAMP_COLUMN_ALIAS, { _type: JSDataType.Date }],
+        [PATTERN_COLUMN_ALIAS, { _type: JSDataType.String }],
+        [SEVERITY_TEXT_COLUMN_ALIAS, { _type: JSDataType.String }],
+        [SERVICE_NAME_COLUMN_ALIAS, { _type: JSDataType.String }],
+      ]),
+    [],
+  );
 
-  const columnTypeMap = React.useMemo(() => {
-    const map = new Map<string, { _type: JSDataType | null }>([
-      [TIMESTAMP_COLUMN_ALIAS, { _type: JSDataType.Date }],
-      [PATTERN_COLUMN_ALIAS, { _type: JSDataType.String }],
-      [SEVERITY_TEXT_COLUMN_ALIAS, { _type: JSDataType.String }],
-      [serviceNameExpression, { _type: JSDataType.String }],
-    ]);
-    return map;
-  }, [serviceNameExpression]);
-
-  const columnNameMap = React.useMemo(() => {
-    return {
+  const columnNameMap = React.useMemo(
+    () => ({
       [TIMESTAMP_COLUMN_ALIAS]: 'Timestamp',
-      [serviceNameExpression]: 'Service',
+      [SERVICE_NAME_COLUMN_ALIAS]: 'Service',
       [SEVERITY_TEXT_COLUMN_ALIAS]: 'level',
       [PATTERN_COLUMN_ALIAS]: 'Body',
-    };
-  }, [serviceNameExpression]);
+    }),
+    [],
+  );
 
   const displayedColumns = React.useMemo(() => {
     return [
       TIMESTAMP_COLUMN_ALIAS,
-      serviceNameExpression,
+      SERVICE_NAME_COLUMN_ALIAS,
       SEVERITY_TEXT_COLUMN_ALIAS,
       PATTERN_COLUMN_ALIAS,
     ];
-  }, [serviceNameExpression]);
+  }, []);
 
   const getRowWhere = useRowWhere({
     meta: [
@@ -129,7 +127,7 @@ export default function PatternSidePanel({
     >
       <ZIndexContext value={drawerZIndex}>
         <IsolatedChartSyncProvider>
-          <div className={styles.panel}>
+          <div className={styles.panel} data-testid="pattern-side-panel">
             <DrawerHeader
               header="Pattern"
               onClose={selectedRowWhere ? handleCloseRowSidePanel : onClose}
@@ -138,10 +136,7 @@ export default function PatternSidePanel({
               <Stack>
                 <Card p="md">
                   <Text size="sm">{pattern.pattern}</Text>
-                  <AISummarizePatternButton
-                    pattern={pattern}
-                    serviceNameExpression={serviceNameExpression}
-                  />
+                  <AISummarizePatternButton pattern={pattern} />
                 </Card>
                 <Card p="md">
                   <Card.Section p="md" py="xs">

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -11,6 +11,7 @@ import { SQLPreview } from '@/components/ChartSQLPreview';
 import { RawLogTable } from '@/components/DBRowTable';
 import { useSearchTotalCount } from '@/components/SearchTotalCountChart';
 import { Pattern, useGroupedPatterns } from '@/hooks/usePatterns';
+import { getLevelExpression } from '@/source';
 
 import {
   buildPatternColumnExpression,
@@ -74,10 +75,7 @@ export default function PatternTable({
     config,
     samples: SAMPLES,
     bodyValueExpression: effectiveBodyValueExpression,
-    severityTextExpression:
-      (source?.kind === SourceKind.Log && source.severityTextExpression) || '',
-    statusCodeExpression:
-      (source?.kind === SourceKind.Trace && source.statusCodeExpression) || '',
+    levelExpression: getLevelExpression(source),
     serviceNameExpression:
       ((source?.kind === SourceKind.Log || source?.kind === SourceKind.Trace) &&
         source.serviceNameExpression) ||
@@ -149,7 +147,7 @@ export default function PatternTable({
             displayedColumns={[
               '__hdx_pattern_trend',
               'countStr',
-              'severityText',
+              'level',
               'pattern',
             ]}
             onRowDetailsClick={row => setSelectedPattern(row as Pattern)}
@@ -162,7 +160,7 @@ export default function PatternTable({
               __hdx_pattern_trend: 'Trend',
               countStr: 'Count',
               pattern: 'Pattern',
-              severityText: 'Level',
+              level: 'Level',
             }}
             config={patternQueryConfig}
             showExpandButton={false}

--- a/packages/app/src/components/PatternTable.tsx
+++ b/packages/app/src/components/PatternTable.tsx
@@ -78,6 +78,10 @@ export default function PatternTable({
       (source?.kind === SourceKind.Log && source.severityTextExpression) || '',
     statusCodeExpression:
       (source?.kind === SourceKind.Trace && source.statusCodeExpression) || '',
+    serviceNameExpression:
+      ((source?.kind === SourceKind.Log || source?.kind === SourceKind.Trace) &&
+        source.serviceNameExpression) ||
+      '',
     totalCount,
   });
 

--- a/packages/app/src/hooks/usePatterns.tsx
+++ b/packages/app/src/hooks/usePatterns.tsx
@@ -108,9 +108,9 @@ async function mineEventPatterns(logs: string[], pyodide: any) {
 
 export const PATTERN_COLUMN_ALIAS = '__hdx_pattern_field';
 export const TIMESTAMP_COLUMN_ALIAS = '__hdx_timestamp';
-export const SEVERITY_TEXT_COLUMN_ALIAS = '__hdx_severity_text';
 export const SERVICE_NAME_COLUMN_ALIAS = '__hdx_service_name';
-const STATUS_CODE_COLUMN_ALIAS = '__hdx_status_code';
+// The source's level column: severity text for logs, status code for traces.
+export const LEVEL_COLUMN_ALIAS = '__hdx_level';
 
 type SampleLog = {
   [PATTERN_COLUMN_ALIAS]: string;
@@ -129,16 +129,14 @@ function usePatterns({
   config,
   samples,
   bodyValueExpression,
-  severityTextExpression,
-  statusCodeExpression,
+  levelExpression,
   serviceNameExpression,
   enabled = true,
 }: {
   config: BuilderChartConfigWithDateRange;
   samples: number;
   bodyValueExpression: string;
-  severityTextExpression?: string;
-  statusCodeExpression?: string;
+  levelExpression?: string;
   serviceNameExpression?: string;
   enabled?: boolean;
 }) {
@@ -148,11 +146,8 @@ function usePatterns({
     select: [
       `${bodyValueExpression} as ${PATTERN_COLUMN_ALIAS}`,
       `${getFirstTimestampValueExpression(config.timestampValueExpression)} as ${TIMESTAMP_COLUMN_ALIAS}`,
-      ...(severityTextExpression
-        ? [`${severityTextExpression} as ${SEVERITY_TEXT_COLUMN_ALIAS}`]
-        : []),
-      ...(statusCodeExpression
-        ? [`${statusCodeExpression} as ${STATUS_CODE_COLUMN_ALIAS}`]
+      ...(levelExpression
+        ? [`${levelExpression} as ${LEVEL_COLUMN_ALIAS}`]
         : []),
       ...(serviceNameExpression
         ? [`${serviceNameExpression} as ${SERVICE_NAME_COLUMN_ALIAS}`]
@@ -229,8 +224,7 @@ export function useGroupedPatterns({
   config,
   samples,
   bodyValueExpression,
-  severityTextExpression,
-  statusCodeExpression,
+  levelExpression,
   serviceNameExpression,
   totalCount,
   enabled = true,
@@ -238,8 +232,7 @@ export function useGroupedPatterns({
   config: BuilderChartConfigWithDateRange;
   samples: number;
   bodyValueExpression: string;
-  severityTextExpression?: string;
-  statusCodeExpression?: string;
+  levelExpression?: string;
   serviceNameExpression?: string;
   totalCount?: number;
   enabled?: boolean;
@@ -253,8 +246,7 @@ export function useGroupedPatterns({
     config,
     samples,
     bodyValueExpression,
-    severityTextExpression,
-    statusCodeExpression,
+    levelExpression,
     serviceNameExpression,
     enabled,
   });
@@ -316,8 +308,7 @@ export function useGroupedPatterns({
         pattern: reconstructedPattern, // last pattern is usually the most up to date templated pattern
         count,
         countStr: `~${count}`,
-        severityText: lastRow?.[SEVERITY_TEXT_COLUMN_ALIAS], // last severitytext is usually representative of the entire pattern set
-        statusCode: lastRow?.[STATUS_CODE_COLUMN_ALIAS],
+        level: lastRow?.[LEVEL_COLUMN_ALIAS], // last level is usually representative of the entire pattern set
         samples: rows,
         __hdx_pattern_trend: {
           data: Object.entries(bucketCounts).map(([bucket, count]) => ({

--- a/packages/app/src/hooks/usePatterns.tsx
+++ b/packages/app/src/hooks/usePatterns.tsx
@@ -109,6 +109,7 @@ async function mineEventPatterns(logs: string[], pyodide: any) {
 export const PATTERN_COLUMN_ALIAS = '__hdx_pattern_field';
 export const TIMESTAMP_COLUMN_ALIAS = '__hdx_timestamp';
 export const SEVERITY_TEXT_COLUMN_ALIAS = '__hdx_severity_text';
+export const SERVICE_NAME_COLUMN_ALIAS = '__hdx_service_name';
 const STATUS_CODE_COLUMN_ALIAS = '__hdx_status_code';
 
 type SampleLog = {
@@ -130,6 +131,7 @@ function usePatterns({
   bodyValueExpression,
   severityTextExpression,
   statusCodeExpression,
+  serviceNameExpression,
   enabled = true,
 }: {
   config: BuilderChartConfigWithDateRange;
@@ -137,6 +139,7 @@ function usePatterns({
   bodyValueExpression: string;
   severityTextExpression?: string;
   statusCodeExpression?: string;
+  serviceNameExpression?: string;
   enabled?: boolean;
 }) {
   const configWithPrimaryAndPartitionKey = useConfigWithAdditionalSelect({
@@ -150,6 +153,9 @@ function usePatterns({
         : []),
       ...(statusCodeExpression
         ? [`${statusCodeExpression} as ${STATUS_CODE_COLUMN_ALIAS}`]
+        : []),
+      ...(serviceNameExpression
+        ? [`${serviceNameExpression} as ${SERVICE_NAME_COLUMN_ALIAS}`]
         : []),
     ].join(','),
     // TODO: Proper sampling
@@ -225,6 +231,7 @@ export function useGroupedPatterns({
   bodyValueExpression,
   severityTextExpression,
   statusCodeExpression,
+  serviceNameExpression,
   totalCount,
   enabled = true,
 }: {
@@ -233,6 +240,7 @@ export function useGroupedPatterns({
   bodyValueExpression: string;
   severityTextExpression?: string;
   statusCodeExpression?: string;
+  serviceNameExpression?: string;
   totalCount?: number;
   enabled?: boolean;
 }) {
@@ -247,6 +255,7 @@ export function useGroupedPatterns({
     bodyValueExpression,
     severityTextExpression,
     statusCodeExpression,
+    serviceNameExpression,
     enabled,
   });
 

--- a/packages/app/src/source.ts
+++ b/packages/app/src/source.ts
@@ -94,6 +94,19 @@ export function getEventBody(eventModel: TSource) {
 }
 
 /**
+ * The source's level column: severity text for logs, status code for traces.
+ */
+export function getLevelExpression(source?: TSource): string {
+  if (source?.kind === SourceKind.Log) {
+    return source.severityTextExpression ?? '';
+  }
+  if (source?.kind === SourceKind.Trace) {
+    return source.statusCodeExpression ?? '';
+  }
+  return '';
+}
+
+/**
  * Check if a select string is a single expression (valid as a pattern body
  * expression) rather than a multi-column list (stale
  * `defaultTableSelectExpression`). Uses bracket-aware comma splitting so

--- a/packages/app/tests/e2e/components/PatternSidePanelComponent.ts
+++ b/packages/app/tests/e2e/components/PatternSidePanelComponent.ts
@@ -6,8 +6,9 @@
 import { Locator, Page } from '@playwright/test';
 
 // Column order rendered by the sample table (see PatternSidePanel's
-// displayedColumns): Timestamp, Service, level, Body.
+// displayedColumns): Timestamp, Service, Level, Body.
 const SERVICE_COLUMN_INDEX = 1;
+const LEVEL_COLUMN_INDEX = 2;
 
 export class PatternSidePanelComponent {
   readonly page: Page;
@@ -40,6 +41,11 @@ export class PatternSidePanelComponent {
     return this.panelContainer.getByRole('columnheader', { name: 'Service' });
   }
 
+  /** The "Level" column header of the sample table. */
+  get levelColumnHeader() {
+    return this.panelContainer.getByRole('columnheader', { name: 'Level' });
+  }
+
   /**
    * The Service-column cell of a sample row. Columns render as sibling divs
    * inside the row's content button, in the order declared by displayedColumns,
@@ -50,5 +56,13 @@ export class PatternSidePanelComponent {
       .nth(rowIndex)
       .locator('td > button > div')
       .nth(SERVICE_COLUMN_INDEX);
+  }
+
+  /** The Level-column cell of a sample row. */
+  levelCell(rowIndex = 0) {
+    return this.sampleRows
+      .nth(rowIndex)
+      .locator('td > button > div')
+      .nth(LEVEL_COLUMN_INDEX);
   }
 }

--- a/packages/app/tests/e2e/components/PatternSidePanelComponent.ts
+++ b/packages/app/tests/e2e/components/PatternSidePanelComponent.ts
@@ -1,0 +1,54 @@
+/**
+ * PatternSidePanelComponent - the "Pattern" drawer opened from the Event
+ * Patterns list. Wraps its "Sample Events" table so specs can assert on the
+ * sample columns (e.g. that the Service column is populated).
+ */
+import { Locator, Page } from '@playwright/test';
+
+// Column order rendered by the sample table (see PatternSidePanel's
+// displayedColumns): Timestamp, Service, level, Body.
+const SERVICE_COLUMN_INDEX = 1;
+
+export class PatternSidePanelComponent {
+  readonly page: Page;
+  private readonly panelContainer: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.panelContainer = page.getByTestId('pattern-side-panel');
+  }
+
+  get container() {
+    return this.panelContainer;
+  }
+
+  /** The "Sample Events" table inside the drawer. */
+  get sampleTable() {
+    return this.panelContainer.getByTestId('search-results-table');
+  }
+
+  get sampleRows() {
+    return this.panelContainer.locator('[data-testid^="table-row-"]');
+  }
+
+  get firstRow() {
+    return this.sampleRows.first();
+  }
+
+  /** The "Service" column header of the sample table. */
+  get serviceColumnHeader() {
+    return this.panelContainer.getByRole('columnheader', { name: 'Service' });
+  }
+
+  /**
+   * The Service-column cell of a sample row. Columns render as sibling divs
+   * inside the row's content button, in the order declared by displayedColumns,
+   * so the Service value is at a fixed position.
+   */
+  serviceCell(rowIndex = 0) {
+    return this.sampleRows
+      .nth(rowIndex)
+      .locator('td > button > div')
+      .nth(SERVICE_COLUMN_INDEX);
+  }
+}

--- a/packages/app/tests/e2e/features/search/event-patterns.spec.ts
+++ b/packages/app/tests/e2e/features/search/event-patterns.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Event Patterns sample flyout — Service column (HDX-5274)
+ *
+ * The 'E2E Generic Logs' source names its service column `AppName` (not the
+ * standard `ServiceName`), keeps it out of the backing table's sort key, and
+ * aliases it in its default SELECT (`AppName as service`). The Event Patterns
+ * view rebuilds its own sample SELECT, so the service only shows up in the
+ * flyout's "Sample Events" table if it is selected explicitly under a stable
+ * alias — the fix for HDX-5274. Before it, the Service column rendered empty for
+ * this shape (it worked elsewhere only because ServiceName happened to be in the
+ * sort key and got appended incidentally).
+ */
+import { SearchPage } from '../../page-objects/SearchPage';
+import { CUSTOM_SERVICE_LOGS_APP_NAMES } from '../../seed-clickhouse';
+import { expect, test } from '../../utils/base-test';
+import { CUSTOM_SERVICE_LOGS_SOURCE_NAME } from '../../utils/constants';
+
+// The seeded AppName values are distinct tokens that never appear in a Body, so
+// matching any of them in the Service column proves it is populated with the
+// service and not accidentally reading another column.
+const APP_NAME_PATTERN = new RegExp(CUSTOM_SERVICE_LOGS_APP_NAMES.join('|'));
+
+test.describe(
+  'Event Patterns sample flyout',
+  { tag: ['@full-stack', '@search'] },
+  () => {
+    test('renders the service name for a non-standard service column that is not in the sort key', async ({
+      page,
+    }) => {
+      const searchPage = new SearchPage(page);
+      await searchPage.goto();
+      await searchPage.selectSource(CUSTOM_SERVICE_LOGS_SOURCE_NAME);
+      await searchPage.timePicker.selectRelativeTime('Last 1 hour');
+      await searchPage.table.waitForRowsToPopulate();
+      await expect(searchPage.getTableError()).toHaveCount(0);
+
+      await searchPage.switchToEventPatterns();
+      await searchPage.openFirstPattern();
+
+      const panel = searchPage.patternSidePanel;
+      await expect(panel.sampleTable).toBeVisible();
+      await expect(panel.serviceColumnHeader).toBeVisible();
+      await expect(panel.serviceCell(0)).toHaveText(APP_NAME_PATTERN);
+    });
+  },
+);

--- a/packages/app/tests/e2e/features/search/event-patterns.spec.ts
+++ b/packages/app/tests/e2e/features/search/event-patterns.spec.ts
@@ -1,46 +1,59 @@
-/**
- * Event Patterns sample flyout — Service column (HDX-5274)
- *
- * The 'E2E Generic Logs' source names its service column `AppName` (not the
- * standard `ServiceName`), keeps it out of the backing table's sort key, and
- * aliases it in its default SELECT (`AppName as service`). The Event Patterns
- * view rebuilds its own sample SELECT, so the service only shows up in the
- * flyout's "Sample Events" table if it is selected explicitly under a stable
- * alias — the fix for HDX-5274. Before it, the Service column rendered empty for
- * this shape (it worked elsewhere only because ServiceName happened to be in the
- * sort key and got appended incidentally).
- */
 import { SearchPage } from '../../page-objects/SearchPage';
 import { CUSTOM_SERVICE_LOGS_APP_NAMES } from '../../seed-clickhouse';
 import { expect, test } from '../../utils/base-test';
-import { CUSTOM_SERVICE_LOGS_SOURCE_NAME } from '../../utils/constants';
+import {
+  CUSTOM_SERVICE_LOGS_SOURCE_NAME,
+  DEFAULT_TRACES_SOURCE_NAME,
+} from '../../utils/constants';
 
 // The seeded AppName values are distinct tokens that never appear in a Body, so
 // matching any of them in the Service column proves it is populated with the
 // service and not accidentally reading another column.
 const APP_NAME_PATTERN = new RegExp(CUSTOM_SERVICE_LOGS_APP_NAMES.join('|'));
 
-test.describe(
-  'Event Patterns sample flyout',
-  { tag: ['@full-stack', '@search'] },
-  () => {
-    test('renders the service name for a non-standard service column that is not in the sort key', async ({
-      page,
-    }) => {
-      const searchPage = new SearchPage(page);
-      await searchPage.goto();
-      await searchPage.selectSource(CUSTOM_SERVICE_LOGS_SOURCE_NAME);
-      await searchPage.timePicker.selectRelativeTime('Last 1 hour');
-      await searchPage.table.waitForRowsToPopulate();
-      await expect(searchPage.getTableError()).toHaveCount(0);
+// The seeded trace StatusCode values. Trace sources have no severity text, so
+// these are what the Level column has to fall back to.
+const TRACE_STATUS_CODE_PATTERN = /STATUS_CODE_(OK|ERROR)/;
 
-      await searchPage.switchToEventPatterns();
-      await searchPage.openFirstPattern();
+test.describe('Event Patterns', { tag: ['@full-stack', '@search'] }, () => {
+  test('renders the service name for a non-standard service column that is not in the sort key', async ({
+    page,
+  }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.goto();
+    await searchPage.selectSource(CUSTOM_SERVICE_LOGS_SOURCE_NAME);
+    await searchPage.timePicker.selectRelativeTime('Last 1 hour');
+    await searchPage.table.waitForRowsToPopulate();
+    await expect(searchPage.getTableError()).toHaveCount(0);
 
-      const panel = searchPage.patternSidePanel;
-      await expect(panel.sampleTable).toBeVisible();
-      await expect(panel.serviceColumnHeader).toBeVisible();
-      await expect(panel.serviceCell(0)).toHaveText(APP_NAME_PATTERN);
-    });
-  },
-);
+    await searchPage.switchToEventPatterns();
+    await searchPage.openFirstPattern();
+
+    const panel = searchPage.patternSidePanel;
+    await expect(panel.sampleTable).toBeVisible();
+    await expect(panel.serviceColumnHeader).toBeVisible();
+    await expect(panel.serviceCell(0)).toHaveText(APP_NAME_PATTERN);
+  });
+
+  test('falls back to the trace status code in the Level column', async ({
+    page,
+  }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.goto();
+    await searchPage.selectSource(DEFAULT_TRACES_SOURCE_NAME);
+    await searchPage.timePicker.selectRelativeTime('Last 1 hour');
+    await searchPage.table.waitForRowsToPopulate();
+    await expect(searchPage.getTableError()).toHaveCount(0);
+
+    await searchPage.switchToEventPatterns();
+    await expect(searchPage.patternListLevelCell(0)).toHaveText(
+      TRACE_STATUS_CODE_PATTERN,
+    );
+
+    await searchPage.openFirstPattern();
+
+    const panel = searchPage.patternSidePanel;
+    await expect(panel.levelColumnHeader).toBeVisible();
+    await expect(panel.levelCell(0)).toHaveText(TRACE_STATUS_CODE_PATTERN);
+  });
+});

--- a/packages/app/tests/e2e/fixtures/e2e-fixtures.json
+++ b/packages/app/tests/e2e/fixtures/e2e-fixtures.json
@@ -185,6 +185,23 @@
       "displayedTimestampValueExpression": "Timestamp"
     },
     {
+      "id": "E2E Custom Service Logs",
+      "kind": "log",
+      "name": "E2E Custom Service Logs",
+      "connection": "local",
+      "from": {
+        "databaseName": "default",
+        "tableName": "e2e_custom_service_name"
+      },
+      "timestampValueExpression": "Timestamp",
+      "defaultTableSelectExpression": "Timestamp, AppName as service, SeverityText as level, Body",
+      "serviceNameExpression": "AppName",
+      "severityTextExpression": "SeverityText",
+      "eventAttributesExpression": "LogAttributes",
+      "implicitColumnExpression": "Body",
+      "displayedTimestampValueExpression": "Timestamp"
+    },
+    {
       "id": "E2E Interesting Filter Keys",
       "kind": "log",
       "name": "E2E Interesting Filter Keys",

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -6,6 +6,7 @@ import { expect, Locator, Page } from '@playwright/test';
 
 import { FilterComponent } from '../components/FilterComponent';
 import { InfrastructurePanelComponent } from '../components/InfrastructurePanelComponent';
+import { PatternSidePanelComponent } from '../components/PatternSidePanelComponent';
 import { SavedSearchModalComponent } from '../components/SavedSearchModalComponent';
 import { SearchPageAlertModalComponent } from '../components/SearchPageAlertModalComponent';
 import { SidePanelComponent } from '../components/SidePanelComponent';
@@ -21,6 +22,7 @@ export class SearchPage {
   readonly table: TableComponent;
   readonly timePicker: TimePickerComponent;
   readonly sidePanel: SidePanelComponent;
+  readonly patternSidePanel: PatternSidePanelComponent;
   readonly infrastructure: InfrastructurePanelComponent;
   readonly filters: FilterComponent;
   readonly savedSearchModal: SavedSearchModalComponent;
@@ -50,6 +52,7 @@ export class SearchPage {
     );
     this.timePicker = new TimePickerComponent(page);
     this.sidePanel = new SidePanelComponent(page, 'row-side-panel');
+    this.patternSidePanel = new PatternSidePanelComponent(page);
     this.infrastructure = new InfrastructurePanelComponent(page);
     this.filters = new FilterComponent(page);
     this.savedSearchModal = new SavedSearchModalComponent(page);
@@ -108,6 +111,43 @@ export class SearchPage {
     await this.page
       .getByRole('option', { name: sourceName, exact: true })
       .click();
+  }
+
+  /** The "Event Patterns" analysis-mode tab in the filters sidebar. */
+  get eventPatternsTab() {
+    return this.page.getByRole('tab', { name: 'Event Patterns' });
+  }
+
+  /**
+   * The pattern list table (the "Event Patterns" grid). It renders before the
+   * flyout in the DOM (the flyout is a portaled drawer), so `.first()` resolves
+   * the pattern list even after the flyout's sample table mounts.
+   */
+  get patternListTable() {
+    return this.page.getByTestId('search-results-table').first();
+  }
+
+  get patternListRows() {
+    return this.patternListTable.locator('[data-testid^="table-row-"]');
+  }
+
+  /**
+   * Switch to Event Patterns mode and wait for the (client-side, Drain-based)
+   * pattern list to finish clustering and render at least one pattern row.
+   */
+  async switchToEventPatterns(timeout = 60_000) {
+    await this.eventPatternsTab.click();
+    await this.patternListRows.first().waitFor({ state: 'visible', timeout });
+  }
+
+  /** Open the first pattern's sample flyout and wait for it to render. */
+  async openFirstPattern(timeout = 30_000) {
+    await this.patternListRows.first().click();
+    await this.patternSidePanel.container.waitFor({
+      state: 'visible',
+      timeout,
+    });
+    await this.patternSidePanel.firstRow.waitFor({ state: 'visible', timeout });
   }
 
   async openEditSourceModal() {

--- a/packages/app/tests/e2e/page-objects/SearchPage.ts
+++ b/packages/app/tests/e2e/page-objects/SearchPage.ts
@@ -140,6 +140,19 @@ export class SearchPage {
     await this.patternListRows.first().waitFor({ state: 'visible', timeout });
   }
 
+  /**
+   * The Level-column cell of a pattern-list row. The list renders its columns
+   * as sibling divs inside the row's content button (see PatternTable's
+   * displayedColumns: Trend, Count, Level, Pattern).
+   */
+  patternListLevelCell(rowIndex = 0) {
+    const PATTERN_LIST_LEVEL_COLUMN_INDEX = 2;
+    return this.patternListRows
+      .nth(rowIndex)
+      .locator('td > button > div')
+      .nth(PATTERN_LIST_LEVEL_COLUMN_INDEX);
+  }
+
   /** Open the first pattern's sample flyout and wait for it to render. */
   async openFirstPattern(timeout = 30_000) {
     await this.patternListRows.first().click();

--- a/packages/app/tests/e2e/seed-clickhouse.ts
+++ b/packages/app/tests/e2e/seed-clickhouse.ts
@@ -14,6 +14,7 @@ import {
   E2E_ALT_METRICS_GAUGE_TABLE,
   E2E_ALT_METRICS_SUM_TABLE,
   E2E_CLICKHOUSE_DATABASE,
+  E2E_CUSTOM_SERVICE_LOGS_TABLE,
   E2E_INTERESTING_FILTER_KEYS_TABLE,
   E2E_LOGS_TABLE,
   E2E_METADATA_MV_KEY_ROLLUP_TABLE,
@@ -162,6 +163,22 @@ export const METADATA_MV_ROWS = [
   },
 ] as const;
 
+// Service (`AppName`) values seeded into `e2e_custom_service_name`.
+export const CUSTOM_SERVICE_LOGS_APP_NAMES = [
+  'checkout-app',
+  'payments-app',
+  'inventory-app',
+  'auth-app',
+] as const;
+
+// Body templates for `e2e_custom_service_name`.
+const CUSTOM_SERVICE_LOG_MESSAGES = [
+  'Started request handler for endpoint',
+  'Completed background reconciliation loop for object',
+  'Cache lookup finished for entry',
+  'Connection pool statistics reported for shard',
+] as const;
+
 const LOG_MESSAGES = [
   'Request processed successfully',
   'Database connection established',
@@ -255,6 +272,35 @@ function generateLogData(
 
     rows.push(
       `('${timestampNs}', '${traceId}', '', 0, '${severity}', 0, '${service}', '${message}', '', {'service.name':'${service}','environment':'test'}, '', '', '', {}, {'request.id':'req-${i}','user.id':'user-${i % 5}'})`,
+    );
+  }
+
+  return rows.join(',\n');
+}
+
+/**
+ * Build the VALUES tuples for `e2e_custom_service_name`. Rows cycle through
+ * CUSTOM_SERVICE_LOGS_APP_NAMES and CUSTOM_SERVICE_LOG_MESSAGES so every Drain pattern's
+ * samples span multiple services. Spread across the seed window like the other
+ * log data so relative time ranges find them.
+ */
+function generateCustomServiceLogData(
+  count: number,
+  startMs: number,
+  endMs: number,
+): string {
+  const rows: string[] = [];
+  const span = endMs - startMs;
+
+  for (let i = 0; i < count; i++) {
+    const t = count > 1 ? startMs + (i / (count - 1)) * span : startMs;
+    const timestampNs = Math.round(t) * 1000000;
+    const appName =
+      CUSTOM_SERVICE_LOGS_APP_NAMES[i % CUSTOM_SERVICE_LOGS_APP_NAMES.length];
+    const severity = SEVERITIES[i % SEVERITIES.length];
+    const message = `${CUSTOM_SERVICE_LOG_MESSAGES[i % CUSTOM_SERVICE_LOG_MESSAGES.length]} ${i}`;
+    rows.push(
+      `('${timestampNs}', '${appName}', '${severity}', '${message}', {'level':'${severity}'})`,
     );
   }
 
@@ -850,6 +896,9 @@ async function clearTestData(
   await client.query(
     `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_METADATA_MV_KEY_ROLLUP_TABLE}`,
   );
+  await client.query(
+    `TRUNCATE TABLE IF EXISTS ${E2E_CLICKHOUSE_DATABASE}.${E2E_CUSTOM_SERVICE_LOGS_TABLE}`,
+  );
   console.log('  Existing data cleared');
 }
 
@@ -1036,6 +1085,14 @@ export async function seedClickHouse(): Promise<void> {
   console.log(
     `  Inserted ${METADATA_MV_ROWS.length} metadata-MV source entries`,
   );
+
+  console.log('  Inserting custom service name logs data...');
+  await client.query(`
+    INSERT INTO ${E2E_CLICKHOUSE_DATABASE}.${E2E_CUSTOM_SERVICE_LOGS_TABLE} (
+      Timestamp, AppName, SeverityText, Body, LogAttributes
+    ) VALUES ${generateCustomServiceLogData(numDataPoints, startMs, endMs)}
+  `);
+  console.log(`  Inserted ${numDataPoints} generic log entries`);
 
   // PromQL series: one per service, labelled with the same `ServiceName` values
   // the logs carry, so a dashboard filter on ServiceName selects values that

--- a/packages/app/tests/e2e/utils/constants.ts
+++ b/packages/app/tests/e2e/utils/constants.ts
@@ -12,6 +12,10 @@ export const DEFAULT_CONNECTION_NAME = 'local';
 // tab, and the Kubernetes dashboard's correlation warning).
 export const K8S_LOGS_NO_METRICS_SOURCE_NAME = 'E2E K8s Logs No Metrics';
 
+// Log source with a a non-standard service name that is NOT part of the
+// backing table's sort/primary key.
+export const CUSTOM_SERVICE_LOGS_SOURCE_NAME = 'E2E Custom Service Logs';
+
 // Source backed by `otel_logs_interesting_filter_keys`, used by the filter-key
 // edge case tests to exercise identifier escaping (dotted/hyphenated column
 // names, Map keys, and JSON paths) in search and dashboard filters.
@@ -78,3 +82,6 @@ export const E2E_INTERESTING_FILTER_KEYS_TABLE =
 export const E2E_METADATA_MV_LOGS_TABLE = 'e2e_otel_logs_metadata_mv';
 export const E2E_METADATA_MV_KV_ROLLUP_TABLE = 'e2e_otel_logs_kv_rollup_15m';
 export const E2E_METADATA_MV_KEY_ROLLUP_TABLE = 'e2e_otel_logs_key_rollup_15m';
+// Table backing CUSTOM_SERVICE_LOGS_SOURCE_NAME. Created in
+// `docker/clickhouse/local/init-db-e2e.sh` and seeded in `seed-clickhouse.ts`.
+export const E2E_CUSTOM_SERVICE_LOGS_TABLE = 'e2e_custom_service_name';


### PR DESCRIPTION
# Summary

This PR fixes two issues with the event patterns sample table:

1.  The table rendered an empty/undefined `service` for sources where the `serviceNameExpression` is not in the Primary Key (or where the Primary Key could not be accurately read by HyperDX due to distributed/merge table topologies).
2. The table rendered an empty/undefined `level` for trace sources

Root causes:

- For ServiceName: `usePatterns` never explicitly selected ServiceName in the first place, rather it just so happened that the ServiceName was added to the select by another optimization (`appendSelectWithAdditionalKeys`) which adds columns from the primary key.
- For Trace sources: `usePatterns` queries StatusCode, but the table did not read it, it was hardcoded to read SeverityText instead.

This fix updates the usePatterns query to explicitly query the correct columns under known alias names that are then referenced by those aliases in the PatternTable. This PR also includes E2E covering these cases.

## Screenshots

### Before:

Trace source level undefined

<img width="1594" height="766" alt="Screenshot 2026-09-02 at 7 14 20 PM" src="https://github.com/user-attachments/assets/81a9e0bd-9127-46d4-a992-361f9a1f5db1" />

Missing Service:

<img width="1861" height="447" alt="Screenshot 2026-09-02 at 7 18 21 PM" src="https://github.com/user-attachments/assets/a9d78c88-e5cd-4678-a6ab-c0571956708b" />


### After:

Trace source level defined

<img width="1853" height="620" alt="Screenshot 2026-09-02 at 7 14 14 PM" src="https://github.com/user-attachments/assets/eee202b5-abdd-43c3-88d4-1bc63de6a3ff" />

Service shown

<img width="1864" height="402" alt="Screenshot 2026-09-02 at 7 18 12 PM" src="https://github.com/user-attachments/assets/831b1beb-bca1-4bb4-b0c3-8b146594841f" />



## Testing

- Open event patterns, test that the sample panel populates all columns for both log and trace sources.

If you'd like to test the service name case, use this as a source:

```sql
CREATE TABLE IF NOT EXISTS e2e_custom_service_name
(
  `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
  `AppName` LowCardinality(String) CODEC(ZSTD(1)),
  `SeverityText` LowCardinality(String) CODEC(ZSTD(1)),
  `Body` String CODEC(ZSTD(1)),
  `LogAttributes` Map(LowCardinality(String), String) CODEC(ZSTD(1))
)
ENGINE = MergeTree
PARTITION BY toDate(Timestamp)
ORDER BY (toStartOfFiveMinutes(Timestamp), Timestamp)
TTL toDateTime(Timestamp) + toIntervalDay(30)
SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

insert into e2e_custom_service_name values (now(), 'service!', 'info', 'hello', {});
```

## References

Linear: Closes HDX-5274