### PR TITLE
feat: Optionally apply dashboard filters to tile editor preview

### DIFF
--- a/.changeset/tile-editor-dashboard-filters.md
+++ b/.changeset/tile-editor-dashboard-filters.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/common-utils': patch
+'@hyperdx/app': patch
+---
+
+feat: Optionally apply the dashboard's filter selections to the tile editor preview

--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -34,7 +34,10 @@ import {
   Granularity,
   isTimeSeriesDisplayType,
 } from '@hyperdx/common-utils/dist/core/utils';
-import { getBlockingRequiredFilters } from '@hyperdx/common-utils/dist/dashboardFilterValues';
+import {
+  configConsumesBroadcastFilters,
+  getBlockingRequiredFilters,
+} from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   displayTypeRequiresSource,
   isBuilderChartConfig,
@@ -591,19 +594,10 @@ const Tile = ({
     [serializedTileVariables],
   );
 
-  // Whether a broadcast filter reaches this tile's query at all. PromQL tiles
-  // are handed no filters, and a raw-SQL tile drops them without a source or
-  // without a macro to apply them.
-  const consumesBroadcastFilters = useMemo(() => {
-    if (isPromqlSavedChartConfig(chart.config)) return false;
-    if (isRawSqlSavedChartConfig(chart.config)) {
-      return (
-        !!chart.config.source &&
-        !isMissingFiltersMacro(chart.config.sqlTemplate)
-      );
-    }
-    return true;
-  }, [chart.config]);
+  const consumesBroadcastFilters = useMemo(
+    () => configConsumesBroadcastFilters(chart.config, chart.config.source),
+    [chart.config],
+  );
 
   // Serialized for the same reason as `tileVariables`: any change to the
   // dashboard's filters hands this tile a new array, and only a change to the
@@ -1622,6 +1616,8 @@ const EditTileModal = ({
   isSaving,
   dateRange,
   variables,
+  getDashboardFilters,
+  unsatisfiedRequiredFilters,
 }: {
   dashboardId?: string;
   chart: Tile | undefined;
@@ -1630,6 +1626,8 @@ const EditTileModal = ({
   isSaving?: boolean;
   onSave: (chart: Tile) => void;
   variables?: ChartVariable[];
+  getDashboardFilters: (sourceId: string | undefined) => Filter[];
+  unsatisfiedRequiredFilters?: DashboardFilter[];
 }) => {
   const contextZIndex = useZIndex();
   const modalZIndex = contextZIndex + 10;
@@ -1689,6 +1687,8 @@ const EditTileModal = ({
                 dashboardId={dashboardId}
                 chartConfig={chart.config}
                 variables={variables}
+                getDashboardFilters={getDashboardFilters}
+                unsatisfiedRequiredFilters={unsatisfiedRequiredFilters}
                 dateRange={dateRange}
                 isSaving={isSaving}
                 onSave={config => {
@@ -2369,6 +2369,20 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
     [dashboard, setDashboard],
   );
 
+  // The dashboard's search input plus the filter selections that broadcast to
+  // `sourceId`. Shared with the tile editor so its preview queries what the
+  // tile does.
+  const getTileFilters = useCallback(
+    (sourceId: string | undefined): Filter[] => [
+      {
+        type: whereLanguage === 'sql' ? 'sql' : 'lucene',
+        condition: where,
+      },
+      ...getFilterQueriesForSource(sourceId),
+    ],
+    [where, whereLanguage, getFilterQueriesForSource],
+  );
+
   const renderTileComponent = useCallback(
     (chart: Tile) => {
       // Resolve the tile's source ID so per-source-scoped filters can be
@@ -2387,13 +2401,7 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           granularity={
             isRefreshEnabled ? granularityOverride : (granularity ?? undefined)
           }
-          filters={[
-            {
-              type: whereLanguage === 'sql' ? 'sql' : 'lucene',
-              condition: where,
-            },
-            ...getFilterQueriesForSource(tileSourceId),
-          ]}
+          filters={getTileFilters(tileSourceId)}
           variables={variables}
           unsatisfiedRequiredFilters={unsatisfiedRequiredFilters}
           onTimeRangeSelect={onTimeRangeSelect}
@@ -2492,12 +2500,10 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
       highlightedTileId,
       confirm,
       setDashboard,
-      where,
-      whereLanguage,
       onTimeRangeSelect,
       showAlertAnnotations,
       showReleaseAnnotations,
-      getFilterQueriesForSource,
+      getTileFilters,
       variables,
       unsatisfiedRequiredFilters,
       moveTargetContainers,
@@ -3189,6 +3195,8 @@ function DBDashboardPage({ presetConfig }: { presetConfig?: Dashboard }) {
           }}
           dateRange={searchedTimeRange}
           variables={variables}
+          getDashboardFilters={getTileFilters}
+          unsatisfiedRequiredFilters={unsatisfiedRequiredFilters}
           isSaving={isSaving}
           onSave={newChart => {
             if (dashboard == null) {

--- a/packages/app/src/components/DBEditTimeChartForm/ChartActionBar.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartActionBar.tsx
@@ -1,7 +1,15 @@
 import { Control, UseFormHandleSubmit } from 'react-hook-form';
 import { TableConnection } from '@hyperdx/common-utils/dist/core/metadata';
 import { SavedChartConfig } from '@hyperdx/common-utils/dist/types';
-import { ActionIcon, Button, Flex, Menu } from '@mantine/core';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Flex,
+  Menu,
+  Switch,
+  Tooltip,
+} from '@mantine/core';
 import {
   IconDotsVertical,
   IconLayoutGrid,
@@ -13,6 +21,41 @@ import { SQLInlineEditorControlled } from '@/components/SQLEditor/SQLInlineEdito
 import { TimePicker } from '@/components/TimePicker';
 import { IS_LOCAL_MODE } from '@/config';
 import { GranularityPickerControlled } from '@/GranularityPicker';
+
+import { tabQueriesData } from './utils';
+
+export type DashboardFiltersToggleProps = {
+  checked: boolean;
+  disabledReason?: string;
+  onChange: (checked: boolean) => void;
+};
+
+function DashboardFiltersToggle({
+  checked,
+  disabledReason,
+  onChange,
+}: DashboardFiltersToggleProps) {
+  const isDisabled = disabledReason != null;
+  const tooltip = isDisabled
+    ? disabledReason
+    : 'Apply dashboard-level filter and variable selections to the chart preview';
+
+  return (
+    <Tooltip label={tooltip} position="top" multiline maw={320}>
+      <Box data-testid="apply-dashboard-filters">
+        <Switch
+          label="Apply filters"
+          size="sm"
+          labelPosition="left"
+          checked={checked}
+          disabled={isDisabled}
+          onChange={event => onChange(event.currentTarget.checked)}
+          style={isDisabled ? { pointerEvents: 'none' } : undefined}
+        />
+      </Box>
+    </Tooltip>
+  );
+}
 
 type ChartActionBarProps = {
   control: Control<ChartEditorFormState>;
@@ -31,6 +74,7 @@ type ChartActionBarProps = {
   displayedTimeInputValue?: string;
   setDisplayedTimeInputValue?: (value: string) => void;
   onTimeRangeSearch?: (value: string) => void;
+  filtersToggle?: DashboardFiltersToggleProps;
   setSaveToDashboardModalOpen: (open: boolean) => void;
 };
 
@@ -51,6 +95,7 @@ export function ChartActionBar({
   displayedTimeInputValue,
   setDisplayedTimeInputValue,
   onTimeRangeSearch,
+  filtersToggle,
   setSaveToDashboardModalOpen,
 }: ChartActionBarProps) {
   return (
@@ -78,6 +123,9 @@ export function ChartActionBar({
         )}
       </Flex>
       <Flex gap="sm" mb="sm" align="center" justify="end">
+        {filtersToggle != null && tabQueriesData(activeTab) && (
+          <DashboardFiltersToggle {...filtersToggle} />
+        )}
         {(activeTab === 'table' ||
           activeTab === 'pie' ||
           activeTab === 'bar') &&
@@ -97,7 +145,7 @@ export function ChartActionBar({
               />
             </div>
           )}
-        {activeTab !== 'markdown' &&
+        {tabQueriesData(activeTab) &&
           setDisplayedTimeInputValue != null &&
           displayedTimeInputValue != null &&
           onTimeRangeSearch != null && (
@@ -115,7 +163,7 @@ export function ChartActionBar({
         {activeTab === 'time' && (
           <GranularityPickerControlled control={control} name="granularity" />
         )}
-        {activeTab !== 'markdown' && (
+        {tabQueriesData(activeTab) && (
           <Button
             data-testid="chart-run-query-button"
             variant="primary"

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -48,6 +48,7 @@ import {
   buildRenderedPromqlExpression,
   buildSampleEventsConfig,
   isQueryReady,
+  tabQueriesData,
 } from './utils';
 
 /** Why a preview accordion is empty before its tile has been run. */
@@ -142,6 +143,8 @@ type ChartPreviewPanelProps = {
   showSampleEvents: boolean;
   showGeneratedPromql: boolean;
   dbTimeChartConfig?: ChartConfigWithDateRange;
+  /** Required dashboard filters with nothing selected that block this tile. */
+  missingRequiredFilterNames?: string[];
   setValue: (name: 'orderBy', value: string) => void;
   onSubmit: () => void;
 };
@@ -159,6 +162,7 @@ export function ChartPreviewPanel({
   showSampleEvents,
   showGeneratedPromql,
   dbTimeChartConfig,
+  missingRequiredFilterNames,
   setValue,
   onSubmit,
 }: ChartPreviewPanelProps) {
@@ -169,7 +173,11 @@ export function ChartPreviewPanel({
     [queriedConfig],
   );
 
-  const queryReady = !!isQueryReady(queriedConfig);
+  const blockingFilterNames = missingRequiredFilterNames ?? [];
+  const isBlockedByRequiredFilters =
+    blockingFilterNames.length > 0 && tabQueriesData(activeTab);
+  const queryReady =
+    !isBlockedByRequiredFilters && !!isQueryReady(queriedConfig);
 
   const onTableSortingChange = useCallback(
     (sortState: SortingState | null) => {
@@ -203,7 +211,16 @@ export function ChartPreviewPanel({
 
   return (
     <>
-      {!queryReady && activeTab !== 'markdown' ? (
+      {isBlockedByRequiredFilters ? (
+        <EmptyState
+          description={`Missing required filters: ${blockingFilterNames.join(
+            ', ',
+          )}. Select a value for each to preview this tile.`}
+          variant="card"
+          fullWidth
+          data-testid="preview-missing-required-filters"
+        />
+      ) : !queryReady && tabQueriesData(activeTab) ? (
         <EmptyState
           description="Please start by defining your chart above and then click the play button to query data."
           variant="card"

--- a/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/EditTimeChartForm.tsx
@@ -16,7 +16,9 @@ import { isRawSqlSavedChartConfig } from '@hyperdx/common-utils/dist/guards';
 import {
   ChartConfigWithDateRange,
   ChartVariable,
+  DashboardFilter,
   DisplayType,
+  Filter,
   SavedChartConfig,
   SourceKind,
   TSource,
@@ -81,7 +83,7 @@ import {
 } from '@/source';
 import { normalizeNoOpAlertScheduleFields } from '@/utils/alerts';
 
-import { ChartActionBar } from './ChartActionBar';
+import { ChartActionBar, DashboardFiltersToggleProps } from './ChartActionBar';
 import { ChartEditorControls } from './ChartEditorControls';
 import { ChartPreviewPanel } from './ChartPreviewPanel';
 import { ErrorNotificationMessage } from './ErrorNotificationMessage';
@@ -90,7 +92,7 @@ import {
   buildChartConfigForExplanations,
   computeDbTimeChartConfig,
   displayTypeToActiveTab,
-  resolvePreviewVariables,
+  resolveTilePreviewFilters,
   TABS_WITH_GENERATED_SQL,
   zSavedChartConfig,
 } from './utils';
@@ -100,6 +102,10 @@ type EditTimeChartFormProps = {
   chartConfig: SavedChartConfig;
   /** Variables and their selected values, from the parent dashboard (if one exists). */
   variables?: ChartVariable[];
+  /** Function returning the dashboard's broadcast filters for the given source, if any. */
+  getDashboardFilters?: (sourceId: string | undefined) => Filter[];
+  /** The dashboard's required filters that have nothing selected, if any */
+  unsatisfiedRequiredFilters?: DashboardFilter[];
   displayedTimeInputValue?: string;
   dateRange: [Date, Date];
   isSaving?: boolean;
@@ -115,6 +121,9 @@ type EditTimeChartFormProps = {
   isDashboardForm?: boolean;
   autoRun?: boolean;
 };
+
+const ALERT_IGNORES_DASHBOARD_FILTERS =
+  'Dashboard-level filter and variable selections cannot be applied when an alert is configured.';
 
 /** Populate form state with the standard heatmap series + duration numberFormat. */
 function applyHeatmapDefaults(
@@ -139,6 +148,8 @@ export default function EditTimeChartForm({
   dashboardId,
   chartConfig,
   variables,
+  getDashboardFilters,
+  unsatisfiedRequiredFilters,
   displayedTimeInputValue,
   dateRange,
   isSaving,
@@ -374,20 +385,63 @@ export default function EditTimeChartForm({
     [],
   );
 
-  // Attach variables so that variable references can be validated and expanded in the preview
+  // Alerts ignore dashboard-level filters and variables,
+  // so disable the toggle when an alert is configured.
+  const [applyFilters, setApplyFilters] = useState(true);
+  const resolvedApplyFilters = applyFilters && alert == null;
+
+  const dashboardFiltersToggleProps = useMemo<
+    DashboardFiltersToggleProps | undefined
+  >(
+    () =>
+      getDashboardFilters == null
+        ? undefined
+        : {
+            checked: resolvedApplyFilters,
+            disabledReason:
+              alert != null ? ALERT_IGNORES_DASHBOARD_FILTERS : undefined,
+            onChange: setApplyFilters,
+          },
+    [getDashboardFilters, resolvedApplyFilters, alert],
+  );
+
+  const previewDashboardFilters = useMemo(() => {
+    if (queriedConfig == null) {
+      return undefined;
+    }
+    // The submitted config carries the source it was built against. Resolving
+    // against that rather than the live selection keeps the filters consistent
+    // with the query on screen when the source is changed without a re-run.
+    const queriedSourceId = queriedConfig.source || undefined;
+
+    return resolveTilePreviewFilters({
+      config: queriedConfig,
+      sourceId: queriedSourceId,
+      filters: getDashboardFilters?.(queriedSourceId),
+      variables,
+      unsatisfiedRequiredFilters,
+      applySelections: resolvedApplyFilters,
+    });
+  }, [
+    queriedConfig,
+    getDashboardFilters,
+    variables,
+    unsatisfiedRequiredFilters,
+    resolvedApplyFilters,
+  ]);
+
+  // Attach the dashboard's filters and variables so that the preview queries
+  // what the tile will, and variable references can be validated.
   const previewConfig = useMemo(() => {
     if (queriedConfig == null) {
       return queriedConfig;
     }
     return {
       ...queriedConfig,
-      variables: resolvePreviewVariables({
-        config: queriedConfig,
-        variables,
-        hasAlert: alert != null,
-      }),
+      filters: previewDashboardFilters?.filters,
+      variables: previewDashboardFilters?.variables,
     };
-  }, [queriedConfig, variables, alert]);
+  }, [queriedConfig, previewDashboardFilters]);
 
   const dbTimeChartConfig = useMemo(
     () => computeDbTimeChartConfig(previewConfig, alert),
@@ -948,6 +1002,7 @@ export default function EditTimeChartForm({
           displayedTimeInputValue={displayedTimeInputValue}
           setDisplayedTimeInputValue={setDisplayedTimeInputValue}
           onTimeRangeSearch={onTimeRangeSearch}
+          filtersToggle={dashboardFiltersToggleProps}
           setSaveToDashboardModalOpen={setSaveToDashboardModalOpen}
         />
       </ErrorBoundary>
@@ -964,6 +1019,9 @@ export default function EditTimeChartForm({
         showSampleEvents={showSampleEvents}
         showGeneratedPromql={isPromqlInput}
         dbTimeChartConfig={dbTimeChartConfig}
+        missingRequiredFilterNames={
+          previewDashboardFilters?.missingRequiredFilterNames
+        }
         setValue={(name, value) => setValue(name, value)}
         onSubmit={onSubmit}
       />

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartActionBar.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartActionBar.test.tsx
@@ -5,7 +5,10 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ChartEditorFormState } from '@/components/ChartEditor/types';
-import { ChartActionBar } from '@/components/DBEditTimeChartForm/ChartActionBar';
+import {
+  ChartActionBar,
+  DashboardFiltersToggleProps,
+} from '@/components/DBEditTimeChartForm/ChartActionBar';
 
 jest.mock('@/components/SQLEditor/SQLInlineEditor', () => ({
   SQLInlineEditorControlled: (props: any) => (
@@ -98,9 +101,64 @@ const renderActionBar = (
   };
 };
 
+const filterSwitch = () =>
+  screen.getByRole('switch', { name: 'Apply filters' });
+
+const queryFilterSwitch = () =>
+  screen.queryByRole('switch', { name: 'Apply filters' });
+
+const toggle = (overrides: Partial<DashboardFiltersToggleProps> = {}) => ({
+  checked: true,
+  onChange: jest.fn(),
+  ...overrides,
+});
+
 describe('ChartActionBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('dashboard filter toggle', () => {
+    it('is absent off a dashboard', () => {
+      renderActionBar();
+
+      expect(queryFilterSwitch()).not.toBeInTheDocument();
+    });
+
+    it('is absent for a markdown tile, which queries nothing', () => {
+      renderActionBar({
+        activeTab: 'markdown',
+        filtersToggle: toggle(),
+      });
+
+      expect(queryFilterSwitch()).not.toBeInTheDocument();
+    });
+
+    it('reports a flip of the switch', async () => {
+      const onChange = jest.fn();
+      renderActionBar({ filtersToggle: toggle({ onChange }) });
+
+      expect(filterSwitch()).toBeChecked();
+      await userEvent.click(filterSwitch());
+
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it('says why it cannot be changed', async () => {
+      const disabledReason = 'Not while this tile has an alert';
+      renderActionBar({
+        filtersToggle: toggle({ checked: false, disabledReason }),
+      });
+
+      expect(filterSwitch()).not.toBeChecked();
+      expect(filterSwitch()).toBeDisabled();
+
+      // Hovering the wrapper, not the control: a disabled Switch emits none of
+      // the pointer events the tooltip opens on.
+      await userEvent.hover(screen.getByTestId('apply-dashboard-filters'));
+
+      expect(await screen.findByText(disabledReason)).toBeInTheDocument();
+    });
   });
 
   it('should render Save button when onSave is provided', () => {

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
@@ -418,4 +418,44 @@ describe('ChartPreviewPanel', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('when required dashboard filters are unsatisfied', () => {
+    const blockedProps = {
+      queriedConfig: baseBuilderConfig,
+      dbTimeChartConfig: baseBuilderConfig,
+      missingRequiredFilterNames: ['Service', 'Environment'],
+    };
+
+    it('names them instead of querying', () => {
+      renderPanel(blockedProps);
+
+      expect(
+        screen.getByText(
+          'Missing required filters: Service, Environment. Select a value for each to preview this tile.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('db-time-chart')).not.toBeInTheDocument();
+      // The block is the reason, not "you haven't run a query yet".
+      expect(
+        screen.queryByText(/please start by defining/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not block a markdown tile, which queries nothing', () => {
+      renderPanel({ ...blockedProps, activeTab: 'markdown' });
+
+      expect(
+        screen.queryByTestId('preview-missing-required-filters'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the chart once one is selected', () => {
+      renderPanel({ ...blockedProps, missingRequiredFilterNames: [] });
+
+      expect(screen.getByTestId('db-time-chart')).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Missing required filters/),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/DBEditTimeChartForm.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+// The `mock` prefix is required for a jest.mock factory to close over it.
+import { useController as mockUseController } from 'react-hook-form';
 import {
+  AlertThresholdType,
   DisplayType,
   MetricsDataType,
   SavedChartConfig,
@@ -80,6 +83,13 @@ jest.mock('@/source', () => ({
   useSources: jest.fn().mockReturnValue({ data: [] }),
 }));
 
+// The mock handle, read back through `requireMock`, is already typed as the
+// mocked shape. `jest.mocked` on the real import would instead demand a
+// complete `UseQueryResult` from a stub that only needs `data`.
+const mockUseSource = jest.requireMock<{ useSource: jest.Mock }>(
+  '@/source',
+).useSource;
+
 // Records every render's props so tests can assert what the form passes down.
 const metricNameSelectProps: any[] = [];
 
@@ -158,12 +168,23 @@ jest.mock('../../MetricNameSelect', () => ({
   },
 }));
 
+// Wired into form state rather than a static select, so tests can switch the
+// tile's source the way a user does.
 jest.mock('../../SourceSelect', () => ({
-  SourceSelectControlled: () => (
-    <select data-testid="source-selector" defaultValue="metric-source">
-      <option value="metric-source">Metric Source</option>
-    </select>
-  ),
+  SourceSelectControlled: ({ control, name }: any) => {
+    const { field } = mockUseController({ control, name });
+    return (
+      <select
+        data-testid="source-selector"
+        value={field.value ?? ''}
+        onChange={event => field.onChange(event.target.value)}
+      >
+        <option value="metric-source">Metric Source</option>
+        <option value="log-source">Logs</option>
+        <option value="other-source">Other Source</option>
+      </select>
+    );
+  },
 }));
 
 jest.mock('../../ChartSQLPreview', () => ({
@@ -1083,5 +1104,119 @@ describe('DBEditTimeChartForm - Metric formulas', () => {
 
     expect(screen.queryByTestId('add-formula-button')).not.toBeInTheDocument();
     expect(screen.queryByTestId('series-ref-badge')).not.toBeInTheDocument();
+  });
+});
+
+describe('DBEditTimeChartForm - dashboard filters', () => {
+  const getDashboardFilters = jest
+    .fn()
+    .mockReturnValue([{ type: 'sql', condition: "ServiceName IN ('api')" }]);
+
+  const filterSwitch = () =>
+    screen.getByRole('switch', { name: 'Apply filters' });
+
+  const logTileConfig: SavedChartConfig = {
+    ...defaultChartConfig,
+    source: 'log-source',
+    select: [
+      {
+        aggFn: 'count',
+        aggCondition: '',
+        aggConditionLanguage: 'lucene',
+        valueExpression: '',
+      },
+    ],
+  };
+
+  const configWithAlert: SavedChartConfig = {
+    ...logTileConfig,
+    alert: {
+      threshold: 1,
+      thresholdType: AlertThresholdType.ABOVE,
+      interval: '5m',
+      channels: [{ type: 'webhook', webhookId: 'w1' }],
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Earlier describes pin their own source with mockReturnValue, which
+    // survives clearAllMocks.
+    mockUseSource.mockReturnValue({
+      data: {
+        id: 'log-source',
+        kind: SourceKind.Log,
+        name: 'Logs',
+        from: { databaseName: 'default', tableName: 'otel_logs' },
+        connection: 'default',
+        timestampValueExpression: 'Timestamp',
+      },
+    });
+  });
+
+  it('is not offered outside a dashboard', () => {
+    renderComponent({ chartConfig: logTileConfig });
+
+    expect(
+      screen.queryByRole('switch', { name: 'Apply filters' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('applies the parent dashboard filters by default', () => {
+    renderComponent({ getDashboardFilters, chartConfig: logTileConfig });
+
+    expect(filterSwitch()).toBeChecked();
+    expect(filterSwitch()).toBeEnabled();
+  });
+
+  it('scopes the filters it applies to the tile source', async () => {
+    renderComponent({ getDashboardFilters, chartConfig: logTileConfig });
+
+    await userEvent.click(screen.getByTestId('chart-run-query-button'));
+
+    await waitFor(() =>
+      expect(getDashboardFilters).toHaveBeenCalledWith('log-source'),
+    );
+  });
+
+  it('keeps the filters scoped to the submitted source until the next run', async () => {
+    renderComponent({ getDashboardFilters, chartConfig: logTileConfig });
+
+    await userEvent.click(screen.getByTestId('chart-run-query-button'));
+    await waitFor(() =>
+      expect(getDashboardFilters).toHaveBeenCalledWith('log-source'),
+    );
+
+    getDashboardFilters.mockClear();
+    await userEvent.selectOptions(
+      screen.getByTestId('source-selector'),
+      'other-source',
+    );
+
+    // The preview still shows the log-source query, so it keeps that source's
+    // filters instead of rescoping to a source it never queried.
+    expect(getDashboardFilters).not.toHaveBeenCalledWith('other-source');
+
+    await userEvent.click(screen.getByTestId('chart-run-query-button'));
+
+    await waitFor(() =>
+      expect(getDashboardFilters).toHaveBeenCalledWith('other-source'),
+    );
+  });
+
+  it('cannot be turned on for a tile with an alert', () => {
+    renderComponent({ getDashboardFilters, chartConfig: configWithAlert });
+
+    expect(filterSwitch()).not.toBeChecked();
+    expect(filterSwitch()).toBeDisabled();
+  });
+
+  it('can be turned back on once the alert is removed', async () => {
+    renderComponent({ getDashboardFilters, chartConfig: configWithAlert });
+
+    await userEvent.click(screen.getByTestId('remove-alert-button'));
+
+    expect(filterSwitch()).toBeChecked();
+    expect(filterSwitch()).toBeEnabled();
   });
 });

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/utils.test.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   ChartConfigWithDateRange,
+  DashboardFilter,
   DisplayType,
   SavedChartConfig,
   SourceKind,
@@ -15,7 +16,9 @@ import {
   displayTypeToActiveTab,
   isQueryReady,
   resolvePreviewVariables,
+  resolveTilePreviewFilters,
   seriesToFilters,
+  tabQueriesData,
   TABS_WITH_GENERATED_SQL,
 } from '@/components/DBEditTimeChartForm/utils';
 
@@ -230,6 +233,14 @@ describe('displayTypeToActiveTab', () => {
 // TABS_WITH_GENERATED_SQL
 // ---------------------------------------------------------------------------
 
+describe('tabQueriesData', () => {
+  it('is false only for the markdown tab', () => {
+    expect(tabQueriesData('markdown')).toBe(false);
+    expect(tabQueriesData('time')).toBe(true);
+    expect(tabQueriesData('search')).toBe(true);
+  });
+});
+
 describe('TABS_WITH_GENERATED_SQL', () => {
   it('includes table, time, number, pie, bar, heatmap', () => {
     expect(TABS_WITH_GENERATED_SQL.has('table')).toBe(true);
@@ -309,7 +320,7 @@ describe('resolvePreviewVariables', () => {
       resolvePreviewVariables({
         config: promqlConfig,
         variables: undefined,
-        hasAlert: false,
+        applySelections: true,
       }),
     ).toBeUndefined();
   });
@@ -319,19 +330,150 @@ describe('resolvePreviewVariables', () => {
       resolvePreviewVariables({
         config: promqlConfig,
         variables,
-        hasAlert: false,
+        applySelections: true,
       }),
     ).toEqual([{ name: 'service', values: ['api'] }]);
   });
 
-  it('drops the selections when the tile has an alert', () => {
+  it('drops the selections when they are not being applied', () => {
     expect(
       resolvePreviewVariables({
         config: promqlConfig,
         variables,
-        hasAlert: true,
+        applySelections: false,
       }),
     ).toEqual([{ name: 'service', values: [] }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTilePreviewFilters
+// ---------------------------------------------------------------------------
+
+describe('resolveTilePreviewFilters', () => {
+  const dashboardFilters = [
+    { type: 'sql' as const, condition: "ServiceName IN ('api')" },
+  ];
+  const variables = [{ name: 'service', values: ['api'] }];
+
+  const promqlConfig: ChartConfigWithDateRange = {
+    configType: 'promql',
+    promqlExpression: 'up{service=~"$service"}',
+    connection: 'local',
+    dateRange,
+  };
+
+  const rawSqlWithFiltersMacro: ChartConfigWithDateRange = {
+    configType: 'sql',
+    sqlTemplate: 'SELECT count() FROM logs WHERE $__filters',
+    connection: 'clickhouse',
+    dateRange,
+  };
+
+  const requiredFilter: DashboardFilter = {
+    id: 'f1',
+    type: 'QUERY_EXPRESSION',
+    name: 'Service',
+    expression: 'ServiceName',
+    source: 'log-source',
+    minSelections: 1,
+  };
+
+  const resolve = (
+    overrides: Partial<Parameters<typeof resolveTilePreviewFilters>[0]> = {},
+  ) =>
+    resolveTilePreviewFilters({
+      config: builderConfig,
+      sourceId: 'log-source',
+      filters: dashboardFilters,
+      variables,
+      unsatisfiedRequiredFilters: undefined,
+      applySelections: true,
+      ...overrides,
+    });
+
+  it('applies the filters to a builder tile', () => {
+    expect(resolve()).toEqual({
+      filters: dashboardFilters,
+      variables: [],
+      missingRequiredFilterNames: [],
+    });
+  });
+
+  it('keeps the selected values of the variables a tile references', () => {
+    expect(resolve({ config: promqlConfig }).variables).toEqual(variables);
+  });
+
+  it('drops the filters and empties the selections when turned off', () => {
+    expect(resolve({ config: promqlConfig, applySelections: false })).toEqual({
+      filters: undefined,
+      variables: [{ name: 'service', values: [] }],
+      missingRequiredFilterNames: [],
+    });
+  });
+
+  it('never hands filters to a PromQL tile', () => {
+    expect(resolve({ config: promqlConfig }).filters).toBeUndefined();
+  });
+
+  it('drops the filters a raw-SQL template would not apply', () => {
+    expect(resolve({ config: rawSqlWithFiltersMacro }).filters).toEqual(
+      dashboardFilters,
+    );
+    expect(resolve({ config: rawSqlConfig }).filters).toBeUndefined();
+  });
+
+  it('reports the required filters that block the preview', () => {
+    expect(
+      resolve({ unsatisfiedRequiredFilters: [requiredFilter] })
+        .missingRequiredFilterNames,
+    ).toEqual(['Service']);
+  });
+
+  // A static-list filter broadcasts nothing, so only a tile referencing its
+  // variable is blocked by it.
+  it('reports a required filter the tile references as a variable', () => {
+    const requiredVariable: DashboardFilter = {
+      id: 'f2',
+      type: 'STATIC_LIST',
+      name: 'Environment',
+      options: ['prod'],
+      isBroadcastEnabled: false,
+      isVariableEnabled: true,
+      variableName: 'service',
+      minSelections: 1,
+    };
+
+    expect(
+      resolve({
+        config: promqlConfig,
+        unsatisfiedRequiredFilters: [requiredVariable],
+      }).missingRequiredFilterNames,
+    ).toEqual(['Environment']);
+    expect(
+      resolve({ unsatisfiedRequiredFilters: [requiredVariable] })
+        .missingRequiredFilterNames,
+    ).toEqual([]);
+  });
+
+  it('reports no block for a tile the required filter does not reach', () => {
+    expect(
+      resolve({
+        sourceId: 'other-source',
+        unsatisfiedRequiredFilters: [
+          { ...requiredFilter, appliesToSourceIds: ['log-source'] },
+        ],
+      }).missingRequiredFilterNames,
+    ).toEqual([]);
+  });
+
+  it('reports no block while the filters are turned off', () => {
+    expect(
+      resolve({
+        unsatisfiedRequiredFilters: [requiredFilter],
+        applySelections: false,
+      }).missingRequiredFilterNames,
+    ).toEqual([]);
   });
 });
 

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -4,6 +4,10 @@ import {
   TableConnectionChoice,
 } from '@hyperdx/common-utils/dist/core/metadata';
 import {
+  configConsumesBroadcastFilters,
+  getBlockingRequiredFilters,
+} from '@hyperdx/common-utils/dist/dashboardFilterValues';
+import {
   isBuilderChartConfig,
   isPromqlChartConfig,
   isRawSqlChartConfig,
@@ -15,6 +19,7 @@ import {
   ChartConfigWithDateRange,
   ChartConfigWithOptTimestamp,
   ChartVariable,
+  DashboardFilter,
   DisplayType,
   Filter,
   SavedChartConfig,
@@ -121,6 +126,15 @@ export function displayTypeToActiveTab(displayType: DisplayType): string {
   }
 }
 
+/**
+ * Whether a tab queries data. Markdown is static content, so it gets no Run
+ * button, time range or dashboard filters, and no required filter can block
+ * its preview — the tab-level counterpart of `displayTypeRequiresSource`.
+ */
+export function tabQueriesData(activeTab: string): boolean {
+  return activeTab !== displayTypeToActiveTab(DisplayType.Markdown);
+}
+
 export const TABS_WITH_GENERATED_SQL = new Set([
   'table',
   'time',
@@ -150,24 +164,90 @@ export function computeDbTimeChartConfig(
 }
 
 /**
- * Returns the dashboard variables a chart preview should use.
- * - Alerts always run with empty variable selections, so they resolve to each referenced variable with an empty `values` array.
- * - Otherwise, variables are filtered to only those referenced by the chart config.
+ * Returns the dashboard variables a chart preview should use, narrowed to the
+ * ones the chart config references. When applySelections is false, return empty
+ * selections for each variable.
  */
 export function resolvePreviewVariables({
   config,
   variables,
-  hasAlert,
+  applySelections,
 }: {
   config: ChartConfigWithDateRange;
   variables: ChartVariable[] | undefined;
-  hasAlert: boolean;
+  applySelections: boolean;
 }): ChartVariable[] | undefined {
   if (!variables) return undefined;
   const referenced = filterReferencedVariables(config, variables);
-  return hasAlert
-    ? referenced.map(variable => ({ ...variable, values: [] }))
-    : referenced;
+  return applySelections
+    ? referenced
+    : referenced.map(variable => ({ ...variable, values: [] }));
+}
+
+/** What the dashboard's filter state contributes to a tile preview. */
+export type TilePreviewFilters = {
+  /** Broadcast filter conditions to query the preview with. */
+  filters: Filter[] | undefined;
+  /** The referenced variables, with or without their selections. */
+  variables: ChartVariable[] | undefined;
+  /** Names of the required filters that have nothing selected. */
+  missingRequiredFilterNames: string[];
+};
+
+/**
+ * Applies the parent dashboard's filter selections to a tile preview.
+ *
+ * With `applySelections` off, the preview runs as an alert would: no broadcast
+ * filters, empty variable selections, and no required-filter block.
+ */
+export function resolveTilePreviewFilters({
+  config,
+  sourceId,
+  filters,
+  variables,
+  unsatisfiedRequiredFilters,
+  applySelections,
+}: {
+  config: ChartConfigWithDateRange;
+  sourceId: string | undefined;
+  filters: Filter[] | undefined;
+  variables: ChartVariable[] | undefined;
+  unsatisfiedRequiredFilters: DashboardFilter[] | undefined;
+  applySelections: boolean;
+}): TilePreviewFilters {
+  const previewVariables = resolvePreviewVariables({
+    config,
+    variables,
+    applySelections,
+  });
+
+  if (!applySelections) {
+    return {
+      filters: undefined,
+      variables: previewVariables,
+      missingRequiredFilterNames: [],
+    };
+  }
+
+  const consumesBroadcastFilters = configConsumesBroadcastFilters(
+    config,
+    sourceId,
+  );
+
+  return {
+    filters: consumesBroadcastFilters ? filters : undefined,
+    variables: previewVariables,
+    missingRequiredFilterNames: getBlockingRequiredFilters(
+      unsatisfiedRequiredFilters ?? [],
+      {
+        sourceId,
+        referencedVariableNames: previewVariables?.map(
+          variable => variable.name,
+        ),
+        consumesBroadcastFilters,
+      },
+    ).map(filter => filter.name),
+  };
 }
 
 /** A PromQL tile's substituted expression, or why there isn't one. */

--- a/packages/app/src/components/SearchInput/SearchInputV2.tsx
+++ b/packages/app/src/components/SearchInput/SearchInputV2.tsx
@@ -165,7 +165,10 @@ export default function SearchInputV2({
       aboveSuggestions={
         <>
           <div className={styles.searchingHeader}>Searching for:</div>
-          <div className={styles.searchingDescription}>
+          <div
+            className={styles.searchingDescription}
+            data-testid="search-query-description"
+          >
             {parsedEnglishQuery === ''
               ? 'Matching all events, enter a query to search.'
               : parsedEnglishQuery}

--- a/packages/app/tests/e2e/components/ChartEditorComponent.ts
+++ b/packages/app/tests/e2e/components/ChartEditorComponent.ts
@@ -584,6 +584,56 @@ export class ChartEditorComponent {
     }
   }
 
+  /**
+   * The "Searching for:" summary of the focused search input, which renders
+   * the query in English. Assertions scope to it because the SQL the query
+   * expands to is also on the page, in the generated-SQL preview.
+   */
+  searchQueryDescription(): Locator {
+    return this.page.getByTestId('search-query-description');
+  }
+
+  /**
+   * The action bar's "Apply filters" control, present only for a tile being
+   * edited from a dashboard.
+   */
+  applyDashboardFilters(): Locator {
+    return this.page.getByTestId('apply-dashboard-filters');
+  }
+
+  applyDashboardFiltersSwitch(): Locator {
+    return this.applyDashboardFilters().getByRole('switch');
+  }
+
+  /** Turn the dashboard's filter selections on or off for the preview. */
+  async setApplyDashboardFilters(apply: boolean) {
+    const toggle = this.applyDashboardFiltersSwitch();
+    await toggle.waitFor({ state: 'visible', timeout: 10000 });
+    if ((await toggle.isChecked()) !== apply) {
+      await toggle.click();
+    }
+  }
+
+  /**
+   * Hover the switch's wrapper rather than the switch, so the tooltip opens
+   * even while the switch is disabled and emits no pointer events itself.
+   */
+  async hoverApplyDashboardFilters() {
+    await this.applyDashboardFilters().hover();
+  }
+
+  /** The placeholder shown while required dashboard filters are unselected. */
+  previewMissingRequiredFilters(): Locator {
+    return this.page.getByTestId('preview-missing-required-filters');
+  }
+
+  /** The rendered chart in the preview panel of the tile editor modal. */
+  tileEditorPreviewChart(): Locator {
+    return this.page
+      .getByTestId('tile-editor-form')
+      .locator('.recharts-responsive-container');
+  }
+
   /** CodeMirror content of the rendered "Generated SQL" preview. */
   generatedSqlContent(): Locator {
     return this.page.getByTestId('chart-sql-preview').locator('.cm-content');

--- a/packages/app/tests/e2e/features/dashboard-tile-editor-filters.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard-tile-editor-filters.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * The tile editor previews a tile as the dashboard renders it: the dashboard's
+ * filter selections and variables are applied by default, and the "Apply
+ * filters" switch turns them off. An alert forces the switch off — alerts
+ * evaluate without the dashboard's selections — and an unsatisfied required
+ * filter blocks the preview the same way it blocks the tile.
+ */
+import { DashboardPage } from '../page-objects/DashboardPage';
+import { expect, test } from '../utils/base-test';
+import { DEFAULT_LOGS_SOURCE_NAME } from '../utils/constants';
+
+const SERVICE = 'frontend';
+
+test.describe(
+  'Dashboard filters in the tile editor preview',
+  { tag: ['@dashboard', '@full-stack'] },
+  () => {
+    let dashboardPage: DashboardPage;
+
+    test.beforeEach(async ({ page }) => {
+      dashboardPage = new DashboardPage(page);
+      await dashboardPage.goto();
+    });
+
+    /** The generated SQL, retried: the preview re-queries when the toggle flips. */
+    const expectGeneratedSql = async (
+      assertion: (sql: string) => void,
+    ): Promise<void> => {
+      await expect(async () => {
+        assertion(await dashboardPage.chartEditor.getGeneratedSqlText());
+      }).toPass({ timeout: 20000 });
+    };
+
+    test('applies the selected filters, and stops when toggled off', async () => {
+      test.setTimeout(180000);
+
+      await test.step('Create a tile and a broadcasting Service filter', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.addTileWithSource(
+          'Logs count',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+        );
+        await dashboardPage.closeFiltersModal();
+        await dashboardPage.toggleFilterValue('Service', SERVICE);
+      });
+
+      await test.step('The preview queries with the selection', async () => {
+        await dashboardPage.editTile(0);
+        await expect(
+          dashboardPage.chartEditor.applyDashboardFiltersSwitch(),
+        ).toBeChecked();
+
+        await dashboardPage.chartEditor.openGeneratedSql();
+        await expectGeneratedSql(sql => expect(sql).toContain(SERVICE));
+      });
+
+      await test.step('Toggling the filters off drops it', async () => {
+        await dashboardPage.chartEditor.setApplyDashboardFilters(false);
+
+        await expectGeneratedSql(sql => expect(sql).not.toContain(SERVICE));
+      });
+
+      await test.step('Toggling them back on restores it', async () => {
+        await dashboardPage.chartEditor.setApplyDashboardFilters(true);
+
+        await expectGeneratedSql(sql => expect(sql).toContain(SERVICE));
+      });
+
+      await test.step('Configuring an alert forces the switch off', async () => {
+        await dashboardPage.chartEditor.clickAddAlert();
+
+        const toggle = dashboardPage.chartEditor.applyDashboardFiltersSwitch();
+        await expect(toggle).not.toBeChecked();
+        await expect(toggle).toBeDisabled();
+        await expectGeneratedSql(sql => expect(sql).not.toContain(SERVICE));
+
+        await dashboardPage.chartEditor.hoverApplyDashboardFilters();
+        await expect(
+          dashboardPage.page.getByText(
+            /cannot be applied when an alert is configured/i,
+          ),
+        ).toBeVisible();
+      });
+    });
+
+    test('blocks the preview on an unsatisfied required filter', async () => {
+      test.setTimeout(180000);
+
+      await test.step('Create a tile and a required Service filter', async () => {
+        await dashboardPage.createNewDashboard();
+        await dashboardPage.addTileWithSource(
+          'Logs count',
+          DEFAULT_LOGS_SOURCE_NAME,
+        );
+        await dashboardPage.openEditFiltersModal();
+        await dashboardPage.addFilterToDashboard(
+          'Service',
+          DEFAULT_LOGS_SOURCE_NAME,
+          'ServiceName',
+          undefined,
+          undefined,
+          { required: true },
+        );
+        await dashboardPage.closeFiltersModal();
+        await expect(
+          dashboardPage.getTileMissingRequiredFilters(0),
+        ).toBeVisible({ timeout: 20000 });
+      });
+
+      await test.step('The preview names the filter it is waiting on', async () => {
+        await dashboardPage.editTile(0);
+
+        const placeholder =
+          dashboardPage.chartEditor.previewMissingRequiredFilters();
+        await expect(placeholder).toBeVisible({ timeout: 20000 });
+        await expect(placeholder).toContainText(
+          'Missing required filters: Service',
+        );
+      });
+
+      await test.step('Turning the filters off unblocks it', async () => {
+        await dashboardPage.chartEditor.setApplyDashboardFilters(false);
+
+        await expect(
+          dashboardPage.chartEditor.previewMissingRequiredFilters(),
+        ).toHaveCount(0);
+        await expect(
+          dashboardPage.chartEditor.tileEditorPreviewChart(),
+        ).toBeVisible({ timeout: 30000 });
+      });
+    });
+  },
+);

--- a/packages/app/tests/e2e/features/dashboard.spec.ts
+++ b/packages/app/tests/e2e/features/dashboard.spec.ts
@@ -2331,8 +2331,8 @@ test.describe('Dashboard', { tag: ['@dashboard'] }, () => {
           // the selection rather than the reference it was written with.
           await dashboardPage.chartEditor.typeLuceneWhere('ServiceName:$svc');
           await expect(
-            dashboardPage.page.getByText(/ServiceName.*accounting/i),
-          ).toBeVisible({ timeout: 10000 });
+            dashboardPage.chartEditor.searchQueryDescription(),
+          ).toHaveText(/ServiceName.*accounting/i, { timeout: 10000 });
 
           // Leave the input empty for the SQL steps below.
           await dashboardPage.chartEditor.typeLuceneWhere('');

--- a/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
+++ b/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
@@ -1,4 +1,5 @@
 import {
+  configConsumesBroadcastFilters,
   filterSelectionKey,
   getBlockingRequiredFilters,
   getUnsatisfiedRequiredFilters,
@@ -8,6 +9,7 @@ import {
 } from '@/dashboardFilterValues';
 import { FilterState, filtersToQuery } from '@/filters';
 import type {
+  ChartConfigWithOptDateRange,
   DashboardFilter,
   DashboardFilterValue,
   PromqlLabelDashboardFilter,
@@ -736,6 +738,65 @@ describe('dashboardFilterValues', () => {
 
     it('returns nothing for an empty list', () => {
       expect(names([], { sourceId: 'logs' })).toEqual([]);
+    });
+  });
+
+  describe('configConsumesBroadcastFilters', () => {
+    const builderTile: ChartConfigWithOptDateRange = {
+      select: 'count()',
+      from: { databaseName: 'default', tableName: 'logs' },
+      where: '',
+      timestampValueExpression: 'Timestamp',
+      connection: 'local',
+    };
+
+    const rawSqlTile = (sqlTemplate: string): ChartConfigWithOptDateRange => ({
+      configType: 'sql',
+      sqlTemplate,
+      connection: 'local',
+    });
+
+    const promqlTile: ChartConfigWithOptDateRange = {
+      configType: 'promql',
+      promqlExpression: 'up',
+      connection: 'local',
+    };
+
+    it('applies to a builder tile', () => {
+      expect(configConsumesBroadcastFilters(builderTile, 'logs')).toBe(true);
+    });
+
+    it('never applies to a PromQL tile', () => {
+      expect(configConsumesBroadcastFilters(promqlTile, 'metrics')).toBe(false);
+    });
+
+    it('applies to a raw-SQL tile with a source and the filters macro', () => {
+      const tile = rawSqlTile('SELECT count() FROM logs WHERE $__filters');
+
+      expect(configConsumesBroadcastFilters(tile, 'logs')).toBe(true);
+      expect(configConsumesBroadcastFilters(tile, undefined)).toBe(false);
+    });
+
+    it('does not apply to a raw-SQL tile whose template drops the filters', () => {
+      expect(
+        configConsumesBroadcastFilters(
+          rawSqlTile('SELECT count() FROM logs'),
+          'logs',
+        ),
+      ).toBe(false);
+    });
+
+    // A variable macro applies the selection the tile names, which is enough to
+    // count as consuming the dashboard's filters.
+    it('applies to a raw-SQL tile that only uses a variable macro', () => {
+      expect(
+        configConsumesBroadcastFilters(
+          rawSqlTile(
+            'SELECT count() FROM logs WHERE $__filter(ServiceName, $svc)',
+          ),
+          'logs',
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/packages/common-utils/src/dashboardFilterValues.ts
+++ b/packages/common-utils/src/dashboardFilterValues.ts
@@ -10,10 +10,13 @@ import {
   isFilterVariableEnabled,
   parseQuery,
 } from '@/filters';
+import { isMissingFiltersMacro } from '@/macros';
 import {
+  ChartConfigWithOptDateRange,
   DashboardFilter,
   DashboardFilterValue,
   Filter,
+  SavedChartConfig,
   VariableFilterValue,
 } from '@/types';
 
@@ -175,6 +178,19 @@ export function getUnsatisfiedRequiredFilters<
       isFilterRequired(filter) &&
       (selectionByFilterId.get(filter.id)?.included.size ?? 0) === 0,
   );
+}
+
+/** Whether a dashboard's broadcast filters reach a tile with the given config. */
+export function configConsumesBroadcastFilters(
+  config: SavedChartConfig | ChartConfigWithOptDateRange,
+  sourceId: string | undefined,
+): boolean {
+  if (!('configType' in config)) return true;
+  if (config.configType === 'promql') return false;
+  if (config.configType === 'sql') {
+    return !!sourceId && !isMissingFiltersMacro(config.sqlTemplate);
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds an option in the dashboard tile editor that propagates the current dashboard filter and variable selections into the chart preview. This is toggled on by default, and disabled when the user toggles it off or when there is an alert configured on the tile (since alerts evaluate without any filters).

Motivation:

1. Variables and core filters (EE-only, currently) were already propagated but broadcast filters weren't; this was an inconsistency
2. Now that we have required filters (#3078), it may be desirable for performance reasons to encourage the user to apply required filters when editing the tile. This will not fully block the user from making unfiltered queries, as that requires further modifications which are the domain of core filters in EE.

### Screenshots or video

https://github.com/user-attachments/assets/451613ba-0e8a-4d9f-93ad-23056228e78b

### How to test on Vercel preview

1.  Create a dashboard, add a filter
2. Open the tile editor under different combos of filter-required modes, variable/broadcast modes, sources, configured alerts, display types, and play around with the toggle.

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5325
- Related PRs:
