### PR TITLE
fix: Keep /api/sources responses stable for sources whose metadata MVs has no nested _id

### DIFF
--- a/.changeset/stable-metadata-materialized-views-id.md
+++ b/.changeset/stable-metadata-materialized-views-id.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+fix: Keep `/api/sources` responses stable for sources whose stored `metadataMaterializedViews` has no nested `_id`

--- a/packages/api/src/models/source.ts
+++ b/packages/api/src/models/source.ts
@@ -133,6 +133,19 @@ const SourceModel = mongoose.model<MongooseSourceBase>(
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 export const Source = SourceModel as unknown as mongoose.Model<ISource>;
 
+// Declared as a nested Schema with `_id: false`, like metricTables below.
+// Left as an inline object, Mongoose makes this a single-nested subdoc with an
+// auto-generated `_id`; documents stored without one get a fresh ObjectId on
+// every hydration, so every /api/sources response body and ETag differs
+const MetadataMaterializedViewsMongoSchema = new Schema(
+  {
+    keyRollupTable: String,
+    kvRollupTable: String,
+    granularity: String,
+  },
+  { _id: false },
+);
+
 // --------------------------
 // Log discriminator
 // --------------------------
@@ -170,11 +183,7 @@ export const LogSource = Source.discriminator<ILogSource>(
       type: mongoose.Schema.Types.Array,
     },
     metadataMaterializedViews: {
-      type: {
-        keyRollupTable: String,
-        kvRollupTable: String,
-        granularity: String,
-      },
+      type: MetadataMaterializedViewsMongoSchema,
       default: undefined,
     },
     orderByExpression: String,
@@ -225,11 +234,7 @@ export const TraceSource = Source.discriminator<ITraceSource>(
       type: mongoose.Schema.Types.Array,
     },
     metadataMaterializedViews: {
-      type: {
-        keyRollupTable: String,
-        kvRollupTable: String,
-        granularity: String,
-      },
+      type: MetadataMaterializedViewsMongoSchema,
       default: undefined,
     },
     orderByExpression: String,

--- a/packages/api/src/routers/api/__tests__/sources.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/sources.int.test.ts
@@ -4,7 +4,7 @@ import {
   UseTextIndex,
 } from '@hyperdx/common-utils/dist/types';
 import express from 'express';
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import request from 'supertest';
 
 import {
@@ -1177,6 +1177,92 @@ describe('sources router', () => {
         kvRollupTable: 'new_kv_rollup',
         granularity: '1 hour',
       });
+    });
+
+    it('GET / - is stable across requests for a source stored without a nested _id', async () => {
+      const { agent, team } = await getLoggedInAgent(server);
+
+      await mongoose.connection.collection('sources').insertOne({
+        ...MOCK_SOURCE,
+        connection: new Types.ObjectId(MOCK_SOURCE.connection),
+        team: team._id,
+        metadataMaterializedViews: {
+          keyRollupTable: 'test_table_key_rollup_15m',
+          kvRollupTable: 'test_table_kv_rollup_15m',
+          granularity: '15 minute',
+        },
+      });
+
+      const first = await agent.get('/sources').expect(200);
+      const second = await agent.get('/sources').expect(200);
+
+      expect(first.body[0].metadataMaterializedViews).toEqual({
+        keyRollupTable: 'test_table_key_rollup_15m',
+        kvRollupTable: 'test_table_kv_rollup_15m',
+        granularity: '15 minute',
+      });
+      expect(second.body).toEqual(first.body);
+      expect(second.headers.etag).toBe(first.headers.etag);
+    });
+
+    it('does not persist a nested _id', async () => {
+      const { team } = await getLoggedInAgent(server);
+
+      const source = await Source.create({
+        ...MOCK_SOURCE,
+        team: team._id,
+        metadataMaterializedViews: {
+          keyRollupTable: 'test_table_key_rollup_15m',
+          kvRollupTable: 'test_table_kv_rollup_15m',
+          granularity: '15 minute',
+        },
+      });
+
+      const stored = await mongoose.connection
+        .collection('sources')
+        .findOne({ _id: source._id });
+
+      expect(stored?.metadataMaterializedViews).not.toHaveProperty('_id');
+    });
+
+    it('GET / - is stable across requests after a source kind change', async () => {
+      const { agent, team } = await getLoggedInAgent(server);
+
+      const source = await Source.create({
+        ...MOCK_SOURCE,
+        team: team._id,
+      });
+
+      await agent
+        .put(`/sources/${source._id}`)
+        .send({
+          id: source._id.toString(),
+          kind: SourceKind.Trace,
+          name: 'Test Trace Source',
+          connection: MOCK_SOURCE.connection,
+          from: { databaseName: 'test_db', tableName: 'otel_traces' },
+          timestampValueExpression: 'Timestamp',
+          defaultTableSelectExpression: 'Timestamp, ServiceName',
+          durationExpression: 'Duration',
+          durationPrecision: 9,
+          traceIdExpression: 'TraceId',
+          spanIdExpression: 'SpanId',
+          parentSpanIdExpression: 'ParentSpanId',
+          spanNameExpression: 'SpanName',
+          spanKindExpression: 'SpanKind',
+          metadataMaterializedViews: {
+            keyRollupTable: 'test_table_key_rollup_15m',
+            kvRollupTable: 'test_table_kv_rollup_15m',
+            granularity: '15 minute',
+          },
+        })
+        .expect(200);
+
+      const first = await agent.get('/sources').expect(200);
+      const second = await agent.get('/sources').expect(200);
+
+      expect(second.body).toEqual(first.body);
+      expect(second.headers.etag).toBe(first.headers.etag);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #3094

Fixes a fetch / mount loop when viewing the trace waterfall panel on sources with metadata MVs. The issue was that Mongo would add a freshly generated `_id` to each metadataMaterializedViews object, when the persisted source had none. This _id is part of the object that exists in the react query key for various queries, so when it changes, old queries are canceled and new ones start. This led to the UI switching from loading to loading state, unmounting and remounting components as the loading state toggled back and forth.

The fix removes the _id from the metadataMaterializedViews sub-schema so that a fresh one is not generated on each read.

Reproduction:

1. Create a traces source and add metadata MVs. Save
2. Change the source's type to Log. Save.
3. Change the source's type back to Trace. Fill in any fields that were removed. Save.
4. Navigate to the waterfall for the source.


### Screenshots or video

**Before:**

Fetch/mount loop:

https://github.com/user-attachments/assets/299c8eeb-7cc0-43fa-8cc5-e8be84419e99

**After:**

Waterfall loads:

<img width="2558" height="1235" alt="Screenshot 2026-09-09 at 11 52 16 AM" src="https://github.com/user-attachments/assets/dd5c22a9-afe4-494f-829c-342e2f1aa748" />


### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue:
- Related PRs:
