### PR TITLE
fix: De-dupe PromQL labels and values to prevent Mantine crash

### DIFF
--- a/.changeset/promql-label-autocomplete-duplicates.md
+++ b/.changeset/promql-label-autocomplete-duplicates.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/app": patch
+---
+
+fix: De-dupe PromQL labels and values to prevent Mantine crash

--- a/packages/app/src/__tests__/prometheusApi.test.ts
+++ b/packages/app/src/__tests__/prometheusApi.test.ts
@@ -50,4 +50,49 @@ describe('prometheusApi.labelValues', () => {
 
     expect(requestedParams().has('match[]')).toBe(false);
   });
+
+  it('reports a repeated value once', async () => {
+    get.mockReturnValue({
+      json: () =>
+        Promise.resolve({ status: 'success', data: ['byoc', 'api', 'byoc'] }),
+    });
+
+    const resp = await prometheusApi.labelValues({
+      label: 'pod',
+      connectionId: 'conn',
+    });
+
+    // Mantine throws on duplicate options, taking the page down with it.
+    expect(resp.data).toEqual(['byoc', 'api']);
+  });
+});
+
+describe('prometheusApi.labels', () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it('reports a repeated label name once', async () => {
+    get.mockReturnValue({
+      json: () =>
+        Promise.resolve({
+          status: 'success',
+          data: ['byoc', 'instance', 'byoc'],
+        }),
+    });
+
+    const resp = await prometheusApi.labels({ connectionId: 'conn' });
+
+    expect(resp.data).toEqual(['byoc', 'instance']);
+  });
+
+  it('leaves a response without data alone', async () => {
+    get.mockReturnValue({
+      json: () => Promise.resolve({ status: 'error', error: 'nope' }),
+    });
+
+    const resp = await prometheusApi.labels({ connectionId: 'conn' });
+
+    expect(resp).toEqual({ status: 'error', error: 'nope' });
+  });
 });

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -619,6 +619,15 @@ async function withPrometheusError<T>(request: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Some Prometheus backends return the same label name or value more than once,
+ * de-dupe to prevent any duplicate option errors downstream.
+ */
+const uniqueLabels = (
+  resp: PrometheusLabelsResponse,
+): PrometheusLabelsResponse =>
+  resp.data ? { ...resp, data: [...new Set(resp.data)] } : resp;
+
 const prometheusFetch = <T>(
   path: string,
   searchParams: Record<string, string>,
@@ -656,7 +665,8 @@ export const prometheusApi = {
       .get('v1/prometheus/labels', {
         searchParams: labelLookupSearchParams(params),
       })
-      .json(),
+      .json<PrometheusLabelsResponse>()
+      .then(uniqueLabels),
 
   labelValues: (params: {
     label: string;
@@ -672,7 +682,8 @@ export const prometheusApi = {
         .get(`v1/prometheus/label/${params.label}/values`, {
           searchParams: labelLookupSearchParams(params),
         })
-        .json<PrometheusLabelsResponse>(),
+        .json<PrometheusLabelsResponse>()
+        .then(uniqueLabels),
     ),
 };
 

--- a/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
+++ b/packages/app/src/components/DashboardFiltersModal/DashboardFilterEditForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Alert, Button, Group, Modal, Stack, TextInput } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 
+import { ErrorBoundary } from '@/components/Error/ErrorBoundary';
 import SelectControlled from '@/components/SelectControlled';
 import { SqlVariablesProvider } from '@/components/SQLEditor/variableCompletions';
 import { IS_PROMQL_ENABLED } from '@/config';
@@ -208,30 +209,35 @@ export const DashboardFilterEditForm = ({
               {...register('name', { required: true, minLength: 1 })}
             />
           </CustomInputWrapper>
-
-          {formFilterType === 'STATIC_LIST' ? (
-            <StaticListFilterEditForm
-              control={control}
-              otherFilters={otherFilters}
-            />
-          ) : formFilterType === 'PROMETHEUS_LABEL' ? (
-            <SqlVariablesProvider variables={otherVariables}>
-              <PromqlLabelFilterEditForm
+          <ErrorBoundary
+            key={formFilterType}
+            message="Failed to load filter"
+            showErrorMessage
+          >
+            {formFilterType === 'STATIC_LIST' ? (
+              <StaticListFilterEditForm
                 control={control}
                 otherFilters={otherFilters}
               />
-            </SqlVariablesProvider>
-          ) : (
-            <SqlVariablesProvider variables={otherVariables}>
-              <QueryExpressionFilterEditForm
-                control={control}
-                trigger={trigger}
-                pinnedSource={presetSource}
-                otherFilters={otherFilters}
-                showVariableOptions={showVariableOptions}
-              />
-            </SqlVariablesProvider>
-          )}
+            ) : formFilterType === 'PROMETHEUS_LABEL' ? (
+              <SqlVariablesProvider variables={otherVariables}>
+                <PromqlLabelFilterEditForm
+                  control={control}
+                  otherFilters={otherFilters}
+                />
+              </SqlVariablesProvider>
+            ) : (
+              <SqlVariablesProvider variables={otherVariables}>
+                <QueryExpressionFilterEditForm
+                  control={control}
+                  trigger={trigger}
+                  pinnedSource={presetSource}
+                  otherFilters={otherFilters}
+                  showVariableOptions={showVariableOptions}
+                />
+              </SqlVariablesProvider>
+            )}
+          </ErrorBoundary>
 
           {formState.errors.root && (
             <Alert


### PR DESCRIPTION
## Summary

This PR fixes a full-page crash occuring when the response from prometheus labels or values endpoints are not unique and are then rendered in a mantine select. It appears that not all prometheus backends guarantee the results are unique.

### Screenshots or video

### How to test on Vercel preview

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5303
- Related PRs:
