### PR TITLE
feat(app): show live ClickHouse query progress during a search

### DIFF
--- a/.changeset/live-query-progress.md
+++ b/.changeset/live-query-progress.md
@@ -1,0 +1,12 @@
+---
+'@hyperdx/app': minor
+'@hyperdx/common-utils': minor
+---
+
+feat: show live ClickHouse query progress while a search runs
+
+The results table footer and the histogram's "Scanned Rows | Elapsed Time" strip
+now report rows read and percent complete as the query streams, measured against
+the whole selected date range rather than the window currently in flight.
+Requires ClickHouse 25.1+ (for `JSONEachRowWithProgress` metadata events); older
+servers keep the previous non-streaming behavior.

--- a/.changeset/proxy-stream-passthrough.md
+++ b/.changeset/proxy-stream-passthrough.md
@@ -1,0 +1,10 @@
+---
+'@hyperdx/api': patch
+---
+
+fix: flush ClickHouse proxy responses per chunk instead of buffering them
+
+The proxy now forwards each upstream chunk as it arrives, so streamed formats
+reach the browser incrementally, and it no longer attempts to write a 500 after
+the response has started (which threw `ERR_HTTP_HEADERS_SENT` from the proxy's
+error listener).

--- a/packages/api/src/routers/api/__tests__/clickhouseProxy.int.test.ts
+++ b/packages/api/src/routers/api/__tests__/clickhouseProxy.int.test.ts
@@ -29,6 +29,10 @@ describe('clickhouse-proxy body forwarding', () => {
   let upstream: http.Server;
   let upstreamUrl: string;
   let captured: CapturedRequest[] = [];
+  /** Set by a test to take over the upstream response (e.g. to stream it). */
+  let streamingHandler:
+    | ((req: http.IncomingMessage, res: http.ServerResponse) => void)
+    | undefined;
 
   beforeAll(async () => {
     await server.start();
@@ -43,6 +47,10 @@ describe('clickhouse-proxy body forwarding', () => {
           headers: req.headers,
           body: Buffer.concat(chunks),
         });
+        if (streamingHandler) {
+          streamingHandler(req, res);
+          return;
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ data: [] }));
       });
@@ -57,6 +65,7 @@ describe('clickhouse-proxy body forwarding', () => {
 
   beforeEach(() => {
     captured = [];
+    streamingHandler = undefined;
   });
 
   afterEach(async () => {
@@ -138,6 +147,98 @@ describe('clickhouse-proxy body forwarding', () => {
       String(Buffer.byteLength(body)),
     );
   });
+
+  /**
+   * ClickHouse streams query progress as its own tiny NDJSON lines, which the
+   * global `compression()` middleware would otherwise hold in zlib's input
+   * buffer until enough bytes accumulate.
+   *
+   * The upstream here refuses to finish the response until the client has seen
+   * its first chunk, so a proxy that buffers cannot complete this request at
+   * all — the test fails by timing out rather than by a timing assertion.
+   */
+  it('streams each upstream chunk to the client instead of buffering', async () => {
+    const { agent, team } = await getLoggedInAgent(server);
+    const connectionId = await createConnection(team._id.toString());
+
+    let onFirstChunkSeen: () => void = () => {};
+    const firstChunkSeen = new Promise<void>(resolve => {
+      onFirstChunkSeen = resolve;
+    });
+
+    streamingHandler = async (_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write(`{"progress":{"read_rows":"1"}}\n`);
+      await firstChunkSeen;
+      res.write(`{"row":{"n":1}}\n`);
+      res.end();
+    };
+
+    const body = await new Promise<string>((resolve, reject) => {
+      const received: string[] = [];
+      void agent
+        .post('/clickhouse-proxy/?query_id=test-streaming')
+        .set('x-hyperdx-connection-id', connectionId)
+        .set('Content-Type', 'text/plain')
+        .send('SELECT 1 FORMAT JSONEachRowWithProgress')
+        .buffer(false)
+        .parse((res, cb) => {
+          res.on('data', (chunk: Buffer) => {
+            received.push(chunk.toString());
+            onFirstChunkSeen();
+          });
+          res.on('error', cb);
+          res.on('end', () => cb(null, received.join('')));
+        })
+        .end((err, res) => (err ? reject(err) : resolve(res.body)));
+    });
+
+    expect(body).toBe('{"progress":{"read_rows":"1"}}\n{"row":{"n":1}}\n');
+  }, 10_000);
+
+  /**
+   * Once a streamed response is in flight the headers are already sent, so the
+   * proxy's error handler cannot write a 500 — attempting to would throw
+   * ERR_HTTP_HEADERS_SENT inside an event listener and take down the process.
+   * The request must fail cleanly instead, and the API must stay up.
+   */
+  it('survives an upstream failure after the response has started streaming', async () => {
+    const { agent, team } = await getLoggedInAgent(server);
+    const connectionId = await createConnection(team._id.toString());
+
+    let onFirstChunkSeen: () => void = () => {};
+    const firstChunkSeen = new Promise<void>(resolve => {
+      onFirstChunkSeen = resolve;
+    });
+
+    streamingHandler = async (_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write(`{"progress":{"read_rows":"1"}}\n`);
+      await firstChunkSeen;
+      // Kill the upstream connection mid-body.
+      res.socket?.destroy();
+    };
+
+    await expect(
+      new Promise((resolve, reject) => {
+        void agent
+          .post('/clickhouse-proxy/?query_id=test-midstream-failure')
+          .set('x-hyperdx-connection-id', connectionId)
+          .set('Content-Type', 'text/plain')
+          .send('SELECT 1 FORMAT JSONEachRowWithProgress')
+          .buffer(false)
+          .parse((res, cb) => {
+            res.on('data', () => onFirstChunkSeen());
+            res.on('error', cb);
+            res.on('end', () => cb(null, null));
+          })
+          .end((err, res) => (err ? reject(err) : resolve(res)));
+      }),
+    ).rejects.toBeDefined();
+
+    // The API is still serving, i.e. the error handler did not throw.
+    await agent.get('/health').expect(200);
+  }, 10_000);
 
   it('rejects requests without a connection id header', async () => {
     const { agent } = await getLoggedInAgent(server);

--- a/packages/api/src/routers/api/clickhouseProxy.ts
+++ b/packages/api/src/routers/api/clickhouseProxy.ts
@@ -279,6 +279,9 @@ const proxyMiddleware: RequestHandler =
         }
       },
       proxyRes: (proxyRes, _req, res) => {
+        // Installed before http-proxy pipes the upstream response into `res`.
+        flushEachChunk(res as Response);
+
         const startedAt = (res as Response).locals?.hdxProxyStartedAt;
         const statusCode = proxyRes.statusCode ?? 0;
         recordOperationOutcome({
@@ -318,10 +321,25 @@ const proxyMiddleware: RequestHandler =
             typeof startedAt === 'number' ? performance.now() - startedAt : 0,
         });
         console.error('Proxy error:', err);
-        (_res as Response).writeHead(500, {
+
+        const res = _res as Response;
+
+        // A streamed response (query progress, or any large result set) has
+        // already sent its status line and headers by the time an upstream
+        // failure can occur. Writing a 500 then throws ERR_HTTP_HEADERS_SENT
+        // from inside this listener — an uncaught exception that takes down
+        // the process in dev. Once the body is in flight the only way to
+        // signal failure is to break the connection, leaving the client with
+        // a truncated response.
+        if (res.headersSent) {
+          res.destroy(err);
+          return;
+        }
+
+        res.writeHead(500, {
           'Content-Type': 'application/json',
         });
-        _res.end(
+        res.end(
           JSON.stringify({
             success: false,
             error: err.message || 'Failed to connect to ClickHouse server',
@@ -338,6 +356,37 @@ const proxyMiddleware: RequestHandler =
 const markProxyStart: RequestHandler = (_req, res, next) => {
   res.locals.hdxProxyStartedAt = performance.now();
   next();
+};
+
+/**
+ * Forces each proxied chunk out through the global `compression()` middleware
+ * instead of letting it sit in zlib's input buffer.
+ *
+ * ClickHouse streams query progress as its own tiny NDJSON lines (a few dozen
+ * bytes each, via `JSONEachRowWithProgress`). Without an explicit flush, zlib
+ * holds them until enough bytes accumulate — typically until the first block of
+ * result rows arrives — which defeats the point of streaming progress at all.
+ * Row data only appears to stream today because those chunks are already large
+ * enough to spill the buffer on their own.
+ *
+ * The cost is a gzip flush point per chunk, which slightly reduces the
+ * compression ratio; responsiveness matters more here than a few percent of
+ * bandwidth.
+ */
+const flushEachChunk = (res: Response): void => {
+  // `flush` is installed by the compression middleware; absent if a response
+  // is not being compressed, in which case chunks already go straight out.
+  const flush = (res as Response & { flush?: () => void }).flush;
+  if (typeof flush !== 'function') {
+    return;
+  }
+
+  const write = res.write.bind(res);
+  res.write = ((...args: Parameters<Response['write']>) => {
+    const result = write(...args);
+    flush.call(res);
+    return result;
+  }) as Response['write'];
 };
 
 router.get(

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -93,6 +93,7 @@ import { DBTimeChart, type SeriesGroupFilter } from '@/components/DBTimeChart';
 import EmptyState from '@/components/EmptyState';
 import { ErrorBoundary } from '@/components/Error/ErrorBoundary';
 import { FavoriteButton } from '@/components/FavoriteButton';
+import { HistogramQueryProgress } from '@/components/HistogramQueryProgress';
 import ResourceTerraformPopover from '@/components/Iac/ResourceTerraformPopover';
 import { InputControlled } from '@/components/InputControlled';
 import OnboardingModal from '@/components/OnboardingModal';
@@ -356,6 +357,9 @@ export function SearchNumRows({
   searchElapsedMs,
   isSearching,
   isLiveTail = false,
+  histogramConfig,
+  queryKeyPrefix,
+  enableParallelQueries,
 }: {
   config: ChartConfigWithDateRange;
   sqlConfig?: ChartConfigWithDateRange;
@@ -363,6 +367,10 @@ export function SearchNumRows({
   searchElapsedMs: number | null;
   isSearching: boolean;
   isLiveTail?: boolean;
+  /** Histogram config, used to surface that query's live progress. */
+  histogramConfig?: BuilderChartConfigWithDateRange;
+  queryKeyPrefix?: string;
+  enableParallelQueries?: boolean;
 }) {
   const [statsOpened, { open: openStats, close: closeStats }] =
     useDisclosure(false);
@@ -418,6 +426,16 @@ export function SearchNumRows({
                 : `Elapsed Time: ${formatDurationMs(searchElapsedMs!)}`}
             </Text>
           </>
+        )}
+        {/* Suppressed during live tail, where the histogram refetches every
+            few seconds and a bar would only flicker — the same reason the
+            elapsed readout keeps its previous value there. */}
+        {histogramConfig != null && queryKeyPrefix != null && !isLiveTail && (
+          <HistogramQueryProgress
+            config={histogramConfig}
+            queryKeyPrefix={queryKeyPrefix}
+            enableParallelQueries={enableParallelQueries}
+          />
         )}
         {/* The generated-SQL preview is derived purely from config, not the
             explain query, so it renders unconditionally. Gating it on explain
@@ -2472,6 +2490,8 @@ export function DBSearchPage() {
                           searchElapsedMs={searchElapsedMs}
                           isSearching={isAnyQueryFetching}
                           isLiveTail={isLive ?? false}
+                          histogramConfig={histogramTimeChartConfig}
+                          queryKeyPrefix={QUERY_KEY_PREFIX}
                         />
                       </Group>
                     </Box>
@@ -2491,6 +2511,7 @@ export function DBSearchPage() {
                           queryKeyPrefix={QUERY_KEY_PREFIX}
                           onTimeRangeSelect={handleTimeRangeSelect}
                           onFocusSeries={handleFocusSeries}
+                          reportProgress
                         />
                       </Box>
                     )}
@@ -2571,6 +2592,9 @@ export function DBSearchPage() {
                               searchElapsedMs={searchElapsedMs}
                               isSearching={isAnyQueryFetching}
                               isLiveTail={isLive ?? false}
+                              histogramConfig={histogramTimeChartConfig}
+                              queryKeyPrefix={QUERY_KEY_PREFIX}
+                              enableParallelQueries
                             />
                           </Group>
                         </Group>
@@ -2592,6 +2616,7 @@ export function DBSearchPage() {
                             onTimeRangeSelect={handleTimeRangeSelect}
                             onFocusSeries={handleFocusSeries}
                             enableParallelQueries
+                            reportProgress
                           />
                         </Box>
                       )}

--- a/packages/app/src/DBSearchPage.tsx
+++ b/packages/app/src/DBSearchPage.tsx
@@ -330,11 +330,13 @@ function SearchResultsCountGroup({
   onExpandFilters,
   histogramTimeChartConfig,
   enableParallelQueries,
+  reportProgress,
 }: {
   isFilterSidebarCollapsed: boolean;
   onExpandFilters: () => void;
   histogramTimeChartConfig: BuilderChartConfigWithDateRange;
   enableParallelQueries?: boolean;
+  reportProgress?: boolean;
 }) {
   return (
     <Group gap={4} align="center">
@@ -345,6 +347,7 @@ function SearchResultsCountGroup({
         config={histogramTimeChartConfig}
         queryKeyPrefix={QUERY_KEY_PREFIX}
         enableParallelQueries={enableParallelQueries}
+        reportProgress={reportProgress}
       />
     </Group>
   );
@@ -2479,6 +2482,7 @@ export function DBSearchPage() {
                             setIsFilterSidebarCollapsed(false)
                           }
                           histogramTimeChartConfig={histogramTimeChartConfig}
+                          reportProgress
                         />
                         <SearchNumRows
                           config={{
@@ -2574,6 +2578,7 @@ export function DBSearchPage() {
                             }
                             histogramTimeChartConfig={histogramTimeChartConfig}
                             enableParallelQueries
+                            reportProgress
                           />
                           <Group gap="sm" align="center">
                             {shouldShowLiveModeHint &&

--- a/packages/app/src/__tests__/useSearchTelemetry.test.tsx
+++ b/packages/app/src/__tests__/useSearchTelemetry.test.tsx
@@ -17,6 +17,23 @@ let mockExplainData: unknown[] | undefined = undefined;
 let mockExplainIsLoading = false;
 let mockExplainError: Error | null = null;
 
+let mockHistogramProgress:
+  | { percent?: number; readRows: number; readBytes: number; elapsedMs: number }
+  | undefined = undefined;
+
+jest.mock('@/components/SearchTotalCountChart', () => ({
+  __esModule: true,
+  default: () => <div />,
+  useSearchTotalCount: () => ({
+    totalCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    isTotalCountComplete: true,
+    progress: mockHistogramProgress,
+  }),
+}));
+
 jest.mock('@/hooks/useExplainQuery', () => ({
   useExplainQuery: () => ({
     data: mockExplainData,
@@ -308,6 +325,7 @@ describe('SearchNumRows', () => {
     mockExplainData = undefined;
     mockExplainIsLoading = false;
     mockExplainError = null;
+    mockHistogramProgress = undefined;
   });
 
   it('renders nothing when enabled=false', () => {
@@ -554,5 +572,91 @@ describe('SearchNumRows', () => {
       screen.queryByText('Generated SQL (Timeline)'),
     ).not.toBeInTheDocument();
     expect(lastSQLPreviewConfig).toEqual(rowsConfig);
+  });
+  describe('histogram progress', () => {
+    const histogramConfig = { ...baseConfig };
+
+    it('shows the histogram progress while the chart query runs', () => {
+      mockHistogramProgress = {
+        percent: 42,
+        readRows: 1234,
+        readBytes: 5678,
+        elapsedMs: 1000,
+      };
+
+      renderWithMantine(
+        <SearchNumRows
+          config={baseConfig}
+          enabled
+          searchElapsedMs={null}
+          isSearching
+          histogramConfig={histogramConfig}
+          queryKeyPrefix="test"
+        />,
+      );
+
+      expect(screen.getByText(/42%/)).toBeInTheDocument();
+      expect(screen.getByText(/1,234 rows read/)).toBeInTheDocument();
+    });
+
+    it('shows nothing once the histogram query has finished', () => {
+      mockHistogramProgress = undefined;
+
+      renderWithMantine(
+        <SearchNumRows
+          config={baseConfig}
+          enabled
+          searchElapsedMs={200}
+          isSearching={false}
+          histogramConfig={histogramConfig}
+          queryKeyPrefix="test"
+        />,
+      );
+
+      expect(screen.queryByText(/rows read/)).not.toBeInTheDocument();
+    });
+
+    it('is suppressed during live tail', () => {
+      mockHistogramProgress = {
+        percent: 42,
+        readRows: 1234,
+        readBytes: 5678,
+        elapsedMs: 1000,
+      };
+
+      renderWithMantine(
+        <SearchNumRows
+          config={baseConfig}
+          enabled
+          searchElapsedMs={200}
+          isSearching
+          isLiveTail
+          histogramConfig={histogramConfig}
+          queryKeyPrefix="test"
+        />,
+      );
+
+      expect(screen.queryByText(/rows read/)).not.toBeInTheDocument();
+    });
+
+    it('shows nothing when no histogram config is provided', () => {
+      mockHistogramProgress = {
+        percent: 42,
+        readRows: 1234,
+        readBytes: 5678,
+        elapsedMs: 1000,
+      };
+
+      renderWithMantine(
+        <SearchNumRows
+          config={baseConfig}
+          enabled
+          searchElapsedMs={null}
+          isSearching
+        />,
+      );
+
+      expect(screen.queryByText(/rows read/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/app/src/components/DBRowTable.tsx
+++ b/packages/app/src/components/DBRowTable.tsx
@@ -72,6 +72,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 
 import api from '@/api';
 import { useChartSyncId } from '@/chartSync';
+import { QueryProgressIndicator } from '@/components/QueryProgressIndicator';
 import { searchChartConfigDefaults } from '@/defaults';
 import {
   useAliasMapFromChartConfig,
@@ -102,6 +103,7 @@ import {
   useLocalStorage,
   usePrevious,
 } from '@/utils';
+import type { QueryProgressSummary } from '@/utils/queryProgress';
 
 import ChartErrorState, {
   ChartErrorStateVariant,
@@ -355,6 +357,7 @@ export const RawLogTable = memo(
     columnTypeMap,
     dateRange,
     loadingDate,
+    progress,
     config,
     onChildModalOpen,
     renderRowDetails,
@@ -391,6 +394,8 @@ export const RawLogTable = memo(
     errorVariant?: ChartErrorStateVariant;
     dateRange?: [Date, Date];
     loadingDate?: Date;
+    /** Live ClickHouse scan progress for the in-flight query, when available. */
+    progress?: QueryProgressSummary;
     config?: BuilderChartConfigWithDateRange;
     onChildModalOpen?: (open: boolean) => void;
     source?: TSource;
@@ -1248,38 +1253,44 @@ export const RawLogTable = memo(
                       )}
                     >
                       {isLoading ? (
-                        <div className="my-3">
-                          <div className="d-inline-block">
-                            <IconRefresh size={14} className="spin-animate" />
-                          </div>{' '}
-                          {loadingDate != null && (
-                            <>
-                              Searched <FormatTime value={loadingDate} />.{' '}
-                            </>
+                        <div className="my-3 d-flex flex-column align-items-center">
+                          <div>
+                            <div className="d-inline-block">
+                              <IconRefresh size={14} className="spin-animate" />
+                            </div>{' '}
+                            {loadingDate != null && (
+                              <>
+                                Searched <FormatTime value={loadingDate} />.{' '}
+                              </>
+                            )}
+                            Loading results
+                            {dateRange?.[0] != null &&
+                            dateRange?.[1] != null ? (
+                              <>
+                                {' '}
+                                across{' '}
+                                {formatDistance(
+                                  dateRange?.[1],
+                                  dateRange?.[0],
+                                )}{' '}
+                                {'('}
+                                <FormatTime
+                                  value={dateRange?.[0]}
+                                  format="withYear"
+                                />{' '}
+                                to{' '}
+                                <FormatTime
+                                  value={dateRange?.[1]}
+                                  format="withYear"
+                                />
+                                {')'}
+                              </>
+                            ) : null}
+                            ...
+                          </div>
+                          {progress != null && (
+                            <QueryProgressIndicator progress={progress} />
                           )}
-                          Loading results
-                          {dateRange?.[0] != null && dateRange?.[1] != null ? (
-                            <>
-                              {' '}
-                              across{' '}
-                              {formatDistance(
-                                dateRange?.[1],
-                                dateRange?.[0],
-                              )}{' '}
-                              {'('}
-                              <FormatTime
-                                value={dateRange?.[0]}
-                                format="withYear"
-                              />{' '}
-                              to{' '}
-                              <FormatTime
-                                value={dateRange?.[1]}
-                                format="withYear"
-                              />
-                              {')'}
-                            </>
-                          ) : null}
-                          ...
                         </div>
                       ) : hasNextPage == false &&
                         isLoading == false &&
@@ -1610,14 +1621,22 @@ function DBSqlRowTableComponent({
 
   const mergedConfig = useConfigWithAdditionalSelect(mergedConfigObj, sourceId);
 
-  const { data, fetchNextPage, hasNextPage, isFetching, isError, error } =
-    useOffsetPaginatedQuery(mergedConfig ?? config, {
-      enabled:
-        enabled && mergedConfig != null && getSelectLength(config.select) > 0,
-      isLive,
-      queryKeyPrefix,
-      enableSmallFirstWindow,
-    });
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isError,
+    error,
+    progress,
+  } = useOffsetPaginatedQuery(mergedConfig ?? config, {
+    enabled:
+      enabled && mergedConfig != null && getSelectLength(config.select) > 0,
+    isLive,
+    queryKeyPrefix,
+    enableSmallFirstWindow,
+    reportProgress: true,
+  });
 
   // The first N columns are the select columns from the user
   // We can't use names as CH may rewrite the names
@@ -1856,6 +1875,7 @@ function DBSqlRowTableComponent({
         columnTypeMap={columnMap}
         dateRange={config.dateRange}
         loadingDate={loadingDate}
+        progress={progress}
         config={mergedConfigObj}
         onChildModalOpen={onChildModalOpen}
         source={source}

--- a/packages/app/src/components/DBTimeChart.tsx
+++ b/packages/app/src/components/DBTimeChart.tsx
@@ -296,6 +296,12 @@ type DBTimeChartComponentProps = {
   disableDrillDown?: boolean;
   enableParallelQueries?: boolean;
   enabled?: boolean;
+  /**
+   * Stream the chart query so ClickHouse progress events are recorded for the
+   * shared query key. Consumers read the progress with `useSearchTotalCount`
+   * (which shares this key) rather than from the chart itself.
+   */
+  reportProgress?: boolean;
   logReferenceTimestamp?: number;
   onSettled?: () => void;
   onTimeRangeSelect?: (start: Date, end: Date) => void;
@@ -332,6 +338,7 @@ function DBTimeChartComponent({
   disableDrillDown,
   enableParallelQueries,
   enabled = true,
+  reportProgress,
   logReferenceTimestamp,
   onTimeRangeSelect,
   queryKeyPrefix,
@@ -487,6 +494,7 @@ function DBTimeChartComponent({
       enableQueryChunking: !disableQueryChunking,
       enableParallelQueries:
         enableParallelQueries && me?.team?.parallelizeWhenPossible,
+      reportProgress,
     });
 
   const previousPeriodChartConfig: ChartConfigWithDateRange = useMemo(() => {

--- a/packages/app/src/components/HistogramQueryProgress.tsx
+++ b/packages/app/src/components/HistogramQueryProgress.tsx
@@ -1,0 +1,41 @@
+import { BuilderChartConfigWithDateRange } from '@hyperdx/common-utils/dist/types';
+import { Text } from '@mantine/core';
+
+import { QueryProgressIndicator } from '@/components/QueryProgressIndicator';
+import { useSearchTotalCount } from '@/components/SearchTotalCountChart';
+
+/**
+ * Live progress for the search page's histogram query, shown beside "Scanned
+ * Rows" and "Elapsed Time" while the chart is still loading.
+ *
+ * Reads the same query as the histogram chart and the results counter — the
+ * three share a query key, so react-query serves all of them from one
+ * ClickHouse request and this adds none of its own.
+ */
+export function HistogramQueryProgress({
+  config,
+  queryKeyPrefix,
+  enableParallelQueries,
+}: {
+  config: BuilderChartConfigWithDateRange;
+  queryKeyPrefix: string;
+  enableParallelQueries?: boolean;
+}) {
+  const { progress } = useSearchTotalCount(config, queryKeyPrefix, {
+    enableParallelQueries,
+    reportProgress: true,
+  });
+
+  if (progress == null) {
+    return null;
+  }
+
+  return (
+    <>
+      <Text size="xs" c="dimmed">
+        |
+      </Text>
+      <QueryProgressIndicator progress={progress} variant="inline" />
+    </>
+  );
+}

--- a/packages/app/src/components/QueryProgressIndicator.tsx
+++ b/packages/app/src/components/QueryProgressIndicator.tsx
@@ -1,0 +1,90 @@
+import { memo } from 'react';
+import { NumericUnit } from '@hyperdx/common-utils/dist/types';
+import { Box, Group, Progress, Text } from '@mantine/core';
+
+import { formatDurationMs, formatNumber } from '@/utils';
+import type { QueryProgressSummary } from '@/utils/queryProgress';
+
+function formatRows(readRows: number): string {
+  return formatNumber(readRows, { output: 'number', thousandSeparated: true });
+}
+
+function formatBytes(readBytes: number): string {
+  return formatNumber(readBytes, {
+    output: 'byte',
+    numericUnit: NumericUnit.BytesIEC,
+    mantissa: 1,
+  });
+}
+
+export type QueryProgressIndicatorProps = {
+  progress: QueryProgressSummary;
+  /**
+   * `block` stacks a full-width bar over its detail text, for the results
+   * footer. `inline` is a short bar with a terse label, for the stats strip
+   * beside "Scanned Rows" and "Elapsed Time".
+   */
+  variant?: 'block' | 'inline';
+};
+
+/**
+ * Renders live ClickHouse scan progress for an in-flight query.
+ *
+ * The bar is indeterminate until the server reports a `total_rows_to_read`
+ * estimate for at least one window, which it does not do on the first ticks of
+ * a query.
+ */
+function QueryProgressIndicatorComponent({
+  progress,
+  variant = 'block',
+}: QueryProgressIndicatorProps) {
+  const { percent, readRows, readBytes, elapsedMs } = progress;
+  const isIndeterminate = percent == null;
+  const percentLabel = percent != null ? `${Math.floor(percent)}%` : undefined;
+
+  if (variant === 'inline') {
+    return (
+      <Group gap="xxs" align="center" wrap="nowrap">
+        <Progress
+          value={percent ?? 100}
+          animated={isIndeterminate}
+          size="xs"
+          w={72}
+          color="gray.6"
+          aria-label="Query progress"
+        />
+        <Text size="xs" c="dimmed">
+          {[percentLabel, `${formatRows(readRows)} rows read`]
+            .filter(Boolean)
+            .join(' · ')}
+        </Text>
+      </Group>
+    );
+  }
+
+  return (
+    <Box w="100%" maw={420} mt="xxs">
+      <Progress
+        value={percent ?? 100}
+        animated={isIndeterminate}
+        size="xs"
+        color="gray.6"
+        aria-label="Query progress"
+      />
+      <Group gap="xs" justify="center" mt={4}>
+        <Text c="dimmed" size="xxs">
+          {[
+            `Read ${formatRows(readRows)} rows`,
+            readBytes > 0 ? formatBytes(readBytes) : undefined,
+            formatDurationMs(elapsedMs),
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+          {percentLabel != null ? ` (${percentLabel})` : ''}
+        </Text>
+      </Group>
+    </Box>
+  );
+}
+
+export const QueryProgressIndicator = memo(QueryProgressIndicatorComponent);

--- a/packages/app/src/components/SearchTotalCountChart.tsx
+++ b/packages/app/src/components/SearchTotalCountChart.tsx
@@ -99,11 +99,18 @@ export default function SearchTotalCountChart({
   queryKeyPrefix,
   disableQueryChunking,
   enableParallelQueries,
+  reportProgress,
 }: {
   config: BuilderChartConfigWithDateRange;
   queryKeyPrefix: string;
   disableQueryChunking?: boolean;
   enableParallelQueries?: boolean;
+  /**
+   * Must match every other observer of this query key. `reportProgress` is not
+   * part of the key, so whichever observer wins the deduplicated fetch decides
+   * whether progress is emitted at all — and this one renders first.
+   */
+  reportProgress?: boolean;
 }) {
   const { totalCount, isLoading, isError } = useSearchTotalCount(
     config,
@@ -111,6 +118,7 @@ export default function SearchTotalCountChart({
     {
       disableQueryChunking,
       enableParallelQueries,
+      reportProgress,
     },
   );
 

--- a/packages/app/src/components/SearchTotalCountChart.tsx
+++ b/packages/app/src/components/SearchTotalCountChart.tsx
@@ -30,9 +30,16 @@ export function useSearchTotalCount(
   {
     disableQueryChunking,
     enableParallelQueries,
+    reportProgress,
   }: {
     disableQueryChunking?: boolean;
     enableParallelQueries?: boolean;
+    /**
+     * Stream the query so ClickHouse progress is recorded and returned as
+     * `progress`. DBTimeChart shares this query key, so it must request
+     * streaming too — either observer's queryFn may be the one that runs.
+     */
+    reportProgress?: boolean;
   } = {},
 ) {
   const { data: me, isLoading: isLoadingMe } = api.useMe();
@@ -47,6 +54,7 @@ export function useSearchTotalCount(
     isLoading,
     isError,
     error,
+    progress,
   } = useQueriedChartConfig(queriedConfig, {
     queryKey: [
       queryKeyPrefix,
@@ -63,6 +71,7 @@ export function useSearchTotalCount(
     placeholderData: keepPreviousData, // no need to flash loading state when in live tail
     enableQueryChunking: true,
     enabled: !isLoadingMe,
+    reportProgress,
   });
 
   const isTotalCountComplete = !!totalCountData?.isComplete;
@@ -81,6 +90,7 @@ export function useSearchTotalCount(
     isError,
     error,
     isTotalCountComplete,
+    progress,
   };
 }
 

--- a/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
+++ b/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
@@ -1355,7 +1355,9 @@ describe('useChartConfig', () => {
 
       // Report half-scanned progress for each chunk before it resolves, and
       // hold the last one open so the in-flight state is observable.
-      let releaseLastChunk: (value: any) => void = () => {};
+      let releaseLastChunk: (
+        value: ResponseJSON<Record<string, string>>,
+      ) => void = () => {};
       const halfway = {
         read_rows: '50',
         read_bytes: '500',

--- a/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
+++ b/packages/app/src/hooks/__tests__/useChartConfig.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { ResponseJSON } from '@hyperdx/common-utils/dist/clickhouse';
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/browser';
 import { isBuilderChartConfig } from '@hyperdx/common-utils/dist/guards';
@@ -17,6 +17,7 @@ import {
   getGranularityAlignedTimeWindows,
   useQueriedChartConfig,
 } from '@/hooks/useChartConfig';
+import { queryChartConfigWithProgress } from '@/hooks/useChartConfig/queryChartConfigWithProgress';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
 
 // Mock DEFAULT_TIME_WINDOWS_SECONDS to remove the 15m window
@@ -54,6 +55,8 @@ jest.mock('@/metadata', () => ({
   getMetadata: jest.fn(() => ({
     sources: [],
     connections: {},
+    // Recent enough for JSONEachRowWithProgress to carry meta/exception.
+    getServerVersion: jest.fn().mockResolvedValue([26, 5, 0, 0]),
   })),
 }));
 
@@ -61,6 +64,17 @@ jest.mock('@/metadata', () => ({
 jest.mock('@/config', () => ({
   IS_MTVIEWS_ENABLED: false,
 }));
+
+// Spy on the chart query helper while keeping its real behavior (which
+// delegates to the mocked clickhouse client unless progress is requested).
+jest.mock('@/hooks/useChartConfig/queryChartConfigWithProgress', () => {
+  const actual = jest.requireActual(
+    '@/hooks/useChartConfig/queryChartConfigWithProgress',
+  );
+  return {
+    queryChartConfigWithProgress: jest.fn(actual.queryChartConfigWithProgress),
+  };
+});
 
 // Mock the MV optimization module
 jest.mock('../useMVOptimizationExplanation', () => ({
@@ -1334,6 +1348,74 @@ describe('useChartConfig', () => {
 
       return { config, mockResponse1, mockResponse2, mockResponse3 };
     };
+
+    it('aggregates progress across parallel chunks and clears it when done', async () => {
+      const { config, mockResponse1, mockResponse2, mockResponse3 } =
+        setupParallelQueries();
+
+      // Report half-scanned progress for each chunk before it resolves, and
+      // hold the last one open so the in-flight state is observable.
+      let releaseLastChunk: (value: any) => void = () => {};
+      const halfway = {
+        read_rows: '50',
+        read_bytes: '500',
+        total_rows_to_read: '100',
+        elapsed_ns: '1',
+      };
+      jest
+        .mocked(queryChartConfigWithProgress)
+        .mockImplementationOnce(async ({ onProgress }) => {
+          onProgress?.(halfway);
+          return mockResponse1;
+        })
+        .mockImplementationOnce(async ({ onProgress }) => {
+          onProgress?.(halfway);
+          return mockResponse2;
+        })
+        .mockImplementationOnce(async ({ onProgress }) => {
+          onProgress?.(halfway);
+          return new Promise(resolve => {
+            releaseLastChunk = resolve;
+          });
+        });
+
+      const { result } = renderHook(
+        () =>
+          useQueriedChartConfig(config, {
+            enableQueryChunking: true,
+            enableParallelQueries: true,
+            reportProgress: true,
+          }),
+        { wrapper },
+      );
+
+      // The 24h range splits into 6h/6h/12h windows (see the searchWindows
+      // mock). Two finished chunks plus the third half-scanned:
+      // (6 + 6 + 12 * 0.5) / 24.
+      await waitFor(() =>
+        expect(result.current.progress?.percent).toBeCloseTo(75, 5),
+      );
+      expect(result.current.progress?.readRows).toBe(150);
+
+      await act(async () => {
+        releaseLastChunk(mockResponse3);
+      });
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+      expect(result.current.progress).toBeUndefined();
+    });
+
+    it('does not stream when reportProgress is not set', async () => {
+      const { config, mockResponse1 } = setupParallelQueries();
+      mockClickhouseClient.queryChartConfig.mockResolvedValue(mockResponse1);
+
+      const { result } = renderHook(() => useQueriedChartConfig(config), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.progress).toBeUndefined();
+    });
 
     it('fetches data in parallel when enableParallelQueries is true', async () => {
       const { config, mockResponse1, mockResponse2, mockResponse3 } =

--- a/packages/app/src/hooks/__tests__/useOffsetPaginatedQuery.test.tsx
+++ b/packages/app/src/hooks/__tests__/useOffsetPaginatedQuery.test.tsx
@@ -101,7 +101,7 @@ describe('useOffsetPaginatedQuery', () => {
   let mockClickhouseClient: any;
   let mockStream: any;
   let mockReader: any;
-  let mockMetadata: { getSetting: jest.Mock };
+  let mockMetadata: { getSetting: jest.Mock; getServerVersion: jest.Mock };
 
   beforeEach(() => {
     // Reset mocks
@@ -153,6 +153,8 @@ describe('useOffsetPaginatedQuery', () => {
     // Mock metadata with getSetting returning null by default
     mockMetadata = {
       getSetting: jest.fn().mockResolvedValue(null),
+      // Recent enough for JSONEachRowWithProgress to carry meta/exception.
+      getServerVersion: jest.fn().mockResolvedValue([25, 1, 0, 0]),
     };
     jest.mocked(useMetadataWithSettings).mockReturnValue(mockMetadata as any);
   });
@@ -1171,6 +1173,326 @@ describe('useOffsetPaginatedQuery', () => {
       ).toBeTruthy();
 
       expect(result2.current.data?.data).toHaveLength(1);
+    });
+  });
+  describe('Progress reporting (reportProgress)', () => {
+    const PROGRESS = {
+      read_rows: '5000',
+      read_bytes: '120000',
+      total_rows_to_read: '20000',
+      elapsed_ns: '250000000',
+    };
+
+    it('keeps the compact format and reports no progress by default', async () => {
+      const config = createMockChartConfig();
+
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ['Body'] },
+            { json: () => ['String'] },
+            { json: () => ['hello'] },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true });
+
+      const { result } = renderHook(() => useOffsetPaginatedQuery(config), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'JSONCompactEachRowWithNamesAndTypes',
+        }),
+      );
+      expect(mockMetadata.getServerVersion).not.toHaveBeenCalled();
+      expect(result.current.progress).toBeUndefined();
+    });
+
+    it('requests the progress format on ClickHouse >= 25.1', async () => {
+      const config = createMockChartConfig();
+
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ({ meta: [{ name: 'Body', type: 'String' }] }) },
+            { json: () => ({ row: { Body: 'hello' } }) },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true });
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({ format: 'JSONEachRowWithProgress' }),
+      );
+      expect(result.current.data?.data).toEqual([{ Body: 'hello' }]);
+      expect(result.current.data?.meta).toEqual([
+        { name: 'Body', type: 'String' },
+      ]);
+    });
+
+    it('falls back to the compact format on ClickHouse < 25.1', async () => {
+      mockMetadata.getServerVersion.mockResolvedValue([24, 12, 0, 0]);
+      const config = createMockChartConfig();
+
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ['Body'] },
+            { json: () => ['String'] },
+            { json: () => ['hello'] },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true });
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'JSONCompactEachRowWithNamesAndTypes',
+        }),
+      );
+      expect(result.current.data?.data).toEqual([{ Body: 'hello' }]);
+    });
+
+    it('falls back to the compact format when the version is unknown', async () => {
+      mockMetadata.getServerVersion.mockResolvedValue(undefined);
+      const config = createMockChartConfig();
+
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [{ json: () => ['Body'] }, { json: () => ['String'] }],
+        })
+        .mockResolvedValueOnce({ done: true });
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockClickhouseClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'JSONCompactEachRowWithNamesAndTypes',
+        }),
+      );
+    });
+
+    it('exposes progress while streaming and clears it once settled', async () => {
+      const config = createMockChartConfig();
+      let releaseSecondRead: (value: unknown) => void = () => {};
+
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ({ meta: [{ name: 'Body', type: 'String' }] }) },
+            { json: () => ({ progress: PROGRESS }) },
+          ],
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseSecondRead = resolve;
+            }),
+        );
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      // 24h range, 15m first window, a quarter of the way through it:
+      // 15m * 0.25 / 24h. The in-flight window must be counted once, even
+      // though incremental streaming also pushed a placeholder page for it.
+      await waitFor(() =>
+        expect(result.current.progress).toEqual({
+          percent: expect.closeTo(((15 * 0.25) / (24 * 60)) * 100, 5),
+          readRows: 5000,
+          readBytes: 120000,
+          elapsedMs: expect.any(Number),
+        }),
+      );
+
+      await act(async () => {
+        releaseSecondRead({ done: true });
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.progress).toBeUndefined();
+    });
+
+    it('accumulates coverage across windows instead of restarting per page', async () => {
+      const config = createMockChartConfig({
+        dateRange: [
+          new Date('2024-01-01T00:00:00Z'),
+          new Date('2024-01-02T00:00:00Z'),
+        ] as [Date, Date],
+      });
+
+      // Window 0 (the last 15m) returns nothing, so pagination advances to
+      // window 1 (the preceding 6h), which streams progress and then stalls.
+      let releaseSecondWindow: (value: unknown) => void = () => {};
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ({ meta: [{ name: 'Body', type: 'String' }] }) },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true })
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            {
+              json: () => ({
+                progress: {
+                  read_rows: '500',
+                  read_bytes: '1000',
+                  total_rows_to_read: '1000',
+                  elapsed_ns: '1',
+                },
+              }),
+            },
+          ],
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseSecondWindow = resolve;
+            }),
+        );
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.progress).toBeUndefined();
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      // Window 0 (15m) fully covered, plus half of window 1 (6h), over 24h.
+      const expectedPercent = ((15 + 6 * 60 * 0.5) / (24 * 60)) * 100;
+      await waitFor(() =>
+        expect(result.current.progress?.percent).toBeCloseTo(
+          expectedPercent,
+          5,
+        ),
+      );
+
+      await act(async () => {
+        releaseSecondWindow({ done: true });
+      });
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+    });
+
+    it('keeps the bar visible across the gap between windows', async () => {
+      const config = createMockChartConfig({
+        dateRange: [
+          new Date('2024-01-01T00:00:00Z'),
+          new Date('2024-01-02T00:00:00Z'),
+        ] as [Date, Date],
+      });
+
+      // Window 0 reports progress and finishes. Window 1 then stalls before
+      // emitting anything, which is the moment the bar used to disappear.
+      let releaseSecondWindow: (value: unknown) => void = () => {};
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            {
+              json: () => ({
+                progress: {
+                  read_rows: '900',
+                  read_bytes: '9000',
+                  total_rows_to_read: '900',
+                  elapsed_ns: '1',
+                },
+              }),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true })
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseSecondWindow = resolve;
+            }),
+        );
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      // Window 1 has reported nothing yet, so this is entirely carried over
+      // from window 0: 15m of the 24h range, and its rows.
+      await waitFor(() => expect(result.current.isFetching).toBe(true));
+      expect(result.current.progress).toBeDefined();
+      expect(result.current.progress?.readRows).toBe(900);
+      expect(result.current.progress?.percent).toBeCloseTo(
+        (15 / (24 * 60)) * 100,
+        5,
+      );
+
+      await act(async () => {
+        releaseSecondWindow({ done: true });
+      });
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+    });
+
+    it('surfaces a mid-stream exception event as a query error', async () => {
+      const config = createMockChartConfig();
+
+      // Not `once`: the hook retries the query once before settling on error.
+      mockReader.read.mockResolvedValue({
+        done: false,
+        value: [
+          { json: () => ({ meta: [{ name: 'Body', type: 'String' }] }) },
+          { json: () => ({ exception: 'Code: 241. Memory limit exceeded' }) },
+        ],
+      });
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true), {
+        timeout: 5000,
+      });
+      expect(result.current.error).toBeInstanceOf(ClickHouseQueryError);
+      expect(result.current.error?.message).toContain('Memory limit exceeded');
+      expect(result.current.progress).toBeUndefined();
     });
   });
 });

--- a/packages/app/src/hooks/__tests__/useOffsetPaginatedQuery.test.tsx
+++ b/packages/app/src/hooks/__tests__/useOffsetPaginatedQuery.test.tsx
@@ -1470,6 +1470,71 @@ describe('useOffsetPaginatedQuery', () => {
       await waitFor(() => expect(result.current.isFetching).toBe(false));
     });
 
+    it('does not credit a whole window while it still has offset pages', async () => {
+      const config = createMockChartConfig({
+        dateRange: [
+          new Date('2024-01-01T00:00:00Z'),
+          new Date('2024-01-02T00:00:00Z'),
+        ] as [Date, Date],
+      });
+
+      // Window 0 (the last 15m) returns a row, so pagination asks for a
+      // further offset in that same window rather than moving on. The second
+      // request then stalls, leaving the window's credit observable.
+      let releaseSecondPage: (value: unknown) => void = () => {};
+      mockReader.read
+        .mockResolvedValueOnce({
+          done: false,
+          value: [
+            { json: () => ({ meta: [{ name: 'Body', type: 'String' }] }) },
+            {
+              json: () => ({
+                progress: {
+                  read_rows: '400',
+                  read_bytes: '4000',
+                  total_rows_to_read: '1600',
+                  elapsed_ns: '1',
+                },
+              }),
+            },
+            { json: () => ({ row: { Body: 'hello' } }) },
+          ],
+        })
+        .mockResolvedValueOnce({ done: true })
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseSecondPage = resolve;
+            }),
+        );
+
+      const { result } = renderHook(
+        () => useOffsetPaginatedQuery(config, { reportProgress: true }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+      await waitFor(() => expect(result.current.isFetching).toBe(true));
+
+      // A quarter of the 15m window over 24h — not the whole window, which
+      // would be (15 / (24 * 60)) * 100.
+      expect(result.current.progress?.percent).toBeCloseTo(
+        ((15 * 0.25) / (24 * 60)) * 100,
+        5,
+      );
+      // The finished request's rows are banked, not dropped.
+      expect(result.current.progress?.readRows).toBe(400);
+
+      await act(async () => {
+        releaseSecondPage({ done: true });
+      });
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+    });
+
     it('surfaces a mid-stream exception event as a query error', async () => {
       const config = createMockChartConfig();
 

--- a/packages/app/src/hooks/__tests__/useQueryProgress.test.tsx
+++ b/packages/app/src/hooks/__tests__/useQueryProgress.test.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  clearQueryProgress,
+  completeChunkProgress,
+  useQueryProgress,
+  writeChunkProgress,
+} from '@/hooks/useQueryProgress';
+
+const QUERY_KEY = ['search', 'abc'] as const;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function progressEvent(readRows: number, totalRows: number) {
+  return {
+    read_rows: String(readRows),
+    read_bytes: String(readRows * 10),
+    total_rows_to_read: String(totalRows),
+    elapsed_ns: '1',
+  };
+}
+
+describe('useQueryProgress', () => {
+  let queryClient: QueryClient;
+  let wrapper: React.FC<{ children: React.ReactNode }>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    queryClient.clear();
+  });
+
+  function renderProgress(initialActive: boolean) {
+    return renderHook(
+      ({ active }: { active: boolean }) =>
+        useQueryProgress({
+          queryKey: QUERY_KEY,
+          active,
+          totalRangeMs: 4 * ONE_HOUR_MS,
+        }),
+      { wrapper, initialProps: { active: initialActive } },
+    );
+  }
+
+  it('returns undefined until a chunk reports something', () => {
+    const { result } = renderProgress(true);
+    expect(result.current).toBeUndefined();
+  });
+
+  it('summarizes reported chunks against the whole range', () => {
+    const { result } = renderProgress(true);
+
+    act(() => {
+      writeChunkProgress(queryClient, QUERY_KEY, {
+        chunkId: 'window-0',
+        rangeMs: 2 * ONE_HOUR_MS,
+        progress: progressEvent(500, 1000),
+      });
+      jest.advanceTimersByTime(1);
+    });
+
+    // Half of a window covering half the range.
+    expect(result.current?.percent).toBeCloseTo(25, 5);
+    expect(result.current?.readRows).toBe(500);
+  });
+
+  it('hides progress as soon as the query stops fetching', () => {
+    const { result, rerender } = renderProgress(true);
+
+    act(() => {
+      writeChunkProgress(queryClient, QUERY_KEY, {
+        chunkId: 'window-0',
+        rangeMs: ONE_HOUR_MS,
+        progress: progressEvent(500, 1000),
+      });
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBeDefined();
+
+    rerender({ active: false });
+    expect(result.current).toBeUndefined();
+  });
+
+  describe('gaps between fetches', () => {
+    it('keeps accumulated progress across a short gap between windows', () => {
+      const { result, rerender } = renderProgress(true);
+
+      act(() => {
+        completeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+        });
+        writeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+          progress: progressEvent(800, 800),
+        });
+      });
+
+      // The gap between one window finishing and the next starting.
+      rerender({ active: false });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      rerender({ active: true });
+
+      // Window 0 still counts towards the 4h range, and its rows are intact,
+      // before the next window has reported anything.
+      expect(result.current?.percent).toBeCloseTo(25, 5);
+      expect(result.current?.readRows).toBe(800);
+    });
+
+    it('survives an arbitrarily long gap, since a rerun is what resets it', () => {
+      const { result, rerender } = renderProgress(true);
+
+      act(() => {
+        completeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+        });
+        jest.advanceTimersByTime(1);
+      });
+
+      // Scrolling for more results minutes later continues the same search.
+      rerender({ active: false });
+      act(() => {
+        jest.advanceTimersByTime(10 * 60 * 1000);
+      });
+      rerender({ active: true });
+
+      expect(result.current?.percent).toBeCloseTo(25, 5);
+      // The whole gap is idle time, not query time.
+      expect(result.current?.elapsedMs).toBeLessThan(1_000);
+    });
+
+    it('excludes the idle gap from the elapsed readout', () => {
+      const { result, rerender } = renderProgress(true);
+
+      act(() => {
+        writeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+          progress: progressEvent(500, 1000),
+        });
+      });
+
+      // 1s fetching, 1.5s idle between windows, then 1s fetching again.
+      act(() => {
+        jest.advanceTimersByTime(1_000);
+      });
+      rerender({ active: false });
+      act(() => {
+        jest.advanceTimersByTime(1_500);
+      });
+      rerender({ active: true });
+      act(() => {
+        jest.advanceTimersByTime(1_000);
+      });
+
+      expect(result.current?.elapsedMs).toBeGreaterThanOrEqual(2_000);
+      expect(result.current?.elapsedMs).toBeLessThan(2_500);
+    });
+  });
+
+  it('restarts from zero after clearQueryProgress', () => {
+    const { result, rerender } = renderProgress(true);
+
+    act(() => {
+      writeChunkProgress(queryClient, QUERY_KEY, {
+        chunkId: 'window-0',
+        rangeMs: ONE_HOUR_MS,
+        progress: progressEvent(500, 1000),
+      });
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current?.readRows).toBe(500);
+
+    // What a rerun does: drop the previous run's totals, then report afresh.
+    act(() => {
+      clearQueryProgress(queryClient, QUERY_KEY);
+      writeChunkProgress(queryClient, QUERY_KEY, {
+        chunkId: 'window-0',
+        rangeMs: ONE_HOUR_MS,
+        progress: progressEvent(10, 1000),
+      });
+      jest.advanceTimersByTime(1);
+    });
+    rerender({ active: true });
+
+    expect(result.current?.readRows).toBe(10);
+  });
+});

