### PR TITLE
feat: Support match[] in promql label filters

### DIFF
--- a/.changeset/promql-label-filter-matchers.md
+++ b/.changeset/promql-label-filter-matchers.md
@@ -1,0 +1,7 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/api': patch
+'@hyperdx/app': patch
+---
+
+feat: Support series filter (matcher) in PromQL label dashboard filters

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3334,6 +3334,12 @@
             "description": "Label whose values populate the dropdown. Use \"__name__\" to list\nmetric names.\n",
             "example": "pod"
           },
+          "match": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional Prometheus series selector narrowing which series the\nlabel values are read from.\n",
+            "example": "up{job=\"api\"}"
+          },
           "isBroadcastEnabled": {
             "type": "boolean",
             "enum": [

--- a/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/dashboard.int.test.ts
@@ -1287,6 +1287,27 @@ describe('dashboard router', () => {
       expect(created.body.filters).toEqual([filter]);
     });
 
+    it('persists a series selector', async () => {
+      const filter = makePromqlFilter({ match: 'up{job=~"$env"}' });
+
+      const created = await agent
+        .post('/dashboards')
+        .send({ ...MOCK_DASHBOARD, filters: [filter] })
+        .expect(200);
+
+      expect(created.body.filters).toEqual([filter]);
+    });
+
+    it('rejects an empty series selector', async () => {
+      await agent
+        .post('/dashboards')
+        .send({
+          ...MOCK_DASHBOARD,
+          filters: [makePromqlFilter({ match: '' })],
+        })
+        .expect(400);
+    });
+
     it('persists an updated label on PATCH', async () => {
       const filter = makePromqlFilter();
       const created = await agent

--- a/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
+++ b/packages/api/src/routers/external-api/__tests__/dashboards.int.test.ts
@@ -5754,6 +5754,21 @@ describe('External API v2 Dashboards - new format', () => {
         expect(response.body.data.filters[0].label).toBe('k8s.pod.name');
       });
 
+      it('round-trips a series selector', async () => {
+        const response = await sendFilters([
+          promqlFilterInput({ match: 'up{job=~"$env"}' }),
+        ]);
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.filters[0].match).toBe('up{job=~"$env"}');
+      });
+
+      it('rejects an empty series selector', async () => {
+        const response = await sendFilters([promqlFilterInput({ match: '' })]);
+
+        expect(response.status).toBe(400);
+      });
+
       // Each mode flag accepts exactly one value, so omitting it fills that
       // value in rather than falling back to the queried filter's defaults.
       it('defaults the mode flags when they are omitted', async () => {

--- a/packages/api/src/routers/external-api/v2/dashboards.ts
+++ b/packages/api/src/routers/external-api/v2/dashboards.ts
@@ -1971,6 +1971,13 @@ const EXTERNAL_DASHBOARD_PROJECTION = {
  *             Label whose values populate the dropdown. Use "__name__" to list
  *             metric names.
  *           example: "pod"
+ *         match:
+ *           type: string
+ *           minLength: 1
+ *           description: |
+ *             Optional Prometheus series selector narrowing which series the
+ *             label values are read from.
+ *           example: 'up{job="api"}'
  *         isBroadcastEnabled:
  *           type: boolean
  *           enum: [false]

--- a/packages/app/src/__tests__/prometheusApi.test.ts
+++ b/packages/app/src/__tests__/prometheusApi.test.ts
@@ -1,0 +1,53 @@
+const get = jest.fn();
+const post = jest.fn();
+
+// The suite-wide ky mock answers every verb with an empty object, which is
+// enough for callers that ignore the response but not for reading back the
+// request this module builds.
+jest.mock('ky-universal', () => {
+  const ky = jest.fn();
+  Object.assign(ky, { create: () => ({ get, post }), extend: () => ky });
+  return ky;
+});
+
+import { prometheusApi } from '@/api';
+
+/** The search params of the single request the call issued. */
+const requestedParams = () =>
+  new URLSearchParams(get.mock.calls[0][1].searchParams);
+
+describe('prometheusApi.labelValues', () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockReturnValue({
+      json: () => Promise.resolve({ status: 'success', data: ['api'] }),
+    });
+  });
+
+  it('sends the selector under the repeatable name Prometheus expects', async () => {
+    await prometheusApi.labelValues({
+      label: 'pod',
+      connectionId: 'conn',
+      database: 'db',
+      table: 'tbl',
+      start: 100,
+      end: 200,
+      match: 'up{job="api"}',
+    });
+
+    expect(get).toHaveBeenCalledWith(
+      'v1/prometheus/label/pod/values',
+      expect.anything(),
+    );
+    const params = requestedParams();
+    expect(params.getAll('match[]')).toEqual(['up{job="api"}']);
+    expect(params.get('start')).toBe('100');
+    expect(params.get('end')).toBe('200');
+  });
+
+  it('omits the selector when there is none', async () => {
+    await prometheusApi.labelValues({ label: 'pod', connectionId: 'conn' });
+
+    expect(requestedParams().has('match[]')).toBe(false);
+  });
+});

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -597,12 +597,10 @@ type PrometheusLabelsResponse = {
   error?: string;
 };
 
-async function prometheusFetch<T>(
-  path: string,
-  searchParams: Record<string, string>,
-): Promise<T> {
+/** Reports the reason a Prometheus-shaped error body carries, not ky's. */
+async function withPrometheusError<T>(request: () => Promise<T>): Promise<T> {
   try {
-    return await server.post(path, { searchParams }).json();
+    return await request();
   } catch (e: any) {
     // ky throws HTTPError on non-2xx — read the response body for the real error
     if (e?.response) {
@@ -620,6 +618,12 @@ async function prometheusFetch<T>(
     throw e;
   }
 }
+
+const prometheusFetch = <T>(
+  path: string,
+  searchParams: Record<string, string>,
+): Promise<T> =>
+  withPrometheusError(() => server.post(path, { searchParams }).json<T>());
 
 export const prometheusApi = {
   queryRange: (params: {
@@ -661,12 +665,15 @@ export const prometheusApi = {
     table?: string;
     start?: number;
     end?: number;
+    match?: string;
   }): Promise<PrometheusLabelsResponse> =>
-    server
-      .get(`v1/prometheus/label/${params.label}/values`, {
-        searchParams: labelLookupSearchParams(params),
-      })
-      .json(),
+    withPrometheusError(() =>
+      server
+        .get(`v1/prometheus/label/${params.label}/values`, {
+          searchParams: labelLookupSearchParams(params),
+        })
+        .json<PrometheusLabelsResponse>(),
+    ),
 };
 
 function labelLookupSearchParams(params: {
@@ -675,6 +682,7 @@ function labelLookupSearchParams(params: {
   table?: string;
   start?: number;
   end?: number;
+  match?: string;
 }): Record<string, string> {
   return {
     connectionId: params.connectionId,
@@ -682,5 +690,6 @@ function labelLookupSearchParams(params: {
     ...(params.table ? { table: params.table } : {}),
     ...(params.start != null ? { start: String(params.start) } : {}),
     ...(params.end != null ? { end: String(params.end) } : {}),
+    ...(params.match ? { 'match[]': params.match } : {}),
   };
 }

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { deriveVariableName } from '@hyperdx/common-utils/dist/filters';
+import {
+  deriveVariableName,
+  getFilterVariableName,
+} from '@hyperdx/common-utils/dist/filters';
 import {
   ChartVariable,
   DashboardFilter,
@@ -150,6 +153,14 @@ export const DashboardFilterEditForm = ({
     [filters, filter?.id],
   );
 
+  // A filter referencing its own variable would narrow its dropdown to the
+  // values already selected in it, so don't offer that reference at all.
+  const otherVariables = useMemo(() => {
+    const ownName = filter && getFilterVariableName(filter);
+    if (!ownName) return variables;
+    return variables?.filter(variable => variable.name !== ownName);
+  }, [variables, filter]);
+
   const isNew = !filter;
   const showTypeInput = !!showVariableOptions;
 
@@ -204,12 +215,14 @@ export const DashboardFilterEditForm = ({
               otherFilters={otherFilters}
             />
           ) : formFilterType === 'PROMETHEUS_LABEL' ? (
-            <PromqlLabelFilterEditForm
-              control={control}
-              otherFilters={otherFilters}
-            />
+            <SqlVariablesProvider variables={otherVariables}>
+              <PromqlLabelFilterEditForm
+                control={control}
+                otherFilters={otherFilters}
+              />
+            </SqlVariablesProvider>
           ) : (
-            <SqlVariablesProvider variables={variables}>
+            <SqlVariablesProvider variables={otherVariables}>
               <QueryExpressionFilterEditForm
                 control={control}
                 trigger={trigger}

--- a/packages/app/src/components/DashboardFiltersModal/PromqlLabelFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/PromqlLabelFilterEditForm.tsx
@@ -1,4 +1,4 @@
-import { useWatch } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
 import {
   DashboardFilter,
   isPromqlSource,
@@ -6,10 +6,15 @@ import {
 } from '@hyperdx/common-utils/dist/types';
 
 import { AutocompleteControlled } from '@/components/InputControlled';
+import PromQLEditor from '@/components/PromQLEditor/PromQLEditor';
 import { SourceSelectControlled } from '@/components/SourceSelect';
-import { usePromqlLabelNames } from '@/hooks/usePromqlMetadata';
+import {
+  usePromqlLabelNames,
+  usePromqlMetricNames,
+} from '@/hooks/usePromqlMetadata';
 import { useSources } from '@/source';
 
+import { TOOLTIP_PORTAL_TARGET } from './constants';
 import { CustomInputWrapper } from './CustomInputWrapper';
 import { FilterFormControl } from './filterFormState';
 import { VariableNameInput } from './VariableNameInput';
@@ -41,6 +46,11 @@ export const PromqlLabelFilterEditForm = ({
   const source = sources?.find(s => s.id === sourceId);
   const promqlSource = source && isPromqlSource(source) ? source : undefined;
   const { data: labelNames } = usePromqlLabelNames(
+    promqlSource?.connection,
+    promqlSource?.from.databaseName,
+    promqlSource?.from.tableName,
+  );
+  const { data: metricNames } = usePromqlMetricNames(
     promqlSource?.connection,
     promqlSource?.from.databaseName,
     promqlSource?.from.tableName,
@@ -83,6 +93,27 @@ export const PromqlLabelFilterEditForm = ({
               'This field is required',
           }}
         />
+      </CustomInputWrapper>
+
+      <CustomInputWrapper
+        label="Series matchers"
+        tooltipText="Optional Prometheus series selector narrowing which series the label values are read from. May reference the dashboard's other variables."
+      >
+        <div data-testid="filter-match-input">
+          <Controller
+            control={control}
+            name="match"
+            render={({ field: { value, onChange } }) => (
+              <PromQLEditor
+                value={value ?? ''}
+                onChange={onChange}
+                placeholder={'e.g. up{job="api"}'}
+                metricNames={metricNames}
+                parentRef={TOOLTIP_PORTAL_TARGET}
+              />
+            )}
+          />
+        </div>
       </CustomInputWrapper>
 
       <VariableNameInput control={control} otherFilters={otherFilters} />

--- a/packages/app/src/components/DashboardFiltersModal/QueryExpressionFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/QueryExpressionFilterEditForm.tsx
@@ -30,6 +30,7 @@ import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEdito
 import { useSource } from '@/source';
 import { getMetricTableName } from '@/utils';
 
+import { TOOLTIP_PORTAL_TARGET } from './constants';
 import { CustomInputWrapper } from './CustomInputWrapper';
 import { FilterFormControl, FilterFormValues } from './filterFormState';
 import { VariableNameInput } from './VariableNameInput';
@@ -44,13 +45,6 @@ interface QueryExpressionFilterEditFormProps {
   /** Whether the broadcast / variable controls are available. */
   showVariableOptions: boolean;
 }
-
-/**
- * The modal body scrolls, so an autocomplete popup rendered inside it is
- * clipped at the modal's edge. Portal it to the document body instead.
- */
-const TOOLTIP_PORTAL_TARGET =
-  typeof document !== 'undefined' ? document.body : null;
 
 /**
  * The fields describing where a filter's dropdown values are queried from.

--- a/packages/app/src/components/DashboardFiltersModal/__tests__/filterFormState.test.ts
+++ b/packages/app/src/components/DashboardFiltersModal/__tests__/filterFormState.test.ts
@@ -59,6 +59,7 @@ describe('toFormValues', () => {
       name: 'Job',
       source: 'prom',
       label: 'job',
+      match: 'up{job="api"}',
       isBroadcastEnabled: false,
       isVariableEnabled: true,
       variableName: 'job',
@@ -69,6 +70,7 @@ describe('toFormValues', () => {
       type: 'PROMETHEUS_LABEL',
       source: 'prom',
       label: 'job',
+      match: 'up{job="api"}',
       variableName: 'job',
       expression: '',
       options: [],
@@ -150,6 +152,22 @@ describe('toSavedFilter', () => {
       isBroadcastEnabled: false,
       isVariableEnabled: true,
       variableName: 'Job',
+    });
+  });
+
+  it('trims a PromQL label filter selector and drops an empty one', () => {
+    const base = {
+      type: 'PROMETHEUS_LABEL' as const,
+      name: 'Job',
+      source: 'prom',
+      label: 'job',
+    };
+
+    expect(
+      toSavedFilter(formValues({ ...base, match: '  up{job="api"}  ' })),
+    ).toMatchObject({ match: 'up{job="api"}' });
+    expect(toSavedFilter(formValues({ ...base, match: '   ' }))).toMatchObject({
+      match: undefined,
     });
   });
 

--- a/packages/app/src/components/DashboardFiltersModal/constants.ts
+++ b/packages/app/src/components/DashboardFiltersModal/constants.ts
@@ -1,1 +1,8 @@
 export const MODAL_SIZE = 'lg';
+
+/**
+ * The modal body scrolls, so an autocomplete popup rendered inside it is
+ * clipped at the modal's edge. Portal it to the document body instead.
+ */
+export const TOOLTIP_PORTAL_TARGET =
+  typeof document !== 'undefined' ? document.body : null;

--- a/packages/app/src/components/DashboardFiltersModal/filterFormState.ts
+++ b/packages/app/src/components/DashboardFiltersModal/filterFormState.ts
@@ -62,6 +62,7 @@ export const toFormValues = (
 
     // PROMETHEUS_LABEL fields
     label: promqlLabel?.label ?? '',
+    match: promqlLabel?.match ?? '',
   };
 };
 
@@ -81,6 +82,7 @@ export const toSavedFilter = (values: FilterFormValues): DashboardFilter => {
     return DashboardFilterSchema.parse({
       ...values,
       label: values.label.trim(),
+      match: values.match?.trim() || undefined,
       isBroadcastEnabled: false,
       isVariableEnabled: true,
       variableName: getFilterVariableName(values),

--- a/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
+++ b/packages/app/src/components/PromQLEditor/PromQLEditor.tsx
@@ -15,6 +15,7 @@ import CodeMirror, {
   keymap,
   Prec,
   ReactCodeMirrorRef,
+  tooltips,
 } from '@uiw/react-codemirror';
 
 import {
@@ -39,6 +40,11 @@ type PromQLEditorProps = {
   placeholder?: string;
   onSubmit?: () => void;
   metricNames?: string[];
+  /**
+   * Where to render the completion popup. Set it to `document.body` inside a
+   * modal or other scroll container, which would otherwise clip the popup.
+   */
+  parentRef?: HTMLElement | null;
 };
 
 const MAX_EDITOR_HEIGHT = '150px';
@@ -104,6 +110,7 @@ export default function PromQLEditor({
   placeholder,
   onSubmit,
   metricNames,
+  parentRef,
 }: PromQLEditorProps) {
   const { colorScheme } = useMantineColorScheme();
   const ref = useRef<ReactCodeMirrorRef>(null);
@@ -147,6 +154,7 @@ export default function PromQLEditor({
 
   const cmExtensions = useMemo(
     () => [
+      ...(parentRef ? [tooltips({ parent: parentRef })] : []),
       createCodeMirrorStyleTheme(MAX_EDITOR_HEIGHT),
       EditorView.lineWrapping,
 
@@ -180,7 +188,7 @@ export default function PromQLEditor({
         },
       ]),
     ],
-    [onSubmit],
+    [onSubmit, parentRef],
   );
 
   const onClickCodeMirror = useCallback(() => {

--- a/packages/app/src/hooks/__tests__/usePromqlLabelFilterValues.test.tsx
+++ b/packages/app/src/hooks/__tests__/usePromqlLabelFilterValues.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  ChartVariable,
   PromqlLabelDashboardFilter,
   SourceKind,
   TSource,
@@ -43,9 +44,17 @@ const DATE_RANGE: [Date, Date] = [
 describe('usePromqlLabelFilterValues', () => {
   let wrapper: React.ComponentType<{ children: React.ReactNode }>;
 
-  const renderFilters = (filters: PromqlLabelDashboardFilter[]) =>
+  const renderFilters = (
+    filters: PromqlLabelDashboardFilter[],
+    variables?: ChartVariable[],
+  ) =>
     renderHook(
-      () => usePromqlLabelFilterValues({ filters, dateRange: DATE_RANGE }),
+      () =>
+        usePromqlLabelFilterValues({
+          filters,
+          dateRange: DATE_RANGE,
+          variables,
+        }),
       { wrapper },
     );
 
@@ -175,6 +184,59 @@ describe('usePromqlLabelFilterValues', () => {
       new Set(['missing', 'wrong-kind']),
     );
     expect(result.current.data.get('missing')).toEqual({
+      values: [],
+      isLoading: false,
+    });
+  });
+
+  it('sends the selector under match', async () => {
+    const { result } = renderFilters([filter({ match: 'up{job="api"}' })]);
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledWith(
+      expect.objectContaining({ match: 'up{job="api"}' }),
+    );
+  });
+
+  it('expands the dashboard variables a selector references', async () => {
+    const { result } = renderFilters(
+      [filter({ match: 'up{service=~"$svc"}' })],
+      [{ name: 'svc', expression: 'ServiceName', values: ['api', 'web'] }],
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledWith(
+      expect.objectContaining({ match: 'up{service=~"(api|web)"}' }),
+    );
+  });
+
+  it('queries separately for two filters differing only in their selector', async () => {
+    const { result } = renderFilters([
+      filter({ match: 'up{job="api"}' }),
+      filter({ id: 'promql2', match: 'up{job="web"}' }),
+    ]);
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(mockLabelValues).toHaveBeenCalledTimes(2);
+  });
+
+  it('errors a filter whose selector cannot be expanded, without querying', async () => {
+    const { result } = renderFilters(
+      [filter({ match: 'up{service=~"${svc:bogus}"}' })],
+      [{ name: 'svc', expression: 'ServiceName', values: ['api'] }],
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mockLabelValues).not.toHaveBeenCalled();
+    expect(result.current.erroredFilterIds).toEqual(new Set(['promql1']));
+    expect(result.current.filterErrorMessages.get('promql1')).toMatch(
+      /Unknown variable format 'bogus'/,
+    );
+    expect(result.current.data.get('promql1')).toEqual({
       values: [],
       isLoading: false,
     });

--- a/packages/app/src/hooks/useDashboardFilterValues.tsx
+++ b/packages/app/src/hooks/useDashboardFilterValues.tsx
@@ -63,6 +63,7 @@ export function useDashboardFilterValues({
   const promqlLabelValues = usePromqlLabelFilterValues({
     filters: promqlLabelFilters,
     dateRange,
+    variables,
   });
 
   const data = useMemo(

--- a/packages/app/src/hooks/usePromqlLabelFilterValues.tsx
+++ b/packages/app/src/hooks/usePromqlLabelFilterValues.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
 import {
+  ResolvedPromqlLabelFilterMatch,
+  resolvePromqlLabelFilterMatch,
+} from '@hyperdx/common-utils/dist/filters';
+import {
+  ChartVariable,
   isPromqlSource,
   PromqlLabelDashboardFilter,
 } from '@hyperdx/common-utils/dist/types';
@@ -19,6 +24,7 @@ type LabelValuesCall = {
   database?: string;
   table?: string;
   label: string;
+  match?: string;
 };
 
 const SOURCE_ERROR =
@@ -27,9 +33,12 @@ const SOURCE_ERROR =
 export function usePromqlLabelFilterValues({
   filters,
   dateRange,
+  variables,
 }: {
   filters: PromqlLabelDashboardFilter[];
   dateRange: [Date, Date];
+  /** The dashboard's variables and their current selections, if any */
+  variables?: ChartVariable[];
 }) {
   const { data: sources, isLoading: isLoadingSources } = useSources();
   const sourcesById = useMemo(() => mapKeyBy(sources ?? [], 'id'), [sources]);
@@ -37,6 +46,16 @@ export function usePromqlLabelFilterValues({
   // Round the date range, since the API accepts whole seconds
   const startSec = Math.floor(dateRange[0].getTime() / 1000);
   const endSec = Math.ceil(dateRange[1].getTime() / 1000);
+
+  // A filter's selector may reference the dashboard's variables. Expand them
+  // here so react-query keys on the resolved selector rather than the template.
+  const resolvedByFilterId = useMemo(() => {
+    const byId = new Map<string, ResolvedPromqlLabelFilterMatch>();
+    for (const filter of filters) {
+      byId.set(filter.id, resolvePromqlLabelFilterMatch(filter, variables));
+    }
+    return byId;
+  }, [filters, variables]);
 
   const { calls, unresolvedFilterIds } = useMemo(() => {
     const resolved: LabelValuesCall[] = [];
@@ -50,17 +69,22 @@ export function usePromqlLabelFilterValues({
         if (!isLoadingSources) unresolved.push(filter.id);
         continue;
       }
+      // An unexpanded `$var` left in the selector is certain to be rejected
+      // upstream, and the expansion failure is the better message, so don't call
+      const resolvedMatch = resolvedByFilterId.get(filter.id);
+      if (resolvedMatch?.error) continue;
       resolved.push({
         filterId: filter.id,
         connectionId: source.connection,
         database: source.from.databaseName,
         table: source.from.tableName,
         label: filter.label,
+        match: resolvedMatch?.match,
       });
     }
 
     return { calls: resolved, unresolvedFilterIds: unresolved };
-  }, [filters, sourcesById, isLoadingSources]);
+  }, [filters, sourcesById, isLoadingSources, resolvedByFilterId]);
 
   const queryClient = useQueryClient();
 
@@ -74,6 +98,7 @@ export function usePromqlLabelFilterValues({
         call.database,
         call.table,
         call.label,
+        call.match,
       ];
       return {
         queryKey: [...queryKeyPrefix, startSec, endSec],
@@ -100,6 +125,7 @@ export function usePromqlLabelFilterValues({
             table: call.table,
             start: startSec,
             end: endSec,
+            match: call.match,
           });
           if (resp.status === 'error') {
             throw new Error(resp.error ?? 'Label values query failed');
@@ -136,6 +162,13 @@ export function usePromqlLabelFilterValues({
       filterErrorMessages.set(filterId, SOURCE_ERROR);
     }
 
+    for (const [filterId, resolved] of resolvedByFilterId) {
+      if (!resolved.error) continue;
+      data.set(filterId, { values: [], isLoading: false });
+      erroredFilterIds.add(filterId);
+      filterErrorMessages.set(filterId, resolved.error);
+    }
+
     return {
       data,
       erroredFilterIds,
@@ -144,5 +177,11 @@ export function usePromqlLabelFilterValues({
       isFetching: isLoadingSources || results.some(r => r.isFetching),
       isError: erroredFilterIds.size > 0,
     };
-  }, [results, calls, unresolvedFilterIds, isLoadingSources]);
+  }, [
+    results,
+    calls,
+    unresolvedFilterIds,
+    isLoadingSources,
+    resolvedByFilterId,
+  ]);
 }

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -5,7 +5,11 @@
 import { DisplayType } from '@hyperdx/common-utils/dist/types';
 import { expect, Locator, Page } from '@playwright/test';
 
-import { dismissSqlAutocomplete, getSqlEditor } from '../utils/locators';
+import {
+  dismissSqlAutocomplete,
+  getSqlEditor,
+  replaceEditorText,
+} from '../utils/locators';
 import { switchWhereToLucene } from '../utils/lucene-autocomplete';
 
 import { WebhookAlertModalComponent } from './WebhookAlertModalComponent';
@@ -434,13 +438,11 @@ export class ChartEditorComponent {
    * "Generated PromQL" accordion holds a second, read-only CodeMirror.
    */
   async replacePromqlExpression(expression: string) {
-    const content = this.page.locator('.cm-editor .cm-content').first();
-    await content.click();
-    await this.page.keyboard.press(
-      process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+    await replaceEditorText(
+      this.page,
+      this.page.locator('.cm-editor .cm-content').first(),
+      expression,
     );
-    await this.page.keyboard.press('Delete');
-    await this.page.keyboard.type(expression);
   }
 
   /** Read the current text of the PromQL expression editor. */

--- a/packages/app/tests/e2e/features/dashboard-promql-label-filters.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-promql-label-filters.spec.ts
@@ -84,9 +84,9 @@ test.describe(
         await expect(
           form.getByTestId('filter-variable-enabled-checkbox'),
         ).toHaveCount(0);
-        // Covers both the filter expression and the dropdown values filter:
-        // each is a CodeMirror editor, and this form has neither.
-        await expect(form.locator('div.cm-editor')).toHaveCount(0);
+        // The series selector is the form's only CodeMirror editor: neither the
+        // filter expression nor the dropdown values filter belongs to this type.
+        await expect(form.locator('div.cm-editor')).toHaveCount(1);
       });
 
       await test.step('Only PromQL sources are offered', async () => {
@@ -241,6 +241,88 @@ test.describe(
         await expect(
           tile.getByTitle('accounting', { exact: true }),
         ).toHaveCount(0);
+      });
+    });
+
+    test('narrows the dropdown to the series the selector matches', async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      await dashboardPage.createNewDashboard();
+      await dashboardPage.openEditFiltersModal();
+      await dashboardPage.addPromqlLabelFilterToDashboard(
+        'Service',
+        PROMQL_SOURCE_NAME,
+        'service',
+        {
+          variableName: 'svc',
+          match: `${E2E_PROMQL_METRIC_NAME}{service="${SORTED_SERVICES[0]}"}`,
+        },
+      );
+      await dashboardPage.closeFiltersModal();
+
+      await dashboardPage.openFilterDropdown('Service');
+      await expect(async () => {
+        expect(await dashboardPage.getOpenFilterDropdownOptions()).toEqual([
+          SORTED_SERVICES[0],
+        ]);
+      }).toPass({ timeout: 20000 });
+      await page.keyboard.press('Escape');
+    });
+
+    test("authors a selector that references another filter's variable", async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      await test.step('Declare an Environment variable for the selector to reference', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addStaticListFilterToDashboard(
+          'Environment',
+          ['prod', 'staging'],
+          { variableName: 'env' },
+        );
+      });
+
+      await test.step("The selector completes the other filter's variable", async () => {
+        await dashboardPage.openAddFilterForm();
+        await dashboardPage.selectFilterType('PromQL label values');
+        await dashboardPage.getFilterNameInput().fill('Pod');
+        await dashboardPage.selectFilterSource(PROMQL_SOURCE_NAME);
+        await dashboardPage.getFilterLabelInput().fill('pod');
+        // The closing `"` and `}` are auto-inserted, and the completion's
+        // replace range reaches over them.
+        await dashboardPage.fillFilterMatch('up{job=~"$en');
+        await dashboardPage.acceptFilterMatchCompletion('$env');
+        expect(await dashboardPage.getFilterMatchText()).toBe(
+          'up{job=~"$env"}',
+        );
+      });
+
+      await test.step('The selector survives a save and a reload', async () => {
+        await dashboardPage.variableNameInput.fill('pod');
+        await page.getByTestId('save-filter-button').click();
+        await expect(dashboardPage.getFilterItemByName('Pod')).toBeVisible();
+        await dashboardPage.closeFiltersModal();
+
+        await page.reload();
+        await dashboardPage.waitForLoaded();
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.openEditFilterForm('Pod');
+        expect(await dashboardPage.getFilterMatchText()).toBe(
+          'up{job=~"$env"}',
+        );
+      });
+
+      // Honoring it would narrow the dropdown to the values already selected
+      // in it, so the reference is never offered in the first place.
+      await test.step('The filter cannot reference its own variable', async () => {
+        await dashboardPage.fillFilterMatch('{job=~"$');
+        const options = dashboardPage.filterMatchCompletionOptions();
+        await expect(options.filter({ hasText: '$env' })).not.toHaveCount(0);
+        await expect(options.filter({ hasText: '$pod' })).toHaveCount(0);
       });
     });
 

--- a/packages/app/tests/e2e/page-objects/DashboardPage.ts
+++ b/packages/app/tests/e2e/page-objects/DashboardPage.ts
@@ -7,7 +7,11 @@ import { expect, Locator, Page } from '@playwright/test';
 
 import { ChartEditorComponent } from '../components/ChartEditorComponent';
 import { TimePickerComponent } from '../components/TimePickerComponent';
-import { dismissSqlAutocomplete, getSqlEditor } from '../utils/locators';
+import {
+  dismissSqlAutocomplete,
+  getSqlEditor,
+  replaceEditorText,
+} from '../utils/locators';
 import { switchWhereLanguage } from '../utils/lucene-autocomplete';
 
 /** The "Dropdown values filter" on a dashboard filter, and its language. */
@@ -1364,6 +1368,45 @@ export class DashboardPage {
   }
 
   /**
+   * The PromQL filter form's series-selector editor. Only rendered when the
+   * chosen source sits on a connection that proxies to a real Prometheus.
+   */
+  getFilterMatchInput(): Locator {
+    return this.getFilterForm().getByTestId('filter-match-input');
+  }
+
+  /** Replace the contents of the series-selector editor. */
+  async fillFilterMatch(selector: string) {
+    await replaceEditorText(
+      this.page,
+      this.getFilterMatchInput().locator('.cm-content'),
+      selector,
+    );
+  }
+
+  /** The current text of the series-selector editor. */
+  async getFilterMatchText(): Promise<string> {
+    return this.getFilterMatchInput().locator('.cm-content').innerText();
+  }
+
+  /**
+   * The series-selector editor's completion options. Portalled to the body
+   * rather than rendered in the modal, so this is not scoped to the form.
+   */
+  filterMatchCompletionOptions(): Locator {
+    return this.page.locator('.cm-tooltip-autocomplete > ul > li');
+  }
+
+  /** Accept the completion labelled `label` from that popup. */
+  async acceptFilterMatchCompletion(label: string) {
+    const option = this.filterMatchCompletionOptions()
+      .filter({ has: this.page.getByText(label, { exact: true }) })
+      .first();
+    await option.waitFor({ state: 'visible', timeout: 10000 });
+    await option.click();
+  }
+
+  /**
    * Add a dashboard filter whose dropdown lists the values of one Prometheus
    * label. Like the static variant it shares only the display name and variable
    * name with a queried filter — there is no expression or broadcast mode, and
@@ -1377,7 +1420,7 @@ export class DashboardPage {
     name: string,
     sourceName: string,
     label: string,
-    variableOptions?: { variableName?: string },
+    variableOptions?: { variableName?: string; match?: string },
   ) {
     await this.addFiltersButton.click();
     await this.selectFilterType('PromQL label values');
@@ -1386,6 +1429,9 @@ export class DashboardPage {
     await nameInput.fill(name);
     await this.selectFilterSource(sourceName);
     await this.getFilterLabelInput().fill(label);
+    if (variableOptions?.match !== undefined) {
+      await this.fillFilterMatch(variableOptions.match);
+    }
     if (variableOptions?.variableName !== undefined) {
       await this.variableNameInput.fill(variableOptions.variableName);
     }

--- a/packages/app/tests/e2e/utils/locators.ts
+++ b/packages/app/tests/e2e/utils/locators.ts
@@ -1,4 +1,24 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
+
+/**
+ * Replace everything in a CodeMirror editor, given its `.cm-content` node.
+ *
+ * Select-all then Delete rather than `fill()`: CodeMirror's content node is
+ * contenteditable, not an input, so the editor only sees text that arrives as
+ * key events.
+ */
+export const replaceEditorText = async (
+  page: Page,
+  content: Locator,
+  text: string,
+) => {
+  await content.click();
+  await page.keyboard.press(
+    process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+  );
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text);
+};
 
 export const getSqlEditor = (page: Page, placeholder?: string) => {
   const locator = placeholder

--- a/packages/common-utils/src/__tests__/filters.test.ts
+++ b/packages/common-utils/src/__tests__/filters.test.ts
@@ -16,6 +16,7 @@ import {
   isRenderablePinnedFilter,
   parseQuery,
   resolveFilterValuesWhere,
+  resolvePromqlLabelFilterMatch,
   serializeFilterState,
   validateDashboardFilterQueries,
   validateSavedFilterValues,
@@ -1023,6 +1024,75 @@ describe('filters', () => {
         [svc(['accounting'])],
       );
       expect(resolved.where).toBe("Body = '$notAVariable'");
+      expect(resolved.error).toBeUndefined();
+    });
+  });
+
+  describe('resolvePromqlLabelFilterMatch', () => {
+    const svc = (values: string[]): ChartVariable => ({
+      name: 'svc',
+      expression: 'ServiceName',
+      values,
+    });
+
+    it('reports no selector when there is none to send', () => {
+      expect(resolvePromqlLabelFilterMatch({}, [svc(['api'])])).toEqual({});
+      expect(
+        resolvePromqlLabelFilterMatch({ match: '   ' }, [svc(['api'])]),
+      ).toEqual({});
+    });
+
+    it('trims the selector', () => {
+      expect(
+        resolvePromqlLabelFilterMatch({ match: '  up{job="api"} ' }, undefined)
+          .match,
+      ).toBe('up{job="api"}');
+    });
+
+    it('returns the template as written when there is no variable context', () => {
+      expect(
+        resolvePromqlLabelFilterMatch({ match: 'up{job=~"$svc"}' }, undefined),
+      ).toEqual({ match: 'up{job=~"$svc"}' });
+    });
+
+    it('expands a reference as a regex alternation', () => {
+      expect(
+        resolvePromqlLabelFilterMatch({ match: 'up{job=~"$svc"}' }, [
+          svc(['api', 'ad']),
+        ]).match,
+      ).toBe('up{job=~"(api|ad)"}');
+    });
+
+    it('expands an empty selection to match everything', () => {
+      expect(
+        resolvePromqlLabelFilterMatch({ match: 'up{job=~"$svc"}' }, [svc([])])
+          .match,
+      ).toBe('up{job=~".*"}');
+    });
+
+    it('expands the csv format for a name rather than a matcher value', () => {
+      expect(
+        resolvePromqlLabelFilterMatch({ match: '${svc:csv}{code="200"}' }, [
+          svc(['up']),
+        ]).match,
+      ).toBe('up{code="200"}');
+    });
+
+    it('reports an unrecognized format without throwing', () => {
+      const resolved = resolvePromqlLabelFilterMatch(
+        { match: 'up{job=~"${svc:bogus}"}' },
+        [svc(['api'])],
+      );
+      expect(resolved.match).toBe('up{job=~"${svc:bogus}"}');
+      expect(resolved.error).toMatch(/Unknown variable format 'bogus'/);
+    });
+
+    it('leaves an undeclared bare reference alone', () => {
+      const resolved = resolvePromqlLabelFilterMatch(
+        { match: 'up{job=~"$nope"}' },
+        [svc(['api'])],
+      );
+      expect(resolved.match).toBe('up{job=~"$nope"}');
       expect(resolved.error).toBeUndefined();
     });
   });

--- a/packages/common-utils/src/filters.ts
+++ b/packages/common-utils/src/filters.ts
@@ -1011,6 +1011,40 @@ export function resolveFilterValuesWhere(
   }
 }
 
+export type ResolvedPromqlLabelFilterMatch = {
+  /** The selector the values lookup actually sends, or undefined for none. */
+  match?: string;
+  /** Set when expansion failed; `match` is then the template as written. */
+  error?: string;
+};
+
+/**
+ * Expand the dashboard variables a Prometheus label filter's series selector
+ * references.
+ *
+ * Never throws. Failures (unknown variables, etc) leave the selector as
+ * written and report an `error`.
+ */
+export function resolvePromqlLabelFilterMatch(
+  filter: { match?: string },
+  variables: ChartVariable[] | undefined,
+): ResolvedPromqlLabelFilterMatch {
+  const match = filter.match?.trim();
+  if (!match) return {};
+  if (variables == null) return { match };
+
+  try {
+    return {
+      match: substituteVariables(match, {
+        variables,
+        inputLanguage: 'promql',
+      }),
+    };
+  } catch (e) {
+    return { match, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 /**
  * Variables whose selection a filter's dropdown-values query needs before it can
  * match anything.

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1981,6 +1981,11 @@ export const PromqlLabelDashboardFilterSchema =
     source: z.string().min(1),
     /** Label whose values populate the dropdown. */
     label: z.string().min(1).max(PROMETHEUS_LABEL_NAME_MAX_LENGTH),
+    /**
+     * Optional Prometheus series selector narrowing which series the label
+     * values are read from.
+     */
+    match: z.string().min(1).optional(),
     // Variable-only: there is no SQL expression to broadcast
     isBroadcastEnabled: z.literal(false),
     isVariableEnabled: z.literal(true),


### PR DESCRIPTION
## Summary

This PR updates PromQL-label dashboard filters to support an optional match filter, allowing users to specify filters that query only labels matching some criteria. The match filter can reference other dashboard filter selections as variables.

### Screenshots or video

<img width="652" height="645" alt="Screenshot 2026-09-04 at 9 07 25 AM" src="https://github.com/user-attachments/assets/b3978a7c-62cd-4f45-9fe0-adef8eff35d3" />
<img width="873" height="190" alt="Screenshot 2026-09-04 at 9 07 49 AM" src="https://github.com/user-attachments/assets/e0e39910-2c89-4a1e-b79a-0252e5297df3" />
<img width="878" height="412" alt="Screenshot 2026-09-04 at 9 07 45 AM" src="https://github.com/user-attachments/assets/3da53c88-84ad-48ee-b29d-d86a8aa39cc2" />
<img width="1216" height="229" alt="Screenshot 2026-09-04 at 9 07 33 AM" src="https://github.com/user-attachments/assets/12fea0cf-8b15-47bd-bcb2-69a339e24816" />
<img width="473" height="205" alt="Screenshot 2026-09-04 at 9 07 31 AM" src="https://github.com/user-attachments/assets/15d6d719-7aaa-4e54-8ee3-f10b933ae554" />


### How to test locally

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5301
- Related PRs:
