### PR TITLE
feat(otel-collector): add statsdreceiver for StatsD/DogStatsD ingestion

### DIFF
--- a/.changeset/statsd-receiver.md
+++ b/.changeset/statsd-receiver.md
@@ -1,0 +1,10 @@
+---
+"@hyperdx/otel-collector": minor
+---
+
+feat(otel-collector): compile in statsdreceiver
+
+Available for a user's own pipeline config (e.g. via
+`CUSTOM_OTELCOL_CONFIG_FILE`) to ingest StatsD/DogStatsD metrics
+directly, without a separate StatsD-to-OTLP bridge. Purely additive:
+being compiled in changes no default pipeline or behavior on its own.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,7 +55,12 @@ services:
       - '${HDX_DEV_OTEL_GRPC_PORT:-4317}:4317' # OTLP gRPC receiver
       - '${HDX_DEV_OTEL_HTTP_PORT:-4318}:4318' # OTLP http receiver
       - '${HDX_DEV_OTEL_METRICS_PORT:-8888}:8888' # metrics extension
-      - '${HDX_DEV_OTEL_STATSD_PORT:-8125}:8125/udp' # statsd receiver (opt-in via custom.config.yaml)
+      # Uncomment to enable statsd ingestion (also requires adding the
+      # `statsd` receiver to a pipeline in custom.config.yaml - see
+      # packages/otel-collector/README.md). Left commented out by default:
+      # a fixed host port mapping fails the whole service's startup if
+      # something else on the host already owns 8125/udp.
+      # - '${HDX_DEV_OTEL_STATSD_PORT:-8125}:8125/udp' # statsd receiver
     restart: always
     networks:
       - internal

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,6 +55,7 @@ services:
       - '${HDX_DEV_OTEL_GRPC_PORT:-4317}:4317' # OTLP gRPC receiver
       - '${HDX_DEV_OTEL_HTTP_PORT:-4318}:4318' # OTLP http receiver
       - '${HDX_DEV_OTEL_METRICS_PORT:-8888}:8888' # metrics extension
+      - '${HDX_DEV_OTEL_STATSD_PORT:-8125}:8125/udp' # statsd receiver (opt-in via custom.config.yaml)
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - '4317:4317' # OTLP gRPC receiver
       - '4318:4318' # OTLP http receiver
       - '8888:8888' # metrics extension
+      - '8125:8125/udp' # statsd receiver (opt-in via CUSTOM_OTELCOL_CONFIG_FILE)
     restart: always
     networks:
       - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,14 @@ services:
       - '4317:4317' # OTLP gRPC receiver
       - '4318:4318' # OTLP http receiver
       - '8888:8888' # metrics extension
-      - '8125:8125/udp' # statsd receiver (opt-in via CUSTOM_OTELCOL_CONFIG_FILE)
+      # Uncomment to enable statsd ingestion (also requires adding the
+      # `statsd` receiver to a pipeline via CUSTOM_OTELCOL_CONFIG_FILE - see
+      # packages/otel-collector/README.md). Left commented out by default:
+      # a fixed host port mapping fails the whole service's startup if
+      # something else on the host (e.g. a local StatsD daemon or Datadog
+      # Agent) already owns 8125/udp, which would otherwise break the
+      # default stack for anyone not using this feature.
+      # - '8125:8125/udp' # statsd receiver
     restart: always
     networks:
       - internal

--- a/docker/hyperdx/Dockerfile
+++ b/docker/hyperdx/Dockerfile
@@ -217,7 +217,7 @@ WORKDIR /app
 # Add hosts entry in entrypoint script instead of here
 
 # Expose ports
-EXPOSE 8080 4317 4318 13133 8123 9000
+EXPOSE 8080 4317 4318 13133 8123 9000 8125/udp
 
 # all-in-one no auth ############################################################################################
 FROM all-in-one-base AS all-in-one-noauth

--- a/docker/otel-collector/Dockerfile
+++ b/docker/otel-collector/Dockerfile
@@ -79,7 +79,7 @@ COPY --chown=10001:10001 docker/otel-collector/config.standalone.promql.yaml /et
 COPY --chown=10001:10001 docker/otel-collector/supervisor_docker.yaml.tmpl /etc/otel/supervisor.yaml.tmpl
 COPY --chown=10001:10001 docker/otel-collector/schema /etc/otel/schema
 
-EXPOSE 4317 4318 13133
+EXPOSE 4317 4318 13133 8125/udp
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD wget -q --spider http://localhost:13133/ || exit 1
@@ -103,7 +103,7 @@ COPY --chown=10001:10001 docker/otel-collector/config.standalone.promql.yaml /et
 COPY --chown=10001:10001 docker/otel-collector/supervisor_docker.yaml.tmpl /etc/otel/supervisor.yaml.tmpl
 COPY --chown=10001:10001 docker/otel-collector/schema /etc/otel/schema
 
-EXPOSE 4317 4318 13133
+EXPOSE 4317 4318 13133 8125/udp
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD wget -q --spider http://localhost:13133/ || exit 1

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -328,20 +328,25 @@ checks aren't hiding a startup-only failure here.
 `statsdreceiver` is compiled in so StatsD-formatted metrics can be ingested
 directly, without a separate StatsD-to-OTLP bridge — this covers any StatsD
 client, not just a particular vendor's dialect. It also understands the
-DogStatsD tag extension (`#tag1:value1,tag2:value2`) if the sender uses it,
-but doesn't require it.
+DogStatsD tag extension: valued tags (`#tag:value`) work with no extra
+config, but bare tags (`#mytag`, no value) need `enable_simple_tags: true`
+(set below) or they're silently dropped.
 
-**This component does not support horizontally-scaled deployments.**
-That's not a HyperDX-specific limitation — it's stated directly in the
-upstream component's own docs: aggregation state lives independently in
-each collector instance's memory, with no cross-replica coordination, so
-the same metric arriving at two different replicas (e.g. behind a
-load-balanced Service) would be aggregated separately by each one instead
-of together, silently splitting/undercounting it. HyperDX's own
-OpAMP-managed `otel-collector` Deployment runs multiple replicas for OTLP
-ingest availability — **do not** wire `statsd` into that Deployment's
-pipelines. Run it on a dedicated, single-replica collector instance
-instead (standalone mode, as below).
+**This component does not support horizontally-scaled deployments** — not
+a HyperDX-specific limitation, it's stated directly in the upstream
+component's own docs. Aggregation state lives independently in each
+collector instance's memory with no cross-replica coordination, so the
+same metric landing on two different replicas (e.g. behind a
+load-balanced Service) gets aggregated separately by each one instead of
+together, silently splitting/undercounting it. HyperDX's default
+deployments (`docker-compose.yml`, the all-in-one image) run the
+OpAMP-managed collector as a single instance, so this doesn't bite out of
+the box — it only matters once *some* collector instance ingesting
+`statsd` is scaled to multiple replicas, at which point that traffic
+needs to go to one dedicated single-replica instance instead.
+
+**In standalone mode**, `metrics` is a plain pipeline in your own config
+file, so add `statsd` to it directly:
 
 ```yaml
 receivers:
@@ -349,18 +354,42 @@ receivers:
     # Defaults to localhost:8125, which only accepts local traffic -
     # override to 0.0.0.0 if metrics arrive from outside the container.
     endpoint: 0.0.0.0:8125
+    enable_simple_tags: true
 service:
   pipelines:
     metrics:
       receivers: [otlp/hyperdx, statsd]
 ```
 
