### PR TITLE
feat: Include alert tags in the tags API response

### DIFF
--- a/.changeset/alert-tags-suggestions.md
+++ b/.changeset/alert-tags-suggestions.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+feat: Include alert tags in the tags API response

--- a/packages/api/src/controllers/team.ts
+++ b/packages/api/src/controllers/team.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import * as config from '@/config';
 import type { ObjectId } from '@/models';
+import Alert from '@/models/alert';
 import Dashboard from '@/models/dashboard';
 import { SavedSearch } from '@/models/savedSearch';
 import Team, { type ITeam, type TeamDocument } from '@/models/team';
@@ -120,23 +121,17 @@ export function updateTeamClickhouseSettings(
 }
 
 export async function getTags(teamId: ObjectId) {
-  const [dashboardTags, savedSearchTags] = await Promise.all([
-    Dashboard.aggregate([
-      { $match: { team: teamId } },
-      { $unwind: '$tags' },
-      { $group: { _id: '$tags' } },
-    ]),
-    SavedSearch.aggregate([
-      { $match: { team: teamId } },
-      { $unwind: '$tags' },
-      { $group: { _id: '$tags' } },
-    ]),
+  const distinctTagsPipeline: mongoose.PipelineStage[] = [
+    { $match: { team: teamId } },
+    { $unwind: '$tags' },
+    { $group: { _id: '$tags' } },
+  ];
+
+  const tagGroups = await Promise.all([
+    Dashboard.aggregate<{ _id: string }>(distinctTagsPipeline),
+    SavedSearch.aggregate<{ _id: string }>(distinctTagsPipeline),
+    Alert.aggregate<{ _id: string }>(distinctTagsPipeline),
   ]);
 
-  return [
-    ...new Set([
-      ...dashboardTags.map(t => t._id),
-      ...savedSearchTags.map(t => t._id),
-    ]),
-  ];
+  return [...new Set(tagGroups.flat().map(t => t._id))];
 }

--- a/packages/api/src/routers/api/__tests__/team.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/team.int.test.ts
@@ -96,8 +96,37 @@ describe('team router', () => {
         tags: ['test', 'test2'],
       })
       .expect(200);
+
+    await Alert.create({
+      team: team.id,
+      source: AlertSource.SAVED_SEARCH,
+      savedSearch: new mongoose.Types.ObjectId(),
+      threshold: 10,
+      thresholdType: AlertThresholdType.ABOVE,
+      interval: '5m',
+      channel: {
+        type: 'webhook',
+        webhookId: new mongoose.Types.ObjectId().toString(),
+      },
+      tags: ['test2', 'test3'],
+    });
+
+    await Alert.create({
+      team: new mongoose.Types.ObjectId(),
+      source: AlertSource.SAVED_SEARCH,
+      savedSearch: new mongoose.Types.ObjectId(),
+      threshold: 10,
+      thresholdType: AlertThresholdType.ABOVE,
+      interval: '5m',
+      channel: {
+        type: 'webhook',
+        webhookId: new mongoose.Types.ObjectId().toString(),
+      },
+      tags: ['other-team'],
+    });
+
     const resp = await agent.get('/team/tags').expect(200);
-    expect(resp.body.data).toStrictEqual(['test', 'test2']);
+    expect(resp.body.data.sort()).toStrictEqual(['test', 'test2', 'test3']);
   });
 
   it('GET /team/members', async () => {


### PR DESCRIPTION
## Summary

This PR updates the team/tags endpoint to return tags from Alert documents, in addition to Dashboards and Saved Searches (existing behavior). Now that Alerts can be tagged independently of dashboards and saved searches, this is necessary so that if a tag is use exclusively by an alert, that tag appears in the suggested tags for other alerts.

There is no existing index on tags in Dashboards or Saved Searches, so this update is consistent with that for alerts.

### Screenshots or video

<img width="289" height="364" alt="Screenshot 2026-09-08 at 9 50 51 AM" src="https://github.com/user-attachments/assets/211e67aa-6c04-431d-ba32-abdbb36dcc82" />


### How to test locally

1. Create an alert and add a new tag to it
2. Create another alert and notice that the tag added to the first alert is present in the tag dropdown

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5287
- Related PRs:
