### PR TITLE
feat: Persist alert-level displayName and tags

### DIFF
--- a/.changeset/alert-display-fields-core.md
+++ b/.changeset/alert-display-fields-core.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': minor
+'@hyperdx/common-utils': patch
+---
+
+feat: Alerts now persist their own `displayName` and `tags`

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -360,9 +360,31 @@
           },
           "name": {
             "type": "string",
-            "description": "Human-friendly alert name.",
+            "description": "Alert name template (Handlebars), rendered as the notification title. When omitted, a default title is generated from the display name, value and threshold.",
             "nullable": true,
-            "example": "Test Alert"
+            "example": "Errors for {{group}} hit {{value}}"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display name shown in the alerts list and in notification titles. Defaults to the name of the referenced saved search, dashboard tile, or inline chart when omitted or null.",
+            "nullable": true,
+            "minLength": 1,
+            "maxLength": 512,
+            "example": "Checkout error spike"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 32
+            },
+            "maxItems": 50,
+            "description": "Tags for the alert. Defaults to the tags of the referenced saved search or dashboard when omitted or null; inline alerts have no parent to inherit from and default to an empty list.",
+            "nullable": true,
+            "example": [
+              "checkout",
+              "p1"
+            ]
           },
           "message": {
             "type": "string",
@@ -394,7 +416,27 @@
           },
           {
             "type": "object",
+            "required": [
+              "displayName",
+              "tags"
+            ],
             "properties": {
+              "displayName": {
+                "type": "string",
+                "description": "The display name for the alert in the UI. Derived from the saved search name, dashboard tile name, or inline chartConfig name when not explicitly set.",
+                "example": "Checkout error spike"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The tags for the alert. Derived from the tags of the referenced saved search or dashboard when not explicitly set; inline alerts default to an empty list.",
+                "example": [
+                  "checkout",
+                  "p1"
+                ]
+              },
               "id": {
                 "type": "string",
                 "description": "Unique alert identifier.",
@@ -5239,6 +5281,11 @@
                         "teamId": "65f5e4a3b9e77c001a345678",
                         "tileId": "65f5e4a3b9e77c001a901234",
                         "dashboardId": "65f5e4a3b9e77c001a567890",
+                        "displayName": "Checkout error spike",
+                        "tags": [
+                          "checkout",
+                          "p1"
+                        ],
                         "numConsecutiveWindows": 3,
                         "createdAt": "2023-03-15T10:20:30.000Z",
                         "updatedAt": "2023-03-15T14:25:10.000Z"
@@ -5322,7 +5369,12 @@
                       "webhookId": "65f5e4a3b9e77c001a789012"
                     },
                     "name": "Updated Alert Name",
-                    "message": "Updated threshold and interval"
+                    "message": "Updated threshold and interval",
+                    "displayName": "Checkout error spike",
+                    "tags": [
+                      "checkout",
+                      "p1"
+                    ]
                   }
                 }
               }
@@ -5506,6 +5558,11 @@
                           "teamId": "65f5e4a3b9e77c001a345678",
                           "tileId": "65f5e4a3b9e77c001a901234",
                           "dashboardId": "65f5e4a3b9e77c001a567890",
+                          "displayName": "Checkout error spike",
+                          "tags": [
+                            "checkout",
+                            "p1"
+                          ],
                           "createdAt": "2023-01-01T00:00:00.000Z",
                           "updatedAt": "2023-01-01T00:00:00.000Z"
                         }
@@ -5576,6 +5633,11 @@
                     },
                     "name": "Error Spike Alert",
                     "message": "Error rate has exceeded 100 in the last hour",
+                    "displayName": "Checkout error spike",
+                    "tags": [
+                      "checkout",
+                      "p1"
+                    ],
                     "numConsecutiveWindows": 3
                   }
                 },

--- a/packages/api/src/controllers/__tests__/alerts.test.ts
+++ b/packages/api/src/controllers/__tests__/alerts.test.ts
@@ -83,4 +83,56 @@ describe('makeAlert', () => {
     expect(result.chartConfig).toBeNull();
     expect(result.savedSearch).toBe('saved-search-id');
   });
+
+  describe('displayName and tags', () => {
+    const base = {
+      interval: '5m' as const,
+      threshold: 1,
+      thresholdType: AlertThresholdType.ABOVE,
+      channels: [{ type: 'webhook' as const, webhookId: 'webhook-id' }],
+      source: AlertSource.SAVED_SEARCH,
+      savedSearchId: 'saved-search-id',
+    };
+    const refs = {
+      savedSearch: { name: 'Checkout errors', tags: ['checkout'] },
+    };
+
+    it('derives from the referenced entity when omitted', () => {
+      const result = makeAlert(base, undefined, refs);
+
+      expect(result.displayName).toBe('Checkout errors');
+      expect(result.tags).toEqual(['checkout']);
+    });
+
+    it('stores explicit values', () => {
+      const result = makeAlert(
+        { ...base, displayName: 'Custom', tags: [] },
+        undefined,
+        refs,
+      );
+
+      expect(result.displayName).toBe('Custom');
+      expect(result.tags).toEqual([]);
+    });
+
+    // Storing the read-path fallback would freeze "Alert" onto a document
+    // whose saved search is perfectly nameable.
+    it('stores null when the referenced entity was not loaded', () => {
+      const result = makeAlert(base);
+
+      expect(result.displayName).toBeNull();
+      expect(result.tags).toBeNull();
+    });
+
+    it('treats null as "derive"', () => {
+      const result = makeAlert(
+        { ...base, displayName: null, tags: null },
+        undefined,
+        refs,
+      );
+
+      expect(result.displayName).toBe('Checkout errors');
+      expect(result.tags).toEqual(['checkout']);
+    });
+  });
 });

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -22,6 +22,7 @@ import { ISavedSearch, SavedSearch } from '@/models/savedSearch';
 import { Source } from '@/models/source';
 import { IUser } from '@/models/user';
 import Webhook from '@/models/webhook';
+import { type AlertRefs, deriveAlertDisplayFields } from '@/utils/alerts';
 import { Api400Error } from '@/utils/errors';
 import { internalAlertSchema, objectIdSchema } from '@/utils/zod';
 
