### PR TITLE
chore: Add isSourceAllowed prop to SourceSelectControlledComponent

### DIFF
--- a/.changeset/angry-frogs-film.md
+++ b/.changeset/angry-frogs-film.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+chore: Add isSourceAllowed prop to SourceSelectControlledComponent

--- a/packages/app/src/components/SourceSelect.tsx
+++ b/packages/app/src/components/SourceSelect.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useMemo } from 'react';
 import { UseControllerProps, useWatch } from 'react-hook-form';
-import { SourceKind } from '@hyperdx/common-utils/dist/types';
+import { SourceKind, TSource } from '@hyperdx/common-utils/dist/types';
 import {
   ActionIcon,
   ComboboxChevron,
@@ -160,6 +160,7 @@ function SourceSelectControlledComponent({
   isSchemaPreviewEnabled,
   allowedSourceKinds,
   connectionId,
+  isSourceAllowed,
   comboboxProps,
   ...props
 }: {
@@ -171,6 +172,8 @@ function SourceSelectControlledComponent({
   isSchemaPreviewEnabled?: boolean;
   allowedSourceKinds?: SourceKind[];
   connectionId?: string;
+  /** Extra per-source gate for restrictions a kind can't express. */
+  isSourceAllowed?: (source: TSource) => boolean;
 } & UseControllerProps<any> &
   SelectProps) {
   const { data } = useSources();
@@ -213,6 +216,7 @@ function SourceSelectControlledComponent({
     sources: data,
     allowedSourceKinds,
     connectionId,
+    isSourceAllowed,
     groupBySection: true,
   });
 

--- a/packages/app/src/components/__tests__/SourceSelect.test.tsx
+++ b/packages/app/src/components/__tests__/SourceSelect.test.tsx
@@ -181,9 +181,19 @@ describe('SourceSelectControlled (grouped rendering + tag-style search)', () => 
     }),
   ];
 
-  function SelectHarness() {
+  function SelectHarness({
+    isSourceAllowed,
+  }: {
+    isSourceAllowed?: (source: TSource) => boolean;
+  } = {}) {
     const { control } = useForm();
-    return <SourceSelectControlled control={control} name="source" />;
+    return (
+      <SourceSelectControlled
+        control={control}
+        name="source"
+        isSourceAllowed={isSourceAllowed}
+      />
+    );
   }
 
   // The searchable Select reuses its placeholder input for typing.
@@ -219,6 +229,21 @@ describe('SourceSelectControlled (grouped rendering + tag-style search)', () => 
     expect(screen.getByText('Billing Logs')).toBeInTheDocument();
     expect(screen.getByText('Billing')).toBeInTheDocument();
     // "Prod Logs" matches "logs" but not "billing", so its whole section drops out.
+    expect(screen.queryByText('Prod Logs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Control Plane Prod')).not.toBeInTheDocument();
+  });
+
+  it('hides sources rejected by isSourceAllowed, along with sections left empty', async () => {
+    asMock(useSources).mockReturnValue({ data: SECTIONED_SOURCES });
+    renderWithMantine(
+      <SelectHarness
+        isSourceAllowed={source => source.section === 'Billing'}
+      />,
+    );
+    await openSelect();
+
+    expect(await screen.findByText('Billing Logs')).toBeInTheDocument();
+    expect(screen.getByText('Refund Logs')).toBeInTheDocument();
     expect(screen.queryByText('Prod Logs')).not.toBeInTheDocument();
     expect(screen.queryByText('Control Plane Prod')).not.toBeInTheDocument();
   });

--- a/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
+++ b/packages/app/src/components/__tests__/sourceSelectUtils.test.tsx
@@ -109,6 +109,49 @@ describe('useFilteredSortedSourceItems', () => {
     expect(result.current).toEqual([]);
   });
 
+  it('filters by isSourceAllowed', () => {
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources,
+        isSourceAllowed: source => source.id === 'm',
+      }),
+    );
+    expect(result.current.map(i => i.value)).toEqual(['m']);
+  });
+
+  it('combines isSourceAllowed with allowedSourceKinds + connectionId (AND semantics)', () => {
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources,
+        allowedSourceKinds: [SourceKind.Log, SourceKind.Metric],
+        connectionId: 'conn-a',
+        isSourceAllowed: source => source.id !== 'z',
+      }),
+    );
+    expect(result.current.map(i => i.value)).toEqual(['m']);
+  });
+
+  it('keeps disabled sources out even when isSourceAllowed accepts them', () => {
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources,
+        isSourceAllowed: source => source.kind === SourceKind.Log,
+      }),
+    );
+    expect(result.current.map(i => i.value)).toEqual(['z']);
+  });
+
+  it('recomputes when the isSourceAllowed predicate changes', () => {
+    const { result, rerender } = renderHook(
+      (props: { isSourceAllowed: (source: TSource) => boolean }) =>
+        useFilteredSortedSourceItems({ sources, ...props }),
+      { initialProps: { isSourceAllowed: (s: TSource) => s.id === 'm' } },
+    );
+    expect(result.current.map(i => i.value)).toEqual(['m']);
+    rerender({ isSourceAllowed: (s: TSource) => s.id === 'z' });
+    expect(result.current.map(i => i.value)).toEqual(['z']);
+  });
+
   it('returns a stable reference when inputs are unchanged', () => {
     const { result, rerender } = renderHook(
       (props: {
@@ -194,6 +237,32 @@ describe('useFilteredSortedSourceItems (grouped by section)', () => {
     );
     expect(result.current).toEqual([
       { group: 'Billing', items: [{ value: 'bl', label: 'Billing Logs' }] },
+    ]);
+  });
+
+  it('applies isSourceAllowed before grouping, dropping sections left empty', () => {
+    const sources = [
+      makeSource('bl', 'Billing Logs', SourceKind.Log, { section: 'Billing' }),
+      makeSource('rl', 'Refund Logs', SourceKind.Log, { section: 'Billing' }),
+      makeSource('cpl', 'Prod Logs', SourceKind.Log, {
+        section: 'Control Plane Prod',
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useFilteredSortedSourceItems({
+        sources,
+        isSourceAllowed: source => source.section === 'Billing',
+        groupBySection: true,
+      }),
+    );
+    expect(result.current).toEqual([
+      {
+        group: 'Billing',
+        items: [
+          { value: 'bl', label: 'Billing Logs' },
+          { value: 'rl', label: 'Refund Logs' },
+        ],
+      },
     ]);
   });
 

--- a/packages/app/src/components/sourceSelectUtils.tsx
+++ b/packages/app/src/components/sourceSelectUtils.tsx
@@ -45,6 +45,11 @@ type FilteredSourceItemsArgs = {
   sources: TSource[] | undefined;
   allowedSourceKinds?: SourceKind[];
   connectionId?: string;
+  /**
+   * Extra per-source gate, for restrictions that allowedSourceKinds and
+   * connectionId can't express. Must be referentially stable.
+   */
+  isSourceAllowed?: (source: TSource) => boolean;
   groupBySection?: boolean;
 };
 
@@ -58,6 +63,7 @@ export function useFilteredSortedSourceItems({
   sources,
   allowedSourceKinds,
   connectionId,
+  isSourceAllowed,
   groupBySection = false,
 }: FilteredSourceItemsArgs): ComboboxItem[] | SourceSelectGroup[] {
   return useMemo(() => {
@@ -66,6 +72,7 @@ export function useFilteredSortedSourceItems({
         source =>
           (!allowedSourceKinds || allowedSourceKinds.includes(source.kind)) &&
           (!connectionId || source.connection === connectionId) &&
+          (!isSourceAllowed || isSourceAllowed(source)) &&
           !source.disabled,
       ) ?? [];
 
@@ -97,7 +104,13 @@ export function useFilteredSortedSourceItems({
       group,
       items: (bySection.get(group) ?? []).sort(byLabel),
     }));
-  }, [sources, allowedSourceKinds, connectionId, groupBySection]);
+  }, [
+    sources,
+    allowedSourceKinds,
+    connectionId,
+    isSourceAllowed,
+    groupBySection,
+  ]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Add a new prop (isSourceAllowed) to SourceSelectControlled, which will be used in the enterprise repo to filter sources that appear in the source select by a custom predicate. Adding this here to minimize drift between repos.

### Screenshots or video

No behavior changes expected.

### How to test on Vercel preview

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Related to HDX-5088
- Related PRs:
