### PR TITLE
[HDX-5179] feat(api): add a token encryption service for stored tokens

### DIFF
--- a/.changeset/token-encryption-service.md
+++ b/.changeset/token-encryption-service.md
@@ -1,0 +1,5 @@
+---
+"@hyperdx/api": patch
+---
+
+feat: add a pluggable token encryption service for stored third-party tokens. Set `TOKEN_ENCRYPTION_KEY` to a 32-byte key (base64 or hex) to encrypt them with AES-256-GCM; without it they are stored unencrypted.

--- a/.env
+++ b/.env
@@ -30,6 +30,9 @@ HYPERDX_BASE_PATH=
 # Comma-separated hostnames or exact IP literals that may receive webhooks.
 # Domain entries also permit their subdomains; IP entries are exact matches.
 WEBHOOK_HOSTNAME_ALLOWLIST=
+# 32-byte key (base64 or hex) that encrypts stored Slack and OAuth tokens.
+# Generate with `openssl rand -base64 32`. Unset means plain text.
+TOKEN_ENCRYPTION_KEY=
 
 # Docker service ports (overridden by scripts/dev-env.sh for isolation)
 HDX_DEV_MONGO_PORT=27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       USAGE_STATS_ENABLED: ${USAGE_STATS_ENABLED:-true}
       # Comma-separated hostnames or exact IP literals that may receive webhooks.
       WEBHOOK_HOSTNAME_ALLOWLIST: ${WEBHOOK_HOSTNAME_ALLOWLIST:-}
+      # 32-byte base64 or hex key. Setting it encrypts stored Slack and OAuth
+      # tokens; unset means they are stored in plain text.
+      TOKEN_ENCRYPTION_KEY: ${TOKEN_ENCRYPTION_KEY:-}
       # Uncomment the next two lines to enable PromQL (Prometheus-compatible metrics)
       # ENABLE_PROMQL: 'true'
       # NEXT_PUBLIC_ENABLE_PROMQL: 'true'

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -47,6 +47,11 @@ export const WEBHOOK_HOSTNAME_ALLOWLIST = env.WEBHOOK_HOSTNAME_ALLOWLIST ?? '';
 export const RUN_SCHEDULED_TASKS_EXTERNALLY =
   env.RUN_SCHEDULED_TASKS_EXTERNALLY === 'true';
 
+// 32-byte key (base64 or hex). Setting it is what turns on encryption of
+// stored third-party tokens; unset means they are stored in plain text. See
+// utils/tokenEncryption.ts.
+export const TOKEN_ENCRYPTION_KEY = env.TOKEN_ENCRYPTION_KEY;
+
 // Only for single container local deployments, disable authentication
 export const IS_LOCAL_APP_MODE =
   env.IS_LOCAL_APP_MODE === 'DANGEROUSLY_is_local_app_mode💀';

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -9,6 +9,7 @@ import { connectDBWithRetry, mongooseConnection } from '@/models';
 import opampApp from '@/opamp/app';
 import { setupTeamDefaults } from '@/setupDefaults';
 import logger from '@/utils/logger';
+import { verifyTokenEncryption } from '@/utils/tokenEncryption';
 
 export default class Server {
   protected shouldHandleGracefulShutdown = true;
@@ -84,6 +85,10 @@ export default class Server {
         });
       });
     }
+
+    // Checked before Mongo so a bad encryption key or KMS policy is reported
+    // even while the Mongo connect below is still retrying.
+    await verifyTokenEncryption();
 
     // The HTTP servers above are already listening so that `/health`
     // (liveness) responds while we connect; `/ready` (readiness) stays 503

--- a/packages/api/src/utils/__tests__/tokenEncryption.test.ts
+++ b/packages/api/src/utils/__tests__/tokenEncryption.test.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+
+import logger from '@/utils/logger';
+import {
+  createAesGcmProvider,
+  decryptToken,
+  encryptToken,
+  isTokenEnvelope,
+  parseEncryptionKey,
+  registerTokenEncryptionProvider,
+  selectDefaultProvider,
+  setActiveTokenEncryptionProvider,
+  TokenEncryptionProvider,
+  verifyTokenEncryption,
+} from '@/utils/tokenEncryption';
+
+const KEY = crypto.randomBytes(32);
+const OTHER_KEY = crypto.randomBytes(32);
+
+// Registered once: re-registering a name is itself a warned-about event, and
+// the suite asserts on that warning below.
+beforeAll(() => {
+  registerTokenEncryptionProvider(createAesGcmProvider('test-aes', () => KEY));
+  registerTokenEncryptionProvider(
+    createAesGcmProvider('test-aes-twin', () => KEY),
+  );
+  registerTokenEncryptionProvider(
+    createAesGcmProvider('test-aes-other', () => OTHER_KEY),
+  );
+  registerTokenEncryptionProvider({
+    name: 'broken',
+    encrypt: async () => {
+      throw new Error('KMS unreachable');
+    },
+    decrypt: async () => {
+      throw new Error('KMS unreachable');
+    },
+  });
+});
+
+describe('tokenEncryption', () => {
+  beforeEach(() => {
+    setActiveTokenEncryptionProvider('test-aes');
+  });
+
+  describe('encryptToken / decryptToken', () => {
+    it('encrypts and decrypts a token', async () => {
+      const token = 'test-bot-token-0123456789';
+
+      await expect(decryptToken(await encryptToken(token))).resolves.toBe(
+        token,
+      );
+    });
+
+    it('encrypts and decrypts an empty token', async () => {
+      await expect(decryptToken(await encryptToken(''))).resolves.toBe('');
+    });
+
+    it('tags the envelope with the version and provider, and hides the plaintext', async () => {
+      const envelope = await encryptToken('xoxb-secret');
+
+      expect(envelope.startsWith('v1:test-aes:')).toBe(true);
+      expect(envelope).not.toContain('xoxb-secret');
+    });
+
+    it('produces a different ciphertext each time', async () => {
+      const [a, b] = await Promise.all([
+        encryptToken('same-token'),
+        encryptToken('same-token'),
+      ]);
+
+      expect(a).not.toBe(b);
+    });
+
+    it('rejects a tampered ciphertext', async () => {
+      const envelope = await encryptToken('xoxb-secret');
+      const payload = Buffer.from(envelope.split(':')[2], 'base64');
+      payload[payload.length - 1] ^= 0xff;
+
+      await expect(
+        decryptToken(`v1:test-aes:${payload.toString('base64')}`),
+      ).rejects.toThrow();
+    });
+
+    it('rejects a ciphertext encrypted under a different key', async () => {
+      const envelope = await encryptToken('xoxb-secret');
+      const relabelled = envelope.replace('v1:test-aes:', 'v1:test-aes-other:');
+
+      await expect(decryptToken(relabelled)).rejects.toThrow();
+    });
+
+    it('rejects a payload replayed under a different provider sharing the key', async () => {
+      const envelope = await encryptToken('xoxb-secret');
+      const relabelled = envelope.replace('v1:test-aes:', 'v1:test-aes-twin:');
+
+      await expect(decryptToken(relabelled)).rejects.toThrow();
+    });
+
+    it('decrypts with the provider named in the envelope, not the active one', async () => {
+      const envelope = await encryptToken('written-by-test-aes');
+      setActiveTokenEncryptionProvider('test-aes-other');
+
+      await expect(decryptToken(envelope)).resolves.toBe('written-by-test-aes');
+      expect(await encryptToken('x')).toContain(':test-aes-other:');
+    });
+
+    it('refuses to encrypt a value that is already an envelope', async () => {
+      const envelope = await encryptToken('xoxb-secret');
+
+      await expect(encryptToken(envelope)).rejects.toThrow(/already/);
+    });
+
+    it('throws when the envelope names an unregistered provider', async () => {
+      await expect(decryptToken('v1:kms:abcd')).rejects.toThrow(/kms/);
+    });
+
+    it('throws on an unsupported envelope version', async () => {
+      await expect(decryptToken('v2:test-aes:abcd')).rejects.toThrow(/v2/);
+    });
+
+    it('throws on a payload too short to hold an IV and tag', async () => {
+      const short = crypto.randomBytes(8).toString('base64');
+
+      await expect(decryptToken(`v1:test-aes:${short}`)).rejects.toThrow();
+    });
+
+    it('rejects a raw token without putting it in the error message', async () => {
+      const raw = 'test-bot-token-0123456789';
+
+      let message = '';
+      try {
+        await decryptToken(raw);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toMatch(/not a token encryption envelope/);
+      expect(message).not.toContain(raw);
+    });
+  });
+
+  describe('provider registry', () => {
+    it('rejects a provider name that would break the envelope prefix', () => {
+      const provider: TokenEncryptionProvider = {
+        name: 'kms:aws',
+        encrypt: async token => token,
+        decrypt: async payload => payload,
+      };
+
+      expect(() => registerTokenEncryptionProvider(provider)).toThrow(
+        /kms:aws/,
+      );
+    });
+
+    it('refuses to activate an unregistered provider', () => {
+      expect(() => setActiveTokenEncryptionProvider('nope')).toThrow(/nope/);
+    });
+
+    it('warns when a provider name is re-registered', () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      registerTokenEncryptionProvider(
+        createAesGcmProvider('test-dup', () => KEY),
+      );
+      registerTokenEncryptionProvider(
+        createAesGcmProvider('test-dup', () => OTHER_KEY),
+      );
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+  });
+
+  describe('the none provider', () => {
+    it('leaves the token readable in the envelope', async () => {
+      setActiveTokenEncryptionProvider('none');
+
+      expect(await encryptToken('xoxb-secret')).toBe('v1:none:xoxb-secret');
+    });
+
+    it('handles a token containing a colon', async () => {
+      setActiveTokenEncryptionProvider('none');
+
+      await expect(decryptToken(await encryptToken('a:b:c'))).resolves.toBe(
+        'a:b:c',
+      );
+    });
+
+    it('still reads plain-text rows once encryption is on, and warns', async () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await expect(
+        decryptToken('v1:none:written-while-disabled'),
+      ).resolves.toBe('written-while-disabled');
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      warn.mockRestore();
+      expect(await encryptToken('x')).toContain(':test-aes:');
+    });
+  });
+
+  describe('isTokenEnvelope', () => {
+    it('recognises an envelope and rejects a bare token', () => {
+      expect(isTokenEnvelope('v1:none:xoxb-secret')).toBe(true);
+      expect(isTokenEnvelope('v2:kms:abcd')).toBe(true);
+      expect(isTokenEnvelope('xoxb-1234567890')).toBe(false);
+      expect(isTokenEnvelope('a:b:c')).toBe(false);
+    });
+  });
+
+  describe('selectDefaultProvider', () => {
+    it('stores tokens in plain text when no key is configured', () => {
+      expect(selectDefaultProvider(undefined)).toBe('none');
+      expect(selectDefaultProvider('')).toBe('none');
+    });
+
+    it('encrypts when a key is configured', () => {
+      expect(selectDefaultProvider(KEY.toString('base64'))).toBe('local');
+    });
+  });
+
+  describe('parseEncryptionKey', () => {
+    it('accepts a base64 32-byte key', () => {
+      expect(parseEncryptionKey(KEY.toString('base64'))).toEqual(KEY);
+    });
+
+    it('accepts a hex 32-byte key', () => {
+      expect(parseEncryptionKey(KEY.toString('hex'))).toEqual(KEY);
+    });
+
+    it('tolerates surrounding whitespace from a piped secret', () => {
+      expect(parseEncryptionKey(`  ${KEY.toString('hex')}\n`)).toEqual(KEY);
+      expect(parseEncryptionKey(`${KEY.toString('base64')}\n`)).toEqual(KEY);
+    });
+
+    it('throws when unset', () => {
+      expect(() => parseEncryptionKey(undefined)).toThrow(
+        /TOKEN_ENCRYPTION_KEY/,
+      );
+    });
+
+    it('rejects a key that is not valid base64 or hex', () => {
+      // Decodes to 32 bytes only because the base64 decoder skips the quotes.
+      const quoted = `"${KEY.toString('base64')}"`;
+
+      expect(() => parseEncryptionKey(quoted)).toThrow(/standard base64/);
+    });
+
+    it('throws on a key of the wrong length without echoing it', () => {
+      const shortKey = crypto.randomBytes(16).toString('base64');
+
+      expect(() => parseEncryptionKey(shortKey)).toThrow(/32 bytes/);
+
+      let message = '';
+      try {
+        parseEncryptionKey(shortKey);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).not.toContain(shortKey);
+    });
+  });
+
+  describe('verifyTokenEncryption', () => {
+    it('does not throw when the active provider is broken', async () => {
+      setActiveTokenEncryptionProvider('broken');
+
+      await expect(verifyTokenEncryption()).resolves.toBeUndefined();
+    });
+
+    it('passes with a working provider', async () => {
+      await expect(verifyTokenEncryption()).resolves.toBeUndefined();
+    });
+
+    it('warns instead of verifying when encryption is disabled', async () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      setActiveTokenEncryptionProvider('none');
+
+      await expect(verifyTokenEncryption()).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Token encryption is disabled'),
+      );
+
+      warn.mockRestore();
+    });
+  });
+});

--- a/packages/api/src/utils/tokenEncryption.ts
+++ b/packages/api/src/utils/tokenEncryption.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+import { serializeError } from 'serialize-error';
+
+import * as config from '@/config';
+import { getCounter, withOperationMetrics } from '@/utils/instrumentation';
+import logger from '@/utils/logger';
+
+/**
+ * Encryption at rest for third-party credentials we store and replay (Slack
+ * bot tokens, OAuth access/refresh tokens).
+ *
+ * Stored values are `v1:<provider>:<payload>`. Decryption dispatches on the
+ * provider named in the envelope rather than the active one, so switching
+ * providers leaves rows written by the previous one readable. Tokens are
+ * stored verbatim unless `TOKEN_ENCRYPTION_KEY` is set.
+ *
+ * Known limitation: the envelope carries no key id, so rotating
+ * `TOKEN_ENCRYPTION_KEY` makes existing rows unreadable. Adding one is what
+ * the version field is for.
+ */
+
+const ENVELOPE_VERSION = 'v1';
+const LOCAL_PROVIDER = 'local';
+const NONE_PROVIDER = 'none';
+const PROVIDER_NAME_PATTERN = /^[a-z0-9-]+$/;
+const ENVELOPE_PATTERN = /^v\d+:[a-z0-9-]+:/;
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const VERIFY_TIMEOUT_MS = 10_000;
+const VERIFY_SENTINEL = 'hyperdx-token-encryption-check';
+
+export type BuiltInProviderName = typeof LOCAL_PROVIDER | typeof NONE_PROVIDER;
+
+export interface TokenEncryptionProvider {
+  readonly name: string;
+  encrypt(plaintext: string): Promise<string>;
+  decrypt(payload: string): Promise<string>;
+}
+
+const plaintextReadCounter = getCounter(
+  'hyperdx.token_encryption.plaintext_reads',
+  {
+    description:
+      'Count of stored tokens read back unencrypted while an encrypting provider was active.',
+  },
+);
+const disabledCounter = getCounter('hyperdx.token_encryption.disabled', {
+  description:
+    'Incremented at startup when token encryption is turned off, so the state is alertable.',
+});
+
+const providers = new Map<string, TokenEncryptionProvider>();
+let activeProviderName: string = NONE_PROVIDER;
+
+export function registerTokenEncryptionProvider(
+  provider: TokenEncryptionProvider,
+): void {
+  if (!PROVIDER_NAME_PATTERN.test(provider.name)) {
+    throw new Error(
+      `Invalid token encryption provider name "${provider.name}": must match ${PROVIDER_NAME_PATTERN}`,
+    );
+  }
+  if (providers.has(provider.name)) {
+    logger.warn(
+      { provider: provider.name },
+      'Token encryption provider replaced; envelopes written by the previous one may no longer decrypt',
+    );
+  }
+  providers.set(provider.name, provider);
+}
+
+/** Selects the provider `encryptToken` writes with. Decryption is unaffected. */
+export function setActiveTokenEncryptionProvider(name: string): void {
+  if (!providers.has(name)) {
+    throw new Error(
+      `Cannot activate unregistered token encryption provider "${name}"; registered: ${[...providers.keys()].join(', ')}`,
+    );
+  }
+  activeProviderName = name;
+}
+
+function getProvider(name: string): TokenEncryptionProvider {
+  const provider = providers.get(name);
+  if (!provider) {
+    throw new Error(
+      `Unknown token encryption provider "${name}"; registered: ${[...providers.keys()].join(', ')}`,
+    );
+  }
+  return provider;
+}
+
+export function isTokenEnvelope(value: string): boolean {
+  return ENVELOPE_PATTERN.test(value);
+}
+
+export async function encryptToken(plaintext: string): Promise<string> {
+  // A re-encrypted envelope cannot be read back, and read-modify-write is the
+  // easy way for a caller to get there.
+  if (isTokenEnvelope(plaintext)) {
+    throw new Error('Value is already a token encryption envelope');
+  }
+  const provider = getProvider(activeProviderName);
+  return `${ENVELOPE_VERSION}:${provider.name}:${await provider.encrypt(plaintext)}`;
+}
+
+export async function decryptToken(envelope: string): Promise<string> {
+  // Checked before any part of the input is interpolated into an error: a
+  // caller passing a raw token would otherwise put the secret into the logs.
+  if (!isTokenEnvelope(envelope)) {
+    throw new Error('Value is not a token encryption envelope');
+  }
+  const [version, name, ...payload] = envelope.split(':');
+  if (version !== ENVELOPE_VERSION) {
+    throw new Error(`Unsupported token envelope version "${version}"`);
+  }
+  if (name === NONE_PROVIDER && activeProviderName !== NONE_PROVIDER) {
+    plaintextReadCounter.add(1);
+    logger.warn(
+      'Read a token stored without encryption; re-save it to encrypt at rest',
+    );
+  }
+  return getProvider(name).decrypt(payload.join(':'));
+}
+
+/** Accepts base64 or hex. Errors never include the key, since they are logged. */
+export function parseEncryptionKey(raw: string | undefined): Buffer {
+  const value = raw?.trim();
+  if (!value) {
+    throw new Error(
+      'TOKEN_ENCRYPTION_KEY is not set; generate one with `openssl rand -base64 32`',
+    );
+  }
+  const isHex = /^[0-9a-f]{64}$/i.test(value);
+  const key = Buffer.from(value, isHex ? 'hex' : 'base64');
+  if (key.length !== KEY_BYTES) {
+    throw new Error(
+      `TOKEN_ENCRYPTION_KEY must decode to ${KEY_BYTES} bytes, got ${key.length}`,
+    );
+  }
+  // Buffer's base64 decoder skips characters outside the alphabet, so a
+  // mistyped key can still decode to the right length as the wrong key.
+  const canonical = key.toString('base64').replace(/=+$/, '');
+  if (!isHex && canonical !== value.replace(/=+$/, '')) {
+    throw new Error(
+      'TOKEN_ENCRYPTION_KEY must be standard base64 or 64 hex characters',
+    );
+  }
+  return key;
+}
+
+/**
+ * Payload layout is `iv || tag || ciphertext`, with the envelope prefix bound
+ * as additional authenticated data so a payload cannot be replayed under a
+ * different provider name. The key is resolved per call so a missing or
+ * malformed key fails when a token is stored, not at import time.
+ */
+export function createAesGcmProvider(
+  name: string,
+  getKey: () => Buffer,
+): TokenEncryptionProvider {
+  const aad = Buffer.from(`${ENVELOPE_VERSION}:${name}`, 'utf8');
+  return {
+    name,
+    async encrypt(plaintext) {
+      const iv = crypto.randomBytes(IV_BYTES);
+      const cipher = crypto.createCipheriv('aes-256-gcm', getKey(), iv);
+      cipher.setAAD(aad);
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+      ]);
+      return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString(
+        'base64',
+      );
+    },
+    async decrypt(payload) {
+      const buffer = Buffer.from(payload, 'base64');
+      if (buffer.length < IV_BYTES + TAG_BYTES) {
+        throw new Error('Encrypted token payload is truncated');
+      }
+      const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        getKey(),
+        buffer.subarray(0, IV_BYTES),
+      );
+      decipher.setAAD(aad);
+      decipher.setAuthTag(buffer.subarray(IV_BYTES, IV_BYTES + TAG_BYTES));
+      return Buffer.concat([
+        decipher.update(buffer.subarray(IV_BYTES + TAG_BYTES)),
+        decipher.final(),
+      ]).toString('utf8');
+    },
+  };
+}
+
+let localKey: Buffer | undefined;
+const getLocalKey = () =>
+  (localKey ??= parseEncryptionKey(config.TOKEN_ENCRYPTION_KEY));
+
+registerTokenEncryptionProvider(
+  createAesGcmProvider(LOCAL_PROVIDER, getLocalKey),
+);
+
+/**
+ * Stores tokens verbatim, for self-hosted deployments that would rather not
+ * manage a key. The payload is left as plain text so that `v1:none:xoxb-…` in
+ * the database is obviously unencrypted to anyone auditing it.
+ *
+ * Stays registered even when another provider is active, since that is what
+ * keeps rows written while encryption was off readable afterwards.
+ */
+registerTokenEncryptionProvider({
+  name: NONE_PROVIDER,
+  encrypt: async plaintext => plaintext,
+  decrypt: async payload => payload,
+});
+
+/**
+ * Having a key is the whole opt-in: no key means no encryption. Deployments
+ * that must encrypt (EE, cloud) activate their own provider in code rather
+ * than depending on an env var being present.
+ */
+export function selectDefaultProvider(
+  key: string | undefined,
+): BuiltInProviderName {
+  return key ? LOCAL_PROVIDER : NONE_PROVIDER;
+}
+
+setActiveTokenEncryptionProvider(
+  selectDefaultProvider(config.TOKEN_ENCRYPTION_KEY),
+);
+
+/**
+ * Encrypts and decrypts a fixed string at boot so a misconfigured key, KMS
+ * key policy, or region shows up in deploy logs instead of at the first
+ * OAuth install.
+ *
+ * A key that cannot be parsed throws, because that is an operator error the
+ * process should not start with. Everything else logs and continues: the
+ * process can still serve every request unrelated to stored tokens.
+ *
+ * Note this proves the active provider works, not that it can read rows
+ * written earlier — a key swapped since the last deploy still verifies.
+ */
+export async function verifyTokenEncryption(): Promise<void> {
+  if (activeProviderName === NONE_PROVIDER) {
+    disabledCounter.add(1);
+    logger.warn(
+      'Token encryption is disabled: third-party tokens will be stored in plain text (set TOKEN_ENCRYPTION_KEY to enable)',
+    );
+    return;
+  }
+  if (activeProviderName === LOCAL_PROVIDER) {
+    getLocalKey();
+  }
+  try {
+    await withOperationMetrics('token_encryption.verify', async () => {
+      // Bounded so a provider that makes network calls cannot hold up the boot
+      // sequence. unref() keeps a pending timer from holding the process open.
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Encryption check timed out after ${VERIFY_TIMEOUT_MS}ms`,
+              ),
+            ),
+          VERIFY_TIMEOUT_MS,
+        ).unref(),
+      );
+      const decrypted = await Promise.race([
+        encryptToken(VERIFY_SENTINEL).then(decryptToken),
+        timeout,
+      ]);
+      if (decrypted !== VERIFY_SENTINEL) {
+        throw new Error('Decrypted value did not match the original');
+      }
+    });
+    logger.info({ provider: activeProviderName }, 'Token encryption verified');
+  } catch (err) {
+    logger.error(
+      { err: serializeError(err), provider: activeProviderName },
+      'Token encryption verification failed; stored tokens cannot be read or written',
+    );
+  }
+}

--- a/packages/api/src/utils/tokenEncryption.ts
+++ b/packages/api/src/utils/tokenEncryption.ts
@@ -50,8 +50,24 @@ const disabledCounter = getCounter('hyperdx.token_encryption.disabled', {
     'Incremented at startup when token encryption is turned off, so the state is alertable.',
 });
 
+/**
+ * Stores tokens verbatim, for self-hosted deployments that would rather not
+ * manage a key. The payload is left as plain text so that `v1:none:xoxb-…` in
+ * the database is obviously unencrypted to anyone auditing it.
+ *
+ * Stays registered even when another provider is active, since that is what
+ * keeps rows written while encryption was off readable afterwards.
+ */
+const noneProvider: TokenEncryptionProvider = {
+  name: NONE_PROVIDER,
+  encrypt: async plaintext => plaintext,
+  decrypt: async payload => payload,
+};
+
 const providers = new Map<string, TokenEncryptionProvider>();
-let activeProviderName: string = NONE_PROVIDER;
+// Resolved at startup and not meant to change afterwards, so the write path
+// holds the provider rather than looking it up on every call.
+let activeProvider: TokenEncryptionProvider = noneProvider;
 
 export function registerTokenEncryptionProvider(
   provider: TokenEncryptionProvider,
@@ -72,12 +88,13 @@ export function registerTokenEncryptionProvider(
 
 /** Selects the provider `encryptToken` writes with. Decryption is unaffected. */
 export function setActiveTokenEncryptionProvider(name: string): void {
-  if (!providers.has(name)) {
+  const provider = providers.get(name);
+  if (!provider) {
     throw new Error(
       `Cannot activate unregistered token encryption provider "${name}"; registered: ${[...providers.keys()].join(', ')}`,
     );
   }
-  activeProviderName = name;
+  activeProvider = provider;
 }
 
 function getProvider(name: string): TokenEncryptionProvider {
@@ -100,8 +117,7 @@ export async function encryptToken(plaintext: string): Promise<string> {
   if (isTokenEnvelope(plaintext)) {
     throw new Error('Value is already a token encryption envelope');
   }
-  const provider = getProvider(activeProviderName);
-  return `${ENVELOPE_VERSION}:${provider.name}:${await provider.encrypt(plaintext)}`;
+  return `${ENVELOPE_VERSION}:${activeProvider.name}:${await activeProvider.encrypt(plaintext)}`;
 }
 
 export async function decryptToken(envelope: string): Promise<string> {
@@ -114,7 +130,7 @@ export async function decryptToken(envelope: string): Promise<string> {
   if (version !== ENVELOPE_VERSION) {
     throw new Error(`Unsupported token envelope version "${version}"`);
   }
-  if (name === NONE_PROVIDER && activeProviderName !== NONE_PROVIDER) {
+  if (name === NONE_PROVIDER && activeProvider.name !== NONE_PROVIDER) {
     plaintextReadCounter.add(1);
     logger.warn(
       'Read a token stored without encryption; re-save it to encrypt at rest',
@@ -202,19 +218,7 @@ registerTokenEncryptionProvider(
   createAesGcmProvider(LOCAL_PROVIDER, getLocalKey),
 );
 
-/**
- * Stores tokens verbatim, for self-hosted deployments that would rather not
- * manage a key. The payload is left as plain text so that `v1:none:xoxb-…` in
- * the database is obviously unencrypted to anyone auditing it.
- *
- * Stays registered even when another provider is active, since that is what
- * keeps rows written while encryption was off readable afterwards.
- */
-registerTokenEncryptionProvider({
-  name: NONE_PROVIDER,
-  encrypt: async plaintext => plaintext,
-  decrypt: async payload => payload,
-});
+registerTokenEncryptionProvider(noneProvider);
 
 /**
  * Having a key is the whole opt-in: no key means no encryption. Deployments
@@ -244,14 +248,14 @@ setActiveTokenEncryptionProvider(
  * written earlier — a key swapped since the last deploy still verifies.
  */
 export async function verifyTokenEncryption(): Promise<void> {
-  if (activeProviderName === NONE_PROVIDER) {
+  if (activeProvider.name === NONE_PROVIDER) {
     disabledCounter.add(1);
     logger.warn(
       'Token encryption is disabled: third-party tokens will be stored in plain text (set TOKEN_ENCRYPTION_KEY to enable)',
     );
     return;
   }
-  if (activeProviderName === LOCAL_PROVIDER) {
+  if (activeProvider.name === LOCAL_PROVIDER) {
     getLocalKey();
   }
   try {
@@ -277,10 +281,10 @@ export async function verifyTokenEncryption(): Promise<void> {
         throw new Error('Decrypted value did not match the original');
       }
     });
-    logger.info({ provider: activeProviderName }, 'Token encryption verified');
+    logger.info({ provider: activeProvider.name }, 'Token encryption verified');
   } catch (err) {
     logger.error(
-      { err: serializeError(err), provider: activeProviderName },
+      { err: serializeError(err), provider: activeProvider.name },
       'Token encryption verification failed; stored tokens cannot be read or written',
     );
   }


### PR DESCRIPTION
Slack bot tokens and OAuth tokens need encrypting at rest before anything stores them. This adds the service that does it. Nothing calls it yet.

- Set `TOKEN_ENCRYPTION_KEY` (32 bytes, base64 or hex) and stored tokens are encrypted with AES-256-GCM. Set nothing and they are stored readable, which stays a supported choice.
- Turning encryption on later does not orphan tokens already stored. Reading a still-unencrypted one warns and increments a counter, so a migration can be finished.
- Encryption state is in the startup log and alertable on `hyperdx.token_encryption.disabled`.
- Adding another encryption method is a new file and one registration call.
- A malformed key stops the API starting. A missing key stays silent.

Two deviations from the acceptance criteria, both worth a look: there is no base64 provider, since it is readable by anyone with database access and that is the threat it was meant to address; and the `test` endpoint is a startup check rather than a route, so nobody has to remember to call it.

Rotating the key makes existing rows unreadable. That is accepted for now, and the version in the stored format is how a key id gets added when it matters.

<details>
<summary>Implementation detail</summary>

- Stored values are `v1:<provider>:<payload>`, with the version and provider prefix bound into AES-GCM as additional authenticated data, so a payload cannot be relabelled and replayed under another provider sharing the key.
- Nothing from a stored value reaches an error message before it matches the envelope pattern. A caller handing a raw token to `decryptToken` would otherwise put that token into the logs.
- Keys are accepted as base64 or hex, trimmed, then re-encoded and compared, because Node's base64 decoder skips characters outside the alphabet and a quoted key would decode to 32 plausible but wrong bytes.
- The startup check is bounded at ten seconds so a provider that makes network calls cannot hold up boot, and logs rather than throws for anything but a malformed key.
- Re-registering a provider name warns, matching how `utils/instrumentation.ts` handles conflicting instrument definitions.
- 31 unit tests cover the encryption, tampering, truncation, cross-provider replay, envelope dispatch, key parsing and the disabled path. Verified with `yarn ci:unit` in `packages/api` (1021 tests), `tsc --noEmit`, and eslint at 299 warnings against the 302 ceiling.

</details>