@@ -67,6 +68,8 @@ export const validateAlertInput = async (
     | 'channels'
   >,
 ) => {
+  const refs: AlertRefs = {};
+
   if (alertInput.source === AlertSource.TILE) {
     validateObjectId(alertInput.dashboardId, 'Invalid dashboard ID');
 
@@ -78,6 +81,7 @@ export const validateAlertInput = async (
     if (dashboard == null) {
       throw new Api400Error('Dashboard not found');
     }
+    refs.dashboard = dashboard;
 
     const tile = dashboard.tiles.find(tile => tile.id === alertInput.tileId);
 
@@ -112,6 +116,7 @@ export const validateAlertInput = async (
     if (savedSearch == null) {
       throw new Api400Error('Saved search not found');
     }
+    refs.savedSearch = savedSearch;
   }
 
   if (alertInput.source === AlertSource.INLINE) {
@@ -225,6 +230,8 @@ export const validateAlertInput = async (
   if (found !== uniqueIds.length) {
     throw new Api400Error('Webhook not found');
   }
+
+  return refs;
 };
 
 // Exported for unit testing the channel-mirroring invariant (see
@@ -232,6 +239,7 @@ export const validateAlertInput = async (
 export const makeAlert = (
   alert: AlertInput,
   userId?: ObjectId,
+  refs: AlertRefs = {},
 ): Partial<IAlert> => {
   // Preserve existing DB value when scheduleStartAt is omitted from updates
   // (undefined), while still allowing explicit clears via null.
@@ -250,6 +258,12 @@ export const makeAlert = (
   const isTile = alert.source === AlertSource.TILE;
   const isInline = alert.source === AlertSource.INLINE;
   const channels = getAlertChannels(alert);
+  // If the input explicitly provides a non-null value, persist it. If the input omits the
+  // field and a referenced entity is available, persist the value derived from the referenced entity.
+  // Otherwise, null.
+  const derivedDisplay = deriveAlertDisplayFields(alert, refs);
+  const displayName = alert.displayName ?? derivedDisplay.displayName ?? null;
+  const tags = alert.tags ?? derivedDisplay.tags ?? null;
 
   return {
     // `channels` is canonical; `channel` mirrors channels[0] so readers that
@@ -278,6 +292,9 @@ export const makeAlert = (
     message: alert.message ?? null,
     note: alert.note ?? null,
 
+    displayName,
+    tags,
+
     // Log alerts
     savedSearch: isSavedSearch
       ? ((alert.savedSearchId ?? null) as unknown as ObjectId)
@@ -301,9 +318,10 @@ export const createAlert = async (
   teamId: ObjectId,
   alertInput: z.infer<typeof internalAlertSchema>,
   userId: ObjectId,
+  refs: AlertRefs = {},
 ) => {
   return new Alert({
-    ...makeAlert(alertInput, userId),
+    ...makeAlert(alertInput, userId, refs),
     team: teamId,
   }).save();
 };
@@ -313,6 +331,7 @@ export const updateAlert = async (
   id: string,
   teamId: ObjectId,
   alertInput: AlertInput,
+  refs: AlertRefs = {},
 ) => {
   // should consider clearing AlertHistory when updating an alert?
   return Alert.findOneAndUpdate(
@@ -320,7 +339,7 @@ export const updateAlert = async (
       _id: id,
       team: teamId,
     },
-    makeAlert(alertInput),
+    makeAlert(alertInput, undefined, refs),
     {
       returnDocument: 'after',
     },
@@ -376,11 +395,12 @@ export const getDashboardAlertsByTile = async (
 };
 
 export const createOrUpdateDashboardAlerts = async (
-  dashboardId: ObjectId | string,
+  dashboard: Pick<IDashboard, '_id' | 'name' | 'tags' | 'tiles'>,
   teamId: ObjectId,
   alertsByTile: Record<string, AlertInput>,
   userId?: ObjectId,
 ) => {
+  const dashboardId = dashboard._id;
   return Promise.all(
     Object.entries(alertsByTile).map(async ([tileId, alert]) => {
       const filter = {
@@ -398,8 +418,8 @@ export const createOrUpdateDashboardAlerts = async (
       const oldAlert = await Alert.findOne(filter);
       const alertValues =
         oldAlert && oldAlert.createdBy
-          ? makeAlert(alertInput)
-          : makeAlert(alertInput, userId);
+          ? makeAlert(alertInput, undefined, { dashboard })
+          : makeAlert(alertInput, userId, { dashboard });
 
       return await Alert.findOneAndUpdate(filter, alertValues, {
         new: true,

--- a/packages/api/src/controllers/alerts.ts
+++ b/packages/api/src/controllers/alerts.ts
@@ -346,18 +346,6 @@ export const updateAlert = async (
   );
 };
 
-export const getAlerts = async (
-  teamId: ObjectId,
-  { limit, offset }: { limit: number; offset: number },
-) => {
-  // Sort by _id so skip/offset paging is stable across requests (MongoDB does
-  // not guarantee natural order between separate find() calls).
-  return Alert.find({ team: teamId })
-    .sort({ _id: 1 })
-    .skip(offset)
-    .limit(limit);
-};
-
 export const countAlerts = async (teamId: ObjectId) => {
   return Alert.countDocuments({ team: teamId });
 };
@@ -450,6 +438,41 @@ export const deleteSavedSearchAlerts = async (
     savedSearch: savedSearchId,
     team: teamId,
   });
+};
+
+/** Represents the documents populated and projected by getAlert[s]WithDisplayRefs */
+type AlertWithDisplayRefs = {
+  savedSearch: Pick<ISavedSearch, '_id' | 'name' | 'tags'> | null;
+  dashboard: Pick<IDashboard, '_id' | 'name' | 'tags' | 'tiles'> | null;
+};
+
+/** Minimal projections to support deriving alert names from referenced searches and dashboard tiles  */
+const DISPLAY_REF_POPULATE = [
+  { path: 'savedSearch', select: 'name tags' },
+  { path: 'dashboard', select: 'name tags tiles.id tiles.config.name' },
+];
+
+/** Get alerts, with a populated (and projected) search or dashboard reference */
+export const getAlertsWithDisplayRefs = async (
+  teamId: ObjectId,
+  { limit, offset }: { limit: number; offset: number },
+) => {
+  return Alert.find({ team: teamId })
+    .sort({ _id: 1 })
+    .skip(offset)
+    .limit(limit)
+    .populate<AlertWithDisplayRefs>(DISPLAY_REF_POPULATE);
+};
+
+/** Get alert, with a populated (and projected) search or dashboard reference */
+export const getAlertWithDisplayRefs = async (
+  alertId: ObjectId | string,
+  teamId: ObjectId | string,
+) => {
+  return Alert.findOne({
+    _id: alertId,
+    team: teamId,
+  }).populate<AlertWithDisplayRefs>(DISPLAY_REF_POPULATE);
 };
 
 export const getAlertsEnhanced = async (teamId: ObjectId) => {

--- a/packages/api/src/controllers/dashboard.ts
+++ b/packages/api/src/controllers/dashboard.ts
@@ -17,6 +17,7 @@ import {
 import type { ObjectId } from '@/models';
 import type { AlertDocument, IAlert } from '@/models/alert';
 import Dashboard, { IDashboard } from '@/models/dashboard';
+import { resolveAlertDisplayFields } from '@/utils/alerts';
 
 function pickAlertsByTile(tiles: Tile[]) {
   return tiles.reduce((acc, tile) => {
@@ -117,6 +118,23 @@ async function syncDashboardAlerts(
   }
 }
 
+/**
+ * Attach the resolved display name/tags so the chart editor prefills real
+ * values for alerts written before the fields existed.
+ */
+function withResolvedDisplayFields(
+  alert: AlertDocument | undefined,
+  dashboard: Pick<IDashboard, 'name' | 'tags' | 'tiles'>,
+) {
+  if (alert == null) {
+    return undefined;
+  }
+  return {
+    ...alert.toJSON(),
+    ...resolveAlertDisplayFields(alert, { dashboard }),
+  };
+}
+
 export async function getDashboards(teamId: ObjectId) {
   const [_dashboards, alerts] = await Promise.all([
     Dashboard.find({ team: teamId })
@@ -133,7 +151,10 @@ export async function getDashboards(teamId: ObjectId) {
         ...t,
         config: {
           ...t.config,
-          alert: alerts[`${d._id.toString()}:${t.id}`]?.[0],
+          alert: withResolvedDisplayFields(
+            alerts[`${d._id.toString()}:${t.id}`]?.[0],
+            d,
+          ),
         },
       })),
     }))
@@ -158,7 +179,10 @@ export async function getDashboard(dashboardId: string, teamId: ObjectId) {
     ..._dashboard.toJSON(),
     tiles: _dashboard.tiles.map(t => ({
       ...t,
-      config: { ...t.config, alert: alerts[t.id]?.[0] },
+      config: {
+        ...t.config,
+        alert: withResolvedDisplayFields(alerts[t.id]?.[0], _dashboard),
+      },
     })),
   });
 }

--- a/packages/api/src/controllers/dashboard.ts
+++ b/packages/api/src/controllers/dashboard.ts
@@ -16,7 +16,7 @@ import {
 } from '@/controllers/alerts';
 import type { ObjectId } from '@/models';
 import type { AlertDocument, IAlert } from '@/models/alert';
-import Dashboard from '@/models/dashboard';
+import Dashboard, { IDashboard } from '@/models/dashboard';
 
 function pickAlertsByTile(tiles: Tile[]) {
   return tiles.reduce((acc, tile) => {
@@ -69,12 +69,13 @@ function extractTileAlertData(tiles: TileForAlertSync[]): {
 }
 
 async function syncDashboardAlerts(
-  dashboardId: string,
+  dashboard: Pick<IDashboard, '_id' | 'name' | 'tags' | 'tiles'>,
   teamId: ObjectId,
   oldTiles: TileForAlertSync[],
   newTiles: Tile[],
   userId?: ObjectId,
 ): Promise<void> {
+  const dashboardId = dashboard._id.toString();
   const { tileIds: oldTileIds, tileIdsWithAlerts: oldTileIdsWithAlerts } =
     extractTileAlertData(oldTiles);
 
@@ -89,7 +90,7 @@ async function syncDashboardAlerts(
   const alertsByTile = pickAlertsByTile(newTiles);
   if (Object.keys(alertsByTile).length > 0) {
     await createOrUpdateDashboardAlerts(
-      dashboardId,
+      dashboard,
       teamId,
       alertsByTile,
       userId,
@@ -175,7 +176,7 @@ export async function createDashboard(
   }).save();
 
   await createOrUpdateDashboardAlerts(
-    newDashboard._id,
+    newDashboard,
     teamId,
     pickAlertsByTile(dashboard.tiles),
     userId,
@@ -224,7 +225,7 @@ export async function updateDashboard(
 
   if (updates.tiles) {
     await syncDashboardAlerts(
-      dashboardId,
+      updatedDashboard,
       teamId,
       oldDashboard?.tiles || [],
       updates.tiles,

--- a/packages/api/src/controllers/savedSearch.ts
+++ b/packages/api/src/controllers/savedSearch.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { deleteSavedSearchAlerts } from '@/controllers/alerts';
 import Alert from '@/models/alert';
 import { SavedSearch } from '@/models/savedSearch';
+import { resolveAlertDisplayFields } from '@/utils/alerts';
 import logger from '@/utils/logger';
 
 type SavedSearchWithoutId = Omit<z.infer<typeof SavedSearchSchema>, 'id'>;
@@ -27,9 +28,10 @@ export async function getSavedSearches(
 
   return savedSearches.map(savedSearch => ({
     ...savedSearch.toJSON(),
-    alerts: alertsBySavedSearchId[savedSearch._id.toString()]?.map(alert => {
-      return alert.toJSON();
-    }),
+    alerts: alertsBySavedSearchId[savedSearch._id.toString()]?.map(alert => ({
+      ...alert.toJSON(),
+      ...resolveAlertDisplayFields(alert, { savedSearch }),
+    })),
   }));
 }
 

--- a/packages/api/src/fixtures.ts
+++ b/packages/api/src/fixtures.ts
@@ -853,12 +853,16 @@ export const makeAlertInput = ({
   threshold = 8,
   tileId,
   webhookId = 'test-webhook-id',
+  displayName,
+  tags,
 }: {
   dashboardId: string;
   interval?: AlertInterval;
   threshold?: number;
   tileId: string;
   webhookId?: string;
+  displayName?: string | null;
+  tags?: string[] | null;
 }): Partial<AlertInput> => ({
   channel: {
     type: 'webhook',
@@ -870,6 +874,8 @@ export const makeAlertInput = ({
   source: AlertSource.TILE,
   dashboardId,
   tileId,
+  ...(displayName !== undefined && { displayName }),
+  ...(tags !== undefined && { tags }),
 });
 
 export const makeSavedSearchAlertInput = ({
@@ -877,11 +883,15 @@ export const makeSavedSearchAlertInput = ({
   interval = '15m',
   threshold = 8,
   webhookId = 'test-webhook-id',
+  displayName,
+  tags,
 }: {
   savedSearchId: string;
   interval?: AlertInterval;
   threshold?: number;
   webhookId?: string;
+  displayName?: string | null;
+  tags?: string[] | null;
 }): Partial<AlertInput> => ({
   channel: {
     type: 'webhook',
@@ -892,6 +902,8 @@ export const makeSavedSearchAlertInput = ({
   thresholdType: AlertThresholdType.ABOVE,
   source: AlertSource.SAVED_SEARCH,
   savedSearchId,
+  ...(displayName !== undefined && { displayName }),
+  ...(tags !== undefined && { tags }),
 });
 
 export const makeAlertChartConfig = (opts: {
@@ -922,11 +934,15 @@ export const makeInlineAlertInput = ({
   interval = '15m',
   threshold = 8,
   webhookId = 'test-webhook-id',
+  displayName,
+  tags,
 }: {
   chartConfig: AlertChartConfig;
   interval?: AlertInterval;
   threshold?: number;
   webhookId?: string;
+  displayName?: string | null;
+  tags?: string[] | null;
 }): Partial<AlertInput> => ({
   channel: {
     type: 'webhook',
@@ -937,4 +953,6 @@ export const makeInlineAlertInput = ({
   thresholdType: AlertThresholdType.ABOVE,
   source: AlertSource.INLINE,
   chartConfig,
+  ...(displayName !== undefined && { displayName }),
+  ...(tags !== undefined && { tags }),
 });

--- a/packages/api/src/mcp/__tests__/alerts.int.test.ts
+++ b/packages/api/src/mcp/__tests__/alerts.int.test.ts
@@ -146,6 +146,8 @@ describe('MCP Alert Tools', () => {
         // Slim summary fields present
         expect(output[0]).toHaveProperty('id');
         expect(output[0]).toHaveProperty('name');
+        expect(output[0]).toHaveProperty('displayName');
+        expect(output[0]).toHaveProperty('tags');
         expect(output[0]).toHaveProperty('state');
         expect(output[0]).toHaveProperty('source');
         expect(output[0]).toHaveProperty('interval');
@@ -210,7 +212,7 @@ describe('MCP Alert Tools', () => {
         await client2.close();
       });
 
-      it('should derive name from saved search when alert has no explicit name', async () => {
+      it('derives displayName from the saved search and leaves name unset', async () => {
         const savedSearch = await createTestSavedSearch(); // name: 'Test Saved Search'
         await new Alert({
           team: team._id,
@@ -230,10 +232,13 @@ describe('MCP Alert Tools', () => {
         expect(result.isError).toBeFalsy();
         const output = JSON.parse(getFirstText(result));
         expect(output).toHaveLength(1);
-        expect(output[0].name).toBe('Test Saved Search');
+        // `name` stays raw so an agent that reads-then-resends the alert can't
+        // freeze the derived title into the Handlebars name template.
+        expect(output[0].name).toBeUndefined();
+        expect(output[0].displayName).toBe('Test Saved Search');
       });
 
-      it('should derive name from dashboard tile when tile alert has no explicit name', async () => {
+      it('derives displayName from the dashboard tile and leaves name unset', async () => {
         const dashboard = await createTestDashboardWithTile(); // tile name: 'Error Count'
         await new Alert({
           team: team._id,
@@ -254,7 +259,8 @@ describe('MCP Alert Tools', () => {
         expect(result.isError).toBeFalsy();
         const output = JSON.parse(getFirstText(result));
         expect(output).toHaveLength(1);
-        expect(output[0].name).toBe('Error Count');
+        expect(output[0].name).toBeUndefined();
+        expect(output[0].displayName).toBe('Test Dashboard - Error Count');
       });
     });
 
@@ -345,6 +351,51 @@ describe('MCP Alert Tools', () => {
         expect(output.source).toBe('saved_search');
         expect(output.threshold).toBe(50);
         expect(output.state).toBe('OK');
+      });
+
+      it('should create an alert with an explicit displayName and tags', async () => {
+        const savedSearch = await createTestSavedSearch();
+        const webhook = await createTestWebhook();
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channel: { type: 'webhook', webhookId: webhook._id.toString() },
+          displayName: 'Checkout errors',
+          tags: ['checkout'],
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.displayName).toBe('Checkout errors');
+        expect(output.tags).toEqual(['checkout']);
+      });
+
+      it('derives displayName and tags from the saved search when omitted', async () => {
+        const savedSearch = await SavedSearch.create({
+          team: team._id,
+          name: 'Payments errors',
+          source: traceSource._id,
+          tags: ['payments'],
+        });
+        const webhook = await createTestWebhook();
+
+        const result = await callTool(client, 'clickstack_save_alert', {
+          source: 'saved_search',
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 50,
+          thresholdType: 'above',
+          interval: '5m',
+          channel: { type: 'webhook', webhookId: webhook._id.toString() },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.displayName).toBe('Payments errors');
+        expect(output.tags).toEqual(['payments']);
       });
 
       it('should create a tile-based alert', async () => {
@@ -831,6 +882,8 @@ describe('MCP Alert Tools', () => {
         expect(output).toHaveLength(1);
         expect(output[0].source).toBe('inline');
         expect(output[0].name).toBe('Inline MCP Alert');
+        expect(output[0]).toHaveProperty('displayName');
+        expect(output[0]).toHaveProperty('tags');
         expect(output[0].chartConfig).toBeUndefined();
       });
 
@@ -859,7 +912,84 @@ describe('MCP Alert Tools', () => {
           displayType: 'line',
           sourceId: traceSource._id.toString(),
         });
-        expect(output.name).toBe('Error Rate Query');
+        // `name` stays the (unset) title template; the chart config name
+        // surfaces as the resolved display name.
+        expect(output.name).toBeNull();
+        expect(output.displayName).toBe('Error Rate Query');
+      });
+
+      it('derives displayName from the chart config name when omitted', async () => {
+        const webhook = await createTestWebhook();
+
+        const result = await callTool(
+          client,
+          'clickstack_save_alert',
+          makeInlineInput(webhook._id.toString(), {
+            chartConfig: makeChartConfig({ name: 'Trace error rate' }),
+          }),
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.displayName).toBe('Trace error rate');
+        // Inline alerts have no parent entity to inherit tags from.
+        expect(output.tags).toEqual([]);
+
+        const stored = await Alert.findById(output.id);
+        expect(stored!.displayName).toBe('Trace error rate');
+        expect(stored!.tags).toEqual([]);
+      });
+
+      it('persists an explicit displayName and tags over the chart config name', async () => {
+        const webhook = await createTestWebhook();
+
+        const result = await callTool(
+          client,
+          'clickstack_save_alert',
+          makeInlineInput(webhook._id.toString(), {
+            chartConfig: makeChartConfig({ name: 'Trace error rate' }),
+            displayName: 'Checkout error spike',
+            tags: ['checkout', 'p1'],
+          }),
+        );
+
+        expect(result.isError).toBeFalsy();
+        const output = JSON.parse(getFirstText(result));
+        expect(output.displayName).toBe('Checkout error spike');
+        expect(output.tags).toEqual(['checkout', 'p1']);
+
+        const detail = await callTool(client, 'clickstack_get_alert', {
+          id: output.id,
+        });
+        expect(JSON.parse(getFirstText(detail))).toMatchObject({
+          displayName: 'Checkout error spike',
+          tags: ['checkout', 'p1'],
+        });
+      });
+
+      it('re-derives displayName when a later save drops it', async () => {
+        const webhook = await createTestWebhook();
+        const createResult = await callTool(
+          client,
+          'clickstack_save_alert',
+          makeInlineInput(webhook._id.toString(), {
+            chartConfig: makeChartConfig({ name: 'Trace error rate' }),
+            displayName: 'Checkout error spike',
+          }),
+        );
+        const created = JSON.parse(getFirstText(createResult));
+
+        const updateResult = await callTool(client, 'clickstack_save_alert', {
+          ...makeInlineInput(webhook._id.toString(), {
+            chartConfig: makeChartConfig({ name: 'Trace error rate' }),
+          }),
+          id: created.id,
+        });
+
+        expect(updateResult.isError).toBeFalsy();
+        expect(JSON.parse(getFirstText(updateResult)).displayName).toBe(
+          'Trace error rate',
+        );
       });
     });
 

--- a/packages/api/src/mcp/tools/alerts/getAlert.ts
+++ b/packages/api/src/mcp/tools/alerts/getAlert.ts
@@ -12,42 +12,7 @@ import Alert from '@/models/alert';
 import type { IDashboard } from '@/models/dashboard';
 import type { ISavedSearch } from '@/models/savedSearch';
 import { translateAlertDocumentToExternalAlertWithChartConfig } from '@/routers/external-api/v2/utils/alertChartConfig';
-
-function deriveAlertName(alert: {
-  name?: string | null;
-  tileId?: string | null;
-  savedSearch?: ISavedSearch | null;
-  dashboard?: IDashboard | null;
-  chartConfig?: { name?: string } | null;
-}): string | null {
-  // Prefer explicit alert name
-  if (alert.name) {
-    return alert.name;
-  }
-
-  // Fall back to saved search name
-  if (alert.savedSearch?.name) {
-    return alert.savedSearch.name;
-  }
-
-  // Inline alerts: fall back to the persisted chart config's name
-  if (alert.chartConfig?.name) {
-    return alert.chartConfig.name;
-  }
-
-  // Fall back to dashboard tile name or dashboard name
-  if (alert.dashboard?.name) {
-    if (alert.tileId) {
-      const tile = alert.dashboard.tiles?.find(t => t.id === alert.tileId);
-      if (tile?.config?.name) {
-        return tile.config.name;
-      }
-    }
-    return alert.dashboard.name;
-  }
-
-  return null;
-}
+import { resolveAlertDisplayFields } from '@/utils/alerts';
 
 export function registerGetAlert({
   context,
@@ -63,10 +28,11 @@ export function registerGetAlert({
       annotations: { readOnlyHint: true },
       description:
         'Without an ID: list all alerts as a high-level summary ' +
-        '(id, name, state, source, interval). Optionally filter by state ' +
+        '(id, name, displayName, tags, state, source, interval). Optionally ' +
+        'filter by state ' +
         '(e.g. state="ALERT" for firing alerts). ' +
-        'With an ID: get full alert detail including configuration and ' +
-        'recent evaluation history.',
+        'With an ID: get full alert detail including configuration, ' +
+        'displayName, tags, and recent evaluation history.',
       inputSchema: z.object({
         id: z
           .string()
@@ -98,10 +64,15 @@ export function registerGetAlert({
         }>(['savedSearch', 'dashboard']);
 
         const output = alerts.map(alert => {
-          const name = deriveAlertName(alert);
+          const { displayName, tags } = resolveAlertDisplayFields(alert, {
+            savedSearch: alert.savedSearch,
+            dashboard: alert.dashboard,
+          });
           return {
             id: alert._id.toString(),
-            name,
+            name: alert.name,
+            displayName,
+            tags,
             state: alert.state,
             source: alert.source,
             interval: alert.interval,
@@ -124,15 +95,15 @@ export function registerGetAlert({
         return mcpUserError('Alert not found');
       }
 
-      const external =
-        translateAlertDocumentToExternalAlertWithChartConfig(alert);
-
-      // Populate refs so deriveAlertName can fall back to the
-      // saved search / dashboard name when the alert has no explicit name.
+      // Populate the refs the display name/tags derive from, so alerts written
+      // before those fields existed still resolve to something meaningful.
       const populated = await alert.populate<{
         savedSearch: ISavedSearch | null;
         dashboard: IDashboard | null;
       }>(['savedSearch', 'dashboard']);
+
+      const external =
+        translateAlertDocumentToExternalAlertWithChartConfig(populated);
 
       const history = await getRecentAlertHistories({
         alertId: new ObjectId(alert._id),
@@ -147,7 +118,6 @@ export function registerGetAlert({
             text: JSON.stringify(
               {
                 ...external,
-                name: deriveAlertName(populated) ?? external.name,
                 history,
                 ...(frontendUrl ? { url: `${frontendUrl}/alerts` } : {}),
               },

--- a/packages/api/src/mcp/tools/alerts/saveAlert.ts
+++ b/packages/api/src/mcp/tools/alerts/saveAlert.ts
@@ -107,6 +107,8 @@ export function registerSaveAlert({
         scheduleStartAt: input.scheduleStartAt,
         name: input.name,
         message: input.message,
+        displayName: input.displayName,
+        tags: input.tags,
         groupBy: input.groupBy,
         savedSearchId: input.savedSearchId,
         dashboardId: input.dashboardId,
@@ -116,8 +118,9 @@ export function registerSaveAlert({
 
       // ── Validate referenced entities exist ──
       const mongoTeamId = new mongoose.Types.ObjectId(teamId);
+      let refs;
       try {
-        await validateAlertInput(mongoTeamId, alertInput);
+        refs = await validateAlertInput(mongoTeamId, alertInput);
       } catch (e) {
         // BaseError subclasses (Api400Error, Api404Error, etc.) store the
         // descriptive message in `name` and a generic string in `message`.
@@ -134,7 +137,12 @@ export function registerSaveAlert({
 
       // ── Update existing alert ──
       if (alertId) {
-        const updated = await updateAlert(alertId, mongoTeamId, alertInput);
+        const updated = await updateAlert(
+          alertId,
+          mongoTeamId,
+          alertInput,
+          refs,
+        );
         if (!updated) {
           return mcpUserError('Alert not found');
         }
@@ -162,6 +170,7 @@ export function registerSaveAlert({
         mongoTeamId,
         alertInput as Parameters<typeof createAlert>[1],
         mongoUserId,
+        refs,
       );
       return {
         content: [

--- a/packages/api/src/mcp/tools/alerts/schemas.ts
+++ b/packages/api/src/mcp/tools/alerts/schemas.ts
@@ -1,10 +1,12 @@
 import {
   ALERT_INTERVAL_TO_MINUTES,
+  alertDisplayNameSchema,
   type AlertInterval,
   checkAlertChannelSelection,
   isRangeThresholdType,
   MAX_ALERT_CHANNELS,
   SearchConditionTrimmedLanguageSchema,
+  tagsSchema,
 } from '@hyperdx/common-utils/dist/types';
 import { z } from 'zod';
 
@@ -206,13 +208,19 @@ export const mcpSaveAlertSchema = z.object({
     .min(1)
     .max(512)
     .optional()
-    .describe('Human-friendly alert name.'),
+    .describe('Alert title template (supports Handlebars syntax).'),
   message: z
     .string()
     .min(1)
     .max(4096)
     .optional()
     .describe('Alert message template (supports Handlebars syntax).'),
+  displayName: alertDisplayNameSchema.describe(
+    'Display name shown for the alert in the UI. Defaults to the saved search name, dashboard tile name, or inline chartConfig name when omitted. Overridden by the "name" field in alert notifications when provided.',
+  ),
+  tags: tagsSchema.describe(
+    'Tags for the alert. Defaults to the tags of the referenced saved search or dashboard when omitted; inline alerts default to an empty list.',
+  ),
 });
 
 export type McpSaveAlertInput = z.infer<typeof mcpSaveAlertSchema>;

--- a/packages/api/src/models/alert.ts
+++ b/packages/api/src/models/alert.ts
@@ -92,12 +92,18 @@ export interface IAlert {
   thresholdType: AlertThresholdType;
   createdBy?: ObjectId;
 
-  // Message template
+  // Message template (handlebars)
   name?: string | null;
   message?: string | null;
 
   // Freeform note (supports markdown)
   note?: string | null;
+
+  // User-facing name shown in the alerts list and notification titles (when not overridden by name template).
+  // Unset means "derive from the referenced saved search / dashboard tile".
+  displayName?: string | null;
+  // Unset (not []) means "derive from the referenced entity".
+  tags?: string[] | null;
 
   // SavedSearch alerts
   groupBy?: string | null;
@@ -209,6 +215,14 @@ const AlertSchema = new Schema<IAlert>(
       type: String,
       required: false,
     },
+    displayName: {
+      type: String,
+      required: false,
+    },
+    // `default: undefined` stops Mongoose materializing [], which would make
+    // an un-backfilled document indistinguishable from one whose tags the user
+    // deliberately emptied.
+    tags: { type: [String], default: undefined },
 
     // Log alerts
     savedSearch: {

--- a/packages/api/src/routers/api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/alerts.int.test.ts
@@ -160,6 +160,9 @@ describe('alerts router', () => {
       channel: { type: 'webhook', webhookId: webhook._id.toString() },
       name: 'My alert',
       message: 'My message template',
+      // Derived from the tile / dashboard, since neither was sent.
+      displayName: 'Test Dashboard - Test Chart',
+      tags: ['test'],
     };
 
     const list = await agent.get('/alerts').expect(200);
@@ -382,6 +385,130 @@ describe('alerts router', () => {
       .get(`/alerts/${alert.body.data._id}`)
       .expect(200);
     expect(afterClear.body.data.note).toBeNull();
+  });
+
+  it('round-trips displayName and tags through create, update, and revert', async () => {
+    const dashboard = await agent
+      .post('/dashboards')
+      .send(MOCK_DASHBOARD)
+      .expect(200);
+
+    const alert = await agent
+      .post('/alerts')
+      .send(
+        makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+          displayName: 'Checkout errors',
+          tags: ['checkout'],
+        }),
+      )
+      .expect(200);
+    const alertId = alert.body.data._id;
+
+    const created = await agent.get(`/alerts/${alertId}`).expect(200);
+    expect(created.body.data).toMatchObject({
+      displayName: 'Checkout errors',
+      tags: ['checkout'],
+    });
+
+    // PUT is full-replace: omitting both fields reverts to the derived values.
+    await agent
+      .put(`/alerts/${alertId}`)
+      .send(
+        makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+        }),
+      )
+      .expect(200);
+
+    const reverted = await agent.get(`/alerts/${alertId}`).expect(200);
+    expect(reverted.body.data).toMatchObject({
+      displayName: 'Test Dashboard - Test Chart',
+      tags: ['test'],
+    });
+
+    // An explicitly emptied tag list is stored, not re-derived.
+    await agent
+      .put(`/alerts/${alertId}`)
+      .send(
+        makeAlertInput({
+          dashboardId: dashboard.body.id,
+          tileId: dashboard.body.tiles[0].id,
+          webhookId: webhook._id.toString(),
+          tags: [],
+        }),
+      )
+      .expect(200);
+
+    const emptied = await agent.get(`/alerts/${alertId}`).expect(200);
+    expect(emptied.body.data.tags).toEqual([]);
+    expect((await Alert.findById(alertId))?.tags).toEqual([]);
+  });
+
+  it('derives displayName from the chart config for inline alerts', async () => {
+    const source = await Source.create({
+      kind: SourceKind.Log,
+      team: team._id,
+      from: { databaseName: 'default', tableName: 'otel_logs' },
+      timestampValueExpression: 'Timestamp',
+      connection: new mongoose.Types.ObjectId(),
+      name: 'Logs',
+    });
+
+    const alert = await agent
+      .post('/alerts')
+      .send(
+        makeInlineAlertInput({
+          chartConfig: makeAlertChartConfig({
+            sourceId: source._id.toString(),
+            name: 'Inline chart',
+          }),
+          webhookId: webhook._id.toString(),
+        }),
+      )
+      .expect(200);
+
+    const single = await agent
+      .get(`/alerts/${alert.body.data._id}`)
+      .expect(200);
+    expect(single.body.data).toMatchObject({
+      displayName: 'Inline chart',
+      tags: [],
+    });
+  });
+
+  // Documents written before the fields existed have neither, and the startup
+  // backfill has not necessarily run yet.
+  it('resolves displayName and tags for a document stored without them', async () => {
+    const savedSearch = await SavedSearch.create({
+      name: 'Legacy search',
+      source: new mongoose.Types.ObjectId(),
+      team: team._id,
+      tags: ['legacy'],
+    });
+    const alert = await Alert.create({
+      team: team._id,
+      channel: { type: 'webhook', webhookId: webhook._id.toString() },
+      interval: '15m',
+      threshold: 8,
+      thresholdType: AlertThresholdType.ABOVE,
+      source: AlertSource.SAVED_SEARCH,
+      savedSearch: savedSearch._id,
+    });
+    expect(alert.displayName).toBeUndefined();
+    expect(alert.tags).toBeUndefined();
+
+    const single = await agent
+      .get(`/alerts/${alert._id.toString()}`)
+      .expect(200);
+    expect(single.body.data).toMatchObject({
+      displayName: 'Legacy search',
+      tags: ['legacy'],
+    });
   });
 
   it('preserves scheduleStartAt when omitted in updates and clears when null', async () => {

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -266,6 +266,30 @@ describe('dashboard router', () => {
     expect(storedAlert?.tags).toEqual(['ops']);
   });
 
+  it('resolves displayName and tags on GET for a tile alert stored without them', async () => {
+    const mockAlert = makeMockAlert(webhook._id.toString());
+    const dashboard = await agent
+      .post('/dashboards')
+      .send({
+        name: 'Test Dashboard',
+        tiles: [makeTile({ alert: mockAlert })],
+        tags: ['ops'],
+      })
+      .expect(200);
+    // Alerts written before the fields existed.
+    await Alert.updateMany(
+      { dashboard: dashboard.body.id },
+      { $set: { displayName: null, tags: null } },
+    );
+
+    const list = await agent.get('/dashboards').expect(200);
+    const fromList = list.body.find(d => d._id === dashboard.body.id);
+    expect(fromList.tiles[0].config.alert).toMatchObject({
+      displayName: 'Test Dashboard - Test Chart',
+      tags: ['ops'],
+    });
+  });
+
   it('persists a tile alert displayName sent through the dashboard PATCH', async () => {
     const mockAlert = makeMockAlert(webhook._id.toString());
     const dashboard = await agent

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -240,7 +240,7 @@ describe('dashboard router', () => {
       .send({
         name: 'Test Dashboard',
         tiles: [makeTile({ alert: mockAlert })],
-        tags: [],
+        tags: ['ops'],
       })
       .expect(200);
 
@@ -261,6 +261,44 @@ describe('dashboard router', () => {
     expect(storedAlert).not.toBeNull();
     expect(storedAlert?.savedSearch).toBeNull();
     expect(storedAlert?.groupBy).toBeNull();
+    // Neither field was sent, so they derive from the tile and dashboard.
+    expect(storedAlert?.displayName).toBe('Test Dashboard - Test Chart');
+    expect(storedAlert?.tags).toEqual(['ops']);
+  });
+
+  it('persists a tile alert displayName sent through the dashboard PATCH', async () => {
+    const mockAlert = makeMockAlert(webhook._id.toString());
+    const dashboard = await agent
+      .post('/dashboards')
+      .send({
+        name: 'Test Dashboard',
+        tiles: [makeTile({ alert: mockAlert })],
+        tags: ['ops'],
+      })
+      .expect(200);
+
+    await agent
+      .patch(`/dashboards/${dashboard.body.id}`)
+      .send({
+        tiles: [
+          {
+            ...dashboard.body.tiles[0],
+            config: {
+              ...dashboard.body.tiles[0].config,
+              alert: { ...mockAlert, displayName: 'Checkout errors' },
+            },
+          },
+        ],
+      })
+      .expect(200);
+
+    const storedAlert = await Alert.findOne({
+      team: team._id,
+      dashboard: dashboard.body.id,
+      tileId: dashboard.body.tiles[0].id,
+      source: AlertSource.TILE,
+    });
+    expect(storedAlert?.displayName).toBe('Checkout errors');
   });
 
   // A tile alert must always end up with a resolvable notification target.

--- a/packages/api/src/routers/api/__tests__/savedSearch.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/savedSearch.int.test.ts
@@ -221,4 +221,31 @@ describe('savedSearch router', () => {
     expect(savedSearches.body[0].alerts[0].createdBy).toBeDefined();
     expect(savedSearches.body[0].alerts[0].createdBy.email).toBe(user.email);
   });
+
+  it('resolves displayName and tags on GET for an alert stored without them', async () => {
+    const savedSearch = await agent
+      .post('/saved-search')
+      .send({ ...MOCK_SAVED_SEARCH, tags: ['prod'] })
+      .expect(200);
+    const alert = await agent
+      .post('/alerts')
+      .send(
+        makeSavedSearchAlertInput({
+          savedSearchId: savedSearch.body._id,
+          webhookId: webhook._id.toString(),
+        }),
+      )
+      .expect(200);
+    // Alerts written before the fields existed.
+    await Alert.updateOne(
+      { _id: alert.body.data._id },
+      { $set: { displayName: null, tags: null } },
+    );
+
+    const savedSearches = await agent.get('/saved-search').expect(200);
+    expect(savedSearches.body[0].alerts[0]).toMatchObject({
+      displayName: MOCK_SAVED_SEARCH.name,
+      tags: ['prod'],
+    });
+  });
 });

--- a/packages/api/src/routers/api/alerts.ts
+++ b/packages/api/src/routers/api/alerts.ts
@@ -28,6 +28,7 @@ import {
 } from '@/controllers/alerts';
 import { getAlertChannels } from '@/models/alert';
 import { IAlertHistory } from '@/models/alertHistory';
+import { resolveAlertDisplayFields } from '@/utils/alerts';
 import { PreSerialized, sendJson } from '@/utils/serialization';
 import { internalAlertSchema, objectIdSchema } from '@/utils/zod';
 
@@ -42,6 +43,13 @@ const formatAlertResponse = (
 ): PreSerialized<AlertsPageItem> => {
   return {
     history,
+    // Resolved (stored ?? derived) so alerts written before the fields existed
+    // still render. Deliberately not in the `pick` below -- a stored
+    // `undefined` there would clobber the resolved value.
+    ...resolveAlertDisplayFields(alert, {
+      savedSearch: alert.savedSearch,
+      dashboard: alert.dashboard,
+    }),
     silenced: alert.silenced
       ? {
           by: alert.silenced.by?.email,
@@ -323,9 +331,9 @@ router.post(
     }
     try {
       const alertInput = req.body;
-      await validateAlertInput(teamId, alertInput);
+      const refs = await validateAlertInput(teamId, alertInput);
       return res.json({
-        data: await createAlert(teamId, alertInput, userId),
+        data: await createAlert(teamId, alertInput, userId, refs),
       });
     } catch (e) {
       next(e);
@@ -349,8 +357,8 @@ router.put(
       }
       const { id } = req.params;
       const alertInput = req.body;
-      await validateAlertInput(teamId, alertInput);
-      const alert = await updateAlert(id, teamId, alertInput);
+      const refs = await validateAlertInput(teamId, alertInput);
+      const alert = await updateAlert(id, teamId, alertInput, refs);
       if (alert == null) {
         return res.sendStatus(404);
       }

--- a/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/alerts.int.test.ts
@@ -190,6 +190,258 @@ describe('External API Alerts', () => {
     });
   };
 
+  // The readers behind these routes project the referenced dashboard down to
+  // the handful of fields the derivation needs, rather than pulling every
+  // tile's full chart config. These cases fail if the projection drops one.
+  describe('display refs are projected, not fetched whole', () => {
+    const createNamedTileDashboard = async () => {
+      const tileId = new ObjectId().toString();
+      const dashboard = await new Dashboard({
+        name: 'Projected Dashboard',
+        tags: ['projected'],
+        tiles: [
+          {
+            id: tileId,
+            x: 0,
+            y: 0,
+            w: 6,
+            h: 3,
+            config: {
+              name: 'Projected Tile',
+              displayType: 'line',
+              source: new ObjectId().toString(),
+              select: [
+                {
+                  aggFn: 'count',
+                  aggCondition: '',
+                  aggConditionLanguage: 'lucene',
+                  valueExpression: '',
+                },
+              ],
+              where: '',
+              whereLanguage: 'lucene',
+            },
+          },
+        ],
+        team: team._id,
+      }).save();
+      await createTestAlertDirectly({ dashboard: dashboard._id, tileId });
+      return dashboard;
+    };
+
+    it('derives the tile name on the list route', async () => {
+      const dashboard = await createNamedTileDashboard();
+
+      const res = await authRequest('get', ALERTS_BASE_URL).expect(200);
+      const alert = res.body.data.find(
+        (a: { dashboardId?: string }) =>
+          a.dashboardId === dashboard._id.toString(),
+      );
+
+      expect(alert).toMatchObject({
+        displayName: 'Projected Dashboard - Projected Tile',
+        tags: ['projected'],
+      });
+    });
+
+    it('derives the tile name on the single-alert route', async () => {
+      const dashboard = await createNamedTileDashboard();
+      const list = await authRequest('get', ALERTS_BASE_URL).expect(200);
+      const id = list.body.data.find(
+        (a: { dashboardId?: string }) =>
+          a.dashboardId === dashboard._id.toString(),
+      ).id;
+
+      const res = await authRequest('get', `${ALERTS_BASE_URL}/${id}`).expect(
+        200,
+      );
+
+      expect(res.body.data).toMatchObject({
+        displayName: 'Projected Dashboard - Projected Tile',
+        tags: ['projected'],
+        dashboardId: dashboard._id.toString(),
+      });
+    });
+  });
+
+  describe('displayName and tags', () => {
+    const createTaggedDashboard = async () => {
+      const tileId = new ObjectId().toString();
+      const dashboard = await new Dashboard({
+        name: 'Tagged Dashboard',
+        tags: ['dashboard-tag'],
+        tiles: [
+          {
+            id: tileId,
+            x: 0,
+            y: 0,
+            w: 6,
+            h: 3,
+            config: {
+              name: 'Error Rate',
+              displayType: 'line',
+              source: new ObjectId().toString(),
+              select: [
+                {
+                  aggFn: 'count',
+                  aggCondition: '',
+                  aggConditionLanguage: 'lucene',
+                  valueExpression: '',
+                },
+              ],
+              where: '',
+              whereLanguage: 'lucene',
+            },
+          },
+        ],
+        team: team._id,
+      }).save();
+      return { dashboard, tileId };
+    };
+
+    const tileAlertInput = async (overrides = {}) => {
+      const { dashboard, tileId } = await createTaggedDashboard();
+      const webhook = await createTestWebhook();
+      return {
+        source: AlertSource.TILE,
+        dashboardId: dashboard._id.toString(),
+        tileId,
+        threshold: 100,
+        interval: '1h',
+        thresholdType: AlertThresholdType.ABOVE,
+        channel: { type: 'webhook', webhookId: webhook._id.toString() },
+        ...overrides,
+      };
+    };
+
+    it('persists an explicit displayName and tags on create', async () => {
+      const input = await tileAlertInput({
+        displayName: 'Checkout error spike',
+        tags: ['checkout', 'p1'],
+      });
+
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send(input)
+        .expect(200);
+      expect(created.body.data).toMatchObject({
+        displayName: 'Checkout error spike',
+        tags: ['checkout', 'p1'],
+      });
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data).toMatchObject({
+        displayName: 'Checkout error spike',
+        tags: ['checkout', 'p1'],
+      });
+    });
+
+    it('treats an explicit empty tags array as a clear, not an omission', async () => {
+      const input = await tileAlertInput({ tags: [] });
+
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send(input)
+        .expect(200);
+      expect(created.body.data.tags).toEqual([]);
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data.tags).toEqual([]);
+      expect(fetched.body.data.displayName).toBe(
+        'Tagged Dashboard - Error Rate',
+      );
+    });
+
+    it('replaces displayName and tags on update when provided', async () => {
+      const input = await tileAlertInput({
+        displayName: 'Before',
+        tags: ['before'],
+      });
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send(input)
+        .expect(200);
+
+      await authRequest('put', `${ALERTS_BASE_URL}/${created.body.data.id}`)
+        .send({ ...input, displayName: 'After', tags: ['after'] })
+        .expect(200);
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data).toMatchObject({
+        displayName: 'After',
+        tags: ['after'],
+      });
+    });
+
+    it('re-derives displayName and tags on update when omitted', async () => {
+      const input = await tileAlertInput({
+        displayName: 'Explicit name',
+        tags: ['explicit'],
+      });
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send(input)
+        .expect(200);
+
+      await authRequest('put', `${ALERTS_BASE_URL}/${created.body.data.id}`)
+        .send(_.omit(input, ['displayName', 'tags']))
+        .expect(200);
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data).toMatchObject({
+        displayName: 'Tagged Dashboard - Error Rate',
+        tags: ['dashboard-tag'],
+      });
+    });
+
+    it('keeps dashboardId when the referenced dashboard has been deleted', async () => {
+      const input = await tileAlertInput();
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send(input)
+        .expect(200);
+      await Dashboard.deleteOne({ _id: input.dashboardId });
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data.dashboardId).toBe(input.dashboardId);
+
+      const listed = await authRequest('get', ALERTS_BASE_URL).expect(200);
+      expect(listed.body.data[0].dashboardId).toBe(input.dashboardId);
+    });
+
+    it('keeps savedSearchId when the referenced saved search has been deleted', async () => {
+      const savedSearch = await createTestSavedSearch();
+      const webhook = await createTestWebhook();
+      const created = await authRequest('post', ALERTS_BASE_URL)
+        .send({
+          source: AlertSource.SAVED_SEARCH,
+          savedSearchId: savedSearch._id.toString(),
+          threshold: 100,
+          interval: '1h',
+          thresholdType: AlertThresholdType.ABOVE,
+          channel: { type: 'webhook', webhookId: webhook._id.toString() },
+        })
+        .expect(200);
+      await SavedSearch.deleteOne({ _id: savedSearch._id });
+
+      const fetched = await authRequest(
+        'get',
+        `${ALERTS_BASE_URL}/${created.body.data.id}`,
+      ).expect(200);
+      expect(fetched.body.data.savedSearchId).toBe(savedSearch._id.toString());
+    });
+  });
+
   describe('Response Format', () => {
     it('should return responses in the expected format', async () => {
       // Create a test dashboard and webhook with known values
@@ -223,6 +475,9 @@ describe('External API Alerts', () => {
         data: {
           id: expect.any(String),
           name: 'Format Test Alert',
+          // Neither was sent, so both derive.
+          displayName: 'Test Dashboard - Tile',
+          tags: [],
           message: 'This is a test alert for format verification',
           note: null,
           numConsecutiveWindows: null,
@@ -270,6 +525,27 @@ describe('External API Alerts', () => {
       expect(listResponse.headers['content-type']).toMatch(/application\/json/);
       expect(listResponse.body).toHaveProperty('data');
       expect(Array.isArray(listResponse.body.data)).toBe(true);
+
+      // A document written before the displayName and tags fields existed still resolves
+      const legacyDashboard = await createTestDashboard({
+        name: 'Legacy Dashboard',
+      });
+      await createTestAlertDirectly({
+        dashboard: legacyDashboard._id,
+        tileId: legacyDashboard.tiles[0].id,
+      });
+
+      const listWithLegacy = await authRequest('get', ALERTS_BASE_URL).expect(
+        200,
+      );
+      const legacy = listWithLegacy.body.data.find(
+        (a: { dashboardId?: string }) =>
+          a.dashboardId === legacyDashboard._id.toString(),
+      );
+      expect(legacy).toMatchObject({
+        displayName: 'Legacy Dashboard - Tile',
+        tags: [],
+      });
 
       // Delete response format
       const deleteResponse = await authRequest(
@@ -772,6 +1048,121 @@ describe('External API Alerts', () => {
       const listed = list.body.data.find(a => a.id === created.body.data.id);
       expect(listed.source).toBe(AlertSource.INLINE);
       expect(listed.chartConfig).toBeUndefined();
+    });
+
+    // Inline alerts reference no dashboard or saved search, so their display
+    // fields derive from the chart config rather than a populated ref.
+    describe('displayName and tags', () => {
+      it('derives displayName from the chart config name and leaves tags empty', async () => {
+        const { source } = await makeSource();
+        const webhook = await createTestWebhook();
+
+        const created = await authRequest('post', ALERTS_BASE_URL)
+          .send(
+            makeInlineAlertInput(
+              makeBuilderChartConfig(source._id.toString(), {
+                name: 'Error rate',
+              }),
+              webhook._id.toString(),
+            ),
+          )
+          .expect(200);
+
+        expect(created.body.data).toMatchObject({
+          displayName: 'Error rate',
+          tags: [],
+        });
+
+        const single = await authRequest(
+          'get',
+          `${ALERTS_BASE_URL}/${created.body.data.id}`,
+        ).expect(200);
+        expect(single.body.data).toMatchObject({
+          displayName: 'Error rate',
+          tags: [],
+        });
+
+        const list = await authRequest('get', ALERTS_BASE_URL).expect(200);
+        const listed = list.body.data.find(a => a.id === created.body.data.id);
+        expect(listed).toMatchObject({ displayName: 'Error rate', tags: [] });
+      });
+
+      it('falls back when the chart config has no name', async () => {
+        const { source } = await makeSource();
+        const webhook = await createTestWebhook();
+
+        const created = await authRequest('post', ALERTS_BASE_URL)
+          .send(
+            makeInlineAlertInput(
+              makeBuilderChartConfig(source._id.toString()),
+              webhook._id.toString(),
+            ),
+          )
+          .expect(200);
+
+        expect(created.body.data).toMatchObject({
+          displayName: 'Alert',
+          tags: [],
+        });
+      });
+
+      it('persists an explicit displayName and tags over the chart config name', async () => {
+        const { source } = await makeSource();
+        const webhook = await createTestWebhook();
+
+        const created = await authRequest('post', ALERTS_BASE_URL)
+          .send(
+            makeInlineAlertInput(
+              makeBuilderChartConfig(source._id.toString(), {
+                name: 'Error rate',
+              }),
+              webhook._id.toString(),
+              { displayName: 'Checkout error spike', tags: ['checkout', 'p1'] },
+            ),
+          )
+          .expect(200);
+
+        expect(created.body.data).toMatchObject({
+          displayName: 'Checkout error spike',
+          tags: ['checkout', 'p1'],
+        });
+
+        const single = await authRequest(
+          'get',
+          `${ALERTS_BASE_URL}/${created.body.data.id}`,
+        ).expect(200);
+        expect(single.body.data).toMatchObject({
+          displayName: 'Checkout error spike',
+          tags: ['checkout', 'p1'],
+        });
+      });
+
+      it('re-derives displayName and tags when an update omits them', async () => {
+        const { source } = await makeSource();
+        const webhook = await createTestWebhook();
+        const input = makeInlineAlertInput(
+          makeBuilderChartConfig(source._id.toString(), { name: 'Error rate' }),
+          webhook._id.toString(),
+          { displayName: 'Checkout error spike', tags: ['checkout'] },
+        );
+
+        const created = await authRequest('post', ALERTS_BASE_URL)
+          .send(input)
+          .expect(200);
+
+        await authRequest('put', `${ALERTS_BASE_URL}/${created.body.data.id}`)
+          .send(_.omit(input, ['displayName', 'tags']))
+          .expect(200);
+
+        const single = await authRequest(
+          'get',
+          `${ALERTS_BASE_URL}/${created.body.data.id}`,
+        ).expect(200);
+        expect(single.body.data).toMatchObject({
+          displayName: 'Error rate',
+          tags: [],
+        });
+      });
     });
 
     it('updates an inline alert config and maps asRatio to the internal ratio return type', async () => {

--- a/packages/api/src/routers/external-api/v2/alerts.ts
+++ b/packages/api/src/routers/external-api/v2/alerts.ts
@@ -6,8 +6,8 @@ import {
   countAlerts,
   createAlert,
   deleteAlert,
-  getAlertById,
-  getAlerts,
+  getAlertsWithDisplayRefs,
+  getAlertWithDisplayRefs,
   updateAlert,
   validateAlertInput,
 } from '@/controllers/alerts';
@@ -277,9 +277,34 @@ function toInternalAlertInput(body: ExternalAlertInput): InternalAlertInput {
  *           description: All notification channels to trigger when the alert fires or resolves.
  *         name:
  *           type: string
- *           description: Human-friendly alert name.
+ *           description: >-
+ *             Alert name template (Handlebars), rendered as the notification
+ *             title. When omitted, a default title is generated from the
+ *             display name, value and threshold.
  *           nullable: true
- *           example: "Test Alert"
+ *           example: "Errors for {{group}} hit {{value}}"
+ *         displayName:
+ *           type: string
+ *           description: >-
+ *             Display name shown in the alerts list and in notification titles.
+ *             Defaults to the name of the referenced saved search, dashboard
+ *             tile, or inline chart when omitted or null.
+ *           nullable: true
+ *           minLength: 1
+ *           maxLength: 512
+ *           example: "Checkout error spike"
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: string
+ *             maxLength: 32
+ *           maxItems: 50
+ *           description: >-
+ *             Tags for the alert. Defaults to the tags of the referenced saved
+ *             search or dashboard when omitted or null; inline alerts have no
+ *             parent to inherit from and default to an empty list.
+ *           nullable: true
+ *           example: ["checkout", "p1"]
  *         message:
  *           type: string
  *           description: Alert message template.
@@ -303,7 +328,24 @@ function toInternalAlertInput(body: ExternalAlertInput): InternalAlertInput {
  *       allOf:
  *         - $ref: '#/components/schemas/Alert'
  *         - type: object
+ *           required:
+ *             - displayName
+ *             - tags
  *           properties:
+ *             displayName:
+ *               type: string
+ *               description: >-
+ *                 The display name for the alert in the UI. Derived from the saved search name,
+ *                 dashboard tile name, or inline chartConfig name when not explicitly set.
+ *               example: "Checkout error spike"
+ *             tags:
+ *               type: array
+ *               items:
+ *                 type: string
+ *               description: >-
+ *                 The tags for the alert. Derived from the tags of the referenced saved search or dashboard when not explicitly set;
+ *                 inline alerts default to an empty list.
+ *               example: ["checkout", "p1"]
  *             id:
  *               type: string
  *               description: Unique alert identifier.
@@ -440,6 +482,8 @@ const router = express.Router();
  *                     teamId: "65f5e4a3b9e77c001a345678"
  *                     tileId: "65f5e4a3b9e77c001a901234"
  *                     dashboardId: "65f5e4a3b9e77c001a567890"
+ *                     displayName: "Checkout error spike"
+ *                     tags: ["checkout", "p1"]
  *                     numConsecutiveWindows: 3
  *                     createdAt: "2023-03-15T10:20:30.000Z"
  *                     updatedAt: "2023-03-15T14:25:10.000Z"
@@ -476,7 +520,7 @@ router.get(
         return res.status(403).json({ message: 'Forbidden' });
       }
 
-      const alert = await getAlertById(req.params.id, teamId);
+      const alert = await getAlertWithDisplayRefs(req.params.id, teamId);
 
       if (alert == null) {
         return res.status(404).json({ message: 'Alert not found' });
@@ -545,6 +589,8 @@ router.get(
  *                       teamId: "65f5e4a3b9e77c001a345678"
  *                       tileId: "65f5e4a3b9e77c001a901234"
  *                       dashboardId: "65f5e4a3b9e77c001a567890"
+ *                       displayName: "Checkout error spike"
+ *                       tags: ["checkout", "p1"]
  *                       createdAt: "2023-01-01T00:00:00.000Z"
  *                       updatedAt: "2023-01-01T00:00:00.000Z"
  *                   meta:
@@ -578,7 +624,7 @@ router.get(
 
       const { limit, offset } = getPagination(req.query);
       const [alerts, total] = await Promise.all([
-        getAlerts(teamId, { limit, offset }),
+        getAlertsWithDisplayRefs(teamId, { limit, offset }),
         countAlerts(teamId),
       ]);
 
@@ -624,6 +670,8 @@ router.get(
  *                   webhookId: "65f5e4a3b9e77c001a789012"
  *                 name: "Error Spike Alert"
  *                 message: "Error rate has exceeded 100 in the last hour"
+ *                 displayName: "Checkout error spike"
+ *                 tags: ["checkout", "p1"]
  *                 numConsecutiveWindows: 3
  *             multiChannelAlert:
  *               summary: Create an alert that notifies several webhooks
@@ -696,9 +744,9 @@ router.post(
     }
     try {
       const alertInput = toInternalAlertInput(req.body);
-      await validateAlertInput(teamId, alertInput);
+      const refs = await validateAlertInput(teamId, alertInput);
 
-      const createdAlert = await createAlert(teamId, alertInput, userId);
+      const createdAlert = await createAlert(teamId, alertInput, userId, refs);
 
       return res.json({
         data: translateAlertDocumentToExternalAlertWithChartConfig(
@@ -748,6 +796,8 @@ router.post(
  *                   webhookId: "65f5e4a3b9e77c001a789012"
  *                 name: "Updated Alert Name"
  *                 message: "Updated threshold and interval"
+ *                 displayName: "Checkout error spike"
+ *                 tags: ["checkout", "p1"]
  *     responses:
  *       '200':
  *         description: Successfully updated alert
@@ -798,9 +848,9 @@ router.put(
       const { id } = req.params;
 
       const alertInput = toInternalAlertInput(req.body);
-      await validateAlertInput(teamId, alertInput);
+      const refs = await validateAlertInput(teamId, alertInput);
 
-      const alert = await updateAlert(id, teamId, alertInput);
+      const alert = await updateAlert(id, teamId, alertInput, refs);
 
       if (alert == null) {
         return res.status(404).json({ message: 'Alert not found' });

--- a/packages/api/src/routers/external-api/v2/utils/alertChartConfig.ts
+++ b/packages/api/src/routers/external-api/v2/utils/alertChartConfig.ts
@@ -5,9 +5,10 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 import { omit } from 'lodash';
 
-import { AlertDocument, AlertSource, IAlert } from '@/models/alert';
+import { AlertSource, IAlert } from '@/models/alert';
 import {
   ExternalAlert,
+  TranslatableAlertDocument,
   translateAlertDocumentToExternalAlert,
 } from '@/utils/externalApi';
 import logger from '@/utils/logger';
@@ -388,7 +389,7 @@ export function convertAlertChartConfigToExternal(
  * to keep the utils -> router-utils import direction one-way.
  */
 export function translateAlertDocumentToExternalAlertWithChartConfig(
-  alert: AlertDocument,
+  alert: TranslatableAlertDocument,
 ): ExternalAlert {
   const external = translateAlertDocumentToExternalAlert(alert);
   const alertObj: Pick<IAlert, 'source' | 'chartConfig'> = alert.toJSON

--- a/packages/api/src/tasks/checkAlerts/__tests__/__snapshots__/renderAlertTemplate.int.test.ts.snap
+++ b/packages/api/src/tasks/checkAlerts/__tests__/__snapshots__/renderAlertTemplate.int.test.ts.snap
@@ -32,41 +32,41 @@ exports[`buildAlertMessageTemplateTitle saved search alerts OK state (resolved) 
 
 exports[`buildAlertMessageTemplateTitle saved search alerts OK state (resolved) not_equal threshold=5 okValue=5 1`] = `"✅ Alert for "My Search" - 5 lines found"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state above threshold=5 alertValue=10 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 10 meets or exceeds 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state above threshold=5 alertValue=10 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 10 meets or exceeds 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state above_exclusive threshold=5 alertValue=10 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 10 exceeds 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state above_exclusive threshold=5 alertValue=10 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 10 exceeds 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state below threshold=5 alertValue=2 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 2 falls below 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state below threshold=5 alertValue=2 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 2 falls below 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state below_or_equal threshold=5 alertValue=3 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 3 falls to or below 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state below_or_equal threshold=5 alertValue=3 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 3 falls to or below 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state between threshold=5 alertValue=6 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 6 falls between 5 and 7"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state between threshold=5 alertValue=6 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 6 falls between 5 and 7"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state decimal threshold 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 10.1 meets or exceeds 1.5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state decimal threshold 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 10.1 meets or exceeds 1.5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state equal threshold=5 alertValue=5 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 5 equals 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state equal threshold=5 alertValue=5 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 5 equals 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state integer threshold rounds value 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 11 meets or exceeds 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state integer threshold rounds value 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 11 meets or exceeds 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state not_between threshold=5 alertValue=12 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 12 falls outside 5 and 7"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state not_between threshold=5 alertValue=12 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 12 falls outside 5 and 7"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts ALERT state not_equal threshold=5 alertValue=10 1`] = `"🚨 Alert for "Test Chart" in "My Dashboard" - 10 does not equal 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts ALERT state not_equal threshold=5 alertValue=10 1`] = `"🚨 Alert for "My Dashboard - Test Chart" - 10 does not equal 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) above threshold=5 okValue=3 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 3 falls below 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) above threshold=5 okValue=3 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 3 falls below 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) above_exclusive threshold=5 okValue=3 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 3 falls to or below 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) above_exclusive threshold=5 okValue=3 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 3 falls to or below 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) below threshold=5 okValue=10 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 10 meets or exceeds 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) below threshold=5 okValue=10 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 10 meets or exceeds 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) below_or_equal threshold=5 okValue=10 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 10 exceeds 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) below_or_equal threshold=5 okValue=10 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 10 exceeds 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) between threshold=5 okValue=10 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 10 falls outside 5 and 7"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) between threshold=5 okValue=10 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 10 falls outside 5 and 7"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) equal threshold=5 okValue=10 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 10 does not equal 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) equal threshold=5 okValue=10 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 10 does not equal 5"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) not_between threshold=5 okValue=6 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 6 falls between 5 and 7"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) not_between threshold=5 okValue=6 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 6 falls between 5 and 7"`;
 
-exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) not_equal threshold=5 okValue=5 1`] = `"✅ Alert for "Test Chart" in "My Dashboard" - 5 equals 5"`;
+exports[`buildAlertMessageTemplateTitle tile alerts OK state (resolved) not_equal threshold=5 okValue=5 1`] = `"✅ Alert for "My Dashboard - Test Chart" - 5 equals 5"`;
 
 exports[`renderAlertTemplate saved search alerts ALERT state above threshold=5 alertValue=10 1`] = `
 "

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -1494,7 +1494,7 @@ describe('checkAlerts', () => {
           view: defaultChartView,
         }),
       ).toMatchInlineSnapshot(
-        `"🚨 Alert for "Test Chart" in "My Dashboard" - 5 meets or exceeds 1"`,
+        `"🚨 Alert for "My Dashboard - Test Chart" - 5 meets or exceeds 1"`,
       );
       // Inline alerts default to the chart config's name
       expect(
@@ -1520,7 +1520,7 @@ describe('checkAlerts', () => {
           state: AlertState.ALERT,
         }),
       ).toMatchInlineSnapshot(
-        `"🚨 Alert for "Test Chart" in "My Dashboard" - 5 meets or exceeds 1"`,
+        `"🚨 Alert for "My Dashboard - Test Chart" - 5 meets or exceeds 1"`,
       );
 
       // Test OK state (should have ✅ emoji)
@@ -1536,7 +1536,7 @@ describe('checkAlerts', () => {
           state: AlertState.OK,
         }),
       ).toMatchInlineSnapshot(
-        `"✅ Alert for "Test Chart" in "My Dashboard" - 5 meets or exceeds 1"`,
+        `"✅ Alert for "My Dashboard - Test Chart" - 5 meets or exceeds 1"`,
       );
     });
 
@@ -1556,7 +1556,7 @@ describe('checkAlerts', () => {
           view: decimalChartView,
         }),
       ).toMatchInlineSnapshot(
-        `"🚨 Alert for "Test Chart" in "My Dashboard" - 1111.1 meets or exceeds 1.5"`,
+        `"🚨 Alert for "My Dashboard - Test Chart" - 1111.1 meets or exceeds 1.5"`,
       );
 
       // Test with multiple decimal places
@@ -1574,7 +1574,7 @@ describe('checkAlerts', () => {
           view: multiDecimalChartView,
         }),
       ).toMatchInlineSnapshot(
-        `"🚨 Alert for "Test Chart" in "My Dashboard" - 1.1235 meets or exceeds 0.1234"`,
+        `"🚨 Alert for "My Dashboard - Test Chart" - 1.1235 meets or exceeds 0.1234"`,
       );
 
       // Test with integer value and decimal threshold
@@ -1592,7 +1592,7 @@ describe('checkAlerts', () => {
           view: integerValueView,
         }),
       ).toMatchInlineSnapshot(
-        `"🚨 Alert for "Test Chart" in "My Dashboard" - 10.00 meets or exceeds 0.12"`,
+        `"🚨 Alert for "My Dashboard - Test Chart" - 10.00 meets or exceeds 0.12"`,
       );
     });
 
@@ -2843,12 +2843,12 @@ describe('checkAlerts', () => {
         1,
         'https://hooks.slack.com/services/123',
         {
-          text: '🚨 Alert for "Logs Count" in "My Dashboard" - 3 meets or exceeds 1',
+          text: '🚨 Alert for "My Dashboard - Logs Count" - 3 meets or exceeds 1',
           blocks: [
             {
               text: {
                 text: [
-                  `*<http://app:8080/dashboards/${dashboard._id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "Logs Count" in "My Dashboard" - 3 meets or exceeds 1>*`,
+                  `*<http://app:8080/dashboards/${dashboard._id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "My Dashboard - Logs Count" - 3 meets or exceeds 1>*`,
                   '',
                   '3 meets or exceeds 1',
                   'Time Range (UTC): [Nov 16 10:05:00 PM - Nov 16 10:10:00 PM)',
@@ -4811,7 +4811,7 @@ describe('checkAlerts', () => {
         method: 'POST',
         redirect: 'manual',
         body: JSON.stringify({
-          text: `http://app:8080/dashboards/${dashboard.id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "Logs Count" in "My Dashboard" - 3 meets or exceeds 1`,
+          text: `http://app:8080/dashboards/${dashboard.id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "My Dashboard - Logs Count" - 3 meets or exceeds 1`,
         }),
         // Idempotency-Key is always injected last (cannot be overridden by user headers)
         // and is a stable objectHash of {eventId, startTime, endTime, state}.
@@ -7145,12 +7145,12 @@ describe('checkAlerts', () => {
         1,
         'https://hooks.slack.com/services/123',
         {
-          text: '🚨 Alert for "CPU" in "My Dashboard" - 6 meets or exceeds 1',
+          text: '🚨 Alert for "My Dashboard - CPU" - 6 meets or exceeds 1',
           blocks: [
             {
               text: {
                 text: [
-                  `*<http://app:8080/dashboards/${dashboard._id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "CPU" in "My Dashboard" - 6 meets or exceeds 1>*`,
+                  `*<http://app:8080/dashboards/${dashboard._id}?from=1700170200000&granularity=5+minute&to=1700174700000&highlightedTileId=17quud | 🚨 Alert for "My Dashboard - CPU" - 6 meets or exceeds 1>*`,
                   '',
                   '6 meets or exceeds 1',
                   'Time Range (UTC): [Nov 16 10:05:00 PM - Nov 16 10:10:00 PM)',

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -707,6 +707,110 @@ describe('buildAlertMessageTemplateTitle', () => {
       );
     });
   });
+
+  // `alert.name` is the title override, read off the view rather than passed
+  // in separately -- these pin that wiring.
+  describe('alert.name as a title override', () => {
+    it('replaces the default title', () => {
+      const view = makeSearchView();
+
+      const result = buildAlertMessageTemplateTitle({
+        view: { ...view, alert: { ...view.alert, name: 'Custom title' } },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toBe('🚨 Custom title');
+    });
+
+    it('renders Handlebars against the view', () => {
+      const view = makeSearchView({ threshold: 5, value: 10 });
+
+      const result = buildAlertMessageTemplateTitle({
+        view: {
+          ...view,
+          alert: { ...view.alert, name: '{{value}} over {{alert.threshold}}' },
+        },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toBe('🚨 10 over 5');
+    });
+  });
+
+  describe('stored displayName', () => {
+    it('names a saved-search alert', () => {
+      const view = makeSearchView();
+
+      const result = buildAlertMessageTemplateTitle({
+        view: {
+          ...view,
+          alert: { ...view.alert, displayName: 'Checkout errors' },
+        },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toBe('🚨 Alert for "Checkout errors" - 10 lines found');
+    });
+
+    it('names a tile alert', () => {
+      const view = makeTileView();
+
+      const result = buildAlertMessageTemplateTitle({
+        view: {
+          ...view,
+          alert: { ...view.alert, displayName: 'Error rate' },
+        },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toContain('Alert for "Error rate" -');
+      expect(result).not.toContain('My Dashboard');
+    });
+
+    it('names an inline alert', () => {
+      const view = makeInlineView({ where: 'level:error' });
+
+      const result = buildAlertMessageTemplateTitle({
+        view: { ...view, alert: { ...view.alert, displayName: 'p99 latency' } },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toContain('Alert for "p99 latency"');
+      expect(result).not.toContain('Inline Chart');
+    });
+  });
+
+  // Saved-search and tile derivation is pinned by the snapshots above; inline
+  // alerts have no referenced entity, so their name comes off the chart config.
+  describe('derived displayName', () => {
+    it('names an inline alert from its chart config', () => {
+      const result = buildAlertMessageTemplateTitle({
+        view: makeInlineView({ where: 'level:error' }),
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toBe(
+        '🚨 Alert for "Inline Chart" - 10 meets or exceeds 5',
+      );
+    });
+
+    it('falls back when an inline chart config has no name', () => {
+      const view = makeInlineView({ where: 'level:error' });
+
+      const result = buildAlertMessageTemplateTitle({
+        view: {
+          ...view,
+          alert: {
+            ...view.alert,
+            chartConfig: { ...view.alert.chartConfig!, name: undefined },
+          },
+        },
+        state: AlertState.ALERT,
+      });
+
+      expect(result).toBe('🚨 Alert for "Alert" - 10 meets or exceeds 5');
+    });
+  });
 });
 
 // MAX_NOTIFICATIONS_PER_EVENT bounds how many targets one fire/resolve event can

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -95,6 +95,7 @@ import {
   roundDownToXMinutes,
   unflattenObject,
 } from '@/tasks/util';
+import { isPopulatedRef } from '@/utils/alerts';
 import {
   getCounter,
   type OperationOutcome,
@@ -516,13 +517,8 @@ const fireChannelEvent = async ({
   }
   // alert.team is typed as a bare ObjectId, but a caller that populated it
   // (int-test setups do `.populate(['team', ...])`; the production path never
-  // does) hands us a full Team document instead — Mongoose documents don't
-  // override toString(), so calling it directly would silently stringify to
-  // "[object Object]" rather than the hex id. Prefer the populated
-  // document's own _id when present.
-  const isPopulatedWithId = (value: unknown): value is { _id: ObjectId } =>
-    typeof value === 'object' && value !== null && '_id' in value;
-  const teamId = (isPopulatedWithId(team) ? team._id : team).toString();
+  // does) hands us a full Team document instead. Prefer its own _id.
+  const teamId = (isPopulatedRef(team) ? team._id : team).toString();
 
   const attributesNested = unflattenObject(attributes);
   const templateView: AlertMessageTemplateDefaultView = {
@@ -541,6 +537,8 @@ const fireChannelEvent = async ({
       }),
       message: alert.message,
       name: alert.name,
+      displayName: alert.displayName,
+      tags: alert.tags,
       savedSearchId: savedSearch?.id,
       silenced: alert.silenced,
       source: alert.source,
@@ -570,7 +568,6 @@ const fireChannelEvent = async ({
     metadata,
     state,
     title: buildAlertMessageTemplateTitle({
-      template: alert.name,
       view: templateView,
       state,
     }),

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -49,6 +49,7 @@ import {
 } from '@/tasks/checkAlerts/providers';
 import { createHandlebarsWithHelpers } from '@/tasks/checkAlerts/transports';
 import { unflattenObject } from '@/tasks/util';
+import { resolveAlertDisplayFields } from '@/utils/alerts';
 import { truncateString } from '@/utils/common';
 import { getCounter } from '@/utils/instrumentation';
 import logger from '@/utils/logger';
@@ -292,16 +293,20 @@ export const buildAlertMessageTemplateHdxLink = (
 };
 
 export const buildAlertMessageTemplateTitle = ({
-  template,
   view,
   state,
 }: {
-  template?: string | null;
   view: AlertMessageTemplateDefaultView;
   state?: AlertState;
 }) => {
   const { alert, dashboard, savedSearch, value } = view;
   const handlebars = createHandlebarsWithHelpers();
+  // `alert.name` is an optional Handlebars template for the notification title.
+  const template = alert.name;
+  const { displayName } = resolveAlertDisplayFields(alert, {
+    savedSearch,
+    dashboard,
+  });
 
   // Add emoji prefix based on alert state
   const emoji = isAlertResolved(state) ? '✅ ' : '🚨 ';
@@ -313,7 +318,7 @@ export const buildAlertMessageTemplateTitle = ({
     // TODO: using template engine to render the title
     const baseTitle = template
       ? handlebars.compile(template)(view)
-      : `Alert for "${savedSearch.name}" - ${value} lines found`;
+      : `Alert for "${displayName}" - ${value} lines found`;
     return `${emoji}${baseTitle}`;
   } else if (alert.source === AlertSource.TILE) {
     if (dashboard == null) {
@@ -328,7 +333,7 @@ export const buildAlertMessageTemplateTitle = ({
     const formattedValue = formatValueToMatchThreshold(value, alert.threshold);
     const baseTitle = template
       ? handlebars.compile(template)(view)
-      : `Alert for "${tile.config.name}" in "${dashboard.name}" - ${formattedValue} ${
+      : `Alert for "${displayName}" - ${formattedValue} ${
           doesExceedThreshold(alert, value)
             ? describeThresholdViolation(alert.thresholdType)
             : describeThresholdResolution(alert.thresholdType)
@@ -337,11 +342,11 @@ export const buildAlertMessageTemplateTitle = ({
   } else if (alert.source === AlertSource.INLINE) {
     const formattedValue = formatValueToMatchThreshold(value, alert.threshold);
     // Inline alerts have no saved search/tile to name them; the alert's `name`
-    // doubles as the title template, so the default falls back to the chart
-    // config's name.
+    // doubles as the title template, so the default falls back to the resolved
+    // display name (itself derived from the chart config's name).
     const baseTitle = template
       ? handlebars.compile(template)(view)
-      : `Alert for "${alert.chartConfig?.name ?? 'chart'}" - ${formattedValue} ${
+      : `Alert for "${displayName}" - ${formattedValue} ${
           doesExceedThreshold(alert, value)
             ? describeThresholdViolation(alert.thresholdType)
             : describeThresholdResolution(alert.thresholdType)

--- a/packages/api/src/utils/__tests__/alerts.test.ts
+++ b/packages/api/src/utils/__tests__/alerts.test.ts
@@ -7,6 +7,7 @@ import {
 import { AlertSource } from '@/models/alert';
 import {
   deriveAlertDisplayFields,
+  isPopulatedRef,
   resolveAlertDisplayFields,
 } from '@/utils/alerts';
 
@@ -224,5 +225,17 @@ describe('resolveAlertDisplayFields', () => {
     const alert = { source: AlertSource.SAVED_SEARCH, tags: ['a'] };
     resolveAlertDisplayFields(alert).tags.push('b');
     expect(alert.tags).toEqual(['a']);
+  });
+});
+
+describe('isPopulatedRef', () => {
+  it.each([
+    [{ _id: 'abc' }, true],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+    ['abc', false],
+  ])('%p -> %p', (value, expected) => {
+    expect(isPopulatedRef(value)).toBe(expected);
   });
 });

--- a/packages/api/src/utils/__tests__/alerts.test.ts
+++ b/packages/api/src/utils/__tests__/alerts.test.ts
@@ -1,0 +1,228 @@
+import {
+  MAX_TAG_LENGTH,
+  MAX_TAGS,
+  tagsSchema,
+} from '@hyperdx/common-utils/dist/types';
+
+import { AlertSource } from '@/models/alert';
+import {
+  deriveAlertDisplayFields,
+  resolveAlertDisplayFields,
+} from '@/utils/alerts';
+
+const savedSearch = { name: 'Checkout errors', tags: ['checkout', 'p1'] };
+const dashboard = {
+  name: 'Checkout',
+  tags: ['team-checkout'],
+  tiles: [{ id: 'tile-1', config: { name: 'Error rate' } }],
+};
+
+describe('deriveAlertDisplayFields', () => {
+  it('derives from the saved search', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch },
+      ),
+    ).toEqual({ displayName: 'Checkout errors', tags: ['checkout', 'p1'] });
+  });
+
+  it('joins the dashboard and tile names for tile alerts', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.TILE, tileId: 'tile-1' },
+        { dashboard },
+      ),
+    ).toEqual({
+      displayName: 'Checkout - Error rate',
+      tags: ['team-checkout'],
+    });
+  });
+
+  it('falls back to "Tile" when the tile is gone or unnamed', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.TILE, tileId: 'deleted-tile' },
+        { dashboard },
+      ).displayName,
+    ).toBe('Checkout - Tile');
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.TILE, tileId: 'tile-1' },
+        {
+          dashboard: {
+            name: 'Checkout',
+            tags: [],
+            tiles: [{ id: 'tile-1', config: {} }],
+          },
+        },
+      ).displayName,
+    ).toBe('Checkout - Tile');
+  });
+
+  // The tile name alone would not say where the alert lives, so an unnamed
+  // dashboard makes the whole name underivable rather than half-derivable.
+  it('yields no name for a tile alert whose dashboard has no name', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.TILE, tileId: 'tile-1' },
+        {
+          dashboard: {
+            name: '  ',
+            tags: ['team-checkout'],
+            tiles: [{ id: 'tile-1', config: { name: 'Error rate' } }],
+          },
+        },
+      ),
+    ).toEqual({ displayName: null, tags: ['team-checkout'] });
+  });
+
+  it('derives from the inline chart config', () => {
+    expect(
+      deriveAlertDisplayFields({
+        source: AlertSource.INLINE,
+        chartConfig: { name: 'p99 latency' },
+      }),
+    ).toEqual({ displayName: 'p99 latency', tags: [] });
+  });
+
+  // Null, not the generic fallback: writers persist this, and a document that
+  // stored "Alert" could never recover its real name once the ref is loaded.
+  it('yields null when the referenced entity is not at hand', () => {
+    expect(
+      deriveAlertDisplayFields({ source: AlertSource.SAVED_SEARCH }),
+    ).toEqual({ displayName: null, tags: null });
+    expect(deriveAlertDisplayFields({ source: AlertSource.TILE })).toEqual({
+      displayName: null,
+      tags: null,
+    });
+    expect(deriveAlertDisplayFields({ source: AlertSource.INLINE })).toEqual({
+      displayName: null,
+      tags: [],
+    });
+  });
+
+  it('treats an empty or blank name as missing', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch: { name: '', tags: [] } },
+      ).displayName,
+    ).toBeNull();
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch: { name: '   ', tags: [] } },
+      ).displayName,
+    ).toBeNull();
+  });
+
+  it('trims the derived name', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch: { name: '  Checkout errors  ', tags: [] } },
+      ).displayName,
+    ).toBe('Checkout errors');
+  });
+
+  // alertDisplayNameSchema caps user input at 512; a longer derived name would
+  // fail validation the first time the form that renders it is submitted.
+  it('truncates the derived name to 512 characters', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch: { name: 'x'.repeat(600), tags: [] } },
+      ).displayName,
+    ).toBe('x'.repeat(512));
+  });
+
+  // Referenced documents predate these fields and are read straight from
+  // Mongo, so anything non-string has to survive derivation.
+  it('drops malformed tags', () => {
+    expect(
+      deriveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH },
+        { savedSearch: { name: 'S', tags: ['ok', 7, '', null, 'fine'] } },
+      ).tags,
+    ).toEqual(['ok', 'fine']);
+  });
+
+  it('truncates over-long tags and caps the count to the alert tag limits', () => {
+    const longTag = 'x'.repeat(MAX_TAG_LENGTH + 20);
+    const { tags } = deriveAlertDisplayFields(
+      { source: AlertSource.SAVED_SEARCH },
+      {
+        savedSearch: {
+          name: 'S',
+          tags: [
+            longTag,
+            ...Array.from({ length: MAX_TAGS }, (_, i) => `t${i}`),
+          ],
+        },
+      },
+    );
+
+    expect(tags).toHaveLength(MAX_TAGS);
+    expect(tags?.[0]).toBe('x'.repeat(MAX_TAG_LENGTH));
+    expect(tagsSchema.safeParse(tags).success).toBe(true);
+  });
+
+  it('returns a copy of the tags so callers cannot mutate the referenced document', () => {
+    const refs = { savedSearch: { name: 'S', tags: ['a'] } };
+    const { tags } = deriveAlertDisplayFields(
+      { source: AlertSource.SAVED_SEARCH },
+      refs,
+    );
+    tags?.push('b');
+    expect(refs.savedSearch.tags).toEqual(['a']);
+  });
+});
+
+describe('resolveAlertDisplayFields', () => {
+  it('prefers the stored value per field', () => {
+    expect(
+      resolveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH, displayName: 'Custom' },
+        { savedSearch },
+      ),
+    ).toEqual({ displayName: 'Custom', tags: ['checkout', 'p1'] });
+
+    expect(
+      resolveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH, tags: ['own'] },
+        { savedSearch },
+      ),
+    ).toEqual({ displayName: 'Checkout errors', tags: ['own'] });
+  });
+
+  it('keeps a deliberately emptied tag list', () => {
+    expect(
+      resolveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH, tags: [] },
+        { savedSearch },
+      ).tags,
+    ).toEqual([]);
+  });
+
+  it('falls back to "Alert" and no tags when nothing is derivable', () => {
+    expect(
+      resolveAlertDisplayFields({ source: AlertSource.SAVED_SEARCH }),
+    ).toEqual({ displayName: 'Alert', tags: [] });
+  });
+
+  it('treats null as unset', () => {
+    expect(
+      resolveAlertDisplayFields(
+        { source: AlertSource.SAVED_SEARCH, displayName: null, tags: null },
+        { savedSearch },
+      ),
+    ).toEqual({ displayName: 'Checkout errors', tags: ['checkout', 'p1'] });
+  });
+
+  it('returns a copy of the stored tags', () => {
+    const alert = { source: AlertSource.SAVED_SEARCH, tags: ['a'] };
+    resolveAlertDisplayFields(alert).tags.push('b');
+    expect(alert.tags).toEqual(['a']);
+  });
+});

--- a/packages/api/src/utils/__tests__/externalApi.test.ts
+++ b/packages/api/src/utils/__tests__/externalApi.test.ts
@@ -54,6 +54,107 @@ describe('utils/externalApi', () => {
     });
   });
 
+  describe('displayName and tags', () => {
+    it('passes stored values through', () => {
+      const alert = createAlertDocument({
+        displayName: 'Checkout errors',
+        tags: ['checkout'],
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.displayName).toBe('Checkout errors');
+      expect(translated.tags).toEqual(['checkout']);
+    });
+
+    it('derives from a populated saved search when unset', () => {
+      const alert = createAlertDocument({
+        savedSearch: {
+          _id: new Types.ObjectId(),
+          name: 'Payment 5xx',
+          tags: ['payments'],
+        },
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.displayName).toBe('Payment 5xx');
+      expect(translated.tags).toEqual(['payments']);
+    });
+
+    it('derives from a populated dashboard tile when unset', () => {
+      const alert = createAlertDocument({
+        source: AlertSource.TILE,
+        tileId: 'tile-1',
+        savedSearch: undefined,
+        dashboard: {
+          _id: new Types.ObjectId(),
+          name: 'Checkout',
+          tags: ['team-checkout'],
+          tiles: [{ id: 'tile-1', config: { name: 'Error rate' } }],
+        },
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.displayName).toBe('Checkout - Error rate');
+      expect(translated.tags).toEqual(['team-checkout']);
+    });
+
+    it('falls back when the refs are unpopulated and the fields are unset', () => {
+      const alert = createAlertDocument({ savedSearch: new Types.ObjectId() });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.displayName).toBe('Alert');
+      expect(translated.tags).toEqual([]);
+    });
+
+    it('derives from an inline chart config when unset', () => {
+      const alert = createAlertDocument({
+        source: AlertSource.INLINE,
+        savedSearch: undefined,
+        chartConfig: { name: 'p99 latency' },
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      // Inline alerts have no parent entity, so tags stay empty rather than
+      // resolving to the generic fallback.
+      expect(translated.displayName).toBe('p99 latency');
+      expect(translated.tags).toEqual([]);
+    });
+
+    it('falls back for an inline alert whose chart config has no name', () => {
+      const alert = createAlertDocument({
+        source: AlertSource.INLINE,
+        savedSearch: undefined,
+        chartConfig: { displayType: 'line' },
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.displayName).toBe('Alert');
+      expect(translated.tags).toEqual([]);
+    });
+
+    // A populated ref is a document, and documents don't override toString();
+    // stringifying one directly yields "[object Object]".
+    it('stringifies ids from populated refs', () => {
+      const savedSearchId = new Types.ObjectId();
+      const dashboardId = new Types.ObjectId();
+      const alert = createAlertDocument({
+        savedSearch: { _id: savedSearchId, name: 'S', tags: [] },
+        dashboard: { _id: dashboardId, name: 'D', tags: [], tiles: [] },
+      });
+
+      const translated = translateAlertDocumentToExternalAlert(alert);
+
+      expect(translated.savedSearchId).toBe(savedSearchId.toString());
+      expect(translated.dashboardId).toBe(dashboardId.toString());
+    });
+  });
+
   describe('note handling', () => {
     it('returns note as null when the value is null', () => {
       const alert = createAlertDocument({ note: null });

--- a/packages/api/src/utils/alerts.ts
+++ b/packages/api/src/utils/alerts.ts
@@ -1,0 +1,147 @@
+import {
+  MAX_ALERT_DISPLAY_NAME_LENGTH,
+  MAX_TAG_LENGTH,
+  MAX_TAGS,
+} from '@hyperdx/common-utils/dist/types';
+
+import { AlertSource } from '@/models/alert';
+
+import logger from './logger';
+
+/**
+ * Documents that an alert may reference. Structural rather than
+ * `Pick<IDashboard | ISavedSearch, ...>` because derivation reads
+ * the data as untrusted from old Mongo documents.
+ */
+export type AlertRefs = {
+  savedSearch?: { name?: unknown; tags?: unknown } | null;
+  dashboard?: {
+    name?: unknown;
+    tags?: unknown;
+    tiles?: { id?: string | null; config?: { name?: unknown } | null }[] | null;
+  } | null;
+};
+
+export type AlertDisplayFields = {
+  displayName: string;
+  tags: string[];
+};
+
+/** `null` means "nothing to derive from", not "derived to empty". */
+export type DerivedAlertDisplayFields = {
+  displayName: string | null;
+  tags: string[] | null;
+};
+
+type AlertDisplayInput = {
+  source?: AlertSource | null;
+  tileId?: string | null;
+  chartConfig?: { name?: string | null } | null;
+  displayName?: string | null;
+  tags?: string[] | null;
+};
+
+const FALLBACK_DISPLAY_NAME = 'Alert';
+const FALLBACK_TILE_NAME = 'Tile';
+
+/**
+ * Referenced entities are read straight from Mongo and predate any of these
+ * fields, so treat their values as untrusted: anything that isn't a non-blank
+ * string is "no name".
+ */
+function normalizeName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+/**
+ * Derived tags are persisted on the alert, which validates them with
+ * `alertTagsSchema`, but they are copied from a dashboard/saved search whose
+ * own schema caps neither length nor count. Apply the alert caps here.
+ */
+function normalizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((tag): tag is string => typeof tag === 'string' && tag !== '')
+    .slice(0, MAX_TAGS)
+    .map(tag => tag.slice(0, MAX_TAG_LENGTH));
+}
+
+/**
+ * The display name/tags an alert falls back to when it has no stored values of
+ * its own, derived from whatever entity it references. Returns `null` per field
+ * when the referenced entity isn't available: writers persist `null` rather than
+ * freezing the generic fallback, so a later read with the ref populated still
+ * resolves to the real name.
+ */
+export function deriveAlertDisplayFields(
+  alert: AlertDisplayInput,
+  refs: AlertRefs = {},
+): DerivedAlertDisplayFields {
+  const { savedSearch, dashboard } = refs;
+
+  let displayName: string | null = null;
+  let tags: string[] | null = null;
+
+  try {
+    switch (alert.source) {
+      case AlertSource.TILE: {
+        const dashboardName = normalizeName(dashboard?.name);
+        if (dashboardName != null) {
+          const tiles = Array.isArray(dashboard?.tiles) ? dashboard.tiles : [];
+          const tile = alert.tileId
+            ? tiles.find(t => t.id === alert.tileId)
+            : undefined;
+          const tileName = normalizeName(tile?.config?.name);
+          displayName = `${dashboardName} - ${tileName ?? FALLBACK_TILE_NAME}`;
+        }
+        tags = dashboard ? normalizeTags(dashboard.tags) : null;
+        break;
+      }
+      case AlertSource.INLINE:
+        displayName = normalizeName(alert.chartConfig?.name);
+        tags = []; // Inline alerts have no parent to inherit tags from.
+        break;
+      case AlertSource.SAVED_SEARCH:
+      default:
+        displayName = normalizeName(savedSearch?.name);
+        tags = savedSearch ? normalizeTags(savedSearch.tags) : null;
+        break;
+    }
+  } catch (e) {
+    logger.error(
+      {
+        alert,
+        refs,
+      },
+      'deriveAlertDisplayFields failed',
+      e,
+    );
+  }
+
+  return {
+    displayName: displayName?.slice(0, MAX_ALERT_DISPLAY_NAME_LENGTH) ?? null,
+    tags,
+  };
+}
+
+/**
+ * Stored value per field, falling back to the derived one. Every read path goes
+ * through this so documents written before the fields existed still render.
+ */
+export function resolveAlertDisplayFields(
+  alert: AlertDisplayInput,
+  refs: AlertRefs = {},
+): AlertDisplayFields {
+  const derived = deriveAlertDisplayFields(alert, refs);
+  return {
+    displayName:
+      alert.displayName ?? derived.displayName ?? FALLBACK_DISPLAY_NAME,
+    tags: alert.tags != null ? [...alert.tags] : (derived.tags ?? []),
+  };
+}

--- a/packages/api/src/utils/alerts.ts
+++ b/packages/api/src/utils/alerts.ts
@@ -1,9 +1,11 @@
 import {
-  MAX_ALERT_DISPLAY_NAME_LENGTH,
-  MAX_TAG_LENGTH,
-  MAX_TAGS,
-} from '@hyperdx/common-utils/dist/types';
+  clampAlertDisplayName,
+  clampAlertTags,
+  formatTileAlertDisplayName,
+} from '@hyperdx/common-utils/dist/alerts';
+import { Types } from 'mongoose';
 
+import type { ObjectId } from '@/models';
 import { AlertSource } from '@/models/alert';
 
 import logger from './logger';
@@ -42,7 +44,6 @@ type AlertDisplayInput = {
 };
 
 const FALLBACK_DISPLAY_NAME = 'Alert';
-const FALLBACK_TILE_NAME = 'Tile';
 
 /**
  * Referenced entities are read straight from Mongo and predate any of these
@@ -57,19 +58,34 @@ function normalizeName(value: unknown): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
-/**
- * Derived tags are persisted on the alert, which validates them with
- * `alertTagsSchema`, but they are copied from a dashboard/saved search whose
- * own schema caps neither length nor count. Apply the alert caps here.
- */
+/** Untrusted Mongo value -> tags that satisfy `alertTagsSchema`. */
 function normalizeTags(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
   }
-  return value
-    .filter((tag): tag is string => typeof tag === 'string' && tag !== '')
-    .slice(0, MAX_TAGS)
-    .map(tag => tag.slice(0, MAX_TAG_LENGTH));
+  return clampAlertTags(
+    value.filter((tag): tag is string => typeof tag === 'string'),
+  );
+}
+
+/**
+ * A Mongoose ref field is either a bare ObjectId or, when the query populated
+ * it, the referenced document. Documents don't override toString(), so an
+ * unguarded `.toString()` on a populated ref silently yields "[object Object]".
+ */
+export function isPopulatedRef(ref: unknown): ref is { _id: ObjectId } {
+  return typeof ref === 'object' && ref !== null && '_id' in ref;
+}
+
+/**
+ * The populated document when the ref field was populated, null otherwise.
+ * The instanceof check is for the type system: the predicate alone can't
+ * remove the bare-ObjectId branch from the union.
+ */
+export function populatedRefOrNull<T extends { _id: ObjectId }>(
+  ref: ObjectId | T | null | undefined,
+): T | null {
+  return isPopulatedRef(ref) && !(ref instanceof Types.ObjectId) ? ref : null;
 }
 
 /**
@@ -97,8 +113,10 @@ export function deriveAlertDisplayFields(
           const tile = alert.tileId
             ? tiles.find(t => t.id === alert.tileId)
             : undefined;
-          const tileName = normalizeName(tile?.config?.name);
-          displayName = `${dashboardName} - ${tileName ?? FALLBACK_TILE_NAME}`;
+          displayName = formatTileAlertDisplayName(
+            dashboardName,
+            normalizeName(tile?.config?.name),
+          );
         }
         tags = dashboard ? normalizeTags(dashboard.tags) : null;
         break;
@@ -125,7 +143,8 @@ export function deriveAlertDisplayFields(
   }
 
   return {
-    displayName: displayName?.slice(0, MAX_ALERT_DISPLAY_NAME_LENGTH) ?? null,
+    displayName:
+      displayName == null ? null : clampAlertDisplayName(displayName),
     tags,
   };
 }

--- a/packages/api/src/utils/externalApi.ts
+++ b/packages/api/src/utils/externalApi.ts
@@ -11,6 +11,7 @@ import {
   SavedChartConfig,
 } from '@hyperdx/common-utils/dist/types';
 import { omit } from 'lodash';
+import { Types } from 'mongoose';
 
 import type { ObjectId } from '@/models';
 import {
@@ -21,8 +22,14 @@ import {
   getAlertChannels,
   IAlert,
 } from '@/models/alert';
-import type { DashboardDocument } from '@/models/dashboard';
+import type { DashboardDocument, IDashboard } from '@/models/dashboard';
+import type { ISavedSearch } from '@/models/savedSearch';
 import { SeriesTile } from '@/routers/external-api/v2/utils/dashboards';
+import {
+  isPopulatedRef,
+  populatedRefOrNull,
+  resolveAlertDisplayFields,
+} from '@/utils/alerts';
 import {
   ExternalAlertChartConfig,
   ExternalDashboardFilterWithId,
@@ -272,6 +279,8 @@ export function translateExternalFilterToFilter(
 export type ExternalAlert = {
   id: string;
   name?: string | null;
+  displayName: string;
+  tags: string[];
   message?: string | null;
   note?: string | null;
   threshold: number;
@@ -310,7 +319,54 @@ export type ExternalAlert = {
   updatedAt?: string;
 };
 
-type AlertDocumentObject = IAlert & { _id: ObjectId };
+// An alert's savedSearch/dashboard ref as this module receives it: a bare
+// ObjectId, or — when the caller used a populating reader — the referenced
+// document, possibly projected down to the display fields.
+type AlertRef<T> = ObjectId | (Partial<T> & { _id: ObjectId }) | null;
+
+type AlertRefFields = {
+  savedSearch?: AlertRef<ISavedSearch>;
+  dashboard?: AlertRef<IDashboard>;
+};
+
+type AlertDocumentObject = Omit<IAlert, keyof AlertRefFields> & {
+  _id: ObjectId;
+} & AlertRefFields;
+
+export type TranslatableAlertDocument = Omit<
+  AlertDocument,
+  keyof AlertRefFields
+> &
+  AlertRefFields;
+
+/**
+ * A populated ref whose target was deleted resolves to `null` in `toJSON()`,
+ * but Mongoose still holds the original id in `populated()`. Prefer that so the
+ * response keeps pointing at the (now dangling) dashboard/saved search instead
+ * of silently dropping the field.
+ */
+function refIdToString(
+  ref: AlertRef<object> | undefined,
+  populatedId: ObjectId | undefined,
+): string | undefined {
+  if (ref == null) {
+    return populatedId?.toString();
+  }
+  return (isPopulatedRef(ref) ? ref._id : ref).toString();
+}
+
+/**
+ * Mongoose types `populated()` as `any`; it returns the original ObjectId for
+ * a populated single ref, and undefined when the path was never populated.
+ */
+function populatedRefId(
+  alert: TranslatableAlertDocument,
+  path: keyof AlertRefFields,
+): ObjectId | undefined {
+  const id: unknown =
+    typeof alert.populated === 'function' ? alert.populated(path) : undefined;
+  return id instanceof Types.ObjectId ? id : undefined;
+}
 
 function hasCreatedAt(
   alert: AlertDocumentObject,
@@ -374,19 +430,28 @@ function transformErrorsToExternalErrors(
 // v2 utils, and list responses stay lean so a team with hundreds of raw-SQL
 // inline alerts does not ship every template on each page.
 export function translateAlertDocumentToExternalAlert(
-  alert: AlertDocument,
+  alert: TranslatableAlertDocument,
 ): ExternalAlert {
-  // Convert to plain object if it's a Mongoose document
+  // Convert to plain object if it's a Mongoose document. `flattenMaps: false`
+  // picks the toJSON overload that doesn't wrap every field in FlattenMaps<>
+  // (which breaks ObjectId); the alert schema has no Map fields, so the
+  // runtime output is identical.
   const alertObj: AlertDocumentObject = alert.toJSON
-    ? alert.toJSON()
+    ? alert.toJSON({ flattenMaps: false })
     : { ...alert };
 
   const channels = getAlertChannels(alertObj);
+
+  // The ref fields are populated documents when the caller used one of the
+  // `*WithDisplayRefs` readers and bare ObjectIds otherwise.
+  const dashboard = populatedRefOrNull(alertObj.dashboard);
+  const savedSearch = populatedRefOrNull(alertObj.savedSearch);
 
   // Copy all fields, renaming _id to id, ensuring ObjectId's are strings
   const result = {
     id: alertObj._id.toString(),
     name: alertObj.name,
+    ...resolveAlertDisplayFields(alertObj, { dashboard, savedSearch }),
     message: alertObj.message,
     note: alertObj.note ?? null,
     threshold: alertObj.threshold,
@@ -408,8 +473,14 @@ export function translateAlertDocumentToExternalAlert(
     ...(channels.length > 0 && { channel: channels[0], channels }),
     teamId: alertObj.team.toString(),
     tileId: alertObj.tileId ?? undefined,
-    dashboardId: alertObj.dashboard?.toString(),
-    savedSearchId: alertObj.savedSearch?.toString(),
+    dashboardId: refIdToString(
+      alertObj.dashboard,
+      populatedRefId(alert, 'dashboard'),
+    ),
+    savedSearchId: refIdToString(
+      alertObj.savedSearch,
+      populatedRefId(alert, 'savedSearch'),
+    ),
     groupBy: alertObj.groupBy ?? undefined,
     silenced: transformSilencedToExternalSilenced(alertObj.silenced),
     executionErrors: transformErrorsToExternalErrors(alertObj.executionErrors),

--- a/packages/api/src/utils/zod.ts
+++ b/packages/api/src/utils/zod.ts
@@ -3,7 +3,9 @@ import {
   addDuplicateTileIdIssues,
   AggregateFunctionSchema,
   AlertChartConfigSchema,
+  alertDisplayNameSchema,
   alertNoteSchema,
+  alertTagsSchema,
   AlertThresholdType,
   BackgroundChartSchema,
   ChartPaletteTokenSchema,
@@ -1002,6 +1004,8 @@ const alertBaseSchema = z.object({
   name: z.string().min(1).max(512).nullish(),
   message: z.string().min(1).max(4096).nullish(),
   note: alertNoteSchema,
+  displayName: alertDisplayNameSchema,
+  tags: alertTagsSchema,
   numConsecutiveWindows: z.number().int().min(1).nullish(),
 });
 

--- a/packages/app/src/AlertDetailPage.tsx
+++ b/packages/app/src/AlertDetailPage.tsx
@@ -28,11 +28,7 @@ import EmptyState from '@/components/EmptyState';
 import { PageHeader } from '@/components/PageHeader';
 import { TimePicker } from '@/components/TimePicker';
 import { IS_ALERT_DETAILS_ENABLED } from '@/config';
-import {
-  getAlertDisplayName,
-  getAlertSourceLabel,
-  getAlertSourceUrl,
-} from '@/utils/alerts';
+import { getAlertSourceLabel, getAlertSourceUrl } from '@/utils/alerts';
 
 import { useBrandDisplayName } from './theme/ThemeProvider';
 import api from './api';
@@ -135,14 +131,16 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
               Alerts
             </Anchor>
             <Text fz="sm" c="dimmed">
-              {getAlertDisplayName(alert) || 'Alert'}
+              {alert.displayName || 'Alert'}
             </Text>
           </Breadcrumbs>
         }
         leading={
           <Group gap="sm">
             {alert.state != null && <AlertStateBadge state={alert.state} />}
-            <Text fw={500}>{getAlertDisplayName(alert)}</Text>
+            <Text fw={500} data-testid="alert-detail-name">
+              {alert.displayName}
+            </Text>
             {alertUrl && (
               /* Next to the name rather than in the actions row: it navigates
                  to what the alert watches, so it belongs with the identity,
@@ -174,7 +172,7 @@ function AlertDetailBody({ alert }: { alert: AlertsPageItem }) {
                 this page carries that link next to the title instead. */}
             <AlertRowMenu
               alert={alert}
-              alertName={getAlertDisplayName(alert)}
+              alertName={alert.displayName}
               dateRange={searchedTimeRange}
               onDeleted={() => router.push('/alerts')}
             />
@@ -255,8 +253,7 @@ export default function AlertDetailPage() {
     >
       <Head>
         <title>
-          {alert ? `${getAlertDisplayName(alert)} - Alerts` : 'Alerts'} -{' '}
-          {brandName}
+          {alert ? `${alert.displayName} - Alerts` : 'Alerts'} - {brandName}
         </title>
       </Head>
       {isLoading && (

--- a/packages/app/src/AlertsPage.tsx
+++ b/packages/app/src/AlertsPage.tsx
@@ -19,12 +19,7 @@ import {
 import { AlertCardList } from '@/components/alerts/AlertCardList';
 import EmptyState from '@/components/EmptyState';
 import { PageHeader } from '@/components/PageHeader';
-import {
-  getAlertCreatorLabel,
-  getAlertDisplayName,
-  getAlertSourceLabel,
-  getAlertTags,
-} from '@/utils/alerts';
+import { getAlertCreatorLabel, getAlertSourceLabel } from '@/utils/alerts';
 
 import { useBrandDisplayName } from './theme/ThemeProvider';
 import api from './api';
@@ -43,7 +38,7 @@ export default function AlertsPage() {
 
   const allTags = React.useMemo(() => {
     const tags = new Set<string>();
-    alerts.forEach(a => getAlertTags(a).forEach(t => tags.add(t)));
+    alerts.forEach(a => a.tags?.forEach(t => tags.add(t)));
     return Array.from(tags).sort();
   }, [alerts]);
 
@@ -70,7 +65,7 @@ export default function AlertsPage() {
       result = result.filter(a => getAlertSourceLabel(a) === sourceFilter);
     }
     if (tagFilter) {
-      result = result.filter(a => getAlertTags(a).includes(tagFilter));
+      result = result.filter(a => a.tags?.includes(tagFilter));
     }
     if (creatorFilter) {
       result = result.filter(a => getAlertCreatorLabel(a) === creatorFilter);
@@ -79,14 +74,14 @@ export default function AlertsPage() {
       const q = search.toLowerCase();
       result = result.filter(
         a =>
-          getAlertDisplayName(a).toLowerCase().includes(q) ||
+          a.displayName?.toLowerCase().includes(q) ||
           // So "tile" / "saved search" narrow the list the same way the type
           // filter does, without having to reach for the dropdown.
           getAlertSourceLabel(a)
             .toLowerCase()
             .split(' ')
             .some(word => word.startsWith(q)) ||
-          getAlertTags(a).some(t => t.toLowerCase().includes(q)),
+          a.tags?.some(t => t.toLowerCase().includes(q)),
       );
     }
     return result;

--- a/packages/app/src/DBSearchPageAlertModal.tsx
+++ b/packages/app/src/DBSearchPageAlertModal.tsx
@@ -3,11 +3,17 @@ import router from 'next/router';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  clampAlertDisplayName,
+  clampAlertTags,
+} from '@hyperdx/common-utils/dist/alerts';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   type Alert,
+  alertDisplayNameSchema,
   AlertIntervalSchema,
   AlertSource,
+  alertTagsSchema,
   AlertThresholdType,
   Filter,
   isRangeThresholdType,
@@ -56,6 +62,7 @@ import {
   toAlertChannels,
 } from '@/utils/alerts';
 
+import { AlertDisplayFields } from './components/AlertDisplayFields';
 import { AlertNoteField } from './components/AlertNoteField';
 import { AlertPreviewChart } from './components/AlertPreviewChart';
 import { AlertChannelForm } from './components/Alerts';
@@ -78,6 +85,8 @@ const SavedSearchAlertFormSchema = z
     scheduleStartAt: scheduleStartAtSchema,
     thresholdType: z.nativeEnum(AlertThresholdType),
     channels: zAlertChannels,
+    displayName: alertDisplayNameSchema,
+    tags: alertTagsSchema,
     // nullish() (not optional()): persisted alerts store this as null, which
     // optional() would reject.
     numConsecutiveWindows: z.number().int().min(1).nullish(),
@@ -93,9 +102,11 @@ const AlertForm = ({
   filters,
   select,
   defaultValues,
+  prefill,
   loading,
   deleteLoading,
   hasSavedSearch,
+  savedSearchName,
   onDelete,
   onSubmit,
   onClose,
@@ -106,9 +117,12 @@ const AlertForm = ({
   filters?: Filter[] | null;
   select?: string | null;
   defaultValues?: null | AlertWithCreatedBy;
+  /** Seed values for a brand-new alert */
+  prefill?: { displayName?: string; tags?: string[] };
   loading?: boolean;
   deleteLoading?: boolean;
   hasSavedSearch?: boolean;
+  savedSearchName?: string;
   onDelete: (id: string) => void;
   onSubmit: (data: Alert) => void;
   onClose: () => void;
@@ -140,6 +154,8 @@ const AlertForm = ({
           source: AlertSource.SAVED_SEARCH,
           channels: [{ type: 'webhook', webhookId: '' }],
           note: null,
+          displayName: prefill?.displayName,
+          tags: prefill?.tags,
         },
     resolver: zodResolver(SavedSearchAlertFormSchema),
   });
@@ -193,6 +209,13 @@ const AlertForm = ({
     >
       <Paper px="sm" py="xs" radius="xs">
         <Stack gap="xs">
+          <AlertDisplayFields
+            control={control}
+            displayNameName="displayName"
+            tagsName="tags"
+            derivedDisplayName={savedSearchName}
+            labelMarginTop="0"
+          />
           <Text size="xxs" opacity={0.5}>
             Trigger
           </Text>
@@ -607,6 +630,15 @@ export const DBSearchPageAlertModal = ({
         <AlertForm
           key={activeIndex}
           hasSavedSearch={!!savedSearch}
+          savedSearchName={savedSearch?.name}
+          prefill={
+            savedSearch
+              ? {
+                  displayName: clampAlertDisplayName(savedSearch.name),
+                  tags: clampAlertTags(savedSearch.tags),
+                }
+              : undefined
+          }
           sourceId={searchedConfig?.source}
           where={searchedConfig?.where}
           whereLanguage={searchedConfig?.whereLanguage}

--- a/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
+++ b/packages/app/src/__tests__/DBSearchPageAlertModal.test.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from 'react';
+import { Controller as MockController } from 'react-hook-form';
 import {
   AlertSource,
   AlertThresholdType,
@@ -5,6 +7,7 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
+import type { AlertChannelForm } from '@/components/Alerts';
 import { DBSearchPageAlertModal } from '@/DBSearchPageAlertModal';
 
 // --- Mutation spies ------------------------------------------------------
@@ -40,7 +43,9 @@ const savedSearch = {
   select: '',
   source: 'source-id',
   orderBy: '',
-  tags: [],
+  // One tag over the alert cap (32): the prefill must clamp it or the form
+  // rejects on mount and Create Alert silently does nothing.
+  tags: ['prod', 'checkout-service-payment-failures'],
   alerts: [firstAlert, secondAlert],
 };
 
@@ -63,6 +68,12 @@ jest.mock('@/api', () => ({
       data: {
         data: [firstAlert, secondAlert].find(a => a.id === id) ?? firstAlert,
       },
+    }),
+    useTags: () => ({
+      data: { data: ['prod'] },
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
     }),
   },
 }));
@@ -98,10 +109,30 @@ jest.mock('@/components/AlertPreviewChart', () => ({
   __esModule: true,
   AlertPreviewChart: () => <div data-testid="alert-preview-chart" />,
 }));
-jest.mock('@/components/Alerts', () => ({
-  __esModule: true,
-  AlertChannelForm: () => <div data-testid="alert-channel-form" />,
-}));
+// Stubbed, but it still has to register the webhook id: the form schema
+// rejects an empty one, so a create submitted through an inert stub would
+// never reach the mutation.
+jest.mock('@/components/Alerts', () => {
+  return {
+    __esModule: true,
+    AlertChannelForm: ({
+      control,
+      channelsName,
+    }: ComponentProps<typeof AlertChannelForm>) => (
+      <MockController
+        control={control}
+        name={`${channelsName}.0.webhookId`}
+        render={({ field }) => (
+          <input
+            data-testid="webhook-id-input"
+            {...field}
+            value={field.value ?? ''}
+          />
+        )}
+      />
+    ),
+  };
+});
 jest.mock('@/components/SQLEditor/SQLInlineEditor', () => ({
   __esModule: true,
   SQLInlineEditorControlled: () => <div data-testid="sql-inline-editor" />,
@@ -177,5 +208,33 @@ describe('DBSearchPageAlertModal', () => {
     expect(payload.channels).toEqual([
       { type: 'webhook', webhookId: 'webhook-id' },
     ]);
+  });
+
+  // A new alert opens prefilled from the saved search it will watch, so the
+  // create payload carries those values rather than relying on the server's
+  // derivation.
+  it('prefills the display name and tags from the saved search, clamped to the alert caps', async () => {
+    renderModal();
+
+    expect(await screen.findByTestId('alert-display-name-input')).toHaveValue(
+      'My Search',
+    );
+
+    fireEvent.change(screen.getByTestId('webhook-id-input'), {
+      target: { value: 'webhook-id' },
+    });
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Create Alert' }),
+    );
+
+    await waitFor(() => {
+      expect(createAlertMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(createAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: 'My Search',
+        tags: ['prod', 'checkout-service-payment-failure'],
+      }),
+    );
   });
 });

--- a/packages/app/src/components/AlertDisplayFields.tsx
+++ b/packages/app/src/components/AlertDisplayFields.tsx
@@ -1,0 +1,109 @@
+import {
+  Control,
+  Controller,
+  FieldError,
+  FieldValues,
+  Merge,
+  Path,
+} from 'react-hook-form';
+import { Button, Group, Stack, Text, TextInput } from '@mantine/core';
+import { IconTags } from '@tabler/icons-react';
+
+import { Tags } from '@/components/Tags';
+
+/**
+ * A tags error usually sits on one element (`tags.3`), not on the array, so
+ * fieldState.error is a sparse array of per-item errors with no message of
+ * its own. Surface the first one found.
+ */
+function firstErrorMessage(
+  error: Merge<FieldError, (FieldError | undefined)[]> | FieldError | undefined,
+): string | undefined {
+  if (error == null) return undefined;
+  if (error.message) return error.message;
+  if (Array.isArray(error)) {
+    return error.find(e => e?.message)?.message;
+  }
+  return undefined;
+}
+
+export function AlertDisplayFields<T extends FieldValues>({
+  control,
+  displayNameName,
+  tagsName,
+  derivedDisplayName,
+  labelMarginTop = 'xs',
+}: {
+  control: Control<T>;
+  displayNameName: Path<T>;
+  tagsName: Path<T>;
+  /** Name the server will derive when the field is left empty. */
+  derivedDisplayName?: string | null;
+  labelMarginTop?: string;
+}) {
+  return (
+    <Group gap="xs" align="flex-start" wrap="nowrap" mt={labelMarginTop}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <Text size="xxs" opacity={0.5} mb={4}>
+          Name
+        </Text>
+        <Controller
+          control={control}
+          name={displayNameName}
+          render={({ field, fieldState }) => (
+            <TextInput
+              data-testid="alert-display-name-input"
+              size="xs"
+              placeholder={
+                derivedDisplayName ||
+                'Defaults to the saved search or dashboard tile name'
+              }
+              error={fieldState.error?.message}
+              {...field}
+              value={field.value ?? ''}
+              // Empty '' means "derive on the server", which is represented as null in the request
+              onChange={e => field.onChange(e.target.value || null)}
+            />
+          )}
+        />
+      </div>
+
+      <div>
+        <Text size="xxs" opacity={0.5} mb={4}>
+          Tags
+        </Text>
+        <Controller
+          control={control}
+          name={tagsName}
+          render={({ field, fieldState }) => {
+            const values: string[] = field.value ?? [];
+            const error = firstErrorMessage(fieldState.error);
+            return (
+              <Stack gap={4}>
+                <Tags allowCreate values={values} onChange={field.onChange}>
+                  <Button
+                    data-testid="alert-tags-button"
+                    variant="secondary"
+                    size="xs"
+                    color={error ? 'red' : undefined}
+                    style={{ flexShrink: 0 }}
+                  >
+                    <IconTags size={14} className="me-1" />
+                    {/* An unset list inherits from the saved search or dashboard,
+                        so a count of 0 would misreport it. */}
+                    {field.value == null ? 'Inherited' : values.length}
+                  </Button>
+                </Tags>
+                {error && (
+                  <Text size="xs" c="red" data-testid="alert-tags-error">
+                    {error}
+                  </Text>
+                )}
+              </Stack>
+            );
+          }}
+        />
+      </div>
+    </Group>
+  );
+}

--- a/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
+++ b/packages/app/src/components/ChartEditor/RawSqlChartEditor.tsx
@@ -140,6 +140,7 @@ export default function RawSqlChartEditor({
   const connection = useWatch({ control, name: 'connection' });
   const source = useWatch({ control, name: 'source' });
   const sqlTemplate = useWatch({ control, name: 'sqlTemplate' });
+  const chartName = useWatch({ control, name: 'name' });
   const sourceObject = sources?.find(s => s.id === source);
 
   const rawSqlConfig = useMemo(
@@ -298,7 +299,12 @@ export default function RawSqlChartEditor({
                 data-testid="alert-button"
                 size="sm"
                 color={'gray'}
-                onClick={() => setValue('alert', DEFAULT_TILE_ALERT)}
+                onClick={() =>
+                  setValue('alert', {
+                    ...DEFAULT_TILE_ALERT,
+                    ...(chartName && { displayName: chartName }),
+                  })
+                }
               >
                 <IconBell size={14} className="me-2" />
                 Add Alert
@@ -361,6 +367,7 @@ export default function RawSqlChartEditor({
           control={control}
           setValue={setValue}
           alert={alert}
+          dashboardId={dashboardId}
           onRemove={() => setValue('alert', undefined)}
           error={alertErrorMessage}
           warning={alertWarningMessage}

--- a/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartEditorControls.tsx
@@ -176,6 +176,7 @@ export function ChartEditorControls({
   // Grouped ratios can divide two ways (see RatioModeSchema); the mode toggle
   // is only meaningful when a Group By is set, so gate it on a non-empty value.
   const groupBy = useWatch({ control, name: 'groupBy' });
+  const chartName = useWatch({ control, name: 'name' });
   const hasGroupBy = typeof groupBy === 'string' && groupBy.trim().length > 0;
 
   return (
@@ -490,7 +491,12 @@ export function ChartEditorControls({
                     variant="subtle"
                     data-testid="alert-button"
                     size="sm"
-                    onClick={() => setValue('alert', DEFAULT_TILE_ALERT)}
+                    onClick={() =>
+                      setValue('alert', {
+                        ...DEFAULT_TILE_ALERT,
+                        ...(chartName && { displayName: chartName }),
+                      })
+                    }
                   >
                     <IconBell size={14} className="me-2" />
                     Add Alert
@@ -559,6 +565,7 @@ export function ChartEditorControls({
             control={control}
             setValue={setValue}
             alert={alert}
+            dashboardId={dashboardId}
             onRemove={() => setValue('alert', undefined)}
             warning={
               additionalWarnings?.length

--- a/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/TileAlertEditor.tsx
@@ -4,6 +4,7 @@ import {
   UseFormSetValue,
   useWatch,
 } from 'react-hook-form';
+import { formatTileAlertDisplayName } from '@hyperdx/common-utils/dist/alerts';
 import {
   AlertThresholdType,
   isRangeThresholdType,
@@ -31,12 +32,14 @@ import {
 } from '@tabler/icons-react';
 
 import api from '@/api';
+import { AlertDisplayFields } from '@/components/AlertDisplayFields';
 import { AlertNoteField } from '@/components/AlertNoteField';
 import { AlertChannelForm } from '@/components/Alerts';
 import { AckAlert } from '@/components/alerts/AckAlert';
 import { AlertHistoryCardList } from '@/components/alerts/AlertHistoryCards';
 import { AlertScheduleFields } from '@/components/AlertScheduleFields';
 import { ChartEditorFormState } from '@/components/ChartEditor/types';
+import { useDashboards } from '@/dashboard';
 import { optionsToSelectData } from '@/utils';
 import {
   ALERT_CHANNEL_OPTIONS,
@@ -49,6 +52,7 @@ export function TileAlertEditor({
   control,
   setValue,
   alert,
+  dashboardId,
   onRemove,
   error,
   warning,
@@ -57,6 +61,7 @@ export function TileAlertEditor({
   control: Control<ChartEditorFormState>;
   setValue: UseFormSetValue<ChartEditorFormState>;
   alert: NonNullable<ChartEditorFormState['alert']>;
+  dashboardId?: string;
   onRemove: () => void;
   error?: string;
   warning?: string;
@@ -84,6 +89,13 @@ export function TileAlertEditor({
 
   const { data: alertData } = api.useAlert(alert.id);
   const alertItem = alertData?.data;
+
+  const tileName = useWatch({ control, name: 'name' });
+  const { data: dashboards } = useDashboards();
+  const dashboardName = dashboards?.find(d => d.id === dashboardId)?.name;
+  const derivedDisplayName = dashboardName
+    ? formatTileAlertDisplayName(dashboardName, tileName)
+    : undefined;
 
   return (
     <Paper data-testid="alert-details">
@@ -228,6 +240,12 @@ export function TileAlertEditor({
               Created by {alert.createdBy.name || alert.createdBy.email}
             </Text>
           )}
+          <AlertDisplayFields
+            control={control}
+            displayNameName="alert.displayName"
+            tagsName="alert.tags"
+            derivedDisplayName={derivedDisplayName}
+          />
           <AlertScheduleFields
             control={control}
             setValue={setValue}

--- a/packages/app/src/components/__tests__/AlertDisplayFields.test.tsx
+++ b/packages/app/src/components/__tests__/AlertDisplayFields.test.tsx
@@ -1,0 +1,175 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  alertDisplayNameSchema,
+  alertTagsSchema,
+  MAX_TAG_LENGTH,
+} from '@hyperdx/common-utils/dist/types';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { AlertDisplayFields } from '@/components/AlertDisplayFields';
+
+const TAGS = ['checkout', 'payments'];
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    useTags: () => ({
+      data: { data: TAGS },
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn().mockResolvedValue({ data: { data: TAGS } }),
+    }),
+  },
+}));
+
+type FormValues = {
+  displayName?: string | null;
+  tags?: string[] | null;
+};
+
+const submitted = jest.fn<void, [FormValues]>();
+
+// The real caps, so the error rendering is tested against the messages the
+// alert forms actually produce.
+const schema = z.object({
+  displayName: alertDisplayNameSchema,
+  tags: alertTagsSchema,
+});
+
+const NO_VALUES: FormValues = {};
+
+const Harness = ({
+  initial = NO_VALUES,
+  derivedDisplayName,
+}: {
+  initial?: FormValues;
+  derivedDisplayName?: string;
+}) => {
+  const { control, handleSubmit } = useForm<FormValues>({
+    defaultValues: initial,
+    resolver: zodResolver(schema),
+  });
+  return (
+    <form onSubmit={handleSubmit(submitted)}>
+      <AlertDisplayFields
+        control={control}
+        displayNameName="displayName"
+        tagsName="tags"
+        derivedDisplayName={derivedDisplayName}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+const submit = async () => {
+  fireEvent.click(screen.getByText('Submit'));
+  await waitFor(() => expect(submitted).toHaveBeenCalledTimes(1));
+  return submitted.mock.calls[0][0];
+};
+
+beforeEach(() => {
+  submitted.mockClear();
+});
+
+describe('AlertDisplayFields', () => {
+  it('emits null when the name is cleared so the server re-derives it', async () => {
+    renderWithMantine(<Harness initial={{ displayName: 'Custom' }} />);
+
+    fireEvent.change(screen.getByTestId('alert-display-name-input'), {
+      target: { value: '' },
+    });
+
+    expect((await submit()).displayName).toBeNull();
+  });
+
+  it('shows the derived name as the placeholder', () => {
+    renderWithMantine(<Harness derivedDisplayName="Checkout - Error rate" />);
+
+    expect(screen.getByTestId('alert-display-name-input')).toHaveAttribute(
+      'placeholder',
+      'Checkout - Error rate',
+    );
+  });
+
+  it('falls back to a generic placeholder without a derived name', () => {
+    renderWithMantine(<Harness />);
+
+    expect(screen.getByTestId('alert-display-name-input')).toHaveAttribute(
+      'placeholder',
+      'Defaults to the saved search or dashboard tile name',
+    );
+  });
+
+  it('emits the typed name', async () => {
+    renderWithMantine(<Harness />);
+
+    fireEvent.change(screen.getByTestId('alert-display-name-input'), {
+      target: { value: 'Checkout 5xx' },
+    });
+
+    expect((await submit()).displayName).toBe('Checkout 5xx');
+  });
+
+  it('shows the schema error for a whitespace-only name and blocks submit', async () => {
+    renderWithMantine(<Harness />);
+
+    fireEvent.change(screen.getByTestId('alert-display-name-input'), {
+      target: { value: '   ' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(
+      await screen.findByText(/at least 1 character/i),
+    ).toBeInTheDocument();
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  it('shows the schema error for an over-long tag and blocks submit', async () => {
+    renderWithMantine(
+      <Harness initial={{ tags: ['x'.repeat(MAX_TAG_LENGTH + 1)] }} />,
+    );
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    expect(await screen.findByTestId('alert-tags-error')).toHaveTextContent(
+      /at most 32 character/i,
+    );
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  it('emits an array once a tag is picked', async () => {
+    renderWithMantine(<Harness />);
+
+    fireEvent.click(screen.getByTestId('alert-tags-button'));
+    fireEvent.click(await screen.findByText('CHECKOUT'));
+
+    expect((await submit()).tags).toEqual(['checkout']);
+  });
+
+  it('leaves untouched tags undefined so the server derives them', async () => {
+    renderWithMantine(<Harness />);
+
+    // An unset list inherits, so the button must not claim zero tags.
+    expect(screen.getByTestId('alert-tags-button')).toHaveTextContent(
+      'Inherited',
+    );
+    expect((await submit()).tags).toBeUndefined();
+  });
+
+  it('counts the tags once the list is set', async () => {
+    renderWithMantine(<Harness initial={{ tags: ['checkout'] }} />);
+
+    expect(screen.getByTestId('alert-tags-button')).toHaveTextContent('1');
+  });
+
+  it('counts zero for a deliberately emptied list', async () => {
+    renderWithMantine(<Harness initial={{ tags: [] }} />);
+
+    const button = screen.getByTestId('alert-tags-button');
+    expect(button).toHaveTextContent('0');
+    expect(button).not.toHaveTextContent('Inherited');
+  });
+});

--- a/packages/app/src/components/alerts/AlertCardList.tsx
+++ b/packages/app/src/components/alerts/AlertCardList.tsx
@@ -13,7 +13,6 @@ import EmptyState from '@/components/EmptyState';
 import { useVirtualList } from '@/hooks/useVirtualList';
 import { APP_CONTENT_SCROLL_CONTAINER_ID } from '@/layout';
 import type { AlertsPageItem } from '@/types';
-import { getAlertTags } from '@/utils/alerts';
 
 import styles from '@styles/AlertsPage.module.scss';
 
@@ -56,7 +55,7 @@ function estimateItemHeight(item: AlertListItem): number {
     default:
       return (
         ROW_HEIGHT +
-        (getAlertTags(item.alert).length > 0 ? TAGS_HEIGHT : 0) +
+        (item.alert.tags?.length > 0 ? TAGS_HEIGHT : 0) +
         (item.alert.note ? NOTE_TOGGLE_HEIGHT : 0)
       );
   }

--- a/packages/app/src/components/alerts/AlertDetailProperties.tsx
+++ b/packages/app/src/components/alerts/AlertDetailProperties.tsx
@@ -30,12 +30,12 @@ function PropertyRow({
 /**
  * Full alert metadata block for the alert detail page: the shared one-line
  * summary (threshold, schedule, targets) plus every other persisted
- * property — name, message template, group-by, schedule anchor/offset,
- * acknowledgement, tags, and created/updated timestamps. Rows render only
- * when the field is set.
+ * property — notification title, message template, group-by, schedule
+ * anchor/offset, acknowledgement, tags, and created/updated timestamps. Rows
+ * render only when the field is set.
  */
 export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
-  const tags = alert.dashboard?.tags ?? alert.savedSearch?.tags ?? [];
+  const tags = alert.tags ?? [];
   const hasScheduleAnchor = alert.scheduleStartAt != null;
   const hasScheduleOffset =
     alert.scheduleOffsetMinutes != null && alert.scheduleOffsetMinutes > 0;
@@ -45,7 +45,7 @@ export function AlertDetailProperties({ alert }: { alert: AlertsPageItem }) {
       <AlertPropertiesSummary alert={alert} variant="detail" />
       <div className="d-flex flex-column gap-1 mt-2">
         {alert.name && (
-          <PropertyRow label="Name" testId="alert-property-name">
+          <PropertyRow label="Notification title" testId="alert-property-name">
             {alert.name}
           </PropertyRow>
         )}

--- a/packages/app/src/components/alerts/AlertDetails.tsx
+++ b/packages/app/src/components/alerts/AlertDetails.tsx
@@ -16,7 +16,6 @@ import { useDisclosure } from '@mantine/hooks';
 import {
   IconChartLine,
   IconChevronDown,
-  IconChevronRight,
   IconHelpCircle,
   IconNote,
   IconTableRow,
@@ -28,12 +27,7 @@ import { AlertPropertiesSummary } from '@/components/alerts/AlertPropertiesSumma
 import { AlertRowMenu } from '@/components/alerts/AlertRowMenu';
 import { IS_ALERT_DETAILS_ENABLED } from '@/config';
 import type { AlertsPageItem } from '@/types';
-import {
-  getAlertDisplayName,
-  getAlertSourceLabel,
-  getAlertSourceUrl,
-  getAlertTags,
-} from '@/utils/alerts';
+import { getAlertSourceLabel, getAlertSourceUrl } from '@/utils/alerts';
 
 import styles from '@styles/AlertsPage.module.scss';
 
@@ -99,29 +93,7 @@ export const AlertDetails = React.memo(function AlertDetails({
 }: {
   alert: AlertsPageItem;
 }) {
-  const alertName = React.useMemo(() => {
-    if (alert.source === AlertSource.TILE && alert.dashboard) {
-      const tile = alert.dashboard?.tiles.find(
-        tile => tile.id === alert.tileId,
-      );
-      const tileName = tile?.config.name || 'Tile';
-      return (
-        <>
-          {alert.dashboard?.name}
-          {tileName ? (
-            <>
-              <IconChevronRight size={14} className="mx-1" />
-              {tileName}
-            </>
-          ) : null}
-        </>
-      );
-    }
-    if (alert.source === AlertSource.SAVED_SEARCH && alert.savedSearch) {
-      return alert.savedSearch?.name;
-    }
-    return '–';
-  }, [alert]);
+  const alertName = alert.displayName || '–';
 
   const alertUrl = React.useMemo(() => getAlertSourceUrl(alert), [alert]);
 
@@ -213,9 +185,9 @@ export const AlertDetails = React.memo(function AlertDetails({
               Created by {alert.createdBy.name || alert.createdBy.email}
             </Text>
           )}
-          {getAlertTags(alert).length > 0 && (
+          {alert.tags?.length > 0 && (
             <Group gap={4}>
-              {getAlertTags(alert).map(tag => (
+              {alert.tags.map(tag => (
                 <Badge key={tag} variant="light" color="gray" size="xs">
                   {tag}
                 </Badge>
@@ -238,7 +210,7 @@ export const AlertDetails = React.memo(function AlertDetails({
           alert={alert}
           alertUrl={IS_ALERT_DETAILS_ENABLED ? alertUrl : undefined}
           linkTitle={linkTitle}
-          alertName={getAlertDisplayName(alert)}
+          alertName={alert.displayName}
         />
       </Group>
     </div>

--- a/packages/app/src/components/alerts/AlertRowMenu.tsx
+++ b/packages/app/src/components/alerts/AlertRowMenu.tsx
@@ -29,9 +29,7 @@ type AlertRowMenuProps = {
   /** Label for that source, e.g. "Saved search". */
   linkTitle?: string;
   /**
-   * Display name, for the delete confirmation and the menu's accessible
-   * label. Both `getAlertDisplayName` and `linkTitle` return an empty string
-   * for an alert whose source can't be resolved, so callers may pass one.
+   * Display name, for the delete confirmation and the menu's accessible label.
    */
   alertName?: string;
   /**

--- a/packages/app/src/components/alerts/EditAlertModal.tsx
+++ b/packages/app/src/components/alerts/EditAlertModal.tsx
@@ -5,8 +5,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { tcFromSource } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   type Alert,
+  alertDisplayNameSchema,
   AlertIntervalSchema,
   AlertSource,
+  alertTagsSchema,
   AlertThresholdType,
   isRangeThresholdType,
   scheduleStartAtSchema,
@@ -32,6 +34,7 @@ import { IconChartLine, IconInfoCircleFilled } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import api from '@/api';
+import { AlertDisplayFields } from '@/components/AlertDisplayFields';
 import { AlertNoteField } from '@/components/AlertNoteField';
 import { AlertChannelForm } from '@/components/Alerts';
 import { AlertDetailChart } from '@/components/alerts/AlertDetailChart';
@@ -42,7 +45,7 @@ import { useSource } from '@/source';
 import { useBrandDisplayName } from '@/theme/ThemeProvider';
 import type { AlertsPageItem } from '@/types';
 import { optionsToSelectData } from '@/utils';
-import { toAlertChannels } from '@/utils/alerts';
+import { getDerivedAlertDisplayName, toAlertChannels } from '@/utils/alerts';
 import {
   ALERT_CHANNEL_OPTIONS,
   ALERT_INTERVAL_OPTIONS,
@@ -66,6 +69,8 @@ const EditAlertFormSchema = z
     thresholdType: z.nativeEnum(AlertThresholdType),
     channel: zAlertChannel.optional(),
     channels: zAlertChannels.optional(),
+    displayName: alertDisplayNameSchema,
+    tags: alertTagsSchema,
     // nullish() (not optional()): persisted alerts store this as null, which
     // optional() would reject.
     numConsecutiveWindows: z.number().int().min(1).nullish(),
@@ -106,6 +111,8 @@ function alertToFormValues(alert: AlertsPageItem): Alert {
     name: alert.name ?? null,
     message: alert.message ?? null,
     note: alert.note ?? null,
+    displayName: alert.displayName,
+    tags: alert.tags,
     // Persisted null -> undefined for the NumberInput.
     numConsecutiveWindows: alert.numConsecutiveWindows ?? undefined,
   };
@@ -380,6 +387,12 @@ export function EditAlertModal({
               )}
             />
           </Group>
+          <AlertDisplayFields
+            control={control}
+            displayNameName="displayName"
+            tagsName="tags"
+            derivedDisplayName={getDerivedAlertDisplayName(alert)}
+          />
           <AlertScheduleFields
             control={control}
             setValue={setValue}

--- a/packages/app/src/components/alerts/__tests__/AlertCardList.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertCardList.test.tsx
@@ -32,6 +32,8 @@ function makeAlert(id: string, state: AlertState): AlertsPageItem {
   return {
     _id: id,
     state,
+    displayName: 'Alert 1',
+    tags: [],
     interval: '5m',
     threshold: 3,
     thresholdType: AlertThresholdType.ABOVE,

--- a/packages/app/src/components/alerts/__tests__/AlertDetailProperties.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertDetailProperties.test.tsx
@@ -30,6 +30,7 @@ jest.mock('@/useFormatTime', () => ({
 
 const baseAlert = {
   _id: 'alert-1',
+  tags: [],
   interval: '5m',
   threshold: 3,
   thresholdType: AlertThresholdType.ABOVE,
@@ -59,6 +60,7 @@ describe('AlertDetailProperties', () => {
               // Far future so the silence reads as active, not expired.
               until: '2099-01-01T00:00:00.000Z',
             },
+            tags: ['prod', 'payments'],
             savedSearch: {
               _id: 'saved-search-id',
               name: 'My Search',
@@ -72,7 +74,7 @@ describe('AlertDetailProperties', () => {
     );
 
     expect(screen.getByTestId('alert-property-name')).toHaveTextContent(
-      'CPU alert',
+      'Notification titleCPU alert',
     );
     expect(screen.getByTestId('alert-property-message')).toHaveTextContent(
       'CPU is high on {{group}}',
@@ -94,6 +96,33 @@ describe('AlertDetailProperties', () => {
     );
     // The summary line resolves the webhook id to its display name.
     expect(screen.getByText(/Team Slack/)).toBeInTheDocument();
+  });
+
+  it("renders the alert's own tags, not the saved search's", () => {
+    renderWithMantine(
+      <AlertDetailProperties
+        alert={
+          {
+            ...baseAlert,
+            tags: ['own-tag'],
+            savedSearch: {
+              _id: 'saved-search-id',
+              name: 'My Search',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+              tags: ['prod'],
+            },
+          } as AlertsPageItem
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('alert-property-tags')).toHaveTextContent(
+      'own-tag',
+    );
+    expect(screen.getByTestId('alert-property-tags')).not.toHaveTextContent(
+      'prod',
+    );
   });
 
   it('omits rows for unset fields and marks expired silences', () => {

--- a/packages/app/src/components/alerts/__tests__/AlertHistoryCards.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertHistoryCards.test.tsx
@@ -12,6 +12,8 @@ import type { AlertsPageItem } from '@/types';
 
 const makeAlert = (history: AlertHistory[]): AlertsPageItem => ({
   _id: 'alert-1',
+  displayName: 'Alert 1',
+  tags: [],
   interval: '5m',
   threshold: 1,
   thresholdType: AlertThresholdType.ABOVE,

--- a/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertPropertiesSummary.test.tsx
@@ -21,6 +21,8 @@ jest.mock('@/api', () => ({
 
 const baseAlert = {
   _id: 'alert-1',
+  displayName: 'Alert 1',
+  tags: [],
   interval: '5m',
   threshold: 3,
   thresholdType: AlertThresholdType.ABOVE,

--- a/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/AlertRowMenu.test.tsx
@@ -179,7 +179,7 @@ describe('AlertRowMenu', () => {
     expect(mutateAsync).toHaveBeenCalledWith('alert-1');
   });
 
-  // getAlertDisplayName and linkTitle both return '' for an alert whose source
+  // linkTitle returns '' for an alert whose source
   // can't be resolved, and '' is not nullish — so `??` would have produced
   // "Delete ?" and "Open ".
   it('falls back to generic wording when the name and source are empty', async () => {

--- a/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
@@ -19,6 +19,12 @@ jest.mock('@/api', () => ({
     }),
     getAlertQueryKey: (alertId: string | undefined) => ['alert', alertId],
     getAlertsQueryKey: () => ['alerts'],
+    useTags: () => ({
+      data: { data: ['checkout'] },
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    }),
   },
 }));
 
@@ -159,6 +165,8 @@ describe('EditAlertModal', () => {
         // clears any that are omitted.
         name: 'My alert',
         message: 'My message template',
+        displayName: 'Checkout errors',
+        tags: ['checkout'],
       }),
     );
   });
@@ -180,6 +188,34 @@ describe('EditAlertModal', () => {
         name: 'My alert',
         message: 'My message template',
       }),
+    );
+  });
+
+  it('sends an edited display name in the PUT payload', async () => {
+    renderModal(savedSearchAlert);
+
+    fireEvent.change(screen.getByTestId('alert-display-name-input'), {
+      target: { value: 'Checkout 5xx' },
+    });
+
+    await submitForm();
+
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'Checkout 5xx' }),
+    );
+  });
+
+  it('clears the display name to null so the server re-derives it', async () => {
+    renderModal(savedSearchAlert);
+
+    fireEvent.change(screen.getByTestId('alert-display-name-input'), {
+      target: { value: '' },
+    });
+
+    await submitForm();
+
+    expect(updateAlertMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: null }),
     );
   });
 

--- a/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/EditAlertModal.test.tsx
@@ -79,6 +79,8 @@ const baseAlert = {
   channel: { type: 'webhook', webhookId: 'webhook-id' },
   name: 'My alert',
   message: 'My message template',
+  displayName: 'Checkout errors',
+  tags: ['checkout'],
   note: null,
   numConsecutiveWindows: null,
   scheduleStartAt: null,

--- a/packages/app/src/utils/__tests__/alerts.test.ts
+++ b/packages/app/src/utils/__tests__/alerts.test.ts
@@ -1,7 +1,9 @@
 import { AlertSource } from '@hyperdx/common-utils/dist/types';
 
+import type { AlertsPageItem } from '@/types';
 import {
   getAlertSourceLabel,
+  getDerivedAlertDisplayName,
   normalizeNoOpAlertScheduleFields,
   toAlertChannels,
 } from '@/utils/alerts';
@@ -182,5 +184,56 @@ describe('getAlertSourceLabel', () => {
   it('falls back for a missing source', () => {
     expect(getAlertSourceLabel({})).toBe('Unknown source');
     expect(getAlertSourceLabel({ source: null })).toBe('Unknown source');
+  });
+});
+
+// Only the fields the two helpers read; `any` keeps these off the
+// no-unsafe-type-assertion budget without spelling out the full page item.
+const asAlert = (partial: any): AlertsPageItem => partial;
+
+describe('getDerivedAlertDisplayName', () => {
+  it('formats a tile alert like the server does', () => {
+    expect(
+      getDerivedAlertDisplayName(
+        asAlert({
+          displayName: 'Custom',
+          source: AlertSource.TILE,
+          tileId: 'tile-1',
+          dashboard: {
+            name: 'Checkout',
+            tiles: [{ id: 'tile-1', config: { name: 'Error rate' } }],
+          },
+        }),
+      ),
+    ).toBe('Checkout - Error rate');
+  });
+
+  it('falls back to a generic tile name', () => {
+    expect(
+      getDerivedAlertDisplayName(
+        asAlert({
+          source: AlertSource.TILE,
+          tileId: 'tile-1',
+          dashboard: { name: 'Checkout', tiles: [] },
+        }),
+      ),
+    ).toBe('Checkout - Tile');
+  });
+
+  it('uses the saved search name', () => {
+    expect(
+      getDerivedAlertDisplayName(
+        asAlert({
+          source: AlertSource.SAVED_SEARCH,
+          savedSearch: { name: 'Checkout 5xx' },
+        }),
+      ),
+    ).toBe('Checkout 5xx');
+  });
+
+  it('is undefined when the source is not embedded', () => {
+    expect(
+      getDerivedAlertDisplayName(asAlert({ source: AlertSource.SAVED_SEARCH })),
+    ).toBeUndefined();
   });
 });

--- a/packages/app/src/utils/alerts.ts
+++ b/packages/app/src/utils/alerts.ts
@@ -6,6 +6,7 @@ import {
 } from 'date-fns';
 import _ from 'lodash';
 import { z } from 'zod';
+import { formatTileAlertDisplayName } from '@hyperdx/common-utils/dist/alerts';
 import { Granularity } from '@hyperdx/common-utils/dist/core/utils';
 import {
   ALERT_INTERVAL_TO_MINUTES,
@@ -256,16 +257,21 @@ export function getAlertSourceLabel(alert: {
   }
 }
 
-export function getAlertDisplayName(alert: AlertsPageItem): string {
+/**
+ * The name the server would derive if the alert had none of its own. Only for
+ * previewing (e.g. the name input's placeholder);
+ */
+export function getDerivedAlertDisplayName(
+  alert: AlertsPageItem,
+): string | undefined {
   if (alert.source === AlertSource.TILE && alert.dashboard) {
     const tile = alert.dashboard.tiles.find(t => t.id === alert.tileId);
-    const tileName = tile?.config.name || 'Tile';
-    return `${alert.dashboard.name} ${tileName}`;
+    return formatTileAlertDisplayName(alert.dashboard.name, tile?.config.name);
   }
   if (alert.source === AlertSource.SAVED_SEARCH && alert.savedSearch) {
     return alert.savedSearch.name;
   }
-  return '';
+  return undefined;
 }
 
 /** URL of the saved search / dashboard tile the alert is watching. */
@@ -277,10 +283,6 @@ export function getAlertSourceUrl(alert: AlertsPageItem): string {
     return `/search/${alert.savedSearchId}`;
   }
   return '';
-}
-
-export function getAlertTags(alert: AlertsPageItem): string[] {
-  return alert.dashboard?.tags ?? alert.savedSearch?.tags ?? [];
 }
 
 export function getAlertCreatorLabel(

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -11,6 +11,7 @@ import {
   replaceEditorText,
 } from '../utils/locators';
 import { switchWhereToLucene } from '../utils/lucene-autocomplete';
+import { addTagViaPicker, removeTagViaPicker } from '../utils/tags';
 
 import { WebhookAlertModalComponent } from './WebhookAlertModalComponent';
 
@@ -798,8 +799,8 @@ export class ChartEditorComponent {
    */
   async save() {
     await this.saveButton.click();
-    // Wait for save button to disappear (modal closes)
-    await this.saveButton.waitFor({ state: 'hidden', timeout: 2000 });
+    // The modal closes once the dashboard mutation resolves.
+    await this.saveButton.waitFor({ state: 'hidden', timeout: 10000 });
   }
 
   /**
@@ -920,6 +921,28 @@ export class ChartEditorComponent {
       .nth(1);
     await input.fill(String(value));
     await input.blur();
+  }
+
+  /** Set the alert's own display name in the tile alert editor. */
+  async setTileAlertDisplayName(name: string) {
+    await this.page
+      .getByTestId('alert-details')
+      .getByTestId('alert-display-name-input')
+      .fill(name);
+  }
+
+  private get tileAlertTagsButton() {
+    return this.page
+      .getByTestId('alert-details')
+      .getByTestId('alert-tags-button');
+  }
+
+  async addTileAlertTag(tag: string) {
+    await addTagViaPicker(this.page, this.tileAlertTagsButton, tag);
+  }
+
+  async removeTileAlertTag(tag: string) {
+    await removeTagViaPicker(this.page, this.tileAlertTagsButton, tag);
   }
 
   /**

--- a/packages/app/tests/e2e/components/SearchPageAlertModalComponent.ts
+++ b/packages/app/tests/e2e/components/SearchPageAlertModalComponent.ts
@@ -1,5 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 
+import { addTagViaPicker, removeTagViaPicker } from '../utils/tags';
+
 import { WebhookAlertModalComponent } from './WebhookAlertModalComponent';
 
 /**
@@ -114,6 +116,26 @@ export class SearchPageAlertModalComponent {
       state: 'detached',
       timeout: 10000,
     });
+  }
+
+  /**
+   * Set the alert's display name. Empty clears it, which makes the server
+   * re-derive it from the saved search.
+   */
+  async setDisplayName(name: string) {
+    await this.modal.getByTestId('alert-display-name-input').fill(name);
+  }
+
+  private get tagsButton() {
+    return this.modal.getByTestId('alert-tags-button');
+  }
+
+  async addTag(tag: string) {
+    await addTagViaPicker(this.page, this.tagsButton, tag);
+  }
+
+  async removeTag(tag: string) {
+    await removeTagViaPicker(this.page, this.tagsButton, tag);
   }
 
   /**

--- a/packages/app/tests/e2e/features/alerts.spec.ts
+++ b/packages/app/tests/e2e/features/alerts.spec.ts
@@ -76,6 +76,117 @@ test.describe('Alert Creation', { tag: ['@alerts', '@full-stack'] }, () => {
   );
 
   test(
+    'should create and update a saved-search alert with a custom display name and tags',
+    { tag: '@full-stack' },
+    async () => {
+      // Two round trips through the alert detail page, which dev mode compiles
+      // on first hit.
+      test.setTimeout(120000);
+      const ts = Date.now();
+      const savedSearchName = `E2E Named Alert Search ${ts}`;
+      const displayName = `E2E Custom Alert Name ${ts}`;
+      const tag = `e2e-tag-${ts}`;
+      const updatedDisplayName = `E2E Renamed Alert ${ts}`;
+      const updatedTag = `e2e-renamed-tag-${ts}`;
+      const webhookName = `E2E Webhook Named ${ts}`;
+      const webhookUrl = `https://example.com/named-${ts}`;
+
+      await test.step('Create a saved search', async () => {
+        await searchPage.goto();
+        await searchPage.openSaveSearchModal();
+        await searchPage.savedSearchModal.saveSearchAndWaitForNavigation(
+          savedSearchName,
+        );
+      });
+
+      await test.step('Open the alerts modal from the saved search page', async () => {
+        await expect(searchPage.alertsButton).toBeVisible();
+        await searchPage.openAlertsModal();
+        await expect(searchPage.alertModal.addNewWebhookButton).toBeVisible();
+      });
+
+      await test.step('Set a custom display name and tag', async () => {
+        await searchPage.alertModal.setDisplayName(displayName);
+        await searchPage.alertModal.addTag(tag);
+      });
+
+      await test.step('Create a new incoming webhook for the alert channel', async () => {
+        await searchPage.alertModal.addWebhookAndWait(
+          'Generic',
+          webhookName,
+          webhookUrl,
+        );
+      });
+
+      await test.step('Create the alert (webhook is auto-selected after creation)', async () => {
+        await searchPage.alertModal.createAlert();
+      });
+
+      await test.step('The alerts page finds it by its custom name and tag', async () => {
+        await alertsPage.goto();
+        await expect(alertsPage.pageContainer).toBeVisible();
+        await alertsPage.filterToAlert(displayName);
+
+        const card = alertsPage.getAlertCardByName(displayName);
+        await expect(card).toBeVisible({ timeout: 10000 });
+        await expect(card.getByText(tag)).toBeVisible();
+      });
+
+      await test.step('The saved search name no longer surfaces it', async () => {
+        await alertsPage.searchByName(savedSearchName);
+        await expect(
+          alertsPage.getAlertCardByName(savedSearchName),
+        ).toHaveCount(0);
+      });
+
+      await test.step('The detail page shows the custom name and tag', async () => {
+        await alertsPage.filterToAlert(displayName);
+        await alertsPage.openDetails(
+          alertsPage.getAlertCardByName(displayName),
+        );
+        await expect(alertsPage.detailName).toHaveText(displayName);
+        await expect(alertsPage.detailTags).toContainText(tag);
+      });
+
+      await test.step('Rename and retag the alert from the saved search page', async () => {
+        await alertsPage.detailSourceLink.click();
+        await alertsPage.page.waitForURL(/\/search\/[a-f0-9]{24}/);
+        await expect(searchPage.alertsButton).toBeVisible();
+        await searchPage.openAlertsModal();
+        await searchPage.alertModal.selectExistingAlertTab(0);
+        await searchPage.alertModal.setDisplayName(updatedDisplayName);
+        await searchPage.alertModal.removeTag(tag);
+        await searchPage.alertModal.addTag(updatedTag);
+        await searchPage.alertModal.saveAlert();
+      });
+
+      await test.step('The alerts page shows the updated name and tag', async () => {
+        await alertsPage.goto();
+        await expect(alertsPage.pageContainer).toBeVisible();
+        await alertsPage.filterToAlert(updatedDisplayName);
+
+        const card = alertsPage.getAlertCardByName(updatedDisplayName);
+        await expect(card).toBeVisible({ timeout: 10000 });
+        await expect(card.getByText(updatedTag)).toBeVisible();
+        await expect(card.getByText(tag, { exact: true })).toHaveCount(0);
+
+        await alertsPage.searchByName(displayName);
+        await expect(alertsPage.getAlertCardByName(displayName)).toHaveCount(0);
+      });
+
+      await test.step('The detail page shows the updated name and tag', async () => {
+        await alertsPage.filterToAlert(updatedDisplayName);
+        await alertsPage.openDetails(
+          alertsPage.getAlertCardByName(updatedDisplayName),
+        );
+        await expect(alertsPage.detailName).toHaveText(updatedDisplayName);
+        await expect(alertsPage.detailTags).toContainText(updatedTag);
+        await expect(alertsPage.detailTags).not.toContainText(tag);
+      });
+    },
+  );
+
+  test(
     'should create an alert from a dashboard tile and verify on the alerts page',
     { tag: '@full-stack' },
     async ({ page }) => {
@@ -136,6 +247,126 @@ test.describe('Alert Creation', { tag: ['@alerts', '@full-stack'] }, () => {
         // for import — this is the eligibility branch in AlertRowMenu.
         await alertsPage.openRowMenu(alertsPage.getAlertCardByName(tileName));
         await expect(alertsPage.terraformMenuItem).toBeHidden();
+      });
+    },
+  );
+
+  test(
+    'should create and update a dashboard tile alert with a custom display name and tags',
+    { tag: '@full-stack' },
+    async ({ page }) => {
+      test.setTimeout(120000);
+      const ts = Date.now();
+      const tileName = `E2E Named Alert Tile ${ts}`;
+      const displayName = `E2E Custom Tile Alert ${ts}`;
+      const tag = `e2e-tile-tag-${ts}`;
+      const updatedDisplayName = `E2E Renamed Tile Alert ${ts}`;
+      const updatedTag = `e2e-tile-retag-${ts}`;
+      const webhookName = `E2E Webhook Named Tile ${ts}`;
+      const webhookUrl = `https://example.com/named-tile-${ts}`;
+
+      await test.step('Create a new dashboard', async () => {
+        await dashboardPage.goto();
+        await dashboardPage.createNewDashboard();
+      });
+
+      await test.step('Add a tile to the dashboard', async () => {
+        await dashboardPage.addTile();
+        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+        await dashboardPage.chartEditor.waitForDataToLoad();
+        await dashboardPage.chartEditor.setChartName(tileName);
+        await dashboardPage.chartEditor.runQuery();
+      });
+
+      await test.step('Enable an alert with a custom display name and tag', async () => {
+        await expect(dashboardPage.chartEditor.alertButton).toBeVisible();
+        await dashboardPage.chartEditor.clickAddAlert();
+        await expect(
+          dashboardPage.chartEditor.addNewWebhookButton,
+        ).toBeVisible();
+        await dashboardPage.chartEditor.setTileAlertDisplayName(displayName);
+        await dashboardPage.chartEditor.addTileAlertTag(tag);
+        await dashboardPage.chartEditor.addNewWebhookButton.click();
+        await expect(page.getByTestId('webhook-name-input')).toBeVisible();
+        await dashboardPage.chartEditor.webhookAlertModal.addWebhook(
+          'Generic',
+          webhookName,
+          webhookUrl,
+        );
+        await expect(page.getByTestId('alert-modal')).toBeHidden();
+      });
+
+      await test.step('Save the tile with the alert configured', async () => {
+        await dashboardPage.chartEditor.save();
+        await expect(dashboardPage.getTiles()).toHaveCount(1, {
+          timeout: 10000,
+        });
+      });
+
+      await test.step('The alerts page finds it by its custom name and tag', async () => {
+        await alertsPage.goto();
+        await expect(alertsPage.pageContainer).toBeVisible();
+        await alertsPage.filterToAlert(displayName);
+
+        const card = alertsPage.getAlertCardByName(displayName);
+        await expect(card).toBeVisible({ timeout: 10000 });
+        await expect(card.getByText(tag)).toBeVisible();
+
+        await alertsPage.searchByName(tileName);
+        await expect(alertsPage.getAlertCardByName(tileName)).toHaveCount(0);
+      });
+
+      await test.step('The detail page shows the custom name and tag', async () => {
+        await alertsPage.filterToAlert(displayName);
+        await alertsPage.openDetails(
+          alertsPage.getAlertCardByName(displayName),
+        );
+        await expect(alertsPage.detailName).toHaveText(displayName);
+        await expect(alertsPage.detailTags).toContainText(tag);
+      });
+
+      await test.step('Rename and retag the alert from the tile editor', async () => {
+        await alertsPage.detailSourceLink.click();
+        await page.waitForURL(/\/dashboards\/[a-f0-9]{24}/);
+        await expect(dashboardPage.getTiles()).toHaveCount(1, {
+          timeout: 10000,
+        });
+        await dashboardPage.editTile(0);
+        await expect(dashboardPage.chartEditor.nameInput).toBeVisible();
+        await dashboardPage.chartEditor.setTileAlertDisplayName(
+          updatedDisplayName,
+        );
+        await dashboardPage.chartEditor.removeTileAlertTag(tag);
+        await dashboardPage.chartEditor.addTileAlertTag(updatedTag);
+        // The tile save issues a fire-and-forget PATCH; navigating away before
+        // it lands would drop the update.
+        const patch = dashboardPage.waitForDashboardPatch();
+        await dashboardPage.chartEditor.save();
+        await patch;
+      });
+
+      await test.step('The alerts page shows the updated name and tag', async () => {
+        await alertsPage.goto();
+        await expect(alertsPage.pageContainer).toBeVisible();
+        await alertsPage.filterToAlert(updatedDisplayName);
+
+        const card = alertsPage.getAlertCardByName(updatedDisplayName);
+        await expect(card).toBeVisible({ timeout: 10000 });
+        await expect(card.getByText(updatedTag)).toBeVisible();
+        await expect(card.getByText(tag, { exact: true })).toHaveCount(0);
+
+        await alertsPage.searchByName(displayName);
+        await expect(alertsPage.getAlertCardByName(displayName)).toHaveCount(0);
+      });
+
+      await test.step('The detail page shows the updated name and tag', async () => {
+        await alertsPage.filterToAlert(updatedDisplayName);
+        await alertsPage.openDetails(
+          alertsPage.getAlertCardByName(updatedDisplayName),
+        );
+        await expect(alertsPage.detailName).toHaveText(updatedDisplayName);
+        await expect(alertsPage.detailTags).toContainText(updatedTag);
+        await expect(alertsPage.detailTags).not.toContainText(tag);
       });
     },
   );

--- a/packages/app/tests/e2e/page-objects/AlertsPage.ts
+++ b/packages/app/tests/e2e/page-objects/AlertsPage.ts
@@ -183,6 +183,34 @@ export class AlertsPage {
     return this.page.locator('[data-testid="alert-detail-page"]');
   }
 
+  /** The alert's name in the detail page header. */
+  get detailName() {
+    return this.page.getByTestId('alert-detail-name');
+  }
+
+  /** The Tags row in the detail page properties. Absent when there are none. */
+  get detailTags() {
+    return this.page.getByTestId('alert-property-tags');
+  }
+
+  /** Link on the detail page to the saved search / dashboard tile watched. */
+  get detailSourceLink() {
+    return this.page.getByTestId('open-alert-source');
+  }
+
+  /**
+   * Follow a card's name link to /alerts/:id and wait for the page to render.
+   * Generous timeouts: in dev mode the first hit compiles the route.
+   */
+  async openDetails(alertCard: Locator) {
+    await this.getDetailsLinkForAlertCard(alertCard).click();
+    await this.page.waitForURL(/\/alerts\/[a-f0-9]{24}/, { timeout: 60000 });
+    await this.detailPageContainer.waitFor({
+      state: 'visible',
+      timeout: 15000,
+    });
+  }
+
   /**
    * The evaluation event-stream table on the alert detail page.
    */

--- a/packages/app/tests/e2e/utils/tags.ts
+++ b/packages/app/tests/e2e/utils/tags.ts
@@ -1,0 +1,52 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Drive the shared Tags popover (components/Tags.tsx) from its trigger button.
+ * The dropdown is portalled, so its search input is looked up on the page.
+ * Closing goes through the trigger rather than Escape, which would bubble to
+ * an enclosing modal and close that too.
+ */
+async function withTagPicker(
+  page: Page,
+  trigger: Locator,
+  fn: (search: Locator) => Promise<void>,
+) {
+  await trigger.click();
+  const search = page.getByPlaceholder(/Search (or create )?tag/);
+  await search.waitFor({ state: 'visible' });
+  await fn(search);
+  await trigger.click();
+  await search.waitFor({ state: 'detached' });
+}
+
+/** Type a new tag and press Enter to create and select it. */
+export async function addTagViaPicker(
+  page: Page,
+  trigger: Locator,
+  tag: string,
+) {
+  await withTagPicker(page, trigger, async search => {
+    await search.fill(tag);
+    await search.press('Enter');
+  });
+}
+
+/**
+ * Deselect a tag. Labels render uppercased. Plain click rather than
+ * `uncheck()`: a tag known only to this picker leaves the list the moment it
+ * is deselected, and `uncheck()` never gets to confirm the new state.
+ */
+export async function removeTagViaPicker(
+  page: Page,
+  trigger: Locator,
+  tag: string,
+) {
+  await withTagPicker(page, trigger, async search => {
+    await search.fill(tag);
+    const name = tag.toUpperCase();
+    await page.getByRole('checkbox', { name }).click();
+    await expect(
+      page.getByRole('checkbox', { name, checked: true }),
+    ).toHaveCount(0);
+  });
+}

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -551,6 +551,8 @@ export interface AlertItem {
   tileId?: string;
   name?: string | null;
   message?: string | null;
+  displayName?: string;
+  tags?: string[];
   createdAt: string;
   updatedAt: string;
   history: AlertHistoryItem[];

--- a/packages/cli/src/components/AlertsPage.tsx
+++ b/packages/cli/src/components/AlertsPage.tsx
@@ -39,7 +39,7 @@ function stateLabel(state?: string): string {
 }
 
 function alertName(alert: AlertItem): string {
-  if (alert.name) return alert.name;
+  if (alert.displayName) return alert.displayName;
   if (alert.dashboard) {
     const tile = alert.dashboard.tiles.find(t => t.id === alert.tileId);
     const tileName = tile?.config.name ?? alert.tileId ?? '';

--- a/packages/common-utils/src/__tests__/alerts.test.ts
+++ b/packages/common-utils/src/__tests__/alerts.test.ts
@@ -1,0 +1,45 @@
+import {
+  clampAlertDisplayName,
+  clampAlertTags,
+  formatTileAlertDisplayName,
+} from '@/alerts';
+import {
+  MAX_ALERT_DISPLAY_NAME_LENGTH,
+  MAX_TAG_LENGTH,
+  MAX_TAGS,
+} from '@/types';
+
+describe('formatTileAlertDisplayName', () => {
+  it('joins the dashboard and tile names', () => {
+    expect(formatTileAlertDisplayName('Checkout', 'Error rate')).toBe(
+      'Checkout - Error rate',
+    );
+  });
+
+  it('falls back for a blank tile name', () => {
+    expect(formatTileAlertDisplayName('Checkout', '  ')).toBe(
+      'Checkout - Tile',
+    );
+  });
+});
+
+describe('clampAlertDisplayName', () => {
+  it('truncates to the alert cap', () => {
+    expect(
+      clampAlertDisplayName('x'.repeat(MAX_ALERT_DISPLAY_NAME_LENGTH + 5)),
+    ).toHaveLength(MAX_ALERT_DISPLAY_NAME_LENGTH);
+  });
+});
+
+describe('clampAlertTags', () => {
+  it('drops empties, truncates each tag, and caps the count', () => {
+    const tags = [
+      '',
+      'a'.repeat(MAX_TAG_LENGTH + 1),
+      ...Array(MAX_TAGS).fill('t'),
+    ];
+    const clamped = clampAlertTags(tags);
+    expect(clamped).toHaveLength(MAX_TAGS);
+    expect(clamped[0]).toBe('a'.repeat(MAX_TAG_LENGTH));
+  });
+});

--- a/packages/common-utils/src/alerts.ts
+++ b/packages/common-utils/src/alerts.ts
@@ -1,0 +1,29 @@
+import {
+  MAX_ALERT_DISPLAY_NAME_LENGTH,
+  MAX_TAG_LENGTH,
+  MAX_TAGS,
+} from './types';
+
+/** Display name derived for a dashboard tile alert with no explicit displayName. */
+export function formatTileAlertDisplayName(
+  dashboardName: string,
+  tileName?: string | null,
+): string {
+  return `${dashboardName} - ${tileName?.trim() || 'Tile'}`;
+}
+
+/**
+ * Alerts cap displayName and tags (alertDisplayNameSchema / alertTagsSchema),
+ * but the saved searches and dashboards they inherit from cap neither. Anything
+ * copied across has to be clamped first or the alert form and API reject it.
+ */
+export function clampAlertDisplayName(name: string): string {
+  return name.slice(0, MAX_ALERT_DISPLAY_NAME_LENGTH);
+}
+
+export function clampAlertTags(tags: readonly string[]): string[] {
+  return tags
+    .filter(tag => tag !== '')
+    .slice(0, MAX_TAGS)
+    .map(tag => tag.slice(0, MAX_TAG_LENGTH));
+}

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -918,7 +918,33 @@ export const scheduleStartAtSchema = z
     },
   );
 
+// --------------------------
+// TAGS
+// --------------------------
+// Shared limits + validator for user-supplied tag arrays. Any write path that
+// accepts tags (external API, MCP tools, internal routers) should validate with
+// `tagsSchema` so the caps stay consistent in one place. Read/model schemas keep
+// a bare `z.array(z.string())` so parsing existing documents never fails on
+// legacy data that predates these caps.
+export const MAX_TAG_LENGTH = 32;
+export const MAX_TAGS = 50;
+
+export const tagsSchema = z
+  .array(z.string().max(MAX_TAG_LENGTH))
+  .max(MAX_TAGS)
+  .optional();
+
 export const alertNoteSchema = z.string().min(1).max(4096).nullish();
+
+export const MAX_ALERT_DISPLAY_NAME_LENGTH = 512;
+export const alertDisplayNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(MAX_ALERT_DISPLAY_NAME_LENGTH)
+  .nullish();
+
+export const alertTagsSchema = tagsSchema.nullish();
 
 export const AlertBaseObjectSchema = z.object({
   id: z.string().optional(),
@@ -939,6 +965,8 @@ export const AlertBaseObjectSchema = z.object({
   name: z.string().min(1).max(512).nullish(),
   message: z.string().min(1).max(4096).nullish(),
   note: alertNoteSchema,
+  displayName: alertDisplayNameSchema,
+  tags: alertTagsSchema,
   silenced: z
     .object({
       by: z.string(),
@@ -1126,22 +1154,6 @@ export const DashboardFilterValueSchema = z.union([
 ]);
 
 export type DashboardFilterValue = z.infer<typeof DashboardFilterValueSchema>;
-
-// --------------------------
-// TAGS
-// --------------------------
-// Shared limits + validator for user-supplied tag arrays. Any write path that
-// accepts tags (external API, MCP tools, internal routers) should validate with
-// `tagsSchema` so the caps stay consistent in one place. Read/model schemas keep
-// a bare `z.array(z.string())` so parsing existing documents never fails on
-// legacy data that predates these caps.
-export const MAX_TAG_LENGTH = 32;
-export const MAX_TAGS = 50;
-
-export const tagsSchema = z
-  .array(z.string().max(MAX_TAG_LENGTH))
-  .max(MAX_TAGS)
-  .optional();
 
 // --------------------------
 // SAVED SEARCH
@@ -2571,6 +2583,8 @@ export const AlertsPageItemSchema = z.object({
   chartConfig: AlertChartConfigSchema.optional(),
   groupBy: z.string().optional(),
   name: z.string().nullish(),
+  displayName: z.string(),
+  tags: z.array(z.string()),
   message: z.string().nullish(),
   note: alertNoteSchema,
   createdAt: z.string(),


### PR DESCRIPTION
## Summary

This PR is part 1 of 3 in introducing alert-level name and tags.

**Context**: We require alert-level name and tags so that the alerts page can sort, filter, and paginate alert documents by name and tags without joining the full alerts collection with the dashboard and saved search collections.

In this PR:

1. Add `displayName` and `tags` to the alert model, types, and schemas. `displayName` is chosen because the existing `name` can be a handlebars template (confirmed that production data includes handlebars templates) and we don't want to show an unrendered handlebars template as an alert's name on the alerts page.
2. Functions for deriving an alert's name and tags from the dashboard tile or saved search it references, more or less matching how these values are derived today for the alerts page, and more or less matching this [backfill PR.](https://github.com/hyperdxio/hyperdx/pull/3029)
3. When writing alerts through internal endpoints (create/update dashboard, create/update alert), if an explicit displayName or tags is provided in the request, use that value. If none is provided, write the name and tags derived from the referenced dashboard or saved search.
4. When reading /alerts or /alert/:id, return a stored displayName and tags if available, otherwise derive the displayName and tags from the referenced dashboard or saved search

In future PRs:

1. Part 2: External API and MCP support. Notification titles use displayName if available (and not overridden by `name`)
2. Part 3: UI updated to allow the user to specify alert's name and tags directly. Alerts page + alerts details page updated to show displayName and tags
3. Part 4: Backfill displayName and tags for existing alerts
4. Part 5+: paginate the alerts page

### Screenshots or video

<details>
<summary>Create dashboard alert</summary>

Request is sent without alert-level displayName or tags, the value saved in Mongo is derived from the dashboard+tile names, and the dashboard's tags

<img width="800" height="363" alt="Screenshot 2026-09-03 at 8 30 53 AM" src="https://github.com/user-attachments/assets/350fc85c-7f71-4d5b-9963-c8360845349d" />
<img width="381" height="199" alt="Screenshot 2026-09-03 at 8 30 00 AM" src="https://github.com/user-attachments/assets/4e435321-7d4d-4654-9e37-48de77c3b87c" />

If displayName or tags are included in the request, they are persisted, instead of a derived displayName and tags:

<img width="360" height="93" alt="Screenshot 2026-09-03 at 8 36 05 AM" src="https://github.com/user-attachments/assets/f0bea253-4453-4dfb-9787-7e1d00da66f4" />

</details>

<details>
<summary>Update dashboard alert</summary>

If an existing tile alert has no persisted displayName or tags, and the request doesn't include one, then the derived values will be saved

<img width="332" height="65" alt="Screenshot 2026-09-03 at 8 33 56 AM" src="https://github.com/user-attachments/assets/7ee69581-6eb4-47a0-88ee-2503ef429bc1" />

If an existing tile is updated and a displayName or tags are included in the request, they are persisted, instead of a derived displayName and tags:

<img width="360" height="93" alt="Screenshot 2026-09-03 at 8 36 05 AM" src="https://github.com/user-attachments/assets/f0bea253-4453-4dfb-9787-7e1d00da66f4" />

</details>

<details>
<summary>Create saved search alert</summary>

Derived values are saved in Mongo

<img width="294" height="76" alt="Screenshot 2026-09-03 at 8 44 56 AM" src="https://github.com/user-attachments/assets/295aa546-05d2-4ef7-9969-b19dbc0d2fd7" />
<img width="553" height="269" alt="Screenshot 2026-09-03 at 8 45 20 AM" src="https://github.com/user-attachments/assets/4b904ca3-309e-4a6a-b32a-5fb52c7cf821" />

</details>


<details>
<summary>Update saved search alert</summary>

Derived values are saved in Mongo, if no displayName/tags are provided in the request

<img width="553" height="269" alt="Screenshot 2026-09-03 at 8 45 20 AM" src="https://github.com/user-attachments/assets/71c53bbd-673b-4ff7-b9b7-45488187f829" />
<img width="259" height="58" alt="Screenshot 2026-09-03 at 8 47 00 AM" src="https://github.com/user-attachments/assets/a63487da-bb2b-4cae-8090-2e8ccf41c0a4" />

</details>

<details>
<summary>GET alerts</summary>

Derived values are returned for displayName / tags if not present in the DB

<img width="915" height="911" alt="Screenshot 2026-09-03 at 8 48 20 AM" src="https://github.com/user-attachments/assets/076460e3-de1f-4a69-9f43-a6f8a92c9422" />

Persisted values are returned, if present

<img width="884" height="362" alt="Screenshot 2026-09-03 at 8 49 45 AM" src="https://github.com/user-attachments/assets/894032b8-cee9-405f-93da-b757d6dac023" />

</details>

<details>
<summary>GET alert/:id</summary>

Derived values are returned if no persistent values exist

<img width="732" height="444" alt="Screenshot 2026-09-03 at 8 50 26 AM" src="https://github.com/user-attachments/assets/622b12e6-de79-4710-99be-65aad62d7fec" />

Persisted values are returned if present

<img width="759" height="444" alt="Screenshot 2026-09-03 at 8 50 40 AM" src="https://github.com/user-attachments/assets/69ed40a7-d8fd-40d8-bc99-546646a40bd7" />

</details>

### How to test locally

Create and update alerts on dashboard tiles and saved searches, observe the displayName and tags values persisted in mongodb.

Observe the response from the `/alerts` and `/alerts/:id` internal endpoints, they should include a derived displayName and tags, or the stored value if it's available.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Related to HDX-5116
- Related PRs:
