### PR TITLE
fix: keep LLM dashboard scope filters clearable when their options fail to load

### DIFF
--- a/.changeset/quiet-pugs-clap.md
+++ b/.changeset/quiet-pugs-clap.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/app': patch
+---
+
+fix: keep the LLM dashboard scope filters clearable when their options fail to
+load
+
+The session and user dropdowns were disabled whenever their distinct-value query
+was loading or had failed. With a filter applied that left the user looking at a
+scope they could see but could not remove — permanently, if the query kept
+failing. They now stay interactive whenever a value is applied.

--- a/packages/app/src/llm/__tests__/DistinctValueSelect.test.tsx
+++ b/packages/app/src/llm/__tests__/DistinctValueSelect.test.tsx
@@ -5,11 +5,12 @@ import { DistinctValueSelect } from '@/llm/dashboard/DistinctValueSelect';
 
 let mockRows: Record<string, unknown>[] | undefined = [];
 let mockLoading = false;
+let mockError = false;
 jest.mock('@/hooks/useChartConfig', () => ({
   useQueriedChartConfig: () => ({
     data: mockRows == null ? undefined : { data: mockRows },
     isLoading: mockLoading,
-    isError: false,
+    isError: mockError,
   }),
 }));
 
@@ -28,6 +29,7 @@ describe('DistinctValueSelect', () => {
   beforeEach(() => {
     mockRows = [];
     mockLoading = false;
+    mockError = false;
   });
 
   it('shows the applied value when it is present in the fetched options', () => {
@@ -81,6 +83,34 @@ describe('DistinctValueSelect', () => {
 
     expect(screen.getByRole('combobox')).toHaveValue('alice@x.com');
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // Otherwise a failing distinct query strands the user with a filter they
+  // can see but cannot remove.
+  it('stays interactive while a value is applied even if the query fails', () => {
+    mockRows = undefined;
+    mockError = true;
+    renderWithMantine(
+      <DistinctValueSelect
+        {...baseProps}
+        value="alice@x.com"
+        onChange={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('alice@x.com');
+    expect(input).not.toBeDisabled();
+  });
+
+  it('disables the control while loading with nothing applied', () => {
+    mockRows = undefined;
+    mockLoading = true;
+    renderWithMantine(
+      <DistinctValueSelect {...baseProps} value="" onChange={jest.fn()} />,
+    );
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
   });
 
   it('falls back to the placeholder when no value is applied', () => {

--- a/packages/app/src/llm/dashboard/DistinctValueSelect.tsx
+++ b/packages/app/src/llm/dashboard/DistinctValueSelect.tsx
@@ -89,7 +89,10 @@ export function DistinctValueSelect({
       data={values}
       value={value || null}
       onChange={v => onChange(v ?? '')}
-      disabled={isLoading || isError}
+      // Never lock the control while a scope is applied: the options are of no
+      // use yet, but clearing the filter must stay possible. On a failing
+      // distinct query that is otherwise permanent.
+      disabled={(isLoading || isError) && !value}
       comboboxProps={{ withinPortal: false }}
       searchable
       clearable


### PR DESCRIPTION
## Summary

Follow-up to #3104, addressing a detail raised in review there that landed after the merge.

#3104 fixed the scope dropdowns (session, user) falling back to their placeholder when the applied value wasn't in the fetched options — the control read "All users" while every chart stayed filtered. Pinning the value made it visible, but the control is still `disabled` whenever the distinct-value query is loading or has failed:

```tsx
disabled={isLoading || isError}
```

So with a filter applied and a failing query, the user can see the scope but can't remove it — and `isError` doesn't clear on its own, so that state is permanent. Mantine also only renders the `clearable` × on an enabled input, so there is no escape from the control itself.

Now only disabled when nothing is applied:

```tsx
disabled={(isLoading || isError) && !value}
```

Loading with no filter still disables, which is the case the guard was for.

## Tests

Two cases added to `DistinctValueSelect.test.tsx`:

- applied value + failing query → input is enabled and still shows the value
- loading with nothing applied → input is disabled (pins the behaviour that's kept)

The first fails against the old `disabled={isLoading || isError}`.

## Verification

- `yarn ci:unit` (app): 233 suites, 3,829 tests, pass
- `make ci-lint`: 0 errors · `tsc --noEmit` clean · `knip` clean

## References

- Follows: #3104
