### PR TITLE
fix: Fix side panel for backticked aliases, hyphenated columns

### DIFF
--- a/.changeset/quote-row-where-identifiers.md
+++ b/.changeset/quote-row-where-identifiers.md
@@ -1,0 +1,6 @@
+---
+"@hyperdx/app": patch
+"@hyperdx/common-utils": patch
+---
+
+fix: Quote column identifiers when opening row details

--- a/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
+++ b/packages/app/src/hooks/__tests__/useRowWhere.test.tsx
@@ -154,7 +154,35 @@ describe('processRowToWhereClause', () => {
     const row = { dynamic_field: 'null' };
     const result = processRowToWhereClause(row, columnMap);
 
-    expect(result).toBe('isNull(`dynamic_field`)');
+    expect(result).toBe('isNull(dynamic_field)');
+  });
+
+  it('should handle Dynamic columns with a null value on a quoted name', () => {
+    const columnMap = new Map([
+      [
+        'x-host-header',
+        {
+          name: 'x-host-header',
+          type: 'Dynamic',
+          valueExpr: '`x-host-header`',
+          jsType: JSDataType.Dynamic,
+        },
+      ],
+      [
+        'lowered',
+        {
+          name: 'lowered',
+          type: 'Dynamic',
+          valueExpr: 'lower(Body)',
+          jsType: JSDataType.Dynamic,
+        },
+      ],
+    ]);
+
+    const row = { 'x-host-header': 'null', lowered: 'null' };
+    const result = processRowToWhereClause(row, columnMap);
+
+    expect(result).toBe('isNull(`x-host-header`) AND isNull(lower(Body))');
   });
 
   it('should handle Dynamic columns with quoted string', () => {
@@ -503,6 +531,54 @@ describe('useRowWhere', () => {
     expect(rowWhereResult.where).toBe("users.id='123' AND status='active'");
     expect(rowWhereResult.aliasWith).toEqual([
       { name: 'id', sql: { sql: 'users.id', params: {} }, isSubquery: false },
+    ]);
+  });
+
+  it('should quote column names that are not bare identifiers', () => {
+    const meta: ColumnMetaType[] = [
+      { name: 'x-host-header', type: 'String' },
+      { name: "ResourceAttributes['service.name']", type: 'String' },
+    ];
+
+    const { result } = renderHook(() => useRowWhere({ meta, aliasMap: {} }));
+
+    const row = {
+      'x-host-header': '136.124.33.174',
+      "ResourceAttributes['service.name']": 'api',
+    };
+    const rowWhereResult = result.current(row);
+
+    expect(rowWhereResult.where).toBe(
+      "`x-host-header`='136.124.33.174' AND ResourceAttributes['service.name']='api'",
+    );
+  });
+
+  it('should not quote a projected literal', () => {
+    const meta: ColumnMetaType[] = [{ name: '1', type: 'Int32' }];
+
+    const { result } = renderHook(() => useRowWhere({ meta, aliasMap: {} }));
+
+    expect(result.current({ '1': 1 }).where).toBe('1=1');
+  });
+
+  it('should prefer the alias expression over quoting the column name', () => {
+    const meta: ColumnMetaType[] = [{ name: 'x-host-header', type: 'String' }];
+
+    const aliasMap = { 'x-host-header': 'client_ip' };
+
+    const { result } = renderHook(() => useRowWhere({ meta, aliasMap }));
+
+    const rowWhereResult = result.current({
+      'x-host-header': '136.124.33.174',
+    });
+
+    expect(rowWhereResult.where).toBe("client_ip='136.124.33.174'");
+    expect(rowWhereResult.aliasWith).toEqual([
+      {
+        name: 'x-host-header',
+        sql: { sql: 'client_ip', params: {} },
+        isSubquery: false,
+      },
     ]);
   });
 

--- a/packages/app/src/hooks/useRowWhere.tsx
+++ b/packages/app/src/hooks/useRowWhere.tsx
@@ -7,6 +7,7 @@ import {
   convertCHDataTypeToJSType,
   JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
+import { quoteResultColumnNameIfNeeded } from '@hyperdx/common-utils/dist/core/metadata';
 import { aliasMapToWithClauses } from '@hyperdx/common-utils/dist/core/utils';
 import { WithClauseSchema } from '@hyperdx/common-utils/dist/types';
 
@@ -89,7 +90,7 @@ export function processRowToWhereClause(
 
           // Currently we can't distinguish null or 'null'
           if (value == null || value === 'null') {
-            return SqlString.format(`isNull(??)`, [valueExpr]);
+            return SqlString.format(`isNull(?)`, [SqlString.raw(valueExpr)]);
           }
           if (value.length > 1000 || column.length > 1000) {
             console.warn('Search value/object key too large.');
@@ -144,9 +145,11 @@ export default function useRowWhere({
       new Map(
         meta?.map(c => {
           // if aliasMap is provided, use the alias as the valueExpr
-          // but if the alias is not found, use the column name as the valueExpr
+          // but if the alias is not found, fall back to the column name.
+          // Alias entries are already SQL expressions; a result column name
+          // needs quoting when it isn't one (e.g. `x-host-header`).
           const valueExpr =
-            aliasMap != null ? (aliasMap[c.name] ?? c.name) : c.name;
+            aliasMap?.[c.name] ?? quoteResultColumnNameIfNeeded(c.name);
 
           return [
             c.name,

--- a/packages/cli/src/__tests__/rowWhere.test.ts
+++ b/packages/cli/src/__tests__/rowWhere.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { ColumnMetaType } from '@hyperdx/common-utils/dist/clickhouse';
+
+import { buildColumnMap, getRowWhere } from '@/shared/useRowWhere';
+
+describe('buildColumnMap', () => {
+  it('quotes a column name that is not a bare identifier', () => {
+    const meta: ColumnMetaType[] = [{ name: 'x-host-header', type: 'String' }];
+
+    const where = getRowWhere(
+      { 'x-host-header': '136.124.33.174' },
+      buildColumnMap(meta, {}),
+      {},
+    ).where;
+
+    expect(where).toBe("`x-host-header`='136.124.33.174'");
+  });
+
+  it('prefers the alias expression over quoting the column name', () => {
+    const meta: ColumnMetaType[] = [{ name: 'x-host-header', type: 'String' }];
+    const aliasMap = { 'x-host-header': 'client_ip' };
+
+    const result = getRowWhere(
+      { 'x-host-header': '136.124.33.174' },
+      buildColumnMap(meta, aliasMap),
+      aliasMap,
+    );
+
+    expect(result.where).toBe("client_ip='136.124.33.174'");
+    expect(result.aliasWith).toEqual([
+      {
+        name: 'x-host-header',
+        sql: { sql: 'client_ip', params: {} },
+        isSubquery: false,
+      },
+    ]);
+  });
+
+  it('handles a Dynamic column whose name needs quoting', () => {
+    const meta: ColumnMetaType[] = [
+      { name: 'x-host-header', type: 'Dynamic' },
+      { name: 'lowered', type: 'Dynamic' },
+    ];
+    const aliasMap = { lowered: 'lower(Body)' };
+
+    const where = getRowWhere(
+      { 'x-host-header': 'null', lowered: 'null' },
+      buildColumnMap(meta, aliasMap),
+      aliasMap,
+    ).where;
+
+    expect(where).toBe('isNull(`x-host-header`) AND isNull(lower(Body))');
+  });
+
+  it('leaves an expression-shaped result column name alone', () => {
+    const meta: ColumnMetaType[] = [
+      { name: "ResourceAttributes['service.name']", type: 'String' },
+    ];
+
+    const where = getRowWhere(
+      { "ResourceAttributes['service.name']": 'api' },
+      buildColumnMap(meta, {}),
+      {},
+    ).where;
+
+    expect(where).toBe("ResourceAttributes['service.name']='api'");
+  });
+});

--- a/packages/cli/src/shared/useRowWhere.ts
+++ b/packages/cli/src/shared/useRowWhere.ts
@@ -18,6 +18,7 @@ import {
   convertCHDataTypeToJSType,
   JSDataType,
 } from '@hyperdx/common-utils/dist/clickhouse';
+import { quoteResultColumnNameIfNeeded } from '@hyperdx/common-utils/dist/core/metadata';
 import { aliasMapToWithClauses } from '@hyperdx/common-utils/dist/core/utils';
 import type { BuilderChartConfig } from '@hyperdx/common-utils/dist/types';
 
@@ -96,7 +97,7 @@ function processRowToWhereClause(
           // Handle case for json element, ex: json.c
           // Currently we can't distinguish null or 'null'
           if (value == null || strValue === 'null') {
-            return SqlString.format(`isNull(??)`, [valueExpr]);
+            return SqlString.format(`isNull(?)`, [SqlString.raw(valueExpr)]);
           }
           if ((strValue?.length ?? 0) > 1000 || column.length > 1000) {
             console.warn('Search value/object key too large.');
@@ -140,9 +141,11 @@ export function buildColumnMap(
   return new Map(
     meta?.map(c => {
       // if aliasMap is provided, use the alias as the valueExpr
-      // but if the alias is not found, use the column name as the valueExpr
+      // but if the alias is not found, fall back to the column name.
+      // Alias entries are already SQL expressions; a result column name
+      // needs quoting when it isn't one (e.g. `x-host-header`).
       const valueExpr =
-        aliasMap != null ? (aliasMap[c.name] ?? c.name) : c.name;
+        aliasMap?.[c.name] ?? quoteResultColumnNameIfNeeded(c.name);
 
       return [
         c.name,

--- a/packages/common-utils/src/__tests__/clickhouse.test.ts
+++ b/packages/common-utils/src/__tests__/clickhouse.test.ts
@@ -265,6 +265,17 @@ describe('chSqlToAliasMap - resilient parsing of ClickHouse-specific SQL', () =>
     });
   });
 
+  it('recovers a quoted alias through the fallback', () => {
+    const chSqlInput: ChSql = {
+      sql: `${samplingCte} SELECT client_ip as \`x-host-header\`, ServiceName as service FROM db.t WHERE ${samplingWhere}`,
+      params: {},
+    };
+    expect(chSqlToAliasMap(chSqlInput)).toEqual({
+      'x-host-header': 'client_ip',
+      service: 'ServiceName',
+    });
+  });
+
   it('restores JSON-path aliases recovered through the fallback', () => {
     const chSqlInput: ChSql = {
       sql: `${samplingCte} SELECT ResourceAttributes.service.name as service, Timestamp as ts FROM db.t WHERE ${samplingWhere}`,
@@ -303,6 +314,98 @@ describe('chSqlToAliasMap - resilient parsing of ClickHouse-specific SQL', () =>
       params: {},
     };
     expect(chSqlToAliasMap(chSqlInput)).toEqual({});
+  });
+});
+
+describe('chSqlToAliasMap - backtick-quoted identifiers', () => {
+  it('resolves an alias whose name needs quoting, keeping its siblings', () => {
+    const res = chSqlToAliasMap({
+      sql: 'SELECT client_ip AS `x-host-header`,time AS `__hdx_timestamp`,ServiceName AS svc FROM otel.logs WHERE time > 1 LIMIT 10',
+      params: {},
+    });
+    expect(res).toEqual({
+      'x-host-header': 'client_ip',
+      __hdx_timestamp: 'time',
+      svc: 'ServiceName',
+    });
+  });
+
+  it('keeps the quoting on a column whose name needs it', () => {
+    const res = chSqlToAliasMap({
+      sql: "SELECT `x-host-header` AS host,`M-1`['a'] AS mapped FROM otel.logs LIMIT 10",
+      params: {},
+    });
+    expect(res).toEqual({
+      host: '`x-host-header`',
+      mapped: "`M-1`['a']",
+    });
+  });
+
+  it('records no entry for a quoted column selected without an alias', () => {
+    const res = chSqlToAliasMap({
+      sql: 'SELECT `x-host-header`,ServiceName AS svc FROM otel.logs LIMIT 10',
+      params: {},
+    });
+    expect(res).toEqual({ svc: 'ServiceName' });
+  });
+
+  it('keeps aliases when the only quoted identifier is in the WHERE', () => {
+    const res = chSqlToAliasMap({
+      sql: "SELECT ServiceName AS svc FROM otel.logs WHERE `x-host-header`='v' LIMIT 10",
+      params: {},
+    });
+    expect(res).toEqual({ svc: 'ServiceName' });
+  });
+
+  it('preserves quoting inside an aliased expression', () => {
+    const res = chSqlToAliasMap({
+      sql: 'SELECT lower(`x-host-header`) AS host,multiIf(`a-b` > 1, `c-d`, 0) AS m FROM otel.logs LIMIT 10',
+      params: {},
+    });
+    expect(res).toEqual({
+      host: 'lower(`x-host-header`)',
+      m: 'multiIf(`a-b` > 1, `c-d`, 0)',
+    });
+  });
+
+  it('re-quotes a double-quoted column name', () => {
+    const res = chSqlToAliasMap({
+      sql: 'SELECT "x-host-header" AS host FROM otel.logs LIMIT 10',
+      params: {},
+    });
+    expect(res).toEqual({ host: '`x-host-header`' });
+  });
+
+  it('restores more than ten quoted identifiers', () => {
+    const select = Array.from(
+      { length: 12 },
+      (_, i) => `\`c-${i}\` AS a${i}`,
+    ).join(',');
+    const res = chSqlToAliasMap({
+      sql: `SELECT ${select} FROM otel.logs LIMIT 10`,
+      params: {},
+    });
+    expect(res).toEqual(
+      Object.fromEntries(
+        Array.from({ length: 12 }, (_, i) => [`a${i}`, `\`c-${i}\``]),
+      ),
+    );
+  });
+
+  it('restores quoted identifiers alongside a JSON path', () => {
+    const res = chSqlToAliasMap({
+      sql: 'SELECT concat(j.p0, `c-1`, `c-10`) AS m FROM otel.logs LIMIT 10',
+      params: {},
+    });
+    expect(res).toEqual({ m: 'concat(j.p0, `c-1`, `c-10`)' });
+  });
+
+  it('leaves backticks inside string literals alone', () => {
+    const res = chSqlToAliasMap({
+      sql: "SELECT Body AS body FROM otel.logs WHERE Body = 'a `b` c' LIMIT 10",
+      params: {},
+    });
+    expect(res).toEqual({ body: 'Body' });
   });
 });
 

--- a/packages/common-utils/src/__tests__/metadata.test.ts
+++ b/packages/common-utils/src/__tests__/metadata.test.ts
@@ -5,6 +5,7 @@ import {
   Metadata,
   MetadataCache,
   parseKeyPath,
+  quoteResultColumnNameIfNeeded,
 } from '@/core/metadata';
 import * as renderChartConfigModule from '@/core/renderChartConfig';
 import { timeFilterExpr } from '@/core/renderChartConfig';
@@ -3251,6 +3252,46 @@ describe('parseKeyPath', () => {
     expect(parseKeyPath("ResourceAttributes['service.name")).toEqual([
       "ResourceAttributes['service.name",
     ]);
+  });
+});
+
+describe('quoteResultColumnNameIfNeeded', () => {
+  it('leaves bare identifiers alone', () => {
+    expect(quoteResultColumnNameIfNeeded('Timestamp')).toBe('Timestamp');
+    expect(quoteResultColumnNameIfNeeded('__hdx_timestamp')).toBe(
+      '__hdx_timestamp',
+    );
+  });
+
+  it('quotes names that are not valid bare identifiers', () => {
+    expect(quoteResultColumnNameIfNeeded('x-host-header')).toBe(
+      '`x-host-header`',
+    );
+    expect(quoteResultColumnNameIfNeeded('my col')).toBe('`my col`');
+  });
+
+  it('leaves expression-shaped names alone', () => {
+    // ClickHouse names unaliased projections after the formatted expression.
+    expect(
+      quoteResultColumnNameIfNeeded("ResourceAttributes['service.name']"),
+    ).toBe("ResourceAttributes['service.name']");
+    expect(quoteResultColumnNameIfNeeded('plus(a, b)')).toBe('plus(a, b)');
+    expect(quoteResultColumnNameIfNeeded('json.a.b')).toBe('json.a.b');
+    expect(quoteResultColumnNameIfNeeded("'literal'")).toBe("'literal'");
+  });
+
+  it('leaves projected literals alone', () => {
+    // `SELECT 1, -1, 0x10, 1.5, 'lit'` -> names `1`, `-1`, `16`, `1.5`, `'lit'`
+    expect(quoteResultColumnNameIfNeeded('1')).toBe('1');
+    expect(quoteResultColumnNameIfNeeded('-1')).toBe('-1');
+    expect(quoteResultColumnNameIfNeeded('16')).toBe('16');
+    expect(quoteResultColumnNameIfNeeded('1.5')).toBe('1.5');
+  });
+
+  it('is idempotent on already-quoted names', () => {
+    expect(quoteResultColumnNameIfNeeded('`x-host-header`')).toBe(
+      '`x-host-header`',
+    );
   });
 });
 

--- a/packages/common-utils/src/clickhouse/index.ts
+++ b/packages/common-utils/src/clickhouse/index.ts
@@ -11,7 +11,11 @@ import type {
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
 import * as SQLParser from 'node-sql-parser';
 
-import { getMetadata, Metadata } from '@/core/metadata';
+import {
+  getMetadata,
+  Metadata,
+  quoteIdentifierIfNeeded,
+} from '@/core/metadata';
 import {
   renderChartConfig,
   setChartSelectsAlias,
@@ -19,7 +23,10 @@ import {
 import {
   extractSettingsClauseFromEnd,
   hashCode,
+  type QuotedIdentifierReplacements,
+  replaceBacktickedIdentifiers,
   replaceJsonExpressions,
+  restoreReplacements,
   splitAndTrimWithBracket,
 } from '@/core/utils';
 import { isBuilderChartConfig } from '@/guards';
@@ -777,6 +784,7 @@ const ALIAS_FALLBACK_TABLE = '__hdx_alias_src';
 function selectColumnsToAliasMap(
   parsedSql: string,
   jsonReplacements: Map<string, string>,
+  identifierReplacements: QuotedIdentifierReplacements,
 ): Record<string, string> {
   const aliasMap: Record<string, string> = {};
   const parser = new SQLParser.Parser();
@@ -791,12 +799,15 @@ function selectColumnsToAliasMap(
     ast.columns.forEach(column => {
       if (column.as != null) {
         if (column.type === 'expr' && column.expr.type === 'column_ref') {
+          const escapedColumnName = quoteIdentifierIfNeeded(
+            column.expr.column.expr.value,
+          );
           aliasMap[column.as] =
             column.expr.array_index && column.expr.array_index[0]?.brackets
               ? // alias with brackets, ex: ResourceAttributes['service.name'] as service_name
-                `${column.expr.column.expr.value}['${column.expr.array_index[0].index.value}']`
+                `${escapedColumnName}['${column.expr.array_index[0].index.value}']`
               : // normal alias
-                column.expr.column.expr.value;
+                escapedColumnName;
         } else if (column.expr.loc != null) {
           aliasMap[column.as] = parsedSql.slice(
             column.expr.loc.start.offset,
@@ -818,7 +829,14 @@ function selectColumnsToAliasMap(
     }
   }
 
-  return aliasMap;
+  // Replace the backticked identifier replacements with the original quoted identifiers
+  const { quotedText, names } = identifierReplacements;
+  return Object.fromEntries(
+    Object.entries(aliasMap).map(([alias, aliasExpression]) => [
+      names.get(alias) ?? alias,
+      restoreReplacements(aliasExpression, quotedText),
+    ]),
+  );
 }
 
 /**
@@ -931,14 +949,22 @@ export function chSqlToAliasMap(
     // Remove the SETTINGS clause because `SQLParser` doesn't understand it.
     const [sqlWithoutSettingsClause] = extractSettingsClauseFromEnd(sql);
 
+    // Replace backtick-quoted identifiers with placeholder tokens so that a
+    // quoted alias doesn't fail the parse
+    const {
+      sqlWithReplacements: sqlWithoutBackticks,
+      replacements: identifierReplacementsToExpressions,
+    } = replaceBacktickedIdentifiers(sqlWithoutSettingsClause);
+
     // Replace JSON expressions with replacement tokens so that node-sql-parser can parse the SQL
     const { sqlWithReplacements, replacements: jsonReplacementsToExpressions } =
-      replaceJsonExpressions(sqlWithoutSettingsClause);
+      replaceJsonExpressions(sqlWithoutBackticks);
 
     try {
       return selectColumnsToAliasMap(
         sqlWithReplacements,
         jsonReplacementsToExpressions,
+        identifierReplacementsToExpressions,
       );
     } catch (fullParseError) {
       // node-sql-parser's Postgresql dialect rejects some ClickHouse-specific
@@ -952,6 +978,7 @@ export function chSqlToAliasMap(
       return selectColumnsToAliasMap(
         `SELECT ${projection} FROM ${ALIAS_FALLBACK_TABLE}`,
         jsonReplacementsToExpressions,
+        identifierReplacementsToExpressions,
       );
     }
   } catch (e) {

--- a/packages/common-utils/src/core/metadata.ts
+++ b/packages/common-utils/src/core/metadata.ts
@@ -150,12 +150,30 @@ const quoteJsonPathSegment = (segment: string): string => {
   return `\`${unquoted.replace(/`/g, '``')}\``;
 };
 
-const quoteIdentifierIfNeeded = (identifier: string): string => {
+/**
+ * Backtick-quote an identifier unless it is already a valid bare ClickHouse
+ * identifier. Strips one level of existing quoting first, so it is idempotent.
+ */
+export const quoteIdentifierIfNeeded = (identifier: string): string => {
   const unquoted = unquoteIdentifier(identifier);
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(unquoted)
     ? unquoted
     : quoteJsonPathSegment(unquoted);
 };
+
+/**
+ * Quote a query result column name so it can be referenced in raw SQL.
+ *
+ * Most result column names do not need quoting:
+ * - Bare identifiers (alphanumeric and underscore, starting with a letter or underscore)
+ * - Numeric literals (e.g., `1`, `0x10`)
+ * - Dotted column names (e.g., `my.col`)
+ * - Function calls (e.g., `plus(a, b)`, `arrayElement(m, 'key')`)
+ */
+export const quoteResultColumnNameIfNeeded = (name: string): string =>
+  /^[^`'"()[\],.]+$/.test(name) && !Number.isFinite(Number(name))
+    ? quoteIdentifierIfNeeded(name)
+    : name;
 
 const columnAppearsInMvSelect = (sql: string, columnName: string): boolean => {
   const escaped = columnName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/common-utils/src/core/utils.ts
+++ b/packages/common-utils/src/core/utils.ts
@@ -402,6 +402,108 @@ export function replaceJsonExpressions(sql: string) {
   return { sqlWithReplacements, replacements };
 }
 
+const QUOTED_IDENTIFIER_REPLACEMENT_PREFIX = '__hdx_quoted_identifier_';
+
+export type QuotedIdentifierReplacements = {
+  /** Map from sentinel token -> the original quoted SQL text, e.g. `` `x-host-header` `` */
+  quotedText: Map<string, string>;
+  /** Map from sentinel token -> the bare identifier, e.g. `x-host-header` */
+  names: Map<string, string>;
+};
+
+/**
+ * Replaces backtick-quoted identifiers with bare placeholder tokens.
+ *
+ * node-sql-parser's Postgresql dialect accepts a backtick-quoted identifier
+ * wherever a column is referenced, but rejects one used as an alias, so one
+ * backtick-quoted alias broke any other aliases.
+ *
+ * Pairs with `replaceJsonExpressions`: run this first, then tokenize JSON
+ * expressions, and restore in the opposite order (JSON, then identifiers).
+ * A JSON replacement's stored text is sliced from the already-tokenized SQL,
+ * so it can hold identifier tokens; restoring identifiers first would strand
+ * the ones that JSON restoration puts back afterwards.
+ */
+export function replaceBacktickedIdentifiers(sql: string): {
+  sqlWithReplacements: string;
+  replacements: QuotedIdentifierReplacements;
+} {
+  const quotedText = new Map<string, string>();
+  const names = new Map<string, string>();
+  let out = '';
+  let i = 0;
+
+  while (i < sql.length) {
+    const c = sql.charAt(i);
+
+    // Copy string literals and double-quoted identifiers verbatim so
+    // backticks inside them survive.
+    if (c === "'" || c === '"') {
+      out += c;
+      i++;
+      while (i < sql.length) {
+        const char = sql.charAt(i);
+        out += char;
+        i++;
+        if (c === "'" && char === '\\' && i < sql.length) {
+          out += sql.charAt(i);
+          i++;
+          continue;
+        }
+        if (char === c) break;
+      }
+      continue;
+    }
+
+    if (c === '`') {
+      const quotedStart = i;
+      i++;
+      let name = '';
+      while (i < sql.length) {
+        if (sql.charAt(i) === '`') {
+          // A doubled backtick is an escaped literal backtick.
+          if (sql.charAt(i + 1) === '`') {
+            name += '`';
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        name += sql.charAt(i);
+        i++;
+      }
+      const token = `${QUOTED_IDENTIFIER_REPLACEMENT_PREFIX}${quotedText.size}`;
+      quotedText.set(token, sql.slice(quotedStart, i));
+      names.set(token, name);
+      out += token;
+      continue;
+    }
+
+    out += c;
+    i++;
+  }
+
+  return { sqlWithReplacements: out, replacements: { quotedText, names } };
+}
+
+/**
+ * Substitutes placeholder tokens from `replaceBacktickedIdentifiers` or
+ * `replaceJsonExpressions` back into an expression.
+ */
+export function restoreReplacements(
+  expression: string,
+  replacements: Map<string, string>,
+): string {
+  let restored = expression;
+  for (const [token, original] of [...replacements].sort(
+    ([a], [b]) => b.length - a.length,
+  )) {
+    restored = restored.replaceAll(token, original);
+  }
+  return restored;
+}
+
 /**
  * To best support Pre-aggregation in Materialized Views, any new
  * granularities should be multiples of all smaller granularities.


### PR DESCRIPTION
## Summary

This PR fixes a few bugs causing failures when opening the row side panel, when not using the _block_number/ _block_offset based lookup.

To reproduce, disable _block_number/ _block_offset based lookup with `ALTER TABLE <source_table> MODIFY SETTING enable_block_offset_column = 0, enable_block_number_column = 0;`

### Screenshots or video

#### Select containing hyphenated column:

Before

<img width="2313" height="839" alt="Screenshot 2026-09-11 at 2 34 39 PM" src="https://github.com/user-attachments/assets/8f44e47e-4866-4da5-89bc-230b6f943f0d" />
<img width="1707" height="774" alt="Screenshot 2026-09-11 at 2 35 05 PM" src="https://github.com/user-attachments/assets/5b8dff75-1b5f-4318-b323-bcd71cff6599" />

After

<img width="2312" height="928" alt="Screenshot 2026-09-11 at 2 30 30 PM" src="https://github.com/user-attachments/assets/1521877a-b661-4e4d-a81f-3657c4b3b593" />

#### Select containing a backtick-quoted alias, with other aliases

Before

<img width="1714" height="861" alt="Screenshot 2026-09-11 at 2 33 55 PM" src="https://github.com/user-attachments/assets/d3e96c2d-cb75-46eb-916c-2be36797a64f" />

After

<img width="2310" height="1193" alt="Screenshot 2026-09-11 at 2 32 11 PM" src="https://github.com/user-attachments/assets/789c4237-9671-476a-849c-26e064cbc65d" />

### How to test locally

Add a hyphenated column to your logs table

```
alter table otel_logs add column `test-hyphen` String
```

Disable the block_number filtering:

```
alter table otel_logs modify setting enable_block_offset_column = 0, enable_block_number_column = 0;
```

### References

<!--
Add any supporting references that help reviewers understand this PR.
Examples: issue/ticket or related PRs.
-->

- Linear Issue: Closes HDX-5363
- Related PRs:
