### PR TITLE
feat: Support match[] on promql labels and values endpoints

### DIFF
--- a/.changeset/promql-label-values-match-selectors.md
+++ b/.changeset/promql-label-values-match-selectors.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/api': patch
+---
+
+feat: Evaluate Prometheus `match[]` series selectors on the labels and label values endpoints for ClickHouse TimeSeries connections

--- a/packages/api/src/controllers/__tests__/timeseriesEngine.int.test.ts
+++ b/packages/api/src/controllers/__tests__/timeseriesEngine.int.test.ts
@@ -68,7 +68,11 @@ describe('timeseriesEngine controller', () => {
       username: config.CLICKHOUSE_USER,
       password: config.CLICKHOUSE_PASSWORD,
     });
-    await seedTimeSeriesTagsTable({ table: BOUNDED_TABLE, series: SERIES });
+    await seedTimeSeriesTagsTable({
+      table: BOUNDED_TABLE,
+      series: SERIES,
+      withSamples: true,
+    });
     await seedTimeSeriesTagsTable({
       table: UNBOUNDED_TABLE,
       series: SERIES,
@@ -175,6 +179,119 @@ describe('timeseriesEngine controller', () => {
       });
     });
 
+    // A selector matches a series only if it has a sample in the window, which
+    // is why BOUNDED_TABLE is seeded with samples.
+    describe('match[] selectors', () => {
+      it('keeps only the values carried by matching series', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: ['recent_metric{job="api"}'],
+          }),
+        ).toEqual(['api']);
+      });
+
+      // Prometheus unions the selectors rather than intersecting them.
+      it('unions the series matched by each selector', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: ['recent_metric{job="api"}', 'old_metric'],
+          }),
+        ).toEqual(['api', 'batch']);
+      });
+
+      it('scopes metric names to the selector', async () => {
+        expect(
+          await labelValues({
+            labelName: '__name__',
+            match: ['{job="batch"}'],
+          }),
+        ).toEqual(['old_metric']);
+      });
+
+      it('evaluates regex matchers', async () => {
+        expect(
+          await labelValues({
+            labelName: '__name__',
+            match: ['{job=~"a.*|w.*"}'],
+          }),
+        ).toEqual(['recent_metric']);
+      });
+
+      // Both filters have to survive: the selector alone would answer with
+      // every job, the window alone with every recent one.
+      it('narrows the selector by the time window', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: ['{job=~".+"}'],
+            startMs: sec(RECENT_START_SEC),
+            endMs: sec(RECENT_START_SEC + HOUR_SEC),
+          }),
+        ).toEqual(['api', 'web']);
+      });
+
+      it('returns nothing when no series matches', async () => {
+        expect(
+          await labelValues({ labelName: 'job', match: ['absent_metric'] }),
+        ).toEqual([]);
+      });
+
+      it('treats an empty selector list as no filter', async () => {
+        expect(await labelValues({ labelName: 'job', match: [] })).toEqual([
+          'api',
+          'batch',
+          'web',
+        ]);
+      });
+
+      it('surfaces a malformed selector as an error', async () => {
+        await expect(
+          labelValues({ labelName: 'job', match: ['recent_metric{'] }),
+        ).rejects.toThrow(/while parsing PromQL query/);
+      });
+
+      // A selector is caller-supplied text. Interpolated, this closes the
+      // enclosing string and the query fails; parameterized, it is a plain miss
+      // — so the assertion is "empty", not "throws".
+      it('parameterizes the selector rather than interpolating it', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: [`{job="a') OR 1=1 --"}`],
+          }),
+        ).toEqual([]);
+      });
+
+      it('collapses a repeated identical selector', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: ['old_metric', 'old_metric'],
+          }),
+        ).toEqual(['batch']);
+      });
+
+      it('applies the limit after the selector', async () => {
+        expect(
+          await labelValues({
+            labelName: 'job',
+            match: ['{job=~".+"}'],
+            limit: 1,
+          }),
+        ).toEqual(['api']);
+      });
+
+      // The label predicate and the selector have to AND together rather than
+      // one standing in for the other.
+      it('returns nothing when the matched series lack the label', async () => {
+        expect(
+          await labelValues({ labelName: 'region', match: ['recent_metric'] }),
+        ).toEqual([]);
+      });
+    });
+
     describe('limit', () => {
       it('caps the number of values returned, keeping the ordering', async () => {
         expect(await labelValues({ labelName: '__name__', limit: 1 })).toEqual([
@@ -213,6 +330,21 @@ describe('timeseriesEngine controller', () => {
             endMs: sec(RECENT_START_SEC + HOUR_SEC),
           }),
         ).toEqual(['old_metric', 'recent_metric']);
+      });
+
+      // A selector needs those columns to evaluate at all. Unlike the bounds it
+      // cannot degrade to "no filter" — that would answer a different question.
+      it('rejects match[] rather than dropping it', async () => {
+        await expect(
+          queryLabelValues({
+            client,
+            connectionId: CONNECTION_ID,
+            databaseName: DEFAULT_DATABASE,
+            tableName: UNBOUNDED_TABLE,
+            labelName: 'job',
+            match: ['recent_metric'],
+          }),
+        ).rejects.toThrow(/store_min_time_and_max_time = 1/);
       });
 
       it('still filters on the label itself', async () => {
@@ -302,6 +434,45 @@ describe('timeseriesEngine controller', () => {
           endMs: sec(RECENT_START_SEC + HOUR_SEC),
         }),
       ).toEqual(['__name__', 'job', 'region']);
+    });
+
+    describe('match[] selectors', () => {
+      // Only the old series carries `region`, so a selector that excludes it
+      // has to drop a label name from the answer.
+      it('keeps only the names carried by matching series', async () => {
+        expect(await labelNames({ match: ['recent_metric'] })).toEqual([
+          '__name__',
+          'job',
+        ]);
+      });
+
+      it('unions the series matched by each selector', async () => {
+        expect(
+          await labelNames({ match: ['{job="web"}', 'old_metric'] }),
+        ).toEqual(['__name__', 'job', 'region']);
+      });
+
+      // Both filters have to survive: the selector alone would answer with
+      // `region` too, the window alone with every recent label.
+      it('narrows the selector by the time window', async () => {
+        expect(
+          await labelNames({
+            match: ['{job=~".+"}'],
+            startMs: sec(RECENT_START_SEC),
+            endMs: sec(RECENT_START_SEC + HOUR_SEC),
+          }),
+        ).toEqual(['__name__', 'job']);
+      });
+
+      it('returns nothing when no series matches', async () => {
+        expect(await labelNames({ match: ['absent_metric'] })).toEqual([]);
+      });
+
+      it('rejects match[] on a table without min_time/max_time', async () => {
+        await expect(
+          labelNames({ tableName: UNBOUNDED_TABLE, match: ['recent_metric'] }),
+        ).rejects.toThrow(/store_min_time_and_max_time = 1/);
+      });
     });
   });
 });

--- a/packages/api/src/controllers/timeseriesEngine.ts
+++ b/packages/api/src/controllers/timeseriesEngine.ts
@@ -22,6 +22,7 @@ export type TimeSeriesTagsQueryArgs = {
   startMs?: number;
   endMs?: number;
   limit?: number;
+  match?: string[];
 };
 
 /**
@@ -58,22 +59,64 @@ async function timeSeriesTagsTableHasTimeBounds({
   }
 }
 
+// `timeSeriesSelector()` requires both bounds, so we define the minimum and maximum possible times
+// as default bounds when explicit bounds are not provided.
+const TIMESERIES_MIN_TIME_MS = -2208988800000; // 1900-01-01T00:00:00Z
+const TIMESERIES_MAX_TIME_MS = 10413791999999; // 2299-12-31T23:59:59.999Z
+
 /**
- * Returns SQL predicates restricting tags rows to series that overlap [startMs, endMs].
- * Empty when no bound is given, or when the table stores no time bounds.
+ * Returns a predicate keeping only the series matched by at least one of
+ * the given `match` selectors.
  */
-async function getTimeFilterCondition({
+function getSeriesSelectorCondition({
+  databaseName,
+  tableName,
+  match,
+  startMs,
+  endMs,
+}: {
+  databaseName: string;
+  tableName: string;
+  match: string[];
+  startMs?: number;
+  endMs?: number;
+}): ChSql {
+  const minTime = { Int64: startMs ?? TIMESERIES_MIN_TIME_MS };
+  const maxTime = { Int64: endMs ?? TIMESERIES_MAX_TIME_MS };
+  const idsPerSelector = match.map(
+    selector => chSql`
+      SELECT id
+      FROM timeSeriesSelector(
+        ${{ String: databaseName }},
+        ${{ String: tableName }},
+        ${{ String: selector }},
+        fromUnixTimestamp64Milli(${minTime}),
+        fromUnixTimestamp64Milli(${maxTime})
+      )`,
+  );
+
+  return chSql`id IN (${concatChSql(' UNION DISTINCT ', idsPerSelector)})`;
+}
+
+/**
+ * Returns SQL predicates restricting tags rows to the series a label lookup
+ * should consider: those overlapping [startMs, endMs], and those matched by
+ * `match`. Empty when neither is given.
+ */
+async function getSeriesFilterConditions({
   client,
   connectionId,
   databaseName,
   tableName,
   startMs,
   endMs,
+  match,
 }: Omit<TimeSeriesTagsQueryArgs, 'limit'>): Promise<ChSql[]> {
-  if (startMs == null && endMs == null) return [];
+  const selectors = match?.length ? match : undefined;
+  if (startMs == null && endMs == null && selectors == null) return [];
 
-  // min and max time columns are optional in the tags inner table,
-  // so we check if they exist before adding time conditions
+  // Both filters lean on min_time/max_time, which the tags inner table carries
+  // only when the table was created with store_min_time_and_max_time on.
   const metadata = new Metadata(client, new MetadataCache());
   const tableHasTimeBounds = await timeSeriesTagsTableHasTimeBounds({
     metadata,
@@ -81,17 +124,40 @@ async function getTimeFilterCondition({
     database: databaseName,
     table: tableName,
   });
-  if (!tableHasTimeBounds) return [];
 
   const conditions: ChSql[] = [];
-  if (endMs != null)
+
+  if (selectors != null) {
+    // timeSeriesSelector() prunes on min_time/max_time unconditionally, so
+    // without those columns it cannot run. Unlike the bounds it also cannot
+    // degrade to "no filter" — that would answer a different question.
+    if (!tableHasTimeBounds) {
+      throw new Error(
+        'match[] requires a TimeSeries table created with store_min_time_and_max_time = 1',
+      );
+    }
     conditions.push(
-      chSql`(min_time IS NULL OR min_time <= fromUnixTimestamp64Milli(${{ Int64: endMs }}))`,
+      getSeriesSelectorCondition({
+        databaseName,
+        tableName,
+        match: selectors,
+        startMs,
+        endMs,
+      }),
     );
-  if (startMs != null)
-    conditions.push(
-      chSql`(max_time IS NULL OR max_time >= fromUnixTimestamp64Milli(${{ Int64: startMs }}))`,
-    );
+  }
+
+  if (tableHasTimeBounds) {
+    if (endMs != null)
+      conditions.push(
+        chSql`(min_time IS NULL OR min_time <= fromUnixTimestamp64Milli(${{ Int64: endMs }}))`,
+      );
+    if (startMs != null)
+      conditions.push(
+        chSql`(max_time IS NULL OR max_time >= fromUnixTimestamp64Milli(${{ Int64: startMs }}))`,
+      );
+  }
+
   return conditions;
 }
 
@@ -144,8 +210,8 @@ async function queryDistinctTagsValues({
 }
 
 /**
- * Queries distinct values for the given label name from the given TimeSeries table,
- * optionally filtering by a time range (if the table has the optional time range columns).
+ * Queries distinct values for the given label name from the given TimeSeries
+ * table, optionally narrowed to a time range and to `match`'s series selectors.
  */
 export async function queryLabelValues({
   labelName,
@@ -162,15 +228,14 @@ export async function queryLabelValues({
     conditions.push(
       chSql`mapContains(${{ Identifier: 'tags' }}, ${{ String: labelName }})`,
     );
-  conditions.push(...(await getTimeFilterCondition(args)));
+  conditions.push(...(await getSeriesFilterConditions(args)));
 
   return queryDistinctTagsValues({ ...args, value, conditions, limit });
 }
 
 /**
  * Queries the distinct label names carried by any series in the given TimeSeries
- * table, optionally filtering by a time range (if the table has the optional time
- * range columns).
+ * table, optionally narrowed to a time range and to `match`'s series selectors.
  */
 export async function queryLabelNames({
   limit,
@@ -179,7 +244,7 @@ export async function queryLabelNames({
   // `all_tags` is EPHEMERAL by default, so the label names come from `tags`,
   // which the engine strips `__name__` out of. It is folded back in explicitly.
   const value = chSql`arrayJoin(arrayConcat([${{ String: '__name__' }}], mapKeys(${{ Identifier: 'tags' }})))`;
-  const conditions = await getTimeFilterCondition(args);
+  const conditions = await getSeriesFilterConditions(args);
 
   return queryDistinctTagsValues({ ...args, value, conditions, limit });
 }

--- a/packages/api/src/fixtures.ts
+++ b/packages/api/src/fixtures.ts
@@ -292,24 +292,35 @@ export type TimeSeriesFixtureSeries = {
 
 /**
  * (Re)creates a TimeSeries table and writes `series` straight into its tags
- * inner table — Prometheus remote-write is the only other way in, and label
- * lookups never read the data inner table.
+ * inner table — Prometheus remote-write is the only other way in.
  *
  * `storeTimeBounds: false` creates the table with
  * `store_min_time_and_max_time = 0`, which leaves the tags table without the
  * min_time/max_time columns a time-bounded lookup reads.
+ *
+ * `withSamples: true` also writes a sample at each series' `startSec` and
+ * `endSec`. A `match[]` lookup matches only series that have a sample in the
+ * window, so on a tags-only table every selector answers nothing.
  */
 export const seedTimeSeriesTagsTable = async ({
   table,
   series,
   database = DEFAULT_DATABASE,
   storeTimeBounds = true,
+  withSamples = false,
 }: {
   table: string;
   series: TimeSeriesFixtureSeries[];
   database?: string;
   storeTimeBounds?: boolean;
+  withSamples?: boolean;
 }) => {
+  if (withSamples && !storeTimeBounds) {
+    throw new Error(
+      'withSamples needs storeTimeBounds: sample timestamps come from min_time/max_time',
+    );
+  }
+
   await dropTimeSeriesTable({ table, database });
   await executeTimeSeriesSqlCommand(
     `CREATE TABLE ${database}.${table} ENGINE = TimeSeries${
@@ -346,6 +357,17 @@ export const seedTimeSeriesTagsTable = async ({
   await executeTimeSeriesSqlCommand(
     `INSERT INTO TABLE FUNCTION timeSeriesTags('${database}', '${table}') ${columns} VALUES ${values}`,
   );
+
+  // The engine derives `id` from the tags, so the samples are read back out of
+  // the tags table rather than recomputed here.
+  if (withSamples) {
+    await executeTimeSeriesSqlCommand(
+      `INSERT INTO TABLE FUNCTION timeSeriesData('${database}', '${table}')
+       SELECT id, ts AS timestamp, 1 AS value
+       FROM timeSeriesTags('${database}', '${table}')
+       ARRAY JOIN [min_time, max_time] AS ts`,
+    );
+  }
 };
 
 export const clearClickhouseTables = async () => {

--- a/packages/api/src/routers/api/__tests__/prometheus.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/prometheus.int.test.ts
@@ -14,6 +14,9 @@ import { PROMETHEUS_MAX_EXEMPLAR_WINDOW_SEC } from '@/routers/api/prometheus';
 
 const mockFetch = jest.mocked(global.fetch);
 
+const matchQueryString = (selectors: string[]) =>
+  selectors.map(s => `match[]=${encodeURIComponent(s)}`).join('&');
+
 // The proxy now streams the upstream response straight through (no
 // `await resp.json()`), so test mocks must expose the fields the pipeline
 // actually reads: `status`, `headers.get()`, and a web `ReadableStream` body.
@@ -1095,17 +1098,23 @@ describe('prometheus router', () => {
       const RECENT_START = 1700000000;
       const SERIES_LENGTH_SEC = 3600;
 
-      const labelValues = async (query: Record<string, string>) => {
+      // `match` goes on as a raw query string: it is repeatable, which a plain
+      // object cannot express.
+      const labelValues = async (
+        query: Record<string, string>,
+        { labelName = '__name__', match = [] as string[] } = {},
+      ) => {
         const { agent, team } = await getLoggedInAgent(server);
         const conn = await seedClickHouseConnection(team._id);
         const res = await agent
-          .get('/v1/prometheus/label/__name__/values')
+          .get(`/v1/prometheus/label/${labelName}/values`)
           .query({
             connectionId: conn._id.toString(),
             database: DEFAULT_DATABASE,
             table: TABLE,
             ...query,
           })
+          .query(matchQueryString(match))
           .expect(200);
         return res.body;
       };
@@ -1127,6 +1136,7 @@ describe('prometheus router', () => {
               endSec: RECENT_START + SERIES_LENGTH_SEC,
             },
           ],
+          withSamples: true,
         });
       });
 
@@ -1200,9 +1210,50 @@ describe('prometheus router', () => {
         });
       });
 
-      // Nothing here evaluates a PromQL selector, so answering 200 with
-      // unfiltered values would be a wrong answer the caller trusts.
-      it('rejects match[] instead of ignoring it', async () => {
+      // Selector evaluation is covered in
+      // controllers/__tests__/timeseriesEngine.int.test.ts; these pin that the
+      // selectors survive the query string on the way there.
+      it('filters values through a match[] selector', async () => {
+        expect(await labelValues({}, { match: ['{job="api"}'] })).toEqual({
+          status: 'success',
+          data: [RECENT_METRIC],
+        });
+      });
+
+      it('unions repeated match[] params', async () => {
+        expect(
+          await labelValues(
+            {},
+            { labelName: 'job', match: [OLD_METRIC, RECENT_METRIC] },
+          ),
+        ).toEqual({ status: 'success', data: ['api', 'batch'] });
+      });
+
+      it('accepts the unbracketed match spelling', async () => {
+        expect(await labelValues({ match: `{job="batch"}` })).toEqual({
+          status: 'success',
+          data: [OLD_METRIC],
+        });
+      });
+
+      it('treats an empty match as no filter', async () => {
+        expect(await labelValues({ match: '' })).toEqual({
+          status: 'success',
+          data: [OLD_METRIC, RECENT_METRIC],
+        });
+      });
+
+      it('narrows a selector by the requested window', async () => {
+        expect(
+          await labelValues({
+            match: '{job=~".+"}',
+            start: String(RECENT_START),
+            end: String(RECENT_START + SERIES_LENGTH_SEC),
+          }),
+        ).toEqual({ status: 'success', data: [RECENT_METRIC] });
+      });
+
+      it('answers 400 when a selector is not valid PromQL', async () => {
         const { agent, team } = await getLoggedInAgent(server);
         const conn = await seedClickHouseConnection(team._id);
 
@@ -1212,15 +1263,14 @@ describe('prometheus router', () => {
             connectionId: conn._id.toString(),
             database: DEFAULT_DATABASE,
             table: TABLE,
-            'match[]': 'up',
+            'match[]': 'up{',
           })
           .expect(400);
 
         expect(res.body).toMatchObject({
           status: 'error',
           errorType: 'bad_data',
-          error:
-            'match[] is not supported for ClickHouse-backed PromQL connections',
+          error: expect.stringContaining('while parsing PromQL query'),
         });
       });
     });
@@ -1298,11 +1348,16 @@ describe('prometheus router', () => {
 
     describe('ClickHouse-backed', () => {
       const TABLE = 'prom_labels_test';
+      const OLD_METRIC = 'labels_old_metric';
+      const RECENT_METRIC = 'labels_recent_metric';
       const OLD_START = 1600000000;
       const RECENT_START = 1700000000;
       const SERIES_LENGTH_SEC = 3600;
 
-      const labels = async (query: Record<string, string>) => {
+      const labels = async (
+        query: Record<string, string>,
+        { match = [] as string[] } = {},
+      ) => {
         const { agent, team } = await getLoggedInAgent(server);
         const conn = await seedClickHouseConnection(team._id);
         const res = await agent
@@ -1313,6 +1368,7 @@ describe('prometheus router', () => {
             table: TABLE,
             ...query,
           })
+          .query(matchQueryString(match))
           .expect(200);
         return res.body;
       };
@@ -1322,18 +1378,19 @@ describe('prometheus router', () => {
           table: TABLE,
           series: [
             {
-              metricName: 'labels_old_metric',
+              metricName: OLD_METRIC,
               tags: { job: 'batch', region: 'eu' },
               startSec: OLD_START,
               endSec: OLD_START + SERIES_LENGTH_SEC,
             },
             {
-              metricName: 'labels_recent_metric',
+              metricName: RECENT_METRIC,
               tags: { job: 'api' },
               startSec: RECENT_START,
               endSec: RECENT_START + SERIES_LENGTH_SEC,
             },
           ],
+          withSamples: true,
         });
       });
 
@@ -1379,7 +1436,32 @@ describe('prometheus router', () => {
         });
       });
 
-      it('rejects match[] instead of ignoring it', async () => {
+      // Only the old series carries `region`, so a selector that excludes it
+      // has to drop a label name from the answer.
+      it('keeps only the label names carried by matching series', async () => {
+        expect(await labels({}, { match: [RECENT_METRIC] })).toEqual({
+          status: 'success',
+          data: ['__name__', 'job'],
+        });
+      });
+
+      it('unions repeated match[] params', async () => {
+        expect(
+          await labels({}, { match: [RECENT_METRIC, '{region="eu"}'] }),
+        ).toEqual({
+          status: 'success',
+          data: ['__name__', 'job', 'region'],
+        });
+      });
+
+      it('returns nothing when no series matches', async () => {
+        expect(await labels({}, { match: ['absent_metric'] })).toEqual({
+          status: 'success',
+          data: [],
+        });
+      });
+
+      it('answers 400 when a selector is not valid PromQL', async () => {
         const { agent, team } = await getLoggedInAgent(server);
         const conn = await seedClickHouseConnection(team._id);
 
@@ -1389,15 +1471,14 @@ describe('prometheus router', () => {
             connectionId: conn._id.toString(),
             database: DEFAULT_DATABASE,
             table: TABLE,
-            'match[]': 'up',
+            'match[]': 'up{',
           })
           .expect(400);
 
         expect(res.body).toMatchObject({
           status: 'error',
           errorType: 'bad_data',
-          error:
-            'match[] is not supported for ClickHouse-backed PromQL connections',
+          error: expect.stringContaining('while parsing PromQL query'),
         });
       });
     });

--- a/packages/api/src/routers/api/prometheus.ts
+++ b/packages/api/src/routers/api/prometheus.ts
@@ -963,16 +963,6 @@ async function handleLabelLookup(
 
     backend = 'clickhouse';
 
-    // TODO: Support `match[]` for ClickHouse-Timeseries engine path
-    if (match != null) {
-      return res.status(400).json({
-        status: 'error',
-        errorType: 'bad_data',
-        error:
-          'match[] is not supported for ClickHouse-backed PromQL connections',
-      });
-    }
-
     const database = params.database ?? 'default';
     const table = params.table;
     if (!table) {
@@ -1000,6 +990,7 @@ async function handleLabelLookup(
       startMs,
       endMs,
       limit,
+      match,
     });
 
     return res.json({ status: 'success', data: values });


### PR DESCRIPTION
## Summary

This PR adds support for the match[] parameter on the prometheus labels and label/values endpoints, when querying from a ClickHouse timeseries engine. Previously these parameters were not supported for ClickHouse.

The match[] parameter filters the series from which labels and label values are queried.

This query is not ideal because it uses timeSeriesSelector() to identify matching series in the data table. In theory, the data table should not need to be read in order to get the matching labels and values, but there is no native function that I can find that evaluates matchers just on the tags table.

### Screenshots or video

Request includes matchers:

<img width="886" height="240" alt="Screenshot 2026-09-04 at 9 09 49 AM" src="https://github.com/user-attachments/assets/f9543b65-3713-435d-8f0e-dd0761a8dd66" />

Response is filtered by the matchers:

<img width="611" height="100" alt="Screenshot 2026-09-04 at 9 09 53 AM" src="https://github.com/user-attachments/assets/dd66924f-02d7-44b2-9dd2-93e3454c7802" />

### How to test locally

1. Create a PromQL source based on the metrics_ts timeseries engine table
2. Test the API either directly through curl/bruno/etc or by setting up a filter using the [second PR](https://github.com/hyperdxio/hyperdx/pull/3080)

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5255
- Related PRs:
