### PR TITLE
fix: report only the delivery time as an alert's notification duration

### DIFF
--- a/.changeset/notification-render-breakdown.md
+++ b/.changeset/notification-render-breakdown.md
@@ -3,13 +3,6 @@
 '@hyperdx/api': patch
 ---
 
-fix: account for message render time in the alert notification breakdown
+fix: show only the delivery time in an alert's notification duration
 
-The notification duration on an alert's evaluation list measures the whole
-notification phase, but the expanded breakdown only listed per-target dispatch
-times. With a single target the two figures should match, and instead the
-target read as milliseconds against a multi-second total — the missing time was
-spent building the message (title, links, the query for log lines in the body)
-before anything was dispatched. That share is now recorded and shown as its own
-row, so the expansion accounts for the total and a slow notification points at
-whichever phase is actually slow.
+The notification duration on an alert's evaluation list was timing everything an alert does once it decides to fire: building the message title and links, querying the log lines that go in the body, rendering the template, and then delivering it. That made the column read in seconds while the webhook underneath it answered in milliseconds — the column and its own per-target breakdown disagreed, and the figure was dominated by work that has nothing to do with how fast the notification target responded. It now times the delivery alone. Evaluations already recorded keep their old figure and will read high.

--- a/.changeset/notification-render-breakdown.md
+++ b/.changeset/notification-render-breakdown.md
@@ -1,0 +1,15 @@
+---
+'@hyperdx/app': patch
+'@hyperdx/api': patch
+---
+
+fix: account for message render time in the alert notification breakdown
+
+The notification duration on an alert's evaluation list measures the whole
+notification phase, but the expanded breakdown only listed per-target dispatch
+times. With a single target the two figures should match, and instead the
+target read as milliseconds against a multi-second total — the missing time was
+spent building the message (title, links, the query for log lines in the body)
+before anything was dispatched. That share is now recorded and shown as its own
+row, so the expansion accounts for the total and a slow notification points at
+whichever phase is actually slow.

--- a/packages/api/src/models/alertHistory.ts
+++ b/packages/api/src/models/alertHistory.ts
@@ -22,19 +22,26 @@ export interface IAlertHistoryAnalytics {
    */
   queryDurationMs?: number;
   /**
-   * Total wall time delivering webhook notifications in the evaluation,
-   * including retries (ms).
+   * Total wall time notifying in the evaluation — message render plus
+   * delivery, including retries (ms).
    */
   webhookDurationMs?: number;
+  /**
+   * The share of `webhookDurationMs` spent rendering the message before any
+   * dispatch (ms): title and links, the log-line query for the body, template
+   * compile.
+   */
+  renderDurationMs?: number;
   /**
    * Earlier buckets backfilled in this run after missed ticks
    * (expected buckets − 1). 0 in steady state.
    */
   backfilledBuckets?: number;
   /**
-   * Per-target breakdown of `webhookDurationMs`, one entry per distinct
-   * target, slowest first. Targets dispatch concurrently, so these do not sum
-   * to `webhookDurationMs`. Absent when the evaluation sent nothing.
+   * Per-target breakdown of the delivery share of `webhookDurationMs`, one
+   * entry per distinct target, slowest first. These do not sum to
+   * `webhookDurationMs` — `renderDurationMs` belongs to no target, and
+   * concurrent dispatches overlap. Absent when the evaluation sent nothing.
    */
   notificationTargets?: AlertNotificationTargetTiming[];
 }
@@ -113,6 +120,7 @@ const AlertHistorySchema = new Schema<IAlertHistory>({
       _id: false,
       queryDurationMs: { type: Number, required: false },
       webhookDurationMs: { type: Number, required: false },
+      renderDurationMs: { type: Number, required: false },
       backfilledBuckets: { type: Number, required: false },
       notificationTargets: {
         type: [

--- a/packages/api/src/models/alertHistory.ts
+++ b/packages/api/src/models/alertHistory.ts
@@ -21,28 +21,16 @@ export interface IAlertHistoryAnalytics {
    * is approximately the configured evaluation timeout.
    */
   queryDurationMs?: number;
-  /**
-   * Total wall time notifying in the evaluation — message render plus
-   * delivery, including retries (ms).
-   */
+  /** Total wall time notifying in the evaluation — render plus delivery, including retries (ms). */
   webhookDurationMs?: number;
-  /**
-   * The share of `webhookDurationMs` spent rendering the message before any
-   * dispatch (ms): title and links, the log-line query for the body, template
-   * compile.
-   */
+  /** The share of `webhookDurationMs` spent building the message before any dispatch (ms). */
   renderDurationMs?: number;
   /**
    * Earlier buckets backfilled in this run after missed ticks
    * (expected buckets − 1). 0 in steady state.
    */
   backfilledBuckets?: number;
-  /**
-   * Per-target breakdown of the delivery share of `webhookDurationMs`, one
-   * entry per distinct target, slowest first. These do not sum to
-   * `webhookDurationMs` — `renderDurationMs` belongs to no target, and
-   * concurrent dispatches overlap. Absent when the evaluation sent nothing.
-   */
+  /** Per-target breakdown of the delivery share, slowest first. See AlertHistoryAnalyticsSchema for why these do not sum to the total. */
   notificationTargets?: AlertNotificationTargetTiming[];
 }
 

--- a/packages/api/src/models/alertHistory.ts
+++ b/packages/api/src/models/alertHistory.ts
@@ -21,16 +21,14 @@ export interface IAlertHistoryAnalytics {
    * is approximately the configured evaluation timeout.
    */
   queryDurationMs?: number;
-  /** Total wall time notifying in the evaluation — render plus delivery, including retries (ms). */
+  /** Wall time delivering the evaluation's notifications (ms) — dispatch only, including retries. */
   webhookDurationMs?: number;
-  /** The share of `webhookDurationMs` spent building the message before any dispatch (ms). */
-  renderDurationMs?: number;
   /**
    * Earlier buckets backfilled in this run after missed ticks
    * (expected buckets − 1). 0 in steady state.
    */
   backfilledBuckets?: number;
-  /** Per-target breakdown of the delivery share, slowest first. See AlertHistoryAnalyticsSchema for why these do not sum to the total. */
+  /** Per-target breakdown, slowest first. See AlertHistoryAnalyticsSchema for why these do not sum to the total. */
   notificationTargets?: AlertNotificationTargetTiming[];
 }
 
@@ -108,7 +106,6 @@ const AlertHistorySchema = new Schema<IAlertHistory>({
       _id: false,
       queryDurationMs: { type: Number, required: false },
       webhookDurationMs: { type: Number, required: false },
-      renderDurationMs: { type: Number, required: false },
       backfilledBuckets: { type: Number, required: false },
       notificationTargets: {
         type: [

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3656,6 +3656,95 @@ describe('checkAlerts', () => {
         expect(targets![0].durationMs).toEqual(expect.any(Number));
         expect(targets![0].dispatches).toBe(1);
         expect(targets![0].failures).toBe(0);
+        // Rendering the message belongs to no target, so it is reported on its
+        // own — otherwise a single-target breakdown reads as much quicker than
+        // the total it is meant to explain. A saved-search alert queries the
+        // log lines for the message body while rendering, so the share is
+        // never zero here. With one target the two phases reconstruct the
+        // total, give or take each figure's own rounding.
+        const { renderDurationMs, webhookDurationMs } =
+          normalHistories[0].analytics!;
+        expect(renderDurationMs).toBeGreaterThan(0);
+        expect(
+          renderDurationMs! + targets![0].durationMs,
+        ).toBeGreaterThanOrEqual(webhookDurationMs! - 2);
+        expect(renderDurationMs! + targets![0].durationMs).toBeLessThanOrEqual(
+          webhookDurationMs! + 2,
+        );
+      });
+
+      // A render-level failure throws before any target is dispatched, so the
+      // whole notification wall time is the render share and no target has a
+      // timing to report. An unclosed Handlebars block fails at compile.
+      it('books the whole notification time as render when the message fails to compile', async () => {
+        const {
+          team,
+          webhook,
+          connection,
+          source,
+          savedSearch,
+          teamWebhooksById,
+          clickhouseClient,
+        } = await setupSavedSearchAlertTest();
+
+        await bulkInsertLogs([
+          {
+            ServiceName: 'api',
+            Timestamp: new Date('2023-11-16T22:05:00.000Z'),
+            SeverityText: 'error',
+            Body: 'oh no',
+          },
+          {
+            ServiceName: 'api',
+            Timestamp: new Date('2023-11-16T22:05:00.000Z'),
+            SeverityText: 'error',
+            Body: 'oh no',
+          },
+        ]);
+
+        const details = await createAlertDetails(
+          team,
+          source,
+          {
+            source: AlertSource.SAVED_SEARCH,
+            channel: {
+              type: 'webhook',
+              webhookId: webhook._id.toString(),
+            },
+            interval: '5m',
+            thresholdType: AlertThresholdType.ABOVE,
+            threshold: 1,
+            savedSearchId: savedSearch.id,
+            message: '{{#if}}',
+          },
+          {
+            taskType: AlertTaskType.SAVED_SEARCH,
+            savedSearch,
+          },
+        );
+
+        await processAlertAtTime(
+          new Date('2023-11-16T22:10:00.000Z'),
+          details,
+          clickhouseClient,
+          connection.id,
+          alertProvider,
+          teamWebhooksById,
+        );
+
+        const errorHistories = await AlertHistory.find({
+          alert: details.alert.id,
+          state: AlertState.ERROR,
+        });
+        expect(errorHistories).toHaveLength(1);
+        expect(errorHistories[0].errors![0].type).toBe(
+          AlertErrorType.WEBHOOK_ERROR,
+        );
+        const { renderDurationMs, webhookDurationMs, notificationTargets } =
+          errorHistories[0].analytics!;
+        expect(notificationTargets).toBeUndefined();
+        expect(renderDurationMs).toBe(webhookDurationMs);
+        expect(renderDurationMs).toBeGreaterThan(0);
       });
 
       it('keeps ERROR rows from older windows when a later window succeeds', async () => {

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3656,22 +3656,20 @@ describe('checkAlerts', () => {
         expect(targets![0].durationMs).toEqual(expect.any(Number));
         expect(targets![0].dispatches).toBe(1);
         expect(targets![0].failures).toBe(0);
-        // With one target the two phases reconstruct the total, give or take
-        // each figure's own rounding. A saved-search render queries the log
-        // lines for the body, so its share is never zero here.
-        const { renderDurationMs, webhookDurationMs } =
-          normalHistories[0].analytics!;
-        expect(renderDurationMs).toBeGreaterThan(0);
-        expect(
-          renderDurationMs! + targets![0].durationMs,
-        ).toBeGreaterThanOrEqual(webhookDurationMs! - 2);
-        expect(renderDurationMs! + targets![0].durationMs).toBeLessThanOrEqual(
-          webhookDurationMs! + 2,
+        // The figure is the dispatch phase alone — with one target it is that
+        // target's own response time, give or take each figure's rounding.
+        // Time spent building the message is deliberately excluded.
+        const { webhookDurationMs } = normalHistories[0].analytics!;
+        expect(webhookDurationMs).toBeGreaterThanOrEqual(
+          targets![0].durationMs - 2,
+        );
+        expect(webhookDurationMs).toBeLessThanOrEqual(
+          targets![0].durationMs + 2,
         );
       });
 
       // An unclosed Handlebars block throws at compile, before any dispatch.
-      it('books the whole notification time as render when the message fails to compile', async () => {
+      it('records no delivery time when the message fails to compile', async () => {
         const {
           team,
           webhook,
@@ -3735,11 +3733,12 @@ describe('checkAlerts', () => {
         expect(errorHistories[0].errors![0].type).toBe(
           AlertErrorType.WEBHOOK_ERROR,
         );
-        const { renderDurationMs, webhookDurationMs, notificationTargets } =
+        // Nothing reached a target, so there is no delivery time to report —
+        // the time spent rendering is not it.
+        const { webhookDurationMs, notificationTargets } =
           errorHistories[0].analytics!;
         expect(notificationTargets).toBeUndefined();
-        expect(renderDurationMs).toBe(webhookDurationMs);
-        expect(renderDurationMs).toBeGreaterThan(0);
+        expect(webhookDurationMs).toBeUndefined();
       });
 
       it('keeps ERROR rows from older windows when a later window succeeds', async () => {

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -3656,12 +3656,9 @@ describe('checkAlerts', () => {
         expect(targets![0].durationMs).toEqual(expect.any(Number));
         expect(targets![0].dispatches).toBe(1);
         expect(targets![0].failures).toBe(0);
-        // Rendering the message belongs to no target, so it is reported on its
-        // own — otherwise a single-target breakdown reads as much quicker than
-        // the total it is meant to explain. A saved-search alert queries the
-        // log lines for the message body while rendering, so the share is
-        // never zero here. With one target the two phases reconstruct the
-        // total, give or take each figure's own rounding.
+        // With one target the two phases reconstruct the total, give or take
+        // each figure's own rounding. A saved-search render queries the log
+        // lines for the body, so its share is never zero here.
         const { renderDurationMs, webhookDurationMs } =
           normalHistories[0].analytics!;
         expect(renderDurationMs).toBeGreaterThan(0);
@@ -3673,9 +3670,7 @@ describe('checkAlerts', () => {
         );
       });
 
-      // A render-level failure throws before any target is dispatched, so the
-      // whole notification wall time is the render share and no target has a
-      // timing to report. An unclosed Handlebars block fails at compile.
+      // An unclosed Handlebars block throws at compile, before any dispatch.
       it('books the whole notification time as render when the message fails to compile', async () => {
         const {
           team,

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -1328,8 +1328,6 @@ export const processAlert = async (
           : `Alert resolved for group "${group}", triggering ${alert.channel.type} notification`,
       );
 
-      const notificationStartedAt = performance.now();
-      let dispatchedForMs = 0;
       try {
         // Casts to any here because this is where I stopped unraveling the
         // alert logic requiring large, nested objects. We should look at
@@ -1354,7 +1352,10 @@ export const processAlert = async (
             windowSizeInMins,
             teamWebhooksById,
           });
-        dispatchedForMs = dispatchDurationMs;
+        // Only the dispatch phase: the column reports how long the targets
+        // took to respond, not the time spent building the message.
+        evaluationAnalytics.webhookDurationMs =
+          (evaluationAnalytics.webhookDurationMs ?? 0) + dispatchDurationMs;
         recordNotificationTimings(timings);
         // Each entry is a target that didn't end up delivered: unresolvable,
         // capped, or (for the inline dispatcher) an actual send rejection —
@@ -1379,15 +1380,6 @@ export const processAlert = async (
           'Failed to fire channel event',
         );
         executionErrors.push(makeWebhookAlertError(e));
-      } finally {
-        // Summed across groups/resolves. Whatever the dispatch didn't account
-        // for is render, so a pre-dispatch throw books the whole total there.
-        const totalMs = Math.round(performance.now() - notificationStartedAt);
-        evaluationAnalytics.webhookDurationMs =
-          (evaluationAnalytics.webhookDurationMs ?? 0) + totalMs;
-        evaluationAnalytics.renderDurationMs =
-          (evaluationAnalytics.renderDurationMs ?? 0) +
-          Math.max(totalMs - dispatchedForMs, 0);
       }
     };
 

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -1329,8 +1329,6 @@ export const processAlert = async (
       );
 
       const notificationStartedAt = performance.now();
-      // Set by the render call below; whatever is left of the wall time is
-      // message render (title/link building, the log-line query, Handlebars).
       let dispatchedForMs = 0;
       try {
         // Casts to any here because this is where I stopped unraveling the
@@ -1382,10 +1380,8 @@ export const processAlert = async (
         );
         executionErrors.push(makeWebhookAlertError(e));
       } finally {
-        // Total wall time spent notifying in this evaluation (summed across
-        // groups/resolves, includes retries and failures), split into the
-        // render and dispatch phases so the UI breakdown accounts for all of
-        // it. A render-level failure never dispatched, so it is all render.
+        // Summed across groups/resolves. Whatever the dispatch didn't account
+        // for is render, so a pre-dispatch throw books the whole total there.
         const totalMs = Math.round(performance.now() - notificationStartedAt);
         evaluationAnalytics.webhookDurationMs =
           (evaluationAnalytics.webhookDurationMs ?? 0) + totalMs;

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -510,7 +510,9 @@ const fireChannelEvent = async ({
   totalCount: number;
   windowSizeInMins: number;
   teamWebhooksById: Map<string, IWebhook>;
-}): Promise<Pick<RenderedAlert, 'failures' | 'timings'>> => {
+}): Promise<
+  Pick<RenderedAlert, 'failures' | 'timings' | 'dispatchDurationMs'>
+> => {
   const team = alert.team;
   if (team == null) {
     throw new Error('Team not found');
@@ -562,7 +564,7 @@ const fireChannelEvent = async ({
     value: totalCount,
   };
 
-  const { failures, timings } = await renderAlertTemplate({
+  const { failures, timings, dispatchDurationMs } = await renderAlertTemplate({
     alertProvider,
     clickhouseClient,
     metadata,
@@ -576,7 +578,7 @@ const fireChannelEvent = async ({
     teamId,
     teamWebhooksById,
   });
-  return { failures, timings };
+  return { failures, timings, dispatchDurationMs };
 };
 
 // Use a delimiter that's unlikely to appear in alert IDs or group names
@@ -1327,29 +1329,34 @@ export const processAlert = async (
       );
 
       const notificationStartedAt = performance.now();
+      // Set by the render call below; whatever is left of the wall time is
+      // message render (title/link building, the log-line query, Handlebars).
+      let dispatchedForMs = 0;
       try {
         // Casts to any here because this is where I stopped unraveling the
         // alert logic requiring large, nested objects. We should look at
         // cleaning this up next. fireChannelEvent guards against null values
         // for these properties.
-        const { failures, timings } = await fireChannelEvent({
-          alert,
-          alertProvider,
-          attributes,
-          clickhouseClient,
-          dashboard: (details as any).dashboard,
-          startTime,
-          endTime: fns.addMinutes(startTime, windowSizeInMins),
-          group,
-          isGroupedAlert: hasGroupBy,
-          metadata,
-          savedSearch: (details as any).savedSearch,
-          source,
-          state,
-          totalCount,
-          windowSizeInMins,
-          teamWebhooksById,
-        });
+        const { failures, timings, dispatchDurationMs } =
+          await fireChannelEvent({
+            alert,
+            alertProvider,
+            attributes,
+            clickhouseClient,
+            dashboard: (details as any).dashboard,
+            startTime,
+            endTime: fns.addMinutes(startTime, windowSizeInMins),
+            group,
+            isGroupedAlert: hasGroupBy,
+            metadata,
+            savedSearch: (details as any).savedSearch,
+            source,
+            state,
+            totalCount,
+            windowSizeInMins,
+            teamWebhooksById,
+          });
+        dispatchedForMs = dispatchDurationMs;
         recordNotificationTimings(timings);
         // Each entry is a target that didn't end up delivered: unresolvable,
         // capped, or (for the inline dispatcher) an actual send rejection —
@@ -1375,11 +1382,16 @@ export const processAlert = async (
         );
         executionErrors.push(makeWebhookAlertError(e));
       } finally {
-        // Total wall time spent delivering notifications in this evaluation
-        // (summed across groups/resolves, includes retries and failures).
+        // Total wall time spent notifying in this evaluation (summed across
+        // groups/resolves, includes retries and failures), split into the
+        // render and dispatch phases so the UI breakdown accounts for all of
+        // it. A render-level failure never dispatched, so it is all render.
+        const totalMs = Math.round(performance.now() - notificationStartedAt);
         evaluationAnalytics.webhookDurationMs =
-          (evaluationAnalytics.webhookDurationMs ?? 0) +
-          Math.round(performance.now() - notificationStartedAt);
+          (evaluationAnalytics.webhookDurationMs ?? 0) + totalMs;
+        evaluationAnalytics.renderDurationMs =
+          (evaluationAnalytics.renderDurationMs ?? 0) +
+          Math.max(totalMs - dispatchedForMs, 0);
       }
     };
 

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -502,11 +502,7 @@ export type RenderedAlert = {
    * time — so this is not the complement of `failures`.
    */
   timings: NotificationTiming[];
-  /**
-   * Wall time of the dispatch phase (ms). Dispatches run concurrently, so the
-   * slowest target sets this. The caller subtracts it from its own
-   * measurement of the whole call to get the message render time.
-   */
+  /** Wall time of the concurrent dispatch phase (ms); the caller subtracts it to get the render share. */
   dispatchDurationMs: number;
 };
 

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -502,6 +502,12 @@ export type RenderedAlert = {
    * time — so this is not the complement of `failures`.
    */
   timings: NotificationTiming[];
+  /**
+   * Wall time of the dispatch phase (ms). Dispatches run concurrently, so the
+   * slowest target sets this. The caller subtracts it from its own
+   * measurement of the whole call to get the message render time.
+   */
+  dispatchDurationMs: number;
 };
 
 // this method will build the body of the alert message and will be used to send the alert to the channel
@@ -913,6 +919,7 @@ ${targetTemplate}`;
     // reports delivery outcomes through its own logs/metrics instead (see
     // agent_docs/observability.md).
     const timings: NotificationTiming[] = [];
+    const dispatchStartedAt = performance.now();
     await Promise.all(
       jobs.map(async job => {
         // Per-job, not around the Promise.all: the whole point is attributing
@@ -947,7 +954,12 @@ ${targetTemplate}`;
       }),
     );
 
-    return { body, failures, timings };
+    return {
+      body,
+      failures,
+      timings,
+      dispatchDurationMs: Math.round(performance.now() - dispatchStartedAt),
+    };
   }
 
   throw new Error(`Unsupported alert source: ${alert.source}`);

--- a/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
+++ b/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
@@ -113,7 +113,7 @@ export function AlertEvaluationsTable({
             <Table.Th>Query duration</Table.Th>
             <Table.Th>
               <Tooltip
-                label="Wall time notifying in this evaluation, including retries: rendering the message, then delivering it. Expand for the breakdown — targets are dispatched concurrently, so the slowest one in each dispatch round sets the delivery share."
+                label="Wall time delivering this evaluation's notifications, including retries. Targets are dispatched concurrently, so the slowest one in each dispatch round sets this figure."
                 multiline
                 maw={320}
                 withArrow

--- a/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
+++ b/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
@@ -113,7 +113,7 @@ export function AlertEvaluationsTable({
             <Table.Th>Query duration</Table.Th>
             <Table.Th>
               <Tooltip
-                label="Wall time delivering notifications in this evaluation, including retries. Targets are dispatched concurrently, so the slowest one sets this figure."
+                label="Wall time notifying in this evaluation, including retries: rendering the message, then delivering it. Expand for the breakdown — targets are dispatched concurrently, so the slowest one sets the delivery share."
                 multiline
                 maw={320}
                 withArrow

--- a/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
+++ b/packages/app/src/components/alerts/AlertEvaluationsTable.tsx
@@ -113,7 +113,7 @@ export function AlertEvaluationsTable({
             <Table.Th>Query duration</Table.Th>
             <Table.Th>
               <Tooltip
-                label="Wall time notifying in this evaluation, including retries: rendering the message, then delivering it. Expand for the breakdown — targets are dispatched concurrently, so the slowest one sets the delivery share."
+                label="Wall time notifying in this evaluation, including retries: rendering the message, then delivering it. Expand for the breakdown — targets are dispatched concurrently, so the slowest one in each dispatch round sets the delivery share."
                 multiline
                 maw={320}
                 withArrow

--- a/packages/app/src/components/alerts/NotificationDurationCell.tsx
+++ b/packages/app/src/components/alerts/NotificationDurationCell.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
 import type { AlertHistoryAnalytics } from '@hyperdx/common-utils/dist/types';
-import { Collapse, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import {
+  Collapse,
+  Group,
+  Stack,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 
 import { formatDurationMs } from '@/utils';
 
 /**
  * The evaluation's notification wall time, expandable in place into a
- * per-target breakdown.
+ * per-target breakdown plus the render time that precedes any dispatch.
  *
  * It expands *within* the cell rather than adding child rows: the parent row
  * already owns a chevron for groups and errors, and a second row-level
@@ -21,14 +28,20 @@ export function NotificationDurationCell({
   const [expanded, setExpanded] = React.useState(false);
   const total = analytics?.webhookDurationMs;
   const targets = analytics?.notificationTargets ?? [];
+  // Rendering the message (title and links, the log-line query, the template)
+  // happens before any dispatch and belongs to no target, so without a row of
+  // its own the breakdown reads as far quicker than the total — most visibly
+  // with a single target, where the two figures should otherwise match.
+  const renderMs = analytics?.renderDurationMs ?? 0;
 
   if (total == null) {
     return <>–</>;
   }
 
-  // Records written before per-target timing existed have the total but no
-  // breakdown, so there is nothing to expand into.
-  if (targets.length === 0) {
+  // Nothing to expand into: records written before per-target timing existed
+  // have the total but no breakdown, and an evaluation whose every target
+  // failed before dispatch has no timing to attribute either.
+  if (targets.length === 0 && renderMs === 0) {
     return <Text size="sm">{formatDurationMs(total)}</Text>;
   }
 
@@ -55,6 +68,22 @@ export function NotificationDurationCell({
       </UnstyledButton>
       <Collapse expanded={expanded}>
         <Stack gap={2} pt={2} data-testid="notification-duration-breakdown">
+          {renderMs > 0 && (
+            <Group gap="xs" wrap="nowrap">
+              <Tooltip
+                label="Building the message before any target is dispatched: the title and links, the query for log lines in the body, and the template render. Summed over every notification this evaluation sent, like the per-target figures."
+                multiline
+                maw={320}
+                withArrow
+                color="dark"
+              >
+                <Text size="xs" c="dimmed" span>
+                  Message render
+                </Text>
+              </Tooltip>
+              <Text size="xs">{formatDurationMs(renderMs)}</Text>
+            </Group>
+          )}
           {targets.map(target => (
             // Keyed on the id, not the label: two webhooks can share a name.
             <Group key={target.targetId} gap="xs" wrap="nowrap">

--- a/packages/app/src/components/alerts/NotificationDurationCell.tsx
+++ b/packages/app/src/components/alerts/NotificationDurationCell.tsx
@@ -13,12 +13,9 @@ import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { formatDurationMs } from '@/utils';
 
 /**
- * The evaluation's notification wall time, expandable in place into a
- * per-target breakdown plus the render time that precedes any dispatch.
- *
- * It expands *within* the cell rather than adding child rows: the parent row
- * already owns a chevron for groups and errors, and a second row-level
- * expander competing with it would be ambiguous to click.
+ * The evaluation's notification wall time, expandable into the render share
+ * and a per-target breakdown. It expands within the cell because the parent
+ * row already owns a chevron, and two would be ambiguous to click.
  */
 export function NotificationDurationCell({
   analytics,
@@ -28,19 +25,16 @@ export function NotificationDurationCell({
   const [expanded, setExpanded] = React.useState(false);
   const total = analytics?.webhookDurationMs;
   const targets = analytics?.notificationTargets ?? [];
-  // Rendering the message (title and links, the log-line query, the template)
-  // happens before any dispatch and belongs to no target, so without a row of
-  // its own the breakdown reads as far quicker than the total — most visibly
-  // with a single target, where the two figures should otherwise match.
+  // Belongs to no target, so without a row of its own a single-target
+  // breakdown reads as far quicker than the total it explains.
   const renderMs = analytics?.renderDurationMs ?? 0;
 
   if (total == null) {
     return <>–</>;
   }
 
-  // Nothing to expand into: records written before per-target timing existed
-  // have the total but no breakdown, and an evaluation whose every target
-  // failed before dispatch has no timing to attribute either.
+  // Nothing to expand into: records predating per-target timing, and
+  // evaluations where every target failed before dispatch.
   if (targets.length === 0 && renderMs === 0) {
     return <Text size="sm">{formatDurationMs(total)}</Text>;
   }
@@ -71,7 +65,7 @@ export function NotificationDurationCell({
           {renderMs > 0 && (
             <Group gap="xs" wrap="nowrap">
               <Tooltip
-                label="Building the message before any target is dispatched: the title and links, the query for log lines in the body, and the template render. Summed over every notification this evaluation sent, like the per-target figures."
+                label="Building the message before any dispatch — title, links, the query for log lines, the template render. Summed over every notification this evaluation sent."
                 multiline
                 maw={320}
                 withArrow

--- a/packages/app/src/components/alerts/NotificationDurationCell.tsx
+++ b/packages/app/src/components/alerts/NotificationDurationCell.tsx
@@ -1,21 +1,14 @@
 import * as React from 'react';
 import type { AlertHistoryAnalytics } from '@hyperdx/common-utils/dist/types';
-import {
-  Collapse,
-  Group,
-  Stack,
-  Text,
-  Tooltip,
-  UnstyledButton,
-} from '@mantine/core';
+import { Collapse, Group, Stack, Text, UnstyledButton } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 
 import { formatDurationMs } from '@/utils';
 
 /**
- * The evaluation's notification wall time, expandable into the render share
- * and a per-target breakdown. It expands within the cell because the parent
- * row already owns a chevron, and two would be ambiguous to click.
+ * The evaluation's notification delivery time, expandable into a per-target
+ * breakdown. It expands within the cell because the parent row already owns a
+ * chevron, and two would be ambiguous to click.
  */
 export function NotificationDurationCell({
   analytics,
@@ -25,17 +18,12 @@ export function NotificationDurationCell({
   const [expanded, setExpanded] = React.useState(false);
   const total = analytics?.webhookDurationMs;
   const targets = analytics?.notificationTargets ?? [];
-  // Belongs to no target, so without a row of its own a single-target
-  // breakdown reads as far quicker than the total it explains.
-  const renderMs = analytics?.renderDurationMs ?? 0;
-
   if (total == null) {
     return <>–</>;
   }
 
-  // Nothing to expand into: records predating per-target timing, and
-  // evaluations where every target failed before dispatch.
-  if (targets.length === 0 && renderMs === 0) {
+  // Records written before per-target timing have the total but no breakdown.
+  if (targets.length === 0) {
     return <Text size="sm">{formatDurationMs(total)}</Text>;
   }
 
@@ -62,22 +50,6 @@ export function NotificationDurationCell({
       </UnstyledButton>
       <Collapse expanded={expanded}>
         <Stack gap={2} pt={2} data-testid="notification-duration-breakdown">
-          {renderMs > 0 && (
-            <Group gap="xs" wrap="nowrap">
-              <Tooltip
-                label="Building the message before any dispatch — title, links, the query for log lines, the template render. Summed over every notification this evaluation sent."
-                multiline
-                maw={320}
-                withArrow
-                color="dark"
-              >
-                <Text size="xs" c="dimmed" span>
-                  Message render
-                </Text>
-              </Tooltip>
-              <Text size="xs">{formatDurationMs(renderMs)}</Text>
-            </Group>
-          )}
           {targets.map(target => (
             // Keyed on the id, not the label: two webhooks can share a name.
             <Group key={target.targetId} gap="xs" wrap="nowrap">

--- a/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
@@ -5,6 +5,7 @@ import { NotificationDurationCell } from '@/components/alerts/NotificationDurati
 
 const analytics = {
   webhookDurationMs: 4120,
+  renderDurationMs: 900,
   notificationTargets: [
     {
       targetId: 'hook-1',
@@ -112,6 +113,73 @@ describe('NotificationDurationCell', () => {
     // Repeated dispatches are marked, so a 50-group total doesn't read as one
     // slow send.
     expect(breakdown).toHaveTextContent('×50');
+  });
+
+  // The render phase precedes any dispatch and belongs to no target, so
+  // without a row of its own the breakdown reads as quicker than the total.
+  it('accounts for the render time in the breakdown', () => {
+    renderWithMantine(
+      <NotificationDurationCell
+        analytics={{
+          webhookDurationMs: 2690,
+          renderDurationMs: 2686,
+          notificationTargets: [
+            {
+              targetId: 'hook-1',
+              target: 'eng-infra',
+              durationMs: 4,
+              dispatches: 1,
+              failures: 0,
+            },
+          ],
+        }}
+      />,
+    );
+
+    const breakdown = screen.getByTestId('notification-duration-breakdown');
+    expect(breakdown).toHaveTextContent('Message render');
+    expect(breakdown).toHaveTextContent('2.69s');
+  });
+
+  // An evaluation whose every target failed before dispatch has no per-target
+  // timing, and the render share is then the whole total — the one case where
+  // the breakdown is worth expanding with no targets in it.
+  it('expands into the render row when no target was dispatched', () => {
+    renderWithMantine(
+      <NotificationDurationCell
+        analytics={{ webhookDurationMs: 2690, renderDurationMs: 2690 }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('notification-duration-toggle'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('notification-duration-breakdown'),
+    ).toHaveTextContent('Message render');
+  });
+
+  it('omits the render row when nothing was spent rendering', () => {
+    renderWithMantine(
+      <NotificationDurationCell
+        analytics={{
+          webhookDurationMs: 210,
+          notificationTargets: [
+            {
+              targetId: 'hook-1',
+              target: 'eng-infra',
+              durationMs: 210,
+              dispatches: 1,
+              failures: 0,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('notification-duration-breakdown'),
+    ).not.toHaveTextContent('Message render');
   });
 
   // The parent row toggles its own expansion on click, so the cell's expander

--- a/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
@@ -5,7 +5,6 @@ import { NotificationDurationCell } from '@/components/alerts/NotificationDurati
 
 const analytics = {
   webhookDurationMs: 4120,
-  renderDurationMs: 900,
   notificationTargets: [
     {
       targetId: 'hook-1',
@@ -113,68 +112,6 @@ describe('NotificationDurationCell', () => {
     // Repeated dispatches are marked, so a 50-group total doesn't read as one
     // slow send.
     expect(breakdown).toHaveTextContent('×50');
-  });
-
-  it('accounts for the render time in the breakdown', () => {
-    renderWithMantine(
-      <NotificationDurationCell
-        analytics={{
-          webhookDurationMs: 2690,
-          renderDurationMs: 2686,
-          notificationTargets: [
-            {
-              targetId: 'hook-1',
-              target: 'eng-infra',
-              durationMs: 4,
-              dispatches: 1,
-              failures: 0,
-            },
-          ],
-        }}
-      />,
-    );
-
-    const breakdown = screen.getByTestId('notification-duration-breakdown');
-    expect(breakdown).toHaveTextContent('Message render');
-    expect(breakdown).toHaveTextContent('2.69s');
-  });
-
-  it('expands into the render row when no target was dispatched', () => {
-    renderWithMantine(
-      <NotificationDurationCell
-        analytics={{ webhookDurationMs: 2690, renderDurationMs: 2690 }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId('notification-duration-toggle'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('notification-duration-breakdown'),
-    ).toHaveTextContent('Message render');
-  });
-
-  it('omits the render row when nothing was spent rendering', () => {
-    renderWithMantine(
-      <NotificationDurationCell
-        analytics={{
-          webhookDurationMs: 210,
-          notificationTargets: [
-            {
-              targetId: 'hook-1',
-              target: 'eng-infra',
-              durationMs: 210,
-              dispatches: 1,
-              failures: 0,
-            },
-          ],
-        }}
-      />,
-    );
-
-    expect(
-      screen.getByTestId('notification-duration-breakdown'),
-    ).not.toHaveTextContent('Message render');
   });
 
   // The parent row toggles its own expansion on click, so the cell's expander

--- a/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
+++ b/packages/app/src/components/alerts/__tests__/NotificationDurationCell.test.tsx
@@ -115,8 +115,6 @@ describe('NotificationDurationCell', () => {
     expect(breakdown).toHaveTextContent('×50');
   });
 
-  // The render phase precedes any dispatch and belongs to no target, so
-  // without a row of its own the breakdown reads as quicker than the total.
   it('accounts for the render time in the breakdown', () => {
     renderWithMantine(
       <NotificationDurationCell
@@ -141,9 +139,6 @@ describe('NotificationDurationCell', () => {
     expect(breakdown).toHaveTextContent('2.69s');
   });
 
-  // An evaluation whose every target failed before dispatch has no per-target
-  // timing, and the render share is then the whole total — the one case where
-  // the breakdown is worth expanding with no targets in it.
   it('expands into the render row when no target was dispatched', () => {
     renderWithMantine(
       <NotificationDurationCell

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1110,22 +1110,14 @@ export const AlertHistoryAnalyticsSchema = z.object({
   queryDurationMs: z.number().optional(),
   /** Total wall time notifying in the evaluation — message render plus delivery, including retries (ms). */
   webhookDurationMs: z.number().optional(),
-  /**
-   * The share of `webhookDurationMs` spent rendering the message before any
-   * dispatch (ms) — building the title and links, fetching log lines for the
-   * body, compiling the template. Absent on records written before the split
-   * existed.
-   */
+  /** The share of `webhookDurationMs` spent building the message before any dispatch (ms). Absent on records written before the split existed. */
   renderDurationMs: z.number().optional(),
   /** Earlier buckets backfilled in this run after missed ticks (expected buckets − 1). */
   backfilledBuckets: z.number().optional(),
   /**
-   * Per-target breakdown of the delivery share of `webhookDurationMs`,
-   * highest duration first. These do not sum to `webhookDurationMs`:
-   * `renderDurationMs` is not attributable to a target, and targets are
-   * dispatched concurrently, so the slowest one in each round sets the
-   * delivery time. Absent on evaluations that sent nothing, and on records
-   * written before per-target timing existed.
+   * Per-target breakdown of the delivery share, highest first. These do not
+   * sum to `webhookDurationMs`: the render share belongs to no target, and
+   * concurrent dispatches overlap. Absent when nothing was dispatched.
    */
   notificationTargets: z
     .array(AlertNotificationTargetTimingSchema)

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1108,16 +1108,14 @@ export type AlertNotificationTargetTiming = z.infer<
 export const AlertHistoryAnalyticsSchema = z.object({
   /** ClickHouse query duration for the evaluation (ms). On query-failure ERROR records, the time until the query failed. */
   queryDurationMs: z.number().optional(),
-  /** Total wall time notifying in the evaluation — message render plus delivery, including retries (ms). */
+  /** Wall time delivering the evaluation's notifications (ms) — dispatch only, including retries. Absent when nothing was dispatched. */
   webhookDurationMs: z.number().optional(),
-  /** The share of `webhookDurationMs` spent building the message before any dispatch (ms). Absent on records written before the split existed. */
-  renderDurationMs: z.number().optional(),
   /** Earlier buckets backfilled in this run after missed ticks (expected buckets − 1). */
   backfilledBuckets: z.number().optional(),
   /**
-   * Per-target breakdown of the delivery share, highest first. These do not
-   * sum to `webhookDurationMs`: the render share belongs to no target, and
-   * concurrent dispatches overlap. Absent when nothing was dispatched.
+   * Per-target breakdown, highest first. Targets in a dispatch round run
+   * concurrently, so the slowest of each round sets `webhookDurationMs` and
+   * these do not sum to it. Absent when nothing was dispatched.
    */
   notificationTargets: z
     .array(AlertNotificationTargetTimingSchema)

--- a/packages/common-utils/src/types.ts
+++ b/packages/common-utils/src/types.ts
@@ -1108,16 +1108,24 @@ export type AlertNotificationTargetTiming = z.infer<
 export const AlertHistoryAnalyticsSchema = z.object({
   /** ClickHouse query duration for the evaluation (ms). On query-failure ERROR records, the time until the query failed. */
   queryDurationMs: z.number().optional(),
-  /** Total wall time delivering webhook notifications in the evaluation, including retries (ms). */
+  /** Total wall time notifying in the evaluation — message render plus delivery, including retries (ms). */
   webhookDurationMs: z.number().optional(),
+  /**
+   * The share of `webhookDurationMs` spent rendering the message before any
+   * dispatch (ms) — building the title and links, fetching log lines for the
+   * body, compiling the template. Absent on records written before the split
+   * existed.
+   */
+  renderDurationMs: z.number().optional(),
   /** Earlier buckets backfilled in this run after missed ticks (expected buckets − 1). */
   backfilledBuckets: z.number().optional(),
   /**
-   * Per-target breakdown of `webhookDurationMs`, highest duration first.
-   * Targets are dispatched concurrently, so these do not sum to
-   * `webhookDurationMs` — the slowest target in each dispatch round sets the
-   * total. Absent on evaluations that sent nothing, and on records written
-   * before per-target timing existed.
+   * Per-target breakdown of the delivery share of `webhookDurationMs`,
+   * highest duration first. These do not sum to `webhookDurationMs`:
+   * `renderDurationMs` is not attributable to a target, and targets are
+   * dispatched concurrently, so the slowest one in each round sets the
+   * delivery time. Absent on evaluations that sent nothing, and on records
+   * written before per-target timing existed.
    */
   notificationTargets: z
     .array(AlertNotificationTargetTimingSchema)


### PR DESCRIPTION
The notification duration on an alert's evaluation list was timing everything an alert does once it decides to fire: building the message title and links, querying the log lines that go in the body, rendering the template, and then delivering it. The result was a column reading 2.69s directly above its own per-target breakdown reading 4ms — the webhook answered in milliseconds and almost all of the rest was spent assembling the message.

The column is meant to be the webhook response time, so it now times the dispatch alone. The message-building time is no longer recorded or displayed anywhere; we agreed that isn't something users need to see.

Two behaviour notes for review. Evaluations already in the database keep their old figure and will read high, with nothing to distinguish them — the field's meaning changes rather than a new field being added, which is the simpler option given the column was its only consumer. And an evaluation that fails before dispatch (a template that won't compile, for instance) now records no delivery time at all and shows a dash, where previously it reported the time it spent failing to build the message.

<details>
<summary>Implementation detail</summary>

`renderAlertTemplate` returns the wall time of its dispatch `Promise.all`, which is the concurrent phase, so the slowest target of each round sets it. The accumulation moved out of the `finally` and into the `try`: a pre-dispatch throw then records nothing instead of attributing its own render time to delivery.

An integration test asserts the recorded figure matches the single target's own response time within rounding, which fails if the render time leaks back in, and another asserts a compile failure records no delivery time. The tooltip also picked up a per-round qualifier from review: a grouped alert notifies once per group, so no single target sets the figure across the whole evaluation.

</details>