--- a/packages/app/src/hooks/__tests__/useQueryProgress.test.tsx
+++ b/packages/app/src/hooks/__tests__/useQueryProgress.test.tsx
@@ -91,6 +91,76 @@ describe('useQueryProgress', () => {
     expect(result.current).toBeUndefined();
   });
 
+  describe('several requests sharing one chunk', () => {
+    // A time window serves its results over multiple offset pages, each its
+    // own ClickHouse query reporting its own counters against the same chunk.
+
+    it('accumulates rows instead of replacing them', () => {
+      const { result, rerender } = renderProgress(true);
+
+      act(() => {
+        writeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+          progress: progressEvent(500, 1000),
+        });
+        completeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+          isChunkExhausted: false,
+        });
+        jest.advanceTimersByTime(1);
+      });
+      expect(result.current?.readRows).toBe(500);
+
+      // The next offset page against the same window.
+      act(() => {
+        writeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: ONE_HOUR_MS,
+          progress: progressEvent(300, 1000),
+        });
+        jest.advanceTimersByTime(1);
+      });
+      rerender({ active: true });
+
+      expect(result.current?.readRows).toBe(800);
+    });
+
+    it("withholds the chunk's full range until it is exhausted", () => {
+      const { result, rerender } = renderProgress(true);
+
+      // Half-scanned, and the page returned rows, so more offsets follow.
+      act(() => {
+        writeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: 2 * ONE_HOUR_MS,
+          progress: progressEvent(500, 1000),
+        });
+        completeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: 2 * ONE_HOUR_MS,
+          isChunkExhausted: false,
+        });
+        jest.advanceTimersByTime(1);
+      });
+
+      // Still only half of the 2h window across a 4h range, not all of it.
+      expect(result.current?.percent).toBeCloseTo(25, 5);
+
+      act(() => {
+        completeChunkProgress(queryClient, QUERY_KEY, {
+          chunkId: 'window-0',
+          rangeMs: 2 * ONE_HOUR_MS,
+        });
+        jest.advanceTimersByTime(1);
+      });
+      rerender({ active: true });
+
+      expect(result.current?.percent).toBeCloseTo(50, 5);
+    });
+  });
+
   describe('gaps between fetches', () => {
     it('keeps accumulated progress across a short gap between windows', () => {
       const { result, rerender } = renderProgress(true);

--- a/packages/app/src/hooks/useChartConfig.tsx
+++ b/packages/app/src/hooks/useChartConfig.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+import type { ClickHouseProgress } from '@hyperdx/common-utils/dist/clickhouse';
 import {
   chSqlToAliasMap,
   ClickHouseQueryError,
@@ -43,7 +45,14 @@ import { toStartOfInterval } from '@/ChartUtils';
 import { useClickhouseClient } from '@/clickhouse';
 import { IS_MTVIEWS_ENABLED } from '@/config';
 import { buildMTViewSelectQuery } from '@/hdxMTViews';
+import { queryChartConfigWithProgress } from '@/hooks/useChartConfig/queryChartConfigWithProgress';
 import { useMetadataWithSettings } from '@/hooks/useMetadata';
+import {
+  clearQueryProgress,
+  completeChunkProgress,
+  useQueryProgress,
+  writeChunkProgress,
+} from '@/hooks/useQueryProgress';
 import { useSource } from '@/source';
 import { generateTimeWindowsDescending } from '@/utils/searchWindows';
 
@@ -59,6 +68,12 @@ interface AdditionalUseQueriedChartConfigOptions {
    */
   enableQueryChunking?: boolean;
   enableParallelQueries?: boolean;
+  /**
+   * Stream the query so ClickHouse progress events can be surfaced as
+   * `progress`. Needs ClickHouse >= 25.1; older servers silently fall back to
+   * the non-streaming query with no progress reporting.
+   */
+  reportProgress?: boolean;
 }
 
 type TimeWindow = {
@@ -74,6 +89,51 @@ type TChunk = {
   chunk: ResponseJSON<Record<string, string | number>>;
   isComplete: boolean;
 };
+
+/**
+ * Reports the progress of one chunk of a chart query. `chunkId` is stable per
+ * window so parallel chunks each keep their own slot; `rangeMs` is how much of
+ * the chart's date range that window covers.
+ */
+export type ChunkProgressReporter = (update: {
+  chunkId: string;
+  rangeMs: number;
+  progress?: ClickHouseProgress;
+  isComplete?: boolean;
+}) => void;
+
+/** Milliseconds spanned by a chunk's window, or by the whole config's range. */
+function rangeMsOf(
+  window: TimeWindow | undefined,
+  config: ChartConfigWithOptDateRange,
+): number {
+  const [start, end] = window?.dateRange ?? config.dateRange ?? [];
+  if (start == null || end == null) return 0;
+  return Math.max(end.getTime() - start.getTime(), 0);
+}
+
+/**
+ * Binds a chunk's identity to the reporter so the query loop only has to say
+ * "progressed" or "done". Returns undefined when nobody is listening, which
+ * also switches the query back to the non-streaming path.
+ */
+function chunkReporterFor(
+  onChunkProgress: ChunkProgressReporter | undefined,
+  index: number,
+  window: TimeWindow | undefined,
+  config: ChartConfigWithOptDateRange,
+) {
+  if (onChunkProgress == null) return undefined;
+
+  const chunkId = `chunk-${index}`;
+  const rangeMs = rangeMsOf(window, config);
+
+  return {
+    onProgress: (progress: ClickHouseProgress) =>
+      onChunkProgress({ chunkId, rangeMs, progress }),
+    onComplete: () => onChunkProgress({ chunkId, rangeMs, isComplete: true }),
+  };
+}
 
 const shouldUseChunking = (
   config: ChartConfigWithOptDateRange,
@@ -147,6 +207,7 @@ async function* fetchDataInChunks({
   enableParallelQueries = false,
   metadata,
   querySettings,
+  onChunkProgress,
 }: {
   config: ChartConfigWithOptDateRange;
   clickhouseClient: ClickhouseClient;
@@ -155,6 +216,7 @@ async function* fetchDataInChunks({
   enableParallelQueries?: boolean;
   metadata: Metadata;
   querySettings: QuerySettings | undefined;
+  onChunkProgress?: ChunkProgressReporter;
 }) {
   const windows =
     enableQueryChunking && shouldUseChunking(config)
@@ -202,18 +264,18 @@ async function* fetchDataInChunks({
     // fetch in parallel
     const promises = windows.map(async (w, index) => {
       const windowedConfig = windowedConfigFor(w);
-      return {
-        index,
-        queryResult: await clickhouseClient.queryChartConfig({
-          config: windowedConfig,
-          metadata,
-          opts: {
-            abort_signal: signal,
-            clickhouse_settings: clickHouseSettings,
-          },
-          querySettings,
-        }),
-      };
+      const reportChunk = chunkReporterFor(onChunkProgress, index, w, config);
+      const queryResult = await queryChartConfigWithProgress({
+        config: windowedConfig,
+        clickhouseClient,
+        metadata,
+        querySettings,
+        signal,
+        clickhouseSettings: clickHouseSettings,
+        onProgress: reportChunk?.onProgress,
+      });
+      reportChunk?.onComplete();
+      return { index, queryResult };
     });
     const remainingPromises = [...promises];
     const bufferedChunks = new Array(windows.length);
@@ -241,15 +303,22 @@ async function* fetchDataInChunks({
   // fetch in series
   for (let i = 0; i < windows.length; i++) {
     const windowedConfig = windowedConfigFor(windows[i]);
+    const reportChunk = chunkReporterFor(
+      onChunkProgress,
+      i,
+      windows[i],
+      config,
+    );
 
-    const result = await clickhouseClient.queryChartConfig({
+    const result = await queryChartConfigWithProgress({
       config: windowedConfig,
+      clickhouseClient,
       metadata,
-      opts: {
-        abort_signal: signal,
-      },
       querySettings,
+      signal,
+      onProgress: reportChunk?.onProgress,
     });
+    reportChunk?.onComplete();
 
     yield { chunk: result, isComplete: i === windows.length - 1 };
   }
@@ -299,7 +368,7 @@ export function useQueriedChartConfig(
   options?: Partial<UseQueryOptions<TQueryFnData>> &
     AdditionalUseQueriedChartConfigOptions,
 ) {
-  const { enabled = true } = options ?? {};
+  const { enabled = true, reportProgress = false } = options ?? {};
   const clickhouseClient = useClickhouseClient();
   const queryClient = useQueryClient();
   const metadata = useMetadataWithSettings();
@@ -315,14 +384,18 @@ export function useQueriedChartConfig(
     id: config.source,
   });
 
+  // Include enableQueryChunking in the query key to ensure that queries with the
+  // same config but different enableQueryChunking values do not share a query.
+  // Callers may override it (DBTimeChart and SearchTotalCountChart pass a
+  // matching key so react-query de-dupes their identical histogram query).
+  const queryKey = options?.queryKey ?? [
+    config,
+    options?.enableQueryChunking ?? false,
+    options?.enableParallelQueries ?? false,
+  ];
+
   const query = useQuery<TQueryFnData, ClickHouseQueryError | Error>({
-    // Include enableQueryChunking in the query key to ensure that queries with the
-    // same config but different enableQueryChunking values do not share a query
-    queryKey: [
-      config,
-      options?.enableQueryChunking ?? false,
-      options?.enableParallelQueries ?? false,
-    ],
+    queryKey,
     // TODO: Replace this with `streamedQuery` when it is no longer experimental. Use 'replace' refetch mode.
     // https://tanstack.com/query/latest/docs/reference/streamedQuery
     queryFn: async context => {
@@ -441,6 +514,13 @@ export function useQueriedChartConfig(
         isComplete: false,
       };
 
+      // Progress outlives a settled query for a short grace period so the
+      // search table's bar survives the gap between windows; a rerun of this
+      // chart must not inherit the previous run's totals.
+      if (reportProgress) {
+        clearQueryProgress(queryClient, context.queryKey);
+      }
+
       const chunks = fetchDataInChunks({
         config: optimizedConfig,
         clickhouseClient,
@@ -449,6 +529,22 @@ export function useQueriedChartConfig(
         enableParallelQueries: options?.enableParallelQueries,
         metadata,
         querySettings: source?.querySettings,
+        onChunkProgress: reportProgress
+          ? ({ chunkId, rangeMs, progress, isComplete }) => {
+              if (isComplete) {
+                completeChunkProgress(queryClient, context.queryKey, {
+                  chunkId,
+                  rangeMs,
+                });
+              } else if (progress != null) {
+                writeChunkProgress(queryClient, context.queryKey, {
+                  chunkId,
+                  rangeMs,
+                  progress,
+                });
+              }
+            }
+          : undefined,
       });
 
       let accumulatedChunks: TQueryFnData = emptyValue;
@@ -486,9 +582,18 @@ export function useQueriedChartConfig(
   if (query.isError && options?.onError) {
     options.onError(query.error);
   }
+
+  const totalRangeMs = useMemo(() => rangeMsOf(undefined, config), [config]);
+  const progress = useQueryProgress({
+    queryKey,
+    active: reportProgress && query.isFetching,
+    totalRangeMs,
+  });
+
   return {
     ...query,
     isLoading: query.isLoading || isLoadingMVOptimization,
+    progress,
   };
 }
 

--- a/packages/app/src/hooks/useChartConfig/__tests__/queryChartConfigWithProgress.test.ts
+++ b/packages/app/src/hooks/useChartConfig/__tests__/queryChartConfigWithProgress.test.ts
@@ -1,0 +1,206 @@
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/browser';
+import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
+import { ChartConfigWithOptDateRange } from '@hyperdx/common-utils/dist/types';
+
+jest.mock('@hyperdx/common-utils/dist/core/renderChartConfig', () => ({
+  ...jest.requireActual('@hyperdx/common-utils/dist/core/renderChartConfig'),
+  renderChartConfig: jest.fn(),
+}));
+
+import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
+
+import { queryChartConfigWithProgress } from '@/hooks/useChartConfig/queryChartConfigWithProgress';
+
+const CONFIG: ChartConfigWithOptDateRange = {
+  connection: 'conn-1',
+  from: { databaseName: 'default', tableName: 'otel_logs' },
+  select: [{ aggFn: 'count' as const, valueExpression: '' }],
+  where: '',
+  whereLanguage: 'sql' as const,
+  timestampValueExpression: 'Timestamp',
+  dateRange: [new Date('2024-01-01'), new Date('2024-01-02')],
+};
+
+function streamOf(batches: unknown[][]) {
+  const queue = batches.map(batch =>
+    batch.map(event => ({ json: () => event })),
+  );
+  let i = 0;
+  return {
+    getReader: () => ({
+      read: async () =>
+        i < queue.length
+          ? { done: false, value: queue[i++] }
+          : { done: true, value: undefined },
+    }),
+  };
+}
+
+function createClient({
+  serverVersion,
+  batches = [],
+}: {
+  serverVersion: number[] | undefined;
+  batches?: unknown[][];
+}) {
+  const query = jest
+    .fn()
+    .mockResolvedValue({ stream: () => streamOf(batches) });
+  const queryChartConfig = jest
+    .fn()
+    .mockResolvedValue({ data: [{ n: 1 }], meta: [], rows: 1 });
+  const metadata = {
+    getServerVersion: jest.fn().mockResolvedValue(serverVersion),
+  };
+  return {
+    query,
+    queryChartConfig,
+    // Only the handful of members the function under test reaches for.
+    client: { query, queryChartConfig } as unknown as ClickhouseClient,
+    metadata: metadata as unknown as Metadata,
+  };
+}
+
+describe('queryChartConfigWithProgress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(renderChartConfig)
+      .mockResolvedValue({ sql: 'SELECT 1', params: {} });
+  });
+
+  it('streams and reports progress on ClickHouse >= 25.1', async () => {
+    const onProgress = jest.fn();
+    const { client, metadata } = createClient({
+      serverVersion: [25, 1, 0, 0],
+      batches: [
+        [
+          { meta: [{ name: 'count', type: 'UInt64' }] },
+          { row: { count: 7 } },
+          {
+            progress: {
+              read_rows: '10',
+              read_bytes: '80',
+              total_rows_to_read: '20',
+              elapsed_ns: '5',
+            },
+          },
+        ],
+        [{ row: { count: 8 } }],
+      ],
+    });
+
+    const result = await queryChartConfigWithProgress({
+      config: CONFIG,
+      clickhouseClient: client,
+      metadata,
+      querySettings: undefined,
+      onProgress,
+    });
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'JSONEachRowWithProgress' }),
+    );
+    expect(client.queryChartConfig).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      data: [{ count: 7 }, { count: 8 }],
+      meta: [{ name: 'count', type: 'UInt64' }],
+      rows: 2,
+    });
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ read_rows: '10' }),
+    );
+  });
+
+  it('falls back to the non-streaming query on ClickHouse < 25.1', async () => {
+    const onProgress = jest.fn();
+    const { client, metadata } = createClient({
+      serverVersion: [24, 12, 0, 0],
+    });
+
+    const result = await queryChartConfigWithProgress({
+      config: CONFIG,
+      clickhouseClient: client,
+      metadata,
+      querySettings: undefined,
+      onProgress,
+    });
+
+    expect(client.queryChartConfig).toHaveBeenCalledTimes(1);
+    expect(client.query).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [{ n: 1 }], meta: [], rows: 1 });
+  });
+
+  it('falls back when the server version is unknown', async () => {
+    const { client, metadata } = createClient({ serverVersion: undefined });
+
+    await queryChartConfigWithProgress({
+      config: CONFIG,
+      clickhouseClient: client,
+      metadata,
+      querySettings: undefined,
+      onProgress: jest.fn(),
+    });
+
+    expect(client.queryChartConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not probe the server version when no progress listener is given', async () => {
+    const { client, metadata } = createClient({ serverVersion: [26, 5, 0, 0] });
+
+    await queryChartConfigWithProgress({
+      config: CONFIG,
+      clickhouseClient: client,
+      metadata,
+      querySettings: undefined,
+    });
+
+    expect(metadata.getServerVersion).not.toHaveBeenCalled();
+    expect(client.queryChartConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a mid-stream exception as a query error', async () => {
+    const { client, metadata } = createClient({
+      serverVersion: [26, 5, 0, 0],
+      batches: [[{ exception: 'Code: 241. Memory limit exceeded' }]],
+    });
+
+    await expect(
+      queryChartConfigWithProgress({
+        config: CONFIG,
+        clickhouseClient: client,
+        metadata,
+        querySettings: undefined,
+        onProgress: jest.fn(),
+      }),
+    ).rejects.toThrow(ClickHouseQueryError);
+  });
+
+  it('passes the abort signal and settings through the streaming path', async () => {
+    const controller = new AbortController();
+    const { client, metadata } = createClient({
+      serverVersion: [26, 5, 0, 0],
+      batches: [[{ meta: [] }]],
+    });
+
+    await queryChartConfigWithProgress({
+      config: CONFIG,
+      clickhouseClient: client,
+      metadata,
+      querySettings: undefined,
+      signal: controller.signal,
+      clickhouseSettings: { readonly: '2' },
+      onProgress: jest.fn(),
+    });
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abort_signal: controller.signal,
+        clickhouse_settings: { readonly: '2' },
+        connectionId: 'conn-1',
+      }),
+    );
+  });
+});

--- a/packages/app/src/hooks/useChartConfig/queryChartConfigWithProgress.ts
+++ b/packages/app/src/hooks/useChartConfig/queryChartConfigWithProgress.ts
@@ -1,0 +1,111 @@
+import type {
+  ClickHouseProgress,
+  ColumnMetaType,
+  ResponseJSON,
+} from '@hyperdx/common-utils/dist/clickhouse';
+import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/browser';
+import { supportsJSONEachRowWithProgressMeta } from '@hyperdx/common-utils/dist/core/clickhouseVersion';
+import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
+import {
+  renderChartConfig,
+  setChartSelectsAlias,
+} from '@hyperdx/common-utils/dist/core/renderChartConfig';
+import { isBuilderChartConfig } from '@hyperdx/common-utils/dist/guards';
+import {
+  ChartConfigWithOptDateRange,
+  QuerySettings,
+} from '@hyperdx/common-utils/dist/types';
+
+import { createEachRowWithProgressParser } from '@/utils/clickhouseStream';
+
+type ChartQueryResult = ResponseJSON<Record<string, string | number>>;
+
+/** One NDJSON line from a ClickHouse result stream, before decoding. */
+type StreamedRow = { json: () => unknown };
+
+/**
+ * Runs a chart config like `ClickhouseClient.queryChartConfig`, but streams the
+ * response so ClickHouse's `{"progress":...}` events can be reported while the
+ * query runs.
+ *
+ * Falls back to the plain (non-streaming) `queryChartConfig` when the server
+ * predates the `meta`/`exception` events of `JSONEachRowWithProgress` (< 25.1),
+ * or when its version cannot be determined.
+ */
+export async function queryChartConfigWithProgress({
+  config,
+  clickhouseClient,
+  metadata,
+  querySettings,
+  signal,
+  clickhouseSettings,
+  onProgress,
+}: {
+  config: ChartConfigWithOptDateRange;
+  clickhouseClient: ClickhouseClient;
+  metadata: Metadata;
+  querySettings: QuerySettings | undefined;
+  signal?: AbortSignal;
+  clickhouseSettings?: Record<string, any>;
+  onProgress?: (progress: ClickHouseProgress) => void;
+}): Promise<ChartQueryResult> {
+  const connectionId = config.connection;
+  const canStreamProgress =
+    onProgress != null &&
+    connectionId != null &&
+    supportsJSONEachRowWithProgressMeta(
+      await metadata.getServerVersion({ connectionId }),
+    );
+
+  if (!canStreamProgress) {
+    return clickhouseClient.queryChartConfig({
+      config,
+      metadata,
+      opts: { abort_signal: signal, clickhouse_settings: clickhouseSettings },
+      querySettings,
+    });
+  }
+
+  const aliasedConfig = isBuilderChartConfig(config)
+    ? setChartSelectsAlias(config)
+    : config;
+  const query = await renderChartConfig(aliasedConfig, metadata, querySettings);
+
+  const resultSet = await clickhouseClient.query<'JSONEachRowWithProgress'>({
+    query: query.sql,
+    query_params: query.params,
+    format: 'JSONEachRowWithProgress',
+    abort_signal: signal,
+    connectionId,
+    clickhouse_settings: clickhouseSettings,
+  });
+
+  const data: Record<string, string | number>[] = [];
+  let meta: ColumnMetaType[] = [];
+
+  const parseBatch = createEachRowWithProgressParser(
+    {
+      onMeta: nextMeta => {
+        meta = nextMeta;
+      },
+      onRows: rows => {
+        // Rows arrive already keyed by column name in this format.
+        data.push(...(rows as Record<string, string | number>[]));
+      },
+      onProgress,
+    },
+    query.sql,
+  );
+
+  // The parser only needs each line decoded, so narrow to that shared shape.
+  const stream: ReadableStream<StreamedRow[]> = resultSet.stream();
+  const reader = stream.getReader();
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done || value == null) break;
+    parseBatch(value.map(row => row.json()));
+  }
+
+  return { data, meta, rows: data.length };
+}

--- a/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
+++ b/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
@@ -2,15 +2,15 @@ import { useMemo } from 'react';
 import { omit } from 'lodash';
 import ms from 'ms';
 import type {
+  ClickHouseProgress,
   ClickHouseSettings,
-  ResponseJSON,
-  Row,
 } from '@hyperdx/common-utils/dist/clickhouse';
 import {
   ChSql,
   ClickHouseQueryError,
   ColumnMetaType,
 } from '@hyperdx/common-utils/dist/clickhouse';
+import { supportsJSONEachRowWithProgressMeta } from '@hyperdx/common-utils/dist/core/clickhouseVersion';
 import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
 import {
@@ -38,7 +38,19 @@ import { getClickhouseClient } from '@/clickhouse';
 import { MAX_TABLE_ROWS } from '@/HDXMultiSeriesTableChart';
 import { useMetadataWithSettings } from '@/hooks/useMetadata';
 import { useMVOptimizationExplanation } from '@/hooks/useMVOptimizationExplanation';
+import {
+  clearQueryProgress,
+  completeChunkProgress,
+  startChunkProgress,
+  useQueryProgress,
+  writeChunkProgress,
+} from '@/hooks/useQueryProgress';
 import { useSource } from '@/source';
+import {
+  createCompactWithNamesAndTypesParser,
+  createEachRowWithProgressParser,
+  StreamParser,
+} from '@/utils/clickhouseStream';
 import {
   DEFAULT_TIME_WINDOWS_SECONDS,
   generateTimeWindowsAscending,
@@ -66,12 +78,58 @@ type TPageParam = {
   offset: number;
 };
 
+/** One NDJSON line from a ClickHouse result stream, before decoding. */
+type StreamedRow = { json: () => unknown };
+
 type TQueryFnData = {
   data: Record<string, any>[];
   meta: ColumnMetaType[];
   chSql: ChSql;
   window: TimeWindow;
 };
+
+/** Milliseconds of the search range covered by a window. */
+function windowRangeMs(window: TimeWindow): number {
+  return Math.max(window.endTime.getTime() - window.startTime.getTime(), 0);
+}
+
+/** Progress chunk id for a search window. Offset pages share their window. */
+function windowChunkId(windowIndex: number): string {
+  return `window-${windowIndex}`;
+}
+
+/**
+ * Total span of the search, and the windows earlier pages already covered.
+ *
+ * Pagination walks the range one window at a time, so progress for the window
+ * currently in flight only describes a slice of what the UI says it is
+ * searching ("across about 1 month"). Crediting the windows already finished
+ * makes the bar describe the whole search instead of restarting per page.
+ *
+ * Ranges are keyed by chunk id so the window currently streaming — which also
+ * has a placeholder page in the cache — is credited once, not twice.
+ */
+function coverageFromPages(
+  config: ChartConfigWithOptTimestamp,
+  pages: TQueryFnData[] | undefined,
+): { totalRangeMs: number; completedRanges: Record<string, number> } {
+  const [start, end] = config.dateRange ?? [];
+  const totalRangeMs =
+    start != null && end != null
+      ? Math.max(end.getTime() - start.getTime(), 0)
+      : 0;
+
+  const completedRanges: Record<string, number> = {};
+  for (const page of pages ?? []) {
+    if (page?.window != null) {
+      completedRanges[windowChunkId(page.window.windowIndex)] = windowRangeMs(
+        page.window,
+      );
+    }
+  }
+
+  return { totalRangeMs, completedRanges };
+}
 
 type TData = {
   pages: TQueryFnData[];
@@ -85,6 +143,7 @@ type QueryMeta = {
   metadata: Metadata;
   optimizedConfig?: ChartConfigWithOptTimestamp;
   source: TSource | undefined;
+  reportProgress: boolean;
 };
 
 // Get time window from page param
@@ -179,7 +238,15 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
     hasPreviousQueries,
     optimizedConfig,
     source,
+    reportProgress,
   } = meta as QueryMeta;
+
+  // Progress is deliberately kept across the gap between windows, so a run
+  // that restarts at the first page — a refetch, or a re-search with identical
+  // params — has to drop what the previous run accumulated.
+  if (reportProgress && pageParam.windowIndex === 0 && pageParam.offset === 0) {
+    clearQueryProgress(queryClient, queryKey);
+  }
 
   // Only stream incrementally if this is a fresh query with no previous
   // response or if it's a paginated query
@@ -251,22 +318,41 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
     clickHouseSettings.result_overflow_mode = 'break';
   }
 
-  const resultSet =
-    await clickhouseClient.query<'JSONCompactEachRowWithNamesAndTypes'>({
-      query: query.sql,
-      query_params: query.params,
-      format: 'JSONCompactEachRowWithNamesAndTypes',
-      abort_signal: abortController?.signal || signal,
-      connectionId: config.connection,
-      clickhouse_settings: clickHouseSettings,
-    });
+  // `JSONEachRowWithProgress` interleaves `{"progress":...}` events with the
+  // rows, which is the only way to observe query progress from a browser:
+  // ClickHouse stops emitting `X-ClickHouse-Progress` headers once the response
+  // body starts, and `fetch` cannot surface headers incrementally anyway.
+  // Requires >= 25.1 for the `meta` and `exception` events.
+  const useProgressFormat =
+    reportProgress &&
+    supportsJSONEachRowWithProgressMeta(
+      await metadata.getServerVersion({ connectionId: config.connection }),
+    );
 
-  const stream = resultSet.stream();
+  const resultSet = useProgressFormat
+    ? await clickhouseClient.query<'JSONEachRowWithProgress'>({
+        query: query.sql,
+        query_params: query.params,
+        format: 'JSONEachRowWithProgress',
+        abort_signal: abortController?.signal || signal,
+        connectionId: config.connection,
+        clickhouse_settings: clickHouseSettings,
+      })
+    : await clickhouseClient.query<'JSONCompactEachRowWithNamesAndTypes'>({
+        query: query.sql,
+        query_params: query.params,
+        format: 'JSONCompactEachRowWithNamesAndTypes',
+        abort_signal: abortController?.signal || signal,
+        connectionId: config.connection,
+        clickhouse_settings: clickHouseSettings,
+      });
+
+  // The two formats yield different `Row<_, Format>` types whose `json()`
+  // return types do not unify into a callable signature. The parsers only need
+  // each line decoded, so narrow to that shared shape.
+  const stream: ReadableStream<StreamedRow[]> = resultSet.stream();
 
   const reader = stream.getReader();
-
-  const headerRows: Row<unknown[], 'JSONCompactEachRowWithNamesAndTypes'>[] =
-    [];
 
   if (isStreamingIncrementally) {
     queryClient.setQueryData<TData>(queryKey, (oldData): TData => {
@@ -290,9 +376,83 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
     });
   }
 
-  const queryResultMeta: NonNullable<ResponseJSON['meta']> = [];
+  let queryResultMeta: ColumnMetaType[] = [];
   // Buffer for all data rows for the current query
   const queryResultData: Record<string, unknown>[] = [];
+
+  // Appends to the in-progress page so partial results render as they stream.
+  // Called with no rows when only `meta` arrived, so the column types reach the
+  // table even for an empty result set.
+  function appendToStreamedPage(rowObjs: Record<string, unknown>[]) {
+    if (!isStreamingIncrementally) {
+      return;
+    }
+
+    queryClient.setQueryData<TData>(queryKey, oldData => {
+      if (oldData == null) {
+        return {
+          pages: [
+            {
+              data: rowObjs,
+              meta: queryResultMeta,
+              chSql: query,
+              window: timeWindow,
+            },
+          ],
+          pageParams: [pageParam],
+        };
+      }
+
+      const oldPages = oldData.pages.slice(0, -1);
+      const page = oldData.pages[oldData.pages.length - 1];
+
+      return {
+        pages: [
+          ...oldPages,
+          {
+            ...page,
+            data: [...(page.data ?? []), ...rowObjs],
+            meta: queryResultMeta,
+            chSql: query,
+            window: timeWindow,
+          },
+        ],
+        pageParams: oldData.pageParams,
+      };
+    });
+  }
+
+  const handlers = {
+    onMeta: (meta: ColumnMetaType[]) => {
+      queryResultMeta = meta;
+      appendToStreamedPage([]);
+    },
+    onRows: (rowObjs: Record<string, unknown>[]) => {
+      queryResultData.push(...rowObjs);
+      appendToStreamedPage(rowObjs);
+    },
+    onProgress: (progress: ClickHouseProgress) => {
+      writeChunkProgress(queryClient, queryKey, {
+        // Offset pages within one window refine the same slice of the range.
+        chunkId: windowChunkId(timeWindow.windowIndex),
+        progress,
+        rangeMs: windowRangeMs(timeWindow),
+      });
+    },
+  };
+
+  if (useProgressFormat) {
+    // Claim this window before reading, so it is not counted as already
+    // covered while it waits for its first progress event.
+    startChunkProgress(queryClient, queryKey, {
+      chunkId: windowChunkId(timeWindow.windowIndex),
+      rangeMs: windowRangeMs(timeWindow),
+    });
+  }
+
+  const parseBatch: StreamParser = useProgressFormat
+    ? createEachRowWithProgressParser(handlers, query.sql)
+    : createCompactWithNamesAndTypesParser(handlers);
 
   async function read(): Promise<void> {
     const { done, value } = await reader.read();
@@ -301,85 +461,13 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
       return;
     }
 
-    if (queryResultMeta.length === 0) {
-      headerRows.push(...value);
-    }
-
-    if (queryResultMeta.length > 0 || headerRows.length >= 2) {
-      let dataRows = value;
-      if (queryResultMeta.length === 0) {
-        const names = headerRows[0].json<string[]>();
-        const values = headerRows[1].json<string[]>();
-
-        if (names.length !== values.length) {
-          throw new Error(
-            'Invalid JSONCompactEachRowWithNamesAndTypes header rows',
-          );
-        }
-
-        for (let i = 0; i < names.length; i++) {
-          queryResultMeta.push({
-            name: names[i],
-            type: values[i],
-          });
-        }
-
-        dataRows = headerRows.slice(2);
-        headerRows.length = 0;
-      }
-
-      const rowObjs: Record<string, unknown>[] = [];
-      for (let i = 0; i < dataRows.length; i++) {
-        const rowArr = dataRows[i].json();
-        const rowObj: Record<string, unknown> = {};
-        for (let j = 0; j < rowArr.length; j++) {
-          rowObj[queryResultMeta[j].name] = rowArr[j];
-        }
-
-        rowObjs.push(rowObj);
-        queryResultData.push(rowObj);
-      }
-
-      if (isStreamingIncrementally) {
-        queryClient.setQueryData<TData>(queryKey, oldData => {
-          if (oldData == null) {
-            return {
-              pages: [
-                {
-                  data: rowObjs,
-                  meta: queryResultMeta,
-                  chSql: query,
-                  window: timeWindow,
-                },
-              ],
-              pageParams: [pageParam],
-            };
-          }
-
-          const oldPages = oldData.pages.slice(0, -1);
-          const page = oldData.pages[oldData.pages.length - 1];
-
-          return {
-            pages: [
-              ...oldPages,
-              {
-                ...page,
-                data: [...(page.data ?? []), ...rowObjs],
-                meta: queryResultMeta,
-                chSql: query,
-                window: timeWindow,
-              },
-            ],
-            pageParams: oldData.pageParams,
-          };
-        });
-      }
-    }
+    parseBatch(value.map(row => row.json()));
 
     return await read();
   }
 
-  function deleteProgressCache() {
+  // Drops the placeholder page that incremental streaming appended.
+  function deleteInProgressPage() {
     queryClient.setQueryData<TData>(queryKey, oldData => {
       if (oldData == null) {
         return;
@@ -396,9 +484,19 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
     await read();
   } catch (e) {
     if (isStreamingIncrementally) {
-      deleteProgressCache();
+      deleteInProgressPage();
     }
     throw e;
+  }
+
+  // This window is fully searched. The entry is not cleared here: pagination
+  // may immediately fetch the next window, and the bar should carry on rather
+  // than blink back to empty. The next run from page one clears it instead.
+  if (useProgressFormat) {
+    completeChunkProgress(queryClient, queryKey, {
+      chunkId: windowChunkId(timeWindow.windowIndex),
+      rangeMs: windowRangeMs(timeWindow),
+    });
   }
 
   if (!isStreamingIncrementally) {
@@ -418,7 +516,7 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
   const { pages } = cachedQueryData;
   const lastPage = pages[pages.length - 1];
 
-  deleteProgressCache();
+  deleteInProgressPage();
 
   return lastPage;
 };
@@ -447,11 +545,19 @@ export default function useOffsetPaginatedQuery(
     enabled = true,
     queryKeyPrefix = '',
     enableSmallFirstWindow,
+    reportProgress = false,
   }: {
     isLive?: boolean;
     enabled?: boolean;
     queryKeyPrefix?: string;
     enableSmallFirstWindow?: boolean;
+    /**
+     * Stream the query in a format that interleaves ClickHouse progress
+     * events, exposing them as `progress`. Costs a slightly larger response
+     * (rows repeat their column names) and needs ClickHouse >= 25.1; on older
+     * servers this is silently ignored.
+     */
+    reportProgress?: boolean;
   } = {},
 ) {
   const { data: meData, isLoading: isLoadingMe } = api.useMe();
@@ -520,6 +626,7 @@ export default function useOffsetPaginatedQuery(
       metadata,
       optimizedConfig: mvOptimizationData?.optimizedConfig,
       source,
+      reportProgress,
     } satisfies QueryMeta,
     queryFn,
     gcTime: isLive ? ms('30s') : ms('5m'), // more aggressive gc for live data, since it can end up holding lots of data
@@ -530,6 +637,18 @@ export default function useOffsetPaginatedQuery(
 
   const flattenedData = useMemo(() => flattenData(data), [data]);
 
+  const { totalRangeMs, completedRanges } = useMemo(
+    () => coverageFromPages(config, data?.pages),
+    [config, data?.pages],
+  );
+
+  const progress = useQueryProgress({
+    queryKey: key,
+    active: reportProgress && isFetching,
+    totalRangeMs,
+    completedRanges,
+  });
+
   return {
     isError,
     error,
@@ -538,5 +657,6 @@ export default function useOffsetPaginatedQuery(
     hasNextPage,
     isFetching: isFetching || isLoadingMe || isLoadingMVOptimization,
     isLoading: isLoading || isLoadingMe || isLoadingMVOptimization,
+    progress,
   };
 }

--- a/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
+++ b/packages/app/src/hooks/useOffsetPaginatedQuery.tsx
@@ -119,9 +119,12 @@ function coverageFromPages(
       ? Math.max(end.getTime() - start.getTime(), 0)
       : 0;
 
+  // Only a page that came back empty proves its window is exhausted; a page
+  // that returned rows will be followed by another request at a higher offset
+  // in the same window.
   const completedRanges: Record<string, number> = {};
   for (const page of pages ?? []) {
-    if (page?.window != null) {
+    if (page?.window != null && page.data.length === 0) {
       completedRanges[windowChunkId(page.window.windowIndex)] = windowRangeMs(
         page.window,
       );
@@ -489,13 +492,19 @@ const queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam> = async ({
     throw e;
   }
 
-  // This window is fully searched. The entry is not cleared here: pagination
-  // may immediately fetch the next window, and the bar should carry on rather
-  // than blink back to empty. The next run from page one clears it instead.
+  // Settle this request's progress. The entry is not cleared here: pagination
+  // may immediately fetch again, and the bar should carry on rather than blink
+  // back to empty. The next run from page one clears it instead.
+  //
+  // A page that returned rows means `getNextPageParam` will ask for a further
+  // offset *within this same window*, so the window is not finished and must
+  // not be credited its whole range yet — only an empty page proves it is
+  // exhausted.
   if (useProgressFormat) {
     completeChunkProgress(queryClient, queryKey, {
       chunkId: windowChunkId(timeWindow.windowIndex),
       rangeMs: windowRangeMs(timeWindow),
+      isChunkExhausted: queryResultData.length === 0,
     });
   }
 

--- a/packages/app/src/hooks/useQueryProgress.ts
+++ b/packages/app/src/hooks/useQueryProgress.ts
@@ -1,0 +1,247 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ClickHouseProgress } from '@hyperdx/common-utils/dist/clickhouse';
+import {
+  hashKey,
+  QueryClient,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import {
+  ChunkProgress,
+  QueryProgressSummary,
+  summarizeChunkProgress,
+  toChunkProgress,
+} from '@/utils/queryProgress';
+
+/**
+ * Every timestamp here is only ever read as a difference, so this uses the
+ * monotonic clock: elapsed time stays correct across a wall-clock adjustment,
+ * and it sidesteps the render-stability concerns that apply to `Date.now()`.
+ */
+const nowMs = () => performance.now();
+
+/** How often the elapsed-time readout advances while a query is in flight. */
+const TICK_MS = 500;
+
+type ProgressState = {
+  startedAt: number;
+  /** Set while the query is between fetches. */
+  pausedAt?: number;
+  /** Time the query spent not fetching, excluded from the elapsed readout. */
+  idleMs: number;
+  /** Keyed by chunk id so parallel chunks can report independently. */
+  chunks: Record<string, ChunkProgress>;
+};
+
+/**
+ * Progress lives in its own cache entry rather than inside the query's data.
+ * Writing it into the data entry would push a placeholder result on every
+ * tick, which makes the table and chart flicker on refetches of an
+ * already-rendered query.
+ */
+function progressKeyFn(queryKey: readonly unknown[]) {
+  return ['query-progress', ...queryKey] as const;
+}
+
+function updateProgress(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  update: (prev: ProgressState) => ProgressState,
+) {
+  queryClient.setQueryData<ProgressState>(progressKeyFn(queryKey), prev =>
+    update(prev ?? { startedAt: nowMs(), idleMs: 0, chunks: {} }),
+  );
+}
+
+/**
+ * Registers a chunk as in flight, before it has reported anything.
+ *
+ * Without this a just-started window has no entry, so `completedRanges` — which
+ * is derived from the pages in the cache, including the placeholder page for
+ * the window being streamed — credits its whole range. The bar would jump
+ * ahead as each window opened and snap back on its first progress event.
+ *
+ * No-ops if the chunk is already known, so the offset pages within a window
+ * cannot reset it.
+ */
+export function startChunkProgress(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  { chunkId, rangeMs }: { chunkId: string; rangeMs: number },
+) {
+  updateProgress(queryClient, queryKey, prev =>
+    prev.chunks[chunkId] != null
+      ? prev
+      : {
+          ...prev,
+          chunks: {
+            ...prev.chunks,
+            [chunkId]: {
+              rangeMs,
+              readRows: 0,
+              readBytes: 0,
+              fraction: 0,
+              isComplete: false,
+            },
+          },
+        },
+  );
+}
+
+/** Records the latest progress event for one chunk of a query. */
+export function writeChunkProgress(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  {
+    chunkId,
+    progress,
+    rangeMs,
+  }: { chunkId: string; progress: ClickHouseProgress; rangeMs: number },
+) {
+  updateProgress(queryClient, queryKey, prev => ({
+    ...prev,
+    chunks: {
+      ...prev.chunks,
+      [chunkId]: {
+        ...toChunkProgress(progress, rangeMs),
+        // A chunk that already finished must not regress if a late progress
+        // event for it arrives afterwards.
+        isComplete: prev.chunks[chunkId]?.isComplete ?? false,
+      },
+    },
+  }));
+}
+
+/**
+ * Marks a chunk fully searched, so it contributes its whole window to the
+ * covered range even when no progress event ever reported a total estimate.
+ */
+export function completeChunkProgress(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  { chunkId, rangeMs }: { chunkId: string; rangeMs: number },
+) {
+  updateProgress(queryClient, queryKey, prev => {
+    const existing = prev.chunks[chunkId];
+    return {
+      ...prev,
+      chunks: {
+        ...prev.chunks,
+        [chunkId]: {
+          rangeMs,
+          readRows: existing?.readRows ?? 0,
+          readBytes: existing?.readBytes ?? 0,
+          fraction: 1,
+          isComplete: true,
+        },
+      },
+    };
+  });
+}
+
+export function clearQueryProgress(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+) {
+  queryClient.removeQueries({ queryKey: progressKeyFn(queryKey), exact: true });
+}
+
+/**
+ * Subscribes to the progress written by a query's `queryFn` and folds it into
+ * a whole-query summary. Returns undefined when the query is not running or
+ * has reported nothing yet.
+ *
+ * `completedRanges` lets a caller credit windows that finished in earlier
+ * fetch cycles (e.g. pages already in the react-query cache), so the bar keeps
+ * climbing across an infinite-scroll sequence instead of restarting per page.
+ * It is keyed by chunk id: an entry whose chunk is currently streaming is
+ * ignored, since the live chunk already accounts for that window.
+ */
+export function useQueryProgress({
+  queryKey,
+  active,
+  totalRangeMs,
+  completedRanges,
+}: {
+  queryKey: readonly unknown[];
+  active: boolean;
+  totalRangeMs: number;
+  completedRanges?: Record<string, number>;
+}): QueryProgressSummary | undefined {
+  const queryClient = useQueryClient();
+
+  const { data: state } = useQuery<ProgressState | undefined>({
+    queryKey: progressKeyFn(queryKey),
+    // The producing queryFn is the only writer; this never fetches.
+    queryFn: () => undefined,
+    enabled: false,
+    gcTime: 0,
+  });
+
+  // Advance the elapsed readout between progress events, which ClickHouse
+  // only emits every `interactive_delay` (100ms by default) and not at all
+  // while a chunk is queued behind others.
+  const [now, setNow] = useState(nowMs);
+  useEffect(() => {
+    if (!active || state == null) return;
+    // The leading resync matters on resume: `now` last advanced before the
+    // gap, and the gap has just been added to `idleMs`, so without it elapsed
+    // would dip until the first interval fires.
+    const resync = setTimeout(() => setNow(nowMs()), 0);
+    const id = setInterval(() => setNow(nowMs()), TICK_MS);
+    return () => {
+      clearTimeout(resync);
+      clearInterval(id);
+    };
+  }, [active, state]);
+
+  // Track the gaps when the query is not fetching, so they are not billed as
+  // query time.
+  //
+  // A paginated search walks the range one window at a time and each window is
+  // a separate fetch, so `isFetching` dips between them. The entry is
+  // deliberately left in place across those dips — discarding it would make the
+  // bar vanish and the timer restart at every window boundary. A fresh run
+  // clears the entry from its `queryFn`, so nothing stale outlives a search.
+  //
+  // Addressed by hash rather than by key: the caller's `queryKey` is rebuilt
+  // every render, so depending on it directly would restart this effect
+  // constantly.
+  const progressHash = hashKey(progressKeyFn(queryKey));
+  useEffect(() => {
+    const query = queryClient.getQueryCache().get<ProgressState>(progressHash);
+    const entry = query?.state.data;
+    if (query == null || entry == null) return;
+
+    if (active) {
+      if (entry.pausedAt == null) return;
+      query.setData({
+        ...entry,
+        pausedAt: undefined,
+        idleMs: entry.idleMs + Math.max(nowMs() - entry.pausedAt, 0),
+      });
+      return;
+    }
+
+    if (entry.pausedAt != null) return;
+    query.setData({ ...entry, pausedAt: nowMs() });
+  }, [active, queryClient, progressHash]);
+
+  return useMemo(() => {
+    if (!active || state == null) return undefined;
+
+    const completedRangeMs = Object.entries(completedRanges ?? {}).reduce(
+      (sum, [chunkId, rangeMs]) =>
+        state.chunks[chunkId] != null ? sum : sum + rangeMs,
+      0,
+    );
+
+    return summarizeChunkProgress({
+      chunks: Object.values(state.chunks),
+      totalRangeMs,
+      completedRangeMs,
+      elapsedMs: Math.max(now - state.startedAt - state.idleMs, 0),
+    });
+  }, [active, state, totalRangeMs, completedRanges, now]);
+}

--- a/packages/app/src/hooks/useQueryProgress.ts
+++ b/packages/app/src/hooks/useQueryProgress.ts
@@ -30,6 +30,14 @@ type ProgressState = {
   pausedAt?: number;
   /** Time the query spent not fetching, excluded from the elapsed readout. */
   idleMs: number;
+  /**
+   * Counters from requests that have finished. A chunk's own counters describe
+   * only the request currently streaming it, so they are banked here when that
+   * request settles — several requests can share one chunk (the offset pages
+   * within a time window), and the later ones must not erase the earlier.
+   */
+  settledRows: number;
+  settledBytes: number;
   /** Keyed by chunk id so parallel chunks can report independently. */
   chunks: Record<string, ChunkProgress>;
 };
@@ -50,7 +58,15 @@ function updateProgress(
   update: (prev: ProgressState) => ProgressState,
 ) {
   queryClient.setQueryData<ProgressState>(progressKeyFn(queryKey), prev =>
-    update(prev ?? { startedAt: nowMs(), idleMs: 0, chunks: {} }),
+    update(
+      prev ?? {
+        startedAt: nowMs(),
+        idleMs: 0,
+        settledRows: 0,
+        settledBytes: 0,
+        chunks: {},
+      },
+    ),
   );
 }
 
@@ -120,20 +136,33 @@ export function writeChunkProgress(
 export function completeChunkProgress(
   queryClient: QueryClient,
   queryKey: readonly unknown[],
-  { chunkId, rangeMs }: { chunkId: string; rangeMs: number },
+  {
+    chunkId,
+    rangeMs,
+    isChunkExhausted = true,
+  }: { chunkId: string; rangeMs: number; isChunkExhausted?: boolean },
 ) {
   updateProgress(queryClient, queryKey, prev => {
     const existing = prev.chunks[chunkId];
     return {
       ...prev,
+      // Bank this request's counters, then zero the chunk's own so a follow-up
+      // request against the same chunk adds to the total instead of replacing
+      // it. Without this, paging deeper into a window would make the reported
+      // row count drop back to whatever the newest page had read.
+      settledRows: prev.settledRows + (existing?.readRows ?? 0),
+      settledBytes: prev.settledBytes + (existing?.readBytes ?? 0),
       chunks: {
         ...prev.chunks,
         [chunkId]: {
           rangeMs,
-          readRows: existing?.readRows ?? 0,
-          readBytes: existing?.readBytes ?? 0,
-          fraction: 1,
-          isComplete: true,
+          readRows: 0,
+          readBytes: 0,
+          // Only credit the chunk's whole range once nothing is left in it.
+          // A window that still has offset pages to serve has not been fully
+          // scanned, so it keeps the fraction its last progress event implied.
+          fraction: isChunkExhausted ? 1 : existing?.fraction,
+          isComplete: isChunkExhausted,
         },
       },
     };
@@ -241,6 +270,8 @@ export function useQueryProgress({
       chunks: Object.values(state.chunks),
       totalRangeMs,
       completedRangeMs,
+      completedRows: state.settledRows,
+      completedBytes: state.settledBytes,
       elapsedMs: Math.max(now - state.startedAt - state.idleMs, 0),
     });
   }, [active, state, totalRangeMs, completedRanges, now]);

--- a/packages/app/src/utils/__tests__/clickhouseStream.test.ts
+++ b/packages/app/src/utils/__tests__/clickhouseStream.test.ts
@@ -1,0 +1,206 @@
+import { ClickHouseQueryError } from '@hyperdx/common-utils/dist/clickhouse';
+
+import {
+  createCompactWithNamesAndTypesParser,
+  createEachRowWithProgressParser,
+  StreamHandlers,
+} from '@/utils/clickhouseStream';
+
+function createHandlers() {
+  return {
+    onMeta: jest.fn(),
+    onRows: jest.fn(),
+    onProgress: jest.fn(),
+  } satisfies StreamHandlers as jest.Mocked<Required<StreamHandlers>>;
+}
+
+describe('createCompactWithNamesAndTypesParser', () => {
+  it('reads the name and type header lines before emitting rows', () => {
+    const handlers = createHandlers();
+    const parse = createCompactWithNamesAndTypesParser(handlers);
+
+    parse([
+      ['Timestamp', 'Body'],
+      ['DateTime', 'String'],
+      ['2024-01-01T00:00:00Z', 'hello'],
+    ]);
+
+    expect(handlers.onMeta).toHaveBeenCalledWith([
+      { name: 'Timestamp', type: 'DateTime' },
+      { name: 'Body', type: 'String' },
+    ]);
+    expect(handlers.onRows).toHaveBeenCalledWith([
+      { Timestamp: '2024-01-01T00:00:00Z', Body: 'hello' },
+    ]);
+  });
+
+  it('buffers header lines that arrive across separate batches', () => {
+    const handlers = createHandlers();
+    const parse = createCompactWithNamesAndTypesParser(handlers);
+
+    parse([['Timestamp']]);
+    expect(handlers.onMeta).not.toHaveBeenCalled();
+
+    parse([['DateTime'], ['2024-01-01T00:00:00Z']]);
+
+    expect(handlers.onMeta).toHaveBeenCalledWith([
+      { name: 'Timestamp', type: 'DateTime' },
+    ]);
+    expect(handlers.onRows).toHaveBeenCalledWith([
+      { Timestamp: '2024-01-01T00:00:00Z' },
+    ]);
+  });
+
+  it('emits meta but no rows for an empty result set', () => {
+    const handlers = createHandlers();
+    const parse = createCompactWithNamesAndTypesParser(handlers);
+
+    parse([['Body'], ['String']]);
+
+    expect(handlers.onMeta).toHaveBeenCalledTimes(1);
+    expect(handlers.onRows).not.toHaveBeenCalled();
+  });
+
+  it('reads meta only once across batches', () => {
+    const handlers = createHandlers();
+    const parse = createCompactWithNamesAndTypesParser(handlers);
+
+    parse([['Body'], ['String'], ['a']]);
+    parse([['b']]);
+
+    expect(handlers.onMeta).toHaveBeenCalledTimes(1);
+    expect(handlers.onRows).toHaveBeenNthCalledWith(1, [{ Body: 'a' }]);
+    expect(handlers.onRows).toHaveBeenNthCalledWith(2, [{ Body: 'b' }]);
+  });
+
+  it('throws when the header lines disagree on column count', () => {
+    const parse = createCompactWithNamesAndTypesParser(createHandlers());
+
+    expect(() => parse([['a', 'b'], ['String']])).toThrow(
+      'Invalid JSONCompactEachRowWithNamesAndTypes header rows',
+    );
+  });
+});
+
+describe('createEachRowWithProgressParser', () => {
+  const QUERY = 'SELECT 1';
+
+  it('routes meta, row, and progress events to their handlers', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    parse([
+      { meta: [{ name: 'Body', type: 'String' }] },
+      { row: { Body: 'hello' } },
+      {
+        progress: {
+          read_rows: '100',
+          read_bytes: '2048',
+          total_rows_to_read: '1000',
+          elapsed_ns: '5000000',
+        },
+      },
+    ]);
+
+    expect(handlers.onMeta).toHaveBeenCalledWith([
+      { name: 'Body', type: 'String' },
+    ]);
+    expect(handlers.onRows).toHaveBeenCalledWith([{ Body: 'hello' }]);
+    expect(handlers.onProgress).toHaveBeenCalledWith({
+      read_rows: '100',
+      read_bytes: '2048',
+      total_rows_to_read: '1000',
+      elapsed_ns: '5000000',
+    });
+  });
+
+  it('accepts progress before meta', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    // ClickHouse writes progress straight from its progress callback, without
+    // first emitting the format prefix, so this ordering is expected.
+    parse([
+      { progress: { read_rows: '10', read_bytes: '64', elapsed_ns: '1000' } },
+    ]);
+    parse([{ meta: [{ name: 'Body', type: 'String' }] }]);
+
+    expect(handlers.onProgress).toHaveBeenCalledTimes(1);
+    expect(handlers.onMeta).toHaveBeenCalledTimes(1);
+    expect(handlers.onRows).not.toHaveBeenCalled();
+  });
+
+  it('batches consecutive rows into a single onRows call', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    parse([{ row: { n: 1 } }, { row: { n: 2 } }, { row: { n: 3 } }]);
+
+    expect(handlers.onRows).toHaveBeenCalledTimes(1);
+    expect(handlers.onRows).toHaveBeenCalledWith([
+      { n: 1 },
+      { n: 2 },
+      { n: 3 },
+    ]);
+  });
+
+  it('ignores rows_before_limit_at_least, totals, and extremes events', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    parse([
+      { rows_before_limit_at_least: 500 },
+      { totals: { n: 6 } },
+      { min: { n: 1 } },
+      { max: { n: 3 } },
+    ]);
+
+    expect(handlers.onRows).not.toHaveBeenCalled();
+    expect(handlers.onMeta).not.toHaveBeenCalled();
+    expect(handlers.onProgress).not.toHaveBeenCalled();
+  });
+
+  it('throws a ClickHouseQueryError on a mid-stream exception event', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    expect(() =>
+      parse([{ exception: 'Code: 241. DB::Exception: Memory limit exceeded' }]),
+    ).toThrow(ClickHouseQueryError);
+  });
+
+  it('emits rows decoded before an exception so partial results survive', () => {
+    const handlers = createHandlers();
+    const parse = createEachRowWithProgressParser(handlers, QUERY);
+
+    expect(() =>
+      parse([{ row: { n: 1 } }, { exception: 'Code: 159. Timeout exceeded' }]),
+    ).toThrow('Code: 159. Timeout exceeded');
+
+    expect(handlers.onRows).toHaveBeenCalledWith([{ n: 1 }]);
+  });
+
+  it('carries the query text on the thrown error for debugging', () => {
+    const parse = createEachRowWithProgressParser(createHandlers(), QUERY);
+
+    try {
+      parse([{ exception: 'boom' }]);
+      throw new Error('expected parse to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ClickHouseQueryError);
+      expect((e as ClickHouseQueryError).query).toBe(QUERY);
+    }
+  });
+
+  it('tolerates a missing onProgress handler', () => {
+    const onMeta = jest.fn();
+    const onRows = jest.fn();
+    const parse = createEachRowWithProgressParser({ onMeta, onRows }, QUERY);
+
+    expect(() =>
+      parse([
+        { progress: { read_rows: '1', read_bytes: '1', elapsed_ns: '1' } },
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/packages/app/src/utils/__tests__/queryProgress.test.ts
+++ b/packages/app/src/utils/__tests__/queryProgress.test.ts
@@ -1,0 +1,197 @@
+import {
+  ChunkProgress,
+  MAX_DISPLAYED_PERCENT,
+  progressFraction,
+  summarizeChunkProgress,
+  toChunkProgress,
+} from '@/utils/queryProgress';
+
+const HOUR = 60 * 60 * 1000;
+
+function chunk(overrides: Partial<ChunkProgress> = {}): ChunkProgress {
+  return {
+    rangeMs: HOUR,
+    readRows: 0,
+    readBytes: 0,
+    fraction: undefined,
+    isComplete: false,
+    ...overrides,
+  };
+}
+
+describe('progressFraction', () => {
+  it('divides read rows by the estimated total', () => {
+    expect(
+      progressFraction({
+        read_rows: '25',
+        read_bytes: '100',
+        total_rows_to_read: '100',
+        elapsed_ns: '1',
+      }),
+    ).toBe(0.25);
+  });
+
+  it('clamps to 1 when read rows exceed the estimate', () => {
+    expect(
+      progressFraction({
+        read_rows: '250',
+        read_bytes: '100',
+        total_rows_to_read: '100',
+        elapsed_ns: '1',
+      }),
+    ).toBe(1);
+  });
+
+  it('is undefined when no estimate has been reported yet', () => {
+    expect(
+      progressFraction({
+        read_rows: '25',
+        read_bytes: '100',
+        elapsed_ns: '1',
+      }),
+    ).toBeUndefined();
+    expect(
+      progressFraction({
+        read_rows: '25',
+        read_bytes: '100',
+        total_rows_to_read: '0',
+        elapsed_ns: '1',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('toChunkProgress', () => {
+  it('parses the stringified counters', () => {
+    expect(
+      toChunkProgress(
+        {
+          read_rows: '120',
+          read_bytes: '4096',
+          total_rows_to_read: '480',
+          elapsed_ns: '1',
+        },
+        HOUR,
+      ),
+    ).toEqual({
+      rangeMs: HOUR,
+      readRows: 120,
+      readBytes: 4096,
+      fraction: 0.25,
+      isComplete: false,
+    });
+  });
+
+  it('treats absent or non-numeric counters as zero', () => {
+    expect(
+      // Counters are strings on the wire, so a malformed one is well-typed.
+      toChunkProgress(
+        { read_rows: 'abc', read_bytes: '', elapsed_ns: '1' },
+        HOUR,
+      ),
+    ).toMatchObject({ readRows: 0, readBytes: 0, fraction: undefined });
+  });
+});
+
+describe('summarizeChunkProgress', () => {
+  it('is indeterminate before anything measurable arrives', () => {
+    expect(
+      summarizeChunkProgress({
+        chunks: [chunk({ readRows: 10 })],
+        totalRangeMs: 4 * HOUR,
+        elapsedMs: 100,
+      }),
+    ).toEqual({
+      percent: undefined,
+      readRows: 10,
+      readBytes: 0,
+      elapsedMs: 100,
+    });
+  });
+
+  it('weights each window by its share of the whole range', () => {
+    // One full hour done, plus half of a second hour, over a 4h range.
+    const summary = summarizeChunkProgress({
+      chunks: [
+        chunk({ isComplete: true, readRows: 100 }),
+        chunk({ fraction: 0.5, readRows: 40 }),
+      ],
+      totalRangeMs: 4 * HOUR,
+      elapsedMs: 500,
+    });
+
+    expect(summary.percent).toBeCloseTo(37.5);
+    expect(summary.readRows).toBe(140);
+  });
+
+  it('counts a complete chunk in full regardless of its last fraction', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [chunk({ isComplete: true, fraction: 0.3 })],
+      totalRangeMs: 2 * HOUR,
+      elapsedMs: 1,
+    });
+
+    expect(summary.percent).toBeCloseTo(50);
+  });
+
+  it('adds windows already completed outside the live chunk set', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [chunk({ fraction: 0.5, readRows: 5, readBytes: 50 })],
+      totalRangeMs: 4 * HOUR,
+      completedRangeMs: 2 * HOUR,
+      completedRows: 900,
+      completedBytes: 9000,
+      elapsedMs: 20,
+    });
+
+    expect(summary.percent).toBeCloseTo(62.5);
+    expect(summary.readRows).toBe(905);
+    expect(summary.readBytes).toBe(9050);
+  });
+
+  it('reports a percentage from completed windows alone', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [],
+      totalRangeMs: 4 * HOUR,
+      completedRangeMs: HOUR,
+      elapsedMs: 5,
+    });
+
+    expect(summary.percent).toBeCloseTo(25);
+  });
+
+  it('caps below 100 so a running query never looks finished', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [chunk({ isComplete: true, rangeMs: 10 * HOUR })],
+      totalRangeMs: HOUR,
+      elapsedMs: 1,
+    });
+
+    expect(summary.percent).toBe(MAX_DISPLAYED_PERCENT);
+  });
+
+  it('sums counters across parallel chunks', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [
+        chunk({ readRows: 10, readBytes: 100 }),
+        chunk({ readRows: 20, readBytes: 200 }),
+        chunk({ readRows: 30, readBytes: 300 }),
+      ],
+      totalRangeMs: 3 * HOUR,
+      elapsedMs: 7,
+    });
+
+    expect(summary.readRows).toBe(60);
+    expect(summary.readBytes).toBe(600);
+  });
+
+  it('is indeterminate when the total range is unknown', () => {
+    const summary = summarizeChunkProgress({
+      chunks: [chunk({ isComplete: true })],
+      totalRangeMs: 0,
+      elapsedMs: 1,
+    });
+
+    expect(summary.percent).toBeUndefined();
+  });
+});

--- a/packages/app/src/utils/clickhouseStream.ts
+++ b/packages/app/src/utils/clickhouseStream.ts
@@ -1,0 +1,131 @@
+import {
+  ClickHouseProgress,
+  ClickHouseQueryError,
+  ColumnMetaType,
+  isException,
+  isProgressRow,
+  isRow,
+} from '@hyperdx/common-utils/dist/clickhouse';
+
+/**
+ * Callbacks invoked as a ClickHouse response stream is decoded.
+ *
+ * `onMeta` fires once, before any `onRows`. `onProgress` may fire at any point,
+ * including before `onMeta`: ClickHouse writes a progress line straight from
+ * its progress callback without first emitting the format prefix.
+ */
+export type StreamHandlers = {
+  onMeta: (meta: ColumnMetaType[]) => void;
+  onRows: (rows: Record<string, unknown>[]) => void;
+  onProgress?: (progress: ClickHouseProgress) => void;
+};
+
+/**
+ * Consumes one batch of decoded NDJSON lines from a ClickHouse result stream.
+ * Each element is the parsed JSON of a single line, in stream order.
+ */
+export type StreamParser = (events: unknown[]) => void;
+
+/**
+ * Parser for `JSONCompactEachRowWithNamesAndTypes`: a line of column names,
+ * then a line of column types, then positional value arrays. Emits no progress.
+ */
+export function createCompactWithNamesAndTypesParser({
+  onMeta,
+  onRows,
+}: StreamHandlers): StreamParser {
+  // Header lines can be split across batches, so buffer until both arrive.
+  const headerEvents: unknown[] = [];
+  const meta: ColumnMetaType[] = [];
+
+  return events => {
+    let dataEvents = events;
+
+    if (meta.length === 0) {
+      headerEvents.push(...events);
+      if (headerEvents.length < 2) {
+        return;
+      }
+
+      const names = headerEvents[0] as string[];
+      const types = headerEvents[1] as string[];
+      if (names.length !== types.length) {
+        throw new Error(
+          'Invalid JSONCompactEachRowWithNamesAndTypes header rows',
+        );
+      }
+      for (let i = 0; i < names.length; i++) {
+        meta.push({ name: names[i], type: types[i] });
+      }
+      onMeta(meta);
+
+      dataEvents = headerEvents.slice(2);
+      headerEvents.length = 0;
+    }
+
+    const rows: Record<string, unknown>[] = [];
+    for (const event of dataEvents) {
+      const values = event as unknown[];
+      const row: Record<string, unknown> = {};
+      for (let i = 0; i < values.length; i++) {
+        row[meta[i].name] = values[i];
+      }
+      rows.push(row);
+    }
+
+    if (rows.length > 0) {
+      onRows(rows);
+    }
+  };
+}
+
+function isMetaEvent(event: unknown): event is { meta: ColumnMetaType[] } {
+  return (
+    event !== null &&
+    typeof event === 'object' &&
+    'meta' in event &&
+    Array.isArray((event as { meta: unknown }).meta)
+  );
+}
+
+/**
+ * Parser for `JSONEachRowWithProgress`: a stream of single-key JSON objects —
+ * `{"meta":[...]}`, `{"row":{...}}`, `{"progress":{...}}`, plus
+ * `rows_before_limit_at_least` / `totals` / `extremes` events which are ignored
+ * here.
+ *
+ * Rows already arrive keyed by column name, so `meta` only carries the column
+ * types upward.
+ *
+ * A mid-stream `{"exception":...}` arrives under HTTP 200 (the status line went
+ * out before the query failed), so it is surfaced as a `ClickHouseQueryError`.
+ */
+export function createEachRowWithProgressParser(
+  { onMeta, onRows, onProgress }: StreamHandlers,
+  query: string,
+): StreamParser {
+  return events => {
+    const rows: Record<string, unknown>[] = [];
+
+    for (const event of events) {
+      if (isRow<Record<string, unknown>>(event)) {
+        rows.push(event.row);
+      } else if (isProgressRow(event)) {
+        onProgress?.(event.progress);
+      } else if (isMetaEvent(event)) {
+        onMeta(event.meta);
+      } else if (isException(event)) {
+        // Emit what was decoded before the failure so partial results are not
+        // dropped on the way to the error handler.
+        if (rows.length > 0) {
+          onRows(rows);
+        }
+        throw new ClickHouseQueryError(event.exception, query);
+      }
+    }
+
+    if (rows.length > 0) {
+      onRows(rows);
+    }
+  };
+}

--- a/packages/app/src/utils/queryProgress.ts
+++ b/packages/app/src/utils/queryProgress.ts
@@ -1,0 +1,122 @@
+import type { ClickHouseProgress } from '@hyperdx/common-utils/dist/clickhouse';
+
+/**
+ * `total_rows_to_read` is an estimate, and a query with a LIMIT over a sorted
+ * table routinely terminates early — so read_rows can reach or exceed it while
+ * rows are still on the way. Cap the reported percentage short of full so a
+ * still-running query never looks finished.
+ */
+export const MAX_DISPLAYED_PERCENT = 99;
+
+/** Progress for one time window of a chunked/windowed query. */
+export type ChunkProgress = {
+  /** Duration of the window this chunk covers, in ms. */
+  rangeMs: number;
+  readRows: number;
+  readBytes: number;
+  /**
+   * How far through its own window this chunk is, 0..1. Undefined when
+   * ClickHouse has not yet reported a `total_rows_to_read` estimate.
+   */
+  fraction: number | undefined;
+  isComplete: boolean;
+};
+
+export type QueryProgressSummary = {
+  /**
+   * Share of the whole requested date range searched so far, 0..100. Undefined
+   * when nothing measurable has arrived yet — render an indeterminate bar.
+   */
+  percent: number | undefined;
+  readRows: number;
+  readBytes: number;
+  elapsedMs: number;
+};
+
+function toCount(value: string | undefined): number {
+  if (value == null) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * How far through its own scan a single ClickHouse query is, 0..1, or
+ * undefined when the server has not estimated `total_rows_to_read` yet.
+ */
+export function progressFraction(
+  progress: ClickHouseProgress,
+): number | undefined {
+  const total = toCount(progress.total_rows_to_read);
+  if (total <= 0) return undefined;
+  return Math.min(toCount(progress.read_rows) / total, 1);
+}
+
+/** Builds a chunk entry from a raw ClickHouse progress event. */
+export function toChunkProgress(
+  progress: ClickHouseProgress,
+  rangeMs: number,
+): ChunkProgress {
+  return {
+    rangeMs,
+    readRows: toCount(progress.read_rows),
+    readBytes: toCount(progress.read_bytes),
+    fraction: progressFraction(progress),
+    isComplete: false,
+  };
+}
+
+/**
+ * Combines per-window progress into one whole-query summary.
+ *
+ * The percentage is *time coverage*, not rows: each window contributes its own
+ * share of the total date range, weighted by how far into it the server has
+ * scanned. Rows are a poor basis here because the only available denominator
+ * (an EXPLAIN estimate) ignores skip indexes and early LIMIT termination, and
+ * goes badly wrong when a chart is rewritten onto a materialized view — so a
+ * row-based bar would routinely stall well short of the end. Time coverage
+ * also matches what the surrounding UI already says ("Searched <date>…
+ * across about 1 month").
+ *
+ * `completedRangeMs` covers windows already fully searched whose per-chunk
+ * entries are gone (e.g. pages restored from cache).
+ */
+export function summarizeChunkProgress({
+  chunks,
+  totalRangeMs,
+  completedRangeMs = 0,
+  completedRows = 0,
+  completedBytes = 0,
+  elapsedMs,
+}: {
+  chunks: ChunkProgress[];
+  totalRangeMs: number;
+  completedRangeMs?: number;
+  completedRows?: number;
+  completedBytes?: number;
+  elapsedMs: number;
+}): QueryProgressSummary {
+  let coveredMs = completedRangeMs;
+  let readRows = completedRows;
+  let readBytes = completedBytes;
+  let hasMeasurableCoverage = completedRangeMs > 0;
+
+  for (const chunk of chunks) {
+    readRows += chunk.readRows;
+    readBytes += chunk.readBytes;
+
+    if (chunk.isComplete) {
+      coveredMs += chunk.rangeMs;
+      hasMeasurableCoverage = true;
+    } else if (chunk.fraction != null) {
+      coveredMs += chunk.rangeMs * chunk.fraction;
+      hasMeasurableCoverage = true;
+    }
+  }
+
+  const percent =
+    hasMeasurableCoverage && totalRangeMs > 0
+      ? Math.min((coveredMs / totalRangeMs) * 100, MAX_DISPLAYED_PERCENT)
+      : undefined;
+
+  return { percent, readRows, readBytes, elapsedMs };
+}

--- a/packages/common-utils/src/__tests__/clickhouseVersion.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouseVersion.test.ts
@@ -3,6 +3,7 @@ import {
   isClickHouseVersionAtLeast,
   parseClickHouseVersion,
   supportsDirectReadMap,
+  supportsJSONEachRowWithProgressMeta,
 } from '@/core/clickhouseVersion';
 
 type ClickHouseVersionTuple = readonly [number, number, number, number];
@@ -253,5 +254,23 @@ describe('supportsDirectReadMap', () => {
         expect(supportsDirectReadMap(version, true)).toBe(true);
       },
     );
+  });
+});
+
+describe('supportsJSONEachRowWithProgressMeta', () => {
+  it.each<readonly [ClickHouseVersionTuple, boolean]>([
+    [[25, 1, 0, 0], true],
+    [[25, 1, 0, 1], true],
+    [[25, 2, 0, 0], true],
+    [[26, 4, 1, 3], true],
+    [[25, 0, 99, 99], false],
+    [[24, 12, 0, 0], false],
+    [[23, 8, 0, 0], false],
+  ])('%j → %s', (version, expected) => {
+    expect(supportsJSONEachRowWithProgressMeta(version)).toBe(expected);
+  });
+
+  it('returns false when the version is unknown', () => {
+    expect(supportsJSONEachRowWithProgressMeta(undefined)).toBe(false);
   });
 });

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -4,10 +4,12 @@ import type {
   ClickHouseSettings,
   DataFormat,
   Logger,
+  ProgressRow,
   ResponseHeaders,
   ResponseJSON,
   Row,
 } from '@clickhouse/client-common';
+import { isException, isProgressRow, isRow } from '@clickhouse/client-common';
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
 import * as SQLParser from 'node-sql-parser';
 
@@ -31,9 +33,23 @@ export type {
   ClickHouseSettings,
   DataFormat,
   Logger,
+  ProgressRow,
   ResponseJSON,
   Row,
 };
+
+/**
+ * Query progress counters carried by a `{"progress":...}` event in the
+ * `JSONEachRowWithProgress` format. All counters are stringified UInt64s.
+ * `total_rows_to_read` is an estimate and is absent until ClickHouse has
+ * decided how much it needs to scan.
+ */
+export type ClickHouseProgress = ProgressRow['progress'];
+
+// Row-kind guards for the `JSONEachRowWithProgress` format. Re-exported here
+// because consumers (e.g. the app) depend on @hyperdx/common-utils rather than
+// on @clickhouse/client-* directly.
+export { isException, isProgressRow, isRow };
 
 export enum JSDataType {
   Array = 'array',

--- a/packages/common-utils/src/core/clickhouseVersion.ts
+++ b/packages/common-utils/src/core/clickhouseVersion.ts
@@ -141,6 +141,31 @@ export function supportsDirectReadMap(
 }
 
 /**
+ * First release where `JSONEachRowWithProgress` emits a leading `{"meta":[...]}`
+ * event (column names and types) and a trailing `{"exception":"..."}` event
+ * (ClickHouse PR #74181). Older servers emit only `row` and `progress` events,
+ * so a reader has no way to learn the result-set column types or to detect a
+ * mid-stream failure — both of which the search table needs.
+ */
+const JSON_EACH_ROW_WITH_PROGRESS_META_MIN: ClickHouseVersion = [25, 1, 0, 0];
+
+/**
+ * Returns true when `JSONEachRowWithProgress` carries the `meta` and
+ * `exception` events (>= 25.1), making it a safe replacement for
+ * `JSONCompactEachRowWithNamesAndTypes`. Returns false when the version is
+ * undefined or older, in which case callers should fall back to a format
+ * without progress reporting.
+ */
+export function supportsJSONEachRowWithProgressMeta(
+  version: ClickHouseVersion | undefined,
+): boolean {
+  return isClickHouseVersionAtLeast(
+    version,
+    JSON_EACH_ROW_WITH_PROGRESS_META_MIN,
+  );
+}
+
+/**
  * First release that shipped the `mergeTreeTextIndex(database, table, index)`
  * table function used to introspect text skip indices.
  */

--- a/scripts/ci/ratchet-baseline.json
+++ b/scripts/ci/ratchet-baseline.json
@@ -6,7 +6,7 @@
     "@source": 0
   },
   "app": {
-    "as-any": 215,
+    "as-any": 213,
     "ts-ignore": 0,
     "eslint-disable": 146,
     "@source": 0


### PR DESCRIPTION
## Why

A search over a long range shows an unqualified spinner for its whole duration.
The user cannot tell whether ClickHouse is 5% or 95% of the way through, or
whether it is doing anything at all. This surfaces ClickHouse's own progress
counters in two places: the results-table footer and the histogram's
"Scanned Rows | Elapsed Time" strip.

## How

**Transport.** Progress comes from `JSONEachRowWithProgress`, which interleaves
`{"progress":...}` lines with rows in the response body. Headers were a dead
end: ClickHouse stops emitting `X-ClickHouse-Progress` once the body starts
(`WriteBufferFromHTTPServerResponse::onProgress` checks `headers_finished_sending`),
and `fetch()` cannot surface headers incrementally anyway. The format needs
**ClickHouse >= 25.1** (PR #74181 added the `meta`/`exception` events); it is
chosen per connection via `metadata.getServerVersion`, and older or unknown
servers silently keep the existing non-streaming path.

**Proxy.** The API's `clickhouse-proxy` now flushes each upstream chunk through
`compression()` instead of letting zlib buffer the tiny progress lines until
enough bytes accumulate. It also no longer tries to write a 500 after the body
has started — that threw `ERR_HTTP_HEADERS_SENT` from inside the error
listener, an uncaught exception that takes down the process in dev.

**Percent is time coverage, not rows.** The only row denominator available is
an EXPLAIN estimate that ignores skip indexes and early LIMIT termination, and
is wrong outright when a chart is rewritten onto a materialized view — a
row-based bar would routinely stall short of the end. Instead each time window
contributes its share of the total range, weighted by how far ClickHouse has
scanned it. This also matches what the surrounding UI already says
("Searched ... across about 1 month").

**Surviving window boundaries.** Search pagination fetches one time window at a
time (`15m, 6h, 6h, 12h, 24h, ...`), so `isFetching` dips between them.
Progress deliberately survives those dips — clearing on that edge made the bar
vanish and the elapsed timer restart at every window, dozens of times over a
month-long range — and idle gaps are excluded from elapsed. A fresh run resets
it from the `queryFn`, which is keyed to an actual new query rather than racing
a timeout. Windows also register themselves as in-flight at 0% before reading,
so a just-opened window's placeholder page is not credited its whole range.

Hidden during live tail, where the query refetches every few seconds and a bar
would only flicker.

## Testing

- `make ci-lint`, `make ci-unit` (7,855 tests), `make dev-int FILE=clickhouseProxy` — all green
- Negative controls run for the three new behaviours (proxy per-chunk flush,
  proxy `headersSent` guard, progress surviving window gaps): each test fails
  without its fix
- **Not yet done:** manual browser verification on a clean `yarn dev` restart.
  Marked draft for that reason.

## Known caveats

- With the 1-minute first window, a search that fills its LIMIT immediately
  shows ~0% for a moment before the bar disappears. Accurate, but may look odd.
- The footer's "Loading results..." text itself unmounts for one frame between
  windows (`DBRowTable.tsx:1255`). Pre-existing; not addressed here.
