### PR TITLE
review: Add getBlockingRequiredFilterNames, update tile editor blocked copy

### DIFF
--- a/packages/app/src/DBDashboardPage.tsx
+++ b/packages/app/src/DBDashboardPage.tsx
@@ -34,10 +34,7 @@ import {
   Granularity,
   isTimeSeriesDisplayType,
 } from '@hyperdx/common-utils/dist/core/utils';
-import {
-  configConsumesBroadcastFilters,
-  getBlockingRequiredFilters,
-} from '@hyperdx/common-utils/dist/dashboardFilterValues';
+import { getBlockingRequiredFilterNames } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   displayTypeRequiresSource,
   isBuilderChartConfig,
@@ -599,31 +596,20 @@ const Tile = ({
     [serializedTileVariables],
   );
 
-  const consumesBroadcastFilters = useMemo(
-    () => configConsumesBroadcastFilters(chart.config, chart.config.source),
-    [chart.config],
-  );
-
   // Serialized for the same reason as `tileVariables`: any change to the
   // dashboard's filters hands this tile a new array, and only a change to the
   // names this tile is blocked on should churn the render memo below.
   const serializedMissingRequiredFilterNames = useMemo(
     () =>
       JSON.stringify(
-        getBlockingRequiredFilters(unsatisfiedRequiredFilters ?? [], {
+        getBlockingRequiredFilterNames({
+          config: chart.config,
           sourceId: chart.config.source,
-          referencedVariableNames: tileVariables?.map(
-            variable => variable.name,
-          ),
-          consumesBroadcastFilters,
-        }).map(filter => filter.name),
+          unsatisfiedRequiredFilters,
+          referencedVariables: tileVariables,
+        }),
       ),
-    [
-      unsatisfiedRequiredFilters,
-      chart.config.source,
-      tileVariables,
-      consumesBroadcastFilters,
-    ],
+    [unsatisfiedRequiredFilters, chart.config, tileVariables],
   );
   const missingRequiredFilterNames = useMemo<string[]>(
     () => JSON.parse(serializedMissingRequiredFilterNames),

--- a/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/ChartPreviewPanel.tsx
@@ -215,7 +215,7 @@ export function ChartPreviewPanel({
         <EmptyState
           description={`Missing required filters: ${blockingFilterNames.join(
             ', ',
-          )}. Select a value for each to preview this tile.`}
+          )}. Select a value for each required filter, or turn off “Apply filters” to preview this tile without them.`}
           variant="card"
           fullWidth
           data-testid="preview-missing-required-filters"

--- a/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
+++ b/packages/app/src/components/DBEditTimeChartForm/__tests__/ChartPreviewPanel.test.tsx
@@ -431,7 +431,7 @@ describe('ChartPreviewPanel', () => {
 
       expect(
         screen.getByText(
-          'Missing required filters: Service, Environment. Select a value for each to preview this tile.',
+          'Missing required filters: Service, Environment. Select a value for each required filter, or turn off “Apply filters” to preview this tile without them.',
         ),
       ).toBeInTheDocument();
       expect(screen.queryByTestId('db-time-chart')).not.toBeInTheDocument();

--- a/packages/app/src/components/DBEditTimeChartForm/utils.ts
+++ b/packages/app/src/components/DBEditTimeChartForm/utils.ts
@@ -5,7 +5,7 @@ import {
 } from '@hyperdx/common-utils/dist/core/metadata';
 import {
   configConsumesBroadcastFilters,
-  getBlockingRequiredFilters,
+  getBlockingRequiredFilterNames,
 } from '@hyperdx/common-utils/dist/dashboardFilterValues';
 import {
   isBuilderChartConfig,
@@ -237,16 +237,12 @@ export function resolveTilePreviewFilters({
   return {
     filters: consumesBroadcastFilters ? filters : undefined,
     variables: previewVariables,
-    missingRequiredFilterNames: getBlockingRequiredFilters(
-      unsatisfiedRequiredFilters ?? [],
-      {
-        sourceId,
-        referencedVariableNames: previewVariables?.map(
-          variable => variable.name,
-        ),
-        consumesBroadcastFilters,
-      },
-    ).map(filter => filter.name),
+    missingRequiredFilterNames: getBlockingRequiredFilterNames({
+      config,
+      sourceId,
+      unsatisfiedRequiredFilters,
+      referencedVariables: previewVariables,
+    }),
   };
 }
 

--- a/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
+++ b/packages/common-utils/src/__tests__/dashboardFilterValues.test.ts
@@ -1,6 +1,7 @@
 import {
   configConsumesBroadcastFilters,
   filterSelectionKey,
+  getBlockingRequiredFilterNames,
   getBlockingRequiredFilters,
   getUnsatisfiedRequiredFilters,
   parseDashboardFilterValues,
@@ -797,6 +798,67 @@ describe('dashboardFilterValues', () => {
           'logs',
         ),
       ).toBe(true);
+    });
+  });
+
+  describe('getBlockingRequiredFilterNames', () => {
+    const builderTile: ChartConfigWithOptDateRange = {
+      select: 'count()',
+      from: { databaseName: 'default', tableName: 'logs' },
+      where: '',
+      timestampValueExpression: 'Timestamp',
+      connection: 'local',
+    };
+
+    const promqlTile: ChartConfigWithOptDateRange = {
+      configType: 'promql',
+      promqlExpression: 'up',
+      connection: 'local',
+    };
+
+    const unsatisfied = [
+      filter({ id: 'a', name: 'Broadcast', minSelections: 1 }),
+      staticFilter({ id: 'b', minSelections: 1 }),
+    ];
+
+    it('derives broadcast consumption from the config', () => {
+      expect(
+        getBlockingRequiredFilterNames({
+          config: builderTile,
+          sourceId: 'logs',
+          unsatisfiedRequiredFilters: unsatisfied,
+          referencedVariables: [{ name: 'env' }],
+        }),
+      ).toEqual(['Broadcast', 'Environment']);
+
+      expect(
+        getBlockingRequiredFilterNames({
+          config: promqlTile,
+          sourceId: 'logs',
+          unsatisfiedRequiredFilters: unsatisfied,
+          referencedVariables: [{ name: 'env' }],
+        }),
+      ).toEqual(['Environment']);
+    });
+
+    it('treats missing filters and variables as none', () => {
+      expect(
+        getBlockingRequiredFilterNames({
+          config: builderTile,
+          sourceId: 'logs',
+          unsatisfiedRequiredFilters: undefined,
+          referencedVariables: undefined,
+        }),
+      ).toEqual([]);
+
+      expect(
+        getBlockingRequiredFilterNames({
+          config: builderTile,
+          sourceId: 'logs',
+          unsatisfiedRequiredFilters: unsatisfied,
+          referencedVariables: undefined,
+        }),
+      ).toEqual(['Broadcast']);
     });
   });
 });

--- a/packages/common-utils/src/dashboardFilterValues.ts
+++ b/packages/common-utils/src/dashboardFilterValues.ts
@@ -226,3 +226,25 @@ export function getBlockingRequiredFilters(
         doesFilterApplyToSource(filter, tile.sourceId)),
   );
 }
+
+/** The names of the required filters that block a tile with the given config. */
+export function getBlockingRequiredFilterNames({
+  config,
+  sourceId,
+  unsatisfiedRequiredFilters,
+  referencedVariables,
+}: {
+  config: SavedChartConfig | ChartConfigWithOptDateRange;
+  sourceId: string | undefined;
+  unsatisfiedRequiredFilters: DashboardFilter[] | undefined;
+  /** The tile's variables, already narrowed to the ones it references. */
+  referencedVariables: readonly { name: string }[] | undefined;
+}): string[] {
+  return getBlockingRequiredFilters(unsatisfiedRequiredFilters ?? [], {
+    sourceId,
+    referencedVariableNames: referencedVariables?.map(
+      variable => variable.name,
+    ),
+    consumesBroadcastFilters: configConsumesBroadcastFilters(config, sourceId),
+  }).map(filter => filter.name);
+}


### PR DESCRIPTION
## Summary

Addresses two comments from #3903:

1. Update the copy in the tile editor when the preview is blocked by required variables to point the user towards turning off Apply Filters as an option to bypass the block
2. Extract a shared getBlockingRequiredFilterNames function wrapping two similar calls to `getBlockingRequiredFilters`

### Screenshots or video

New Copy:

<img width="2069" height="243" alt="Screenshot 2026-09-09 at 7 54 32 AM" src="https://github.com/user-attachments/assets/2269ff9e-1e56-4480-afcd-10a605560231" />


### How to test on Vercel preview

1. Create a dashboard, add a filter and set it to required
2. Create a tile that uses that filter, check that the preview is disabled with the new message

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue:
- Related PRs:
