### PR TITLE
fix(api): fetch a grouped alert's example log lines once, not once per group

### DIFF
--- a/.changeset/alert-sample-rows-per-window.md
+++ b/.changeset/alert-sample-rows-per-window.md
@@ -2,13 +2,6 @@
 '@hyperdx/api': patch
 ---
 
-fix: fetch a saved-search alert's sample rows once per window
+fix: fetch a grouped alert's example log lines once per window
 
-A saved-search alert quotes five sample rows in its notification body, fetched
-with a query that carries the saved search's filter and the evaluation window
-but no group predicate. That query ran inside the per-group render, so a grouped
-alert re-ran it once per group for a byte-identical result — ten groups meant
-ten scans of the same window. It now runs once per window and every
-notification for that window shares the result, and the alias clauses the
-evaluation already resolved are reused instead of being recomputed for each
-group.
+A saved-search alert puts a handful of example log lines into the notification it sends, and fetching them takes a second query. That query was being made while building each message, so an alert grouped by service asked ClickHouse for the same lines once per breaching service — ten services meant ten identical queries over the same data, because the query only filters by the saved search and the time window, never by the group. It now runs once and every notification for that window shares the answer. An alert catching up on skipped ticks still fetches lines for each window it backfills, since those genuinely differ. Ungrouped alerts are unaffected; they only ever asked once.

--- a/.changeset/alert-sample-rows-per-window.md
+++ b/.changeset/alert-sample-rows-per-window.md
@@ -1,0 +1,14 @@
+---
+'@hyperdx/api': patch
+---
+
+fix: fetch a saved-search alert's sample rows once per window
+
+A saved-search alert quotes five sample rows in its notification body, fetched
+with a query that carries the saved search's filter and the evaluation window
+but no group predicate. That query ran inside the per-group render, so a grouped
+alert re-ran it once per group for a byte-identical result — ten groups meant
+ten scans of the same window. It now runs once per window and every
+notification for that window shares the result, and the alias clauses the
+evaluation already resolved are reused instead of being recomputed for each
+group.

--- a/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
+++ b/packages/api/src/tasks/checkAlerts/__tests__/checkAlerts.int.test.ts
@@ -6512,6 +6512,89 @@ describe('checkAlerts', () => {
       expect(resolutionCall).toBeDefined();
     });
 
+    // The sample rows quoted in the message body carry no group predicate, so
+    // every group's notification used to re-run the identical query.
+    it('fetches the message body sample rows once for all groups in a window', async () => {
+      const {
+        team,
+        webhook,
+        connection,
+        source,
+        savedSearch,
+        teamWebhooksById,
+        clickhouseClient,
+      } = await setupSavedSearchAlertTest();
+
+      const eventMs = new Date('2023-11-16T22:05:00.000Z');
+      await bulkInsertLogs([
+        {
+          ServiceName: 'service-a',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Error from service-a',
+        },
+        {
+          ServiceName: 'service-a',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Error from service-a',
+        },
+        {
+          ServiceName: 'service-b',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Error from service-b',
+        },
+        {
+          ServiceName: 'service-b',
+          Timestamp: eventMs,
+          SeverityText: 'error',
+          Body: 'Error from service-b',
+        },
+      ]);
+
+      const details = await createAlertDetails(
+        team,
+        source,
+        {
+          source: AlertSource.SAVED_SEARCH,
+          channel: {
+            type: 'webhook',
+            webhookId: webhook._id.toString(),
+          },
+          interval: '5m',
+          thresholdType: AlertThresholdType.ABOVE,
+          threshold: 1,
+          savedSearchId: savedSearch.id,
+          groupBy: 'ServiceName',
+        },
+        {
+          taskType: AlertTaskType.SAVED_SEARCH,
+          savedSearch,
+        },
+      );
+
+      // The sample fetch is the only CSV query in an evaluation.
+      const querySpy = jest.spyOn(clickhouseClient, 'query');
+
+      await processAlertAtTime(
+        new Date('2023-11-16T22:12:00.000Z'),
+        details,
+        clickhouseClient,
+        connection.id,
+        alertProvider,
+        teamWebhooksById,
+      );
+
+      const histories = await AlertHistory.find({ alert: details.alert.id });
+      expect(histories).toHaveLength(2);
+      expect(histories.every(h => h.state === AlertState.ALERT)).toBe(true);
+      const sampleQueries = querySpy.mock.calls.filter(
+        ([input]) => input.format === 'CSV',
+      );
+      expect(sampleQueries).toHaveLength(1);
+    });
+
     it('Group-by alerts skip logic - should skip when any group history exists in current window', async () => {
       const {
         team,

--- a/packages/api/src/tasks/checkAlerts/index.ts
+++ b/packages/api/src/tasks/checkAlerts/index.ts
@@ -82,6 +82,7 @@ import {
 import {
   AlertMessageTemplateDefaultView,
   buildAlertMessageTemplateTitle,
+  fetchSampleLines,
   NotificationFailure,
   NotificationTiming,
   renderAlertTemplate,
@@ -493,6 +494,7 @@ const fireChannelEvent = async ({
   totalCount,
   windowSizeInMins,
   teamWebhooksById,
+  sampleLines,
 }: {
   alert: IAlert;
   alertProvider: AlertProvider;
@@ -510,6 +512,7 @@ const fireChannelEvent = async ({
   totalCount: number;
   windowSizeInMins: number;
   teamWebhooksById: Map<string, IWebhook>;
+  sampleLines?: () => Promise<string>;
 }): Promise<Pick<RenderedAlert, 'failures' | 'timings'>> => {
   const team = alert.team;
   if (team == null) {
@@ -575,6 +578,7 @@ const fireChannelEvent = async ({
     view: templateView,
     teamId,
     teamWebhooksById,
+    sampleLines,
   });
   return { failures, timings };
 };
@@ -1136,6 +1140,9 @@ export const processAlert = async (
     // The alert query itself uses count(*), not the saved search's select,
     // so we render the saved search's select separately to discover aliases
     // and inject them as WITH clauses into the alert query.
+    // Reused by the notification body's sample-row query, which resolves the
+    // same aliases against the same source.
+    let aliasWithClauses: BuilderChartConfigWithOptDateRange['with'];
     if (details.taskType === AlertTaskType.SAVED_SEARCH) {
       if (!isBuilderChartConfig(chartConfig)) {
         logger.error({
@@ -1151,6 +1158,7 @@ export const processAlert = async (
           details.source,
           metadata,
         );
+        aliasWithClauses = withClauses;
         if (withClauses) {
           chartConfig.with = withClauses;
         }
@@ -1284,6 +1292,32 @@ export const processAlert = async (
       return histories.get(groupKey)!;
     };
 
+    // The sample rows a saved-search body quotes depend on the window, not on
+    // the group or the state, so every group notifying for one window shares a
+    // fetch instead of repeating it. Backfilled buckets each notify for their
+    // own window, hence the key. A failed fetch is shared too — the body falls
+    // back to no sample lines rather than re-running the query per group.
+    const sampleLinesByWindow = new Map<number, Promise<string>>();
+    const sampleLinesFor =
+      details.taskType === AlertTaskType.SAVED_SEARCH
+        ? (startTime: Date) => () => {
+            const key = startTime.getTime();
+            const pending =
+              sampleLinesByWindow.get(key) ??
+              fetchSampleLines({
+                aliasWith: aliasWithClauses,
+                clickhouseClient,
+                endTime: fns.addMinutes(startTime, windowSizeInMins),
+                metadata,
+                savedSearch: details.savedSearch,
+                source: details.source,
+                startTime,
+              });
+            sampleLinesByWindow.set(key, pending);
+            return pending;
+          }
+        : undefined;
+
     // Helper to send a notification, catching and logging any errors.
     const trySendNotification = async ({
       group,
@@ -1349,6 +1383,7 @@ export const processAlert = async (
           totalCount,
           windowSizeInMins,
           teamWebhooksById,
+          sampleLines: sampleLinesFor?.(startTime),
         });
         recordNotificationTimings(timings);
         // Each entry is a target that didn't end up delivered: unresolvable,

--- a/packages/api/src/tasks/checkAlerts/template.ts
+++ b/packages/api/src/tasks/checkAlerts/template.ts
@@ -9,6 +9,7 @@ import {
 import {
   AlertChannelType,
   AlertThresholdType,
+  BuilderChartConfigWithOptDateRange,
   ChartConfigWithOptDateRange,
   DisplayType,
   Filter,
@@ -504,6 +505,103 @@ export type RenderedAlert = {
   timings: NotificationTiming[];
 };
 
+/**
+ * The sample rows a saved-search alert quotes in its message body. Keyed to
+ * the evaluation window and the saved search's own filter — not to the group
+ * or the alert state — so one evaluation's notifications can share a result.
+ *
+ * Returns '' when the query fails: a message without its sample lines still
+ * carries the count and the link, so this never fails the notification.
+ */
+export const fetchSampleLines = async ({
+  aliasWith,
+  clickhouseClient,
+  endTime,
+  metadata,
+  savedSearch,
+  source,
+  startTime,
+}: {
+  /** Reuses the evaluation's clauses; recomputed here when absent. */
+  aliasWith?: BuilderChartConfigWithOptDateRange['with'];
+  clickhouseClient: ClickhouseClient;
+  endTime: Date;
+  metadata: Metadata;
+  savedSearch: Pick<
+    ISavedSearch,
+    'id' | 'select' | 'where' | 'whereLanguage' | 'orderBy'
+  >;
+  source: ISource;
+  startTime: Date;
+}): Promise<string> => {
+  const isEventSource =
+    source.kind === SourceKind.Log || source.kind === SourceKind.Trace;
+  const chartConfig: ChartConfigWithOptDateRange = {
+    connection: '', // no need for the connection id since clickhouse client is already initialized
+    displayType: DisplayType.Search,
+    dateRange: [startTime, endTime],
+    from: source.from,
+    select:
+      savedSearch.select ||
+      (isEventSource && source.defaultTableSelectExpression) ||
+      '',
+    where: savedSearch.where,
+    whereLanguage: savedSearch.whereLanguage,
+    implicitColumnExpression: isEventSource
+      ? source.implicitColumnExpression
+      : undefined,
+    useTextIndexForImplicitColumn: isEventSource
+      ? source.useTextIndexForImplicitColumn
+      : undefined,
+    ...pickSampleWeightExpressionProps(source),
+    timestampValueExpression: source.timestampValueExpression,
+    orderBy: savedSearch.orderBy,
+    limit: {
+      limit: 5,
+      offset: 0,
+    },
+  };
+
+  try {
+    const withClauses =
+      aliasWith ??
+      (await computeAliasWithClauses(savedSearch, source, metadata));
+    if (withClauses) {
+      chartConfig.with = withClauses;
+    }
+    const query = await renderChartConfig(
+      chartConfig,
+      metadata,
+      source.querySettings,
+    );
+    const raw = await clickhouseClient
+      .query<'CSV'>({
+        query: query.sql,
+        query_params: query.params,
+        format: 'CSV',
+      })
+      .then(res => res.text());
+
+    return truncateString(
+      raw
+        .split('\n')
+        .map(line => truncateString(line, MAX_MESSAGE_LENGTH))
+        .join('\n'),
+      2500,
+    );
+  } catch (e) {
+    logger.error(
+      {
+        savedSearchId: savedSearch.id,
+        chartConfig,
+        error: serializeError(e),
+      },
+      'Failed to fetch sample logs',
+    );
+    return '';
+  }
+};
+
 // this method will build the body of the alert message and will be used to send the alert to the channel
 export const renderAlertTemplate = async ({
   alertProvider,
@@ -516,6 +614,7 @@ export const renderAlertTemplate = async ({
   teamId,
   teamWebhooksById,
   dispatcher = inlineNotificationDispatcher,
+  sampleLines,
 }: {
   alertProvider: AlertProvider;
   clickhouseClient: ClickhouseClient;
@@ -527,6 +626,12 @@ export const renderAlertTemplate = async ({
   teamId: string;
   teamWebhooksById: Map<string, IWebhook>;
   dispatcher?: NotificationDispatcher;
+  /**
+   * Supplies the sample rows for a saved-search body. The evaluation passes a
+   * memoised provider so a grouped alert fetches them once rather than once
+   * per group; without one they are fetched here.
+   */
+  sampleLines?: () => Promise<string>;
 }): Promise<RenderedAlert> => {
   // Internal mutable view with __hdx_query_results__ populated on the
   // saved-search path. Untrusted values must flow through the view so
@@ -796,71 +901,20 @@ ${targetTemplate}`;
       );
     }
     // TODO: show group + total count for group-by alerts
-    // fetch sample logs
-    const resolvedSelect =
-      savedSearch.select || source.defaultTableSelectExpression || '';
-    const chartConfig: ChartConfigWithOptDateRange = {
-      connection: '', // no need for the connection id since clickhouse client is already initialized
-      displayType: DisplayType.Search,
-      dateRange: [startTime, endTime],
-      from: source.from,
-      select: resolvedSelect,
-      where: savedSearch.where,
-      whereLanguage: savedSearch.whereLanguage,
-      implicitColumnExpression: source.implicitColumnExpression,
-      useTextIndexForImplicitColumn: source.useTextIndexForImplicitColumn,
-      ...pickSampleWeightExpressionProps(source),
-      timestampValueExpression: source.timestampValueExpression,
-      orderBy: savedSearch.orderBy,
-      limit: {
-        limit: 5,
-        offset: 0,
-      },
-    };
-
-    let truncatedResults = '';
-    try {
-      const aliasWith = await computeAliasWithClauses(
-        savedSearch,
-        source,
-        metadata,
-      );
-      if (aliasWith) {
-        chartConfig.with = aliasWith;
-      }
-      const query = await renderChartConfig(
-        chartConfig,
-        metadata,
-        source.querySettings,
-      );
-      const raw = await clickhouseClient
-        .query<'CSV'>({
-          query: query.sql,
-          query_params: query.params,
-          format: 'CSV',
-        })
-        .then(res => res.text());
-
-      const lines = raw.split('\n');
-
-      truncatedResults = truncateString(
-        lines.map(line => truncateString(line, MAX_MESSAGE_LENGTH)).join('\n'),
-        2500,
-      );
-    } catch (e) {
-      logger.error(
-        {
-          savedSearchId: savedSearch.id,
-          chartConfig,
-          error: serializeError(e),
-        },
-        'Failed to fetch sample logs',
-      );
-    }
-
     // Pass query results through the view so Handlebars syntax in log lines
     // is treated as literal text rather than parsed as template source.
-    view.__hdx_query_results__ = truncatedResults;
+    view.__hdx_query_results__ = await (
+      sampleLines ??
+      (() =>
+        fetchSampleLines({
+          clickhouseClient,
+          endTime,
+          metadata,
+          savedSearch,
+          source,
+          startTime,
+        }))
+    )();
 
     rawTemplateBody = `{{#if group}}Group: "{{{group}}}"{{/if}}
 ${value} lines found, which ${describeThresholdViolation(alert.thresholdType)} the threshold of ${describeThreshold(alert)} lines\n${timeRangeMessage}


### PR DESCRIPTION
When a saved-search alert fires, the notification includes a handful of example log lines — the rows that actually tripped the threshold — so you can see what happened without opening the app. Fetching those lines means a second question to ClickHouse, separate from the one that counted the rows and decided to fire.

An alert can also be grouped. Grouped by service, one run sends a separate notification per breaching service: one for checkout, one for search, one for billing. Each message was built independently, and the example-lines query was being made while building each one — so ten breaching services meant asking ClickHouse ten times. It really was the same question every time: that query filters by the saved search and the evaluation window, and never by the group. Ten queries, ten identical answers, ten scans of the same data. Now it asks once and all the messages for that run share the answer.

The one wrinkle is that a run which is catching up on skipped ticks evaluates several windows at once, and each window genuinely needs its own example lines. So this is "once per window" rather than "once per run", which is why there's a small lookup keyed on the window start instead of a single saved value. A failed fetch is shared the same way a successful one is: the message falls back to carrying no example lines, exactly as it did before, rather than retrying a failing query once per group.

Two things not to read into this. An ungrouped alert is completely unaffected, because it only ever asked once — if you are looking at a slow single-group alert, this changes nothing for it. And the query stays the expensive part of sending a notification either way: it fetches raw rows in a sort order, so unlike the count that decides whether to fire, it can never be answered from a materialised view. This makes it happen fewer times, not faster.

One thing this deliberately leaves alone: because the query carries no group predicate, a grouped alert's message can quote lines belonging to a different group than the one it is reporting on. There is a standing `TODO` about that above the query. It is a correctness wart rather than a performance one, and fixing it would mean going back to a query per group — the opposite of this change — so it wants a deliberate decision rather than a quiet fix here.

<details>
<summary>Implementation detail</summary>

The fetch moved out of `renderAlertTemplate` into an exported `fetchSampleLines`, and the render now takes an optional provider that the evaluation supplies as a memoised closure keyed on the window. Callers that don't pass one still fetch inline, so the query itself has a single code path. The evaluation also hands over the alias `WITH` clauses it had already resolved from the same saved search and source, which the render had been recomputing per group.

The new integration test asserts that a two-group evaluation issues one `CSV` query, which is the only CSV query an evaluation makes. Without the fix it fails with two — identical SQL, identical parameters, identical window.

</details>
