### PR TITLE
Apply saved-search filters to alert sample queries

### DIFF
--- a/.changeset/silent-pandas-search.md
+++ b/.changeset/silent-pandas-search.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/api': patch
+---
+
+Apply saved-search pinned filters to alert notification sample queries so sample
+log lines come from the same row set the alert counted.

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -713,6 +713,36 @@ describe('enriched message fields', () => {
     });
   });
 
+  it('applies the saved search pinned filters to the sample log query', async () => {
+    const seenQueries: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const capturingClickhouseClient = {
+      query: jest.fn().mockImplementation((args: { query: string }) => {
+        seenQueries.push(args.query);
+        return Promise.resolve({
+          json: jest.fn().mockResolvedValue({ data: [] }),
+          text: jest.fn().mockResolvedValue(sampleLogsCsv),
+        });
+      }),
+    } as any;
+
+    await renderAlertTemplate({
+      alertProvider,
+      clickhouseClient: capturingClickhouseClient,
+      metadata: mockMetadata,
+      state: AlertState.ALERT,
+      template: null,
+      title: 'Test Alert Title',
+      view: makeSearchView({
+        filters: [{ type: 'sql', condition: "ServiceName = 'checkout'" }],
+      }),
+      teamId: TEST_TEAM_ID,
+      teamWebhooksById: new Map(),
+    });
+
+    expect(seenQueries.join('\n')).toContain("ServiceName = 'checkout'");
+  });
+
   it('reports an empty sourceQuery when the chart carries no condition', async () => {
     const { dispatched } = await renderWithWebhook(
       AlertState.ALERT,

--- a/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/renderAlertTemplate.int.test.ts
@@ -5,6 +5,7 @@ import {
   SourceKind,
   Tile,
 } from '@hyperdx/common-utils/dist/types';
+import type { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import mongoose from 'mongoose';
 
 import {
@@ -716,7 +717,7 @@ describe('enriched message fields', () => {
   it('applies the saved search pinned filters to the sample log query', async () => {
     const seenQueries: string[] = [];
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const capturingClickhouseClient = {
+    const capturingClickhouseClient: Pick<ClickhouseClient, 'query'> = {
       query: jest.fn().mockImplementation((args: { query: string }) => {
         seenQueries.push(args.query);
         return Promise.resolve({

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -1,6 +1,7 @@
 import { ClickhouseClient } from '@hyperdx/common-utils/dist/clickhouse/node';
 import { Metadata } from '@hyperdx/common-utils/dist/core/metadata';
 import { renderChartConfig } from '@hyperdx/common-utils/dist/core/renderChartConfig';
+import { buildSearchChartConfig } from '@hyperdx/common-utils/dist/core/searchChartConfig';
 import { formatDate, objectHash } from '@hyperdx/common-utils/dist/core/utils';
 import {
   isPromqlSavedChartConfig,
@@ -797,24 +798,18 @@ ${targetTemplate}`;
     }
     // TODO: show group + total count for group-by alerts
     // fetch sample logs
-    const resolvedSelect =
-      savedSearch.select || source.defaultTableSelectExpression || '';
     const chartConfig: ChartConfigWithOptDateRange = {
-      connection: '', // no need for the connection id since clickhouse client is already initialized
-      displayType: DisplayType.Search,
-      dateRange: [startTime, endTime],
-      from: source.from,
-      select: resolvedSelect,
-      where: savedSearch.where,
-      whereLanguage: savedSearch.whereLanguage,
-      // The alert evaluation counts the filtered row set, so the sample
-      // query must apply the same pinned filters or it shows unrelated lines.
-      filters: savedSearch.filters?.map(f => ({ ...f })),
-      implicitColumnExpression: source.implicitColumnExpression,
-      useTextIndexForImplicitColumn: source.useTextIndexForImplicitColumn,
-      ...pickSampleWeightExpressionProps(source),
-      timestampValueExpression: source.timestampValueExpression,
-      orderBy: savedSearch.orderBy,
+      ...buildSearchChartConfig(source, {
+        connection: '', // no need for the connection id since clickhouse client is already initialized
+        dateRange: [startTime, endTime],
+        select: savedSearch.select,
+        where: savedSearch.where,
+        whereLanguage: savedSearch.whereLanguage,
+        filters: savedSearch.filters,
+        orderBy: savedSearch.orderBy,
+        dateRangeStartInclusive: true,
+        dateRangeEndInclusive: false,
+      }),
       limit: {
         limit: 5,
         offset: 0,

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -807,6 +807,9 @@ ${targetTemplate}`;
       select: resolvedSelect,
       where: savedSearch.where,
       whereLanguage: savedSearch.whereLanguage,
+      // The alert evaluation counts the filtered row set, so the sample
+      // query must apply the same pinned filters or it shows unrelated lines.
+      filters: savedSearch.filters?.map(f => ({ ...f })),
       implicitColumnExpression: source.implicitColumnExpression,
       useTextIndexForImplicitColumn: source.useTextIndexForImplicitColumn,
       ...pickSampleWeightExpressionProps(source),


### PR DESCRIPTION
Fixes #3059.

## Why
A saved search scoped through the filter bar evaluated correctly, but the sample events rendered into the notification came from an unfiltered query, so alerts showed unrelated log lines as evidence next to a correct count.

## What changed
The sample fetch in renderAlertTemplate hand-built its chart config from where/whereLanguage only. It now also passes savedSearch.filters, the same input the evaluation path feeds buildSearchChartConfig, so renderChartConfig narrows both queries to the same row set. TILE and INLINE paths are untouched. Includes a changeset (patch, @hyperdx/api).

## Tests
- New integration case in renderAlertTemplate.int.test.ts renders a saved-search alert whose search carries a pinned filter and asserts the generated sample SQL contains the filter condition. It fails on unpatched main and passes with the fix.
- Targeted run against local ClickHouse/Mongo services: 1 passed.
- ESLint on touched files: 0 errors (8 pre-existing warnings elsewhere in the files); Prettier clean.