-Verified against the real compiled binary via `otelcontribcol validate
---config` and an actual startup run (`otelcontribcol --config ...`,
-reaching `"Everything is ready. Begin running and processing data."`),
-in both cases using the same multi-`--config` merge the container
-actually uses (base `config.yaml` + `standalone-config.yaml` + this
-fragment).
+**In OpAMP supervisor mode** (HyperDX's default), editing the `metrics`
+pipeline this way will not work: `receivers:`/`exporters:` on it are set
+dynamically by `opampController.ts`, and the remote config overwrites
+(not merges) those keys — see the [span metrics section
+above](#computing-span-metrics-from-ingested-traces) for the same
+behavior. Adding `statsd` to `metrics.receivers` from
+`CUSTOM_OTELCOL_CONFIG_FILE` gets silently dropped: no error, the receiver
+just starts and is wired to nothing. Use a separate pipeline name instead,
+which the remote config never touches:
+
+```yaml
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:8125
+    enable_simple_tags: true
+service:
+  pipelines:
+    metrics/statsd:
+      receivers: [statsd]
+      exporters: [clickhouse]
+      processors: [memory_limiter, batch]
+```
+
+Both shapes are verified against the real compiled binary via
+`otelcontribcol validate --config`, and the standalone shape was also
+actually run (`otelcontribcol --config ...`, not just `validate`),
+reaching `"Everything is ready. Begin running and processing data."` —
+the same rigor as the span metrics section above, using the same
+multi-`--config` merge the container actually uses.
 
 ## Overriding base components via `CUSTOM_OTELCOL_CONFIG_FILE`
 

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -345,11 +345,15 @@ the box — it only matters once *some* collector instance ingesting
 `statsd` is scaled to multiple replicas, at which point that traffic
 needs to go to one dedicated single-replica instance instead.
 
-`docker-compose.yml`/`docker-compose.dev.yml` publish `8125:8125/udp` on
-the `otel-collector` service, and the standalone/all-in-one images
-`EXPOSE 8125/udp`, so the port is reachable from outside the container as
-soon as `statsd` is added to a pipeline below — no separate port-mapping
-step needed on top of these examples.
+`docker-compose.yml`/`docker-compose.dev.yml` have an `8125/udp` port
+mapping for the `otel-collector` service, commented out by default —
+uncomment it to enable statsd ingestion. It's opt-in rather than always
+on because a fixed host port mapping fails that service's entire startup
+if something else on the host (e.g. a local StatsD daemon or Datadog
+Agent) already owns 8125/udp, which would otherwise break the default
+stack for anyone not using this feature. The standalone/all-in-one images
+also `EXPOSE 8125/udp` (metadata only, doesn't reserve the host port on
+its own).
 
 **In standalone mode**, `metrics` is a plain pipeline in your own config
 file, so add `statsd` to it directly:

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -345,6 +345,12 @@ the box — it only matters once *some* collector instance ingesting
 `statsd` is scaled to multiple replicas, at which point that traffic
 needs to go to one dedicated single-replica instance instead.
 
+`docker-compose.yml`/`docker-compose.dev.yml` publish `8125:8125/udp` on
+the `otel-collector` service, and the standalone/all-in-one images
+`EXPOSE 8125/udp`, so the port is reachable from outside the container as
+soon as `statsd` is added to a pipeline below — no separate port-mapping
+step needed on top of these examples.
+
 **In standalone mode**, `metrics` is a plain pipeline in your own config
 file, so add `statsd` to it directly:
 
@@ -352,7 +358,9 @@ file, so add `statsd` to it directly:
 receivers:
   statsd:
     # Defaults to localhost:8125, which only accepts local traffic -
-    # override to 0.0.0.0 if metrics arrive from outside the container.
+    # 0.0.0.0 is required here since traffic arrives from outside the
+    # container (the published port above forwards to the container's
+    # own loopback otherwise).
     endpoint: 0.0.0.0:8125
     enable_simple_tags: true
 service:

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -323,14 +323,13 @@ run (`otelcontribcol --config ...`, not just `validate`): it reaches
 `span_metrics` connector, confirming `validate`'s static schema/graph
 checks aren't hiding a startup-only failure here.
 
-## Ingesting StatsD/DogStatsD metrics
+## Ingesting StatsD metrics
 
-`statsdreceiver` is compiled in so StatsD and DogStatsD-formatted metrics
-(e.g. from a Datadog Agent's local DogStatsD listener, or anything else
-speaking the StatsD wire protocol) can be ingested directly, without a
-separate StatsD-to-OTLP bridge. It understands DogStatsD's tag extension
-natively (`<metric>:<value>|<type>|#tag1:value1,tag2:value2`), so
-Datadog-originated StatsD traffic doesn't need any translation.
+`statsdreceiver` is compiled in so StatsD-formatted metrics can be ingested
+directly, without a separate StatsD-to-OTLP bridge — this covers any StatsD
+client, not just a particular vendor's dialect. It also understands the
+DogStatsD tag extension (`#tag1:value1,tag2:value2`) if the sender uses it,
+but doesn't require it.
 
 **This component does not support horizontally-scaled deployments.**
 That's not a HyperDX-specific limitation — it's stated directly in the
@@ -347,20 +346,9 @@ instead (standalone mode, as below).
 ```yaml
 receivers:
   statsd:
+    # Defaults to localhost:8125, which only accepts local traffic -
+    # override to 0.0.0.0 if metrics arrive from outside the container.
     endpoint: 0.0.0.0:8125
-    # DogStatsD supports bare tags with no value (`#mytag`, not just
-    # `#mytag:myvalue`) - without this, those get dropped.
-    enable_simple_tags: true
-    # Optional: route timer/histogram-type StatsD metrics to an
-    # exponential histogram (HyperDX's ClickHouse schema already has a
-    # dedicated otel_metrics_exponential_histogram table for these,
-    # verified elsewhere in this README) instead of the default
-    # explicit-bucket histogram.
-    timer_histogram_mapping:
-      - statsd_type: "timing"
-        observer_type: "histogram"
-        histogram:
-          max_size: 160
 service:
   pipelines:
     metrics:

--- a/packages/otel-collector/README.md
+++ b/packages/otel-collector/README.md
@@ -68,6 +68,7 @@ custom OTel configurations without rebuilding the collector.
 | `k8scluster`    | contrib | user configs                                            |
 | `kubeletstats`  | contrib | user configs                                            |
 | `prometheus`    | contrib | OpAMP controller, smoke tests                           |
+| `statsd`        | contrib | user configs                                            |
 
 ### Processors
 
@@ -321,6 +322,57 @@ run (`otelcontribcol --config ...`, not just `validate`): it reaches
 `"Everything is ready. Begin running and processing data."` and starts the
 `span_metrics` connector, confirming `validate`'s static schema/graph
 checks aren't hiding a startup-only failure here.
+
+## Ingesting StatsD/DogStatsD metrics
+
+`statsdreceiver` is compiled in so StatsD and DogStatsD-formatted metrics
+(e.g. from a Datadog Agent's local DogStatsD listener, or anything else
+speaking the StatsD wire protocol) can be ingested directly, without a
+separate StatsD-to-OTLP bridge. It understands DogStatsD's tag extension
+natively (`<metric>:<value>|<type>|#tag1:value1,tag2:value2`), so
+Datadog-originated StatsD traffic doesn't need any translation.
+
+**This component does not support horizontally-scaled deployments.**
+That's not a HyperDX-specific limitation — it's stated directly in the
+upstream component's own docs: aggregation state lives independently in
+each collector instance's memory, with no cross-replica coordination, so
+the same metric arriving at two different replicas (e.g. behind a
+load-balanced Service) would be aggregated separately by each one instead
+of together, silently splitting/undercounting it. HyperDX's own
+OpAMP-managed `otel-collector` Deployment runs multiple replicas for OTLP
+ingest availability — **do not** wire `statsd` into that Deployment's
+pipelines. Run it on a dedicated, single-replica collector instance
+instead (standalone mode, as below).
+
+```yaml
+receivers:
+  statsd:
+    endpoint: 0.0.0.0:8125
+    # DogStatsD supports bare tags with no value (`#mytag`, not just
+    # `#mytag:myvalue`) - without this, those get dropped.
+    enable_simple_tags: true
+    # Optional: route timer/histogram-type StatsD metrics to an
+    # exponential histogram (HyperDX's ClickHouse schema already has a
+    # dedicated otel_metrics_exponential_histogram table for these,
+    # verified elsewhere in this README) instead of the default
+    # explicit-bucket histogram.
+    timer_histogram_mapping:
+      - statsd_type: "timing"
+        observer_type: "histogram"
+        histogram:
+          max_size: 160
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp/hyperdx, statsd]
+```
+
+Verified against the real compiled binary via `otelcontribcol validate
+--config` and an actual startup run (`otelcontribcol --config ...`,
+reaching `"Everything is ready. Begin running and processing data."`),
+in both cases using the same multi-`--config` merge the container
+actually uses (base `config.yaml` + `standalone-config.yaml` + this
+fragment).
 
 ## Overriding base components via `CUSTOM_OTELCOL_CONFIG_FILE`
 

--- a/packages/otel-collector/builder-config.yaml
+++ b/packages/otel-collector/builder-config.yaml
@@ -51,6 +51,9 @@ receivers:
   - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
       v__OTEL_COLLECTOR_VERSION__
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
+      v__OTEL_COLLECTOR_VERSION__
 
 processors:
   # Core


### PR DESCRIPTION
## Summary

Adds the OpenTelemetry `statsdreceiver` to HyperDX's custom collector build, so users can ingest StatsD metrics directly without a separate bridge. Purely additive/opt-in — no default pipeline or behavior changes.

The docs call out one real limitation from upstream: this receiver keeps aggregation state per-instance with no cross-replica coordination, so it shouldn't be wired into HyperDX's multi-replica `otel-collector` Deployment — it needs a dedicated single-replica instance.

## Test plan

- Built the collector and confirmed `statsdreceiver` wasn't previously compiled in, then confirmed it's present after the change (`otelcontribcol components`).
- Validated the documented config against the compiled binary and actually started the collector with it (reached "Everything is ready"), not just `validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
